### PR TITLE
Use in-place sort in stiching example

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -387,7 +387,7 @@ def main():
     focals = []
     for cam in cameras:
         focals.append(cam.focal)
-    sorted(focals)
+    focals.sort()
     if len(focals) % 2 == 1:
         warped_image_scale = focals[len(focals) // 2]
     else:


### PR DESCRIPTION
A small bugfix, closes #18650.

<cut/>

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
