### PR TITLE
Support for Pool1d layer for OpenCV and OpenCL targets

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -248,7 +248,6 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         int type;
         std::vector<size_t> kernel_size, strides;
         std::vector<size_t> pads_begin, pads_end;
-        CV_DEPRECATED_EXTERNAL int pad_l, pad_t, pad_r, pad_b;
         bool globalPooling; //!< Flag is true if at least one of the axes is global pooled.
         std::vector<bool> isGlobalPooling;
         bool computeMaxIdx;

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -248,7 +248,6 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         int type;
         std::vector<size_t> kernel_size, strides;
         std::vector<size_t> pads_begin, pads_end;
-        CV_DEPRECATED_EXTERNAL Size kernel, stride, pad;
         CV_DEPRECATED_EXTERNAL int pad_l, pad_t, pad_r, pad_b;
         bool globalPooling; //!< Flag is true if at least one of the axes is global pooled.
         std::vector<bool> isGlobalPooling;

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -461,8 +461,8 @@ virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inp
 
             PoolingInvoker p;
 
-            bool isConv1D = src.dims == 3;
-            bool isConv3D = src.dims == 5;
+            bool isPool1D = src.dims == 3;
+            bool isPool3D = src.dims == 5;
 
             p.src = &src;
             p.rois = &rois;
@@ -477,9 +477,9 @@ virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inp
             p.kernel = Size(kernel_size[1], kernel_size[0]);
             p.stride = Size(strides[1], strides[0]);
             p.pad_l = pads_begin.back();
-            p.pad_t = isConv1D? 0 : pads_begin[pads_begin.size() - 2];
+            p.pad_t = isPool1D ? 0 : pads_begin[pads_begin.size() - 2];
             p.pad_r = pads_end.back();
-            p.pad_b = isConv1D? 0 : pads_end[pads_end.size() - 2];
+            p.pad_b = isPool1D ? 0 : pads_end[pads_end.size() - 2];
 
             p.avePoolPaddedArea = avePoolPaddedArea;
             p.nstripes = nstripes;
@@ -489,11 +489,11 @@ virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inp
 
             if( !computeMaxIdx )
             {
-                int height = isConv1D? 1 : src.size[src.dims - 2];
+                int height = isPool1D ? 1 : src.size[src.dims - 2];
                 int width = src.size[src.dims - 1];
 
-                int kernel_d = isConv3D? kernel_size[0] : 1;
-                int kernel_h = isConv1D? 1 : kernel_size[kernel_size.size() - 2];
+                int kernel_d = isPool3D ? kernel_size[0] : 1;
+                int kernel_h = isPool1D ? 1 : kernel_size[kernel_size.size() - 2];
                 int kernel_w = kernel_size.back();
 
                 p.ofsbuf.resize(kernel_d * kernel_h * kernel_w);

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -204,12 +204,8 @@ public:
         {
             if (kernel_size.size() == 3)
                 return preferableTarget == DNN_TARGET_CPU;
-            if (kernel_size.empty() || kernel_size.size() == 2)
+            if (kernel_size.size() <= 2)
                 return true;
-            if (kernel_size.size() == 1)
-                return preferableTarget == DNN_TARGET_CPU ||
-                       preferableTarget == DNN_TARGET_OPENCL ||
-                       preferableTarget == DNN_TARGET_OPENCL_FP16;
             else
                 return false;
         }

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -732,6 +732,8 @@ virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inp
                             }
                         }
                         else
+#else
+                        CV_UNUSED(isPool2D);
 #endif
                         if( isPool1D )
                         {

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -200,20 +200,24 @@ public:
         {
             return !computeMaxIdx && type != STOCHASTIC && kernel_size.size() > 1;
         }
-        else if (backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_HALIDE)
+        else if (backendId == DNN_BACKEND_OPENCV)
         {
             if (kernel_size.size() == 3)
-                return (backendId == DNN_BACKEND_OPENCV && preferableTarget == DNN_TARGET_CPU);
+                return preferableTarget == DNN_TARGET_CPU;
             if (kernel_size.empty() || kernel_size.size() == 2)
-                return backendId == DNN_BACKEND_OPENCV ||
-                       (backendId == DNN_BACKEND_HALIDE && haveHalide() &&
-                       (type == MAX || (type == AVE && !pads_begin[0] && !pads_begin[1] && !pads_end[0] && !pads_end[1])));
+                return true;
             if (kernel_size.size() == 1)
-                return (backendId == DNN_BACKEND_OPENCV && preferableTarget == DNN_TARGET_CPU) ||
-                       (backendId == DNN_BACKEND_OPENCV && preferableTarget == DNN_TARGET_OPENCL) ||
-                       (backendId == DNN_BACKEND_OPENCV && preferableTarget == DNN_TARGET_OPENCL_FP16);
+                return preferableTarget == DNN_TARGET_CPU ||
+                       preferableTarget == DNN_TARGET_OPENCL ||
+                       preferableTarget == DNN_TARGET_OPENCL_FP16;
             else
                 return false;
+        }
+        else if (backendId == DNN_BACKEND_HALIDE)
+        {
+            if (kernel_size.empty() || kernel_size.size() == 2)
+                return haveHalide() &&
+                       (type == MAX || (type == AVE && !pads_begin[0] && !pads_begin[1] && !pads_end[0] && !pads_end[1]));
         }
         return false;
     }

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -230,6 +230,14 @@ public:
         bool use_half = (inps.depth() == CV_16S);
         inps.getUMatVector(inputs);
         outs.getUMatVector(outputs);
+        if (inputs[0].dims==3)
+        {
+            //Pool1D
+            kernel.height = 1;
+            pad_t = 0;
+            pad_b = 0;
+            stride.height = 1;
+        }
 
         if (poolOp.empty())
         {

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
@@ -51,18 +51,20 @@ template<typename Dtype>
 OCL4DNNPool<Dtype>::OCL4DNNPool(OCL4DNNPoolConfig config)
 {
     int dims = config.in_shape.size();
-    int spatial_dims = 2;
+    int spatial_dims = config.in_shape.size()-2;
 
     channels_ = config.channels;
     pool_method_ = config.pool_method;
     avePoolPaddedArea = config.avePoolPaddedArea;
     computeMaxIdx = config.computeMaxIdx;
     use_half = config.use_half;
+    kernel_shape_.push_back(config.kernel.height);
+    kernel_shape_.push_back(config.kernel.width);
+    stride_.push_back(config.stride.height);
+    stride_.push_back(config.stride.width);
 
     for (int i = 0; i < spatial_dims; ++i)
     {
-        kernel_shape_.push_back(i == 0 ? config.kernel.height : config.kernel.width);
-        stride_.push_back(i == 0 ? config.stride.height : config.stride.width);
         im_in_shape_.push_back(config.in_shape[dims - spatial_dims + i]);
         im_out_shape_.push_back(config.out_shape[dims - spatial_dims + i]);
     }
@@ -75,10 +77,10 @@ OCL4DNNPool<Dtype>::OCL4DNNPool(OCL4DNNPoolConfig config)
     pad_l_ = config.pad_l;
     pad_r_ = config.pad_r;
     pad_b_ = config.pad_b;
-    height_ = im_in_shape_[0];
-    width_ = im_in_shape_[1];
-    pooled_height_ = im_out_shape_[0];
-    pooled_width_ = im_out_shape_[1];
+    height_ = spatial_dims == 1? 1 : im_in_shape_[0];
+    width_ = im_in_shape_.back();
+    pooled_height_ = spatial_dims == 1? 1 : im_out_shape_[0];
+    pooled_width_ = im_out_shape_.back();
 
     count_ = 1;
     for (int i = 0; i < config.out_shape.size(); ++i)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -742,7 +742,7 @@ TEST_P(Test_ONNX_layers, DynamicAxes)
     testONNXModels("maxpooling_sigmoid_dynamic_axes");
 }
 
-TEST_P(Test_ONNX_layers, Pool1d)
+TEST_P(Test_ONNX_layers, MaxPool1d)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
     {
@@ -753,10 +753,70 @@ TEST_P(Test_ONNX_layers, Pool1d)
         if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     }
     testONNXModels("maxpooling_1d");
+}
+
+TEST_P(Test_ONNX_layers, MaxPoolSigmoid1d)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
     testONNXModels("maxpooling_sigmoid_1d");
+}
+
+TEST_P(Test_ONNX_layers, MaxPool1d_Twise)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
     testONNXModels("two_maxpooling_1d");
+}
+
+TEST_P(Test_ONNX_layers, AvePool1d)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
     testONNXModels("average_pooling_1d");
+}
+
+TEST_P(Test_ONNX_layers, PoolConv1d)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
     testONNXModels("pool_conv_1d");
+}
+
+TEST_P(Test_ONNX_layers, ConvResizePool1d)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
     testONNXModels("conv_resize_pool_1d");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -753,11 +753,11 @@ TEST_P(Test_ONNX_layers, Pool1d)
         if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     }
     testONNXModels("maxpooling_1d");
-    //testONNXModels("maxpooling_sigmoid_1d");
-    //testONNXModels("two_maxpooling_1d");
-    //testONNXModels("average_pooling_1d");
-    //testONNXModels("pool_conv_1d");
-    //testONNXModels("conv_resize_pool_1d");
+    testONNXModels("maxpooling_sigmoid_1d");
+    testONNXModels("two_maxpooling_1d");
+    testONNXModels("average_pooling_1d");
+    testONNXModels("pool_conv_1d");
+    testONNXModels("conv_resize_pool_1d");
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -742,6 +742,24 @@ TEST_P(Test_ONNX_layers, DynamicAxes)
     testONNXModels("maxpooling_sigmoid_dynamic_axes");
 }
 
+TEST_P(Test_ONNX_layers, Pool1d)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    }
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
+    testONNXModels("maxpooling_1d");
+    //testONNXModels("maxpooling_sigmoid_1d");
+    //testONNXModels("two_maxpooling_1d");
+    //testONNXModels("average_pooling_1d");
+    //testONNXModels("pool_conv_1d");
+    //testONNXModels("conv_resize_pool_1d");
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 
 class Test_ONNX_nets : public Test_ONNX_layers


### PR DESCRIPTION
Resolves: https://github.com/opencv/opencv/issues/18643

**Merge with extra:** https://github.com/opencv/opencv_extra/pull/820

<cut/>

```
opencv_extra=test_pool1d

force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
