### PR TITLE
calib3d: eliminate 'register' build warning

### DIFF
--- a/modules/calib3d/src/sqpnp.cpp
+++ b/modules/calib3d/src/sqpnp.cpp
@@ -631,7 +631,7 @@ void PoseSolver::computeRowAndNullspace(const cv::Matx<double, 9, 1>& r,
 void PoseSolver::nearestRotationMatrix(const cv::Matx<double, 9, 1>& e,
     cv::Matx<double, 9, 1>& r)
 {
-    register int i;
+    int i;
     double l, lprev, det_e, e_sq, adj_e_sq, adj_e[9];
 
     // e's adjoint


### PR DESCRIPTION
relates #18371