### PR TITLE
[G-API] Wrap GArray

### DIFF
--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -368,6 +368,8 @@ private:
     detail::GArrayU m_ref;
 };
 
+using GArrayP2f = GArray<cv::Point2f>;
+
 /** @} */
 
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -49,6 +49,7 @@ namespace detail
         CV_UINT64,     // uint64_t user G-API data
         CV_STRING,     // std::string user G-API data
         CV_POINT,      // cv::Point user G-API data
+        CV_POINT2F,    // cv::Point2f user G-API data
         CV_SIZE,       // cv::Size user G-API data
         CV_RECT,       // cv::Rect user G-API data
         CV_SCALAR,     // cv::Scalar user G-API data
@@ -68,15 +69,16 @@ namespace detail
     template<> struct GOpaqueTraits<cv::Size>    { static constexpr const OpaqueKind kind = OpaqueKind::CV_SIZE; };
     template<> struct GOpaqueTraits<cv::Scalar>  { static constexpr const OpaqueKind kind = OpaqueKind::CV_SCALAR; };
     template<> struct GOpaqueTraits<cv::Point>   { static constexpr const OpaqueKind kind = OpaqueKind::CV_POINT; };
+    template<> struct GOpaqueTraits<cv::Point2f> { static constexpr const OpaqueKind kind = OpaqueKind::CV_POINT2F; };
     template<> struct GOpaqueTraits<cv::Mat>     { static constexpr const OpaqueKind kind = OpaqueKind::CV_MAT; };
     template<> struct GOpaqueTraits<cv::Rect>    { static constexpr const OpaqueKind kind = OpaqueKind::CV_RECT; };
     template<> struct GOpaqueTraits<cv::GMat>    { static constexpr const OpaqueKind kind = OpaqueKind::CV_MAT; };
     template<> struct GOpaqueTraits<cv::gapi::wip::draw::Prim>
                                                  { static constexpr const OpaqueKind kind = OpaqueKind::CV_DRAW_PRIM; };
-    using GOpaqueTraitsArrayTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Scalar, cv::Point,
+    using GOpaqueTraitsArrayTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Scalar, cv::Point, cv::Point2f,
                                                cv::Mat, cv::Rect, cv::gapi::wip::draw::Prim>;
     // GOpaque is not supporting cv::Mat and cv::Scalar since there are GScalar and GMat types
-    using GOpaqueTraitsOpaqueTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Point, cv::Rect,
+    using GOpaqueTraitsOpaqueTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Point, cv::Point2f, cv::Rect,
                                                 cv::gapi::wip::draw::Prim>;
 } // namespace detail
 

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -26,9 +26,16 @@
 
 namespace cv {
 
-using GShapes = std::vector<GShape>;
-using GKinds = std::vector<cv::detail::OpaqueKind>;
-using GCtors  = std::vector<detail::HostCtor>;
+struct GTypeInfo
+{
+    GShape                 shape;
+    cv::detail::OpaqueKind kind;
+};
+
+using GShapes    = std::vector<GShape>;
+using GKinds     = std::vector<cv::detail::OpaqueKind>;
+using GCtors     = std::vector<detail::HostCtor>;
+using GTypesInfo = std::vector<GTypeInfo>;
 
 // GKernel describes kernel API to the system
 // FIXME: add attributes of a kernel, (e.g. number and types

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -1035,7 +1035,7 @@ or #cornerMinEigenVal.
 
 @return vector of detected corners.
  */
-GAPI_EXPORTS GArray<Point2f> goodFeaturesToTrack(const GMat  &image,
+GAPI_EXPORTS_W GArray<Point2f> goodFeaturesToTrack(const GMat  &image,
                                                        int    maxCorners,
                                                        double qualityLevel,
                                                        double minDistance,
@@ -1350,7 +1350,7 @@ Resulting gray color value computed as
 @param src input image: 8-bit unsigned 3-channel image @ref CV_8UC1.
 @sa RGB2YUV
  */
-GAPI_EXPORTS GMat RGB2Gray(const GMat& src);
+GAPI_EXPORTS_W GMat RGB2Gray(const GMat& src);
 
 /** @overload
 Resulting gray color value computed as

--- a/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
+++ b/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
@@ -21,11 +21,12 @@
 #  include <opencv2/gapi/own/mat.hpp>
 // replacement of cv's structures:
 namespace cv {
-    using Rect   = gapi::own::Rect;
-    using Size   = gapi::own::Size;
-    using Point  = gapi::own::Point;
-    using Scalar = gapi::own::Scalar;
-    using Mat    = gapi::own::Mat;
+    using Rect    = gapi::own::Rect;
+    using Size    = gapi::own::Size;
+    using Point   = gapi::own::Point;
+    using Point2f = gapi::own::Point2f;
+    using Scalar  = gapi::own::Scalar;
+    using Mat     = gapi::own::Mat;
 }  // namespace cv
 #endif // !defined(GAPI_STANDALONE)
 

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -28,6 +28,16 @@ public:
     int y = 0;
 };
 
+class Point2f
+{
+public:
+    Point2f() = default;
+    Point2f(float _x, float _y) : x(_x),  y(_y)  {};
+
+    float x = 0.f;
+    float y = 0.f;
+};
+
 class Rect
 {
 public:

--- a/modules/gapi/include/opencv2/gapi/s11n.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n.hpp
@@ -121,6 +121,9 @@ GAPI_EXPORTS std::unique_ptr<IIStream> getInStream(const std::vector<char> &p);
 GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Point &pt);
 GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Point &pt);
 
+GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Point2f &pt);
+GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Point2f &pt);
+
 GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Size &sz);
 GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Size &sz);
 

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -16,6 +16,8 @@ namespace cv
    class GAPI_EXPORTS_W_SIMPLE GRunArg { };
    class GAPI_EXPORTS_W_SIMPLE GMetaArg { };
 
+   class GAPI_EXPORTS_W_SIMPLE GArrayP2f { };
+
    using GProtoInputArgs  = GIOProtoArgs<In_Tag>;
    using GProtoOutputArgs = GIOProtoArgs<Out_Tag>;
 

--- a/modules/gapi/misc/python/test/test_gapi_core.py
+++ b/modules/gapi/misc/python/test/test_gapi_core.py
@@ -2,17 +2,18 @@
 
 import numpy as np
 import cv2 as cv
+import os
 
 from tests_common import NewOpenCVTests
 
 
 # Plaidml is an optional backend
 pkgs = [
-         cv.gapi.core.ocl.kernels(),
-         cv.gapi.core.cpu.kernels(),
-         cv.gapi.core.fluid.kernels()
-         # cv.gapi.core.plaidml.kernels()
-       ]
+          ('ocl'    , cv.gapi.core.ocl.kernels()),
+          ('cpu'    , cv.gapi.core.cpu.kernels()),
+          ('fluid'  , cv.gapi.core.fluid.kernels())
+          # ('plaidml', cv.gapi.core.plaidml.kernels())
+      ]
 
 
 class gapi_core_test(NewOpenCVTests):
@@ -20,8 +21,8 @@ class gapi_core_test(NewOpenCVTests):
     def test_add(self):
         # TODO: Extend to use any type and size here
         sz = (1280, 720)
-        in1 = np.random.randint(0, 100, sz)
-        in2 = np.random.randint(0, 100, sz)
+        in1 = np.full(sz, 100)
+        in2 = np.full(sz, 50)
 
         # OpenCV
         expected = cv.add(in1, in2)
@@ -32,17 +33,18 @@ class gapi_core_test(NewOpenCVTests):
         g_out = cv.gapi.add(g_in1, g_in2)
         comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in1, in2), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-            self.assertEqual(expected.dtype, actual.dtype)
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
+            self.assertEqual(expected.dtype, actual.dtype, 'Failed on ' + pkg_name + ' backend')
 
 
     def test_add_uint8(self):
         sz = (1280, 720)
-        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
-        in2 = np.random.randint(0, 100, sz).astype(np.uint8)
+        in1 = np.full(sz, 100, dtype=np.uint8)
+        in2 = np.full(sz, 50 , dtype=np.uint8)
 
         # OpenCV
         expected = cv.add(in1, in2)
@@ -53,16 +55,17 @@ class gapi_core_test(NewOpenCVTests):
         g_out = cv.gapi.add(g_in1, g_in2)
         comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in1, in2), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-            self.assertEqual(expected.dtype, actual.dtype)
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
+            self.assertEqual(expected.dtype, actual.dtype, 'Failed on ' + pkg_name + ' backend')
 
 
     def test_mean(self):
-        sz = (1280, 720, 3)
-        in_mat = np.random.randint(0, 100, sz)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in_mat = cv.imread(img_path)
 
         # OpenCV
         expected = cv.mean(in_mat)
@@ -72,15 +75,16 @@ class gapi_core_test(NewOpenCVTests):
         g_out = cv.gapi.mean(g_in)
         comp = cv.GComputation(g_in, g_out)
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
 
 
     def test_split3(self):
-        sz = (1280, 720, 3)
-        in_mat = np.random.randint(0, 100, sz)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in_mat = cv.imread(img_path)
 
         # OpenCV
         expected = cv.split(in_mat)
@@ -90,19 +94,19 @@ class gapi_core_test(NewOpenCVTests):
         b, g, r = cv.gapi.split3(g_in)
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
             # Comparison
             for e, a in zip(expected, actual):
-                self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-                self.assertEqual(e.dtype, a.dtype)
+                self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF),
+                                 'Failed on ' + pkg_name + ' backend')
+                self.assertEqual(e.dtype, a.dtype, 'Failed on ' + pkg_name + ' backend')
 
 
     def test_threshold(self):
-        sz = (1280, 720)
-        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-        rand_int = np.random.randint(0, 50)
-        maxv = (rand_int, rand_int)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in_mat = cv.cvtColor(cv.imread(img_path), cv.COLOR_RGB2GRAY)
+        maxv = (30, 30)
 
         # OpenCV
         expected_thresh, expected_mat = cv.threshold(in_mat, maxv[0], maxv[0], cv.THRESH_TRIANGLE)
@@ -113,12 +117,15 @@ class gapi_core_test(NewOpenCVTests):
         mat, threshold = cv.gapi.threshold(g_in, g_sc, cv.THRESH_TRIANGLE)
         comp = cv.GComputation(cv.GIn(g_in, g_sc), cv.GOut(mat, threshold))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual_mat, actual_thresh = comp.apply(cv.gin(in_mat, maxv), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected_mat, actual_mat, cv.NORM_INF))
-            self.assertEqual(expected_mat.dtype, actual_mat.dtype)
-            self.assertEqual(expected_thresh, actual_thresh[0])
+            self.assertEqual(0.0, cv.norm(expected_mat, actual_mat, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
+            self.assertEqual(expected_mat.dtype, actual_mat.dtype,
+                             'Failed on ' + pkg_name + ' backend')
+            self.assertEqual(expected_thresh, actual_thresh[0],
+                             'Failed on ' + pkg_name + ' backend')
 
 
 if __name__ == '__main__':

--- a/modules/gapi/misc/python/test/test_gapi_imgproc.py
+++ b/modules/gapi/misc/python/test/test_gapi_imgproc.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+# Plaidml is an optional backend
+
+pkgs = [
+        cv.gapi.core.ocl.kernels(),
+        cv.gapi.core.cpu.kernels(),
+        cv.gapi.core.fluid.kernels()
+        # cv.gapi.core.plaidml.kernels()
+      ]
+
+
+class gapi_imgproc_test(NewOpenCVTests):
+
+    def test_good_features_to_track(self):
+        # TODO: Extend to use any type and size here
+        sz = (1280, 720)
+        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+
+        # NB: goodFeaturesToTrack configuration
+        max_corners         = 50
+        quality_lvl         = 0.01
+        min_distance        = 10
+        block_sz            = 3
+        use_harris_detector = True
+        k                   = 0.04
+        mask                = None
+
+        # OpenCV
+        expected = cv.goodFeaturesToTrack(in1, max_corners, quality_lvl,
+                                          min_distance, mask=mask,
+                                          blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+
+        # G-API
+        g_in = cv.GMat()
+        g_out = cv.gapi.goodFeaturesToTrack(g_in, max_corners, quality_lvl,
+                                            min_distance, mask, block_sz, use_harris_detector, k)
+
+        comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+        for pkg in pkgs:
+            actual = comp.apply(cv.gin(in1), args=cv.compile_args(pkg))
+            # NB: OpenCV & G-API have different output shapes:
+            # OpenCV - (num_points, 1, 2)
+            # G-API  - (num_points, 2)
+            # Comparison
+            self.assertEqual(0.0, cv.norm(expected.flatten(), actual.flatten(), cv.NORM_INF))
+
+
+    def test_rgb2gray(self):
+        # TODO: Extend to use any type and size here
+        sz = (1280, 720, 3)
+        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+
+        # OpenCV
+        expected = cv.cvtColor(in1, cv.COLOR_RGB2GRAY)
+
+        # G-API
+        g_in = cv.GMat()
+        g_out = cv.gapi.RGB2Gray(g_in)
+
+        comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+        for pkg in pkgs:
+            actual = comp.apply(cv.gin(in1), args=cv.compile_args(pkg))
+            # Comparison
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/gapi/misc/python/test/test_gapi_imgproc.py
+++ b/modules/gapi/misc/python/test/test_gapi_imgproc.py
@@ -2,26 +2,26 @@
 
 import numpy as np
 import cv2 as cv
+import os
 
 from tests_common import NewOpenCVTests
 
 
 # Plaidml is an optional backend
-
 pkgs = [
-        cv.gapi.core.ocl.kernels(),
-        cv.gapi.core.cpu.kernels(),
-        cv.gapi.core.fluid.kernels()
-        # cv.gapi.core.plaidml.kernels()
-      ]
+           ('ocl'    , cv.gapi.core.ocl.kernels()),
+           ('cpu'    , cv.gapi.core.cpu.kernels()),
+           ('fluid'  , cv.gapi.core.fluid.kernels())
+           # ('plaidml', cv.gapi.core.plaidml.kernels())
+       ]
 
 
 class gapi_imgproc_test(NewOpenCVTests):
 
     def test_good_features_to_track(self):
         # TODO: Extend to use any type and size here
-        sz = (1280, 720)
-        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in1 = cv.cvtColor(cv.imread(img_path), cv.COLOR_RGB2GRAY)
 
         # NB: goodFeaturesToTrack configuration
         max_corners         = 50
@@ -44,19 +44,20 @@ class gapi_imgproc_test(NewOpenCVTests):
 
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in1), args=cv.compile_args(pkg))
             # NB: OpenCV & G-API have different output shapes:
             # OpenCV - (num_points, 1, 2)
             # G-API  - (num_points, 2)
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected.flatten(), actual.flatten(), cv.NORM_INF))
+            self.assertEqual(0.0, cv.norm(expected.flatten(), actual.flatten(), cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
 
 
     def test_rgb2gray(self):
         # TODO: Extend to use any type and size here
-        sz = (1280, 720, 3)
-        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in1 = cv.imread(img_path)
 
         # OpenCV
         expected = cv.cvtColor(in1, cv.COLOR_RGB2GRAY)
@@ -67,10 +68,11 @@ class gapi_imgproc_test(NewOpenCVTests):
 
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in1), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
 
 
 if __name__ == '__main__':

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -2,25 +2,26 @@
 
 import numpy as np
 import cv2 as cv
+import os
 
 from tests_common import NewOpenCVTests
 
 
 # Plaidml is an optional backend
 pkgs = [
-         cv.gapi.core.ocl.kernels(),
-         cv.gapi.core.cpu.kernels(),
-         cv.gapi.core.fluid.kernels()
-         # cv.gapi.core.plaidml.kernels()
-       ]
+         ('ocl'    , cv.gapi.core.ocl.kernels()),
+         ('cpu'    , cv.gapi.core.cpu.kernels()),
+         ('fluid'  , cv.gapi.core.fluid.kernels())
+         # ('plaidml', cv.gapi.core.plaidml.kernels())
+     ]
 
 
 class gapi_sample_pipelines(NewOpenCVTests):
 
     # NB: This test check multiple outputs for operation
     def test_mean_over_r(self):
-        sz = (100, 100, 3)
-        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+        in_mat = cv.imread(img_path)
 
         # # OpenCV
         _, _, r_ch = cv.split(in_mat)
@@ -32,10 +33,11 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_out = cv.gapi.mean(r)
         comp = cv.GComputation(g_in, g_out)
 
-        for pkg in pkgs:
+        for pkg_name, pkg in pkgs:
             actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
             # Comparison
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF),
+                             'Failed on ' + pkg_name + ' backend')
 
 
 if __name__ == '__main__':

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -47,6 +47,8 @@ class test_gapi_streaming(NewOpenCVTests):
         ccomp.start()
 
         # Assert
+        max_num_frames  = 10
+        proc_num_frames = 0
         while cap.isOpened():
             has_expected, expected = cap.read()
             has_actual,   actual   = ccomp.pull()
@@ -57,6 +59,10 @@ class test_gapi_streaming(NewOpenCVTests):
                 break
 
             self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+
+            proc_num_frames += 1
+            if proc_num_frames == max_num_frames:
+                break;
 
 
     def test_video_split3(self):
@@ -76,6 +82,8 @@ class test_gapi_streaming(NewOpenCVTests):
         ccomp.start()
 
         # Assert
+        max_num_frames  = 10
+        proc_num_frames = 0
         while cap.isOpened():
             has_expected, frame = cap.read()
             has_actual,   actual   = ccomp.pull()
@@ -88,6 +96,10 @@ class test_gapi_streaming(NewOpenCVTests):
             expected = cv.split(frame)
             for e, a in zip(expected, actual):
                 self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+            proc_num_frames += 1
+            if proc_num_frames == max_num_frames:
+                break;
 
 
     def test_video_add(self):
@@ -111,6 +123,8 @@ class test_gapi_streaming(NewOpenCVTests):
         ccomp.start()
 
         # Assert
+        max_num_frames  = 10
+        proc_num_frames = 0
         while cap.isOpened():
             has_expected, frame  = cap.read()
             has_actual,   actual = ccomp.pull()
@@ -122,6 +136,10 @@ class test_gapi_streaming(NewOpenCVTests):
 
             expected = cv.add(frame, in_mat)
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+            proc_num_frames += 1
+            if proc_num_frames == max_num_frames:
+                break;
 
 
     def test_video_good_features_to_track(self):
@@ -153,9 +171,11 @@ class test_gapi_streaming(NewOpenCVTests):
         ccomp.start()
 
         # Assert
+        max_num_frames  = 10
+        proc_num_frames = 0
         while cap.isOpened():
-            has_expected, frame = cap.read()
-            has_actual,   actual   = ccomp.pull()
+            has_expected, frame  = cap.read()
+            has_actual,   actual = ccomp.pull()
 
             self.assertEqual(has_expected, has_actual)
 
@@ -173,6 +193,9 @@ class test_gapi_streaming(NewOpenCVTests):
                 # G-API  - (num_points, 2)
                 self.assertEqual(0.0, cv.norm(e.flatten(), a.flatten(), cv.NORM_INF))
 
+            proc_num_frames += 1
+            if proc_num_frames == max_num_frames:
+                break;
 
 
 if __name__ == '__main__':

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -9,6 +9,7 @@
 #include <algorithm> // remove_if
 #include <cctype>    // isspace (non-locale version)
 #include <ade/util/algorithm.hpp>
+#include <ade/util/zip_range.hpp>   // util::indexed
 
 #include "logger.hpp" // GAPI_LOG
 
@@ -21,6 +22,7 @@
 
 #include "compiler/gmodelbuilder.hpp"
 #include "compiler/gcompiler.hpp"
+#include "compiler/gcompiled_priv.hpp"
 
 // cv::GComputation private implementation /////////////////////////////////////
 // <none>
@@ -180,8 +182,9 @@ cv::GRunArgs cv::GComputation::apply(GRunArgs &&ins, GCompileArgs &&args)
     run_args.reserve(out_metas.size());
     outs.reserve(out_metas.size());
 
-    for (auto&& meta : out_metas)
+    for (auto&& it : ade::util::indexed(out_metas))
     {
+        const auto& meta = ade::util::value(it);
         switch (meta.index())
         {
             case cv::GMetaArg::index_of<cv::GMatDesc>():
@@ -194,6 +197,21 @@ cv::GRunArgs cv::GComputation::apply(GRunArgs &&ins, GCompileArgs &&args)
             {
                 run_args.emplace_back(cv::Scalar{});
                 outs.emplace_back(&cv::util::get<cv::Scalar>(run_args.back()));
+                break;
+            }
+            case cv::GMetaArg::index_of<GArrayDesc>():
+            {
+                const auto& kinds = m_priv->m_lastCompiled.priv().outKinds();
+                auto idx = ade::util::index(it);
+                switch (kinds[idx])
+                {
+                    case cv::detail::OpaqueKind::CV_POINT2F:
+                        run_args.emplace_back(cv::detail::VectorRef{std::vector<cv::Point2f>{}});
+                        outs.emplace_back(cv::util::get<cv::detail::VectorRef>(run_args.back()));
+                        break;
+                    default:
+                        util::throw_error(std::logic_error("Unsupported kind for GArray"));
+                }
                 break;
             }
             default:

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -176,34 +176,32 @@ cv::GRunArgs cv::GComputation::apply(GRunArgs &&ins, GCompileArgs &&args)
 {
     recompile(descr_of(ins), std::move(args));
 
-    const auto& out_metas = m_priv->m_lastCompiled.outMetas();
+    const auto& out_info = m_priv->m_lastCompiled.priv().outInfo();
+
     GRunArgs run_args;
     GRunArgsP outs;
-    run_args.reserve(out_metas.size());
-    outs.reserve(out_metas.size());
+    run_args.reserve(out_info.size());
+    outs.reserve(out_info.size());
 
-    for (auto&& it : ade::util::indexed(out_metas))
+    for (auto&& info : out_info)
     {
-        const auto& meta = ade::util::value(it);
-        switch (meta.index())
+        switch (info.shape)
         {
-            case cv::GMetaArg::index_of<cv::GMatDesc>():
+            case cv::GShape::GMAT:
             {
                 run_args.emplace_back(cv::Mat{});
                 outs.emplace_back(&cv::util::get<cv::Mat>(run_args.back()));
                 break;
             }
-            case cv::GMetaArg::index_of<cv::GScalarDesc>():
+            case cv::GShape::GSCALAR:
             {
                 run_args.emplace_back(cv::Scalar{});
                 outs.emplace_back(&cv::util::get<cv::Scalar>(run_args.back()));
                 break;
             }
-            case cv::GMetaArg::index_of<GArrayDesc>():
+            case cv::GShape::GARRAY:
             {
-                const auto& kinds = m_priv->m_lastCompiled.priv().outKinds();
-                auto idx = ade::util::index(it);
-                switch (kinds[idx])
+                switch (info.kind)
                 {
                     case cv::detail::OpaqueKind::CV_POINT2F:
                         run_args.emplace_back(cv::detail::VectorRef{std::vector<cv::Point2f>{}});

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -152,6 +152,13 @@ IIStream& operator>> (IIStream& is, cv::Point& pt) {
     return is >> pt.x >> pt.y;
 }
 
+IOStream& operator<< (IOStream& os, const cv::Point2f &pt) {
+    return os << pt.x << pt.y;
+}
+IIStream& operator>> (IIStream& is, cv::Point2f& pt) {
+    return is >> pt.x >> pt.y;
+}
+
 IOStream& operator<< (IOStream& os, const cv::Size &sz) {
     return os << sz.width << sz.height;
 }
@@ -516,17 +523,18 @@ IOStream& operator<< (IOStream& os, const cv::GArg &arg) {
         GAPI_Assert(arg.kind == cv::detail::ArgKind::OPAQUE_VAL);
         GAPI_Assert(arg.opaque_kind != cv::detail::OpaqueKind::CV_UNKNOWN);
         switch (arg.opaque_kind) {
-        case cv::detail::OpaqueKind::CV_BOOL:   os << arg.get<bool>();         break;
-        case cv::detail::OpaqueKind::CV_INT:    os << arg.get<int>();          break;
-        case cv::detail::OpaqueKind::CV_UINT64: os << arg.get<uint64_t>();     break;
-        case cv::detail::OpaqueKind::CV_DOUBLE: os << arg.get<double>();       break;
-        case cv::detail::OpaqueKind::CV_FLOAT:  os << arg.get<float>();        break;
-        case cv::detail::OpaqueKind::CV_STRING: os << arg.get<std::string>();  break;
-        case cv::detail::OpaqueKind::CV_POINT:  os << arg.get<cv::Point>();    break;
-        case cv::detail::OpaqueKind::CV_SIZE:   os << arg.get<cv::Size>();     break;
-        case cv::detail::OpaqueKind::CV_RECT:   os << arg.get<cv::Rect>();     break;
-        case cv::detail::OpaqueKind::CV_SCALAR: os << arg.get<cv::Scalar>();   break;
-        case cv::detail::OpaqueKind::CV_MAT:    os << arg.get<cv::Mat>();      break;
+        case cv::detail::OpaqueKind::CV_BOOL:    os << arg.get<bool>();         break;
+        case cv::detail::OpaqueKind::CV_INT:     os << arg.get<int>();          break;
+        case cv::detail::OpaqueKind::CV_UINT64:  os << arg.get<uint64_t>();     break;
+        case cv::detail::OpaqueKind::CV_DOUBLE:  os << arg.get<double>();       break;
+        case cv::detail::OpaqueKind::CV_FLOAT:   os << arg.get<float>();        break;
+        case cv::detail::OpaqueKind::CV_STRING:  os << arg.get<std::string>();  break;
+        case cv::detail::OpaqueKind::CV_POINT:   os << arg.get<cv::Point>();    break;
+        case cv::detail::OpaqueKind::CV_POINT2F: os << arg.get<cv::Point2f>();  break;
+        case cv::detail::OpaqueKind::CV_SIZE:    os << arg.get<cv::Size>();     break;
+        case cv::detail::OpaqueKind::CV_RECT:    os << arg.get<cv::Rect>();     break;
+        case cv::detail::OpaqueKind::CV_SCALAR:  os << arg.get<cv::Scalar>();   break;
+        case cv::detail::OpaqueKind::CV_MAT:     os << arg.get<cv::Mat>();      break;
         default: GAPI_Assert(false && "GArg: Unsupported (unknown?) opaque value type");
         }
     }
@@ -550,17 +558,18 @@ IIStream& operator>> (IIStream& is, cv::GArg &arg) {
         switch (arg.opaque_kind) {
 #define HANDLE_CASE(E,T) case cv::detail::OpaqueKind::CV_##E:           \
             { T t{}; is >> t; arg = (cv::GArg(t)); } break
-            HANDLE_CASE(BOOL   , bool);
-            HANDLE_CASE(INT    , int);
-            HANDLE_CASE(UINT64 , uint64_t);
-            HANDLE_CASE(DOUBLE , double);
-            HANDLE_CASE(FLOAT  , float);
-            HANDLE_CASE(STRING , std::string);
-            HANDLE_CASE(POINT  , cv::Point);
-            HANDLE_CASE(SIZE   , cv::Size);
-            HANDLE_CASE(RECT   , cv::Rect);
-            HANDLE_CASE(SCALAR , cv::Scalar);
-            HANDLE_CASE(MAT    , cv::Mat);
+            HANDLE_CASE(BOOL    , bool);
+            HANDLE_CASE(INT     , int);
+            HANDLE_CASE(UINT64  , uint64_t);
+            HANDLE_CASE(DOUBLE  , double);
+            HANDLE_CASE(FLOAT   , float);
+            HANDLE_CASE(STRING  , std::string);
+            HANDLE_CASE(POINT   , cv::Point);
+            HANDLE_CASE(POINT2F , cv::Point2f);
+            HANDLE_CASE(SIZE    , cv::Size);
+            HANDLE_CASE(RECT    , cv::Rect);
+            HANDLE_CASE(SCALAR  , cv::Scalar);
+            HANDLE_CASE(MAT     , cv::Mat);
 #undef HANDLE_CASE
         default: GAPI_Assert(false && "GArg: Unsupported (unknown?) opaque value type");
         }

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -530,7 +530,6 @@ IOStream& operator<< (IOStream& os, const cv::GArg &arg) {
         case cv::detail::OpaqueKind::CV_FLOAT:   os << arg.get<float>();        break;
         case cv::detail::OpaqueKind::CV_STRING:  os << arg.get<std::string>();  break;
         case cv::detail::OpaqueKind::CV_POINT:   os << arg.get<cv::Point>();    break;
-        case cv::detail::OpaqueKind::CV_POINT2F: os << arg.get<cv::Point2f>();  break;
         case cv::detail::OpaqueKind::CV_SIZE:    os << arg.get<cv::Size>();     break;
         case cv::detail::OpaqueKind::CV_RECT:    os << arg.get<cv::Rect>();     break;
         case cv::detail::OpaqueKind::CV_SCALAR:  os << arg.get<cv::Scalar>();   break;

--- a/modules/gapi/src/compiler/gcompiled_priv.hpp
+++ b/modules/gapi/src/compiler/gcompiled_priv.hpp
@@ -37,7 +37,10 @@ class GAPI_EXPORTS GCompiled::Priv
     GMetaArgs  m_metas;    // passed by user
     GMetaArgs  m_outMetas; // inferred by compiler
     std::unique_ptr<cv::gimpl::GExecutor> m_exec;
-    std::vector<cv::detail::OpaqueKind>   m_out_kinds;
+
+    // NB: Used by python wrapper to clarify input/output types
+    GTypesInfo m_out_info;
+    GTypesInfo m_in_info;
 
     void checkArgs(const cv::gimpl::GRuntimeArgs &args) const;
 
@@ -57,8 +60,11 @@ public:
 
     const cv::gimpl::GModel::Graph& model() const;
 
-    void setOutKinds(std::vector<cv::detail::OpaqueKind> kinds) { m_out_kinds = std::move(kinds); }
-    const std::vector<cv::detail::OpaqueKind>& outKinds() const { return m_out_kinds; }
+    void setOutInfo(const GTypesInfo& info) { m_out_info = std::move(info); }
+    const GTypesInfo& outInfo() const { return m_out_info; }
+
+    void setInInfo(const GTypesInfo& info) { m_in_info = std::move(info); }
+    const GTypesInfo& inInfo() const { return m_in_info; }
 };
 
 }

--- a/modules/gapi/src/compiler/gcompiled_priv.hpp
+++ b/modules/gapi/src/compiler/gcompiled_priv.hpp
@@ -37,6 +37,7 @@ class GAPI_EXPORTS GCompiled::Priv
     GMetaArgs  m_metas;    // passed by user
     GMetaArgs  m_outMetas; // inferred by compiler
     std::unique_ptr<cv::gimpl::GExecutor> m_exec;
+    std::vector<cv::detail::OpaqueKind>   m_out_kinds;
 
     void checkArgs(const cv::gimpl::GRuntimeArgs &args) const;
 
@@ -55,6 +56,9 @@ public:
     const GMetaArgs& outMetas() const;
 
     const cv::gimpl::GModel::Graph& model() const;
+
+    void setOutKinds(std::vector<cv::detail::OpaqueKind> kinds) { m_out_kinds = std::move(kinds); }
+    const std::vector<cv::detail::OpaqueKind>& outKinds() const { return m_out_kinds; }
 };
 
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -417,8 +417,8 @@ void cv::gimpl::GCompiler::compileIslands(ade::Graph &g, const cv::GCompileArgs 
     GIslandModel::compileIslands(gim, g, args);
 }
 
-static cv::GTypesInfo collectArgsInfo(const cv::gimpl::GModel::ConstGraph& g,
-                                      const std::vector<ade::NodeHandle>& nhs) {
+static cv::GTypesInfo collectInfo(const cv::gimpl::GModel::ConstGraph& g,
+                                  const std::vector<ade::NodeHandle>& nhs) {
     cv::GTypesInfo info;
     info.reserve(nhs.size());
 
@@ -460,8 +460,8 @@ cv::GCompiled cv::gimpl::GCompiler::produceCompiled(GPtr &&pg)
     compiled.priv().setup(m_metas, outMetas, std::move(pE));
 
     // NB: Need to store input/output GTypeInfo to allocate output arrays for python bindings
-    auto out_meta = collectArgsInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().out_nhs);
-    auto in_meta  = collectArgsInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().in_nhs);
+    auto out_meta = collectInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().out_nhs);
+    auto in_meta  = collectInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().in_nhs);
 
     compiled.priv().setOutInfo(std::move(out_meta));
     compiled.priv().setInInfo(std::move(in_meta));
@@ -485,8 +485,8 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::produceStreamingCompiled(GPtr &&pg)
     GModel::ConstGraph cgr(*pg);
 
     // NB: Need to store input/output GTypeInfo to allocate output arrays for python bindings
-    auto out_meta = collectArgsInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().out_nhs);
-    auto in_meta  = collectArgsInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().in_nhs);
+    auto out_meta = collectInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().out_nhs);
+    auto in_meta  = collectInfo(cgr, cgr.metadata().get<cv::gimpl::Protocol>().in_nhs);
 
     compiled.priv().setOutInfo(std::move(out_meta));
     compiled.priv().setInInfo(std::move(in_meta));

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -8,6 +8,7 @@
 #include "precomp.hpp"
 
 #include <ade/graph.hpp>
+#include <ade/util/zip_range.hpp>   // util::indexed
 
 #include <opencv2/gapi/gproto.hpp> // can_describe
 #include <opencv2/gapi/gcompiled.hpp>
@@ -125,8 +126,9 @@ std::tuple<bool, cv::GRunArgs> cv::GStreamingCompiled::pull()
     run_args.reserve(out_shapes.size());
     outs.reserve(out_shapes.size());
 
-    for (auto&& shape : out_shapes)
+    for (auto&& it : ade::util::indexed(out_shapes))
     {
+        const auto& shape = ade::util::value(it);
         switch (shape)
         {
             case cv::GShape::GMAT:
@@ -139,6 +141,21 @@ std::tuple<bool, cv::GRunArgs> cv::GStreamingCompiled::pull()
             {
                 run_args.emplace_back(cv::Scalar{});
                 outs.emplace_back(&cv::util::get<cv::Scalar>(run_args.back()));
+                break;
+            }
+            case cv::GShape::GARRAY:
+            {
+                const auto& kinds = m_priv->outKinds();
+                auto idx = ade::util::index(it);
+                switch (kinds[idx])
+                {
+                    case cv::detail::OpaqueKind::CV_POINT2F:
+                        run_args.emplace_back(cv::detail::VectorRef{std::vector<cv::Point2f>{}});
+                        outs.emplace_back(cv::util::get<cv::detail::VectorRef>(run_args.back()));
+                        break;
+                    default:
+                        util::throw_error(std::logic_error("Unsupported kind for GArray"));
+                }
                 break;
             }
             default:

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -122,14 +122,13 @@ std::tuple<bool, cv::GRunArgs> cv::GStreamingCompiled::pull()
     // FIXME: Why it is not @ priv??
     GRunArgs run_args;
     GRunArgsP outs;
-    const auto& out_shapes = m_priv->outShapes();
-    run_args.reserve(out_shapes.size());
-    outs.reserve(out_shapes.size());
+    const auto& out_info = m_priv->outInfo();
+    run_args.reserve(out_info.size());
+    outs.reserve(out_info.size());
 
-    for (auto&& it : ade::util::indexed(out_shapes))
+    for (auto&& info : out_info)
     {
-        const auto& shape = ade::util::value(it);
-        switch (shape)
+        switch (info.shape)
         {
             case cv::GShape::GMAT:
             {
@@ -145,9 +144,7 @@ std::tuple<bool, cv::GRunArgs> cv::GStreamingCompiled::pull()
             }
             case cv::GShape::GARRAY:
             {
-                const auto& kinds = m_priv->outKinds();
-                auto idx = ade::util::index(it);
-                switch (kinds[idx])
+                switch (info.kind)
                 {
                     case cv::detail::OpaqueKind::CV_POINT2F:
                         run_args.emplace_back(cv::detail::VectorRef{std::vector<cv::Point2f>{}});

--- a/modules/gapi/src/compiler/gstreaming_priv.hpp
+++ b/modules/gapi/src/compiler/gstreaming_priv.hpp
@@ -27,8 +27,10 @@ class GAPI_EXPORTS GStreamingCompiled::Priv
     GMetaArgs  m_metas;    // passed by user
     GMetaArgs  m_outMetas; // inferred by compiler
     std::unique_ptr<cv::gimpl::GStreamingExecutor> m_exec;
-    GShapes m_out_shapes;
-    std::vector<cv::detail::OpaqueKind> m_out_kinds;
+
+    // NB: Used by python wrapper to clarify input/output types
+    GTypesInfo m_out_info;
+    GTypesInfo m_in_info;
 
 public:
     void setup(const GMetaArgs &metaArgs,
@@ -49,14 +51,11 @@ public:
 
     bool running() const;
 
-    // NB: std::tuple<bool, cv::GRunArgs> pull() creates GRunArgs for outputs,
-    // so need to know out shapes to create corresponding GRunArg
-    void setOutShapes(GShapes shapes) { m_out_shapes = std::move(shapes); }
-    const GShapes& outShapes() const { return m_out_shapes; }
+    void setOutInfo(const GTypesInfo& info) { m_out_info = std::move(info); }
+    const GTypesInfo& outInfo() const { return m_out_info; }
 
-    // NB: Needed for python bindings to recognize GArray type
-    void setOutKinds(std::vector<cv::detail::OpaqueKind> kinds) { m_out_kinds = std::move(kinds); }
-    const std::vector<cv::detail::OpaqueKind>& outKinds() const { return m_out_kinds; }
+    void setInInfo(const GTypesInfo& info) { m_in_info = std::move(info); }
+    const GTypesInfo& inInfo() const { return m_in_info; }
 };
 
 } // namespace cv

--- a/modules/gapi/src/compiler/gstreaming_priv.hpp
+++ b/modules/gapi/src/compiler/gstreaming_priv.hpp
@@ -28,6 +28,7 @@ class GAPI_EXPORTS GStreamingCompiled::Priv
     GMetaArgs  m_outMetas; // inferred by compiler
     std::unique_ptr<cv::gimpl::GStreamingExecutor> m_exec;
     GShapes m_out_shapes;
+    std::vector<cv::detail::OpaqueKind> m_out_kinds;
 
 public:
     void setup(const GMetaArgs &metaArgs,
@@ -52,6 +53,10 @@ public:
     // so need to know out shapes to create corresponding GRunArg
     void setOutShapes(GShapes shapes) { m_out_shapes = std::move(shapes); }
     const GShapes& outShapes() const { return m_out_shapes; }
+
+    // NB: Needed for python bindings to recognize GArray type
+    void setOutKinds(std::vector<cv::detail::OpaqueKind> kinds) { m_out_kinds = std::move(kinds); }
+    const std::vector<cv::detail::OpaqueKind>& outKinds() const { return m_out_kinds; }
 };
 
 } // namespace cv

--- a/modules/gapi/test/own/gapi_types_tests.cpp
+++ b/modules/gapi/test/own/gapi_types_tests.cpp
@@ -27,6 +27,22 @@ TEST(Point, CreateWithParams)
     EXPECT_EQ(2, p.y);
 }
 
+TEST(Point2f, CreateEmpty)
+{
+    cv::gapi::own::Point2f p;
+
+    EXPECT_EQ(0.f, p.x);
+    EXPECT_EQ(0.f, p.y);
+}
+
+TEST(Point2f, CreateWithParams)
+{
+    cv::gapi::own::Point2f p = {3.14f, 2.71f};
+
+    EXPECT_EQ(3.14f, p.x);
+    EXPECT_EQ(2.71f, p.y);
+}
+
 TEST(Rect, CreateEmpty)
 {
     cv::gapi::own::Rect r;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request


- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


## Overview

### Changes
* Added struct `GTypeInfo` which stores `GShape` & `GKind`.
* Implemented function `collectInfo` which collect `GTypeInfo` from input/output node handles in the `ade::Graph`, such kind of information are needed to:
    * Properly allocate outputs ( Python `GComputation.apply()` doesn't take output args, so need to allocate their inside)
    * Properly extract inputs ( Need to know how to represent values coming from python. Example: If we have tuple contains 4 values and can be represented as `cv::Scalar` or `cv::Rect`) 
* Added `CV_POINT2F` to `GKind` to handle `GArray<cv::Point2f>`
* Wrapped `GGoodFeatures` operation
* Wrapped `GArray<cv::Point2f>` as `GArrayP2f` into python (**GArray is supported only for output**)

### Implementation details
`GArray` is a template class, so it can't be wrapped to python `as is`. The solution is wrap all instances  corresponding in `GKind`. Now only instance for `GArray<cv::Point2f>` `(cv::GShape::CV_POINT2F)`  is wrapped. For this, need to create using on GArray<cv::Point2f>`:
```
using GArrayP2f = cv::GArray<cv::Point2f>
```
and put this:
```
class GAPI_EXPORTS_W_SIMPLE GArrayP2f { };
```
to `shadow_gapi.hpp` to force python generate code for this instance.
Such principle will be used for wrapping other `GArray` & `GOpaque` types.

**Kind `cv::GKind::CV_UNKNOWN` isn't planned to be supported, yet**

## Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
