### PR TITLE
Add support for Conv1D on OpenCV backend

### DIFF
--- a/modules/dnn/perf/perf_convolution.cpp
+++ b/modules/dnn/perf/perf_convolution.cpp
@@ -533,7 +533,7 @@ struct ConvParamID
         CONV_100 = 100,
         CONV_LAST = sizeof(testConvolutionConfigs) / sizeof(testConvolutionConfigs[0])
     };
-    int val_;                                                                  \
+    int val_;
     ConvParamID(int val = 0) : val_(val) {}
     operator int() const { return val_; }
     static ::testing::internal::ParamGenerator<ConvParamID> all()
@@ -546,7 +546,7 @@ struct ConvParamID
         ConvParamID v_[NUM]; for (int i = 0; i < NUM; ++i) { v_[i] = ConvParamID(i); } // reduce generated code size
         return ::testing::ValuesIn(v_, v_ + NUM);
     }
-};                                                                                  \
+};
 static inline void PrintTo(const ConvParamID& v, std::ostream* os)
 {
     CV_Assert((int)v >= 0); CV_Assert((int)v < ConvParamID::CONV_LAST);

--- a/modules/dnn/perf/perf_convolution1d.cpp
+++ b/modules/dnn/perf/perf_convolution1d.cpp
@@ -1,0 +1,166 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace opencv_test {
+
+    struct Conv1DParam_t {
+        int kernel;
+        struct BlobShape { int dims[3]; } shapeIn;
+        int outCN;
+        int groups;
+        int stride;
+        int dilation;
+        int pad[2];
+        const char* padMode;
+        bool hasBias;
+        double declared_flops;
+    };
+// Details: #12142
+    static const Conv1DParam_t testConvolution1DConfigs[] = {
+            {3, {{1, 6, 10}}, 6, 1, 1, 1, {0, 0}, "VALID", true, 1776.},
+            {3, {{1, 2, 19}}, 2, 2, 2, 1, {1, 1}, "", true, 260.},
+            {3, {{1, 2, 25}}, 2, 2, 1, 1, {2, 2}, "SAME", false, 650.},
+    };
+
+    struct Conv1DParamID
+    {
+        enum {
+            CONV_0 = 0,
+            CONV_LAST = sizeof(testConvolution1DConfigs) / sizeof(testConvolution1DConfigs[0])
+        };
+        int val_;                                                                  \
+    Conv1DParamID(int val = 0) : val_(val) {}
+        operator int() const { return val_; }
+        static ::testing::internal::ParamGenerator<Conv1DParamID> all()
+        {
+#if 0
+            enum { NUM = (int)CONV_LAST };
+#else
+            enum { NUM = (int)CONV_LAST };
+#endif
+            Conv1DParamID v_[NUM]; for (int i = 0; i < NUM; ++i) { v_[i] = Conv1DParamID(i); } // reduce generated code size
+            return ::testing::ValuesIn(v_, v_ + NUM);
+        }
+    };                                                                                  \
+static inline void PrintTo(const Conv1DParamID& v, std::ostream* os)
+    {
+        CV_Assert((int)v >= 0); CV_Assert((int)v < Conv1DParamID::CONV_LAST);
+        const Conv1DParam_t& p = testConvolution1DConfigs[(int)v];
+
+        *os << "GFLOPS=" << cv::format("%.3f", p.declared_flops * 1e-9)
+            << ", K=[" << p.kernel << "]"
+            << ", IN={" << p.shapeIn.dims[0] << ", " << p.shapeIn.dims[1] << ", " << p.shapeIn.dims[2] << "}"
+            << ", OCN=" << p.outCN;
+        if (p.groups > 1)
+            *os << ", G=" << p.groups;
+        if (p.stride != 1)
+            *os << ", S=" << p.stride;
+        if (p.dilation != 1)
+            *os << ", D="  << p.dilation;
+        if (p.pad[0] != 0 && p.pad[1] != 0 )
+            *os << ", P=(" << p.pad[0] << ", " << p.pad[1] << ")";
+        if (!((std::string)p.padMode).empty())
+            *os << ", PM=" << ((std::string)p.padMode);
+        if (p.hasBias)
+            *os << ", BIAS";
+    }
+
+
+    typedef tuple<Conv1DParamID, tuple<Backend, Target> > Conv1DTestParam_t;
+    typedef TestBaseWithParam<Conv1DTestParam_t> Conv1D;
+
+    PERF_TEST_P_(Conv1D, conv1d)
+{
+    int test_id = (int)get<0>(GetParam());
+    ASSERT_GE(test_id, 0); ASSERT_LT(test_id, Conv1DParamID::CONV_LAST);
+    const Conv1DParam_t& params = testConvolution1DConfigs[test_id];
+    double declared_flops = params.declared_flops;
+
+    DictValue kernel   = DictValue::arrayInt(&params.kernel, 1);
+    DictValue stride   = DictValue::arrayInt(&params.stride, 1);
+    DictValue pad      = DictValue::arrayInt(&params.pad[0], 2);
+    DictValue dilation = DictValue::arrayInt(&params.dilation, 1);
+
+    MatShape inputShape = MatShape(params.shapeIn.dims, params.shapeIn.dims + 3);
+    int outChannels = params.outCN;
+    int groups = params.groups;
+    std::string padMode(params.padMode);
+
+    bool hasBias = params.hasBias;
+    Backend backendId = get<0>(get<1>(GetParam()));
+    Target targetId = get<1>(get<1>(GetParam()));
+
+    if (targetId != DNN_TARGET_CPU)
+    throw SkipTestException("Only CPU is supported");
+
+    int inChannels = inputShape[1];
+
+    int sz[] = {outChannels, inChannels / groups, params.kernel};
+    Mat weights(3, &sz[0], CV_32F);
+    randu(weights, -1.0f, 1.0f);
+
+    LayerParams lp;
+    lp.set("kernel_size", kernel);
+    lp.set("pad", pad);
+    if (!padMode.empty())
+    lp.set("pad_mode", padMode);
+
+    lp.set("stride", stride);
+    lp.set("dilation", dilation);
+    lp.set("num_output", outChannels);
+    lp.set("group", groups);
+    lp.set("bias_term", hasBias);
+    lp.set("is_1d", true);
+    lp.type = "Convolution";
+    lp.name = "testLayer";
+    lp.blobs.push_back(weights);
+
+    if (hasBias)
+{
+    Mat bias(1, outChannels, CV_32F);
+    randu(bias, -1.0f, 1.0f);
+    lp.blobs.push_back(bias);
+}
+int inpSz[] = {1, inChannels, inputShape[2]};
+Mat input(3, &inpSz[0], CV_32F);
+randu(input, -1.0f, 1.0f);
+
+Net net;
+net.addLayerToPrev(lp.name, lp.type, lp);
+
+net.setInput(input);
+net.setPreferableBackend(backendId);
+net.setPreferableTarget(targetId);
+
+Mat output = net.forward();
+
+MatShape netInputShape = shape(input);
+size_t weightsMemory = 0, blobsMemory = 0;
+net.getMemoryConsumption(netInputShape, weightsMemory, blobsMemory);
+int64 flops = net.getFLOPS(netInputShape);
+CV_Assert(flops > 0);
+
+std::cout
+<< "IN=" << divUp(input.total() * input.elemSize(), 1u<<10) << " Kb " << netInputShape
+<< "    OUT=" << divUp(output.total() * output.elemSize(), 1u<<10) << " Kb " << shape(output)
+<< "    Weights(parameters): " << divUp(weightsMemory, 1u<<10) << " Kb"
+<< "    MFLOPS=" << flops * 1e-6 << std::endl;
+
+TEST_CYCLE()
+{
+    Mat res = net.forward();
+}
+EXPECT_NEAR(flops, declared_flops, declared_flops * 1e-6);
+SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Conv1D, Combine(
+        Conv1DParamID::all(),
+        dnnBackendsAndTargets(false, false)  // defined in ../test/test_common.hpp
+));
+
+} // namespace

--- a/modules/dnn/perf/perf_convolution1d.cpp
+++ b/modules/dnn/perf/perf_convolution1d.cpp
@@ -110,7 +110,6 @@ PERF_TEST_P_(Conv1D, conv1d)
     lp.set("num_output", outChannels);
     lp.set("group", groups);
     lp.set("bias_term", hasBias);
-    lp.set("is_1d", true);
     lp.type = "Convolution";
     lp.name = "testLayer";
     lp.blobs.push_back(weights);

--- a/modules/dnn/perf/perf_convolution1d.cpp
+++ b/modules/dnn/perf/perf_convolution1d.cpp
@@ -32,8 +32,8 @@ struct Conv1DParamID
         CONV_0 = 0,
         CONV_LAST = sizeof(testConvolution1DConfigs) / sizeof(testConvolution1DConfigs[0])
     };
-    int val_;                                                                  \
-Conv1DParamID(int val = 0) : val_(val) {}
+    int val_;
+    Conv1DParamID(int val = 0) : val_(val) {}
     operator int() const { return val_; }
     static ::testing::internal::ParamGenerator<Conv1DParamID> all()
     {
@@ -41,29 +41,29 @@ Conv1DParamID(int val = 0) : val_(val) {}
         Conv1DParamID v_[NUM]; for (int i = 0; i < NUM; ++i) { v_[i] = Conv1DParamID(i); } // reduce generated code size
         return ::testing::ValuesIn(v_, v_ + NUM);
     }
-};                                                                                  \
+};
 static inline void PrintTo(const Conv1DParamID& v, std::ostream* os)
-    {
-        CV_Assert((int)v >= 0); CV_Assert((int)v < Conv1DParamID::CONV_LAST);
-        const Conv1DParam_t& p = testConvolution1DConfigs[(int)v];
+{
+    CV_Assert((int)v >= 0); CV_Assert((int)v < Conv1DParamID::CONV_LAST);
+    const Conv1DParam_t& p = testConvolution1DConfigs[(int)v];
 
-        *os << "GFLOPS=" << cv::format("%.3f", p.declared_flops * 1e-9)
-            << ", K=[" << p.kernel << "]"
-            << ", IN={" << p.shapeIn.dims[0] << ", " << p.shapeIn.dims[1] << ", " << p.shapeIn.dims[2] << "}"
-            << ", OCN=" << p.outCN;
-        if (p.groups > 1)
-            *os << ", G=" << p.groups;
-        if (p.stride != 1)
-            *os << ", S=" << p.stride;
-        if (p.dilation != 1)
-            *os << ", D="  << p.dilation;
-        if (p.pad[0] != 0 && p.pad[1] != 0 )
-            *os << ", P=(" << p.pad[0] << ", " << p.pad[1] << ")";
-        if (!((std::string)p.padMode).empty())
-            *os << ", PM=" << ((std::string)p.padMode);
-        if (p.hasBias)
-            *os << ", BIAS";
-    }
+    *os << "GFLOPS=" << cv::format("%.3f", p.declared_flops * 1e-9)
+        << ", K=[" << p.kernel << "]"
+        << ", IN={" << p.shapeIn.dims[0] << ", " << p.shapeIn.dims[1] << ", " << p.shapeIn.dims[2] << "}"
+        << ", OCN=" << p.outCN;
+    if (p.groups > 1)
+        *os << ", G=" << p.groups;
+    if (p.stride != 1)
+        *os << ", S=" << p.stride;
+    if (p.dilation != 1)
+        *os << ", D="  << p.dilation;
+    if (p.pad[0] != 0 && p.pad[1] != 0 )
+        *os << ", P=(" << p.pad[0] << ", " << p.pad[1] << ")";
+    if (!((std::string)p.padMode).empty())
+        *os << ", PM=" << ((std::string)p.padMode);
+    if (p.hasBias)
+        *os << ", BIAS";
+}
 
 
 typedef tuple<Conv1DParamID, tuple<Backend, Target> > Conv1DTestParam_t;
@@ -91,7 +91,7 @@ PERF_TEST_P_(Conv1D, conv1d)
     Target targetId = get<1>(get<1>(GetParam()));
 
     if (targetId != DNN_TARGET_CPU)
-    throw SkipTestException("Only CPU is supported");
+        throw SkipTestException("Only CPU is supported");
 
     int inChannels = inputShape[1];
 
@@ -103,7 +103,7 @@ PERF_TEST_P_(Conv1D, conv1d)
     lp.set("kernel_size", kernel);
     lp.set("pad", pad);
     if (!padMode.empty())
-    lp.set("pad_mode", padMode);
+        lp.set("pad_mode", padMode);
 
     lp.set("stride", stride);
     lp.set("dilation", dilation);

--- a/modules/dnn/perf/perf_convolution1d.cpp
+++ b/modules/dnn/perf/perf_convolution1d.cpp
@@ -133,6 +133,7 @@ PERF_TEST_P_(Conv1D, conv1d)
     net.setPreferableBackend(backendId);
     net.setPreferableTarget(targetId);
 
+    // warmup
     Mat output = net.forward();
 
     MatShape netInputShape = shape(input);

--- a/modules/dnn/perf/perf_convolution3d.cpp
+++ b/modules/dnn/perf/perf_convolution3d.cpp
@@ -46,7 +46,7 @@ struct Conv3DParamID
         CONV_100 = 16,
         CONV_LAST = sizeof(testConvolution3DConfigs) / sizeof(testConvolution3DConfigs[0])
     };
-    int val_;                                                                  \
+    int val_;
     Conv3DParamID(int val = 0) : val_(val) {}
     operator int() const { return val_; }
     static ::testing::internal::ParamGenerator<Conv3DParamID> all()
@@ -59,7 +59,7 @@ struct Conv3DParamID
         Conv3DParamID v_[NUM]; for (int i = 0; i < NUM; ++i) { v_[i] = Conv3DParamID(i); } // reduce generated code size
         return ::testing::ValuesIn(v_, v_ + NUM);
     }
-};                                                                                  \
+};
 static inline void PrintTo(const Conv3DParamID& v, std::ostream* os)
 {
     CV_Assert((int)v >= 0); CV_Assert((int)v < Conv3DParamID::CONV_LAST);

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -748,22 +748,20 @@ public:
                     for( int k_c = 0; k_c < kernel_w; k_c++ )
                         ofstab[k*kernel_w + k_c] = k*width + k_c*dil_w;
             }
-            else {
-                if (isConv2D) {
-                    for (int k = 0; k < ncn; k++)
+            else if (isConv2D) {
+                for (int k = 0; k < ncn; k++)
+                    for (int k_r = 0; k_r < kernel_h; k_r++)
+                        for (int k_c = 0; k_c < kernel_w; k_c++)
+                            ofstab[(k * kernel_h + k_r) * kernel_w + k_c] =
+                                    (k * height + k_r * dil_h) * width + k_c * dil_w;
+            } else {
+                for (int k = 0; k < ncn; k++)
+                    for (int k_d = 0; k_d < kernel_d; k_d++)
                         for (int k_r = 0; k_r < kernel_h; k_r++)
                             for (int k_c = 0; k_c < kernel_w; k_c++)
-                                ofstab[(k * kernel_h + k_r) * kernel_w + k_c] =
-                                        (k * height + k_r * dil_h) * width + k_c * dil_w;
-                } else {
-                    for (int k = 0; k < ncn; k++)
-                        for (int k_d = 0; k_d < kernel_d; k_d++)
-                            for (int k_r = 0; k_r < kernel_h; k_r++)
-                                for (int k_c = 0; k_c < kernel_w; k_c++)
-                                    ofstab[(k * kernel_d * kernel_h + k_d * kernel_h + k_r) * kernel_w + k_c] =
-                                            (k * depth * height + k_d * dil_d * height + k_r * dil_h) * width +
-                                            k_c * dil_w;
-                }
+                                ofstab[(k * kernel_d * kernel_h + k_d * kernel_h + k_r) * kernel_w + k_c] =
+                                        (k * depth * height + k_d * dil_d * height + k_r * dil_h) * width +
+                                        k_c * dil_w;
             }
 
             p.biasvec_ = &biasvec;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -313,6 +313,7 @@ public:
         {
             getConvPoolOutParams(inpShape, kernel_size, strides, padMode, dilations, outShape);
         }
+
         int ngroups = inpCn / weightShape[1];
         if (ngroups == 0 || ngroups * weightShape[1] != inpCn)
             CV_Error(Error::StsError, format("Number of input channels should "
@@ -758,16 +759,16 @@ public:
                     for( int k_r = 0; k_r < kernel_h; k_r++ )
                         for( int k_c = 0; k_c < kernel_w; k_c++ )
                             ofstab[(k*kernel_h + k_r)*kernel_w + k_c] =
-                                    (k*height + k_r*dil_h)*width + k_c*dil_w;
+                                   (k*height + k_r*dil_h)*width + k_c*dil_w;
             }
             else
             {
                 for( int k = 0; k < ncn; k++ )
-                    for( int k_d = 0; k_d < kernel_d; k_d++ )
+                    for (int k_d = 0; k_d < kernel_d; k_d++)
                         for( int k_r = 0; k_r < kernel_h; k_r++ )
                             for( int k_c = 0; k_c < kernel_w; k_c++ )
                                 ofstab[(k*kernel_d*kernel_h + k_d*kernel_h + k_r)*kernel_w + k_c] =
-                                        (k*depth*height + k_d*dil_d*height + k_r*dil_h)*width + k_c*dil_w;
+                                       (k*depth*height + k_d*dil_d*height + k_r*dil_h)*width + k_c*dil_w;
             }
 
             p.biasvec_ = &biasvec;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -113,6 +113,10 @@ public:
         MatSize weightShape = blobs.empty() ? inputs[1].size : blobs[0].size;
 
         CV_Assert(inputs[0].dims == outputs[0].dims);
+        if (weightShape.dims() == 3)
+        {
+            kernel_size.assign(1, kernel_size[0]);
+        }
         CV_Assert(weightShape.dims() == kernel_size.size() + 2);
         for (int i = 0; i < kernel_size.size(); i++) {
             CV_Assert(weightShape[i + 2] == kernel_size[i]);
@@ -680,11 +684,11 @@ public:
         {
             size_t karea = std::accumulate(kernel_size.begin(), kernel_size.end(),
                                            1, std::multiplies<size_t>());
-            bool isConv1D = kernel_size.size() == 1;
-            bool isConv2D = kernel_size.size() == 2;
-            bool isConv3D = kernel_size.size() == 3;
+            bool isConv1D = input.dims == 3;
+            bool isConv2D = input.dims == 4;
+            bool isConv3D = input.dims == 5;
             CV_Assert_N(
-                       ((input.dims == 3 && isConv1D) || (input.dims == 4 && isConv2D) || (input.dims == 5 && isConv3D))
+                       ((kernel_size.size() == 1 && isConv1D) || (kernel_size.size() == 2 && isConv2D) || (kernel_size.size() == 3 && isConv3D))
                        && input.dims == output.dims,
                        input.size[0] == output.size[0],
                        weights.rows == output.size[1],

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -116,6 +116,7 @@ public:
         if (weightShape.dims() == 3)
         {
             kernel_size.assign(1, kernel_size[0]);
+            strides.assign(1, strides[0]);
         }
         CV_Assert(weightShape.dims() == kernel_size.size() + 2);
         for (int i = 0; i < kernel_size.size(); i++) {

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -119,11 +119,11 @@ public:
         }
 
         const Mat &input = inputs[0];
-        CV_Assert((input.dims == 4 || input.dims == 5) && (input.type() == CV_32F || input.type() == CV_16S));
+        CV_Assert(((input.dims == 3 && kernel_size.size() == 1) || input.dims == 4 || input.dims == 5) && (input.type() == CV_32F || input.type() == CV_16S));
         for (size_t i = 0; i < outputs.size(); i++)
         {
             CV_Assert(inputs[i].type() == input.type());
-            CV_Assert((inputs[i].dims == 4 || inputs[i].dims == 5) && inputs[i].size[1] == input.size[1]);
+            CV_Assert(((input.dims == 3 && kernel_size.size() == 1) || inputs[i].dims == 4 || inputs[i].dims == 5) && inputs[i].size[1] == input.size[1]);
             for (int j = 0; j < inputs[i].dims; j++) {
                 CV_Assert(inputs[i].size[j] == input.size[j]);
             }
@@ -264,6 +264,8 @@ public:
 #ifdef HAVE_INF_ENGINE
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         {
+            if (kernel_size.size() == 1)
+                return false;
             if (kernel_size.size() == 3)
                 return preferableTarget == DNN_TARGET_CPU;
             if ((backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || preferableTarget != DNN_TARGET_MYRIAD) && blobs.empty())
@@ -273,6 +275,7 @@ public:
         else
 #endif
             return (kernel_size.size() == 3 && preferableTarget == DNN_TARGET_CPU && backendId == DNN_BACKEND_OPENCV) ||
+                   (kernel_size.size() == 1 && preferableTarget == DNN_TARGET_CPU && backendId == DNN_BACKEND_OPENCV) ||
                    (kernel_size.size() == 2 && (backendId == DNN_BACKEND_OPENCV || (backendId == DNN_BACKEND_HALIDE && !blobs.empty())));
     }
 
@@ -305,7 +308,6 @@ public:
         {
             getConvPoolOutParams(inpShape, kernel_size, strides, padMode, dilations, outShape);
         }
-
         int ngroups = inpCn / weightShape[1];
         if (ngroups == 0 || ngroups * weightShape[1] != inpCn)
             CV_Error(Error::StsError, format("Number of input channels should "
@@ -554,7 +556,7 @@ public:
         CV_Assert_N(inputs.size() >= 1, nodes.size() >= 1);
         auto& ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         std::vector<size_t> dims = ieInpNode->get_shape();
-        CV_Assert(dims.size() == 4 || dims.size() == 5);
+        CV_Assert((dims.size() == 3 && kernel_size.size() == 1) || dims.size() == 4 || dims.size() == 5);
         std::shared_ptr<ngraph::Node> ieWeights = nodes.size() > 1 ? nodes[1].dynamicCast<InfEngineNgraphNode>()->node : nullptr;
         if (nodes.size() > 1)
             CV_Assert(ieWeights);  // dynamic_cast should not fail
@@ -678,8 +680,12 @@ public:
         {
             size_t karea = std::accumulate(kernel_size.begin(), kernel_size.end(),
                                            1, std::multiplies<size_t>());
+            bool isConv1D = kernel_size.size() == 1;
+            bool isConv2D = kernel_size.size() == 2;
+            bool isConv3D = kernel_size.size() == 3;
             CV_Assert_N(
-                       (input.dims == 4 || input.dims == 5) && (input.dims == output.dims),
+                       ((input.dims == 3 && isConv1D) || (input.dims == 4 && isConv2D) || (input.dims == 5 && isConv3D))
+                       && input.dims == output.dims,
                        input.size[0] == output.size[0],
                        weights.rows == output.size[1],
                        weights.cols == (input.size[1]/ngroups)*karea,
@@ -694,7 +700,8 @@ public:
             p.input_ = &input;
             p.weights_ = &weights;
             p.output_ = &output;
-            for( int i = 0; i < 4; i++ ) p.outShape[i] = output.size[i];
+            int max_ind = isConv1D? 3: 4;
+            for( int i = 0; i < max_ind; i++ ) p.outShape[i] = output.size[i];
             p.outShape[1] /= ngroups;
 
             p.kernel_size = kernel_size; p.strides = strides; p.dilations = dilations;
@@ -706,20 +713,19 @@ public:
             int inpCnAll = input.size[1];
             int depth = (input.dims == 5) ? input.size[2] : 1;
             int width = input.size[input.dims - 1];
-            int height = input.size[input.dims - 2];
+            int height = isConv1D? 1 : input.size[input.dims - 2];
             int inpCn = inpCnAll / ngroups;
 
-            bool isConv2D = kernel_size.size() == 2;
-
-            p.is1x1_ = isConv2D && kernel_size[0] == 1 && kernel_size[1] == 1 &&
-                       pads_begin[0] == 0  && pads_begin[1] == 0;
+            p.is1x1_ = (isConv2D && kernel_size[0] == 1 && kernel_size[1] == 1 &&
+                       pads_begin[0] == 0  && pads_begin[1] == 0) ||
+                       (isConv1D && pads_begin[0] == 0 && kernel_size[0] == 1);
 
             p.useAVX    = checkHardwareSupport(CPU_AVX)  && isConv2D;
             p.useAVX2   = checkHardwareSupport(CPU_AVX2) && isConv2D;
             p.useAVX512 = CV_CPU_HAS_SUPPORT_AVX512_SKX  && isConv2D;
 
-            int kernel_d = !isConv2D? kernel_size[0] : 1;
-            int kernel_h = kernel_size[kernel_size.size() - 2];
+            int kernel_d = isConv3D? kernel_size[0] : 1;
+            int kernel_h = isConv1D? 1 : kernel_size[kernel_size.size() - 2];
             int kernel_w = kernel_size.back();
 
             int blk_size_cn0 = cvCeil(800./(kernel_w*kernel_h));
@@ -729,29 +735,35 @@ public:
             ncn = std::min(ncn, inpCn);
             p.blk_size_cn = ncn;
 
-            int dil_d = !isConv2D? dilations[0] : 1;
-            int dil_h = dilations[dilations.size() - 2];
+            int dil_d = isConv3D? dilations[0] : 1;
+            int dil_h = isConv1D? 1 : dilations[dilations.size() - 2];
             int dil_w = dilations.back();
 
             p.ofstab_.resize(karea * ncn);
             int* ofstab = &p.ofstab_[0];
 
-            if (isConv2D)
+            if (isConv1D)
             {
                 for( int k = 0; k < ncn; k++ )
-                    for( int k_r = 0; k_r < kernel_h; k_r++ )
-                        for( int k_c = 0; k_c < kernel_w; k_c++ )
-                            ofstab[(k*kernel_h + k_r)*kernel_w + k_c] =
-                                   (k*height + k_r*dil_h)*width + k_c*dil_w;
+                    for( int k_c = 0; k_c < kernel_w; k_c++ )
+                        ofstab[k*kernel_w + k_c] = k*width + k_c*dil_w;
             }
-            else
-            {
-                for( int k = 0; k < ncn; k++ )
-                    for (int k_d = 0; k_d < kernel_d; k_d++)
-                        for( int k_r = 0; k_r < kernel_h; k_r++ )
-                            for( int k_c = 0; k_c < kernel_w; k_c++ )
-                                ofstab[(k*kernel_d*kernel_h + k_d*kernel_h + k_r)*kernel_w + k_c] =
-                                       (k*depth*height + k_d*dil_d*height + k_r*dil_h)*width + k_c*dil_w;
+            else {
+                if (isConv2D) {
+                    for (int k = 0; k < ncn; k++)
+                        for (int k_r = 0; k_r < kernel_h; k_r++)
+                            for (int k_c = 0; k_c < kernel_w; k_c++)
+                                ofstab[(k * kernel_h + k_r) * kernel_w + k_c] =
+                                        (k * height + k_r * dil_h) * width + k_c * dil_w;
+                } else {
+                    for (int k = 0; k < ncn; k++)
+                        for (int k_d = 0; k_d < kernel_d; k_d++)
+                            for (int k_r = 0; k_r < kernel_h; k_r++)
+                                for (int k_c = 0; k_c < kernel_w; k_c++)
+                                    ofstab[(k * kernel_d * kernel_h + k_d * kernel_h + k_r) * kernel_w + k_c] =
+                                            (k * depth * height + k_d * dil_d * height + k_r * dil_h) * width +
+                                            k_c * dil_w;
+                }
             }
 
             p.biasvec_ = &biasvec;
@@ -765,34 +777,36 @@ public:
         {
             const int valign = ConvolutionLayerImpl::VEC_ALIGN;
             int ngroups = ngroups_, batchSize = input_->size[0]*ngroups;
+            bool isConv1D = input_->dims == 3;
             bool isConv2D = input_->dims == 4;
+            bool isConv3D = input_->dims == 5;
 
             int outW = output_->size[output_->dims - 1];
-            int outH = output_->size[output_->dims - 2];
+            int outH = isConv1D? 1 : output_->size[output_->dims - 2];
             int outCn = output_->size[1]/ngroups;
 
-            int depth = !isConv2D? input_->size[2] : 1;
-            int height = input_->size[input_->dims - 2];
+            int depth = isConv3D? input_->size[2] : 1;
+            int height = isConv1D? 1 : input_->size[input_->dims - 2];
             int width = input_->size[input_->dims - 1];
             int inpCn = input_->size[1]/ngroups;
 
             const int nstripes = nstripes_;
 
-            int kernel_d = !isConv2D? kernel_size[0] : 1;
-            int kernel_h = kernel_size[kernel_size.size() - 2];
+            int kernel_d = isConv3D? kernel_size[0] : 1;
+            int kernel_h = isConv1D? 1 : kernel_size[kernel_size.size() - 2];
             int kernel_w = kernel_size.back();
             int karea = kernel_w*kernel_h*kernel_d;
 
-            int pad_d = !isConv2D? pads_begin[0] : 0;
-            int pad_t = pads_begin[pads_begin.size() - 2];
+            int pad_d = isConv3D? pads_begin[0] : 0;
+            int pad_t = isConv1D? 0 : pads_begin[pads_begin.size() - 2];
             int pad_l = pads_begin.back();
 
-            int stride_d = !isConv2D? strides[0] : 0;
-            int stride_h = strides[strides.size() - 2];
+            int stride_d = isConv3D? strides[0] : 0;
+            int stride_h = isConv1D? 0 : strides[strides.size() - 2];
             int stride_w = strides.back();
 
-            int dilation_d = !isConv2D? dilations[0] : 1;
-            int dilation_h = dilations[dilations.size() - 2];
+            int dilation_d = isConv3D? dilations[0] : 1;
+            int dilation_h = isConv1D? 1 : dilations[dilations.size() - 2];
             int dilation_w = dilations.back();
 
             int i, j, k, d;
@@ -1032,7 +1046,71 @@ public:
                         // do im2row for a part of input tensor
                         float* rowbuf = rowbuf0;
 
-                        if (isConv2D)
+                        if (isConv1D)
+                        {
+                            for( ofs = ofs0; ofs < ofs1; out_j = 0, ++out_i )
+                            {
+                                int delta = std::min(ofs1 - ofs, outW - out_j);
+                                int out_j1 = out_j + delta;
+
+                                int in_j = out_j * stride_w - pad_l;
+                                const float* imgptr = data_inp0 + cn0*width + in_j;
+                                ofs += delta;
+
+                                // do im2row for a part of input tensor
+                                if( is1x1 )
+                                {
+                                    for( ; out_j < out_j1; out_j++, rowbuf += vsz_a, imgptr += stride_w )
+                                    {
+                                        for( k = 0; k < vsz; k++ )
+                                            rowbuf[k] = imgptr[k*inpPlaneSize];
+                                    }
+                                }
+                                else
+                                {
+                                    for( ; out_j < out_j1; out_j++, rowbuf += vsz_a, imgptr += stride_w, in_j += stride_w )
+                                    {
+                                        // this condition should be true for most of the tensor elements, i.e.
+                                        // most of the time the kernel aperture is inside the tensor X-Y plane.
+                                        if( out_j + 2 <= out_j1 && 0 <= in_j && in_j + stride_w*2 <= width - (kernel_w-1)*dilation_w )
+                                        {
+                                            for( k = 0; k < vsz; k++ )
+                                            {
+                                                int k1 = ofstab[k];
+                                                float v0 = imgptr[k1];
+                                                float v1 = imgptr[k1 + stride_w];
+                                                rowbuf[k] = v0;
+                                                rowbuf[k+vsz_a] = v1;
+                                            }
+                                            out_j++;
+                                            rowbuf += vsz_a;
+                                            imgptr += stride_w;
+                                            in_j += stride_w;
+                                        }
+                                        else
+                                        {
+                                            int i0 = std::max(0, (-in_j + dilation_w-1)/dilation_w);
+                                            int i1 = std::min(kernel_w, (width - in_j + dilation_w-1)/dilation_w);
+
+                                            // here some non-continuous sub-row of the row will not be
+                                            // filled from the tensor; we need to make sure that the uncovered
+                                            // elements are explicitly set to 0's. the easiest way is to
+                                            // set all the elements to 0's before the loop.
+                                            memset(rowbuf, 0, vsz*sizeof(rowbuf[0]));
+                                            for( k = 0; k < ncn; k++ )
+                                            {
+                                                for( i = i0; i < i1; i++ )
+                                                {
+                                                    int imgofs = k*width + i*dilation_w;
+                                                    rowbuf[k*kernel_w + i] = imgptr[imgofs];
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else if (isConv2D)
                         {
                             if( is1x1 && stride_w == 1 && stride_h == 1 )
                             {
@@ -1535,11 +1613,18 @@ public:
                 }
             }
         }
-
-        /*printf("conv %s: input (%d x %d x %d x %d), kernel (%d x %d), pad (%d x %d), stride (%d x %d), dilation (%d x %d)\n",
-               name.c_str(), inputs[0].size[0], inputs[0].size[1], inputs[0].size[2], inputs[0].size[3],
-               kernel.width, kernel.height, pad.width, pad.height,
-               stride.width, stride.height, dilation.width, dilation.height);*/
+        /*if (inputs[0].dims > 3) {
+            printf("conv %s: input (%d x %d x %d x %d), kernel (%d x %d), pad (%d x %d), stride (%d x %d), dilation (%d x %d)\n",
+                   name.c_str(), inputs[0].size[0], inputs[0].size[1], inputs[0].size[2], inputs[0].size[3],
+                   kernel.width, kernel.height, pad.width, pad.height,
+                   stride.width, stride.height, dilation.width, dilation.height);
+        }
+        else {
+            printf("conv %s: input (%d x %d x %d), kernel (%d x %d), pad (%d x %d), stride (%d x %d), dilation (%d x %d)\n",
+                   name.c_str(), inputs[0].size[0], inputs[0].size[1], inputs[0].size[2],
+                   kernel.width, kernel.height, pad.width, pad.height,
+                   stride.width, stride.height, dilation.width, dilation.height);
+        }*/
         int inpGroupCn = blobs.empty() ? inputs[1].size[1] : blobs[0].size[1];
         CV_Assert_N(inputs.size() >= (size_t)1, inputs[0].size[1] % inpGroupCn == 0,
                     outputs.size() == 1, inputs[0].data != outputs[0].data);

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -753,13 +753,16 @@ public:
                     for( int k_c = 0; k_c < kernel_w; k_c++ )
                         ofstab[k*kernel_w + k_c] = k*width + k_c*dil_w;
             }
-            else if (isConv2D) {
+            else if (isConv2D)
+            {
                 for (int k = 0; k < ncn; k++)
                     for (int k_r = 0; k_r < kernel_h; k_r++)
                         for (int k_c = 0; k_c < kernel_w; k_c++)
                             ofstab[(k * kernel_h + k_r) * kernel_w + k_c] =
                                     (k * height + k_r * dil_h) * width + k_c * dil_w;
-            } else {
+            }
+            else
+            {
                 for (int k = 0; k < ncn; k++)
                     for (int k_d = 0; k_d < kernel_d; k_d++)
                         for (int k_r = 0; k_r < kernel_h; k_r++)

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -81,7 +81,7 @@ bool getParameter(const LayerParams &params, const std::string& nameBase, const 
                 CV_Assert(param.get<int>(i) >= 0);
                 parameter.push_back(param.get<int>(i));
             }
-            if (parameter.size() == 1 && !params.has("is_1d"))
+            if (parameter.size() == 1)
                 parameter.resize(2, parameter[0]);
             return true;
         }
@@ -122,7 +122,7 @@ void getStrideAndPadding(const LayerParams &params, std::vector<size_t>& pads_be
     }
     else {
         util::getParameter(params, "pad", "pad", pads_begin, true, std::vector<size_t>(kernel_size, 0));
-        if (pads_begin.size() < 4 && !params.has("is_1d"))
+        if (pads_begin.size() < 4)
             pads_end = pads_begin;
         else
         {

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -81,7 +81,7 @@ bool getParameter(const LayerParams &params, const std::string& nameBase, const 
                 CV_Assert(param.get<int>(i) >= 0);
                 parameter.push_back(param.get<int>(i));
             }
-            if (parameter.size() == 1)
+            if (parameter.size() == 1 && !params.has("is_1d"))
                 parameter.resize(2, parameter[0]);
             return true;
         }
@@ -122,7 +122,7 @@ void getStrideAndPadding(const LayerParams &params, std::vector<size_t>& pads_be
     }
     else {
         util::getParameter(params, "pad", "pad", pads_begin, true, std::vector<size_t>(kernel_size, 0));
-        if (pads_begin.size() < 4)
+        if (pads_begin.size() < 4 && !params.has("is_1d"))
             pads_end = pads_begin;
         else
         {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1185,12 +1185,6 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto_)
         else if (layer_type == "Conv")
         {
             CV_Assert(node_proto.input_size() >= 2);
-            if (layerParams.has("kernel_size")) {
-                const DictValue &kernel = layerParams.get("kernel_size");
-                if (kernel.size() == 1) {
-                    layerParams.set("is_1d", true);
-                }
-            }
             layerParams.type = "Convolution";
             for (int j = 1; j < node_proto.input_size(); j++) {
                 if (constBlobs.find(node_proto.input(j)) != constBlobs.end())

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -200,12 +200,12 @@ LayerParams ONNXImporter::getLayerParams(const opencv_onnx::NodeProto& node_prot
 
         if(attribute_name == "kernel_shape")
         {
-            CV_Assert(attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+            CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
             lp.set("kernel_size", parse(attribute_proto.ints()));
         }
         else if(attribute_name == "strides")
         {
-            CV_Assert(attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+            CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
             lp.set("stride", parse(attribute_proto.ints()));
         }
         else if(attribute_name == "pads")
@@ -229,7 +229,7 @@ LayerParams ONNXImporter::getLayerParams(const opencv_onnx::NodeProto& node_prot
             else
             {
                 // Convolution or pooling.
-                CV_Assert(attribute_proto.ints_size() == 4 || attribute_proto.ints_size() == 6);
+                CV_Assert(attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 4 || attribute_proto.ints_size() == 6);
                 lp.set("pad", parse(attribute_proto.ints()));
             }
         }
@@ -244,7 +244,7 @@ LayerParams ONNXImporter::getLayerParams(const opencv_onnx::NodeProto& node_prot
         }
         else if(attribute_name == "dilations")
         {
-            CV_Assert(attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+            CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
             lp.set("dilation", parse(attribute_proto.ints()));
         }
         else if (attribute_proto.has_i())
@@ -1185,6 +1185,12 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto_)
         else if (layer_type == "Conv")
         {
             CV_Assert(node_proto.input_size() >= 2);
+            if (layerParams.has("kernel_size")) {
+                const DictValue &kernel = layerParams.get("kernel_size");
+                if (kernel.size() == 1) {
+                    layerParams.set("is_1d", true);
+                }
+            }
             layerParams.type = "Convolution";
             for (int j = 1; j < node_proto.input_size(); j++) {
                 if (constBlobs.find(node_proto.input(j)) != constBlobs.end())

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -650,7 +650,7 @@ TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
 
 TEST_P(Test_ONNX_layers, Conv1d)
 {
-    if (backend != DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
+    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
         throw SkipTestException("Only OpenCV CPU is supported");
     testONNXModels("conv1d");
 }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -648,6 +648,11 @@ TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
     testONNXModels("resize_opset11_torch1.6");
 }
 
+TEST_P(Test_ONNX_layers, Conv1d)
+{
+    testONNXModels("conv1d");
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 
 class Test_ONNX_nets : public Test_ONNX_layers

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -650,6 +650,8 @@ TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
 
 TEST_P(Test_ONNX_layers, Conv1d)
 {
+    if (backend != DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
+        throw SkipTestException("Only OpenCV CPU is supported");
     testONNXModels("conv1d");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -183,9 +183,14 @@ TEST_P(Test_ONNX_layers, Convolution3D)
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2019010000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
-    if (target != DNN_TARGET_CPU)
-        throw SkipTestException("Only CPU is supported");
     testONNXModels("conv3d");
+}
+
+TEST_P(Test_ONNX_layers, Convolution3D_bias)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2019010000)
+    applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+#endif
     testONNXModels("conv3d_bias");
 }
 
@@ -650,17 +655,16 @@ TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
 
 TEST_P(Test_ONNX_layers, Conv1d)
 {
-    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
-        throw SkipTestException("Only OpenCV CPU is supported");
     testONNXModels("conv1d");
+}
+
+TEST_P(Test_ONNX_layers, Conv1d_bias)
+{
     testONNXModels("conv1d_bias");
 }
 
 TEST_P(Test_ONNX_layers, Conv1d_variable_weight)
 {
-    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
-        throw SkipTestException("Only OpenCV CPU is supported");
-
     String basename = "conv1d_variable_w";
     Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
     ASSERT_FALSE(net.empty());
@@ -681,9 +685,6 @@ TEST_P(Test_ONNX_layers, Conv1d_variable_weight)
 
 TEST_P(Test_ONNX_layers, Conv1d_variable_weight_bias)
 {
-    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
-        throw SkipTestException("Only OpenCV CPU is supported");
-
     String basename = "conv1d_variable_wb";
     Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
     ASSERT_FALSE(net.empty());

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -653,6 +653,55 @@ TEST_P(Test_ONNX_layers, Conv1d)
     if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
         throw SkipTestException("Only OpenCV CPU is supported");
     testONNXModels("conv1d");
+    testONNXModels("conv1d_bias");
+}
+
+TEST_P(Test_ONNX_layers, Conv1d_variable_weight)
+{
+    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
+        throw SkipTestException("Only OpenCV CPU is supported");
+
+    String basename = "conv1d_variable_w";
+    Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
+    ASSERT_FALSE(net.empty());
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    Mat input = blobFromNPY(_tf("data/input_" + basename + "_0.npy"));
+    Mat weights = blobFromNPY(_tf("data/input_" + basename + "_1.npy"));
+    Mat ref = blobFromNPY(_tf("data/output_" + basename + ".npy"));
+
+    net.setInput(input, "0");
+    net.setInput(weights, "1");
+
+    Mat out = net.forward();
+    normAssert(ref, out, "", default_l1, default_lInf);
+}
+
+TEST_P(Test_ONNX_layers, Conv1d_variable_weight_bias)
+{
+    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
+        throw SkipTestException("Only OpenCV CPU is supported");
+
+    String basename = "conv1d_variable_wb";
+    Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
+    ASSERT_FALSE(net.empty());
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    Mat input = blobFromNPY(_tf("data/input_" + basename + "_0.npy"));
+    Mat weights = blobFromNPY(_tf("data/input_" + basename + "_1.npy"));
+    Mat bias = blobFromNPY(_tf("data/input_" + basename + "_2.npy"));
+    Mat ref = blobFromNPY(_tf("data/output_" + basename + ".npy"));
+
+    net.setInput(input, "0");
+    net.setInput(weights, "1");
+    net.setInput(bias, "bias");
+
+    Mat out = net.forward();
+    normAssert(ref, out, "", default_l1, default_lInf);
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -173,8 +173,6 @@ TEST_P(Test_TensorFlow_layers, Convolution3D)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);  // Only CPU on DLIE backend is supported
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target != DNN_TARGET_CPU)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);  // Only CPU on DLIE backend is supported
-    if (target != DNN_TARGET_CPU)
-        throw SkipTestException("Only CPU is supported");
     runTensorFlowNet("conv3d");
 }
 


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/18205

**merge with extra:** https://github.com/opencv/opencv_extra/pull/813
<cut/>

```
opencv_extra=test_conv1d

force_builders=Custom,Custom Win,Custom Mac

Xbuildworker:Custom=linux-3
Xbuild_image:Custom=ubuntu:18.04
XCPU_BASELINE:Custom=AVX512_SKX
Xdisable_ipp:Custom=ON

build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```