### PR TITLE
ts: cvtest::debugLevel / --test_debug=<N> option

### DIFF
--- a/modules/calib3d/test/test_cornerssubpix.cpp
+++ b/modules/calib3d/test/test_cornerssubpix.cpp
@@ -153,9 +153,8 @@ void CV_ChessboardSubpixelTest::run( int )
 
         vector<Point2f> test_corners;
         bool result = findChessboardCorners(chessboard_image, pattern_size, test_corners, 15);
-        if(!result)
+        if (!result && cvtest::debugLevel > 0)
         {
-#if 0
             ts->printf(cvtest::TS::LOG, "Warning: chessboard was not detected! Writing image to test.png\n");
             ts->printf(cvtest::TS::LOG, "Size = %d, %d\n", pattern_size.width, pattern_size.height);
             ts->printf(cvtest::TS::LOG, "Intrinsic params: fx = %f, fy = %f, cx = %f, cy = %f\n",
@@ -167,7 +166,9 @@ void CV_ChessboardSubpixelTest::run( int )
                        distortion_coeffs_.at<double>(0, 4));
 
             imwrite("test.png", chessboard_image);
-#endif
+        }
+        if (!result)
+        {
             continue;
         }
 

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -449,7 +449,10 @@ TEST_F(fisheyeTest, stereoRectify)
             << "Q =" << std::endl << Q << std::endl;
     }
 
-#if 1 // Debug code
+    if (cvtest::debugLevel == 0)
+        return;
+    // DEBUG code is below
+
     cv::Mat lmapx, lmapy, rmapx, rmapy;
     //rewrite for fisheye
     cv::fisheye::initUndistortRectifyMap(K1, D1, R1, P1, requested_size, CV_32F, lmapx, lmapy);
@@ -482,7 +485,6 @@ TEST_F(fisheyeTest, stereoRectify)
 
         cv::imwrite(cv::format("fisheye_rectification_AB_%03d.png", i), rectification);
     }
-#endif
 }
 
 TEST_F(fisheyeTest, stereoCalibrate)

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -487,7 +487,8 @@ protected:
             img->copyTo(sub);
             shift += img->size().height + 1;
         }
-        //imwrite("/tmp/all_fonts.png", result);
+        if (cvtest::debugLevel > 0)
+            imwrite("all_fonts.png", result);
     }
 };
 

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -13,6 +13,7 @@ void checkIppStatus();
 extern bool skipUnstableTests;
 extern bool runBigDataTests;
 extern int testThreads;
+extern int debugLevel;  //< 0 - no debug, 1 - basic test debug information, >1 - extra debug information
 
 void testSetUp();
 void testTearDown();

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -774,6 +774,7 @@ static bool checkTestData = cv::utils::getConfigurationParameterBool("OPENCV_TES
 bool skipUnstableTests = false;
 bool runBigDataTests = false;
 int testThreads = 0;
+int debugLevel = (int)cv::utils::getConfigurationParameterSizeT("OPENCV_TEST_DEBUG", 0);
 
 
 static size_t memory_usage_base = 0;
@@ -883,6 +884,7 @@ void parseCustomOptions(int argc, char **argv)
         "{ test_threads       |-1       |the number of worker threads, if parallel execution is enabled}"
         "{ skip_unstable      |false    |skip unstable tests }"
         "{ test_bigdata       |false    |run BigData tests (>=2Gb) }"
+        "{ test_debug         |         |0 - no debug (default), 1 - basic test debug information, >1 - extra debug information }"
         "{ test_require_data  |") + (checkTestData ? "true" : "false") + string("|fail on missing non-required test data instead of skip (env:OPENCV_TEST_REQUIRE_DATA)}"
         CV_TEST_TAGS_PARAMS
         "{ h   help           |false    |print help info                          }"
@@ -909,6 +911,14 @@ void parseCustomOptions(int argc, char **argv)
 
     skipUnstableTests = parser.get<bool>("skip_unstable");
     runBigDataTests = parser.get<bool>("test_bigdata");
+    if (parser.has("test_debug"))
+    {
+        cv::String s = parser.get<cv::String>("test_debug");
+        if (s.empty() || s == "true")
+            debugLevel = 1;
+        else
+            debugLevel = parser.get<int>("test_debug");
+    }
     if (parser.has("test_require_data"))
         checkTestData = parser.get<bool>("test_require_data");
 


### PR DESCRIPTION
OpenCV tests should not write any test results by default.

However sometimes it is useful to collect extra information for problem investigation (test failure).
- on devices/configurations without properly configured debugger
- on devices where compilation is not available (cross-compilation case) to modify test code or replace `#if 0`

Available options:
- `--test_debug` / `--test_debug=N`
- `OPENCV_TEST_DEBUG` environment variable
- variable `cvtest::debugLevel`

---

**Note**: Use debug mode for "debugging" single test case only. There is no requirement for unique filenames (`result.png` / `test.png` is a common practice).

**Note**: Use `imshow()` for debug levels >= 10 (to avoid test crashes due to lack of UI backend).