### PR TITLE
G-API: Adding skip for GraphMeta tests

### DIFF
--- a/modules/gapi/test/gapi_graph_meta_tests.cpp
+++ b/modules/gapi/test/gapi_graph_meta_tests.cpp
@@ -99,7 +99,12 @@ TEST(GraphMeta, Streaming_AccessInput) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
 
     auto ccomp = graph.compileStreaming();
-    ccomp.setSource<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi", false));
+    const auto path = findDataFile("cv/video/768x576.avi", false);
+    try {
+        ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
 
     cv::Mat out_mat;
@@ -122,7 +127,12 @@ TEST(GraphMeta, Streaming_AccessOutput) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2, out3));
 
     auto ccomp = graph.compileStreaming();
-    ccomp.setSource<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi", false));
+    const auto path = findDataFile("cv/video/768x576.avi", false);
+    try {
+        ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
 
     cv::Mat out_mat;
@@ -155,7 +165,12 @@ TEST(GraphMeta, Streaming_AccessDesync) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2, out3, out4, out5));
 
     auto ccomp = graph.compileStreaming();
-    ccomp.setSource<cv::gapi::wip::GCaptureSource>(findDataFile("cv/video/768x576.avi", false));
+    const auto path = findDataFile("cv/video/768x576.avi", false);
+    try {
+        ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
     ccomp.start();
 
     cv::optional<int64_t> out_sync_id;

--- a/modules/gapi/test/gapi_graph_meta_tests.cpp
+++ b/modules/gapi/test/gapi_graph_meta_tests.cpp
@@ -99,7 +99,7 @@ TEST(GraphMeta, Streaming_AccessInput) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2));
 
     auto ccomp = graph.compileStreaming();
-    const auto path = findDataFile("cv/video/768x576.avi", false);
+    const auto path = findDataFile("cv/video/768x576.avi");
     try {
         ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
     } catch(...) {
@@ -127,7 +127,7 @@ TEST(GraphMeta, Streaming_AccessOutput) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2, out3));
 
     auto ccomp = graph.compileStreaming();
-    const auto path = findDataFile("cv/video/768x576.avi", false);
+    const auto path = findDataFile("cv/video/768x576.avi");
     try {
         ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
     } catch(...) {
@@ -165,7 +165,7 @@ TEST(GraphMeta, Streaming_AccessDesync) {
     cv::GComputation graph(cv::GIn(in), cv::GOut(out1, out2, out3, out4, out5));
 
     auto ccomp = graph.compileStreaming();
-    const auto path = findDataFile("cv/video/768x576.avi", false);
+    const auto path = findDataFile("cv/video/768x576.avi");
     try {
         ccomp.setSource<cv::gapi::wip::GCaptureSource>(path);
     } catch(...) {


### PR DESCRIPTION
It is a continuation of this: https://github.com/opencv/opencv/pull/18819
Fixes: https://github.com/opencv/opencv/issues/17470

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Magic centOs commands:
```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```