### PR TITLE
CMake: make OPENCV_TEST_DATA_PATH cached, add warning if tests are built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,8 +524,13 @@ ocv_cmake_hook(POST_OPTIONS)
 #  Build & install layouts
 # ----------------------------------------------------------------------------
 
+set(OPENCV_TEST_DATA_PATH "" CACHE PATH "Path to the testdata directory in the opencv_extra repository")
 if(OPENCV_TEST_DATA_PATH)
   get_filename_component(OPENCV_TEST_DATA_PATH ${OPENCV_TEST_DATA_PATH} ABSOLUTE)
+else()
+	if (INSTALL_TESTS)
+		message(STATUS "INSTALL_TESTS is ON but OPENCV_TEST_DATA_PATH is not set. Some tests will fail without test data available.")
+	endif()
 endif()
 
 # Save libs and executables in the same place


### PR DESCRIPTION
Add warning if INSTALL_TESTS is ON but OPENCV_TEST_DATA_PATH is not set

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] The PR is proposed to proper branch

I propose setting `OPENCV_TEST_DATA_PATH` as cached variable, with docstring hinting to the required path as well as a status message warning users some tests will fail unless they set the variable when `INSTALL_TESTS` is on. This should alleviate the confusion between `OPENCV_EXTRA_MODULES_PATH` pointing to `opencv_contrib/modules` and `OPENCV_TEST_DATA_PATH` pointing to `opencv_extra/testdata`, mentioned in #18610 
