### PR TITLE
G-API: eliminate std::rand() and RAND_MAX from tests

### DIFF
--- a/modules/gapi/test/common/gapi_parsers_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_parsers_tests_common.hpp
@@ -176,7 +176,7 @@ private:
     int randInRange(const int start, const int end)
     {
         GAPI_Assert(start <= end);
-        return start + std::rand() % (end - start + 1);
+        return theRNG().uniform(start, end);
     }
 
     cv::Rect generateBox(const cv::Size& in_sz)
@@ -211,7 +211,7 @@ private:
         SSDitem it;
         it.image_id = static_cast<float>(i);
         it.label = static_cast<float>(randInRange(0, 9));
-        it.confidence = static_cast<float>(std::rand()) / RAND_MAX;
+        it.confidence = theRNG().uniform(0.f, 1.f);
         auto box = generateBox(in_sz);
         it.rc_left   = normalize(box.x, in_sz.width);
         it.rc_right  = normalize(box.x + box.width, in_sz.width);
@@ -245,9 +245,10 @@ public:
         auto data = mat.ptr<float>();
 
         const size_t range = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
+        cv::RNG& rng = theRNG();
         for (size_t i = 0; i < range; ++i)
         {
-            data[i] = static_cast<float>(std::rand()) / RAND_MAX;
+            data[i] = rng.uniform(0.f, 1.f);
         }
         return mat;
     }

--- a/modules/gapi/test/rmat/rmat_tests.cpp
+++ b/modules/gapi/test/rmat/rmat_tests.cpp
@@ -116,11 +116,11 @@ public:
 // we have some specific data hidden under RMat,
 // test that we can obtain it via RMat.as<T>() method
 TEST(RMat, UsageInBackend) {
-    int i = std::rand();
+    int i = 123456;
     auto rmat = cv::make_rmat<RMatAdapterForBackend>(i);
 
     auto adapter = rmat.get<RMatAdapterForBackend>();
-    EXPECT_NE(nullptr, adapter);
+    ASSERT_NE(nullptr, adapter);
     EXPECT_EQ(i, adapter->deviceSpecificData());
 }
 } // namespace opencv_test

--- a/modules/gapi/test/test_precomp.hpp
+++ b/modules/gapi/test/test_precomp.hpp
@@ -34,4 +34,7 @@ static inline void countNonZero_is_forbidden_in_tests_use_norm_instead() {}
 }
 #define countNonZero() countNonZero_is_forbidden_in_tests_use_norm_instead()
 
+#undef RAND_MAX
+#define RAND_MAX RAND_MAX_is_banned_in_tests__use_cv_theRNG_instead
+
 #endif // __OPENCV_GAPI_TEST_PRECOMP_HPP__


### PR DESCRIPTION
Compilation warning (clang):

```
modules/gapi/test/common/gapi_parsers_tests_common.hpp:214:59: warning:
implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
        it.confidence = static_cast<float>(std::rand()) / RAND_MAX;
                                                        ~ ^~~~~~~~
/usr/include/stdlib.h:86:18: note: expanded from macro 'RAND_MAX'
#define RAND_MAX        2147483647
                        ^~~~~~~~~~
```

