### PR TITLE
Not serialize compile arguments which have no S11N<T> template specialization

### DIFF
--- a/modules/gapi/include/opencv2/gapi/s11n/base.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n/base.hpp
@@ -8,6 +8,7 @@
 #define OPENCV_GAPI_S11N_BASE_HPP
 
 #include <opencv2/gapi/own/assert.hpp>
+#include <opencv2/gapi/own/exports.hpp>
 
 namespace cv {
 namespace gapi {
@@ -16,16 +17,25 @@ struct IOStream;
 struct IIStream;
 
 namespace detail {
-// Will be used along with default types if possible in specific cases (compile args, etc)
-// Note: actual implementation is defined by user
+
+struct NotImplemented {
+};
+
+// The default S11N for custom types is NotImplemented
+// Don't! sublass from NotImplemented if you actually implement S11N.
 template<typename T>
-struct S11N {
+struct S11N: public NotImplemented {
     static void serialize(IOStream &, const T &) {
         GAPI_Assert(false && "No serialization routine is provided!");
     }
     static T deserialize(IIStream &) {
         GAPI_Assert(false && "No deserialization routine is provided!");
     }
+};
+
+template<typename T> struct has_S11N_spec {
+    static constexpr bool value = !std::is_base_of<NotImplemented,
+                                        S11N<typename std::decay<T>::type>>::value;
 };
 
 } // namespace detail

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -338,8 +338,13 @@ IIStream& operator>> (IIStream& is,       cv::gapi::wip::draw::Line &l) {
 
 IOStream& operator<< (IOStream& os, const cv::GCompileArg& arg)
 {
+    ByteMemoryOutStream tmpS;
+    arg.serialize(tmpS);
+    std::vector<char> data = tmpS.data();
+
     os << arg.tag;
-    arg.serialize(os);
+    os << data;
+
     return os;
 }
 

--- a/modules/gapi/test/s11n/gapi_s11n_tests.cpp
+++ b/modules/gapi/test/s11n/gapi_s11n_tests.cpp
@@ -4,32 +4,86 @@
 #include <opencv2/gapi/rmat.hpp>
 
 namespace {
-    struct MyCustomType {
-        int val;
-        std::string name;
-        std::vector<float> vec;
-        std::map<int, uint64_t> mmap;
-        bool operator==(const MyCustomType& other) const {
-            return val == other.val && name == other.name &&
-                   vec == other.vec && mmap == other.mmap;
-        }
-    };
-}
+struct EmptyCustomType { };
+
+struct SimpleCustomType {
+    bool val;
+    bool operator==(const SimpleCustomType& other) const {
+        return val == other.val;
+    }
+};
+
+struct SimpleCustomType2 {
+    int id;
+    bool operator==(const SimpleCustomType2& other) const {
+        return id == other.id;
+    }
+};
+
+struct MyCustomType {
+    int val;
+    std::string name;
+    std::vector<float> vec;
+    std::map<int, uint64_t> mmap;
+    bool operator==(const MyCustomType& other) const {
+        return val == other.val && name == other.name &&
+                vec == other.vec && mmap == other.mmap;
+    }
+};
+
+struct MyCustomTypeNoS11N {
+    char sym;
+    int id;
+    std::string name;
+
+    bool operator==(const MyCustomTypeNoS11N& other) const {
+        return sym == other.sym && id == other.id &&
+                name == other.name;
+    }
+};
+} // anonymous namespace
 
 namespace cv {
 namespace gapi {
 namespace s11n {
 namespace detail {
-    template<> struct S11N<MyCustomType> {
-        static void serialize(IOStream &os, const MyCustomType &p) {
-            os << p.val << p.name << p.vec << p.mmap;
-        }
-        static MyCustomType deserialize(IIStream &is) {
-            MyCustomType p;
-            is >> p.val >> p.name >> p.vec >> p.mmap;
-            return p;
-        }
-    };
+template<> struct S11N<EmptyCustomType> {
+    static void serialize(IOStream &, const EmptyCustomType &) { }
+    static EmptyCustomType deserialize(IIStream &) { return EmptyCustomType { }; }
+};
+
+template<> struct S11N<SimpleCustomType> {
+    static void serialize(IOStream &os, const SimpleCustomType &p) {
+        os << p.val;
+    }
+    static SimpleCustomType deserialize(IIStream &is) {
+        SimpleCustomType p;
+        is >> p.val;
+        return p;
+    }
+};
+
+template<> struct S11N<SimpleCustomType2> {
+    static void serialize(IOStream &os, const SimpleCustomType2 &p) {
+        os << p.id;
+    }
+    static SimpleCustomType2 deserialize(IIStream &is) {
+        SimpleCustomType2 p;
+        is >> p.id;
+        return p;
+    }
+};
+
+template<> struct S11N<MyCustomType> {
+    static void serialize(IOStream &os, const MyCustomType &p) {
+        os << p.val << p.name << p.vec << p.mmap;
+    }
+    static MyCustomType deserialize(IIStream &is) {
+        MyCustomType p;
+        is >> p.val >> p.name >> p.vec >> p.mmap;
+        return p;
+    }
+};
 } // namespace detail
 } // namespace s11n
 } // namespace gapi
@@ -38,9 +92,33 @@ namespace detail {
 
 namespace cv {
 namespace detail {
+template<> struct CompileArgTag<EmptyCustomType> {
+    static const char* tag() {
+        return "org.opencv.test.empty_custom_type";
+    }
+};
+
+template<> struct CompileArgTag<SimpleCustomType> {
+    static const char* tag() {
+        return "org.opencv.test.simple_custom_type";
+    }
+};
+
+template<> struct CompileArgTag<SimpleCustomType2> {
+    static const char* tag() {
+        return "org.opencv.test.simple_custom_type_2";
+    }
+};
+
 template<> struct CompileArgTag<MyCustomType> {
     static const char* tag() {
-        return "org.opencv.test.mycustomtype";
+        return "org.opencv.test.my_custom_type";
+    }
+};
+
+template<> struct CompileArgTag<MyCustomTypeNoS11N> {
+    static const char* tag() {
+        return "org.opencv.test.my_custom_type_no_s11n";
     }
 };
 } // namespace detail
@@ -586,7 +664,7 @@ TEST_F(S11N_Basic, Test_Custom_Type) {
     EXPECT_EQ(var, new_var);
 }
 
-TEST_F(S11N_Basic, Test_Custom_CompileArg) {
+TEST_F(S11N_Basic, Test_CompileArg) {
     MyCustomType customVar{1248, "World", {1280, 720, 640, 480}, {{5, 32434142342}, {7, 34242432}}};
 
     std::vector<char> sArgs = cv::gapi::serialize(cv::compile_args(customVar));
@@ -596,4 +674,151 @@ TEST_F(S11N_Basic, Test_Custom_CompileArg) {
     MyCustomType dCustomVar = cv::gapi::getCompileArg<MyCustomType>(dArgs).value();
     EXPECT_EQ(customVar, dCustomVar);
 }
+
+TEST_F(S11N_Basic, Test_CompileArg_Without_UserCallback) {
+    SimpleCustomType   customVar1 { false };
+    MyCustomTypeNoS11N customVar2 { 'z', 189, "Name" };
+    MyCustomType       customVar3 { 1248, "World", {1280, 720, 640, 480},
+                                    {{5, 32434142342}, {7, 34242432}} };
+
+    EXPECT_NO_THROW(cv::gapi::serialize(cv::compile_args(customVar1, customVar2, customVar3)));
+
+    std::vector<char> sArgs = cv::gapi::serialize(
+        cv::compile_args(customVar1, customVar2, customVar3));
+
+    GCompileArgs dArgs = cv::gapi::deserialize<GCompileArgs,
+                                               SimpleCustomType,
+                                               MyCustomType>(sArgs);
+
+    SimpleCustomType dCustomVar1 = cv::gapi::getCompileArg<SimpleCustomType>(dArgs).value();
+    MyCustomType     dCustomVar3 = cv::gapi::getCompileArg<MyCustomType>(dArgs).value();
+
+    EXPECT_EQ(customVar1, dCustomVar1);
+    EXPECT_EQ(customVar3, dCustomVar3);
+}
+
+TEST_F(S11N_Basic, Test_Deserialize_Only_Requested_CompileArgs) {
+    MyCustomType     myCustomVar { 1248, "World", {1280, 720, 640, 480},
+                                   {{5, 32434142342}, {7, 34242432}} };
+    SimpleCustomType simpleCustomVar { false };
+
+    std::vector<char> sArgs = cv::gapi::serialize(cv::compile_args(myCustomVar, simpleCustomVar));
+
+    GCompileArgs dArgs = cv::gapi::deserialize<GCompileArgs, MyCustomType>(sArgs);
+    EXPECT_EQ(1u, dArgs.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgs).value());
+
+    dArgs.clear();
+    dArgs = cv::gapi::deserialize<GCompileArgs, SimpleCustomType>(sArgs);
+    EXPECT_EQ(1u, dArgs.size());
+    EXPECT_EQ(simpleCustomVar, cv::gapi::getCompileArg<SimpleCustomType>(dArgs).value());
+
+    dArgs.clear();
+    dArgs = cv::gapi::deserialize<GCompileArgs, SimpleCustomType2>(sArgs);
+    EXPECT_EQ(0u, dArgs.size());
+
+    dArgs.clear();
+    dArgs = cv::gapi::deserialize<GCompileArgs, MyCustomType, SimpleCustomType>(sArgs);
+    EXPECT_EQ(2u, dArgs.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgs).value());
+    EXPECT_EQ(simpleCustomVar, cv::gapi::getCompileArg<SimpleCustomType>(dArgs).value());
+
+    SimpleCustomType2 simpleCustomVar2 { 5 };
+    std::vector<char> sArgs2 = cv::gapi::serialize(
+        cv::compile_args(myCustomVar, simpleCustomVar, simpleCustomVar2));
+    GCompileArgs dArgs2 = cv::gapi::deserialize<GCompileArgs,
+                                                MyCustomType,
+                                                SimpleCustomType2>(sArgs2);
+    EXPECT_EQ(2u, dArgs2.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgs2).value());
+    EXPECT_EQ(simpleCustomVar2, cv::gapi::getCompileArg<SimpleCustomType2>(dArgs2).value());
+}
+
+TEST_F(S11N_Basic, Test_Deserialize_CompileArgs_RandomOrder) {
+    SimpleCustomType  simpleCustomVar { false };
+    SimpleCustomType2 simpleCustomVar2 { 5 };
+
+    std::vector<char> sArgs = cv::gapi::serialize(
+        cv::compile_args(simpleCustomVar, simpleCustomVar2));
+    GCompileArgs dArgs = cv::gapi::deserialize<GCompileArgs,
+                                               // Here, types of passed to serialize() arguments
+                                               // are enumerated in reverse order
+                                               SimpleCustomType2,
+                                               SimpleCustomType>(sArgs);
+
+    EXPECT_EQ(simpleCustomVar, cv::gapi::getCompileArg<SimpleCustomType>(dArgs).value());
+    EXPECT_EQ(simpleCustomVar2, cv::gapi::getCompileArg<SimpleCustomType2>(dArgs).value());
+}
+
+TEST_F(S11N_Basic, Test_CompileArgs_With_EmptyCompileArg) {
+    MyCustomType      myCustomVar { 1248, "World", {1280, 720, 640, 480},
+                                    {{5, 32434142342}, {7, 34242432}} };
+    SimpleCustomType  simpleCustomVar { false };
+    EmptyCustomType   emptyCustomVar {  };
+
+    //----{ emptyCustomVar, myCustomVar }----
+    std::vector<char> sArgs1 = cv::gapi::serialize(cv::compile_args(emptyCustomVar, myCustomVar));
+    GCompileArgs dArgsEmptyVar1 = cv::gapi::deserialize<GCompileArgs, EmptyCustomType>(sArgs1);
+    GCompileArgs dArgsMyVar1 = cv::gapi::deserialize<GCompileArgs, MyCustomType>(sArgs1);
+    GCompileArgs dArgsEmptyAndMyVars1 = cv::gapi::deserialize<GCompileArgs,
+                                                              EmptyCustomType,
+                                                              MyCustomType>(sArgs1);
+    EXPECT_EQ(1u, dArgsEmptyVar1.size());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsEmptyVar1).has_value());
+    EXPECT_EQ(1u, dArgsMyVar1.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsMyVar1).value());
+    EXPECT_EQ(2u, dArgsEmptyAndMyVars1.size());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsEmptyAndMyVars1).has_value());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsEmptyAndMyVars1).value());
+
+    //----{ myCustomVar, emptyCustomVar }----
+    std::vector<char> sArgs2 = cv::gapi::serialize(cv::compile_args(myCustomVar, emptyCustomVar));
+    GCompileArgs dArgsMyVar2 = cv::gapi::deserialize<GCompileArgs, MyCustomType>(sArgs2);
+    GCompileArgs dArgsEmptyVar2 = cv::gapi::deserialize<GCompileArgs, EmptyCustomType>(sArgs2);
+    GCompileArgs dArgsMyAndEmptyVars2 = cv::gapi::deserialize<GCompileArgs,
+                                                              MyCustomType,
+                                                              EmptyCustomType>(sArgs2);
+    EXPECT_EQ(1u, dArgsMyVar2.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsMyVar2).value());
+    EXPECT_EQ(1u, dArgsEmptyVar2.size());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsEmptyVar2).has_value());
+    EXPECT_EQ(2u, dArgsMyAndEmptyVars2.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsMyAndEmptyVars2).value());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsMyAndEmptyVars2).has_value());
+
+    //----{ myCustomVar, emptyCustomVar, simpleCustomVar }----
+    std::vector<char> sArgs3 = cv::gapi::serialize(
+        cv::compile_args(myCustomVar, emptyCustomVar, simpleCustomVar));
+    GCompileArgs dArgsMyVar3 = cv::gapi::deserialize<GCompileArgs, MyCustomType>(sArgs3);
+    GCompileArgs dArgsEmptyVar3 = cv::gapi::deserialize<GCompileArgs, EmptyCustomType>(sArgs3);
+    GCompileArgs dArgsSimpleVar3 = cv::gapi::deserialize<GCompileArgs, SimpleCustomType>(sArgs3);
+    GCompileArgs dArgsMyAndSimpleVars3 = cv::gapi::deserialize<GCompileArgs,
+                                                               MyCustomType,
+                                                               SimpleCustomType>(sArgs3);
+    GCompileArgs dArgs3 = cv::gapi::deserialize<GCompileArgs,
+                                                MyCustomType,
+                                                EmptyCustomType,
+                                                SimpleCustomType>(sArgs3);
+    EXPECT_EQ(1u, dArgsMyVar3.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsMyVar3).value());
+    EXPECT_EQ(1u, dArgsEmptyVar3.size());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsEmptyVar3).has_value());
+    EXPECT_EQ(1u, dArgsSimpleVar3.size());
+    EXPECT_EQ(simpleCustomVar, cv::gapi::getCompileArg<SimpleCustomType>(dArgsSimpleVar3).value());
+    EXPECT_EQ(2u, dArgsMyAndSimpleVars3.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgsMyAndSimpleVars3).value());
+    EXPECT_EQ(simpleCustomVar,
+              cv::gapi::getCompileArg<SimpleCustomType>(dArgsMyAndSimpleVars3).value());
+    EXPECT_EQ(3u, dArgs3.size());
+    EXPECT_EQ(myCustomVar, cv::gapi::getCompileArg<MyCustomType>(dArgs3).value());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgs3).has_value());
+    EXPECT_EQ(simpleCustomVar, cv::gapi::getCompileArg<SimpleCustomType>(dArgs3).value());
+
+    //----{ emptyCustomVar }----
+    std::vector<char> sArgs4 = cv::gapi::serialize(cv::compile_args(emptyCustomVar));
+    GCompileArgs dArgsEmptyVar4 = cv::gapi::deserialize<GCompileArgs, EmptyCustomType>(sArgs4);
+    EXPECT_EQ(1u, dArgsEmptyVar4.size());
+    EXPECT_TRUE(cv::gapi::getCompileArg<EmptyCustomType>(dArgsEmptyVar4).has_value());
+}
+
 } // namespace opencv_test


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

Xtest_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*
```