### PR TITLE
[G-API]: Eliminates detail::ParamDesc mention from public tests

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -67,6 +67,17 @@ namespace detail {
         Kind kind;
         bool is_generic;
         IEConfig config;
+
+        ParamDesc(std::string model, std::string weights, std::string device,
+                  std::vector<std::string> inputNames, std::vector<std::string> outputNames,
+                  std::unordered_map<std::string, ConstInput> constInputs,
+                  std::size_t numIn, std::size_t numOut, Kind kind_, bool isGen, IEConfig config_)
+            : model_path(model), weights_path(weights), device_id(device), input_names(inputNames),
+              output_names(outputNames), const_inputs(constInputs), num_in(numIn), num_out(numOut),
+              kind(kind_), is_generic(isGen), config(config_) {}
+
+        ParamDesc(std::string model, std::string weights, std::string device)
+            : model_path(model), weights_path(weights), device_id(device) {};
     };
 } // namespace detail
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -68,18 +68,19 @@ namespace detail {
         bool is_generic;
         IEConfig config;
 
-        ParamDesc(const std::string& model, const std::string& weights, const std::string& device,
-                  const std::vector<std::string>& inputNames,
-                  const std::vector<std::string>& outputNames,
-                  const std::unordered_map<std::string, ConstInput>& constInputs,
-                  const std::size_t numIn, const std::size_t numOut, const Kind kind_,
-                  const bool isGen, const IEConfig& config_)
-            : model_path(model), weights_path(weights), device_id(device), input_names(inputNames),
-              output_names(outputNames), const_inputs(constInputs), num_in(numIn), num_out(numOut),
-              kind(kind_), is_generic(isGen), config(config_) {}
+        ParamDesc(std::string model, std::string weights, std::string device,
+                  std::vector<std::string> inputNames, std::vector<std::string> outputNames,
+                  std::unordered_map<std::string, ConstInput> constInputs, std::size_t numIn,
+                  std::size_t numOut, Kind kind_, bool isGen, IEConfig config_)
+            : model_path(std::move(model)), weights_path(std::move(weights)),
+              device_id(std::move(device)), input_names(std::move(inputNames)),
+              output_names(std::move(outputNames)), const_inputs(std::move(constInputs)),
+              num_in(std::move(numIn)), num_out(std::move(numOut)), kind(std::move(kind_)),
+              is_generic(std::move(isGen)), config(std::move(config_)) {}
 
-        ParamDesc(const std::string& model, const std::string& weights, const std::string& device)
-            : model_path(model), weights_path(weights), device_id(device) {};
+        ParamDesc(std::string model, std::string weights, std::string device)
+            : model_path(std::move(model)), weights_path(std::move(weights)),
+              device_id(std::move(device)) {};
     };
 } // namespace detail
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -68,15 +68,17 @@ namespace detail {
         bool is_generic;
         IEConfig config;
 
-        ParamDesc(std::string model, std::string weights, std::string device,
-                  std::vector<std::string> inputNames, std::vector<std::string> outputNames,
-                  std::unordered_map<std::string, ConstInput> constInputs,
-                  std::size_t numIn, std::size_t numOut, Kind kind_, bool isGen, IEConfig config_)
+        ParamDesc(const std::string& model, const std::string& weights, const std::string& device,
+                  const std::vector<std::string>& inputNames,
+                  const std::vector<std::string>& outputNames,
+                  const std::unordered_map<std::string, ConstInput>& constInputs,
+                  const std::size_t numIn, const std::size_t numOut, const Kind kind_,
+                  const bool isGen, const IEConfig& config_)
             : model_path(model), weights_path(weights), device_id(device), input_names(inputNames),
               output_names(outputNames), const_inputs(constInputs), num_in(numIn), num_out(numOut),
               kind(kind_), is_generic(isGen), config(config_) {}
 
-        ParamDesc(std::string model, std::string weights, std::string device)
+        ParamDesc(const std::string& model, const std::string& weights, const std::string& device)
             : model_path(model), weights_path(weights), device_id(device) {};
     };
 } // namespace detail

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -68,19 +68,18 @@ namespace detail {
         bool is_generic;
         IEConfig config;
 
-        ParamDesc(std::string model, std::string weights, std::string device,
-                  std::vector<std::string> inputNames, std::vector<std::string> outputNames,
-                  std::unordered_map<std::string, ConstInput> constInputs, std::size_t numIn,
-                  std::size_t numOut, Kind kind_, bool isGen, IEConfig config_)
-            : model_path(std::move(model)), weights_path(std::move(weights)),
-              device_id(std::move(device)), input_names(std::move(inputNames)),
-              output_names(std::move(outputNames)), const_inputs(std::move(constInputs)),
-              num_in(std::move(numIn)), num_out(std::move(numOut)), kind(std::move(kind_)),
-              is_generic(std::move(isGen)), config(std::move(config_)) {}
+        ParamDesc(const std::string& model, const std::string& weights, const std::string& device,
+                  const std::vector<std::string>& inputNames,
+                  const std::vector<std::string>& outputNames,
+                  const std::unordered_map<std::string, ConstInput>& constInputs,
+                  std::size_t numIn, std::size_t numOut, Kind kind_, bool isGen,
+                  const IEConfig& config_)
+            : model_path(model), weights_path(weights), device_id(device), input_names(inputNames),
+              output_names(outputNames), const_inputs(constInputs), num_in(std::move(numIn)),
+              num_out(numOut), kind(kind_), is_generic(isGen), config(config_) {};
 
-        ParamDesc(std::string model, std::string weights, std::string device)
-            : model_path(std::move(model)), weights_path(std::move(weights)),
-              device_id(std::move(device)) {};
+        ParamDesc(const std::string& model, const std::string& weights, const std::string& device)
+            : model_path(model), weights_path(weights), device_id(device) {};
     };
 } // namespace detail
 

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -573,7 +573,8 @@ TEST(TestAgeGenderIE, CPUConfigGeneric)
                                                       model_path,
                                                       weights_path,
                                                       device_id
-                                                     }.pluginConfig({{"ENFORCE_BF16", "NO"}});
+                                                     }.pluginConfig({{"CPU_THROUGHPUT_STREAMS",
+                                                                      "CPU_THROUGHPUT_NUMA"}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));
@@ -622,7 +623,8 @@ TEST(TestAgeGenderIE, CPUConfig)
 
     auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
                                               }.cfgOutputLayers({ "age_conv3", "prob" })
-                                               .pluginConfig({{"ENFORCE_BF16", "NO"}});
+                                               .pluginConfig({{"CPU_THROUGHPUT_STREAMS",
+                                                               "CPU_THROUGHPUT_NUMA"}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -216,7 +216,7 @@ TEST(TestAgeGenderIE, InferBasicImage)
 }
 
 struct ROIList: public ::testing::Test {
-    std::string model_path   = "", weights_path = "", device_id    = "";
+    std::string model_path, weights_path, device_id;
 
     cv::Mat m_in_mat;
     std::vector<cv::Rect> m_roi_list;

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -511,10 +511,8 @@ TEST(TestAgeGenderIE, GenericInfer)
 
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    cv::gapi::ie::Params<cv::gapi::Generic> pp{"age-gender-generic",
-                                               model_path,
-                                               weights_path,
-                                               device_id};
+    cv::gapi::ie::Params<cv::gapi::Generic> pp{
+        "age-gender-generic", model_path, weights_path, device_id};
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -542,12 +540,9 @@ TEST(TestAgeGenderIE, InvalidConfigGeneric)
     auto gender  = outputs.at("prob");
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{"age-gender-generic",
-                                                      model_path,
-                                                      weights_path,
-                                                      device_id
-                                                     }.pluginConfig({{"unsupported_config",
-                                                                      "some_value"}});
+    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{
+        "age-gender-generic", model_path, weights_path, device_id
+    }.pluginConfig({{"unsupported_config", "some_value"}});
 
     EXPECT_ANY_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                      cv::compile_args(cv::gapi::networks(pp))));
@@ -571,12 +566,10 @@ TEST(TestAgeGenderIE, CPUConfigGeneric)
     auto gender  = outputs.at("prob");
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{"age-gender-generic",
-                                                      model_path,
-                                                      weights_path,
-                                                      device_id
-                                                     }.pluginConfig({{"CPU_THROUGHPUT_STREAMS",
-                                                                      "CPU_THROUGHPUT_NUMA"}});
+    auto pp = cv::gapi::ie::Params<cv::gapi::Generic> {
+        "age-gender-generic", model_path, weights_path, device_id
+    }.pluginConfig({{IE::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,
+                     IE::PluginConfigParams::CPU_THROUGHPUT_NUMA}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));
@@ -598,10 +591,10 @@ TEST(TestAgeGenderIE, InvalidConfig)
     std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" })
-                                               .pluginConfig({{"unsupported_config",
-                                                               "some_value"}});
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .pluginConfig({{"unsupported_config", "some_value"}});
 
     EXPECT_ANY_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                      cv::compile_args(cv::gapi::networks(pp))));
@@ -623,10 +616,11 @@ TEST(TestAgeGenderIE, CPUConfig)
     std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" })
-                                               .pluginConfig({{"CPU_THROUGHPUT_STREAMS",
-                                                               "CPU_THROUGHPUT_NUMA"}});
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .pluginConfig({{IE::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,
+                     IE::PluginConfigParams::CPU_THROUGHPUT_NUMA}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -156,8 +156,9 @@ TEST(TestAgeGenderIE, InferBasicTensor)
     std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -205,8 +206,9 @@ TEST(TestAgeGenderIE, InferBasicImage)
     std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -374,8 +376,9 @@ TEST_F(ROIList, TestInfer)
     std::tie(age, gender) = cv::gapi::infer<AgeGender>(rr, in);
     cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(m_in_mat, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -390,8 +393,9 @@ TEST_F(ROIList, TestInfer2)
     std::tie(age, gender) = cv::gapi::infer2<AgeGender>(in, rr);
     cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(m_in_mat, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -455,10 +459,12 @@ TEST(DISABLED_TestTwoIENNPipeline, InferBasicImage)
     std::tie(age2, gender2) = cv::gapi::infer<AgeGender2>(cv::gapi::copy(in));
     cv::GComputation comp(cv::GIn(in), cv::GOut(age1, gender1, age2, gender2));
 
-    auto age_net1 = cv::gapi::ie::Params<AgeGender1> {model_path, weights_path, device_id
-                                                     }.cfgOutputLayers({ "age_conv3", "prob" });
-    auto age_net2 = cv::gapi::ie::Params<AgeGender2> {model_path, weights_path, device_id
-                                                     }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto age_net1 = cv::gapi::ie::Params<AgeGender1> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto age_net2 = cv::gapi::ie::Params<AgeGender2> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age1, gapi_gender1, gapi_age2, gapi_gender2),
                cv::compile_args(cv::gapi::networks(age_net1, age_net2)));
@@ -638,8 +644,9 @@ TEST_F(ROIList, MediaInputBGR)
 
     auto frame = MediaFrame::Create<TestMediaBGR>(m_in_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -659,8 +666,9 @@ TEST_F(ROIListNV12, MediaInputNV12)
 
     auto frame = MediaFrame::Create<TestMediaNV12>(m_in_y, m_in_uv);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -711,8 +719,9 @@ TEST(TestAgeGenderIE, MediaInputNV12)
 
     auto frame = MediaFrame::Create<TestMediaNV12>(in_y_mat, in_uv_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -763,8 +772,9 @@ TEST(TestAgeGenderIE, MediaInputBGR)
 
     auto frame = MediaFrame::Create<TestMediaBGR>(in_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -825,8 +835,9 @@ TEST(InferROI, MediaInputBGR)
 
     auto frame = MediaFrame::Create<TestMediaBGR>(in_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, rect), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -889,8 +900,9 @@ TEST(InferROI, MediaInputNV12)
 
     auto frame = MediaFrame::Create<TestMediaNV12>(in_y_mat, in_uv_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, rect), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
 
@@ -910,8 +922,9 @@ TEST_F(ROIList, Infer2MediaInputBGR)
 
     auto frame = MediaFrame::Create<TestMediaBGR>(m_in_mat);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -928,8 +941,9 @@ TEST_F(ROIListNV12, Infer2MediaInputNV12)
 
     auto frame = MediaFrame::Create<TestMediaNV12>(m_in_y, m_in_uv);
 
-    auto pp = cv::gapi::ie::Params<AgeGender> {model_path, weights_path, device_id
-                                              }.cfgOutputLayers({ "age_conv3", "prob" });
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        model_path, weights_path, device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
     comp.apply(cv::gin(frame, m_roi_list),
                cv::gout(m_out_gapi_ages, m_out_gapi_genders),
                cv::compile_args(cv::gapi::networks(pp)));


### PR DESCRIPTION
This change:
 - replaces explicit ParamDesc objects declarations by brace-enclosed initializer lists
 - has to add constructors for ParamDesc
 - unifies tests appearance as possible

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```