### PR TITLE
Add Python Bindings for getCacheDirectory function

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -81,7 +81,10 @@ AsyncArray testAsyncException()
     return p.getArrayResult();
 }
 
+namespace fs {
+    CV_EXPORTS_AS(getCacheDirectory) cv::String getCacheDirectoryForDownloads();
+}
 //! @}
-}} // namespace
+}} // namespace fs
 
 #endif // OPENCV_CORE_BINDINGS_UTILS_HPP

--- a/modules/core/src/bindings_utils.cpp
+++ b/modules/core/src/bindings_utils.cpp
@@ -5,6 +5,7 @@
 #include "precomp.hpp"
 #include "opencv2/core/bindings_utils.hpp"
 #include <sstream>
+#include <opencv2/core/utils/filesystem.hpp>
 
 namespace cv { namespace utils {
 
@@ -207,5 +208,12 @@ CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argume
     }
     return ss.str();
 }
+
+namespace fs {
+cv::String getCacheDirectoryForDownloads()
+{
+    return cv::utils::fs::getCacheDirectory("downloads", "OPENCV_DOWNLOADS_CACHE_DIR");
+}
+} // namespace fs
 
 }} // namespace

--- a/modules/python/test/test_fs_cache_dir.py
+++ b/modules/python/test/test_fs_cache_dir.py
@@ -1,0 +1,24 @@
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import cv2 as cv
+import os
+import datetime
+
+from tests_common import NewOpenCVTests
+
+class get_cache_dir_test(NewOpenCVTests):
+    def test_get_cache_dir(self):
+        #New binding
+        path = cv.utils.fs.getCacheDirectory()
+        try:
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(os.path.isdir(path))
+            os.rmdir(path)
+        except:
+            print("Tried to create cache directory ", path)
+            pass
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
This PR adds new Python binding for getCacheDirectory, necessary for the PR: https://github.com/opencv/opencv/pull/18591

<cut/>

```
force_builders=linux,docs,Custom
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.4.0
build_image:Custom Mac=openvino-2020.4.0

test_modules:Custom=python2,python3,java,samples
test_modules:Custom Win=python2,python3,java,samples
test_modules:Custom Mac=python2,python3,java,samples

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```