### PR TITLE
videoio/plugin: Propagate type instead of number of channels.

### DIFF
--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -465,13 +465,13 @@ public:
                 return true;
         return false;
     }
-    static CvResult CV_API_CALL retrieve_callback(int stream_idx, const unsigned char* data, int step, int width, int height, int cn, void* userdata)
+    static CvResult CV_API_CALL retrieve_callback(int stream_idx, const unsigned char* data, int step, int width, int height, int type, void* userdata)
     {
         CV_UNUSED(stream_idx);
         cv::_OutputArray* dst = static_cast<cv::_OutputArray*>(userdata);
         if (!dst)
             return CV_ERROR_FAIL;
-        cv::Mat(cv::Size(width, height), CV_MAKETYPE(CV_8U, cn), (void*)data, step).copyTo(*dst);
+        cv::Mat(cv::Size(width, height), type, (void*)data, step).copyTo(*dst);
         return CV_ERROR_OK;
     }
     bool retrieveFrame(int idx, cv::OutputArray img) CV_OVERRIDE

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -321,7 +321,7 @@ CvResult CV_API_CALL cv_capture_retrieve(CvPluginCapture handle, int stream_idx,
         Mat img;
         // TODO: avoid unnecessary copying
         if (instance->retrieveFrame(stream_idx, img))
-            return callback(stream_idx, img.data, img.step, img.cols, img.rows, img.channels(), userdata);
+            return callback(stream_idx, img.data, img.step, img.cols, img.rows, img.type(), userdata);
         return CV_ERROR_FAIL;
     }
     catch(...)

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1911,7 +1911,7 @@ CvResult CV_API_CALL cv_capture_retrieve(CvPluginCapture handle, int stream_idx,
         Mat img;
         // TODO: avoid unnecessary copying - implement lower level GStreamerCapture::retrieve
         if (instance->retrieveFrame(stream_idx, img))
-            return callback(stream_idx, img.data, img.step, img.cols, img.rows, img.channels(), userdata);
+            return callback(stream_idx, img.data, img.step, img.cols, img.rows, img.type(), userdata);
         return CV_ERROR_FAIL;
     }
     catch(...)

--- a/modules/videoio/src/cap_mfx_plugin.cpp
+++ b/modules/videoio/src/cap_mfx_plugin.cpp
@@ -114,7 +114,7 @@ CvResult CV_API_CALL cv_capture_retrieve(CvPluginCapture handle, int stream_idx,
         VideoCapture_IntelMFX* instance = (VideoCapture_IntelMFX*)handle;
         Mat img;
         if (instance->retrieveFrame(stream_idx, img))
-            return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.channels(), userdata);
+            return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.type(), userdata);
         return CV_ERROR_FAIL;
     }
     catch(...)

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1789,7 +1789,7 @@ CvResult CV_API_CALL cv_capture_retrieve(CvPluginCapture handle, int stream_idx,
         CaptureT* instance = (CaptureT*)handle;
         Mat img;
         if (instance->retrieveFrame(stream_idx, img))
-            return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.channels(), userdata);
+            return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.type(), userdata);
         return CV_ERROR_FAIL;
     }
     catch (...)

--- a/modules/videoio/src/cap_ueye.cpp
+++ b/modules/videoio/src/cap_ueye.cpp
@@ -432,7 +432,7 @@ CvResult CV_API_CALL cv_capture_retrieve(CvPluginCapture handle, int stream_idx,
     VideoCapture_uEye* instance = (VideoCapture_uEye*)handle;
     Mat img;
     if (instance->retrieveFrame(stream_idx, img))
-        return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.channels(), userdata);
+        return callback(stream_idx, img.data, (int)img.step, img.cols, img.rows, img.type(), userdata);
     return CV_ERROR_FAIL;
 
     CV_PLUGIN_CALL_END

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-typedef CvResult (CV_API_CALL *cv_videoio_retrieve_cb_t)(int stream_idx, unsigned const char* data, int step, int width, int height, int cn, void* userdata);
+typedef CvResult (CV_API_CALL *cv_videoio_retrieve_cb_t)(int stream_idx, unsigned const char* data, int step, int width, int height, int type, void* userdata);
 
 typedef struct CvPluginCapture_t* CvPluginCapture;
 typedef struct CvPluginWriter_t* CvPluginWriter;
@@ -137,11 +137,11 @@ typedef struct OpenCV_VideoIO_Plugin_API_preview
     @param step step in bytes
     @param width frame width in pixels
     @param height frame height
-    @param cn number of channels per pixel
+    @param type pixel data type
 
     @note API-CALL 12, API-Version == 0
      */
-    CvResult (CV_API_CALL *Writer_write)(CvPluginWriter handle, const unsigned char *data, int step, int width, int height, int cn);
+    CvResult (CV_API_CALL *Writer_write)(CvPluginWriter handle, const unsigned char *data, int step, int width, int height, int type);
 
 } OpenCV_VideoIO_Plugin_API_preview;
 


### PR DESCRIPTION
This avoids assuming that data type is 8U and allows backends built as plugins to work with other data types.

Required for #18694.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=linux,windows,docs
```