### PR TITLE
Add option for NMS for boxes with different labels

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1303,10 +1303,12 @@ CV__DNN_INLINE_NS_BEGIN
           *  @param[out] boxes A set of bounding boxes.
           *  @param[in] confThreshold A threshold used to filter boxes by confidences.
           *  @param[in] nmsThreshold A threshold used in non maximum suppression.
+          *  @param[in] nmsDifferentLabels Determines if non maximum suppression should be applied when labels are different.
           */
          CV_WRAP void detect(InputArray frame, CV_OUT std::vector<int>& classIds,
                              CV_OUT std::vector<float>& confidences, CV_OUT std::vector<Rect>& boxes,
-                             float confThreshold = 0.5f, float nmsThreshold = 0.0f);
+                             float confThreshold = 0.5f, float nmsThreshold = 0.0f,
+                             bool nmsDifferentLabels = false);
      };
 
 //! @}


### PR DESCRIPTION
In the detect function in modules/dnn/include/opencv2/dnn/dnn.hpp, whose implementation can be found at modules/dnn/src/model.cpp, the Non Max Suppression (NMS) is applied only for objects of the same label. Thus, a flag
was added with the purpose to allow developers to choose if they want to keep the default implementation or wether they would like NMS to be applied to all the boxes, regardless of label.

The flag is called nmsDifferentLabels, and is given a default value of false, which applies the current default implementation, thus allowing existing projects to update opencv without disruption

Solves Issue #18832 

The following image was generated using YoloV4 trained on the MSCOCO dataset (weights here: https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights) . The numer '20' is the label for 'elephant' while the label '0' is the label for 'person'. You can see that the person and elephant have a very close bounding box, however they are not being suppressed when nmsDifferentLabels is False, but they are being suppressed when nmsDifferentLabels is True. You can also see that the box chosen was that with the highest confidence.

![nmsDiferentLabels](https://user-images.githubusercontent.com/33454325/99886634-6cce8380-2c3e-11eb-9575-d66976580577.png)

This is useful when an object is determined as 2 objects at once. In my case, I had some cars which were being classified as both a car and a truck at the same time, and I could not NMS them properly without adding more code. It was also difficult to find out why NMS was not behaving 'properly', leaving me to have to actually dig into the source code. This fixes this issue and in my opinion makes the code clearer without taking assumptions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
