### PR TITLE
objc: fix std::string handling

### DIFF
--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -215,6 +215,13 @@
             "from_cpp": "[NSString stringWithUTF8String:%(n)s.c_str()]",
             "swift_type": "String"
         },
+        "string": {
+            "cast_to": "std::string",
+            "objc_type": "NSString*",
+            "to_cpp": "std::string(%(n)s.UTF8String)",
+            "from_cpp": "[NSString stringWithUTF8String:%(n)s.c_str()]",
+            "swift_type": "String"
+        },
         "TermCriteria": {
             "objc_type": "TermCriteria*",
             "to_cpp": "%(n)s.nativeRef",


### PR DESCRIPTION
- arg types may be passed as `string` instead of `std::string`

/cc @komakai 
