### PR TITLE
norm.cpp(normL2Sqr_): improve performance of pipeline

### DIFF
--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -152,10 +152,10 @@ float normL2Sqr_(const float* a, const float* b, int n)
     {
         v_float32 t0 = vx_load(a + j) - vx_load(b + j);
         v_float32 t1 = vx_load(a + j + v_float32::nlanes) - vx_load(b + j + v_float32::nlanes);
-        v_float32 t2 = vx_load(a + j + 2 * v_float32::nlanes) - vx_load(b + j + 2 * v_float32::nlanes);
-        v_float32 t3 = vx_load(a + j + 3 * v_float32::nlanes) - vx_load(b + j + 3 * v_float32::nlanes);
         v_d0 = v_muladd(t0, t0, v_d0);
+        v_float32 t2 = vx_load(a + j + 2 * v_float32::nlanes) - vx_load(b + j + 2 * v_float32::nlanes);
         v_d1 = v_muladd(t1, t1, v_d1);
+        v_float32 t3 = vx_load(a + j + 3 * v_float32::nlanes) - vx_load(b + j + 3 * v_float32::nlanes);
         v_d2 = v_muladd(t2, t2, v_d2);
         v_d3 = v_muladd(t3, t3, v_d3);
     }


### PR DESCRIPTION
The most of target machine use one type cpu unit resource
to execute some one type of instruction, e.g.
all vx_load API use load/store cpu unit,
and v_muladd API use mul/mula cpu unit, we interleave
vx_load and v_muladd to improve performance on most targets like
RISCV or ARM.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [Y] I agree to contribute to the project under Apache 2 License.
- [Y] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [Y] The PR is proposed to proper branch
- [N] There is reference to original bug report and related work
- [N] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [Y] The feature is well documented and sample code can be built with the project CMake
