### PR TITLE
Expose CGImage <-> Mat conversion for iOS platforms

### DIFF
--- a/modules/imgcodecs/CMakeLists.txt
+++ b/modules/imgcodecs/CMakeLists.txt
@@ -113,7 +113,7 @@ file(GLOB imgcodecs_ext_hdrs
      "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/legacy/*.h"
      )
 
-if(APPLE)
+if(APPLE OR APPLE_FRAMEWORK)
   list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/apple_conversions.h)
   list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/apple_conversions.mm)
 endif()

--- a/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
@@ -50,7 +50,7 @@
 //! @addtogroup imgcodecs_ios
 //! @{
 
-CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist = false);
 CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
 CV_EXPORTS void UIImageToMat(const UIImage* image,

--- a/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
@@ -50,6 +50,8 @@
 //! @addtogroup imgcodecs_ios
 //! @{
 
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist = false);
 CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
 CV_EXPORTS void UIImageToMat(const UIImage* image,
                              cv::Mat& m, bool alphaExist = false);

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -12,7 +12,7 @@
 //! @addtogroup imgcodecs_macosx
 //! @{
 
-CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist = false);
 CV_EXPORTS NSImage* MatToNSImage(const cv::Mat& image);
 CV_EXPORTS void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist = false);

--- a/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
+++ b/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 CV_EXPORTS @interface Mat (Converters)
 
+-(CGImageRef)toCGImage;
+-(instancetype)initWithCGImage:(CGImageRef)image;
+-(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist;
 -(UIImage*)toUIImage;
 -(instancetype)initWithUIImage:(UIImage*)image;
 -(instancetype)initWithUIImage:(UIImage*)image alphaExist:(BOOL)alphaExist;

--- a/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
+++ b/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 CV_EXPORTS @interface Mat (Converters)
 
--(CGImageRef)toCGImage;
+-(CGImageRef)toCGImage CF_RETURNS_RETAINED;
 -(instancetype)initWithCGImage:(CGImageRef)image;
 -(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist;
 -(UIImage*)toUIImage;

--- a/modules/imgcodecs/misc/objc/ios/Mat+Converters.mm
+++ b/modules/imgcodecs/misc/objc/ios/Mat+Converters.mm
@@ -9,6 +9,22 @@
 
 @implementation Mat (Converters)
 
+-(CGImageRef)toCGImage {
+    return MatToCGImage(self.nativeRef);
+}
+
+-(instancetype)initWithCGImage:(CGImageRef)image {
+    return [self initWithCGImage:image alphaExist:NO];
+}
+
+-(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist {
+    self = [self init];
+    if (self) {
+        CGImageToMat(image, self.nativeRef, (bool)alphaExist);
+    }
+    return self;
+}
+
 -(UIImage*)toUIImage {
     return MatToUIImage(self.nativeRef);
 }

--- a/modules/imgcodecs/misc/objc/macosx/Mat+Converters.h
+++ b/modules/imgcodecs/misc/objc/macosx/Mat+Converters.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 CV_EXPORTS @interface Mat (Converters)
 
--(CGImageRef)toCGImage;
+-(CGImageRef)toCGImage CF_RETURNS_RETAINED;
 -(instancetype)initWithCGImage:(CGImageRef)image;
 -(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist;
 -(NSImage*)toNSImage;

--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -7,5 +7,5 @@
 #import <ImageIO/ImageIO.h>
 #include "opencv2/core.hpp"
 
-CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);


### PR DESCRIPTION
#18547 introduces `CGImage`<->`Mat` conversion for MacOS platforms. This PR enables the same capabilities for iOS platforms. C++ users can now use `MatToCGImage` and `CGImageToMat` in `ios.h`, and Objc users can now do the equivalent conversions in `Mat+Converters.h`.

I also took the liberty of adding `CF_RETURNS_RETAINED` annotations to methods that return `CGImageRef`, so that the Swift compiler knows to `CFRelease()` when the reference count goes to 0. This is technically a breaking change, as the prior implementation required users to explicitly use `takeRetainedValue()` to properly reference count; however, I think the expectation is that such objects are reference counted by default, so I would categorize the prior behavior as a bug and my changes as a bugfix.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=Custom Mac
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-2
build_contrib:Custom Mac=OFF
```