### PR TITLE
G-API: ONNX. Added small fix for cmake

### DIFF
--- a/cmake/FindONNX.cmake
+++ b/cmake/FindONNX.cmake
@@ -4,7 +4,7 @@ set(ONNXRT_ROOT_DIR "" CACHE PATH "ONNX Runtime install directory")
 
 # For now, check the old name ORT_INSTALL_DIR
 if(ORT_INSTALL_DIR AND NOT ONNXRT_ROOT_DIR)
-  set(ONNXRT_ROOT_DIR ORT_INSTALL_DIR)
+  set(ONNXRT_ROOT_DIR ${ORT_INSTALL_DIR})
 endif()
 
 if(ONNXRT_ROOT_DIR)


### PR DESCRIPTION
The path to the ORT installation directory was set incorrectly with `DORT_INSTALL_DIR=`. It is a fix for this problem.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=ubuntu-onnx:20.04
test_modules:Custom=gapi
test_filter:Custom=*ONNX*
