### PR TITLE
Fix code snippets inclusion into video tutorials

### DIFF
--- a/doc/tutorials/video/background_subtraction/background_subtraction.markdown
+++ b/doc/tutorials/video/background_subtraction/background_subtraction.markdown
@@ -32,8 +32,7 @@ In this tutorial you will learn how to:
 -#  Create and update the background model by using @ref cv::BackgroundSubtractor class;
 -#  Get and show the foreground mask by using @ref cv::imshow ;
 
-Code
-----
+### Code
 
 In the following you can find the source code. We will let the user choose to process either a video
 file or a sequence of images.

--- a/doc/tutorials/videoio/video-input-psnr-ssim/video_input_psnr_ssim.markdown
+++ b/doc/tutorials/videoio/video-input-psnr-ssim/video_input_psnr_ssim.markdown
@@ -126,8 +126,7 @@ captRefrnc.set(CAP_PROP_POS_FRAMES, 10); // go to the 10th frame of the video
 For properties you can read and change look into the documentation of the @ref cv::VideoCapture::get and
 @ref cv::VideoCapture::set functions.
 
-Image similarity - PSNR and SSIM
---------------------------------
+### Image similarity - PSNR and SSIM
 
 We want to check just how imperceptible our video converting operation went, therefore we need a
 system to check frame by frame the similarity or differences. The most common algorithm used for
@@ -145,15 +144,15 @@ Here the \f$MAX_I\f$ is the maximum valid value for a pixel. In case of the simp
 per pixel per channel this is 255. When two images are the same the MSE will give zero, resulting in
 an invalid divide by zero operation in the PSNR formula. In this case the PSNR is undefined and as
 we'll need to handle this case separately. The transition to a logarithmic scale is made because the
-pixel values have a very wide dynamic range. All this translated to OpenCV and a C++ function looks
+pixel values have a very wide dynamic range. All this translated to OpenCV and a function looks
 like:
 
 @add_toggle_cpp
-@include cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp get-psnr
+@snippet cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp get-psnr
 @end_toggle
 
 @add_toggle_python
-@include samples/python/tutorial_code/videoio/video-input-psnr-ssim.py get-psnr
+@snippet samples/python/tutorial_code/videoio/video-input-psnr-ssim.py get-psnr
 @end_toggle
 
 Typically result values are anywhere between 30 and 50 for video compression, where higher is
@@ -172,11 +171,11 @@ implementation below.
     Transactions on Image Processing, vol. 13, no. 4, pp. 600-612, Apr. 2004." article.
 
 @add_toggle_cpp
-@include cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp get-mssim
+@snippet samples/cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp get-mssim
 @end_toggle
 
 @add_toggle_python
-@include samples/python/tutorial_code/videoio/video-input-psnr-ssim.py get-mssim
+@snippet samples/python/tutorial_code/videoio/video-input-psnr-ssim.py get-mssim
 @end_toggle
 
 This will return a similarity index for each channel of the image. This value is between zero and

--- a/doc/tutorials/videoio/video-write/video_write.markdown
+++ b/doc/tutorials/videoio/video-write/video_write.markdown
@@ -63,7 +63,7 @@ specialized video writing libraries such as *FFMpeg* or codecs as *HuffYUV*, *Co
 an alternative, create the video track with OpenCV and expand it with sound tracks or convert it to
 other formats by using video manipulation programs such as *VirtualDub* or *AviSynth*.
 
-The *VideoWriter* class
+The VideoWriter class
 -----------------------
 
 The content written here builds on the assumption you


### PR DESCRIPTION
Code snippets need a section marked with `###` above to render properly.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under the Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other licenses that are incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
