### PR TITLE
samples: cmake: digits needs opencv_dnn module to build

### DIFF
--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ set(OPENCV_CPP_SAMPLES_REQUIRED_DEPS
   opencv_features2d
   opencv_calib3d
   opencv_stitching
+  opencv_dnn
   ${OPENCV_MODULES_PUBLIC}
   ${OpenCV_LIB_COMPONENTS})
 ocv_check_dependencies(${OPENCV_CPP_SAMPLES_REQUIRED_DEPS})


### PR DESCRIPTION
Intrudeced in commit 397ba2d9aafb5312e777ce2f886d7b568109e931:
add OpenCV sample for digit and text recongnition, and provide multiple OCR models.
https://github.com/opencv/opencv/commit/397ba2d9aafb5312e777ce2f886d7b568109e931

Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
