### PR TITLE
Change naming of keypoints comparator

### DIFF
--- a/modules/features2d/src/keypoint.cpp
+++ b/modules/features2d/src/keypoint.cpp
@@ -44,9 +44,9 @@
 namespace cv
 {
 
-struct KeypointResponseGreaterThanThreshold
+struct KeypointResponseGreaterThanOrEqualToThreshold
 {
-    KeypointResponseGreaterThanThreshold(float _value) :
+    KeypointResponseGreaterThanOrEqualToThreshold(float _value) :
     value(_value)
     {
     }
@@ -83,7 +83,7 @@ void KeyPointsFilter::retainBest(std::vector<KeyPoint>& keypoints, int n_points)
         //use std::partition to grab all of the keypoints with the boundary response.
         std::vector<KeyPoint>::const_iterator new_end =
         std::partition(keypoints.begin() + n_points, keypoints.end(),
-                       KeypointResponseGreaterThanThreshold(ambiguous_response));
+                       KeypointResponseGreaterThanOrEqualToThreshold(ambiguous_response));
         //resize the keypoints, given this new end point. nth_element and partition reordered the points inplace
         keypoints.resize(new_end - keypoints.begin());
     }


### PR DESCRIPTION
Implementation (and usage in context of std::partition) of KeypointResponseGreaterThanThreshold does actually compare a keypoint with given threshold by greatness OR equality.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
