### PR TITLE
[G-API]: fitLine() Standard Kernel Implementation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -234,6 +234,50 @@ namespace imgproc {
         }
     };
 
+    G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine2DMat") {
+        static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
+            GAPI_Assert(in.isVectorPoints(2, -1));
+            return empty_gopaque_desc();
+        }
+    };
+
+    G_TYPED_KERNEL(GFitLine2DVector32S, <GOpaque<Vec4f>(GArray<Point2i>,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine2DVector32S") {
+        static GOpaqueDesc outMeta(GArrayDesc,int,double,double,double) {
+            return empty_gopaque_desc();
+        }
+    };
+
+    G_TYPED_KERNEL(GFitLine2DVector32F, <GOpaque<Vec4f>(GArray<Point2f>,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine2DVector32F") {
+        static GOpaqueDesc outMeta(GArrayDesc,int,double,double,double) {
+            return empty_gopaque_desc();
+        }
+    };
+
+    G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine3DMat") {
+        static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
+            GAPI_Assert(in.isVectorPoints(3, -1));
+            return empty_gopaque_desc();
+        }
+    };
+
+    G_TYPED_KERNEL(GFitLine3DVector32S, <GOpaque<Vec6f>(GArray<Point3i>,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine3DVector32S") {
+        static GOpaqueDesc outMeta(GArrayDesc,int,double,double,double) {
+            return empty_gopaque_desc();
+        }
+    };
+
+    G_TYPED_KERNEL(GFitLine3DVector32F, <GOpaque<Vec6f>(GArray<Point3f>,int,double,double,double)>,
+                   "org.opencv.imgproc.shape.fitLine3DVector32F") {
+        static GOpaqueDesc outMeta(GArrayDesc,int,double,double,double) {
+            return empty_gopaque_desc();
+        }
+    };
+
     G_TYPED_KERNEL(GBGR2RGB, <GMat(GMat)>, "org.opencv.imgproc.colorconvert.bgr2rgb") {
         static GMatDesc outMeta(GMatDesc in) {
             return in; // type still remains CV_8UC3;
@@ -1110,6 +1154,133 @@ Calculates the up-right bounding rectangle of a point set.
 @param src Input 2D point set, stored in std::vector<cv::Point2f>.
  */
 GAPI_EXPORTS GOpaque<Rect> boundingRect(const GArray<Point2f>& src);
+
+/** @brief Fits a line to a 2D point set.
+
+The function fits a line to a 2D point set by minimizing \f$\sum_i \rho(r_i)\f$ where
+\f$r_i\f$ is a distance between the \f$i^{th}\f$ point, the line and \f$\rho(r)\f$ is a distance
+function, one of the following:
+-  DIST_L2
+\f[\rho (r) = r^2/2  \quad \text{(the simplest and the fastest least-squares method)}\f]
+- DIST_L1
+\f[\rho (r) = r\f]
+- DIST_L12
+\f[\rho (r) = 2  \cdot ( \sqrt{1 + \frac{r^2}{2}} - 1)\f]
+- DIST_FAIR
+\f[\rho \left (r \right ) = C^2  \cdot \left (  \frac{r}{C} -  \log{\left(1 + \frac{r}{C}\right)} \right )  \quad \text{where} \quad C=1.3998\f]
+- DIST_WELSCH
+\f[\rho \left (r \right ) =  \frac{C^2}{2} \cdot \left ( 1 -  \exp{\left(-\left(\frac{r}{C}\right)^2\right)} \right )  \quad \text{where} \quad C=2.9846\f]
+- DIST_HUBER
+\f[\rho (r) =  \fork{r^2/2}{if \(r < C\)}{C \cdot (r-C/2)}{otherwise} \quad \text{where} \quad C=1.345\f]
+
+The algorithm is based on the M-estimator ( <http://en.wikipedia.org/wiki/M-estimator> ) technique
+that iteratively fits the line using the weighted least-squares algorithm. After each iteration the
+weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine2DMat"
+
+@param src Input set of 2D points stored in Mat.
+
+@note In case of a N-dimentional points' set given, Mat should be 2-dimensional, have a single row
+or column if there are N channels, or have N columns if there is a single channel.
+
+@param distType Distance used by the M-estimator, see #DistanceTypes. @ref DIST_USER
+and @ref DIST_C are not suppored.
+@param param Numerical parameter ( C ) for some types of distances. If it is 0, an optimal value
+is chosen.
+@param reps Sufficient accuracy for the radius (distance between the coordinate origin and the
+line). 1.0 would be a good default value for reps.
+@param aeps Sufficient accuracy for the angle. 0.01 would be a good default value for aeps.
+
+@return Output line parameters: a vector of 4 elements (like Vec4f) - (vx, vy, x0, y0),
+where (vx, vy) is a normalized vector collinear to the line and (x0, y0) is a point on the line.
+ */
+GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GMat& src, const int distType, const double param = 0.,
+                                      const double reps = 0., const double aeps = 0.);
+
+/** @overload
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine2DVector32S"
+
+@param src Input 2D point set, stored in std::vector<cv::Point2i>.
+ */
+GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const int distType,
+                                      const double param = 0., const double reps = 0.,
+                                      const double aeps = 0.);
+
+/** @overload
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine2DVector32F"
+
+@param src Input 2D point set, stored in std::vector<cv::Point2f>.
+ */
+GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const int distType,
+                                      const double param = 0., const double reps = 0.,
+                                      const double aeps = 0.);
+
+/** @brief Fits a line to a 3D point set.
+
+The function fits a line to a 3D point set by minimizing \f$\sum_i \rho(r_i)\f$ where
+\f$r_i\f$ is a distance between the \f$i^{th}\f$ point, the line and \f$\rho(r)\f$ is a distance
+function, one of the following:
+-  DIST_L2
+\f[\rho (r) = r^2/2  \quad \text{(the simplest and the fastest least-squares method)}\f]
+- DIST_L1
+\f[\rho (r) = r\f]
+- DIST_L12
+\f[\rho (r) = 2  \cdot ( \sqrt{1 + \frac{r^2}{2}} - 1)\f]
+- DIST_FAIR
+\f[\rho \left (r \right ) = C^2  \cdot \left (  \frac{r}{C} -  \log{\left(1 + \frac{r}{C}\right)} \right )  \quad \text{where} \quad C=1.3998\f]
+- DIST_WELSCH
+\f[\rho \left (r \right ) =  \frac{C^2}{2} \cdot \left ( 1 -  \exp{\left(-\left(\frac{r}{C}\right)^2\right)} \right )  \quad \text{where} \quad C=2.9846\f]
+- DIST_HUBER
+\f[\rho (r) =  \fork{r^2/2}{if \(r < C\)}{C \cdot (r-C/2)}{otherwise} \quad \text{where} \quad C=1.345\f]
+
+The algorithm is based on the M-estimator ( <http://en.wikipedia.org/wiki/M-estimator> ) technique
+that iteratively fits the line using the weighted least-squares algorithm. After each iteration the
+weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine3DMat"
+
+@param src Input set of 3D points stored in Mat.
+
+@note In case of a N-dimentional points' set given, Mat should be 2-dimensional, have a single row
+or column if there are N channels, or have N columns if there is a single channel.
+
+@param distType Distance used by the M-estimator, see #DistanceTypes. @ref DIST_USER
+and @ref DIST_C are not suppored.
+@param param Numerical parameter ( C ) for some types of distances. If it is 0, an optimal value
+is chosen.
+@param reps Sufficient accuracy for the radius (distance between the coordinate origin and the
+line). 1.0 would be a good default value for reps.
+@param aeps Sufficient accuracy for the angle. 0.01 would be a good default value for aeps.
+
+@return Output line parameters: a vector of 6 elements (like Vec6f) - (vx, vy, vz, x0, y0, z0),
+where (vx, vy, vz) is a normalized vector collinear to the line and (x0, y0, z0) is a point on
+the line.
+ */
+GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GMat& src, const int distType, const double param = 0.,
+                                      const double reps = 0., const double aeps = 0.);
+
+/** @overload
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine3DVector32S"
+
+@param src Input 3D point set, stored in std::vector<cv::Point3i>.
+ */
+GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const int distType,
+                                      const double param = 0., const double reps = 0.,
+                                      const double aeps = 0.);
+
+/** @overload
+
+@note Function textual ID is "org.opencv.imgproc.shape.fitLine3DVector32F"
+
+@param src Input 3D point set, stored in std::vector<cv::Point3f>.
+ */
+GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const int distType,
+                                      const double param = 0., const double reps = 0.,
+                                      const double aeps = 0.);
 
 //! @} gapi_shape
 

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -1199,7 +1199,8 @@ weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine2DMat"
 
-@param src Input set of 2D points stored in Mat.
+@param src Input set of 2D points stored in one of possible containers: Mat,
+std::vector<cv::Point2i>, std::vector<cv::Point2f>, std::vector<cv::Point2d>.
 
 @note In case of an N-dimentional points' set given, Mat should be 2-dimensional, have a single row
 or column if there are N channels, or have N columns if there is a single channel.
@@ -1224,7 +1225,6 @@ GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GMat& src, const DistanceTypes distT
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine2DVector32S"
 
-@param src Input 2D point set, stored in std::vector<cv::Point2i>.
  */
 GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,
@@ -1244,7 +1244,6 @@ GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const Distance
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine2DVector64F"
 
-@param src Input 2D point set, stored in std::vector<cv::Point2d>.
  */
 GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2d>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,
@@ -1274,7 +1273,8 @@ weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine3DMat"
 
-@param src Input set of 3D points stored in Mat.
+@param src Input set of 3D points stored in one of possible containers: Mat,
+std::vector<cv::Point3i>, std::vector<cv::Point3f>, std::vector<cv::Point3d>.
 
 @note In case of an N-dimentional points' set given, Mat should be 2-dimensional, have a single row
 or column if there are N channels, or have N columns if there is a single channel.
@@ -1300,7 +1300,6 @@ GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GMat& src, const DistanceTypes distT
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine3DVector32S"
 
-@param src Input 3D point set, stored in std::vector<cv::Point3i>.
  */
 GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,
@@ -1310,7 +1309,6 @@ GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const Distance
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine3DVector32F"
 
-@param src Input 3D point set, stored in std::vector<cv::Point3f>.
  */
 GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,
@@ -1320,7 +1318,6 @@ GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const Distance
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine3DVector64F"
 
-@param src Input 3D point set, stored in std::vector<cv::Point3d>.
  */
 GAPI_EXPORTS GOpaque<Vec6f> fitLine3D(const GArray<Point3d>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -1234,7 +1234,6 @@ GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const Distance
 
 @note Function textual ID is "org.opencv.imgproc.shape.fitLine2DVector32F"
 
-@param src Input 2D point set, stored in std::vector<cv::Point2f>.
  */
 GAPI_EXPORTS GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const DistanceTypes distType,
                                       const double param = 0., const double reps = 0.,

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -164,40 +164,52 @@ GOpaque<Rect> boundingRect(const GArray<Point2f>& src)
     return imgproc::GBoundingRectVector32F::on(src);
 }
 
-GOpaque<Vec4f> fitLine2D(const GMat& src, const int distType, const double param,
+GOpaque<Vec4f> fitLine2D(const GMat& src, const DistanceTypes distType, const double param,
                          const double reps, const double aeps)
 {
     return imgproc::GFitLine2DMat::on(src, distType, param, reps, aeps);
 }
 
-GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const int distType, const double param,
-                         const double reps, const double aeps)
+GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
 {
     return imgproc::GFitLine2DVector32S::on(src, distType, param, reps, aeps);
 }
 
-GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const int distType, const double param,
-                         const double reps, const double aeps)
+GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
 {
     return imgproc::GFitLine2DVector32F::on(src, distType, param, reps, aeps);
 }
 
-GOpaque<Vec6f> fitLine3D(const GMat& src, const int distType, const double param,
+GOpaque<Vec4f> fitLine2D(const GArray<Point2d>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
+{
+    return imgproc::GFitLine2DVector64F::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec6f> fitLine3D(const GMat& src, const DistanceTypes distType, const double param,
                          const double reps, const double aeps)
 {
     return imgproc::GFitLine3DMat::on(src, distType, param, reps, aeps);
 }
 
-GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const int distType, const double param,
-                         const double reps, const double aeps)
+GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
 {
     return imgproc::GFitLine3DVector32S::on(src, distType, param, reps, aeps);
 }
 
-GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const int distType, const double param,
-                         const double reps, const double aeps)
+GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
 {
     return imgproc::GFitLine3DVector32F::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec6f> fitLine3D(const GArray<Point3d>& src, const DistanceTypes distType,
+                         const double param, const double reps, const double aeps)
+{
+    return imgproc::GFitLine3DVector64F::on(src, distType, param, reps, aeps);
 }
 
 GMat BGR2RGB(const GMat& src)

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -164,6 +164,42 @@ GOpaque<Rect> boundingRect(const GArray<Point2f>& src)
     return imgproc::GBoundingRectVector32F::on(src);
 }
 
+GOpaque<Vec4f> fitLine2D(const GMat& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine2DMat::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec4f> fitLine2D(const GArray<Point2i>& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine2DVector32S::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec4f> fitLine2D(const GArray<Point2f>& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine2DVector32F::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec6f> fitLine3D(const GMat& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine3DMat::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec6f> fitLine3D(const GArray<Point3i>& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine3DVector32S::on(src, distType, param, reps, aeps);
+}
+
+GOpaque<Vec6f> fitLine3D(const GArray<Point3f>& src, const int distType, const double param,
+                         const double reps, const double aeps)
+{
+    return imgproc::GFitLine3DVector32F::on(src, distType, param, reps, aeps);
+}
+
 GMat BGR2RGB(const GMat& src)
 {
     return imgproc::GBGR2RGB::on(src);

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -285,6 +285,60 @@ GAPI_OCV_KERNEL(GCPUBoundingRectVector32F, cv::gapi::imgproc::GBoundingRectVecto
     }
 };
 
+GAPI_OCV_KERNEL(GCPUFitLine2DMat, cv::gapi::imgproc::GFitLine2DMat)
+{
+    static void run(const cv::Mat& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec4f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine2DVector32S, cv::gapi::imgproc::GFitLine2DVector32S)
+{
+    static void run(const std::vector<cv::Point2i>& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec4f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine2DVector32F, cv::gapi::imgproc::GFitLine2DVector32F)
+{
+    static void run(const std::vector<cv::Point2f>& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec4f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine3DMat, cv::gapi::imgproc::GFitLine3DMat)
+{
+    static void run(const cv::Mat& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec6f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine3DVector32S, cv::gapi::imgproc::GFitLine3DVector32S)
+{
+    static void run(const std::vector<cv::Point3i>& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec6f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine3DVector32F, cv::gapi::imgproc::GFitLine3DVector32F)
+{
+    static void run(const std::vector<cv::Point3f>& in, const int distType, const double param,
+                    const double reps, const double aeps, cv::Vec6f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
 GAPI_OCV_KERNEL(GCPUBGR2RGB, cv::gapi::imgproc::GBGR2RGB)
 {
     static void run(const cv::Mat& in, cv::Mat &out)
@@ -569,6 +623,12 @@ cv::gapi::GKernelPackage cv::gapi::imgproc::cpu::kernels()
         , GCPUBoundingRectMat
         , GCPUBoundingRectVector32S
         , GCPUBoundingRectVector32F
+        , GCPUFitLine2DMat
+        , GCPUFitLine2DVector32S
+        , GCPUFitLine2DVector32F
+        , GCPUFitLine3DMat
+        , GCPUFitLine3DVector32S
+        , GCPUFitLine3DVector32F
         , GCPUYUV2RGB
         , GCPUBGR2I420
         , GCPURGB2I420

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -287,7 +287,7 @@ GAPI_OCV_KERNEL(GCPUBoundingRectVector32F, cv::gapi::imgproc::GBoundingRectVecto
 
 GAPI_OCV_KERNEL(GCPUFitLine2DMat, cv::gapi::imgproc::GFitLine2DMat)
 {
-    static void run(const cv::Mat& in, const int distType, const double param,
+    static void run(const cv::Mat& in, const cv::DistanceTypes distType, const double param,
                     const double reps, const double aeps, cv::Vec4f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
@@ -296,8 +296,8 @@ GAPI_OCV_KERNEL(GCPUFitLine2DMat, cv::gapi::imgproc::GFitLine2DMat)
 
 GAPI_OCV_KERNEL(GCPUFitLine2DVector32S, cv::gapi::imgproc::GFitLine2DVector32S)
 {
-    static void run(const std::vector<cv::Point2i>& in, const int distType, const double param,
-                    const double reps, const double aeps, cv::Vec4f& out)
+    static void run(const std::vector<cv::Point2i>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec4f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
     }
@@ -305,8 +305,17 @@ GAPI_OCV_KERNEL(GCPUFitLine2DVector32S, cv::gapi::imgproc::GFitLine2DVector32S)
 
 GAPI_OCV_KERNEL(GCPUFitLine2DVector32F, cv::gapi::imgproc::GFitLine2DVector32F)
 {
-    static void run(const std::vector<cv::Point2f>& in, const int distType, const double param,
-                    const double reps, const double aeps, cv::Vec4f& out)
+    static void run(const std::vector<cv::Point2f>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec4f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine2DVector64F, cv::gapi::imgproc::GFitLine2DVector64F)
+{
+    static void run(const std::vector<cv::Point2d>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec4f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
     }
@@ -314,7 +323,7 @@ GAPI_OCV_KERNEL(GCPUFitLine2DVector32F, cv::gapi::imgproc::GFitLine2DVector32F)
 
 GAPI_OCV_KERNEL(GCPUFitLine3DMat, cv::gapi::imgproc::GFitLine3DMat)
 {
-    static void run(const cv::Mat& in, const int distType, const double param,
+    static void run(const cv::Mat& in, const cv::DistanceTypes distType, const double param,
                     const double reps, const double aeps, cv::Vec6f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
@@ -323,8 +332,8 @@ GAPI_OCV_KERNEL(GCPUFitLine3DMat, cv::gapi::imgproc::GFitLine3DMat)
 
 GAPI_OCV_KERNEL(GCPUFitLine3DVector32S, cv::gapi::imgproc::GFitLine3DVector32S)
 {
-    static void run(const std::vector<cv::Point3i>& in, const int distType, const double param,
-                    const double reps, const double aeps, cv::Vec6f& out)
+    static void run(const std::vector<cv::Point3i>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec6f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
     }
@@ -332,8 +341,17 @@ GAPI_OCV_KERNEL(GCPUFitLine3DVector32S, cv::gapi::imgproc::GFitLine3DVector32S)
 
 GAPI_OCV_KERNEL(GCPUFitLine3DVector32F, cv::gapi::imgproc::GFitLine3DVector32F)
 {
-    static void run(const std::vector<cv::Point3f>& in, const int distType, const double param,
-                    const double reps, const double aeps, cv::Vec6f& out)
+    static void run(const std::vector<cv::Point3f>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec6f& out)
+    {
+        cv::fitLine(in, out, distType, param, reps, aeps);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUFitLine3DVector64F, cv::gapi::imgproc::GFitLine3DVector64F)
+{
+    static void run(const std::vector<cv::Point3d>& in, const cv::DistanceTypes distType,
+                    const double param, const double reps, const double aeps, cv::Vec6f& out)
     {
         cv::fitLine(in, out, distType, param, reps, aeps);
     }
@@ -626,9 +644,11 @@ cv::gapi::GKernelPackage cv::gapi::imgproc::cpu::kernels()
         , GCPUFitLine2DMat
         , GCPUFitLine2DVector32S
         , GCPUFitLine2DVector32F
+        , GCPUFitLine2DVector64F
         , GCPUFitLine3DMat
         , GCPUFitLine3DVector32S
         , GCPUFitLine3DVector32F
+        , GCPUFitLine3DVector64F
         , GCPUYUV2RGB
         , GCPUBGR2I420
         , GCPURGB2I420

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -83,6 +83,22 @@ GAPI_TEST_FIXTURE(BoundingRectVector32STest, initNothing, FIXTURE_API(CompareRec
 GAPI_TEST_FIXTURE(BoundingRectVector32FTest, initNothing, FIXTURE_API(CompareRects), 1, cmpF)
 GAPI_TEST_FIXTURE(BGR2RGBTest, initMatrixRandN, FIXTURE_API(CompareMats), 1, cmpF)
 GAPI_TEST_FIXTURE(RGB2GrayTest, initMatrixRandN, FIXTURE_API(CompareMats), 1, cmpF)
+GAPI_TEST_FIXTURE(FitLine2DMatVectorTest, initMatByPointsVectorRandU<cv::Point_>,
+                  FIXTURE_API(CompareVecs<float, 4>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine2DVector32STest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 4>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine2DVector32FTest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 4>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine2DVector64FTest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 4>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine3DMatVectorTest, initMatByPointsVectorRandU<cv::Point3_>,
+                  FIXTURE_API(CompareVecs<float, 6>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine3DVector32STest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 6>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine3DVector32FTest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 6>,cv::DistanceTypes), 2, cmpF, distType)
+GAPI_TEST_FIXTURE(FitLine3DVector64FTest, initNothing,
+                  FIXTURE_API(CompareVecs<float, 6>,cv::DistanceTypes), 2, cmpF, distType)
 GAPI_TEST_FIXTURE(BGR2GrayTest, initMatrixRandN, FIXTURE_API(CompareMats), 1, cmpF)
 GAPI_TEST_FIXTURE(RGB2YUVTest, initMatrixRandN, FIXTURE_API(CompareMats), 1, cmpF)
 GAPI_TEST_FIXTURE(BGR2I420Test, initMatrixRandN, FIXTURE_API(CompareMats), 1, cmpF)

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -752,6 +752,192 @@ TEST_P(BoundingRectVector32FTest, AccuracyTest)
     }
 }
 
+TEST_P(FitLine2DMatVectorTest, AccuracyTest)
+{
+    cv::Vec4f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_mat1, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine2DVector32STest, AccuracyTest)
+{
+    cv::Vec4f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point2i> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point2i> in;
+    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine2DVector32FTest, AccuracyTest)
+{
+    cv::Vec4f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point2f> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point2f> in;
+    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine2DVector64FTest, AccuracyTest)
+{
+    cv::Vec4f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point2d> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point2d> in;
+    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine3DMatVectorTest, AccuracyTest)
+{
+    cv::Vec6f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_mat1, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine3DVector32STest, AccuracyTest)
+{
+    cv::Vec6f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point3i> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point3i> in;
+    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine3DVector32FTest, AccuracyTest)
+{
+    cv::Vec6f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point3f> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point3f> in;
+    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
+TEST_P(FitLine3DVector64FTest, AccuracyTest)
+{
+    cv::Vec6f out_vec_gapi, out_vec_ocv;
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    std::vector<cv::Point3d> in_vec;
+    initPointsVectorRandU(sz.width, in_vec);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GArray<cv::Point3d> in;
+    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+    }
+}
+
 TEST_P(BGR2RGBTest, AccuracyTest)
 {
     // G-API code //////////////////////////////////////////////////////////////

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -78,16 +78,16 @@ namespace
     template <typename T> inline void initPointRandU(cv::RNG &rng, cv::Point_<T>& pt)
     {
         GAPI_Assert(std::is_integral<T>::value);
-        pt = cv::Point_<T>(static_cast<T>(rng(CHAR_MAX + 1U)),
-                           static_cast<T>(rng(CHAR_MAX + 1U)));
+        pt = cv::Point_<T>(static_cast<T>(static_cast<char>(rng(CHAR_MAX + 1U))),
+                           static_cast<T>(static_cast<char>(rng(CHAR_MAX + 1U))));
     }
 
     template <typename T> inline void initPointRandU(cv::RNG &rng, cv::Point3_<T>& pt)
     {
         GAPI_Assert(std::is_integral<T>::value);
-        pt = cv::Point3_<T>(static_cast<T>(rng(CHAR_MAX + 1U)),
-                            static_cast<T>(rng(CHAR_MAX + 1U)),
-                            static_cast<T>(rng(CHAR_MAX + 1U)));
+        pt = cv::Point3_<T>(static_cast<T>(static_cast<char>(rng(CHAR_MAX + 1U))),
+                            static_cast<T>(static_cast<char>(rng(CHAR_MAX + 1U))),
+                            static_cast<T>(static_cast<char>(rng(CHAR_MAX + 1U))));
     }
 
     template <typename F> inline void initFloatPointRandU(cv::RNG &rng, cv::Point_<F> &pt)
@@ -331,10 +331,6 @@ public:
     template <typename T, template <typename> class Pt>
     void initPointsVectorRandU(const int sz_in, std::vector<Pt<T>> &vec_)
     {
-        bool is_Point_2D_or_3D = std::is_same<Pt<T>, cv::Point_ <T>>::value ||
-                                 std::is_same<Pt<T>, cv::Point3_<T>>::value;
-        GAPI_Assert(is_Point_2D_or_3D);
-
         cv::RNG& rng = theRNG();
 
         vec_.clear();

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -327,6 +327,11 @@ public:
     inline void initPointRandU(cv::RNG& rng, T& pt)
     { ::initPointRandU(rng, pt); }
 
+// Disable unreachable code warning for MSVS 2015
+#if defined _MSC_VER && _MSC_VER < 1910 /*MSVS 2017*/
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     // initialize std::vector<cv::Point_<T>>/std::vector<cv::Point3_<T>>
     template <typename T, template <typename> class Pt>
     void initPointsVectorRandU(const int sz_in, std::vector<Pt<T>> &vec_)
@@ -343,6 +348,9 @@ public:
             vec_.emplace_back(pt);
         }
     }
+#if defined _MSC_VER && _MSC_VER < 1910 /*MSVS 2017*/
+#pragma warning(pop)
+#endif
 
     template<typename Pt>
     inline void initMatByPointsVectorRandU(const cv::Size &sz_in)

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -343,23 +343,33 @@ INSTANTIATE_TEST_CASE_P(FitLine2DMatVectorTestCPU, FitLine2DMatVectorTest,
                                 Values(cv::Size(8, 0), cv::Size(1024, 0)),
                                 Values(-1),
                                 Values(IMGPROC_CPU),
-                                Values(AvgDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
                                 Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
                                        DIST_WELSCH, DIST_HUBER)));
 
-#define INSTANTIATE_FITLINE_2DVECTOR_TEST(type) INSTANTIATE_TEST_CASE_P(                      \
-                        FitLine2DVector##type##TestCPU,                                       \
-                        FitLine2DVector##type##Test,                                          \
-                        Combine(Values(-1),                                                   \
-                                Values(cv::Size(8, 0)),                                       \
-                                Values(-1),                                                   \
-                                Values(IMGPROC_CPU),                                          \
-                                Values(AvgDiffToleranceVec<float, 4>(0.01).to_compare_obj()), \
-                                Values(DIST_L1)))
+INSTANTIATE_TEST_CASE_P(FitLine2DVector32STestCPU, FitLine2DVector32STest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
 
-INSTANTIATE_FITLINE_2DVECTOR_TEST(32S);
-INSTANTIATE_FITLINE_2DVECTOR_TEST(32F);
-INSTANTIATE_FITLINE_2DVECTOR_TEST(64F);
+INSTANTIATE_TEST_CASE_P(FitLine2DVector32FTestCPU, FitLine2DVector32FTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
+
+INSTANTIATE_TEST_CASE_P(FitLine2DVector64FTestCPU, FitLine2DVector64FTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
 
 INSTANTIATE_TEST_CASE_P(FitLine3DMatVectorTestCPU, FitLine3DMatVectorTest,
                         Combine(Values(CV_8UC1, CV_8SC1, CV_16UC1, CV_16SC1,
@@ -367,23 +377,33 @@ INSTANTIATE_TEST_CASE_P(FitLine3DMatVectorTestCPU, FitLine3DMatVectorTest,
                                 Values(cv::Size(8, 0), cv::Size(1024, 0)),
                                 Values(-1),
                                 Values(IMGPROC_CPU),
-                                Values(AvgDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
                                 Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
                                        DIST_WELSCH, DIST_HUBER)));
 
-#define INSTANTIATE_FITLINE_3DVECTOR_TEST(type) INSTANTIATE_TEST_CASE_P(                      \
-                        FitLine3DVector##type##TestCPU,                                       \
-                        FitLine3DVector##type##Test,                                          \
-                        Combine(Values(-1),                                                   \
-                                Values(cv::Size(8, 0)),                                       \
-                                Values(-1),                                                   \
-                                Values(IMGPROC_CPU),                                          \
-                                Values(AvgDiffToleranceVec<float, 6>(0.01).to_compare_obj()), \
-                                Values(DIST_L1)))
+INSTANTIATE_TEST_CASE_P(FitLine3DVector32STestCPU, FitLine3DVector32STest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
 
-INSTANTIATE_FITLINE_3DVECTOR_TEST(32S);
-INSTANTIATE_FITLINE_3DVECTOR_TEST(32F);
-INSTANTIATE_FITLINE_3DVECTOR_TEST(64F);
+INSTANTIATE_TEST_CASE_P(FitLine3DVector32FTestCPU, FitLine3DVector32FTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
+
+INSTANTIATE_TEST_CASE_P(FitLine3DVector64FTestCPU, FitLine3DVector64FTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(8, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(DIST_L1)));
 
 INSTANTIATE_TEST_CASE_P(BGR2RGBTestCPU, BGR2RGBTest,
                         Combine(Values(CV_8UC3),

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -337,6 +337,54 @@ INSTANTIATE_TEST_CASE_P(BoundingRectVector32STestCPU, BoundingRectVector32STest,
                                  Values(IMGPROC_CPU),
                                  Values(IoUToleranceRect(1e-5).to_compare_obj())));
 
+INSTANTIATE_TEST_CASE_P(FitLine2DMatVectorTestCPU, FitLine2DMatVectorTest,
+                        Combine(Values(CV_8U, CV_8S, CV_16U, CV_16S,
+                                       CV_32S, CV_32F, CV_64F),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(AvgDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER)));
+
+#define INSTANTIATE_FITLINE_2DVECTOR_TEST(type) INSTANTIATE_TEST_CASE_P(                      \
+                        FitLine2DVector##type##TestCPU,                                       \
+                        FitLine2DVector##type##Test,                                          \
+                        Combine(Values(-1),                                                   \
+                                Values(cv::Size(8, 0)),                                       \
+                                Values(-1),                                                   \
+                                Values(IMGPROC_CPU),                                          \
+                                Values(AvgDiffToleranceVec<float, 4>(0.01).to_compare_obj()), \
+                                Values(DIST_L1)))
+
+INSTANTIATE_FITLINE_2DVECTOR_TEST(32S);
+INSTANTIATE_FITLINE_2DVECTOR_TEST(32F);
+INSTANTIATE_FITLINE_2DVECTOR_TEST(64F);
+
+INSTANTIATE_TEST_CASE_P(FitLine3DMatVectorTestCPU, FitLine3DMatVectorTest,
+                        Combine(Values(CV_8UC1, CV_8SC1, CV_16UC1, CV_16SC1,
+                                       CV_32SC1, CV_32FC1, CV_64FC1),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(-1),
+                                Values(IMGPROC_CPU),
+                                Values(AvgDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER)));
+
+#define INSTANTIATE_FITLINE_3DVECTOR_TEST(type) INSTANTIATE_TEST_CASE_P(                      \
+                        FitLine3DVector##type##TestCPU,                                       \
+                        FitLine3DVector##type##Test,                                          \
+                        Combine(Values(-1),                                                   \
+                                Values(cv::Size(8, 0)),                                       \
+                                Values(-1),                                                   \
+                                Values(IMGPROC_CPU),                                          \
+                                Values(AvgDiffToleranceVec<float, 6>(0.01).to_compare_obj()), \
+                                Values(DIST_L1)))
+
+INSTANTIATE_FITLINE_3DVECTOR_TEST(32S);
+INSTANTIATE_FITLINE_3DVECTOR_TEST(32F);
+INSTANTIATE_FITLINE_3DVECTOR_TEST(64F);
+
 INSTANTIATE_TEST_CASE_P(BGR2RGBTestCPU, BGR2RGBTest,
                         Combine(Values(CV_8UC3),
                                 Values(cv::Size(1280, 720),


### PR DESCRIPTION
These changes:

 - Add `fitLine()` standard kernel
   - provide API and documentation:
     - to support all the original OpenCV functionality, provide two different API (for 2D and 3D points) with several overloads for both (for input `cv::GMat`, `cv::GArray<Point{2,3}i>`, `cv::GArray<Point{2,3}f>`, `cv::GArray<Point{2,3}d>`)
   - support OCV backend
   - provide accuracy tests
- comparison function for `cv::Vec<T, n>` provided
 ### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```