### PR TITLE
[G-API]: morphologyEx() Standard Kernel Implementation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -78,6 +78,13 @@ namespace imgproc {
         }
     };
 
+    G_TYPED_KERNEL(GMorphologyEx, <GMat(GMat,int,Mat,Point,int,int,Scalar)>,
+                   "org.opencv.imgproc.filters.morphologyEx") {
+        static GMatDesc outMeta(GMatDesc in, int, Mat, Point, int, int, Scalar) {
+            return in;
+        }
+    };
+
     G_TYPED_KERNEL(GSobel, <GMat(GMat,int,int,int,int,double,double,int,Scalar)>, "org.opencv.imgproc.filters.sobel") {
         static GMatDesc outMeta(GMatDesc in, int ddepth, int, int, int, double, double, int, Scalar) {
             return in.withDepth(ddepth);
@@ -595,6 +602,37 @@ Output image must have the same type, size, and number of channels as the input 
 GAPI_EXPORTS GMat dilate3x3(const GMat& src, int iterations = 1,
                             int borderType = BORDER_CONSTANT,
                             const  Scalar& borderValue = morphologyDefaultBorderValue());
+
+/** @brief Performs advanced morphological transformations.
+
+The function can perform advanced morphological transformations using an erosion and dilation as
+basic operations.
+
+Any of the operations can be done in-place. In case of multi-channel images, each channel is
+processed independently.
+
+@note Function textual ID is "org.opencv.imgproc.filters.morphologyEx"
+
+@param src Input image.
+@param op Type of a morphological operation, see #MorphTypes
+@param kernel Structuring element. It can be created using #getStructuringElement.
+@param anchor Anchor position within the element. Both negative values mean that the anchor is at
+the kernel center.
+@param iterations Number of times erosion and dilation are applied.
+@param borderType Pixel extrapolation method, see #BorderTypes. #BORDER_WRAP is not supported.
+@param borderValue Border value in case of a constant border. The default value has a special
+meaning.
+@sa  dilate, erode, getStructuringElement
+@note The number of iterations is the number of times erosion or dilatation operation will be
+applied. For instance, an opening operation (#MORPH_OPEN) with two iterations is equivalent to
+apply successively: erode -> erode -> dilate -> dilate
+(and not erode -> dilate -> erode -> dilate).
+ */
+GAPI_EXPORTS GMat morphologyEx(const GMat &src, int op, const Mat &kernel,
+                               const Point  &anchor      = Point(-1,-1),
+                                     int     iterations  = 1,
+                                     int     borderType  = BORDER_CONSTANT,
+                               const Scalar &borderValue = morphologyDefaultBorderValue());
 
 /** @brief Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.
 

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -80,7 +80,7 @@ namespace imgproc {
 
     G_TYPED_KERNEL(GMorphologyEx, <GMat(GMat,int,Mat,Point,int,int,Scalar)>,
                    "org.opencv.imgproc.filters.morphologyEx") {
-        static GMatDesc outMeta(GMatDesc in, int, Mat, Point, int, int, Scalar) {
+        static GMatDesc outMeta(const GMatDesc &in, int, Mat, Point, int, int, Scalar) {
             return in;
         }
     };
@@ -628,10 +628,10 @@ applied. For instance, an opening operation (#MORPH_OPEN) with two iterations is
 apply successively: erode -> erode -> dilate -> dilate
 (and not erode -> dilate -> erode -> dilate).
  */
-GAPI_EXPORTS GMat morphologyEx(const GMat &src, int op, const Mat &kernel,
+GAPI_EXPORTS GMat morphologyEx(const GMat &src, const int op, const Mat &kernel,
                                const Point  &anchor      = Point(-1,-1),
-                                     int     iterations  = 1,
-                                     int     borderType  = BORDER_CONSTANT,
+                               const int     iterations  = 1,
+                               const int     borderType  = BORDER_CONSTANT,
                                const Scalar &borderValue = morphologyDefaultBorderValue());
 
 /** @brief Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -78,9 +78,10 @@ namespace imgproc {
         }
     };
 
-    G_TYPED_KERNEL(GMorphologyEx, <GMat(GMat,int,Mat,Point,int,int,Scalar)>,
+    G_TYPED_KERNEL(GMorphologyEx, <GMat(GMat,MorphTypes,Mat,Point,int,BorderTypes,Scalar)>,
                    "org.opencv.imgproc.filters.morphologyEx") {
-        static GMatDesc outMeta(const GMatDesc &in, int, Mat, Point, int, int, Scalar) {
+        static GMatDesc outMeta(const GMatDesc &in, MorphTypes, Mat, Point, int,
+                                BorderTypes, Scalar) {
             return in;
         }
     };
@@ -528,7 +529,7 @@ anchor is at the element center.
 @param iterations number of times erosion is applied.
 @param borderType pixel extrapolation method, see cv::BorderTypes
 @param borderValue border value in case of a constant border
-@sa  dilate
+@sa  dilate, morphologyEx
  */
 GAPI_EXPORTS GMat erode(const GMat& src, const Mat& kernel, const Point& anchor = Point(-1,-1), int iterations = 1,
                         int borderType = BORDER_CONSTANT,
@@ -628,11 +629,11 @@ applied. For instance, an opening operation (#MORPH_OPEN) with two iterations is
 apply successively: erode -> erode -> dilate -> dilate
 (and not erode -> dilate -> erode -> dilate).
  */
-GAPI_EXPORTS GMat morphologyEx(const GMat &src, const int op, const Mat &kernel,
-                               const Point  &anchor      = Point(-1,-1),
-                               const int     iterations  = 1,
-                               const int     borderType  = BORDER_CONSTANT,
-                               const Scalar &borderValue = morphologyDefaultBorderValue());
+GAPI_EXPORTS GMat morphologyEx(const GMat &src, const MorphTypes op, const Mat &kernel,
+                               const Point       &anchor      = Point(-1,-1),
+                               const int          iterations  = 1,
+                               const BorderTypes  borderType  = BORDER_CONSTANT,
+                               const Scalar      &borderValue = morphologyDefaultBorderValue());
 
 /** @brief Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.
 

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -73,8 +73,8 @@ GMat dilate3x3(const GMat& src, int iterations,
     return dilate(src, cv::Mat(), cv::Point(-1,-1), iterations, borderType, borderValue);
 }
 
-GMat morphologyEx(const GMat &src, const int op, const Mat &kernel, const Point &anchor,
-                  const int iterations, const int borderType, const Scalar &borderValue)
+GMat morphologyEx(const GMat &src, const MorphTypes op, const Mat &kernel, const Point &anchor,
+                  const int iterations, const BorderTypes borderType, const Scalar &borderValue)
 {
     return imgproc::GMorphologyEx::on(src, op, kernel, anchor, iterations,
                                       borderType, borderValue);

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -73,8 +73,8 @@ GMat dilate3x3(const GMat& src, int iterations,
     return dilate(src, cv::Mat(), cv::Point(-1,-1), iterations, borderType, borderValue);
 }
 
-GMat morphologyEx(const GMat &src, int op, const Mat &kernel, const Point &anchor, int iterations,
-                  int borderType, const Scalar &borderValue)
+GMat morphologyEx(const GMat &src, const int op, const Mat &kernel, const Point &anchor,
+                  const int iterations, const int borderType, const Scalar &borderValue)
 {
     return imgproc::GMorphologyEx::on(src, op, kernel, anchor, iterations,
                                       borderType, borderValue);

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -73,6 +73,13 @@ GMat dilate3x3(const GMat& src, int iterations,
     return dilate(src, cv::Mat(), cv::Point(-1,-1), iterations, borderType, borderValue);
 }
 
+GMat morphologyEx(const GMat &src, int op, const Mat &kernel, const Point &anchor, int iterations,
+                  int borderType, const Scalar &borderValue)
+{
+    return imgproc::GMorphologyEx::on(src, op, kernel, anchor, iterations,
+                                      borderType, borderValue);
+}
+
 GMat Sobel(const GMat& src, int ddepth, int dx, int dy, int ksize,
            double scale, double delta,
            int borderType, const Scalar& bordVal)

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -145,6 +145,15 @@ GAPI_OCV_KERNEL(GCPUDilate, cv::gapi::imgproc::GDilate)
     }
 };
 
+GAPI_OCV_KERNEL(GCPUMorphologyEx, cv::gapi::imgproc::GMorphologyEx)
+{
+    static void run(const cv::Mat &in, int op, const cv::Mat &kernel, const cv::Point &anchor,
+                    int iterations, int borderType, const cv::Scalar &borderValue, cv::Mat &out)
+    {
+        cv::morphologyEx(in, out, op, kernel, anchor, iterations, borderType, borderValue);
+    }
+};
+
 GAPI_OCV_KERNEL(GCPUSobel, cv::gapi::imgproc::GSobel)
 {
     static void run(const cv::Mat& in, int ddepth, int dx, int dy, int ksize, double scale, double delta, int borderType,
@@ -478,6 +487,7 @@ cv::gapi::GKernelPackage cv::gapi::imgproc::cpu::kernels()
         , GCPUMedianBlur
         , GCPUErode
         , GCPUDilate
+        , GCPUMorphologyEx
         , GCPUSobel
         , GCPUSobelXY
         , GCPULaplacian

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -147,9 +147,9 @@ GAPI_OCV_KERNEL(GCPUDilate, cv::gapi::imgproc::GDilate)
 
 GAPI_OCV_KERNEL(GCPUMorphologyEx, cv::gapi::imgproc::GMorphologyEx)
 {
-    static void run(const cv::Mat &in, const int op, const cv::Mat &kernel,
-                    const cv::Point &anchor, const int iterations, const int borderType,
-                    const cv::Scalar &borderValue, cv::Mat &out)
+    static void run(const cv::Mat &in, const cv::MorphTypes op, const cv::Mat &kernel,
+                    const cv::Point &anchor, const int iterations,
+                    const cv::BorderTypes borderType, const cv::Scalar &borderValue, cv::Mat &out)
     {
         cv::morphologyEx(in, out, op, kernel, anchor, iterations, borderType, borderValue);
     }

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -147,8 +147,9 @@ GAPI_OCV_KERNEL(GCPUDilate, cv::gapi::imgproc::GDilate)
 
 GAPI_OCV_KERNEL(GCPUMorphologyEx, cv::gapi::imgproc::GMorphologyEx)
 {
-    static void run(const cv::Mat &in, int op, const cv::Mat &kernel, const cv::Point &anchor,
-                    int iterations, int borderType, const cv::Scalar &borderValue, cv::Mat &out)
+    static void run(const cv::Mat &in, const int op, const cv::Mat &kernel,
+                    const cv::Point &anchor, const int iterations, const int borderType,
+                    const cv::Scalar &borderValue, cv::Mat &out)
     {
         cv::morphologyEx(in, out, op, kernel, anchor, iterations, borderType, borderValue);
     }

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -46,7 +46,8 @@ GAPI_TEST_FIXTURE(Erode3x3Test, initMatrixRandN, FIXTURE_API(CompareMats,int), 2
 GAPI_TEST_FIXTURE(DilateTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,
     cmpF, kernSize, kernType)
 GAPI_TEST_FIXTURE(Dilate3x3Test, initMatrixRandN, FIXTURE_API(CompareMats,int), 2, cmpF, numIters)
-GAPI_TEST_FIXTURE(MorphologyExTest, initMatrixRandN, FIXTURE_API(CompareMats,int), 2, cmpF, op)
+GAPI_TEST_FIXTURE(MorphologyExTest, initMatrixRandN, FIXTURE_API(CompareMats,MorphTypes),
+                  2, cmpF, op)
 GAPI_TEST_FIXTURE(SobelTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int,int), 4,
     cmpF, kernSize, dx, dy)
 GAPI_TEST_FIXTURE(SobelXYTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int,int,int), 5,

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -46,6 +46,7 @@ GAPI_TEST_FIXTURE(Erode3x3Test, initMatrixRandN, FIXTURE_API(CompareMats,int), 2
 GAPI_TEST_FIXTURE(DilateTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,
     cmpF, kernSize, kernType)
 GAPI_TEST_FIXTURE(Dilate3x3Test, initMatrixRandN, FIXTURE_API(CompareMats,int), 2, cmpF, numIters)
+GAPI_TEST_FIXTURE(MorphologyExTest, initMatrixRandN, FIXTURE_API(CompareMats,int), 2, cmpF, op)
 GAPI_TEST_FIXTURE(SobelTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int,int), 4,
     cmpF, kernSize, dx, dy)
 GAPI_TEST_FIXTURE(SobelXYTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int,int,int), 5,

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -292,7 +292,8 @@ TEST_P(Dilate3x3Test, AccuracyTest)
 
 TEST_P(MorphologyExTest, AccuracyTest)
 {
-    int defShape = cv::MORPH_RECT, defKernSize = 3;
+    MorphShapes defShape = cv::MORPH_RECT;
+    int defKernSize = 3;
     cv::Mat kernel = cv::getStructuringElement(defShape, cv::Size(defKernSize, defKernSize));
 
     // G-API code //////////////////////////////////////////////////////////////

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -290,6 +290,28 @@ TEST_P(Dilate3x3Test, AccuracyTest)
     }
 }
 
+TEST_P(MorphologyExTest, AccuracyTest)
+{
+    int defShape = cv::MORPH_RECT, defKernSize = 3;
+    cv::Mat kernel = cv::getStructuringElement(defShape, cv::Size(defKernSize, defKernSize));
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    auto out = cv::gapi::morphologyEx(in, op, kernel);
+
+    cv::GComputation c(in, out);
+    c.apply(in_mat1, out_mat_gapi, getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::morphologyEx(in_mat1, out_mat_ocv, op, kernel);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
+        EXPECT_EQ(out_mat_gapi.size(), sz);
+    }
+}
+
 TEST_P(SobelTest, AccuracyTest)
 {
     // G-API code //////////////////////////////////////////////////////////////

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -848,6 +848,25 @@ inline std::ostream& operator<<(std::ostream& os, NormTypes op)
 #undef CASE
     return os;
 }
+
+inline std::ostream& operator<<(std::ostream& os, MorphTypes op)
+{
+#define CASE(v) case MorphTypes::v: os << #v; break
+    switch (op)
+    {
+        CASE(MORPH_ERODE);
+        CASE(MORPH_DILATE);
+        CASE(MORPH_OPEN);
+        CASE(MORPH_CLOSE);
+        CASE(MORPH_GRADIENT);
+        CASE(MORPH_TOPHAT);
+        CASE(MORPH_BLACKHAT);
+        CASE(MORPH_HITMISS);
+        default: GAPI_Assert(false && "unknown MorphTypes value");
+    }
+#undef CASE
+    return os;
+}
 }  // namespace cv
 
 #endif //OPENCV_GAPI_TESTS_COMMON_HPP

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -130,6 +130,30 @@ INSTANTIATE_TEST_CASE_P(Dilate3x3TestCPU, Dilate3x3Test,
                                 Values(AbsExact().to_compare_obj()),
                                 Values(1,2,4)));
 
+INSTANTIATE_TEST_CASE_P(MorphologyExTestCPU, MorphologyExTest,
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(AbsExact().to_compare_obj()),
+                                Values(cv::MorphTypes::MORPH_ERODE,
+                                       cv::MorphTypes::MORPH_DILATE,
+                                       cv::MorphTypes::MORPH_OPEN,
+                                       cv::MorphTypes::MORPH_CLOSE,
+                                       cv::MorphTypes::MORPH_GRADIENT,
+                                       cv::MorphTypes::MORPH_TOPHAT,
+                                       cv::MorphTypes::MORPH_BLACKHAT)));
+
+INSTANTIATE_TEST_CASE_P(MorphologyExHitMissTestCPU, MorphologyExTest,
+                        Combine(Values(CV_8UC1),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(AbsExact().to_compare_obj()),
+                                Values(cv::MorphTypes::MORPH_HITMISS)));
+
 INSTANTIATE_TEST_CASE_P(SobelTestCPU, SobelTest,
                         Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
                                 Values(cv::Size(1280, 720),


### PR DESCRIPTION
These changes:

 - Add morphologyEx() standard kernel
    - provide API and documentation (without separate 3x3 version)
    - support OCV backend
    - provide accuracy tests: check only different operations, not kernels/borders

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```