### PR TITLE
Add adding and subtraction operations between a number and a quaternion;

### DIFF
--- a/modules/core/include/opencv2/core/quaternion.inl.hpp
+++ b/modules/core/include/opencv2/core/quaternion.inl.hpp
@@ -149,6 +149,30 @@ inline Quat<T> Quat<T>::operator+(const Quat<T> &q1) const
 }
 
 template <typename T>
+inline Quat<T> operator+(const T a, const Quat<T>& q)
+{
+    return Quat<T>(q.w + a, q.x, q.y, q.z);
+}
+
+template <typename T>
+inline Quat<T> operator+(const Quat<T>& q, const T a)
+{
+    return Quat<T>(q.w + a, q.x, q.y, q.z);
+}
+
+template <typename T>
+inline Quat<T> operator-(const T a, const Quat<T>& q)
+{
+    return Quat<T>(a - q.w, -q.x, -q.y, -q.z);
+}
+
+template <typename T>
+inline Quat<T> operator-(const Quat<T>& q, const T a)
+{
+    return Quat<T>(q.w - a, q.x, q.y, q.z);
+}
+
+template <typename T>
 inline Quat<T> Quat<T>::operator-(const Quat<T> &q1) const
 {
     return Quat<T>(w - q1.w, x - q1.x, y - q1.y, z - q1.z);
@@ -183,14 +207,14 @@ inline Quat<T> Quat<T>::operator*(const Quat<T> &q1) const
 }
 
 
-template <typename T, typename S>
-Quat<T> operator*(const Quat<T> &q1, const S a)
+template <typename T>
+Quat<T> operator*(const Quat<T> &q1, const T a)
 {
     return Quat<T>(a * q1.w, a * q1.x, a * q1.y, a * q1.z);
 }
 
-template <typename T, typename S>
-Quat<T> operator*(const S a, const Quat<T> &q1)
+template <typename T>
+Quat<T> operator*(const T a, const Quat<T> &q1)
 {
     return Quat<T>(a * q1.w, a * q1.x, a * q1.y, a * q1.z);
 }
@@ -221,7 +245,7 @@ inline Quat<T>& Quat<T>::operator/=(const Quat<T> &q1)
     return *this;
 }
 template <typename T>
-Quat<T>& Quat<T>::operator*=(const T &q1)
+Quat<T>& Quat<T>::operator*=(const T q1)
 {
     w *= q1;
     x *= q1;
@@ -231,7 +255,7 @@ Quat<T>& Quat<T>::operator*=(const T &q1)
 }
 
 template <typename T>
-inline Quat<T>& Quat<T>::operator/=(const T &a)
+inline Quat<T>& Quat<T>::operator/=(const T a)
 {
     const T a_inv = 1.0 / a;
     w *= a_inv;
@@ -242,7 +266,7 @@ inline Quat<T>& Quat<T>::operator/=(const T &a)
 }
 
 template <typename T>
-inline Quat<T> Quat<T>::operator/(const T &a) const
+inline Quat<T> Quat<T>::operator/(const T a) const
 {
     const T a_inv = 1.0 / a;
     return Quat<T>(w * a_inv, x * a_inv, y * a_inv, z * a_inv);
@@ -353,15 +377,14 @@ Quat<T> Quat<T>::log(QuatAssumeType assumeUnit) const
     return Quat<T>(std::log(qNorm), v[0] * k, v[1] * k, v[2] *k);
 }
 
-template <typename T, typename _T>
-inline Quat<T> power(const Quat<T> &q1, _T alpha, QuatAssumeType assumeUnit)
+template <typename T>
+inline Quat<T> power(const Quat<T> &q1, const T alpha, QuatAssumeType assumeUnit)
 {
     return q1.power(alpha, assumeUnit);
 }
 
 template <typename T>
-template <typename _T>
-inline Quat<T> Quat<T>::power(_T alpha, QuatAssumeType assumeUnit) const
+inline Quat<T> Quat<T>::power(const T alpha, QuatAssumeType assumeUnit) const
 {
     if (x * x + y * y + z * z > CV_QUAT_EPS)
     {

--- a/modules/core/test/test_quaternion.cpp
+++ b/modules/core/test/test_quaternion.cpp
@@ -18,7 +18,7 @@ protected:
     }
     double scalar = 2.5;
     double angle = CV_PI;
-    int qNorm2 = 2;
+    double qNorm2 = 2;
     Vec<double, 3> axis{1, 1, 1};
     Vec<double, 3> unAxis{0, 0, 0};
     Vec<double, 3> unitAxis{1.0 / sqrt(3), 1.0 / sqrt(3), 1.0 / sqrt(3)};
@@ -124,7 +124,7 @@ TEST_F(QuatTest, basicfuns){
     EXPECT_EQ(exp(qNull), qIdentity);
     EXPECT_EQ(exp(Quatd(0, angle * unitAxis[0] / 2, angle * unitAxis[1] / 2, angle * unitAxis[2] / 2)), q3);
 
-    EXPECT_EQ(power(q3, 2), Quatd::createFromAngleAxis(2*angle, axis));
+    EXPECT_EQ(power(q3, 2.0), Quatd::createFromAngleAxis(2*angle, axis));
     EXPECT_EQ(power(Quatd(0.5, 0.5, 0.5, 0.5), 2.0, assumeUnit), Quatd(-0.5,0.5,0.5,0.5));
     EXPECT_EQ(power(Quatd(0.5, 0.5, 0.5, 0.5), -2.0), Quatd(-0.5,-0.5,-0.5,-0.5));
     EXPECT_EQ(sqrt(q1), power(q1, 0.5));
@@ -160,7 +160,7 @@ TEST_F(QuatTest, basicfuns){
     EXPECT_EQ(tan(atan(q1)), q1);
 }
 
-TEST_F(QuatTest, opeartor){
+TEST_F(QuatTest, operator){
     Quatd minusQ{-1, -2, -3, -4};
     Quatd qAdd{3.5, 0, 6.5, 8};
     Quatd qMinus{-1.5, 4, -0.5, 0};
@@ -171,7 +171,15 @@ TEST_F(QuatTest, opeartor){
 
     EXPECT_EQ(-q1, minusQ);
     EXPECT_EQ(q1 + q2, qAdd);
+    EXPECT_EQ(q1 + scalar, Quatd(3.5, 2, 3, 4));
+    EXPECT_EQ(scalar + q1, Quatd(3.5, 2, 3, 4));
+    EXPECT_EQ(q1 + 2.0, Quatd(3, 2, 3, 4));
+    EXPECT_EQ(2.0 + q1, Quatd(3, 2, 3, 4));
     EXPECT_EQ(q1 - q2, qMinus);
+    EXPECT_EQ(q1 - scalar, Quatd(-1.5, 2, 3, 4));
+    EXPECT_EQ(scalar - q1, Quatd(1.5, -2, -3, -4));
+    EXPECT_EQ(q1 - 2.0, Quatd(-1, 2, 3, 4));
+    EXPECT_EQ(2.0 - q1, Quatd(1, -2, -3, -4));
     EXPECT_EQ(q1 * q2, qMultq);
     EXPECT_EQ(q1 * scalar, qMults);
     EXPECT_EQ(scalar * q1, qMults);


### PR DESCRIPTION
I found that many papers directly write a number plus a quaternion. 
It has to write like this
```
double number = 2.0;
Quatd q{1, 2, 3, 4};
Quatd ans = Quatd(number,0,0,0) + q;
```
which is too much trouble for users. So adding this operations may be friendly and convenience
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PxR is proposed to proper branch
- [ ] There is refxerence to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
