### PR TITLE
G-API: ONNX. Support tensor input for CNN with dynamic input 

### DIFF
--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -167,8 +167,16 @@ inline void preprocess(const cv::Mat& src,
         // No layout or dimension transformations done here!
         // TODO: This needs to be aligned across all NN backends.
         GAPI_Assert(toCV(ti.type) == CV_32F && "Only 32F model input is supported for 32F data");
-        GAPI_Assert(toORT(src.size) == ti.dims && "32F tensor dimensions should match with NN input");
-        GAPI_Assert(!ti.is_dynamic && "Dynamic inputs are not supported for this case");
+        const auto tensor_dims = toORT(src.size);
+        if (tensor_dims.size() == ti.dims.size()) {
+            for (size_t i = 0; i < ti.dims.size(); ++i) {
+                GAPI_Assert((ti.dims[i] == -1 || ti.dims[i] == tensor_dims[i]) &&
+                            "32F tensor dimensions should match with all non-dynamic NN input dimensions");
+            }
+        } else {
+            GAPI_Assert(false && "32F tensor size should match with NN input");
+        }
+
         dst = src;
     } else {
         // 8U input: full preprocessing path

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -12,6 +12,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <ade/util/iota_range.hpp>
 
+#include <opencv2/gapi/own/convert.hpp>
 #include <opencv2/gapi/infer/onnx.hpp>
 
 namespace {
@@ -60,124 +61,223 @@ void normAssert(cv::InputArray ref, cv::InputArray test,
 
 std::string findModel(const std::string &model_name)
 {
-    return findDataFile("vision/classification/squeezenet/model/" + model_name + ".onnx", false);
+    return findDataFile("vision/" + model_name + ".onnx", false);
 }
 
-inline void preprocess(const cv::Mat& src,
-                             cv::Mat& dst,
-                       const cv::Scalar& mean,
-                       const cv::Scalar& std) {
-    int new_h = 224;
-    int new_w = 224;
-    cv::Mat tmp, nmat, cvt;
-    cv::resize(src, dst, cv::Size(new_w, new_h));
-    dst.convertTo(cvt, CV_32F, 1.f / 255);
-    nmat = cvt - mean;
-    tmp = nmat / std;
-    dst.create(cv::Size(new_w, new_h * src.channels()), CV_32F);
+void remap_yolo(const std::unordered_map<std::string, cv::Mat> &onnx,
+                       std::unordered_map<std::string, cv::Mat> &gapi) {
+    GAPI_Assert(onnx.size() == 1u);
+    GAPI_Assert(gapi.size() == 1u);
+    const auto size = onnx.begin()->second.total();
+    GAPI_Assert(onnx.begin()->second.size == gapi.begin()->second.size);
+    const float* onnx_ptr = onnx.begin()->second.ptr<float>();
+          float* gapi_ptr = gapi.begin()->second.ptr<float>();
+
+    // Simple copy. Same sizes.
+    for (size_t i = 0; i < size; ++i) {
+       gapi_ptr[i] = onnx_ptr[i];
+    }
+}
+
+void toCHW(cv::Mat& src, cv::Mat& dst, int new_h, int new_w, int new_c) {
+    dst.create(cv::Size(new_w, new_h * new_c), CV_32F);
     std::vector<cv::Mat> planes;
-    for (int i = 0; i < src.channels(); ++i) {
+    for (int i = 0; i < new_c; ++i) {
         planes.push_back(dst.rowRange(i * new_h, (i + 1) * new_h));
     }
-    cv::split(tmp, planes);
+    cv::split(src, planes);
 }
 
-void InferONNX(const std::string& model_path,
-               const cv::Mat& in,
-                     cv::Mat& out,
-               const cv::Scalar& mean,
-               const cv::Scalar& std)
-{
-    // FIXME: It must be a FIXTURE test!
-    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "test");
-    Ort::SessionOptions session_options;
-    Ort::Session session(env, model_path.data(), session_options);
-    auto input_node_dims = //    0 - one input
-        session.GetInputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
-    auto output_node_dims = //    0 - one output
-        session.GetOutputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
+inline int toCV(ONNXTensorElementDataType prec) {
+    switch (prec) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8: return CV_8U;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: return CV_32F;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32: return CV_32S;
+    default: GAPI_Assert(false && "Unsupported data type");
+    }
+    return -1;
+}
+
+inline std::vector<int64_t> toORT(const cv::MatSize &sz) {
+    return cv::to_own<int64_t>(sz);
+}
+
+inline std::vector<const char*> getCharNames(const std::vector<std::string>& names) {
+    std::vector<const char*> out_vec;
+    for (const auto& el : names) {
+            out_vec.push_back(el.data());
+    }
+    return out_vec;
+}
+
+class ONNXtest : public ::testing::Test {
+public:
+    Ort::Env env{nullptr};
+    Ort::MemoryInfo memory_info{nullptr};
     Ort::AllocatorWithDefaultOptions allocator;
-    char* in_node_name_p = session.GetInputName(0, allocator);
-    char* out_node_name_p = session.GetOutputName(0, allocator);
-    std::string in_node_name(in_node_name_p);
-    std::string out_node_name(out_node_name_p);
-    allocator.Free(in_node_name_p);
-    allocator.Free(out_node_name_p);
+    Ort::SessionOptions session_options;
+    Ort::Session session{nullptr};
 
-    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-    cv::Mat dst;
-    preprocess(in, dst, mean, std);
+    std::string model_path;
+    cv::Mat in_mat1;
+    std::vector<cv::Mat> out_gapi;
+    std::vector<cv::Mat> out_onnx;
 
-    out.create(std::vector<int>(output_node_dims.begin(),
-                                output_node_dims.end()), CV_32F); // empty output Mat
-    auto in_tensor = Ort::Value::CreateTensor<float>(memory_info,
-                                                     dst.ptr<float>(),
-                                                     dst.total(),
-                                                     input_node_dims.data(),
-                                                     input_node_dims.size());
-    auto out_tensor = Ort::Value::CreateTensor<float>(memory_info,
-                                                      out.ptr<float>(),
-                                                      out.total(),
-                                                      output_node_dims.data(),
-                                                      output_node_dims.size());
-    std::vector<const char *> in_names = {in_node_name.data()};
-    std::vector<const char *> out_names = {out_node_name.data()};
-    session.Run(Ort::RunOptions{nullptr},
-                in_names.data(),
-                &in_tensor,
-                session.GetInputCount(),
-                out_names.data(),
-                &out_tensor,
-                session.GetOutputCount());
-}
+    std::vector<int64_t> output_node_dims;
+    std::vector<int64_t> input_node_dims;
+    std::vector<std::string> in_node_names;
+    std::vector<std::string> out_node_names;
+
+    ONNXtest() {
+        env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "test");
+        memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+        out_gapi.resize(1);
+        out_onnx.resize(1);
+        in_mat1 = initMatrixRandU(CV_8UC3, cv::Size{640, 480});
+    }
+
+    void validate() {
+        GAPI_Assert(!out_gapi.empty() && !out_onnx.empty());
+        ASSERT_EQ(out_gapi.size(), out_onnx.size());
+        auto size = out_gapi.size();
+        for (size_t i = 0; i < size; ++i) {
+            normAssert(out_onnx[i], out_gapi[i], "Test output");
+        }
+    }
+
+    void useModel(const std::string& model_name) {
+        model_path = findModel(model_name);
+    }
+};
+
+class ONNXSimpleTest : public ONNXtest {
+public:
+    cv::Scalar mean, std;
+
+    virtual void SetUp() {
+        mean = { 0.485, 0.456, 0.406 };
+        std = { 0.229, 0.224, 0.225 };
+    }
+
+    virtual void prepareInfer() {
+        session = Ort::Session(env, model_path.data(), session_options);
+        char* in_node_name_p = session.GetInputName(0, allocator);
+        char* out_node_name_p = session.GetOutputName(0, allocator);
+        in_node_names = {std::string(in_node_name_p)};
+        out_node_names = {std::string(out_node_name_p)};
+        allocator.Free(in_node_name_p);
+        allocator.Free(out_node_name_p);
+    }
+
+    void infer(const cv::Mat& in, cv::Mat& out) {
+        prepareInfer();
+        input_node_dims.clear();
+        for (int i = 0; i < in.size.dims(); ++i) {
+            input_node_dims.push_back(in.size[i]);
+        }
+        auto in_tensor = Ort::Value::CreateTensor<float>(memory_info,
+                                                         const_cast<float*>(in.ptr<float>()),
+                                                         in.total(),
+                                                         input_node_dims.data(),
+                                                         input_node_dims.size());
+
+        std::vector<const char *> in_names = {in_node_names[0].data()};
+        std::vector<const char *> out_names = {out_node_names[0].data()};
+        auto result = session.Run(Ort::RunOptions{nullptr},
+                                  in_names.data(),
+                                  &in_tensor,
+                                  session.GetInputCount(),
+                                  out_names.data(),
+                                  session.GetOutputCount());
+
+        auto info = result.front().GetTensorTypeAndShapeInfo();
+        auto shape = info.GetShape();
+        auto type = info.GetElementType();
+        cv::Mat mt(std::vector<int>(shape.begin(), shape.end()), toCV(type),
+                   reinterpret_cast<void*>(result.front().GetTensorMutableData<uint8_t*>()));
+        mt.copyTo(out);
+    }
+
+    virtual void preprocess(const cv::Mat& src, cv::Mat& dst) {
+        const int new_h = 224;
+        const int new_w = 224;
+        cv::Mat tmp, nmat, cvt;
+        cv::resize(src, dst, cv::Size(new_w, new_h));
+        dst.convertTo(cvt, CV_32F, 1.f / 255);
+        nmat = cvt - mean;
+        tmp = nmat / std;
+        toCHW(tmp, dst, new_h, new_w, 3);
+        dst = dst.reshape(1, {1, 3, new_h, new_w});
+    }
+};
+
+class ONNXGRayScaleTest : public ONNXSimpleTest {
+public:
+    virtual void preprocess(const cv::Mat& src, cv::Mat& dst) {
+        const int new_h = 64;
+        const int new_w = 64;
+        cv::Mat csc, rsc, cvt;
+        cv::cvtColor(src, csc, cv::COLOR_BGR2GRAY);
+        cv::resize(csc, rsc, cv::Size(new_w, new_h));
+        rsc.convertTo(cvt, CV_32F);
+        toCHW(cvt, dst, new_h, new_w, 1);
+        dst = dst.reshape(1, {1, 1, new_h, new_w});
+    }
+};
 
 } // anonymous namespace
 
-TEST(ONNX, Infer)
+TEST_F(ONNXSimpleTest, Infer)
 {
-    cv::Mat in_mat1, out_gapi, out_onnx;
-    std::string model_path = findModel("squeezenet1.0-9");
-    // NOTE: All tests chek "random" image
-    // Ideally it should be a real image
-    in_mat1 = initMatrixRandU(CV_8UC3, cv::Size{640, 480});
-
-    cv::Scalar mean = { 0.485, 0.456, 0.406 };
-    cv::Scalar std  = { 0.229, 0.224, 0.225 };
-
+    useModel("classification/squeezenet/model/squeezenet1.0-9");
     // ONNX_API code
-    InferONNX(model_path, in_mat1, out_onnx, mean, std);
-
+    cv::Mat processed_mat;
+    preprocess(in_mat1, processed_mat);
+    infer(processed_mat, out_onnx.front());
     // G_API code
     G_API_NET(SqueezNet, <cv::GMat(cv::GMat)>, "squeeznet");
     cv::GMat in;
     cv::GMat out = cv::gapi::infer<SqueezNet>(in);
     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
-    // NOTE: We have to normalize U8 tensor
-    // so cfgMeanStd() is here
     auto net = cv::gapi::onnx::Params<SqueezNet> { model_path }.cfgMeanStd({mean},{std});
     comp.apply(cv::gin(in_mat1),
-               cv::gout(out_gapi),
+               cv::gout(out_gapi.front()),
                cv::compile_args(cv::gapi::networks(net)));
-
     // Validate
-    ASSERT_EQ(1000u, out_onnx.total());
-    ASSERT_EQ(1000u, out_gapi.total());
-    normAssert(out_onnx, out_gapi, "Test classification output");
+    validate();
 }
 
-TEST(ONNX, InferROI)
+TEST_F(ONNXSimpleTest, InferTensor)
 {
-    cv::Mat in_mat1, out_gapi, out_onnx;
-    std::string model_path = findModel("squeezenet1.0-9");
-    in_mat1 = initMatrixRandU(CV_8UC3, cv::Size{640, 480});
-
-    cv::Scalar mean = { 0.485, 0.456, 0.406 }; // squeeznet mean
-    cv::Scalar std  = { 0.229, 0.224, 0.225 }; // squeeznet std
-
-    cv::Rect ROI(cv::Point{0, 0}, cv::Size{250, 250});
+    useModel("classification/squeezenet/model/squeezenet1.0-9");
+    // Create tensor
+    const cv::Mat rand_mat = initMatrixRandU(CV_32FC3, cv::Size{224, 224});
+    const std::vector<int> dims = {1, rand_mat.channels(), rand_mat.rows, rand_mat.cols};
+    const cv::Mat tensor(dims, CV_32F, rand_mat.data);
     // ONNX_API code
-    InferONNX(model_path, in_mat1(ROI), out_onnx, mean, std);
+    infer(tensor, out_onnx.front());
+    // G_API code
+    G_API_NET(SqueezNet, <cv::GMat(cv::GMat)>, "squeeznet");
+    cv::GMat in;
+    cv::GMat out = cv::gapi::infer<SqueezNet>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(out));
 
+    auto net = cv::gapi::onnx::Params<SqueezNet> { model_path };
+    comp.apply(cv::gin(tensor),
+               cv::gout(out_gapi.front()),
+               cv::compile_args(cv::gapi::networks(net)));
+    // Validate
+    validate();
+}
+
+TEST_F(ONNXSimpleTest, InferROI)
+{
+    useModel("classification/squeezenet/model/squeezenet1.0-9");
+    const cv::Rect ROI(cv::Point{0, 0}, cv::Size{250, 250});
+    // ONNX_API code
+    cv::Mat roi_mat;
+    preprocess(in_mat1(ROI), roi_mat);
+    infer(roi_mat, out_onnx.front());
     // G_API code
     G_API_NET(SqueezNet, <cv::GMat(cv::GMat)>, "squeeznet");
     cv::GMat in;
@@ -185,36 +285,27 @@ TEST(ONNX, InferROI)
     cv::GMat out = cv::gapi::infer<SqueezNet>(rect, in);
     cv::GComputation comp(cv::GIn(in, rect), cv::GOut(out));
     auto net = cv::gapi::onnx::Params<SqueezNet> { model_path }.cfgMeanStd({mean},{std});
-    comp.apply(cv::gin(in_mat1, ROI),
-               cv::gout(out_gapi),
+    comp.apply(cv::gin(in_mat1(ROI), ROI),
+               cv::gout(out_gapi.front()),
                cv::compile_args(cv::gapi::networks(net)));
-
     // Validate
-    ASSERT_EQ(1000u, out_onnx.total());
-    ASSERT_EQ(1000u, out_gapi.total());
-    normAssert(out_onnx, out_gapi, "Test classification output");
+    validate();
 }
 
-TEST(ONNX, InferROIList)
+TEST_F(ONNXSimpleTest, InferROIList)
 {
-    cv::Mat in_mat1;
-    std::string model_path = findModel("squeezenet1.0-9");
-    in_mat1 = initMatrixRandU(CV_8UC3, cv::Size{640, 480});
-
-    cv::Scalar mean = { 0.485, 0.456, 0.406 }; // squeeznet mean
-    cv::Scalar std  = { 0.229, 0.224, 0.225 }; // squeeznet std
-
-    std::vector<cv::Rect> rois = {
+    useModel("classification/squeezenet/model/squeezenet1.0-9");
+    const std::vector<cv::Rect> rois = {
         cv::Rect(cv::Point{ 0,   0}, cv::Size{80, 120}),
         cv::Rect(cv::Point{50, 100}, cv::Size{250, 360}),
     };
-    std::vector<cv::Mat> out_gapi;
-    std::vector<cv::Mat> out_onnx(rois.size());
     // ONNX_API code
+    out_onnx.resize(rois.size());
     for (size_t i = 0; i < rois.size(); ++i) {
-        InferONNX(model_path, in_mat1(rois[i]), out_onnx[i], mean, std);
+        cv::Mat roi_mat;
+        preprocess(in_mat1(rois[i]), roi_mat);
+        infer(roi_mat, out_onnx[i]);
     }
-
     // G_API code
     G_API_NET(SqueezNet, <cv::GMat(cv::GMat)>, "squeeznet");
     cv::GMat in;
@@ -225,35 +316,24 @@ TEST(ONNX, InferROIList)
     comp.apply(cv::gin(in_mat1, rois),
                cv::gout(out_gapi),
                cv::compile_args(cv::gapi::networks(net)));
-
     // Validate
-    for (size_t i = 0; i < rois.size(); ++i) {
-        ASSERT_EQ(1000u, out_onnx[i].total());
-        ASSERT_EQ(1000u, out_gapi[i].total());
-        normAssert(out_onnx[i], out_gapi[i], "Test classification output");
-    }
+    validate();
 }
 
-TEST(ONNX, Infer2ROIList)
+TEST_F(ONNXSimpleTest, Infer2ROIList)
 {
-    cv::Mat in_mat1;
-    std::string model_path = findModel("squeezenet1.0-9");
-    in_mat1 = initMatrixRandU(CV_8UC3, cv::Size{640, 480});
-
-    cv::Scalar mean = { 0.485, 0.456, 0.406 }; // squeeznet mean
-    cv::Scalar std  = { 0.229, 0.224, 0.225 }; // squeeznet std
-
-    std::vector<cv::Rect> rois = {
+    useModel("classification/squeezenet/model/squeezenet1.0-9");
+    const std::vector<cv::Rect> rois = {
         cv::Rect(cv::Point{ 0,   0}, cv::Size{80, 120}),
         cv::Rect(cv::Point{50, 100}, cv::Size{250, 360}),
     };
-    std::vector<cv::Mat> out_gapi;
-    std::vector<cv::Mat> out_onnx(rois.size());
     // ONNX_API code
+    out_onnx.resize(rois.size());
     for (size_t i = 0; i < rois.size(); ++i) {
-        InferONNX(model_path, in_mat1(rois[i]), out_onnx[i], mean, std);
+        cv::Mat roi_mat;
+        preprocess(in_mat1(rois[i]), roi_mat);
+        infer(roi_mat, out_onnx[i]);
     }
-
     // G_API code
     G_API_NET(SqueezNet, <cv::GMat(cv::GMat)>, "squeeznet");
     cv::GMat in;
@@ -266,11 +346,55 @@ TEST(ONNX, Infer2ROIList)
                cv::compile_args(cv::gapi::networks(net)));
 
     // Validate
-    for (size_t i = 0; i < rois.size(); ++i) {
-        ASSERT_EQ(1000u, out_onnx[i].total());
-        ASSERT_EQ(1000u, out_gapi[i].total());
-        normAssert(out_onnx[i], out_gapi[i], "Test classification output");
-    }
+    validate();
+}
+
+TEST_F(ONNXSimpleTest, InferDynamicInputTensor)
+{
+    useModel("object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8");
+    // Create tensor
+    const cv::Mat rand_mat = initMatrixRandU(CV_32FC3, cv::Size{416, 416});
+    const std::vector<int> dims = {1, rand_mat.channels(), rand_mat.rows, rand_mat.cols};
+    cv::Mat tensor(dims, CV_32F, rand_mat.data);
+    const cv::Mat in_tensor = tensor / 255.f;
+    // ONNX_API code
+    infer(in_tensor, out_onnx.front());
+    // G_API code
+    G_API_NET(YoloNet, <cv::GMat(cv::GMat)>, "YoloNet");
+    auto net = cv::gapi::onnx::Params<YoloNet>{model_path}
+        .cfgPostProc({cv::GMatDesc{CV_32F, {1,125,13,13}}}, remap_yolo)
+        .cfgOutputLayers({"out"});
+
+    cv::GMat in;
+    cv::GMat out = cv::gapi::infer<YoloNet>(in);
+
+    cv::GComputation comp(cv::GIn(in), cv::GOut(out));
+    comp.apply(cv::gin(in_tensor),
+               cv::gout(out_gapi.front()),
+               cv::compile_args(cv::gapi::networks(net)));
+    // Validate
+    validate();
+}
+
+TEST_F(ONNXGRayScaleTest, InferImage)
+{
+    useModel("body_analysis/emotion_ferplus/model/emotion-ferplus-8");
+    // ONNX_API code
+    cv::Mat prep_mat;
+    preprocess(in_mat1, prep_mat);
+    infer(prep_mat, out_onnx.front());
+    // G_API code
+    G_API_NET(EmotionNet, <cv::GMat(cv::GMat)>, "emotion-ferplus");
+    cv::GMat in;
+    cv::GMat out = cv::gapi::infer<EmotionNet>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(out));
+    auto net = cv::gapi::onnx::Params<EmotionNet> { model_path }
+    .cfgNormalize({false}); // model accepts 0..255 range in FP32;
+    comp.apply(cv::gin(in_mat1),
+               cv::gout(out_gapi.front()),
+               cv::compile_args(cv::gapi::networks(net)));
+    // Validate
+    validate();
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -323,7 +323,7 @@ TEST_F(ONNXClassificationTest, InferROI)
     cv::GMat out = cv::gapi::infer<SqueezNet>(rect, in);
     cv::GComputation comp(cv::GIn(in, rect), cv::GOut(out));
     auto net = cv::gapi::onnx::Params<SqueezNet> { model_path }.cfgMeanStd({mean},{std});
-    comp.apply(cv::gin(in_mat1(ROI), ROI),
+    comp.apply(cv::gin(in_mat1, ROI),
                cv::gout(out_gapi.front()),
                cv::compile_args(cv::gapi::networks(net)));
     // Validate

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -234,7 +234,6 @@ private:
 
 class ONNXClassificationTest : public ONNXtest {
 public:
-    // cv::Scalar mean, std;
     const cv::Scalar mean = { 0.485, 0.456, 0.406 };
     const cv::Scalar std  = { 0.229, 0.224, 0.225 };
 

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -83,7 +83,7 @@ inline std::vector<int64_t> toORT(const cv::MatSize &sz) {
 inline std::vector<const char*> getCharNames(const std::vector<std::string>& names) {
     std::vector<const char*> out_vec;
     for (const auto& el : names) {
-            out_vec.push_back(el.data());
+        out_vec.push_back(el.data());
     }
     return out_vec;
 }
@@ -208,7 +208,7 @@ public:
     void validate() {
         GAPI_Assert(!out_gapi.empty() && !out_onnx.empty());
         ASSERT_EQ(out_gapi.size(), out_onnx.size());
-        auto size = out_gapi.size();
+        cosnt auto size = out_gapi.size();
         for (size_t i = 0; i < size; ++i) {
             normAssert(out_onnx[i], out_gapi[i], "Test output");
         }

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -54,7 +54,7 @@ void normAssert(const cv::InputArray& ref, const cv::InputArray& test,
     EXPECT_LE(normInf, lInf) << comment;
 }
 
-std::string findModel(const std::string &model_name) {
+inline std::string findModel(const std::string &model_name) {
     return findDataFile("vision/" + model_name + ".onnx", false);
 }
 
@@ -92,7 +92,7 @@ inline void copyToOut(const cv::Mat& in, cv::Mat& out) {
     GAPI_Assert(in.depth() == CV_32F);
     GAPI_Assert(in.size == out.size);
     const float* const inptr = in.ptr<float>();
-    float* optr = out.ptr<float>();
+    float* const optr = out.ptr<float>();
     const int size = in.total();
     for (int i = 0; i < size; ++i) {
         optr[i] = inptr[i];
@@ -155,6 +155,7 @@ public:
         session = Ort::Session(env, model_path.data(), session_options);
         num_in = session.GetInputCount();
         num_out = session.GetOutputCount();
+        GAPI_Assert(num_in == ins.size());
         in_node_names.clear();
         out_node_names.clear();
         // Inputs Run params

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -46,7 +46,7 @@ namespace {
 // FIXME: taken from the DNN module
 void normAssert(const cv::InputArray& ref, const cv::InputArray& test,
                 const char *comment /*= ""*/,
-                double l1 = 0.00001, double lInf = 0.0001) {
+                const double l1 = 0.00001, const double lInf = 0.0001) {
     const double normL1 = cvtest::norm(ref, test, cv::NORM_L1) / ref.getMat().total();
     EXPECT_LE(normL1, l1) << comment;
 
@@ -436,7 +436,7 @@ TEST_F(ONNXtest, InferMultOutput)
 {
     useModel("object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_10");
     // ONNX_API code
-    auto prep_mat = in_mat1.reshape(1, {1, in_mat1.rows, in_mat1.cols, in_mat1.channels()});
+    const auto prep_mat = in_mat1.reshape(1, {1, in_mat1.rows, in_mat1.cols, in_mat1.channels()});
     infer<uint8_t>({prep_mat}, out_onnx);
     // G_API code
     using OUT = std::tuple<cv::GMat, cv::GMat, cv::GMat, cv::GMat>;

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -208,7 +208,7 @@ public:
     void validate() {
         GAPI_Assert(!out_gapi.empty() && !out_onnx.empty());
         ASSERT_EQ(out_gapi.size(), out_onnx.size());
-        cosnt auto size = out_gapi.size();
+        const auto size = out_gapi.size();
         for (size_t i = 0; i < size; ++i) {
             normAssert(out_onnx[i], out_gapi[i], "Test output");
         }
@@ -286,7 +286,7 @@ TEST_F(ONNXClassificationTest, Infer)
     validate();
 }
 
-TEST_F(ONNXClassificationTest, InferTensor)
+TEST_F(ONNXtest, InferTensor)
 {
     useModel("classification/squeezenet/model/squeezenet1.0-9");
     // Create tensor

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -263,7 +263,6 @@ public:
         dst = dst.reshape(1, {1, 1, new_h, new_w});
     }
 };
-
 } // anonymous namespace
 
 TEST_F(ONNXClassificationTest, Infer)

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -20,7 +20,7 @@ struct ONNXInitPath {
     ONNXInitPath() {
         const char* env_path = getenv("OPENCV_GAPI_ONNX_MODEL_PATH");
         if (env_path) {
-            cvtest::addDataSearchPath(env_path); 
+            cvtest::addDataSearchPath(env_path);
         }
     }
 };


### PR DESCRIPTION
### ONNX. Support tensor input for CNN with dynamic input 

- Changed assert for CV_32F case. Added test.

<cut/>

### Added new tests and refactored olds. 

New tests:
- InferTensor;
- InferDynamicInputTensor;
- Infer(Gray)Image;
- InferMultiNodes.

Refactored tests:
- Infer;
- InferROI;
- InferROIList;
- Infer2ROIList.

Tests contain unsupported(OCV bb) models:
- tinyyolov2-8.onnx from https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/tiny-yolov2

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=ubuntu-onnx:20.04
test_modules:Custom=gapi
test_filter:Custom=*ONNX*
```
