### PR TITLE
Remove unnecessary condition (will never reach)

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -1032,8 +1032,7 @@ void flip( InputArray _src, OutputArray _dst, int flip_mode )
     }
 
     if ((size.width == 1 && flip_mode > 0) ||
-        (size.height == 1 && flip_mode == 0) ||
-        (size.height == 1 && size.width == 1 && flip_mode < 0))
+        (size.height == 1 && flip_mode == 0))
     {
         return _src.copyTo(_dst);
     }


### PR DESCRIPTION
The code
```
    if (flip_mode < 0)
    {
        if (size.width == 1)
            flip_mode = 0;
        if (size.height == 1)
            flip_mode = 1;
    }
```
above will always override that condition.

<cut/>

# Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
