### PR TITLE
GAPI: New BackgroundSubtractor stateful kernel

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -1065,6 +1065,8 @@ The algorithm normalizes the brightness and increases the contrast of the image.
  */
 GAPI_EXPORTS GMat equalizeHist(const GMat& src);
 
+//! @} gapi_filters
+
 //! @addtogroup gapi_shape
 //! @{
 /** @brief Finds contours in a binary image.
@@ -1326,20 +1328,6 @@ GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3d>& src, const Distance
 
 //! @addtogroup gapi_colorconvert
 //! @{
-/** @brief Converts an image from BGR color space to RGB color space.
-
-The function converts an input image from BGR color space to RGB.
-The conventional ranges for B, G, and R channel values are 0 to 255.
-
-Output image is 8-bit unsigned 3-channel image @ref CV_8UC3.
-
-@note Function textual ID is "org.opencv.imgproc.colorconvert.bgr2rgb"
-
-@param src input image: 8-bit unsigned 3-channel image @ref CV_8UC3.
-@sa RGB2BGR
-*/
-GAPI_EXPORTS GMat BGR2RGB(const GMat& src);
-
 /** @brief Converts an image from RGB color space to gray-scaled.
 The conventional ranges for R, G, and B channel values are 0 to 255.
 Resulting gray color value computed as
@@ -1394,6 +1382,20 @@ Output image must be 8-bit unsigned 3-channel image @ref CV_8UC3.
 @sa YUV2RGB, RGB2Lab
 */
 GAPI_EXPORTS GMat RGB2YUV(const GMat& src);
+
+/** @brief Converts an image from BGR color space to RGB color space.
+
+The function converts an input image from BGR color space to RGB.
+The conventional ranges for B, G, and R channel values are 0 to 255.
+
+Output image is 8-bit unsigned 3-channel image @ref CV_8UC3.
+
+@note Function textual ID is "org.opencv.imgproc.colorconvert.bgr2rgb"
+
+@param src input image: 8-bit unsigned 3-channel image @ref CV_8UC3.
+@sa RGB2BGR
+*/
+GAPI_EXPORTS GMat BGR2RGB(const GMat& src);
 
 /** @brief Converts an image from BGR color space to I420 color space.
 

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -1065,8 +1065,6 @@ The algorithm normalizes the brightness and increases the contrast of the image.
  */
 GAPI_EXPORTS GMat equalizeHist(const GMat& src);
 
-//! @} gapi_filters
-
 //! @addtogroup gapi_shape
 //! @{
 /** @brief Finds contours in a binary image.
@@ -1328,6 +1326,20 @@ GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3d>& src, const Distance
 
 //! @addtogroup gapi_colorconvert
 //! @{
+/** @brief Converts an image from BGR color space to RGB color space.
+
+The function converts an input image from BGR color space to RGB.
+The conventional ranges for B, G, and R channel values are 0 to 255.
+
+Output image is 8-bit unsigned 3-channel image @ref CV_8UC3.
+
+@note Function textual ID is "org.opencv.imgproc.colorconvert.bgr2rgb"
+
+@param src input image: 8-bit unsigned 3-channel image @ref CV_8UC3.
+@sa RGB2BGR
+*/
+GAPI_EXPORTS GMat BGR2RGB(const GMat& src);
+
 /** @brief Converts an image from RGB color space to gray-scaled.
 The conventional ranges for R, G, and B channel values are 0 to 255.
 Resulting gray color value computed as
@@ -1382,20 +1394,6 @@ Output image must be 8-bit unsigned 3-channel image @ref CV_8UC3.
 @sa YUV2RGB, RGB2Lab
 */
 GAPI_EXPORTS GMat RGB2YUV(const GMat& src);
-
-/** @brief Converts an image from BGR color space to RGB color space.
-
-The function converts an input image from BGR color space to RGB.
-The conventional ranges for B, G, and R channel values are 0 to 255.
-
-Output image is 8-bit unsigned 3-channel image @ref CV_8UC3.
-
-@note Function textual ID is "org.opencv.imgproc.colorconvert.bgr2rgb"
-
-@param src input image: 8-bit unsigned 3-channel image @ref CV_8UC3.
-@sa RGB2BGR
-*/
-GAPI_EXPORTS GMat BGR2RGB(const GMat& src);
 
 /** @brief Converts an image from BGR color space to I420 color space.
 

--- a/modules/gapi/include/opencv2/gapi/video.hpp
+++ b/modules/gapi/include/opencv2/gapi/video.hpp
@@ -63,9 +63,70 @@ G_TYPED_KERNEL(GCalcOptFlowLKForPyr,
     }
 };
 
-G_TYPED_KERNEL(GBackSubMOG2, <GMat(GMat)>, "org.opencv.video.backgroundSubtractormog2")
+enum BackgroundSubtractorType
 {
-    static GMatDesc outMeta(GMatDesc in) { return in.withType(CV_8U, 1); }
+    TYPE_BS_MOG2,
+    TYPE_BS_KNN
+};
+
+/** @brief Structure for the Background Subtractor operation's initialization parameters.*/
+
+struct BackgroundSubtractorParams
+{
+    //! Type of the Background Subtractor operation.
+    BackgroundSubtractorType operation = TYPE_BS_MOG2;
+
+    //! Length of the history.
+    int history = 500;
+
+    //! For MOG2: Threshold on the squared Mahalanobis distance between the pixel
+    //! and the model to decide whether a pixel is well described by
+    //! the background model.
+    //! For KNN: Threshold on the squared distance between the pixel and the sample
+    //! to decide whether a pixel is close to that sample.
+    double threshold = 16;
+
+    //! If true, the algorithm will detect shadows and mark them.
+    bool detectShadows = true;
+
+    //! The value between 0 and 1 that indicates how fast
+    //! the background model is learnt.
+    //! Negative parameter value makes the algorithm use some automatically
+    //! chosen learning rate.
+    double learningRate = -1;
+
+    //! default constructor
+    BackgroundSubtractorParams() {}
+
+    /** Full constructor
+    @param op MOG2/KNN Background Subtractor type.
+    @param histLength Length of the history.
+    @param thrshld For MOG2: Threshold on the squared Mahalanobis distance between
+    the pixel and the model to decide whether a pixel is well described by the background model.
+    For KNN: Threshold on the squared distance between the pixel and the sample to decide
+    whether a pixel is close to that sample.
+    @param detect If true, the algorithm will detect shadows and mark them. It decreases the
+    speed a bit, so if you do not need this feature, set the parameter to false.
+    @param lRate The value between 0 and 1 that indicates how fast the background model is learnt.
+    Negative parameter value makes the algorithm to use some automatically chosen learning rate.
+    */
+    BackgroundSubtractorParams(BackgroundSubtractorType op, int histLength,
+                               double thrshld, bool detect, double lRate) : operation(op),
+                                                                            history(histLength),
+                                                                            threshold(thrshld),
+                                                                            detectShadows(detect),
+                                                                            learningRate(lRate){}
+};
+
+G_TYPED_KERNEL(GBackgroundSubtractor, <GMat(GMat, BackgroundSubtractorParams)>,
+               "org.opencv.video.BackgroundSubtractor")
+{
+    static GMatDesc outMeta(const GMatDesc& in, const BackgroundSubtractorParams& bsParams)
+    {
+        GAPI_Assert(bsParams.history >= 0);
+        GAPI_Assert(bsParams.learningRate <= 1);
+        return in.withType(CV_8U, 1);
+    }
 };
 
 } //namespace video
@@ -175,22 +236,32 @@ calcOpticalFlowPyrLK(const GArray<GMat>    &prevPyr,
                            int              flags        = 0,
                            double           minEigThresh = 1e-4);
 
-/** @brief Gaussian Mixture based Background/Foreground Segmentation.
-The class generates a foreground mask.
+/** @brief Gaussian Mixture-based or K-nearest neighbours-based Background/Foreground Segmentation Algorithm.
+The operation generates a foreground mask.
 
-Output image is foreground mask, i.e. 8-bit unsigned 1-channel (binary) matrix @ref CV_8UC1.
+@return Output image is foreground mask, i.e. 8-bit unsigned 1-channel (binary) matrix @ref CV_8UC1.
 
-@note Functional textual ID is "org.opencv.videoanalysis.backgroundSubtractormog2"
+@note Functional textual ID is "org.opencv.video.BackgroundSubtractor"
 
 @param src input image: Floating point frame is used without scaling and should be in range [0,255].
-@ref CV_32FC3.
-
-@sa BackSubMOG2
+@param bsParams Set of initialization parameters for Background Subtractor kernel.
 */
-GAPI_EXPORTS GMat BackSubMOG2(const GMat& src);
+GAPI_EXPORTS GMat BackgroundSubtractor(const GMat& src, const cv::gapi::video::BackgroundSubtractorParams& bsParams);
 
 //! @} gapi_video
 } //namespace gapi
 } //namespace cv
+
+
+namespace cv { namespace detail {
+template<> struct CompileArgTag<cv::gapi::video::BackgroundSubtractorParams>
+{
+    static const char* tag()
+    {
+        return "org.opencv.video.background_substractor_params";
+    }
+};
+}  // namespace detail
+}  //namespace cv
 
 #endif // OPENCV_GAPI_VIDEO_HPP

--- a/modules/gapi/include/opencv2/gapi/video.hpp
+++ b/modules/gapi/include/opencv2/gapi/video.hpp
@@ -62,6 +62,12 @@ G_TYPED_KERNEL(GCalcOptFlowLKForPyr,
         return std::make_tuple(empty_array_desc(), empty_array_desc(), empty_array_desc());
     }
 };
+
+G_TYPED_KERNEL(GBackSubMOG2, <GMat(GMat)>, "org.opencv.video.backgroundSubtractormog2")
+{
+    static GMatDesc outMeta(GMatDesc in) { return in.withType(CV_8U, 1); }
+};
+
 } //namespace video
 
 //! @addtogroup gapi_video
@@ -168,6 +174,20 @@ calcOpticalFlowPyrLK(const GArray<GMat>    &prevPyr,
                                                                         30, 0.01),
                            int              flags        = 0,
                            double           minEigThresh = 1e-4);
+
+/** @brief Gaussian Mixture based Background/Foreground Segmentation.
+The class generates a foreground mask.
+
+Output image is foreground mask, i.e. 8-bit unsigned 1-channel (binary) matrix @ref CV_8UC1.
+
+@note Functional textual ID is "org.opencv.videoanalysis.backgroundSubtractormog2"
+
+@param src input image: Floating point frame is used without scaling and should be in range [0,255].
+@ref CV_32FC3.
+
+@sa BackSubMOG2
+*/
+GAPI_EXPORTS GMat BackSubMOG2(const GMat& src);
 
 //! @} gapi_video
 } //namespace gapi

--- a/modules/gapi/src/api/kernels_video.cpp
+++ b/modules/gapi/src/api/kernels_video.cpp
@@ -52,5 +52,10 @@ GOptFlowLKOutput calcOpticalFlowPyrLK(const cv::GArray<cv::GMat>    &prevPyr,
                                     criteria, flags, minEigThresh);
 }
 
+GMat BackSubMOG2(const GMat& src)
+{
+    return GBackSubMOG2::on(src);
+}
+
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/api/kernels_video.cpp
+++ b/modules/gapi/src/api/kernels_video.cpp
@@ -52,9 +52,9 @@ GOptFlowLKOutput calcOpticalFlowPyrLK(const cv::GArray<cv::GMat>    &prevPyr,
                                     criteria, flags, minEigThresh);
 }
 
-GMat BackSubMOG2(const GMat& src)
+GMat BackgroundSubtractor(const GMat& src, const BackgroundSubtractorParams& bsp)
 {
-    return GBackSubMOG2::on(src);
+    return GBackgroundSubtractor::on(src, bsp);
 }
 
 } //namespace gapi

--- a/modules/gapi/src/backends/cpu/gcpuvideo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuvideo.cpp
@@ -80,12 +80,27 @@ GAPI_OCV_KERNEL(GCPUCalcOptFlowLKForPyr, cv::gapi::video::GCalcOptFlowLKForPyr)
     }
 };
 
+GAPI_OCV_KERNEL_ST(GCPUBackSubMOG2, cv::gapi::video::GBackSubMOG2, cv::BackgroundSubtractorMOG2)
+{
+    static void setup(const cv::GMatDesc &/* desc */, std::shared_ptr<cv::BackgroundSubtractorMOG2> &state)
+    {
+        state = cv::createBackgroundSubtractorMOG2();
+        GAPI_Assert(state);
+    }
+
+    static void run(const cv::Mat& in, cv::Mat &out, cv::BackgroundSubtractorMOG2& state)
+    {
+        state.apply(in, out, -1);
+    }
+};
+
 cv::gapi::GKernelPackage cv::gapi::video::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
         < GCPUBuildOptFlowPyramid
         , GCPUCalcOptFlowLK
         , GCPUCalcOptFlowLKForPyr
+        , GCPUBackSubMOG2
         >();
     return pkg;
 }

--- a/modules/gapi/test/common/gapi_video_tests.hpp
+++ b/modules/gapi/test/common/gapi_video_tests.hpp
@@ -28,6 +28,8 @@ GAPI_TEST_FIXTURE_SPEC_PARAMS(BuildPyr_CalcOptFlow_PipelineTest,
                               FIXTURE_API(std::string,int,int,bool), 4,
                               fileNamePattern, winSize, maxLevel, withDerivatives)
 
+GAPI_TEST_FIXTURE_SPEC_PARAMS(BackSubMOG2Test, FIXTURE_API(std::string, std::string), 2, filePath1, filePath2)
+
 } // opencv_test
 
 

--- a/modules/gapi/test/common/gapi_video_tests.hpp
+++ b/modules/gapi/test/common/gapi_video_tests.hpp
@@ -28,8 +28,9 @@ GAPI_TEST_FIXTURE_SPEC_PARAMS(BuildPyr_CalcOptFlow_PipelineTest,
                               FIXTURE_API(std::string,int,int,bool), 4,
                               fileNamePattern, winSize, maxLevel, withDerivatives)
 
-GAPI_TEST_FIXTURE_SPEC_PARAMS(BackSubMOG2Test, FIXTURE_API(std::string, std::string), 2, filePath1, filePath2)
-
+GAPI_TEST_FIXTURE_SPEC_PARAMS(BackgroundSubtractorTest, FIXTURE_API(tuple<cv::gapi::video::BackgroundSubtractorType,double>,
+                                                                    int, bool, double, std::string, std::size_t),
+                              6, typeAndThreshold, histLength, detectShadows, learningRate, filePath, testNumFrames)
 } // opencv_test
 
 

--- a/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
@@ -98,9 +98,17 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTe
                                       Values(3),
                                       Values(true)));
 
-INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackSubMOG2InternalTestCPU),
-                              BackSubMOG2Test,
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackgroundSubtractorTestCPU),
+                              BackgroundSubtractorTest,
                               Combine(Values(VIDEO_CPU),
-                              Values("cv/video/768x576.avi"),
-                              Values("cv/video/1920x1080.avi")));
+                                      Values(std::make_tuple(cv::gapi::video::TYPE_BS_MOG2, 16),
+                                             std::make_tuple(cv::gapi::video::TYPE_BS_MOG2, 8),
+                                             std::make_tuple(cv::gapi::video::TYPE_BS_KNN, 400),
+                                             std::make_tuple(cv::gapi::video::TYPE_BS_KNN, 200)),
+                                             Values(500, 50),
+                                             Values(true, false),
+                                             Values(-1, 0, 0.5, 1),
+                                             Values("cv/video/768x576.avi"),
+                                             Values(3)));
 } // opencv_test

--- a/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
@@ -97,4 +97,10 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTe
                                       Values(15),
                                       Values(3),
                                       Values(true)));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackSubMOG2InternalTestCPU),
+                              BackSubMOG2Test,
+                              Combine(Values(VIDEO_CPU),
+                              Values("cv/video/768x576.avi"),
+                              Values("cv/video/1920x1080.avi")));
 } // opencv_test


### PR DESCRIPTION
New BackgroundSubtractor kernel represents 2 types of operation such as:

- Background Subtractor MOG2 (default);

- Background Subtractor KNN


<cut/>
Published for review on 27th of October. 

@dmatveev , @OrestChura , please take a look.

```

force_builders_only=linux,docs,Custom
Xforce_builders=Custom,Custom Win,Custom Mac,Linux32,Win32
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

```