### PR TITLE
python: restore sys.path in bootstrap()

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -18,6 +18,10 @@ except ImportError:
 
 def bootstrap():
     import sys
+
+    import copy
+    save_sys_path = copy.copy(sys.path)
+
     if hasattr(sys, 'OpenCV_LOADER'):
         print(sys.path)
         raise ImportError('ERROR: recursion is detected during loading of "cv2" binary extensions. Check OpenCV installation.')
@@ -84,6 +88,8 @@ def bootstrap():
     if DEBUG: print('OpenCV loader: replacing cv2 module')
     del sys.modules['cv2']
     import cv2
+
+    sys.path = save_sys_path  # multiprocessing should start from bootstrap code (https://github.com/opencv/opencv/issues/18502)
 
     try:
         import sys


### PR DESCRIPTION
resolves #18502

- multiprocessing need to start from bootstrap code
- loading may fail due to missing os.add_dll_directory() calls
