### PR TITLE
Added support of 1x1x1xN input for parseYolo

### DIFF
--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -157,7 +157,7 @@ GAPI_TEST_EXT_BASE_FIXTURE(ParseSSDBLTest, ParserSSDTest, initNothing,
 GAPI_TEST_EXT_BASE_FIXTURE(ParseSSDTest, ParserSSDTest, initNothing,
     FIXTURE_API(float, bool, bool), 3, confidence_threshold, alignment_to_square, filter_out_of_bounds)
 GAPI_TEST_EXT_BASE_FIXTURE(ParseYoloTest, ParserYoloTest, initNothing,
-    FIXTURE_API(float, float, int), 3, confidence_threshold, nms_threshold, num_classes)
+    FIXTURE_API(float, float, int, std::pair<bool,int>), 4, confidence_threshold, nms_threshold, num_classes, dims_config)
 GAPI_TEST_FIXTURE(SizeTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(SizeRTest, initNothing, <>, 0)
 } // opencv_test

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1666,7 +1666,7 @@ TEST_P(ParseSSDTest, ParseTest)
 
 TEST_P(ParseYoloTest, ParseTest)
 {
-    cv::Mat in_mat = generateYoloOutput(num_classes);
+    cv::Mat in_mat = generateYoloOutput(num_classes, dims_config);
     auto anchors = cv::gapi::nn::parsers::GParseYolo::defaultAnchors();
     std::vector<cv::Rect> boxes_gapi, boxes_ref;
     std::vector<int> labels_gapi, labels_ref;

--- a/modules/gapi/test/common/gapi_parsers_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_parsers_tests_common.hpp
@@ -225,13 +225,26 @@ private:
 class ParserYoloTest
 {
 public:
-    cv::Mat generateYoloOutput(const int num_classes)
+    cv::Mat generateYoloOutput(const int num_classes, std::pair<bool,int> dims_config = {false, 4})
     {
-        std::vector<int> dims = { 1, 13, 13, (num_classes + 5) * 5 };
+        bool one_dim = false;
+        int num_dims = 0;
+        std::tie(one_dim, num_dims) = dims_config;
+        GAPI_Assert(num_dims <= 4);
+        GAPI_Assert((!one_dim && num_dims >= 3) ||
+                    ( one_dim && num_dims >= 1));
+        std::vector<int> dims(num_dims, 1);
+        if (one_dim) {
+            dims.back() = (num_classes+5)*5*13*13;
+        } else {
+            dims.back() = (num_classes+5)*5;
+            dims[num_dims-2] = 13;
+            dims[num_dims-3] = 13;
+        }
         cv::Mat mat(dims, CV_32FC1);
         auto data = mat.ptr<float>();
 
-        const size_t range = dims[0] * dims[1] * dims[2] * dims[3];
+        const size_t range = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
         for (size_t i = 0; i < range; ++i)
         {
             data[i] = static_cast<float>(std::rand()) / RAND_MAX;

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -531,7 +531,12 @@ INSTANTIATE_TEST_CASE_P(ParseTestCPU, ParseYoloTest,
                                 Values(CORE_CPU),
                                 Values(0.3f, 0.5f, 0.7f),
                                 Values(0.5f, 1.0f),
-                                Values(80, 7)));
+                                Values(80, 7),
+                                Values(std::make_pair(false, 3),
+                                       std::make_pair(false, 4),
+                                       std::make_pair(true,  2),
+                                       std::make_pair(true,  3),
+                                       std::make_pair(true,  4))));
 
 INSTANTIATE_TEST_CASE_P(SizeTestCPU, SizeTest,
                         Combine(Values(CV_8UC1, CV_8UC3, CV_32FC1),


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```