### PR TITLE
G-API(test): avoid anonymous namespace types as template parameters

### DIFF
--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_test_utils.hpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_test_utils.hpp
@@ -22,8 +22,10 @@ struct Name                                      \
 
 namespace opencv_test
 {
-namespace
-{
+
+// types from anonymous namespace doesn't work well with templates
+inline namespace gapi_ocv_stateful_kernel_test_utils {
+
 struct UserStruct
 {
     UserStruct() = default;
@@ -41,7 +43,8 @@ private:
     short _myShortVal;
     float _myFloatVal;
 };
-} // anonymous namespace
+
+} // namespace
 } // opencv_test
 
 #endif // OPENCV_GAPI_OCV_STATEFUL_KERNEL_TESTS_UTILS_HPP

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -240,7 +240,8 @@ TEST(GArray_VectorRef, TestMov)
     EXPECT_EQ(V{}, vtest);
 }
 
-namespace {
+// types from anonymous namespace doesn't work well with templates
+inline namespace gapi_array_tests {
     struct MyTestStruct {
         int i;
         float f;

--- a/modules/gapi/test/gapi_opaque_tests.cpp
+++ b/modules/gapi/test/gapi_opaque_tests.cpp
@@ -284,7 +284,8 @@ TEST(GOpaque_OpaqueRef, TestMov)
     EXPECT_NE(test, mov.rref<I>());         // ref lost the data
 }
 
-namespace {
+// types from anonymous namespace doesn't work well with templates
+inline namespace gapi_opaque_tests {
     struct MyTestStruct {
         int i;
         float f;


### PR DESCRIPTION
resolves #18865