### PR TITLE
G-API: ONNX. Disable unnecessary outputs

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -58,6 +58,8 @@ struct ParamDesc {
     PostProc custom_post_proc;
 
     std::vector<bool> normalize;
+
+    std::vector<std::string> names_to_remap;
 };
 } // namespace detail
 
@@ -115,10 +117,67 @@ public:
         return *this;
     }
 
-    Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &outs,
+    /** @brief Configures graph output and sets the post processing function from user.
+
+    The function is used for the case of infer of networks with dynamic outputs.
+    Since these networks haven't known output parameters needs provide them for
+    construction of output of graph.
+    The function provides meta information of outputs and post processing function.
+    Post processing function is used for copy information from ONNX infer's result
+    to output of graph which is allocated by out meta information.
+
+    @param out_metas out meta information.
+    @param pp post processing function, which has two parameters. First is onnx
+    result, second is graph output. Both parameters is std::map that contain pair of
+    layer's name and cv::Mat.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
                              const PostProc &pp) {
-        desc.out_metas = outs;
+        desc.out_metas        = out_metas;
         desc.custom_post_proc = pp;
+        return *this;
+    }
+
+    /** @overload
+    The function has rvalue parameters.
+    */
+    Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
+                             PostProc &&pp) {
+        desc.out_metas        = std::move(out_metas);
+        desc.custom_post_proc = std::move(pp);
+        return *this;
+    }
+
+    /** @overload
+    The function has additional parameter names_to_remap. This parameter provides
+    information about output layers which will be used for infer and in post
+    processing function.
+
+    @param out_metas out meta information.
+    @param pp post processing function.
+    @param names_to_remap contains names of output layers. CNN's infer will be done on these layers.
+    Infer's result will be processed in post processing function using these names.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
+                             const PostProc &pp,
+                             const std::vector<std::string> &names_to_remap) {
+        desc.out_metas        = out_metas;
+        desc.custom_post_proc = pp;
+        desc.names_to_remap   = names_to_remap;
+        return *this;
+    }
+
+    /** @overload
+    The function has rvalue parameters.
+    */
+    Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
+                             PostProc &&pp,
+                             std::vector<std::string> &&names_to_remap) {
+        desc.out_metas        = std::move(out_metas);
+        desc.custom_post_proc = std::move(pp);
+        desc.names_to_remap   = std::move(names_to_remap);
         return *this;
     }
 


### PR DESCRIPTION
### Disable unnecessary outputs

### How it works:
Unnecessary network outputs can be omitted. For example: FRCNN has output with `INT_64` data type, which unsupported for OCV. Name of this output is "6381". We can "disable" this output. It works for dynamic output case only when we should remap onnx outputs to g-api out.
You can set layer names which you will use in remapping. You should call overload of cfgPostProc function for this.
```
.cfgOutputLayers({"gapi_out1", "gapi_out2"})
.cfgPostProc({cv::GMatDesc{CV_32F, {1,20}}, cv::GMatDesc{CV_32F, {5}}},
             remapRcnnPorts,
             {"6383", "6379"}
);
```
There are two layers with names "6383" and "6379" will be used for remapping. Data will be remapped from "6383", "6379" to "gapi_out1", "gapi_out2" with remapRcnnPorts function logic (Unfortunately we can't set out_meta for network with dynamic outputs, but we can set own outputs and remap data to them from onnx result).
Disabling is independent of cfgOutputLayers function in this case.

For CNN with static outputs use another logic. We know out_meta and don't need remapping in tis case.
### Tests:
Test contains infer for FRCNN. FRCNN output with name "6381" has unsupported type. 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Custom build:
```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=ubuntu-onnx:20.04
test_modules:Custom=gapi
test_filter:Custom=*ONNX*
```
