### PR TITLE
cmake: prefer using Eigen configuration files

### DIFF
--- a/cmake/OpenCVFindLibsPerf.cmake
+++ b/cmake/OpenCVFindLibsPerf.cmake
@@ -51,7 +51,12 @@ endif(WITH_CUDA)
 
 # --- Eigen ---
 if(WITH_EIGEN AND NOT HAVE_EIGEN)
-  find_package(Eigen3 QUIET)
+  if(NOT OPENCV_SKIP_EIGEN_FIND_PACKAGE_CONFIG)
+    find_package(Eigen3 CONFIG QUIET)  # Ceres 2.0.0 CMake scripts doesn't work with CMake's FindEigen3.cmake module (due to missing EIGEN3_VERSION_STRING)
+  endif()
+  if(NOT Eigen3_FOUND)
+    find_package(Eigen3 QUIET)
+  endif()
 
   if(Eigen3_FOUND)
     if(TARGET Eigen3::Eigen)


### PR DESCRIPTION
**Merge with opencv_contrib**: https://github.com/opencv/opencv_contrib/pull/2732

Compatibility with Ceres 2.0.0 CMake scripts

Related CMake message:

> Failed to find Ceres - Found Eigen dependency, but the version of Eigen found () does not exactly match the version of Eigen Ceres was compiled with (3.3.7).

```
opencv_contrib=
```