### PR TITLE
Fix typo in OpenCVFindOpenBLAS.cmake file

### DIFF
--- a/cmake/OpenCVFindOpenBLAS.cmake
+++ b/cmake/OpenCVFindOpenBLAS.cmake
@@ -57,7 +57,7 @@ SET(Open_BLAS_INCLUDE_SEARCH_PATHS
 )
 
 SET(Open_BLAS_LIB_SEARCH_PATHS
-        $ENV{OpenBLAS}cd
+        $ENV{OpenBLAS}
         $ENV{OpenBLAS}/lib
         $ENV{OpenBLAS_HOME}
         $ENV{OpenBLAS_HOME}/lib


### PR DESCRIPTION
Fix typo coming from the original Caffe file: https://github.com/BVLC/caffe/blob/9b891540183ddc834a02b2bd81b31afae71b2153/cmake/Modules/FindOpenBLAS.cmake#L25

Has been fixed in PyTorch: https://github.com/pytorch/pytorch/commit/63df9ffd0bd13f46600046e53ad9610ddbe752df

---

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- N/A There is reference to original bug report and related work
- N/A There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- N/A The feature is well documented and sample code can be built with the project CMake
