### PR TITLE
videoio: added frameSize to MFX capture

### DIFF
--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -111,6 +111,7 @@ VideoCapture_IntelMFX::VideoCapture_IntelMFX(const cv::String &filename)
         return;
     }
 
+    frameSize = Size(params.mfx.FrameInfo.CropW, params.mfx.FrameInfo.CropH);
     good = true;
 }
 
@@ -126,10 +127,23 @@ VideoCapture_IntelMFX::~VideoCapture_IntelMFX()
     cleanup(deviceHandler);
 }
 
-double VideoCapture_IntelMFX::getProperty(int) const
+double VideoCapture_IntelMFX::getProperty(int prop) const
 {
-    MSG(cerr << "MFX: getProperty() is not implemented" << endl);
-    return 0;
+    if (!good)
+    {
+        MSG(cerr << "MFX: can not call getProperty(), backend has not been initialized" << endl);
+        return 0;
+    }
+    switch (prop)
+    {
+        case CAP_PROP_FRAME_WIDTH:
+            return frameSize.width;
+        case CAP_PROP_FRAME_HEIGHT:
+            return frameSize.height;
+        default:
+            MSG(cerr << "MFX: unsupported property" << endl);
+            return 0;
+    }
 }
 
 bool VideoCapture_IntelMFX::setProperty(int, double)

--- a/modules/videoio/src/cap_mfx_reader.hpp
+++ b/modules/videoio/src/cap_mfx_reader.hpp
@@ -34,6 +34,7 @@ private:
     MFXVideoDECODE *decoder;
     SurfacePool *pool;
     void *outSurface;
+    cv::Size frameSize;
     bool good;
 };
 

--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -111,6 +111,8 @@ TEST_P(Videoio_MFX, read_write_raw)
     VideoCapture cap;
     cap.open(filename, CAP_INTEL_MFX);
     ASSERT_TRUE(cap.isOpened());
+    EXPECT_EQ(FRAME_SIZE.width, cap.get(CAP_PROP_FRAME_WIDTH));
+    EXPECT_EQ(FRAME_SIZE.height, cap.get(CAP_PROP_FRAME_HEIGHT));
     for (int i = 0; i < FRAME_COUNT; ++i)
     {
         ASSERT_TRUE(cap.read(frame));


### PR DESCRIPTION
<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom Win
build_image:Custom Win=openvino-2021.1.0
test_modules:Custom Win=dnn,python2,python3,java,videoio
```