### PR TITLE
G-API: Introduce runtime in-graph metadata

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -57,6 +57,7 @@ file(GLOB gapi_ext_hdrs
 
 set(gapi_srcs
     # Front-end part
+    src/api/grunarg.cpp
     src/api/gorigin.cpp
     src/api/gmat.cpp
     src/api/garray.cpp
@@ -131,18 +132,19 @@ set(gapi_srcs
     src/backends/ie/giebackend.cpp
     src/backends/ie/giebackend/giewrapper.cpp
 
-    # ONNX Backend.
+    # ONNX backend
     src/backends/onnx/gonnxbackend.cpp
 
-    # Render Backend.
+    # Render backend
     src/backends/render/grenderocv.cpp
     src/backends/render/ft_render.cpp
 
-    #PlaidML Backend
+    # PlaidML Backend
     src/backends/plaidml/gplaidmlcore.cpp
     src/backends/plaidml/gplaidmlbackend.cpp
 
-    # Compound
+    # Common backend code
+    src/backends/common/gmetabackend.cpp
     src/backends/common/gcompoundbackend.cpp
     src/backends/common/gcompoundkernel.cpp
 

--- a/modules/gapi/include/opencv2/gapi/gopaque.hpp
+++ b/modules/gapi/include/opencv2/gapi/gopaque.hpp
@@ -15,6 +15,7 @@
 #include <opencv2/gapi/own/exports.hpp>
 #include <opencv2/gapi/opencv_includes.hpp>
 
+#include <opencv2/gapi/util/any.hpp>
 #include <opencv2/gapi/util/variant.hpp>
 #include <opencv2/gapi/util/throw.hpp>
 #include <opencv2/gapi/util/type_traits.hpp>
@@ -119,6 +120,7 @@ namespace detail
 
         virtual void mov(BasicOpaqueRef &ref) = 0;
         virtual const void* ptr() const = 0;
+        virtual void set(const cv::util::any &a) = 0;
     };
 
     template<typename T> class OpaqueRefT final: public BasicOpaqueRef
@@ -212,6 +214,10 @@ namespace detail
         }
 
         virtual const void* ptr() const override { return &rref(); }
+
+        virtual void set(const cv::util::any &a) {
+            wref() = util::any_cast<T>(a);
+        }
     };
 
     // This class strips type information from OpaqueRefT<> and makes it usable
@@ -285,6 +291,13 @@ namespace detail
 
         // May be used to uniquely identify this object internally
         const void *ptr() const { return m_ref->ptr(); }
+
+        // Introduced for in-graph meta handling
+        OpaqueRef& operator= (const cv::util::any &a)
+        {
+            m_ref->set(a);
+            return *this;
+        }
     };
 } // namespace detail
 

--- a/modules/gapi/include/opencv2/gapi/gopaque.hpp
+++ b/modules/gapi/include/opencv2/gapi/gopaque.hpp
@@ -215,7 +215,7 @@ namespace detail
 
         virtual const void* ptr() const override { return &rref(); }
 
-        virtual void set(const cv::util::any &a) {
+        virtual void set(const cv::util::any &a) override {
             wref() = util::any_cast<T>(a);
         }
     };

--- a/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
@@ -21,9 +21,11 @@
  * Note for developers: please don't put videoio dependency in G-API
  * because of this file.
  */
+#include <chrono>
 
 #include <opencv2/videoio.hpp>
 #include <opencv2/gapi/garg.hpp>
+#include <opencv2/gapi/streaming/meta.hpp>
 
 namespace cv {
 namespace gapi {
@@ -55,6 +57,7 @@ protected:
     cv::VideoCapture cap;
     cv::Mat first;
     bool first_pulled = false;
+    int64_t counter = 0;
 
     void prep()
     {
@@ -80,19 +83,26 @@ protected:
             GAPI_Assert(!first.empty());
             first_pulled = true;
             data = first; // no need to clone here since it was cloned already
-            return true;
         }
-
-        if (!cap.isOpened()) return false;
-
-        cv::Mat frame;
-        if (!cap.read(frame))
+        else
         {
-            // end-of-stream happened
-            return false;
+            if (!cap.isOpened()) return false;
+
+            cv::Mat frame;
+            if (!cap.read(frame))
+            {
+                // end-of-stream happened
+                return false;
+            }
+            // Same reason to clone as in prep()
+            data = frame.clone();
         }
-        // Same reason to clone as in prep()
-        data = frame.clone();
+        // Tag data with seq_id/ts
+        const auto now = std::chrono::system_clock::now();
+        const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>
+            (now.time_since_epoch());
+        data.meta[cv::gapi::streaming::meta_tag::timestamp] = int64_t{dur.count()};
+        data.meta[cv::gapi::streaming::meta_tag::seq_id]    = int64_t{counter++};
         return true;
     }
 

--- a/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
@@ -99,7 +99,7 @@ protected:
         }
         // Tag data with seq_id/ts
         const auto now = std::chrono::system_clock::now();
-        const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>
+        const auto dur = std::chrono::duration_cast<std::chrono::microseconds>
             (now.time_since_epoch());
         data.meta[cv::gapi::streaming::meta_tag::timestamp] = int64_t{dur.count()};
         data.meta[cv::gapi::streaming::meta_tag::seq_id]    = int64_t{counter++};

--- a/modules/gapi/include/opencv2/gapi/streaming/meta.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/meta.hpp
@@ -1,0 +1,79 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+
+#ifndef OPENCV_GAPI_GSTREAMING_META_HPP
+#define OPENCV_GAPI_GSTREAMING_META_HPP
+
+#include <opencv2/gapi/gopaque.hpp>
+#include <opencv2/gapi/gcall.hpp>
+#include <opencv2/gapi/gkernel.hpp>
+#include <opencv2/gapi/gtype_traits.hpp>
+
+namespace cv {
+namespace gapi {
+namespace streaming {
+
+// FIXME: the name is debatable
+namespace meta_tag {
+static constexpr const char * timestamp = "org.opencv.gapi.meta.timestamp";
+static constexpr const char * seq_id    = "org.opencv.gapi.meta.seq_id";
+} // namespace meta_tag
+
+namespace detail {
+struct GMeta {
+    static const char *id() {
+        return "org.opencv.streaming.meta";
+    }
+    // An universal yield for meta(), same as in GDesync
+    template<typename... R, int... IIs>
+    static std::tuple<R...> yield(cv::GCall &call, cv::detail::Seq<IIs...>) {
+        return std::make_tuple(cv::detail::Yield<R>::yield(call, IIs)...);
+    }
+    // Also an universal outMeta stub here
+    static GMetaArgs getOutMeta(const GMetaArgs &args, const GArgs &) {
+        return args;
+    }
+};
+} // namespace detail
+
+template<typename T, typename G>
+cv::GOpaque<T> meta(G g, const std::string &tag) {
+    using O = cv::GOpaque<T>;
+    cv::GKernel k{
+          detail::GMeta::id()                    // kernel id
+        , tag                                    // kernel tag. Use meta tag here
+        , &detail::GMeta::getOutMeta             // outMeta callback
+        , {cv::detail::GTypeTraits<O>::shape}    // output Shape
+        , {cv::detail::GTypeTraits<G>::op_kind}  // input data kinds
+        , {cv::detail::GObtainCtor<O>::get()}    // output template ctors
+    };
+    cv::GCall call(std::move(k));
+    call.pass(g);
+    return std::get<0>(detail::GMeta::yield<O>(call, cv::detail::MkSeq<1>::type()));
+}
+
+template<typename G>
+cv::GOpaque<int64_t> timestamp(G g) {
+    return meta<int64_t>(g, meta_tag::timestamp);
+}
+
+template<typename G>
+cv::GOpaque<int64_t> seq_id(G g) {
+    return meta<int64_t>(g, meta_tag::seq_id);
+}
+
+template<typename G>
+cv::GOpaque<int64_t> seqNo(G g) {
+    // Old name, compatibility only
+    return seqNo(g);
+}
+
+} // namespace streaming
+} // namespace gapi
+} // namespace cv
+
+#endif // OPENCV_GAPI_GSTREAMING_DESYNC_HPP

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -143,6 +143,14 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, HandleRMat handle
         if (handleRMat == HandleRMat::SKIP) return;
         GAPI_Assert(arg.index() == GRunArg::index_of<cv::RMat>());
         bindRMat(mag, rc, util::get<cv::RMat>(arg), RMat::Access::R);
+
+        // FIXME: Here meta may^WILL be copied multiple times!
+        // Replace it is reference-counted object?
+        mag.meta<cv::RMat>()[rc.id] = arg.meta;
+        mag.meta<cv::Mat>()[rc.id] = arg.meta;
+#if !defined(GAPI_STANDALONE)
+        mag.meta<cv::UMat>()[rc.id] = arg.meta;
+#endif
         break;
     }
 
@@ -154,19 +162,23 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, HandleRMat handle
         case GRunArg::index_of<cv::Scalar>() : mag_scalar = util::get<cv::Scalar>(arg);    break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
+        mag.meta<cv::Scalar>()[rc.id] = arg.meta;
         break;
     }
 
     case GShape::GARRAY:
-        mag.template slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg);
+        mag.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg);
+        mag.meta<cv::detail::VectorRef>()[rc.id] = arg.meta;
         break;
 
     case GShape::GOPAQUE:
-        mag.template slot<cv::detail::OpaqueRef>()[rc.id] = util::get<cv::detail::OpaqueRef>(arg);
+        mag.slot<cv::detail::OpaqueRef>()[rc.id] = util::get<cv::detail::OpaqueRef>(arg);
+        mag.meta<cv::detail::OpaqueRef>()[rc.id] = arg.meta;
         break;
 
     case GShape::GFRAME:
-        mag.template slot<cv::MediaFrame>()[rc.id] = util::get<cv::MediaFrame>(arg);
+        mag.slot<cv::MediaFrame>()[rc.id] = util::get<cv::MediaFrame>(arg);
+        mag.meta<cv::MediaFrame>()[rc.id] = arg.meta;
         break;
 
     default:
@@ -250,13 +262,23 @@ cv::GRunArg getArg(const Mag& mag, const RcDesc &ref)
     // Wrap associated CPU object (either host or an internal one)
     switch (ref.shape)
     {
-    case GShape::GMAT:    return GRunArg(mag.template slot<cv::RMat>().at(ref.id));
-    case GShape::GSCALAR: return GRunArg(mag.template slot<cv::Scalar>().at(ref.id));
+    case GShape::GMAT:
+        return GRunArg(mag.slot<cv::RMat>().at(ref.id),
+                       mag.meta<cv::RMat>().at(ref.id));
+    case GShape::GSCALAR:
+        return GRunArg(mag.slot<cv::Scalar>().at(ref.id),
+                       mag.meta<cv::Scalar>().at(ref.id));
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
-    case GShape::GARRAY:  return GRunArg(mag.template slot<cv::detail::VectorRef>().at(ref.id));
-    case GShape::GOPAQUE: return GRunArg(mag.template slot<cv::detail::OpaqueRef>().at(ref.id));
-    case GShape::GFRAME:  return GRunArg(mag.template slot<cv::MediaFrame>().at(ref.id));
+    case GShape::GARRAY:
+        return GRunArg(mag.slot<cv::detail::VectorRef>().at(ref.id),
+                       mag.meta<cv::detail::VectorRef>().at(ref.id));
+    case GShape::GOPAQUE:
+        return GRunArg(mag.slot<cv::detail::OpaqueRef>().at(ref.id),
+                       mag.meta<cv::detail::OpaqueRef>().at(ref.id));
+    case GShape::GFRAME:
+        return GRunArg(mag.slot<cv::MediaFrame>().at(ref.id),
+                       mag.meta<cv::MediaFrame>().at(ref.id));
     default:
         util::throw_error(std::logic_error("Unsupported GShape type"));
         break;

--- a/modules/gapi/src/api/grunarg.cpp
+++ b/modules/gapi/src/api/grunarg.cpp
@@ -1,0 +1,33 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+#include "precomp.hpp"
+#include <opencv2/gapi/garg.hpp>
+
+cv::GRunArg::GRunArg() {
+}
+
+cv::GRunArg::GRunArg(const cv::GRunArg &arg)
+    : cv::GRunArgBase(static_cast<const cv::GRunArgBase&>(arg))
+    , meta(arg.meta) {
+}
+
+cv::GRunArg::GRunArg(cv::GRunArg &&arg)
+    : cv::GRunArgBase(std::move(static_cast<const cv::GRunArgBase&>(arg)))
+    , meta(std::move(arg.meta)) {
+}
+
+cv::GRunArg& cv::GRunArg::operator= (const cv::GRunArg &arg) {
+    cv::GRunArgBase::operator=(static_cast<const cv::GRunArgBase&>(arg));
+    meta = arg.meta;
+    return *this;
+}
+
+cv::GRunArg& cv::GRunArg::operator= (cv::GRunArg &&arg) {
+    cv::GRunArgBase::operator=(std::move(static_cast<const cv::GRunArgBase&>(arg)));
+    meta = std::move(arg.meta);
+    return *this;
+}

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -48,6 +48,8 @@ namespace magazine {
     template<typename... Ts> struct Class
     {
         template<typename T> using MapT = std::unordered_map<int, T>;
+        using MapM = std::unordered_map<int, GRunArg::Meta>;
+
         template<typename T>       MapT<T>& slot()
         {
             return std::get<ade::util::type_list_index<T, Ts...>::value>(slots);
@@ -56,8 +58,17 @@ namespace magazine {
         {
             return std::get<ade::util::type_list_index<T, Ts...>::value>(slots);
         }
+        template<typename T> MapM& meta()
+        {
+            return metas[ade::util::type_list_index<T, Ts...>::value];
+        }
+        template<typename T> const MapM& meta() const
+        {
+            return metas[ade::util::type_list_index<T, Ts...>::value];
+        }
     private:
         std::tuple<MapT<Ts>...> slots;
+        std::array<MapM, sizeof...(Ts)> metas;
     };
 
 } // namespace magazine

--- a/modules/gapi/src/backends/common/gmetabackend.cpp
+++ b/modules/gapi/src/backends/common/gmetabackend.cpp
@@ -1,0 +1,105 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019-2020 Intel Corporation
+
+#include "precomp.hpp"
+
+#include <opencv2/gapi/gcommon.hpp>        // compile args
+#include <opencv2/gapi/util/any.hpp>       // any
+#include <opencv2/gapi/streaming/meta.hpp> // GMeta
+
+#include "compiler/gobjref.hpp"            // RcDesc
+#include "compiler/gmodel.hpp"             // GModel, Op
+#include "backends/common/gbackend.hpp"
+#include "api/gbackend_priv.hpp" // FIXME: Make it part of Backend SDK!
+
+#include "backends/common/gmetabackend.hpp"
+
+namespace {
+
+class GraphMetaExecutable final: public cv::gimpl::GIslandExecutable {
+    std::string m_meta_tag;
+
+public:
+    GraphMetaExecutable(const ade::Graph& g,
+                        const std::vector<ade::NodeHandle>& nodes);
+    bool canReshape() const override;
+    void reshape(ade::Graph&, const cv::GCompileArgs&) override;
+
+    void run(std::vector<InObj> &&input_objs,
+             std::vector<OutObj> &&output_objs) override;
+};
+
+bool GraphMetaExecutable::canReshape() const {
+    return true;
+}
+void GraphMetaExecutable::reshape(ade::Graph&, const cv::GCompileArgs&) {
+    // do nothing here
+}
+
+GraphMetaExecutable::GraphMetaExecutable(const ade::Graph& g,
+                                         const std::vector<ade::NodeHandle>& nodes) {
+    // There may be only one node in the graph
+    GAPI_Assert(nodes.size() == 1u);
+
+    cv::gimpl::GModel::ConstGraph cg(g);
+    const auto &op = cg.metadata(nodes[0]).get<cv::gimpl::Op>();
+    GAPI_Assert(op.k.name == cv::gapi::streaming::detail::GMeta::id());
+    m_meta_tag = op.k.tag;
+}
+
+void GraphMetaExecutable::run(std::vector<InObj>  &&input_objs,
+                              std::vector<OutObj> &&output_objs) {
+    GAPI_Assert(input_objs.size() == 1u);
+    GAPI_Assert(output_objs.size() == 1u);
+
+    const cv::GRunArg in_arg = input_objs[0].second;
+    cv::GRunArgP out_arg = output_objs[0].second;
+
+    auto it = in_arg.meta.find(m_meta_tag);
+    if (it == in_arg.meta.end()) {
+        cv::util::throw_error
+            (std::logic_error("Run-time meta "
+                              + m_meta_tag
+                              + " is not found in object "
+                              + std::to_string(static_cast<int>(input_objs[0].first.shape))
+                              + "/"
+                              + std::to_string(input_objs[0].first.id)));
+    }
+    cv::util::get<cv::detail::OpaqueRef>(out_arg) = it->second;
+}
+
+class GraphMetaBackendImpl final: public cv::gapi::GBackend::Priv {
+    virtual void unpackKernel(ade::Graph            &,
+                              const ade::NodeHandle &,
+                              const cv::GKernelImpl &) override {
+        // Do nothing here
+    }
+
+    virtual EPtr compile(const ade::Graph& graph,
+                         const cv::GCompileArgs&,
+                         const std::vector<ade::NodeHandle>& nodes,
+                         const std::vector<cv::gimpl::Data>&,
+                         const std::vector<cv::gimpl::Data>&) const override {
+        return EPtr{new GraphMetaExecutable(graph, nodes)};
+    }
+};
+
+cv::gapi::GBackend graph_meta_backend() {
+    static cv::gapi::GBackend this_backend(std::make_shared<GraphMetaBackendImpl>());
+    return this_backend;
+}
+
+struct InGraphMetaKernel final: public cv::detail::KernelTag {
+    using API = cv::gapi::streaming::detail::GMeta;
+    static cv::gapi::GBackend backend() { return graph_meta_backend(); }
+    static int                kernel()  { return 42; }
+};
+
+} // anonymous namespace
+
+cv::gapi::GKernelPackage cv::gimpl::meta::kernels() {
+    return cv::gapi::kernels<InGraphMetaKernel>();
+}

--- a/modules/gapi/src/backends/common/gmetabackend.hpp
+++ b/modules/gapi/src/backends/common/gmetabackend.hpp
@@ -1,0 +1,16 @@
+#ifndef OPENCV_GAPI_SRC_COMMON_META_BACKEND_HPP
+#define OPENCV_GAPI_SRC_COMMON_META_BACKEND_HPP
+
+#include <opencv2/gapi/gkernel.hpp>
+
+namespace cv {
+namespace gimpl {
+namespace meta {
+
+cv::gapi::GKernelPackage kernels();
+
+} // namespace meta
+} // namespace gimpl
+} // namespace cv
+
+#endif // OPENCV_GAPI_SRC_COMMON_META_BACKEND_HPP

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -35,6 +35,7 @@
 #include "executor/gexecutor.hpp"
 #include "executor/gstreamingexecutor.hpp"
 #include "backends/common/gbackend.hpp"
+#include "backends/common/gmetabackend.hpp"
 
 // <FIXME:>
 #if !defined(GAPI_STANDALONE)
@@ -58,7 +59,8 @@ namespace
             for (const auto &b : pkg.backends()) {
                 aux_pkg = combine(aux_pkg, b.priv().auxiliaryKernels());
             }
-            return combine(pkg, aux_pkg);
+            // Always include built-in meta<> implementation
+            return combine(pkg, aux_pkg, cv::gimpl::meta::kernels());
         };
 
         auto has_use_only = cv::gapi::getCompileArg<cv::gapi::use_only>(args);

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -172,6 +172,10 @@ struct GIslandExecutable::IOutput: public GIslandExecutable::IODesc {
     virtual GRunArgP get(int idx) = 0;  // Allocate (wrap) a new data object for output idx
     virtual void post(GRunArgP&&) = 0;  // Release the object back to the framework (mark available)
     virtual void post(EndOfStream&&) = 0; // Post end-of-stream marker back to the framework
+
+    // Assign accumulated metadata to the given output object.
+    // This method can only be called after get() and before post().
+    virtual void meta(const GRunArgP&, const GRunArg::Meta &) = 0;
 };
 
 // GIslandEmitter - a backend-specific thing which feeds data into

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -171,7 +171,7 @@ void assignMetaStubExec(Mag& mag, const RcDesc &rc, const cv::GRunArg::Meta &met
     case GShape::GMAT:
         mag.meta<cv::Mat>() [rc.id] = meta;
         mag.meta<cv::RMat>()[rc.id] = meta;
-#if defined(GAPI_STANDALONE)
+#if !defined(GAPI_STANDALONE)
         mag.meta<cv::UMat>()[rc.id] = meta;
 #endif
         break;

--- a/modules/gapi/test/gapi_graph_meta_tests.cpp
+++ b/modules/gapi/test/gapi_graph_meta_tests.cpp
@@ -1,0 +1,116 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+#include <tuple>
+
+#include "test_precomp.hpp"
+#include "opencv2/gapi/streaming/meta.hpp"
+#include "opencv2/gapi/streaming/cap.hpp"
+
+namespace opencv_test {
+
+namespace {
+void initTestDataPath() {
+#ifndef WINRT
+    static bool initialized = false;
+    if (!initialized)
+    {
+        // Since G-API has no own test data (yet), it is taken from the common space
+        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
+        if (testDataPath != nullptr) {
+            cvtest::addDataSearchPath(testDataPath);
+            initialized = true;
+        }
+    }
+#endif // WINRT
+}
+} // anonymous namespace
+
+TEST(GraphMeta, Trad_AccessInput) {
+    cv::GMat in;
+    cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
+    cv::GOpaque<int> out2 = cv::gapi::streaming::meta<int>(in, "foo");
+    cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
+
+    cv::Mat in_mat = cv::Mat::eye(cv::Size(64, 64), CV_8UC1);
+    cv::Mat out_mat;
+    int out_meta = 0;
+
+    // manually set metadata in the input fields
+    auto inputs = cv::gin(in_mat);
+    inputs[0].meta["foo"] = 42;
+
+    graph.apply(std::move(inputs), cv::gout(out_mat, out_meta));
+    EXPECT_EQ(42, out_meta);
+}
+
+TEST(GraphMeta, Trad_AccessTmp) {
+    cv::GMat in;
+    cv::GMat tmp = cv::gapi::blur(in, cv::Size(3,3));
+    cv::GMat out1 = tmp+1;
+    cv::GOpaque<float> out2 = cv::gapi::streaming::meta<float>(tmp, "bar");
+    cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
+
+    cv::Mat in_mat = cv::Mat::eye(cv::Size(64, 64), CV_8UC1);
+    cv::Mat out_mat;
+    float out_meta = 0.f;
+
+    // manually set metadata in the input fields
+    auto inputs = cv::gin(in_mat);
+    inputs[0].meta["bar"] = 1.f;
+
+    graph.apply(std::move(inputs), cv::gout(out_mat, out_meta));
+    EXPECT_EQ(1.f, out_meta);
+}
+
+TEST(GraphMeta, Trad_AccessOutput) {
+    cv::GMat in;
+    cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
+    cv::GOpaque<std::string> out2 = cv::gapi::streaming::meta<std::string>(out1, "baz");
+    cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
+
+    cv::Mat in_mat = cv::Mat::eye(cv::Size(64, 64), CV_8UC1);
+    cv::Mat out_mat;
+    std::string out_meta;
+
+    // manually set metadata in the input fields
+    auto inputs = cv::gin(in_mat);
+
+    // NOTE: Assigning explicitly an std::string is important,
+    // otherwise a "const char*" will be stored and won't be
+    // translated properly by util::any since std::string is
+    // used within the graph.
+    inputs[0].meta["baz"] = std::string("opencv");
+
+    graph.apply(std::move(inputs), cv::gout(out_mat, out_meta));
+    EXPECT_EQ("opencv", out_meta);
+}
+
+TEST(GraphMeta, Streaming_AccessInput)
+{
+    initTestDataPath();
+
+    cv::GMat in;
+    cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
+    cv::GOpaque<int64_t> out2 = cv::gapi::streaming::seq_id(in);
+    cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
+
+    auto ccomp = graph.compileStreaming();
+    ccomp.setSource<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+    ccomp.start();
+
+    cv::Mat out_mat;
+    int64_t out_meta = 0;
+    int64_t expected_counter = 0;
+
+    while (ccomp.pull(cv::gout(out_mat, out_meta))) {
+        EXPECT_EQ(expected_counter, out_meta);
+        ++expected_counter;
+    }
+}
+
+
+} // namespace opencv_test


### PR DESCRIPTION
## Intro

This PR brings support of generic in-graph metadata in the G-API.
The metadata comes into graph with its input arguments and propagates through the graph then.

The main idea behind this metadata today is to tag every object with extra streaming-related info (e.g., a frame number and a timestamp) to allow app-side data synchronization when `streaming::desync()` feature is used (see tests).

## Overview of changes

* `cv::GRunArg` is not an alias over `variant<>` anymore, now it is a distinct type;
* `cv::GRunArg` is extended with a metadata dictionary;
* `cv::GCaptureSource` is extended to put the meta information to the captured frames;
* Introduced a generic `streaming::meta<T>(obj, str)` operation which accesses a metadata field `str` of object `obj` and of the given type `T`; its return value is `GOpaque<T>` which can be later used in the graph;
* Introduced an internal backend (in `backends/common`) which implements this generic `meta<>()` operation;
* Implemented a simple metadata propagation model at the `GExecutor`/`GStreamingExecutor` level. This is the most debatable part of the patch -- now asynchronous islands have to manage and post this metadata information for outputs on their own. However, there is a default implementation for the synchronous islands (which covers 100% of our public backends).

## Sporadic failures in desync* tests

There was an issue with some tests on desync failing in different configurations. The failing check compared number of frames received through the "main" path against the number of frames received through a "desynchronized" path, what in theory shouldn't happen.

The issue occurred due to the main path actually running _slower_ than a desync path on a particular machine or in a particular build configuration. Because of that, a desync path has got its "Stop" message earlier and broadcasted it down to the output queue while the "main" path was still busy. It led to terminating the streaming pipeline earlier that expected and that "counter mismatch" problem occurred because of that.

<cut/>

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.1.0:18.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```