### PR TITLE
G-API: ONNX. Support for networks with three dimensional input.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <array>
 #include <tuple> // tuple, tuple_size
-#include <codecvt> // wstring_convert
 
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/util/any.hpp>

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -58,6 +58,8 @@ struct ParamDesc {
     PostProc custom_post_proc;
 
     std::vector<bool> normalize;
+    std::vector<float> range_anchor;
+    std::vector<float> divisibility;
 };
 } // namespace detail
 
@@ -75,6 +77,9 @@ struct PortCfg {
     using Normalize = std::array
         < bool
         , std::tuple_size<typename Net::InArgs>::value >;
+    using PaddingCoefs = std::array
+        < float
+        , std::tuple_size<typename Net::InArgs>::value >;
 };
 
 template<typename Net> class Params {
@@ -86,7 +91,7 @@ public:
     };
 
     // BEGIN(G-API's network parametrization API)
-    GBackend      backend() const { return cv::gapi::onnx::backend();  }
+    GBackend      backend() const { return cv::gapi::onnx::backend(); }
     std::string   tag()     const { return Net::tag(); }
     cv::util::any params()  const { return { desc }; }
     // END(G-API's network parametrization API)
@@ -124,6 +129,13 @@ public:
 
     Params<Net>& cfgNormalize(const typename PortCfg<Net>::Normalize &n) {
         desc.normalize.assign(n.begin(), n.end());
+        return *this;
+    }
+
+    Params<Net>& cfgPadding(const typename PortCfg<Net>::PaddingCoefs &ra,
+                            const typename PortCfg<Net>::PaddingCoefs &d) {
+        desc.range_anchor.assign(ra.begin(), ra.end());
+        desc.divisibility.assign(d.begin(), d.end());
         return *this;
     }
 

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -128,16 +128,6 @@ public:
         return *this;
     }
 
-<<<<<<< HEAD
-    Params<Net>& cfgPadding(const typename PortCfg<Net>::PaddingCoefs &ra,
-                            const typename PortCfg<Net>::PaddingCoefs &d) {
-        desc.range_anchor.assign(ra.begin(), ra.end());
-        desc.divisibility.assign(d.begin(), d.end());
-        return *this;
-    }
-
-=======
->>>>>>> Removed padding
 protected:
     detail::ParamDesc desc;
 };

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -58,8 +58,6 @@ struct ParamDesc {
     PostProc custom_post_proc;
 
     std::vector<bool> normalize;
-    std::vector<float> range_anchor;
-    std::vector<float> divisibility;
 };
 } // namespace detail
 
@@ -76,9 +74,6 @@ struct PortCfg {
         , std::tuple_size<typename Net::InArgs>::value >;
     using Normalize = std::array
         < bool
-        , std::tuple_size<typename Net::InArgs>::value >;
-    using PaddingCoefs = std::array
-        < float
         , std::tuple_size<typename Net::InArgs>::value >;
 };
 
@@ -132,6 +127,7 @@ public:
         return *this;
     }
 
+<<<<<<< HEAD
     Params<Net>& cfgPadding(const typename PortCfg<Net>::PaddingCoefs &ra,
                             const typename PortCfg<Net>::PaddingCoefs &d) {
         desc.range_anchor.assign(ra.begin(), ra.end());
@@ -139,6 +135,8 @@ public:
         return *this;
     }
 
+=======
+>>>>>>> Removed padding
 protected:
     detail::ParamDesc desc;
 };

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <array>
 #include <tuple> // tuple, tuple_size
+#include <codecvt> // wstring_convert
 
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/util/any.hpp>

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -583,7 +583,8 @@ ONNXCompiled::ONNXCompiled(const gapi::onnx::detail::ParamDesc &pp)
 #ifndef _WIN32
     this_session = Ort::Session(this_env, params.model_path.data(), session_options);
 #else
-    std::wstring w_model_path(params.model_path.begin(), params.model_path.end());
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+    std::wstring w_model_path = converter.from_bytes(params.model_path.data());
     this_session = Ort::Session(this_env, w_model_path.data(), session_options);
 #endif
     this_memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -91,12 +91,14 @@ struct TensorInfo {
         cv::Scalar stdev;
     };
 
+<<<<<<< HEAD
     struct Padding {
         float range_anchor;
         float divisibility;
     };
+=======
+>>>>>>> Removed padding
     cv::util::optional<MeanStdev> mstd;
-    cv::util::optional<Padding> pad;
 };
 
 using Views = std::vector<std::unique_ptr<cv::MediaFrame::View>>;
@@ -293,24 +295,6 @@ inline void preprocess(const cv::Mat& src,
         } else {
             // Keep HWC
             dst = pp;
-        }
-
-        if (with_pad) {
-            const auto div = ti.pad->divisibility;
-            const int padded_h = std::ceil(new_h / div) * div;
-            const int padded_w = std::ceil(new_w / div) * div;
-            int type = -1;
-            if (!is_hwc && new_c >= 1) {
-                type = ddepth;
-            } else {
-                type = ddepth == CV_32F ? CV_32FC3 : CV_8UC3;
-            }
-            GAPI_Assert(type != -1);
-            cv::Mat pad_im(cv::Size(padded_w, (!is_hwc ? new_c : 1) * padded_h), type, 0.f);
-            pad_im(cv::Rect(0, 0, dst.cols, dst.rows)) += dst;
-            dst = pad_im;
-            new_h = padded_h;
-            new_w = padded_w;
         }
 
         // Ensure dst is a tensor shape (not a 2D image)
@@ -603,7 +587,12 @@ ONNXCompiled::ONNXCompiled(const gapi::onnx::detail::ParamDesc &pp)
     // Create and initialize the ONNX session
     Ort::SessionOptions session_options;
     this_env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "");
+#ifndef _WIN32
     this_session = Ort::Session(this_env, params.model_path.data(), session_options);
+#else
+    std::wstring w_model_path(params.model_path.begin(), params.model_path.end());
+    this_session = Ort::Session(this_env, w_model_path.data(), session_options);
+#endif
     this_memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
     in_tensor_info = getTensorInfo(INPUT);

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -14,6 +14,7 @@
 #include <opencv2/gapi/infer.hpp>
 #include <opencv2/gapi/own/convert.hpp>
 #include <opencv2/gapi/gframe.hpp>
+#include <codecvt> // wstring_convert
 
 #include "api/gbackend_priv.hpp" // FIXME: Make it part of Backend SDK!
 #include "logger.hpp"

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -91,13 +91,6 @@ struct TensorInfo {
         cv::Scalar stdev;
     };
 
-<<<<<<< HEAD
-    struct Padding {
-        float range_anchor;
-        float divisibility;
-    };
-=======
->>>>>>> Removed padding
     cv::util::optional<MeanStdev> mstd;
 };
 

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -90,7 +90,6 @@ struct TensorInfo {
         cv::Scalar mean;
         cv::Scalar stdev;
     };
-
     cv::util::optional<MeanStdev> mstd;
 };
 
@@ -271,7 +270,7 @@ inline void preprocess(const cv::Mat& src,
             pp = rsz;
         }
 
-        if (!is_hwc && new_c >= 1) {
+        if (!is_hwc && new_c > 1) {
             // Convert to CHW
             dst.create(cv::Size(new_w, new_h * new_c), ddepth);
             std::vector<cv::Mat> planes(new_c);

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -231,9 +231,9 @@ inline void preprocess(const cv::Mat& src,
 
         // Assess the expected input layout
         const bool is_hwc = [&](int ch) {
-            if (ti.is_grayscale)       return false; // 1,1,h,w
-            else if (ti.dims[3 - shift] == ch) return true;  // _,_,_,c
-            else if (ti.dims[1 - shift] == ch) return false; // _,c,_,_
+            if (ti.is_grayscale)               return false; // 1,1,h,w
+            else if (ti.dims[3 - shift] == ch) return true;  // ?,_,_,c
+            else if (ti.dims[1 - shift] == ch) return false; // ?,c,_,_
             else cv::util::throw_error(std::logic_error("Couldn't identify input tensor layout"));
         } (src.channels());
 
@@ -259,12 +259,6 @@ inline void preprocess(const cv::Mat& src,
         }
         GAPI_Assert(new_h != -1 && new_w != -1);
 
-        bool with_pad = ti.pad.has_value();
-        if (with_pad) {
-            const float ratio = ti.pad->range_anchor / std::min(src.cols, src.rows);
-            new_h = static_cast<int>(ratio * src.rows);
-            new_w = static_cast<int>(ratio * src.cols);
-        }
         cv::Mat rsz, pp;
         cv::resize(csc, rsz, cv::Size(new_w, new_h));
         if (src.depth() == CV_8U && ddepth == CV_32F) {

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <onnxruntime_cxx_api.h>
 #include <ade/util/iota_range.hpp>
+#include <codecvt> // wstring_convert
 
 #include <opencv2/gapi/own/convert.hpp>
 #include <opencv2/gapi/infer/onnx.hpp>

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -257,7 +257,13 @@ public:
     template<typename T>
     void infer(const std::vector<cv::Mat>& ins, std::vector<cv::Mat>& outs) {
         // Prepare session
+#ifndef _WIN32
         session = Ort::Session(env, model_path.data(), session_options);
+#else
+        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+        std::wstring w_model_path = converter.from_bytes(model_path.data());
+        session = Ort::Session(env, w_model_path.data(), session_options);
+#endif
         num_in = session.GetInputCount();
         num_out = session.GetOutputCount();
         GAPI_Assert(num_in == ins.size());

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -910,7 +910,6 @@ TEST_F(ONNXYoloV3MultiInput, InferBSConstInput)
     // Validate
     validate();
 }
-
 } // namespace opencv_test
 
 #endif //  HAVE_ONNX


### PR DESCRIPTION
We can call infer with images (not tensors) for networks like this:
https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/faster-rcnn#input-to-model

Fix for build on Windows (ort::Session on Windows expects wchar_t* instead char*).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=ubuntu-onnx:20.04
test_modules:Custom=gapi
test_filter:Custom=*ONNX*
```
