### PR TITLE
cmake: update condition for find_package(Eigen3 CONFIG)

### DIFF
--- a/cmake/OpenCVFindLibsPerf.cmake
+++ b/cmake/OpenCVFindLibsPerf.cmake
@@ -51,7 +51,10 @@ endif(WITH_CUDA)
 
 # --- Eigen ---
 if(WITH_EIGEN AND NOT HAVE_EIGEN)
-  if(NOT OPENCV_SKIP_EIGEN_FIND_PACKAGE_CONFIG)
+  if((OPENCV_FORCE_EIGEN_FIND_PACKAGE_CONFIG
+      OR NOT (CMAKE_VERSION VERSION_LESS "3.0.0")  # Eigen3Targets.cmake required CMake 3.0.0+
+      ) AND NOT OPENCV_SKIP_EIGEN_FIND_PACKAGE_CONFIG
+  )
     find_package(Eigen3 CONFIG QUIET)  # Ceres 2.0.0 CMake scripts doesn't work with CMake's FindEigen3.cmake module (due to missing EIGEN3_VERSION_STRING)
   endif()
   if(NOT Eigen3_FOUND)


### PR DESCRIPTION
relates #18699

Failed [nightly CentOS build](http://pullrequest.opencv.org/buildbot/builders/3_4_etc-centos-lin64/builds/41).
Caused by old CMake 2.8.12

```
build_image:Custom=centos:7
buildworker:Custom=linux-1
```
