### PR TITLE
Removed redundant call of handleNewStream in streaming executor

### DIFF
--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1231,10 +1231,6 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
                                real_video_completion_cb);
     }
 
-    for (auto &&op : m_ops) {
-        op.isl_exec->handleNewStream();
-    }
-
     // Now do this for every island (in a topological order)
     for (auto &&op : m_ops)
     {


### PR DESCRIPTION
### Summary

* There are two `handleNewStream()` calls performed in `GStreamingExecutor::setSource()`, removed one of them (https://github.com/opencv/opencv/blob/master/modules/gapi/src/executor/gstreamingexecutor.cpp#L1258 remains)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```