### PR TITLE
fix missing addref() in ocl::Context::create(str)

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2437,6 +2437,7 @@ public:
         if (impl)
         {
             CV_LOG_INFO(NULL, "OpenCL: reuse context@" << impl->contextId << " for configuration: " << configuration)
+            impl->addref();
             return impl;
         }
 


### PR DESCRIPTION
fix https://github.com/opencv/opencv/issues/18906
add two test cases

I ran `opencv_test_cored.exe --gtest_filter=OCL*` and all passed successfully including the two new test cases

```
[----------] Global test environment tear-down
[==========] 6837 tests from 60 test cases ran. (267680 ms total)
[  PASSED  ] 6837 tests.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
