### PR TITLE
[G-API]: kmeans() Standard Kernel Implementation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -519,7 +519,7 @@ namespace core {
         outMeta(const GMatDesc& in, int K, const GMatDesc& in_labels, const TermCriteria&, int,
                 KmeansFlags flags) {
             int quantity = -1, dimensionality = -1;
-            std::tie(quantity, dimensionality) = checkVector(in, -1, CV_32F);
+            std::tie(quantity, dimensionality) = detail::checkVector(in, -1, CV_32F);
             if (quantity == -1)  // Mat with height != 1, width != 1, channels != 1 given
             {                    // which means that kmeans will consider the following:
                 quantity       = in.size.height;
@@ -532,7 +532,7 @@ namespace core {
             if (flags & KMEANS_USE_INITIAL_LABELS)
             {
                 int labels_quantity = -1;
-                std::tie(labels_quantity, std::ignore) = checkVector(in_labels, 1, CV_32S);
+                std::tie(labels_quantity, std::ignore) = detail::checkVector(in_labels, 1, CV_32S);
                 GAPI_Assert(labels_quantity == quantity);
                 out_labels = in_labels;  // kmeans preserves in_labels' sizes if given
             }
@@ -549,7 +549,7 @@ namespace core {
         outMeta(const GMatDesc& in, int K, const TermCriteria&, int, KmeansFlags flags) {
             GAPI_Assert( !(flags & KMEANS_USE_INITIAL_LABELS) );
             int quantity = -1, dimensionality = -1;
-            std::tie(quantity, dimensionality) = checkVector(in, -1, CV_32F);
+            std::tie(quantity, dimensionality) = detail::checkVector(in, -1, CV_32F);
             if (quantity == -1)  // Mat with height != 1, width != 1, channels != 1 given
             {                    // which means that kmeans will consider the following:
                 quantity       = in.size.height;

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -519,9 +519,9 @@ namespace core {
         outMeta(const GMatDesc& in, int K, const GMatDesc& in_labels, const TermCriteria&, int,
                 KmeansFlags flags) {
             int quantity = -1, dimensionality = -1;
-            std::tie(quantity, dimensionality) = detail::checkVector(in, -1, CV_32F);
-            if (quantity == -1)  // Mat with height != 1, width != 1, channels != 1 given
-            {                    // which means that kmeans will consider the following:
+            bool isVector = detail::checkVector(in, -1, CV_32F, quantity, dimensionality);
+            if (!isVector) // Mat with height != 1, width != 1, channels != 1 given
+            {              // which means that kmeans will consider the following:
                 quantity       = in.size.height;
                 dimensionality = in.size.width * in.chan;
             }
@@ -531,9 +531,10 @@ namespace core {
                      centers   (CV_32F, 1, Size{dimensionality, K});
             if (flags & KMEANS_USE_INITIAL_LABELS)
             {
-                int labels_quantity = -1;
-                std::tie(labels_quantity, std::ignore) = detail::checkVector(in_labels, 1, CV_32S);
-                GAPI_Assert(labels_quantity == quantity);
+                int labels_quantity = -1, labels_dimensionality = -1;
+                bool isLabelVector = detail::checkVector(in_labels, 1, CV_32S,
+                                                         labels_quantity, labels_dimensionality);
+                GAPI_Assert(isLabelVector && labels_quantity == quantity);
                 out_labels = in_labels;  // kmeans preserves in_labels' sizes if given
             }
             return std::make_tuple(empty_gopaque_desc(), out_labels, centers);
@@ -549,9 +550,9 @@ namespace core {
         outMeta(const GMatDesc& in, int K, const TermCriteria&, int, KmeansFlags flags) {
             GAPI_Assert( !(flags & KMEANS_USE_INITIAL_LABELS) );
             int quantity = -1, dimensionality = -1;
-            std::tie(quantity, dimensionality) = detail::checkVector(in, -1, CV_32F);
-            if (quantity == -1)  // Mat with height != 1, width != 1, channels != 1 given
-            {                    // which means that kmeans will consider the following:
+            bool isVector = detail::checkVector(in, -1, CV_32F, quantity, dimensionality);
+            if (!isVector) // Mat with height != 1, width != 1, channels != 1 given
+            {              // which means that kmeans will consider the following:
                 quantity       = in.size.height;
                 dimensionality = in.size.width * in.chan;
             }

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -518,10 +518,11 @@ namespace core {
         static std::tuple<GOpaqueDesc,GMatDesc,GMatDesc>
         outMeta(const GMatDesc& in, int K, const GMatDesc& in_labels, const TermCriteria&, int,
                 KmeansFlags flags) {
-            int quantity = -1, dimensionality = -1;
-            bool isVector = detail::checkVector(in, -1, CV_32F, quantity, dimensionality);
-            if (!isVector) // Mat with height != 1, width != 1, channels != 1 given
-            {              // which means that kmeans will consider the following:
+            GAPI_Assert(in.depth == CV_32F);
+            std::vector<int> q_n_d = detail::checkVector(in);
+            int quantity = q_n_d[0], dimensionality = q_n_d[1];
+            if (quantity == -1) // Mat with height != 1, width != 1, channels != 1 given
+            {                   // which means that kmeans will consider the following:
                 quantity       = in.size.height;
                 dimensionality = in.size.width * in.chan;
             }
@@ -531,10 +532,9 @@ namespace core {
                      centers   (CV_32F, 1, Size{dimensionality, K});
             if (flags & KMEANS_USE_INITIAL_LABELS)
             {
-                int labels_quantity = -1, labels_dimensionality = -1;
-                bool isLabelVector = detail::checkVector(in_labels, 1, CV_32S,
-                                                         labels_quantity, labels_dimensionality);
-                GAPI_Assert(isLabelVector && labels_quantity == quantity);
+                GAPI_Assert(in_labels.depth == CV_32S);
+                int labels_quantity = detail::checkVector(in_labels, 1u);
+                GAPI_Assert(labels_quantity == quantity);
                 out_labels = in_labels;  // kmeans preserves in_labels' sizes if given
             }
             return std::make_tuple(empty_gopaque_desc(), out_labels, centers);
@@ -549,10 +549,11 @@ namespace core {
         static std::tuple<GOpaqueDesc,GMatDesc,GMatDesc>
         outMeta(const GMatDesc& in, int K, const TermCriteria&, int, KmeansFlags flags) {
             GAPI_Assert( !(flags & KMEANS_USE_INITIAL_LABELS) );
-            int quantity = -1, dimensionality = -1;
-            bool isVector = detail::checkVector(in, -1, CV_32F, quantity, dimensionality);
-            if (!isVector) // Mat with height != 1, width != 1, channels != 1 given
-            {              // which means that kmeans will consider the following:
+            GAPI_Assert(in.depth == CV_32F);
+            std::vector<int> q_n_d = detail::checkVector(in);
+            int quantity = q_n_d[0], dimensionality = q_n_d[1];
+            if (quantity == -1) // Mat with height != 1, width != 1, channels != 1 given
+            {                   // which means that kmeans will consider the following:
                 quantity       = in.size.height;
                 dimensionality = in.size.width * in.chan;
             }

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -1871,10 +1871,11 @@ height = in_labels.height if in_labels given.
 @note In case of GMat given as data, the cluster centers are returned as 1-channel GMat with sizes
 width = d, height = K, where d is samples' dimentionality and K is clusters' quantity.
 
-@note As one of possible usages, if you don't want to allow the function to set initial labels
-randomly, you can utilize just the core of the function: set the number of attempts to 1,
-initialize labels each time using a custom algorithm, pass them with the
+@note As one of possible usages, if you want to control the initial labels for each attempt
+by yourself randomly, you can utilize just the core of the function. To do that, set the number
+of attempts to 1, initialize labels each time using a custom algorithm, pass them with the
 ( flags = #KMEANS_USE_INITIAL_LABELS ) flag, and then choose the best (most-compact) clustering.
+To do this
 */
 GAPI_EXPORTS std::tuple<GOpaque<double>,GMat,GMat>
 kmeans(const GMat& data, const int K, const GMat& bestLabels,

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -1867,7 +1867,8 @@ compactness value are returned by the function.
 @return Integer array that stores the cluster indices for every sample.
 @return Array of the cluster centers.
 
-@note Basically, you can use only the core of the function: set the number of attempts to 1,
+@note As one of possible usages, if you don't want to allow the function to set initial labels
+randomly, you can utilize just the core of the function: set the number of attempts to 1,
 initialize labels each time using a custom algorithm, pass them with the
 ( flags = #KMEANS_USE_INITIAL_LABELS ) flag, and then choose the best (most-compact) clustering.
 */

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -526,10 +526,10 @@ namespace core {
                 amount = in.size.height;
                 dim    = in.size.width * in.chan;
             }
-                     // kmeans sets these labels' sizes when no bestLabels given:
-            GMatDesc out_labels(CV_32S, 1, Size{1, amount}),
-                     // kmeans always sets these centers' sizes:
-                     centers   (CV_32F, 1, Size{dim, K});
+            // kmeans sets these labels' sizes when no bestLabels given:
+            GMatDesc out_labels(CV_32S, 1, Size{1, amount});
+            // kmeans always sets these centers' sizes:
+            GMatDesc centers   (CV_32F, 1, Size{dim, K});
             if (flags & KMEANS_USE_INITIAL_LABELS)
             {
                 GAPI_Assert(bestLabels.depth == CV_32S);
@@ -557,8 +557,8 @@ namespace core {
                 amount = in.size.height;
                 dim    = in.size.width * in.chan;
             }
-            GMatDesc out_labels(CV_32S, 1, Size{1, amount}),
-                     centers   (CV_32F, 1, Size{dim, K});
+            GMatDesc out_labels(CV_32S, 1, Size{1, amount});
+            GMatDesc centers   (CV_32F, 1, Size{dim, K});
             return std::make_tuple(empty_gopaque_desc(), out_labels, centers);
         }
     };
@@ -1835,19 +1835,27 @@ The function kmeans implements a k-means algorithm that finds the centers of K c
 and groups the input samples around the clusters. As an output, \f$\texttt{bestLabels}_i\f$
 contains a 0-based cluster index for the \f$i^{th}\f$ sample.
 
-@note Function textual ID is "org.opencv.core.kmeansND"
+@note
+ - Function textual ID is "org.opencv.core.kmeansND"
+ - In case of an N-dimentional points' set given, input GMat can have the following traits:
+2 dimensions, a single row or column if there are N channels,
+or N columns if there is a single channel. Mat should have @ref CV_32F depth.
+ - Although, if GMat with height != 1, width != 1, channels != 1 given as data, n-dimensional
+samples are considered given in amount of A, where A = height, n = width * channels.
+ - In case of GMat given as data:
+     - the output labels are returned as 1-channel GMat with sizes
+width = 1, height = A, where A is samples amount, or width = bestLabels.width,
+height = bestLabels.height if bestLabels given;
+     - the cluster centers are returned as 1-channel GMat with sizes
+width = n, height = K, where n is samples' dimentionality and K is clusters' amount.
+ - As one of possible usages, if you want to control the initial labels for each attempt
+by yourself, you can utilize just the core of the function. To do that, set the number
+of attempts to 1, initialize labels each time using a custom algorithm, pass them with the
+( flags = #KMEANS_USE_INITIAL_LABELS ) flag, and then choose the best (most-compact) clustering.
 
 @param data Data for clustering. An array of N-Dimensional points with float coordinates is needed.
 Function can take GArray<Point2f>, GArray<Point3f> for 2D and 3D cases or GMat for any
 dimentionality and channels.
-
-@note In case of an N-dimentional points' set given, input GMat can have the following traits:
-2 dimensions, a single row or column if there are N channels,
-or N columns if there is a single channel. Mat should have @ref CV_32F depth.
-
-@note Although, if GMat with height != 1, width != 1, channels != 1 given as data, n-dimensional
-samples are considered given in amount of A, where A = height, n = width * channels.
-
 @param K Number of clusters to split the set by.
 @param bestLabels Optional input integer array that can store the supposed initial cluster indices
 for every sample. Used when ( flags = #KMEANS_USE_INITIAL_LABELS ) flag is set.
@@ -1859,33 +1867,22 @@ initial labellings. The algorithm returns the labels that yield the best compact
 function return value).
 @param flags Flag that can take values of cv::KmeansFlags .
 
-@return Compactness measure that is computed as
+@return
+ - Compactness measure that is computed as
 \f[\sum _i  \| \texttt{samples} _i -  \texttt{centers} _{ \texttt{labels} _i} \| ^2\f]
 after every attempt. The best (minimum) value is chosen and the corresponding labels and the
 compactness value are returned by the function.
-@return Integer array that stores the cluster indices for every sample.
-@return Array of the cluster centers.
-
-@note In case of GMat given as data, the output labels are returned as 1-channel GMat with sizes
-width = 1, height = A, where A is samples amount, or width = bestLabels.width,
-height = bestLabels.height if bestLabels given.
-
-@note In case of GMat given as data, the cluster centers are returned as 1-channel GMat with sizes
-width = n, height = K, where n is samples' dimentionality and K is clusters' amount.
-
-@note As one of possible usages, if you want to control the initial labels for each attempt
-by yourself, you can utilize just the core of the function. To do that, set the number
-of attempts to 1, initialize labels each time using a custom algorithm, pass them with the
-( flags = #KMEANS_USE_INITIAL_LABELS ) flag, and then choose the best (most-compact) clustering.
+ - Integer array that stores the cluster indices for every sample.
+ - Array of the cluster centers.
 */
 GAPI_EXPORTS std::tuple<GOpaque<double>,GMat,GMat>
 kmeans(const GMat& data, const int K, const GMat& bestLabels,
        const TermCriteria& criteria, const int attempts, const KmeansFlags flags);
 
 /** @overload
-@note Function textual ID is "org.opencv.core.kmeansNDNoInit"
-
-@note #KMEANS_USE_INITIAL_LABELS flag must not be set while using this overload.
+@note
+ - Function textual ID is "org.opencv.core.kmeansNDNoInit"
+ - #KMEANS_USE_INITIAL_LABELS flag must not be set while using this overload.
  */
 GAPI_EXPORTS std::tuple<GOpaque<double>,GMat,GMat>
 kmeans(const GMat& data, const int K, const TermCriteria& criteria, const int attempts,

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -204,16 +204,24 @@ struct GAPI_EXPORTS GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 namespace gapi { namespace detail {
-// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
-// Returns true if input Mat can be described as vector of points of given dimensionality,
-// and false otherwise.
-// If n <= 0 given, the function counts the dimentionality by itself.
-// If expectedDepth < 0 given, there is no assert on the depth of the passed matrix.
-// Outputs are quantity of the elements and their dimentionality.
-// In case input matrix can't be described as vector of points, returns
-// quantity = -1, dimensionality = -1.
-bool checkVector(const GMatDesc& in, const int n, const int expectedDepth,
-                 int& quantity, int& dimensionality);
+/** Checks GMatDesc fields if the passed matrix is a set of n-dimentional points.
+@param in GMatDesc to check.
+@param n expected dimensionality.
+@return the quantity of the elements. In case input matrix can't be described as vector of points
+of expected dimensionality, returns -1.
+ */
+int checkVector(const GMatDesc& in, const size_t n);
+
+/** @overload
+
+Checks GMatDesc fields if the passed matrix can be described as a set of points of any
+dimensionality.
+
+@return array of two elements in form of std::vector<int>: the quantity of the elements
+and their calculated dimensionality. In case input matrix can't be described as vector of points,
+returns {-1, -1}.
+ */
+std::vector<int> checkVector(const GMatDesc& in);
 }} // namespace gapi::detail
 
 #if !defined(GAPI_STANDALONE)

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -203,12 +203,14 @@ struct GAPI_EXPORTS GMatDesc
 
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
+namespace gapi { namespace detail {
 // Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
 // If n <= 0 given, the function counts the dimentionality by itself.
 // If ddepth < 0 given, there is no assert on the depth of the passed matrix
 // Returns two ints: quantity of the elements and their dimentionality.
 // In case input matrix can't be described as vector of points, returns (-1,-1).
 std::tuple<int,int> checkVector(const GMatDesc& in, const int n = -1, const int expectedDepth = -1);
+}} // namespace gapi::detail
 
 #if !defined(GAPI_STANDALONE)
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -203,6 +203,13 @@ struct GAPI_EXPORTS GMatDesc
 
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
+// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
+// If n <= 0 given, there are no checks on sizes of elements.
+// If ddepth < 0 given, there is no assert on the depth of the passed matrix
+// Returns quantity of the elements.
+// In case input matrix can't be described as vector of points, returns -1.
+int checkVector(const GMatDesc& in, const int n = -1, const int ddepth = -1);
+
 #if !defined(GAPI_STANDALONE)
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -204,10 +204,11 @@ struct GAPI_EXPORTS GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 namespace gapi { namespace detail {
-// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth
-// and returns ture or false.
+// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
+// Returns true if input Mat can be described as vector of points of given dimensionality,
+// and false otherwise.
 // If n <= 0 given, the function counts the dimentionality by itself.
-// If ddepth < 0 given, there is no assert on the depth of the passed matrix.
+// If expectedDepth < 0 given, there is no assert on the depth of the passed matrix.
 // Outputs are quantity of the elements and their dimentionality.
 // In case input matrix can't be described as vector of points, returns
 // quantity = -1, dimensionality = -1.

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -204,12 +204,15 @@ struct GAPI_EXPORTS GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 namespace gapi { namespace detail {
-// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
+// Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth
+// and returns ture or false.
 // If n <= 0 given, the function counts the dimentionality by itself.
-// If ddepth < 0 given, there is no assert on the depth of the passed matrix
-// Returns two ints: quantity of the elements and their dimentionality.
-// In case input matrix can't be described as vector of points, returns (-1,-1).
-std::tuple<int,int> checkVector(const GMatDesc& in, const int n = -1, const int expectedDepth = -1);
+// If ddepth < 0 given, there is no assert on the depth of the passed matrix.
+// Outputs are quantity of the elements and their dimentionality.
+// In case input matrix can't be described as vector of points, returns
+// quantity = -1, dimensionality = -1.
+bool checkVector(const GMatDesc& in, const int n, const int expectedDepth,
+                 int& quantity, int& dimensionality);
 }} // namespace gapi::detail
 
 #if !defined(GAPI_STANDALONE)

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -204,11 +204,11 @@ struct GAPI_EXPORTS GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 // Checks GMatDesc fields if the passed matrix is a set of n-dimentional points of the given depth.
-// If n <= 0 given, there are no checks on sizes of elements.
+// If n <= 0 given, the function counts the dimentionality by itself.
 // If ddepth < 0 given, there is no assert on the depth of the passed matrix
-// Returns quantity of the elements.
-// In case input matrix can't be described as vector of points, returns -1.
-int checkVector(const GMatDesc& in, const int n = -1, const int expectedDepth = -1);
+// Returns two ints: quantity of the elements and their dimentionality.
+// In case input matrix can't be described as vector of points, returns (-1,-1).
+std::tuple<int,int> checkVector(const GMatDesc& in, const int n = -1, const int expectedDepth = -1);
 
 #if !defined(GAPI_STANDALONE)
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -208,7 +208,7 @@ static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 // If ddepth < 0 given, there is no assert on the depth of the passed matrix
 // Returns quantity of the elements.
 // In case input matrix can't be described as vector of points, returns -1.
-int checkVector(const GMatDesc& in, const int n = -1, const int ddepth = -1);
+int checkVector(const GMatDesc& in, const int n = -1, const int expectedDepth = -1);
 
 #if !defined(GAPI_STANDALONE)
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -207,7 +207,7 @@ namespace gapi { namespace detail {
 /** Checks GMatDesc fields if the passed matrix is a set of n-dimentional points.
 @param in GMatDesc to check.
 @param n expected dimensionality.
-@return the quantity of the elements. In case input matrix can't be described as vector of points
+@return the amount of points. In case input matrix can't be described as vector of points
 of expected dimensionality, returns -1.
  */
 int checkVector(const GMatDesc& in, const size_t n);
@@ -217,7 +217,7 @@ int checkVector(const GMatDesc& in, const size_t n);
 Checks GMatDesc fields if the passed matrix can be described as a set of points of any
 dimensionality.
 
-@return array of two elements in form of std::vector<int>: the quantity of the elements
+@return array of two elements in form of std::vector<int>: the amount of points
 and their calculated dimensionality. In case input matrix can't be described as vector of points,
 returns {-1, -1}.
  */

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -211,7 +211,7 @@ namespace imgproc {
             {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
                 int quantity = -1;
-                std::tie(quantity, std::ignore) = checkVector(in, 2);
+                std::tie(quantity, std::ignore) = detail::checkVector(in, 2);
                 GAPI_Assert(quantity != -1 &&
                             "Input Mat can't be described as vector of 2-dimentional points");
             }
@@ -237,7 +237,7 @@ namespace imgproc {
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
             int quantity = -1;
-            std::tie(quantity, std::ignore) = checkVector(in, 2);
+            std::tie(quantity, std::ignore) = detail::checkVector(in, 2);
             GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
@@ -272,7 +272,7 @@ namespace imgproc {
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
             int quantity = -1;
-            std::tie(quantity, std::ignore) = checkVector(in, 3);
+            std::tie(quantity, std::ignore) = detail::checkVector(in, 3);
             GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -210,8 +210,8 @@ namespace imgproc {
             else
             {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
-                int quantity = detail::checkVector(in, 2u);
-                GAPI_Assert(quantity != -1 &&
+                int amount = detail::checkVector(in, 2u);
+                GAPI_Assert(amount != -1 &&
                             "Input Mat can't be described as vector of 2-dimentional points");
             }
             return empty_gopaque_desc();
@@ -235,8 +235,8 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
-            int quantity = detail::checkVector(in, 2u);
-            GAPI_Assert(quantity != -1 &&
+            int amount = detail::checkVector(in, 2u);
+            GAPI_Assert(amount != -1 &&
                         "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
         }
@@ -269,8 +269,8 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
-            int quantity = detail::checkVector(in, 3u);
-            GAPI_Assert(quantity != -1 &&
+            int amount = detail::checkVector(in, 3u);
+            GAPI_Assert(amount != -1 &&
                         "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();
         }

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -210,8 +210,9 @@ namespace imgproc {
             else
             {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
-                int quantity = checkVector(in, 2);
-                GAPI_Assert(quantity > 0 &&
+                int quantity = -1;
+                std::tie(quantity, std::ignore) = checkVector(in, 2);
+                GAPI_Assert(quantity != -1 &&
                             "Input Mat can't be described as vector of 2-dimentional points");
             }
             return empty_gopaque_desc();
@@ -235,8 +236,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
-            int quantity = checkVector(in, 2);
-            GAPI_Assert(quantity > 0 &&
+            int quantity = -1;
+            std::tie(quantity, std::ignore) = checkVector(in, 2);
+            GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
         }
@@ -269,8 +271,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
-            int quantity = checkVector(in, 3);
-            GAPI_Assert(quantity > 0 &&
+            int quantity = -1;
+            std::tie(quantity, std::ignore) = checkVector(in, 3);
+            GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();
         }

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -43,15 +43,6 @@ void validateFindingContoursMeta(const int depth, const int chan, const int mode
         break;
     }
 }
-
-// Checks if the passed mat is a set of n-dimentional points of the given depth
-bool isPointsVector(const int chan, const cv::Size &size, const int depth,
-                    const int n, const int ddepth = -1)
-{
-    return (ddepth == depth || ddepth < 0) &&
-           ((chan == n && (size.height == 1 || size.width == 1)) ||
-            (chan == 1 && size.width == n));
-}
 } // anonymous namespace
 
 namespace cv { namespace gapi {
@@ -212,10 +203,17 @@ namespace imgproc {
     G_TYPED_KERNEL(GBoundingRectMat, <GOpaque<Rect>(GMat)>,
                    "org.opencv.imgproc.shape.boundingRectMat") {
         static GOpaqueDesc outMeta(GMatDesc in) {
-            GAPI_Assert((in.depth == CV_8U && in.chan == 1) ||
-                        (isPointsVector(in.chan, in.size, in.depth, 2, CV_32S) ||
-                         isPointsVector(in.chan, in.size, in.depth, 2, CV_32F)));
-
+            if (in.depth == CV_8U)
+            {
+                GAPI_Assert(in.chan == 1);
+            }
+            else
+            {
+                GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
+                int quantity = checkVector(in, 2);
+                GAPI_Assert(quantity > 0 &&
+                            "Input Mat can't be described as vector of 2-dimentional points");
+            }
             return empty_gopaque_desc();
         }
     };
@@ -237,7 +235,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
-            GAPI_Assert(isPointsVector(in.chan, in.size, in.depth, 2, -1));
+            int quantity = checkVector(in, 2);
+            GAPI_Assert(quantity > 0 &&
+                        "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
         }
     };
@@ -269,7 +269,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
-            GAPI_Assert(isPointsVector(in.chan, in.size, in.depth, 3, -1));
+            int quantity = checkVector(in, 3);
+            GAPI_Assert(quantity > 0 &&
+                        "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();
         }
     };

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -210,9 +210,9 @@ namespace imgproc {
             else
             {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
-                int quantity = -1;
-                std::tie(quantity, std::ignore) = detail::checkVector(in, 2);
-                GAPI_Assert(quantity != -1 &&
+                int quantity = -1, dimensionality = -1;
+                bool isVector = detail::checkVector(in, 2, -1, quantity, dimensionality);
+                GAPI_Assert(isVector &&
                             "Input Mat can't be described as vector of 2-dimentional points");
             }
             return empty_gopaque_desc();
@@ -236,9 +236,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
-            int quantity = -1;
-            std::tie(quantity, std::ignore) = detail::checkVector(in, 2);
-            GAPI_Assert(quantity != -1 &&
+            int quantity = -1, dimensionality = -1;
+            bool isVector = detail::checkVector(in, 2, -1, quantity, dimensionality);
+            GAPI_Assert(isVector &&
                         "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
         }
@@ -271,9 +271,9 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
-            int quantity = -1;
-            std::tie(quantity, std::ignore) = detail::checkVector(in, 3);
-            GAPI_Assert(quantity != -1 &&
+            int quantity = -1, dimensionality = -1;
+            bool isVector = detail::checkVector(in, 3, -1, quantity, dimensionality);
+            GAPI_Assert(isVector &&
                         "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();
         }

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -210,9 +210,8 @@ namespace imgproc {
             else
             {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
-                int quantity = -1, dimensionality = -1;
-                bool isVector = detail::checkVector(in, 2, -1, quantity, dimensionality);
-                GAPI_Assert(isVector &&
+                int quantity = detail::checkVector(in, 2u);
+                GAPI_Assert(quantity != -1 &&
                             "Input Mat can't be described as vector of 2-dimentional points");
             }
             return empty_gopaque_desc();
@@ -236,9 +235,8 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine2DMat, <GOpaque<Vec4f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine2DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
-            int quantity = -1, dimensionality = -1;
-            bool isVector = detail::checkVector(in, 2, -1, quantity, dimensionality);
-            GAPI_Assert(isVector &&
+            int quantity = detail::checkVector(in, 2u);
+            GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 2-dimentional points");
             return empty_gopaque_desc();
         }
@@ -271,9 +269,8 @@ namespace imgproc {
     G_TYPED_KERNEL(GFitLine3DMat, <GOpaque<Vec6f>(GMat,DistanceTypes,double,double,double)>,
                    "org.opencv.imgproc.shape.fitLine3DMat") {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
-            int quantity = -1, dimensionality = -1;
-            bool isVector = detail::checkVector(in, 3, -1, quantity, dimensionality);
-            GAPI_Assert(isVector &&
+            int quantity = detail::checkVector(in, 3u);
+            GAPI_Assert(quantity != -1 &&
                         "Input Mat can't be described as vector of 3-dimentional points");
             return empty_gopaque_desc();
         }

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,36 +36,37 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-// FIXME: implement different overloads for clarity and convenience
-bool cv::gapi::detail::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth,
-                                   int& quantity, int& dimensionality)
+namespace {
+std::vector<int> checkVectorImpl(const int width, const int height, const int chan, const int n)
 {
-    GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
-    const int chan = in.chan, width = in.size.width, height = in.size.height;
-    if (width  == 1 && (n <= 0 || n == chan))
+    if (width == 1 && (n == -1 || n == chan))
     {
-        quantity       = height;
-        dimensionality = chan;
-        return true;
+        return {height, chan};
     }
-    else if (height == 1 && (n <= 0 || n == chan))
+    else if (height == 1 && (n == -1 || n == chan))
     {
-        quantity       = width;
-        dimensionality = chan;
-        return true;
+        return {width, chan};
     }
-    else if (chan   == 1 && (n <= 0 || n == width))
+    else if (chan == 1 && (n == -1 || n == width))
     {
-        quantity       = height;
-        dimensionality = width;
-        return true;
+        return {height, width};
     }
     else // input Mat can't be described as vector of points of given dimensionality
     {
-        quantity       = -1;
-        dimensionality = -1;
-        return false;
+        return {-1, -1};
     }
+}
+} // anonymous namespace
+
+int cv::gapi::detail::checkVector(const cv::GMatDesc& in, const size_t n)
+{
+    GAPI_Assert(n != 0u);
+    return checkVectorImpl(in.size.width, in.size.height, in.chan, static_cast<int>(n))[0];
+}
+
+std::vector<int> cv::gapi::detail::checkVector(const cv::GMatDesc& in)
+{
+    return checkVectorImpl(in.size.width, in.size.height, in.chan, -1);
 }
 
 namespace{

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,8 +36,8 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-namespace {
-std::vector<int> checkVectorImpl(const int width, const int height, const int chan, const int n)
+static std::vector<int> checkVectorImpl(const int width, const int height, const int chan,
+                                        const int n)
 {
     if (width == 1 && (n == -1 || n == chan))
     {
@@ -56,7 +56,6 @@ std::vector<int> checkVectorImpl(const int width, const int height, const int ch
         return {-1, -1};
     }
 }
-} // anonymous namespace
 
 int cv::gapi::detail::checkVector(const cv::GMatDesc& in, const size_t n)
 {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,6 +36,7 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
+// FIXME: implement different overloads for clarity and convenience
 bool cv::gapi::detail::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth,
                                    int& quantity, int& dimensionality)
 {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -38,24 +38,24 @@ const cv::GOrigin& cv::GMat::priv() const
 
 std::tuple<int,int> cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
 {
-     GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
-     const int chan = in.chan, width = in.size.width, height = in.size.height;
-     if (width  == 1 && (n <= 0 || n == chan))
-     {
-         return std::make_tuple(height, chan);
-     }
-else if (height == 1 && (n <= 0 || n == chan))
-     {
-         return std::make_tuple(width, chan);
-     }
-else if (chan   == 1 && (n <= 0 || n == width))
-     {
-         return std::make_tuple(height, width);
-     }
-else // input Mat can't be described as vector of points of given dimensionality
-     {
-         return std::make_tuple(-1, -1);
-     }
+    GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
+    const int chan = in.chan, width = in.size.width, height = in.size.height;
+    if (width  == 1 && (n <= 0 || n == chan))
+    {
+        return std::make_tuple(height, chan);
+    }
+    else if (height == 1 && (n <= 0 || n == chan))
+    {
+        return std::make_tuple(width, chan);
+    }
+    else if (chan   == 1 && (n <= 0 || n == width))
+    {
+        return std::make_tuple(height, width);
+    }
+    else // input Mat can't be described as vector of points of given dimensionality
+    {
+        return std::make_tuple(-1, -1);
+    }
 }
 
 namespace{

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,26 +36,34 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-int cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
+std::tuple<int,int> cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
 {
     GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
     const int chan = in.chan;
     const cv::Size size = in.size;
-    int quantity = -1;
+    int quantity = -1, dimensionality = -1;
     if (n <= 0)
     {
-        if (size.width == 1 || chan == 1)
+        if (size.width == 1)
         {
             quantity = size.height;
+            dimensionality = chan;
+        }
+        else if (chan == 1)
+        {
+            quantity = size.height;
+            dimensionality = size.width;
         }
         else if (size.height == 1)
         {
             quantity = size.width;
+            dimensionality = chan;
         }
         // else input Mat can't be described as vector of points
     }
-    else // n is given
+    else // dimensionality is given
     {
+        dimensionality = n;
         if (chan == n && size.height == 1)
         {
             quantity = size.width;
@@ -64,9 +72,9 @@ int cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth
         {
             quantity = size.height;
         }
-        // else input Mat can't be described as vector of n-dimentional points
+        // else input Mat can't be described as vector of points of given dimensionality
     }
-    return quantity;
+    return std::make_tuple(quantity, dimensionality);
 }
 
 namespace{

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,7 +36,8 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-std::tuple<int,int> cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
+std::tuple<int,int> cv::gapi::detail::checkVector(const cv::GMatDesc& in, const int n,
+                                                  const int expectedDepth)
 {
     GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
     const int chan = in.chan, width = in.size.width, height = in.size.height;

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -38,43 +38,24 @@ const cv::GOrigin& cv::GMat::priv() const
 
 std::tuple<int,int> cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
 {
-    GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
-    const int chan = in.chan;
-    const cv::Size size = in.size;
-    int quantity = -1, dimensionality = -1;
-    if (n <= 0)
-    {
-        if (size.width == 1)
-        {
-            quantity = size.height;
-            dimensionality = chan;
-        }
-        else if (chan == 1)
-        {
-            quantity = size.height;
-            dimensionality = size.width;
-        }
-        else if (size.height == 1)
-        {
-            quantity = size.width;
-            dimensionality = chan;
-        }
-        // else input Mat can't be described as vector of points
-    }
-    else // dimensionality is given
-    {
-        dimensionality = n;
-        if (chan == n && size.height == 1)
-        {
-            quantity = size.width;
-        }
-        else if ((chan == n && size.width == 1) || (chan == 1 && size.width == n))
-        {
-            quantity = size.height;
-        }
-        // else input Mat can't be described as vector of points of given dimensionality
-    }
-    return std::make_tuple(quantity, dimensionality);
+     GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
+     const int chan = in.chan, width = in.size.width, height = in.size.height;
+     if (width  == 1 && (n <= 0 || n == chan))
+     {
+         return std::make_tuple(height, chan);
+     }
+else if (height == 1 && (n <= 0 || n == chan))
+     {
+         return std::make_tuple(width, chan);
+     }
+else if (chan   == 1 && (n <= 0 || n == width))
+     {
+         return std::make_tuple(height, width);
+     }
+else // input Mat can't be described as vector of points of given dimensionality
+     {
+         return std::make_tuple(-1, -1);
+     }
 }
 
 namespace{

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,26 +36,34 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-std::tuple<int,int> cv::gapi::detail::checkVector(const cv::GMatDesc& in, const int n,
-                                                  const int expectedDepth)
+bool cv::gapi::detail::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth,
+                                   int& quantity, int& dimensionality)
 {
     GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
     const int chan = in.chan, width = in.size.width, height = in.size.height;
     if (width  == 1 && (n <= 0 || n == chan))
     {
-        return std::make_tuple(height, chan);
+        quantity       = height;
+        dimensionality = chan;
+        return true;
     }
     else if (height == 1 && (n <= 0 || n == chan))
     {
-        return std::make_tuple(width, chan);
+        quantity       = width;
+        dimensionality = chan;
+        return true;
     }
     else if (chan   == 1 && (n <= 0 || n == width))
     {
-        return std::make_tuple(height, width);
+        quantity       = height;
+        dimensionality = width;
+        return true;
     }
     else // input Mat can't be described as vector of points of given dimensionality
     {
-        return std::make_tuple(-1, -1);
+        quantity       = -1;
+        dimensionality = -1;
+        return false;
     }
 }
 

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,6 +36,39 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
+int cv::checkVector(const cv::GMatDesc& in, const int n, const int ddepth)
+{
+    GAPI_Assert(ddepth == in.depth || ddepth < 0);
+    const int chan = in.chan;
+    const cv::Size size = in.size;
+    int quantity = -1;
+    if (n <= 0)
+    {
+        if (size.width == 1 || chan == 1)
+        {
+            quantity = size.height;
+        }
+        else if (size.height == 1)
+        {
+            quantity = size.width;
+        }
+        // else input Mat can't be described as vector of points
+    }
+    else // n is given
+    {
+        if (chan == n && size.height == 1)
+        {
+            quantity = size.width;
+        }
+        else if ((chan == n && size.width == 1) || (chan == 1 && size.width == n))
+        {
+            quantity = size.height;
+        }
+        // else input Mat can't be described as vector of n-dimentional points
+    }
+    return quantity;
+}
+
 namespace{
     template <typename T> cv::GMetaArgs vec_descr_of(const std::vector<T> &vec)
         {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -36,9 +36,9 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-int cv::checkVector(const cv::GMatDesc& in, const int n, const int ddepth)
+int cv::checkVector(const cv::GMatDesc& in, const int n, const int expectedDepth)
 {
-    GAPI_Assert(ddepth == in.depth || ddepth < 0);
+    GAPI_Assert(expectedDepth == in.depth || expectedDepth == -1);
     const int chan = in.chan;
     const cv::Size size = in.size;
     int quantity = -1;

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -388,6 +388,40 @@ GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, int flags,
     return core::GWarpAffine::on(src, M, dsize, flags, borderMode, borderValue);
 }
 
+std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K,
+                                             const TermCriteria& criteria, const int attempts,
+                                             const KmeansFlags flags, const GMat& bestLabels)
+{
+    return core::GKMeansND::on(data, K, criteria, attempts, flags, bestLabels);
+}
+
+std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K,
+                                             const TermCriteria& criteria, const int attempts,
+                                             const KmeansFlags flags)
+{
+    return core::GKMeansNDNoInit::on(data, K, criteria, attempts, flags);
+}
+
+std::tuple<GOpaque<double>,GArray<int>,GArray<Point2f>> kmeans(const GArray<Point2f>& data,
+                                                               const int              K,
+                                                               const TermCriteria&    criteria,
+                                                               const int              attempts,
+                                                               const KmeansFlags      flags,
+                                                               const GArray<int>&     bestLabels)
+{
+    return core::GKMeans2D::on(data, K, criteria, attempts, flags, bestLabels);
+}
+
+std::tuple<GOpaque<double>,GArray<int>,GArray<Point3f>> kmeans(const GArray<Point3f>& data,
+                                                               const int              K,
+                                                               const TermCriteria&    criteria,
+                                                               const int              attempts,
+                                                               const KmeansFlags      flags,
+                                                               const GArray<int>&     bestLabels)
+{
+    return core::GKMeans3D::on(data, K, criteria, attempts, flags, bestLabels);
+}
+
 GOpaque<Size> streaming::size(const GMat& src)
 {
     return streaming::GSize::on(src);

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -388,11 +388,11 @@ GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, int flags,
     return core::GWarpAffine::on(src, M, dsize, flags, borderMode, borderValue);
 }
 
-std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K,
+std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K, const GMat& bestLabels,
                                              const TermCriteria& criteria, const int attempts,
-                                             const KmeansFlags flags, const GMat& bestLabels)
+                                             const KmeansFlags flags)
 {
-    return core::GKMeansND::on(data, K, criteria, attempts, flags, bestLabels);
+    return core::GKMeansND::on(data, K, bestLabels, criteria, attempts, flags);
 }
 
 std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K,
@@ -404,22 +404,22 @@ std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K,
 
 std::tuple<GOpaque<double>,GArray<int>,GArray<Point2f>> kmeans(const GArray<Point2f>& data,
                                                                const int              K,
+                                                               const GArray<int>&     bestLabels,
                                                                const TermCriteria&    criteria,
                                                                const int              attempts,
-                                                               const KmeansFlags      flags,
-                                                               const GArray<int>&     bestLabels)
+                                                               const KmeansFlags      flags)
 {
-    return core::GKMeans2D::on(data, K, criteria, attempts, flags, bestLabels);
+    return core::GKMeans2D::on(data, K, bestLabels, criteria, attempts, flags);
 }
 
 std::tuple<GOpaque<double>,GArray<int>,GArray<Point3f>> kmeans(const GArray<Point3f>& data,
                                                                const int              K,
+                                                               const GArray<int>&     bestLabels,
                                                                const TermCriteria&    criteria,
                                                                const int              attempts,
-                                                               const KmeansFlags      flags,
-                                                               const GArray<int>&     bestLabels)
+                                                               const KmeansFlags      flags)
 {
-    return core::GKMeans3D::on(data, K, criteria, attempts, flags, bestLabels);
+    return core::GKMeans3D::on(data, K, bestLabels, criteria, attempts, flags);
 }
 
 GOpaque<Size> streaming::size(const GMat& src)

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -587,9 +587,9 @@ GAPI_OCV_KERNEL(GCPUWarpAffine, cv::gapi::core::GWarpAffine)
 
 GAPI_OCV_KERNEL(GCPUKMeansND, cv::gapi::core::GKMeansND)
 {
-    static void run(const cv::Mat& data, const int K,
+    static void run(const cv::Mat& data, const int K, const cv::Mat& inBestLabels,
                     const cv::TermCriteria& criteria, const int attempts,
-                    const cv::KmeansFlags flags, const cv::Mat& inBestLabels,
+                    const cv::KmeansFlags flags,
                     double& compactness, cv::Mat& outBestLabels, cv::Mat& centers)
     {
         if (flags & cv::KMEANS_USE_INITIAL_LABELS)
@@ -613,13 +613,15 @@ GAPI_OCV_KERNEL(GCPUKMeansNDNoInit, cv::gapi::core::GKMeansNDNoInit)
 GAPI_OCV_KERNEL(GCPUKMeans2D, cv::gapi::core::GKMeans2D)
 {
     static void run(const std::vector<cv::Point2f>& data, const int K,
-                    const cv::TermCriteria& criteria, const int attempts,
-                    const cv::KmeansFlags flags, const std::vector<int>& inBestLabels,
+                    const std::vector<int>& inBestLabels, const cv::TermCriteria& criteria,
+                    const int attempts, const cv::KmeansFlags flags,
                     double& compactness, std::vector<int>& outBestLabels,
                     std::vector<cv::Point2f>& centers)
     {
         if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+        {
             outBestLabels = inBestLabels;
+        }
         compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
     }
 };
@@ -627,13 +629,15 @@ GAPI_OCV_KERNEL(GCPUKMeans2D, cv::gapi::core::GKMeans2D)
 GAPI_OCV_KERNEL(GCPUKMeans3D, cv::gapi::core::GKMeans3D)
 {
     static void run(const std::vector<cv::Point3f>& data, const int K,
-                    const cv::TermCriteria& criteria, const int attempts,
-                    const cv::KmeansFlags flags, const std::vector<int>& inBestLabels,
+                    const std::vector<int>& inBestLabels, const cv::TermCriteria& criteria,
+                    const int attempts, const cv::KmeansFlags flags,
                     double& compactness, std::vector<int>& outBestLabels,
                     std::vector<cv::Point3f>& centers)
     {
         if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+        {
             outBestLabels = inBestLabels;
+        }
         compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
     }
 };

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -585,6 +585,59 @@ GAPI_OCV_KERNEL(GCPUWarpAffine, cv::gapi::core::GWarpAffine)
     }
 };
 
+GAPI_OCV_KERNEL(GCPUKMeansND, cv::gapi::core::GKMeansND)
+{
+    static void run(const cv::Mat& data, const int K,
+                    const cv::TermCriteria& criteria, const int attempts,
+                    const cv::KmeansFlags flags, const cv::Mat& inBestLabels,
+                    double& compactness, cv::Mat& outBestLabels, cv::Mat& centers)
+    {
+        if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+        {
+            inBestLabels.copyTo(outBestLabels);
+        }
+        compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUKMeansNDNoInit, cv::gapi::core::GKMeansNDNoInit)
+{
+    static void run(const cv::Mat& data, const int K, const cv::TermCriteria& criteria,
+                    const int attempts, const cv::KmeansFlags flags,
+                    double& compactness, cv::Mat& outBestLabels, cv::Mat& centers)
+    {
+        compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUKMeans2D, cv::gapi::core::GKMeans2D)
+{
+    static void run(const std::vector<cv::Point2f>& data, const int K,
+                    const cv::TermCriteria& criteria, const int attempts,
+                    const cv::KmeansFlags flags, const std::vector<int>& inBestLabels,
+                    double& compactness, std::vector<int>& outBestLabels,
+                    std::vector<cv::Point2f>& centers)
+    {
+        if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+            outBestLabels = inBestLabels;
+        compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
+    }
+};
+
+GAPI_OCV_KERNEL(GCPUKMeans3D, cv::gapi::core::GKMeans3D)
+{
+    static void run(const std::vector<cv::Point3f>& data, const int K,
+                    const cv::TermCriteria& criteria, const int attempts,
+                    const cv::KmeansFlags flags, const std::vector<int>& inBestLabels,
+                    double& compactness, std::vector<int>& outBestLabels,
+                    std::vector<cv::Point3f>& centers)
+    {
+        if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+            outBestLabels = inBestLabels;
+        compactness = cv::kmeans(data, K, outBestLabels, criteria, attempts, flags, centers);
+    }
+};
+
 GAPI_OCV_KERNEL(GCPUParseSSDBL, cv::gapi::nn::parsers::GParseSSDBL)
 {
     static void run(const cv::Mat&  in_ssd_result,
@@ -714,6 +767,10 @@ cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
          , GCPUNormalize
          , GCPUWarpPerspective
          , GCPUWarpAffine
+         , GCPUKMeansND
+         , GCPUKMeansNDNoInit
+         , GCPUKMeans2D
+         , GCPUKMeans3D
          , GCPUParseSSDBL
          , GOCVParseSSD
          , GCPUParseYolo

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -151,6 +151,16 @@ GAPI_TEST_FIXTURE(WarpPerspectiveTest, initMatrixRandU,
 GAPI_TEST_FIXTURE(WarpAffineTest, initMatrixRandU,
         FIXTURE_API(CompareMats, double , double, int, int, cv::Scalar),
         6, cmpF, angle, scale, flags, border_mode, border_value)
+GAPI_TEST_FIXTURE(KMeansNDNoInitTest, initMatrixRandU, FIXTURE_API(int, cv::KmeansFlags),
+                  2, K, flags)
+GAPI_TEST_FIXTURE(KMeansNDInitTest, initMatrixRandU,
+                  FIXTURE_API(CompareMats, int, cv::KmeansFlags), 3, cmpF, K, flags)
+GAPI_TEST_FIXTURE(KMeans2DNoInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags),
+                  2, K, flags)
+GAPI_TEST_FIXTURE(KMeans2DInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
+GAPI_TEST_FIXTURE(KMeans3DNoInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags),
+                  2, K, flags)
+GAPI_TEST_FIXTURE(KMeans3DInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
 
 GAPI_TEST_EXT_BASE_FIXTURE(ParseSSDBLTest, ParserSSDTest, initNothing,
     FIXTURE_API(float, int), 2, confidence_threshold, filter_label)

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1425,7 +1425,7 @@ TEST_P(KMeansNDInitTest, AccuracyTest)
     cv::GMat in, gLabelsIn, gLabelsOut, centers;
     cv::GOpaque<double> compactness;
     std::tie(compactness, gLabelsOut, centers) =
-        cv::gapi::kmeans(in, K, criteria, attempts, flags, gLabelsIn);
+        cv::gapi::kmeans(in, K, gLabelsIn, criteria, attempts, flags);
     cv::GComputation c(cv::GIn(in, gLabelsIn), cv::GOut(compactness, gLabelsOut, centers));
     c.apply(cv::gin(in_mat1, in_labels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
             getCompileArgs());
@@ -1450,9 +1450,10 @@ TEST_P(KMeans2DNoInitTest, AccuracyTest)
     initPointsVectorRandU(quantity, in_vector);
     // G-API code //////////////////////////////////////////////////////////////
     cv::GArray<cv::Point2f> in, centers;
-    cv::GArray<int> labels;
+    cv::GArray<int> labels, gLabelsIn(std::vector<int>{});
     cv::GOpaque<double> compactness;
-    std::tie(compactness, labels, centers) = cv::gapi::kmeans(in, K, criteria, attempts, flags);
+    std::tie(compactness, labels, centers) =
+        cv::gapi::kmeans(in, K, gLabelsIn, criteria, attempts, flags);
     cv::GComputation c(cv::GIn(in), cv::GOut(compactness, labels, centers));
     c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi), getCompileArgs());
     // Validation //////////////////////////////////////////////////////////////
@@ -1480,7 +1481,7 @@ TEST_P(KMeans2DInitTest, AccuracyTest)
     cv::GArray<int> gLabelsIn, gLabelsOut;
     cv::GOpaque<double> compactness;
     std::tie(compactness, gLabelsOut, centers) =
-        cv::gapi::kmeans(in, K, criteria, attempts, flags, gLabelsIn);
+        cv::gapi::kmeans(in, K, gLabelsIn, criteria, attempts, flags);
     cv::GComputation c(cv::GIn(in, gLabelsIn), cv::GOut(compactness, gLabelsOut, centers));
     c.apply(cv::gin(in_vector, in_labels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
             getCompileArgs());
@@ -1505,9 +1506,10 @@ TEST_P(KMeans3DNoInitTest, AccuracyTest)
     initPointsVectorRandU(quantity, in_vector);
     // G-API code //////////////////////////////////////////////////////////////
     cv::GArray<cv::Point3f> in, centers;
-    cv::GArray<int> labels;
+    cv::GArray<int> labels, gLabelsIn(std::vector<int>{});
     cv::GOpaque<double> compactness;
-    std::tie(compactness, labels, centers) = cv::gapi::kmeans(in, K, criteria, attempts, flags);
+    std::tie(compactness, labels, centers) =
+        cv::gapi::kmeans(in, K, gLabelsIn, criteria, attempts, flags);
     cv::GComputation c(cv::GIn(in), cv::GOut(compactness, labels, centers));
     c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi), getCompileArgs());
     // Validation //////////////////////////////////////////////////////////////
@@ -1535,7 +1537,7 @@ TEST_P(KMeans3DInitTest, AccuracyTest)
     cv::GArray<int> gLabelsIn, gLabelsOut;
     cv::GOpaque<double> compactness;
     std::tie(compactness, gLabelsOut, centers) =
-        cv::gapi::kmeans(in, K, criteria, attempts, flags, gLabelsIn);
+        cv::gapi::kmeans(in, K, gLabelsIn, criteria, attempts, flags);
     cv::GComputation c(cv::GIn(in, gLabelsIn), cv::GOut(compactness, gLabelsOut, centers));
     c.apply(cv::gin(in_vector, in_labels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
             getCompileArgs());

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1389,7 +1389,9 @@ TEST_P(NormalizeTest, Test)
 
 TEST_P(KMeansNDNoInitTest, AccuracyTest)
 {
-    const int quantity = sz.height, dimensions = sz.width;
+    const int quantity   = sz.height != 1 ? sz.height : sz.width,
+              dimensions = sz.height != 1 ? sz.width : (CV_MAT_DEPTH(type) >> CV_CN_SHIFT) + 1;
+                                                       // amount of channels
     const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
     const int attempts = 1;
     double compact_gapi = -1.;
@@ -1415,7 +1417,7 @@ TEST_P(KMeansNDNoInitTest, AccuracyTest)
 
 TEST_P(KMeansNDInitTest, AccuracyTest)
 {
-    const int quantity = sz.height;
+    const int quantity = sz.height != 1 ? sz.height : sz.width;
     const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
     const int attempts = 1;
     cv::Mat in_labels(cv::Size{1, quantity}, CV_32SC1);

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -1174,6 +1174,28 @@ inline std::ostream& operator<<(std::ostream& os, DistanceTypes op)
 #undef CASE
     return os;
 }
+
+inline std::ostream& operator<<(std::ostream& os, KmeansFlags op)
+{
+    int op_(op);
+    switch (op_)
+    {
+    case KmeansFlags::KMEANS_RANDOM_CENTERS:
+        os << "KMEANS_RANDOM_CENTERS";
+        break;
+    case KmeansFlags::KMEANS_PP_CENTERS:
+        os << "KMEANS_PP_CENTERS";
+        break;
+    case KmeansFlags::KMEANS_RANDOM_CENTERS | KmeansFlags::KMEANS_USE_INITIAL_LABELS:
+        os << "KMEANS_RANDOM_CENTERS | KMEANS_USE_INITIAL_LABELS";
+        break;
+    case KmeansFlags::KMEANS_PP_CENTERS | KmeansFlags::KMEANS_USE_INITIAL_LABELS:
+        os << "KMEANS_PP_CENTERS | KMEANS_USE_INITIAL_LABELS";
+        break;
+    default: GAPI_Assert(false && "unknown KmeansFlags value");
+    }
+    return os;
+}
 }  // namespace cv
 
 #endif //OPENCV_GAPI_TESTS_COMMON_HPP

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -492,7 +492,6 @@ INSTANTIATE_TEST_CASE_P(KMeansNDNoInitTestCPU, KMeansNDNoInitTest,
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
-
 INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDInitTest,
                         Combine(Values(CV_32FC1),
                                 Values(cv::Size(5, 720),
@@ -512,7 +511,6 @@ INSTANTIATE_TEST_CASE_P(KMeans2DNoInitTestCPU, KMeans2DNoInitTest,
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
-
 INSTANTIATE_TEST_CASE_P(KMeans2DInitTestCPU, KMeans2DInitTest,
                         Combine(Values(-1),
                                 Values(cv::Size(-1, 720),
@@ -530,7 +528,6 @@ INSTANTIATE_TEST_CASE_P(KMeans3DNoInitTestCPU, KMeans3DNoInitTest,
                                 Values(CORE_CPU),
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
-
 
 INSTANTIATE_TEST_CASE_P(KMeans3DInitTestCPU, KMeans3DInitTest,
                         Combine(Values(-1),

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -484,6 +484,64 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
 
+INSTANTIATE_TEST_CASE_P(KMeansNDNoInitTestCPU, KMeansNDNoInitTest,
+                        Combine(Values(CV_32FC1),
+                                Values(cv::Size(2, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(5),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
+
+
+INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDInitTest,
+                        Combine(Values(CV_32FC1),
+                                Values(cv::Size(5, 720),
+                                       cv::Size(2, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(AbsTolerance(0.01).to_compare_obj()),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
+
+INSTANTIATE_TEST_CASE_P(KMeans2DNoInitTestCPU, KMeans2DNoInitTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(-1, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(5),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
+
+
+INSTANTIATE_TEST_CASE_P(KMeans2DInitTestCPU, KMeans2DInitTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(-1, 720),
+                                       cv::Size(-1, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
+
+INSTANTIATE_TEST_CASE_P(KMeans3DNoInitTestCPU, KMeans3DNoInitTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(-1, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(5),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
+
+
+INSTANTIATE_TEST_CASE_P(KMeans3DInitTestCPU, KMeans3DInitTest,
+                        Combine(Values(-1),
+                                Values(cv::Size(-1, 720),
+                                       cv::Size(-1, 20)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
+
 // PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
 
 INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestCPU, BackendOutputAllocationTest,

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -493,9 +493,20 @@ INSTANTIATE_TEST_CASE_P(KMeansNDNoInitTestCPU, KMeansNDNoInitTest,
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
 INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDInitTest,
-                        Combine(Values(CV_32FC1),
-                                Values(cv::Size(5, 720),
-                                       cv::Size(2, 20)),
+                        Combine(Values(CV_32FC1, CV_32FC3),
+                                Values(cv::Size(1, 20),
+                                       cv::Size(2, 20),
+                                       cv::Size(5, 720)),
+                                Values(-1),
+                                Values(CORE_CPU),
+                                Values(AbsTolerance(0.01).to_compare_obj()),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
+
+INSTANTIATE_TEST_CASE_P(KMeansNDInitReverseTestCPU, KMeansNDInitTest,
+                        Combine(Values(CV_32FC3),
+                                Values(cv::Size(20, 1)),
                                 Values(-1),
                                 Values(CORE_CPU),
                                 Values(AbsTolerance(0.01).to_compare_obj()),


### PR DESCRIPTION
These changes:

 - Add `kmeans()` standard kernel
    -  provide API and documentation - 4 overloads:
        - standard `GMat` - for any dimensionality
        - `GMat` without bestLabels initialization for convenience
        - `GArray<Point2f>` - for 2D
        - `GArray<Point3f>` - for 3D
   - support OCV backend
 - Accuracy tests:
   - for every input - 2 tests
      1) without initializing. In this case, no comparison with cv::kmeans is done as kmeans uses random auto-initialization
      2) with initialization
   - in both cases, only 1 attempt is done as after first attempt kmeans initializes bestLabels randomly
   ### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
