### PR TITLE
Bugfix: Manual page sizes now overwrite the default page size if they…

### DIFF
--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -92,11 +92,11 @@ def main():
                         dest="square_size", type=float)
     parser.add_argument("-R", "--radius_rate", help="circles_radius = square_size/radius_rate", default="5.0",
                         action="store", dest="radius_rate", type=float)
-    parser.add_argument("-w", "--page_width", help="page width in units", default="216", action="store",
+    parser.add_argument("-w", "--page_width", help="page width in units", default=argparse.SUPPRESS, action="store",
                         dest="page_width", type=float)
-    parser.add_argument("-h", "--page_height", help="page height in units", default="279", action="store",
-                        dest="page_width", type=float)
-    parser.add_argument("-a", "--page_size", help="page size, supersedes -h -w arguments", default="A4", action="store",
+    parser.add_argument("-h", "--page_height", help="page height in units", default=argparse.SUPPRESS, action="store",
+                        dest="page_height", type=float)
+    parser.add_argument("-a", "--page_size", help="page size, superseded if -h and -w are set", default="A4", action="store",
                         dest="page_size", choices=["A0", "A1", "A2", "A3", "A4", "A5"])
     args = parser.parse_args()
 
@@ -111,12 +111,16 @@ def main():
     units = args.units
     square_size = args.square_size
     radius_rate = args.radius_rate
-    page_size = args.page_size
-    # page size dict (ISO standard, mm) for easy lookup. format - size: [width, height]
-    page_sizes = {"A0": [840, 1188], "A1": [594, 840], "A2": [420, 594], "A3": [297, 420], "A4": [210, 297],
-                  "A5": [148, 210]}
-    page_width = page_sizes[page_size.upper()][0]
-    page_height = page_sizes[page_size.upper()][1]
+    if 'page_width' and 'page_height' in args:
+        page_width = args.page_width
+        page_height = args.page_height
+    else:
+        page_size = args.page_size
+        # page size dict (ISO standard, mm) for easy lookup. format - size: [width, height]
+        page_sizes = {"A0": [840, 1188], "A1": [594, 840], "A2": [420, 594], "A3": [297, 420], "A4": [210, 297],
+                      "A5": [148, 210]}
+        page_width = page_sizes[page_size][0]
+        page_height = page_sizes[page_size][1]
     pm = PatternMaker(columns, rows, output, units, square_size, radius_rate, page_width, page_height)
     # dict for easy lookup of pattern type
     mp = {"circles": pm.make_circles_pattern, "acircles": pm.make_acircles_pattern,


### PR DESCRIPTION
Bugfix: Manual page sizes now overwrite the default page size if they are both specified.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x] I agree to contribute to the project under Apache 2 License.
- [ x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
