### PR TITLE
G-API: Adding a skip for failed streaming tests

### DIFF
--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -51,8 +51,6 @@ namespace
         {
             // Since G-API has no own test data (yet), it is taken from the common space
             const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-            GAPI_Assert(testDataPath != nullptr);
-
             cvtest::addDataSearchPath(testDataPath);
             initialized = true;
         }
@@ -192,8 +190,12 @@ TEST(StatefulKernel, StateIsAutoResetForNewStream)
     // Compilation & testing
     auto ccomp = c.compileStreaming(cv::compile_args(pkg));
 
-    ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                               (findDataFile("cv/video/768x576.avi")));
+    try {
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
+                                   (findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
     EXPECT_TRUE(ccomp.running());
 
@@ -335,14 +337,22 @@ TEST(StatefulKernel, StateIsInitViaCompArgsInStreaming)
                            cv::compile_args(pkg, BackSubStateParams { "knn" }));
 
     // Testing G-API Background Substractor in streaming mode
-    gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                               (findDataFile("cv/video/768x576.avi")));
+    try {
+        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
+                                   (findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     // Allowing 1% difference of all pixels between G-API and reference OpenCV results
     testBackSubInStreaming(gapiBackSub, 1);
 
-    // Additionally, test the case when the new stream happens
-    gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                               (findDataFile("cv/video/1920x1080.avi")));
+    try {
+        // Additionally, test the case when the new stream happens
+        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
+                                   (findDataFile("cv/video/1920x1080.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     // Allowing 5% difference of all pixels between G-API and reference OpenCV results
     testBackSubInStreaming(gapiBackSub, 5);
 }

--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -51,7 +51,9 @@ namespace
         {
             // Since G-API has no own test data (yet), it is taken from the common space
             const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-            cvtest::addDataSearchPath(testDataPath);
+            if (testDataPath) {
+                cvtest::addDataSearchPath(testDataPath);
+            }
             initialized = true;
         }
 #endif // WINRT
@@ -190,9 +192,9 @@ TEST(StatefulKernel, StateIsAutoResetForNewStream)
     // Compilation & testing
     auto ccomp = c.compileStreaming(cv::compile_args(pkg));
 
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                                   (findDataFile("cv/video/768x576.avi")));
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -206,8 +208,12 @@ TEST(StatefulKernel, StateIsAutoResetForNewStream)
     }
     EXPECT_FALSE(ccomp.running());
 
-    ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                               (findDataFile("cv/video/1920x1080.avi")));
+    path = findDataFile("cv/video/1920x1080.avi");
+    try {
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
     EXPECT_TRUE(ccomp.running());
 
@@ -337,19 +343,19 @@ TEST(StatefulKernel, StateIsInitViaCompArgsInStreaming)
                            cv::compile_args(pkg, BackSubStateParams { "knn" }));
 
     // Testing G-API Background Substractor in streaming mode
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                                   (findDataFile("cv/video/768x576.avi")));
+        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
     // Allowing 1% difference of all pixels between G-API and reference OpenCV results
     testBackSubInStreaming(gapiBackSub, 1);
 
+    path = findDataFile("cv/video/1920x1080.avi");
     try {
         // Additionally, test the case when the new stream happens
-        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
-                                   (findDataFile("cv/video/1920x1080.avi")));
+        gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -34,8 +34,6 @@ void initTestDataPath()
     {
         // Since G-API has no own test data (yet), it is taken from the common space
         const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        GAPI_Assert(testDataPath != nullptr);
-
         cvtest::addDataSearchPath(testDataPath);
         initialized = true;
     }
@@ -202,8 +200,11 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoInput_GMat)
     EXPECT_TRUE(ccomp);
     EXPECT_FALSE(ccomp.running());
 
-    ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
-
+    try {
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
     EXPECT_TRUE(ccomp.running());
 
@@ -273,7 +274,11 @@ TEST_P(GAPI_Streaming, SmokeTest_StartRestart)
 
     // Run 1
     std::size_t num_frames1 = 0u;
-    ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    try {
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
     EXPECT_TRUE(ccomp.running());
 
@@ -284,7 +289,11 @@ TEST_P(GAPI_Streaming, SmokeTest_StartRestart)
 
     // Run 2
     std::size_t num_frames2 = 0u;
-    ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    try {
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
     EXPECT_TRUE(ccomp.running());
     while (ccomp.pull(cv::gout(out1, out2))) num_frames2++;
@@ -306,7 +315,11 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoConstSource_NoHang)
     }).compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                         cv::compile_args(cv::gapi::use_only{getKernelPackage()}));
 
-    refc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    try {
+        refc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     refc.start();
     std::size_t ref_frames = 0u;
     cv::Mat tmp;
@@ -348,8 +361,13 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
     cv::Mat tmp;
 
     // Test with one video source
-    auto in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-    testc.setSource(cv::gin(in_const, in_src));
+    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+        testc.setSource(cv::gin(in_const, in_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     std::size_t test_frames = 0u;
@@ -357,8 +375,12 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one
-    in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
-    testc.setSource(cv::gin(in_const, in_src));
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
+        testc.setSource(cv::gin(in_const, in_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     test_frames = 0u;
@@ -411,8 +433,13 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
 
     cv::Mat tmp;
     // Test with one video source and scalar
-    auto in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-    testc.setSource(cv::gin(in_src, cv::Scalar{1.25}));
+    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+        testc.setSource(cv::gin(in_src, cv::Scalar{1.25}));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     std::size_t test_frames = 0u;
@@ -420,8 +447,12 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one video source and scalar
-    in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
-    testc.setSource(cv::gin(in_src, cv::Scalar{0.75}));
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
+        testc.setSource(cv::gin(in_src, cv::Scalar{0.75}));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     test_frames = 0u;
@@ -516,9 +547,14 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
 
     cv::Mat tmp;
     // Test with one video source and vector
-    auto in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-    std::vector<int> first_in_vec(768*3, 1);
-    testc.setSource(cv::gin(in_src, first_in_vec));
+    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+        std::vector<int> first_in_vec(768*3, 1);
+        testc.setSource(cv::gin(in_src, first_in_vec));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     std::size_t test_frames = 0u;
@@ -526,9 +562,13 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one
-    in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
-    std::vector<int> second_in_vec(1920*3, 1);
-    testc.setSource(cv::gin(in_src, second_in_vec));
+    try {
+        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
+        std::vector<int> second_in_vec(1920*3, 1);
+        testc.setSource(cv::gin(in_src, second_in_vec));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     testc.start();
 
     test_frames = 0u;
@@ -647,8 +687,12 @@ TEST(GAPI_Streaming_Types, XChangeScalar)
 
     // Compile streaming pipeline
     auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
-                                 cv::compile_args(cv::gapi::use_only{kernels}));
-    sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+                                cv::compile_args(cv::gapi::use_only{kernels}));
+    try {
+        sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::Mat in_frame;
@@ -708,8 +752,12 @@ TEST(GAPI_Streaming_Types, XChangeVector)
     auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                                  cv::GMatDesc{CV_8U,3,cv::Size{576,576}},
                                  cv::compile_args(cv::gapi::use_only{kernels}));
-    sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")),
-                         in_eye));
+    try {
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")),
+                             in_eye));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::Mat in_frame;
@@ -737,8 +785,13 @@ TEST(GAPI_Streaming_Types, OutputScalar)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out))
         .compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}});
 
-    const auto video_path = findDataFile("cv/video/768x576.avi");
-    sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path));
+    std::string video_path;
+    try {
+        video_path = findDataFile("cv/video/768x576.avi");
+        sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::VideoCapture cap;
@@ -783,8 +836,13 @@ TEST(GAPI_Streaming_Types, OutputVector)
     };
 
     cv::Mat in_eye = cv::Mat::eye(cv::Size(256, 256), CV_8UC3);
-    const auto video_path = findDataFile("cv/video/768x576.avi");
-    sc.setSource(cv::gin(in_eye, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path)));
+    std::string video_path;
+    try {
+        video_path = findDataFile("cv/video/768x576.avi");
+        sc.setSource(cv::gin(in_eye, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path)));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::VideoCapture cap;
@@ -936,15 +994,21 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
 
 TEST_F(GAPI_Streaming_Unit, TestTwoVideoSourcesFail)
 {
-    const auto c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+    cv::gapi::wip::IStreamSource::Ptr c_ptr = nullptr;
     auto c_desc = cv::GMatDesc{CV_8U,3,{768,576}};
     auto m_desc = cv::descr_of(m);
 
-    sc = cc.compileStreaming(c_desc, m_desc);
-    EXPECT_NO_THROW(sc.setSource(cv::gin(c_ptr, m)));
-
-    sc = cc.compileStreaming(m_desc, c_desc);
-    EXPECT_NO_THROW(sc.setSource(cv::gin(m, c_ptr)));
+    try {
+        c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+        sc = cc.compileStreaming(c_desc, m_desc);
+        // FIXME: it should be EXPECT_NO_THROW()
+        sc.setSource(cv::gin(c_ptr, m));
+        sc = cc.compileStreaming(m_desc, c_desc);
+        // FIXME: it should be EXPECT_NO_THROW()
+        sc.setSource(cv::gin(m, c_ptr));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     sc = cc.compileStreaming(c_desc, c_desc);
     EXPECT_ANY_THROW(sc.setSource(cv::gin(c_ptr, c_ptr)));
@@ -1017,9 +1081,14 @@ TEST_F(GAPI_Streaming_Unit, StartStopStress_Video)
     m = cv::Mat::eye(cv::Size{768,576}, CV_8UC3);
     for (int i = 0; i < 100; i++)
     {
-        auto src = cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-        sc.stop();
-        sc.setSource(cv::gin(src, m));
+        cv::gapi::wip::IStreamSource::Ptr src = nullptr;
+        try {
+            src = cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+            sc.stop();
+            sc.setSource(cv::gin(src, m));
+        } catch(...) {
+            throw SkipTestException("Video file can not be opened");
+        }
         sc.start();
         cv::Mat out;
         for (int j = 0; j < 5; j++) EXPECT_TRUE(sc.pull(cv::gout(out)));
@@ -1158,9 +1227,14 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming(cv::compile_args(cv::gapi::kernels<OCVDelay>()));
-    auto sc_file = findDataFile("cv/video/768x576.avi");
-    auto sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-    sc.setSource(cv::gin(sc_src));
+    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
+    try {
+        auto sc_file = findDataFile("cv/video/768x576.avi");
+        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
+        sc.setSource(cv::gin(sc_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     std::size_t out1_hits = 0u;
@@ -1195,9 +1269,14 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
     // The code should compile and execute well (desynchronized parts don't cross)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2, out3))
         .compileStreaming();
-    auto sc_file = findDataFile("cv/video/768x576.avi");
-    auto sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-    sc.setSource(cv::gin(sc_src));
+    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
+    try {
+        auto sc_file = findDataFile("cv/video/768x576.avi");
+        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
+        sc.setSource(cv::gin(sc_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     std::size_t test_frames = 0u;
@@ -1323,9 +1402,14 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
-    auto sc_file = findDataFile("cv/video/768x576.avi");
-    auto sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-    sc.setSource(cv::gin(sc_src));
+    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
+    try {
+        auto sc_file = findDataFile("cv/video/768x576.avi");
+        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
+        sc.setSource(cv::gin(sc_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::Mat o1, o2;
@@ -1345,9 +1429,14 @@ TEST(GAPI_Streaming_Desync, UseSpecialPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
-    auto sc_file = findDataFile("cv/video/768x576.avi");
-    auto sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-    sc.setSource(cv::gin(sc_src));
+    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
+    try {
+        auto sc_file = findDataFile("cv/video/768x576.avi");
+        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
+        sc.setSource(cv::gin(sc_src));
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     sc.start();
 
     cv::optional<cv::Mat> o1, o2;

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -361,10 +361,8 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
     cv::Mat tmp;
 
     // Test with one video source
-    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-        testc.setSource(cv::gin(in_const, in_src));
+        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -376,8 +374,7 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
 
     // Now test with another one
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
-        testc.setSource(cv::gin(in_const, in_src));
+        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -433,10 +430,8 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
 
     cv::Mat tmp;
     // Test with one video source and scalar
-    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
-        testc.setSource(cv::gin(in_src, cv::Scalar{1.25}));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), cv::Scalar{1.25}));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -448,8 +443,7 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
 
     // Now test with another one video source and scalar
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
-        testc.setSource(cv::gin(in_src, cv::Scalar{0.75}));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi")), cv::Scalar{0.75}));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -547,11 +541,9 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
 
     cv::Mat tmp;
     // Test with one video source and vector
-    cv::gapi::wip::IStreamSource::Ptr in_src = nullptr;
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
         std::vector<int> first_in_vec(768*3, 1);
-        testc.setSource(cv::gin(in_src, first_in_vec));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), first_in_vec));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -563,9 +555,8 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
 
     // Now test with another one
     try {
-        in_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"));
         std::vector<int> second_in_vec(1920*3, 1);
-        testc.setSource(cv::gin(in_src, second_in_vec));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi")), second_in_vec));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -994,23 +985,22 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
 
 TEST_F(GAPI_Streaming_Unit, TestTwoVideoSourcesFail)
 {
-    cv::gapi::wip::IStreamSource::Ptr c_ptr = nullptr;
     auto c_desc = cv::GMatDesc{CV_8U,3,{768,576}};
     auto m_desc = cv::descr_of(m);
 
     try {
-        c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
         sc = cc.compileStreaming(c_desc, m_desc);
         // FIXME: it should be EXPECT_NO_THROW()
-        sc.setSource(cv::gin(c_ptr, m));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), m));
         sc = cc.compileStreaming(m_desc, c_desc);
         // FIXME: it should be EXPECT_NO_THROW()
-        sc.setSource(cv::gin(m, c_ptr));
+        sc.setSource(cv::gin(m, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
 
     sc = cc.compileStreaming(c_desc, c_desc);
+    auto c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
     EXPECT_ANY_THROW(sc.setSource(cv::gin(c_ptr, c_ptr)));
 }
 
@@ -1081,11 +1071,9 @@ TEST_F(GAPI_Streaming_Unit, StartStopStress_Video)
     m = cv::Mat::eye(cv::Size{768,576}, CV_8UC3);
     for (int i = 0; i < 100; i++)
     {
-        cv::gapi::wip::IStreamSource::Ptr src = nullptr;
         try {
-            src = cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
             sc.stop();
-            sc.setSource(cv::gin(src, m));
+            sc.setSource(cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), m));
         } catch(...) {
             throw SkipTestException("Video file can not be opened");
         }
@@ -1227,11 +1215,8 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming(cv::compile_args(cv::gapi::kernels<OCVDelay>()));
-    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
     try {
-        auto sc_file = findDataFile("cv/video/768x576.avi");
-        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-        sc.setSource(cv::gin(sc_src));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1269,11 +1254,8 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
     // The code should compile and execute well (desynchronized parts don't cross)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2, out3))
         .compileStreaming();
-    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
     try {
-        auto sc_file = findDataFile("cv/video/768x576.avi");
-        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-        sc.setSource(cv::gin(sc_src));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1402,11 +1384,8 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
-    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
     try {
-        auto sc_file = findDataFile("cv/video/768x576.avi");
-        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-        sc.setSource(cv::gin(sc_src));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1429,11 +1408,8 @@ TEST(GAPI_Streaming_Desync, UseSpecialPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
-    cv::gapi::wip::IStreamSource::Ptr sc_src = nullptr;
     try {
-        auto sc_file = findDataFile("cv/video/768x576.avi");
-        sc_src = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(sc_file);
-        sc.setSource(cv::gin(sc_src));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -34,7 +34,9 @@ void initTestDataPath()
     {
         // Since G-API has no own test data (yet), it is taken from the common space
         const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        cvtest::addDataSearchPath(testDataPath);
+        if (testDataPath) {
+            cvtest::addDataSearchPath(testDataPath);
+        }
         initialized = true;
     }
 #endif // WINRT
@@ -200,8 +202,9 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoInput_GMat)
     EXPECT_TRUE(ccomp);
     EXPECT_FALSE(ccomp.running());
 
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -273,9 +276,10 @@ TEST_P(GAPI_Streaming, SmokeTest_StartRestart)
     EXPECT_FALSE(ccomp.running());
 
     // Run 1
+    auto path = findDataFile("cv/video/768x576.avi");
     std::size_t num_frames1 = 0u;
     try {
-        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -290,7 +294,7 @@ TEST_P(GAPI_Streaming, SmokeTest_StartRestart)
     // Run 2
     std::size_t num_frames2 = 0u;
     try {
-        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+        ccomp.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -315,8 +319,9 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoConstSource_NoHang)
     }).compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                         cv::compile_args(cv::gapi::use_only{getKernelPackage()}));
 
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        refc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+        refc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -338,7 +343,7 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoConstSource_NoHang)
 
     cv::Mat in_const = cv::Mat::eye(cv::Size(256,256), CV_8UC3);
     testc.setSource(cv::gin(in_const,
-                            gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+                            gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     testc.start();
     std::size_t test_frames = 0u;
     while (testc.pull(cv::gout(tmp))) test_frames++;
@@ -361,8 +366,9 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
     cv::Mat tmp;
 
     // Test with one video source
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -373,8 +379,9 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one
+    path = findDataFile("cv/video/1920x1080.avi");
     try {
-        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"))));
+        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -430,8 +437,9 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
 
     cv::Mat tmp;
     // Test with one video source and scalar
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), cv::Scalar{1.25}));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), cv::Scalar{1.25}));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -442,8 +450,9 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one video source and scalar
+    path = findDataFile("cv/video/1920x1080.avi");
     try {
-        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi")), cv::Scalar{0.75}));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), cv::Scalar{0.75}));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -541,9 +550,10 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
 
     cv::Mat tmp;
     // Test with one video source and vector
+    auto path = findDataFile("cv/video/768x576.avi");
+    std::vector<int> first_in_vec(768*3, 1);
     try {
-        std::vector<int> first_in_vec(768*3, 1);
-        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), first_in_vec));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), first_in_vec));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -554,9 +564,10 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoArray)
     EXPECT_EQ(100u, test_frames);
 
     // Now test with another one
+    path = findDataFile("cv/video/1920x1080.avi");
+    std::vector<int> second_in_vec(1920*3, 1);
     try {
-        std::vector<int> second_in_vec(1920*3, 1);
-        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi")), second_in_vec));
+        testc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), second_in_vec));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -679,8 +690,9 @@ TEST(GAPI_Streaming_Types, XChangeScalar)
     // Compile streaming pipeline
     auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                                 cv::compile_args(cv::gapi::use_only{kernels}));
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")));
+        sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -743,8 +755,9 @@ TEST(GAPI_Streaming_Types, XChangeVector)
     auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                                  cv::GMatDesc{CV_8U,3,cv::Size{576,576}},
                                  cv::compile_args(cv::gapi::use_only{kernels}));
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")),
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path),
                              in_eye));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
@@ -777,8 +790,8 @@ TEST(GAPI_Streaming_Types, OutputScalar)
         .compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}});
 
     std::string video_path;
+    video_path = findDataFile("cv/video/768x576.avi");
     try {
-        video_path = findDataFile("cv/video/768x576.avi");
         sc.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
@@ -828,8 +841,8 @@ TEST(GAPI_Streaming_Types, OutputVector)
 
     cv::Mat in_eye = cv::Mat::eye(cv::Size(256, 256), CV_8UC3);
     std::string video_path;
+    video_path = findDataFile("cv/video/768x576.avi");
     try {
-        video_path = findDataFile("cv/video/768x576.avi");
         sc.setSource(cv::gin(in_eye, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(video_path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
@@ -987,20 +1000,20 @@ TEST_F(GAPI_Streaming_Unit, TestTwoVideoSourcesFail)
 {
     auto c_desc = cv::GMatDesc{CV_8U,3,{768,576}};
     auto m_desc = cv::descr_of(m);
-
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
         sc = cc.compileStreaming(c_desc, m_desc);
         // FIXME: it should be EXPECT_NO_THROW()
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), m));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), m));
         sc = cc.compileStreaming(m_desc, c_desc);
         // FIXME: it should be EXPECT_NO_THROW()
-        sc.setSource(cv::gin(m, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        sc.setSource(cv::gin(m, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
 
     sc = cc.compileStreaming(c_desc, c_desc);
-    auto c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"));
+    auto c_ptr = gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path);
     EXPECT_ANY_THROW(sc.setSource(cv::gin(c_ptr, c_ptr)));
 }
 
@@ -1069,11 +1082,12 @@ TEST_F(GAPI_Streaming_Unit, StartStopStress_Video)
     sc = cc.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
                              cv::GMatDesc{CV_8U,3,cv::Size{768,576}});
     m = cv::Mat::eye(cv::Size{768,576}, CV_8UC3);
+    auto path = findDataFile("cv/video/768x576.avi");
     for (int i = 0; i < 100; i++)
     {
+        sc.stop();
         try {
-            sc.stop();
-            sc.setSource(cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi")), m));
+            sc.setSource(cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path), m));
         } catch(...) {
             throw SkipTestException("Video file can not be opened");
         }
@@ -1215,8 +1229,9 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming(cv::compile_args(cv::gapi::kernels<OCVDelay>()));
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1254,8 +1269,9 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
     // The code should compile and execute well (desynchronized parts don't cross)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2, out3))
         .compileStreaming();
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1384,8 +1400,9 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -1408,8 +1425,9 @@ TEST(GAPI_Streaming_Desync, UseSpecialPull)
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out1, out2))
         .compileStreaming();
 
+    auto path = findDataFile("cv/video/768x576.avi");
     try {
-        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path)));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -26,7 +26,7 @@ namespace opencv_test
 {
 namespace
 {
-void initTestDataPath()
+/*void initTestDataPath()
 {
 #ifndef WINRT
     static bool initialized = false;
@@ -38,7 +38,7 @@ void initTestDataPath()
         initialized = true;
     }
 #endif // WINRT
-}
+}*/
 
 enum class KernelPackage: int
 {
@@ -63,8 +63,6 @@ std::ostream& operator<< (std::ostream &os, const KernelPackage &e)
 }
 
 struct GAPI_Streaming: public ::testing::TestWithParam<KernelPackage> {
-    GAPI_Streaming() { initTestDataPath(); }
-
     cv::gapi::GKernelPackage getKernelPackage()
     {
         using namespace cv::gapi;
@@ -362,7 +360,7 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta)
 
     // Test with one video source
     try {
-        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/1920x1080.avi"))));
+        testc.setSource(cv::gin(in_const, gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi"))));
     } catch(...) {
         throw SkipTestException("Video file can not be opened");
     }
@@ -637,8 +635,6 @@ TEST(GAPI_Streaming_Types, XChangeScalar)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Scalar data.
 
-    initTestDataPath();
-
     cv::GMat in;
     cv::GScalar m = cv::gapi::mean(in);
     cv::GMat tmp = cv::gapi::convertTo(in, CV_32F) - m;
@@ -704,8 +700,6 @@ TEST(GAPI_Streaming_Types, XChangeVector)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Vector data.
 
-    initTestDataPath();
-
     cv::GMat in1, in2;
     cv::GMat in = cv::gapi::crop(in1, cv::Rect{0,0,576,576});
     cv::GScalar m = cv::gapi::mean(in);
@@ -769,8 +763,6 @@ TEST(GAPI_Streaming_Types, OutputScalar)
     // This test verifies if Streaming works when pipeline
     // produces scalar data only
 
-    initTestDataPath();
-
     cv::GMat in;
     cv::GScalar out = cv::gapi::mean(in);
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out))
@@ -808,7 +800,6 @@ TEST(GAPI_Streaming_Types, OutputVector)
     // This test verifies if Streaming works when pipeline
     // produces vector data only
 
-    initTestDataPath();
     auto pkg = cv::gapi::kernels<TypesTest::OCVSumV>();
 
     cv::GMat in1, in2;
@@ -970,8 +961,6 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
                 return cv::GComputation(cv::GIn(a, b), cv::GOut(c));
             })
     {
-        initTestDataPath();
-
         const auto a_desc = cv::descr_of(m);
         const auto b_desc = cv::descr_of(m);
         sc  = cc.compileStreaming(a_desc, b_desc);
@@ -1204,8 +1193,6 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Regular)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1237,8 +1224,6 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1373,8 +1358,6 @@ TEST(GAPI_Streaming_Desync, Negative_CrossOtherDesync_Tier1)
 
 TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 
@@ -1397,8 +1380,6 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 
 TEST(GAPI_Streaming_Desync, UseSpecialPull)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -26,7 +26,7 @@ namespace opencv_test
 {
 namespace
 {
-/*void initTestDataPath()
+void initTestDataPath()
 {
 #ifndef WINRT
     static bool initialized = false;
@@ -38,7 +38,7 @@ namespace
         initialized = true;
     }
 #endif // WINRT
-}*/
+}
 
 enum class KernelPackage: int
 {
@@ -63,6 +63,8 @@ std::ostream& operator<< (std::ostream &os, const KernelPackage &e)
 }
 
 struct GAPI_Streaming: public ::testing::TestWithParam<KernelPackage> {
+    GAPI_Streaming() { initTestDataPath(); }
+
     cv::gapi::GKernelPackage getKernelPackage()
     {
         using namespace cv::gapi;
@@ -635,6 +637,8 @@ TEST(GAPI_Streaming_Types, XChangeScalar)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Scalar data.
 
+    initTestDataPath();
+
     cv::GMat in;
     cv::GScalar m = cv::gapi::mean(in);
     cv::GMat tmp = cv::gapi::convertTo(in, CV_32F) - m;
@@ -700,6 +704,8 @@ TEST(GAPI_Streaming_Types, XChangeVector)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Vector data.
 
+    initTestDataPath();
+
     cv::GMat in1, in2;
     cv::GMat in = cv::gapi::crop(in1, cv::Rect{0,0,576,576});
     cv::GScalar m = cv::gapi::mean(in);
@@ -763,6 +769,8 @@ TEST(GAPI_Streaming_Types, OutputScalar)
     // This test verifies if Streaming works when pipeline
     // produces scalar data only
 
+    initTestDataPath();
+
     cv::GMat in;
     cv::GScalar out = cv::gapi::mean(in);
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out))
@@ -800,6 +808,7 @@ TEST(GAPI_Streaming_Types, OutputVector)
     // This test verifies if Streaming works when pipeline
     // produces vector data only
 
+    initTestDataPath();
     auto pkg = cv::gapi::kernels<TypesTest::OCVSumV>();
 
     cv::GMat in1, in2;
@@ -961,6 +970,8 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
                 return cv::GComputation(cv::GIn(a, b), cv::GOut(c));
             })
     {
+        initTestDataPath();
+
         const auto a_desc = cv::descr_of(m);
         const auto b_desc = cv::descr_of(m);
         sc  = cc.compileStreaming(a_desc, b_desc);
@@ -1193,6 +1204,8 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Regular)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 {
+    initTestDataPath();
+
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1224,6 +1237,8 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
 {
+    initTestDataPath();
+
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1358,6 +1373,8 @@ TEST(GAPI_Streaming_Desync, Negative_CrossOtherDesync_Tier1)
 
 TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 {
+    initTestDataPath();
+
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 
@@ -1380,6 +1397,8 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 
 TEST(GAPI_Streaming_Desync, UseSpecialPull)
 {
+    initTestDataPath();
+
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 


### PR DESCRIPTION
### Added a skip for failed streaming tests
Tests failed for standalone centOs build.

<cut/>

Case:

```
try {
    setSource(make_src(dataPath))
} catch(...) {
    skipTest("Warning!")
}
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Magic centos commands:

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```