### PR TITLE
Fix cmake configure error

### DIFF
--- a/modules/videoio/cmake/init.cmake
+++ b/modules/videoio/cmake/init.cmake
@@ -13,12 +13,15 @@ function(ocv_add_external_target name inc link def)
     INTERFACE_INCLUDE_DIRECTORIES "${inc}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${inc}"
     INTERFACE_COMPILE_DEFINITIONS "${def}")
+  # When cmake version is greater than or equal to 3.11, INTERFACE_LINK_LIBRARIES no longer applies to interface library
+  # See https://github.com/opencv/opencv/pull/18658
   if (CMAKE_VERSION VERSION_LESS 3.11)
     set_target_properties(ocv.3rdparty.${name} PROPERTIES
       INTERFACE_LINK_LIBRARIES "${link}")
   else()
     target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
   endif()
+  #
   if(NOT BUILD_SHARED_LIBS)
     install(TARGETS ocv.3rdparty.${name} EXPORT OpenCVModules)
   endif()

--- a/modules/videoio/cmake/init.cmake
+++ b/modules/videoio/cmake/init.cmake
@@ -13,7 +13,12 @@ function(ocv_add_external_target name inc link def)
     INTERFACE_INCLUDE_DIRECTORIES "${inc}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${inc}"
     INTERFACE_COMPILE_DEFINITIONS "${def}")
-  target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
+  if (CMAKE_VERSION VERSION_LESS 3.11)
+    set_target_properties(ocv.3rdparty.${name} PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${link}")
+  else()
+    target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
+  endif()
   if(NOT BUILD_SHARED_LIBS)
     install(TARGETS ocv.3rdparty.${name} EXPORT OpenCVModules)
   endif()

--- a/modules/videoio/cmake/init.cmake
+++ b/modules/videoio/cmake/init.cmake
@@ -12,8 +12,8 @@ function(ocv_add_external_target name inc link def)
   set_target_properties(ocv.3rdparty.${name} PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${inc}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${inc}"
-    INTERFACE_LINK_LIBRARIES "${link}"
     INTERFACE_COMPILE_DEFINITIONS "${def}")
+  target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
   if(NOT BUILD_SHARED_LIBS)
     install(TARGETS ocv.3rdparty.${name} EXPORT OpenCVModules)
   endif()


### PR DESCRIPTION
Fix configure error using cmake 3.18.*:
```
INTERFACE_LINK_LIBRARIES: optimized;F:/vcpkg/installed/x64-windows/lib/avcodec.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avcodec.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avdevice.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avdevice.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avfilter.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avfilter.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avformat.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avformat.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avresample.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avresample.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avutil.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avutil.lib;optimized;F:/vcpkg/installed/x64-windows/lib/postproc.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/postproc.lib;optimized;F:/vcpkg/installed/x64-windows/lib/swresample.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/swresample.lib;optimized;F:/vcpkg/installed/x64-windows/lib/swscale.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/swscale.lib;optimized;wsock32;debug;wsock32;optimized;ws2_32;debug;ws2_32;optimized;secur32;debug;secur32;optimized;bcrypt;debug;bcrypt;optimized;strmiids;debug;strmiids;optimized;Vfw32;debug;Vfw32;optimized;Shlwapi;debug;Shlwapi;optimized;mfplat;debug;mfplat;optimized;mfuuid;debug;mfuuid
CMake Error at modules/videoio/cmake/init.cmake:13 (set_target_properties):
  Property INTERFACE_LINK_LIBRARIES may not contain link-type keyword
  "optimized".  The INTERFACE_LINK_LIBRARIES property may contain
  configuration-sensitive generator-expressions which may be used to specify
  per-configuration rules.
Call Stack (most recent call first):
  modules/videoio/cmake/detect_ffmpeg.cmake:60 (ocv_add_external_target)
  modules/videoio/cmake/init.cmake:3 (include)
  modules/videoio/cmake/init.cmake:23 (add_backend)
  cmake/OpenCVModule.cmake:312 (include)
  cmake/OpenCVModule.cmake:375 (_add_modules_1)
  modules/CMakeLists.txt:7 (ocv_glob_modules)
```
Related PR: https://github.com/microsoft/vcpkg/pull/14177


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
