### PR TITLE
GAPI: Reuse move through copy

### DIFF
--- a/modules/gapi/src/executor/gasync.cpp
+++ b/modules/gapi/src/executor/gasync.cpp
@@ -11,6 +11,8 @@
 #include <opencv2/gapi/gcompiled.hpp>
 #include <opencv2/gapi/gasync_context.hpp>
 
+#include <opencv2/gapi/util/copy_through_move.hpp>
+
 #include <condition_variable>
 
 #include <future>
@@ -18,16 +20,6 @@
 #include <stdexcept>
 #include <queue>
 
-namespace {
-    //This is a tool to move initialize captures of a lambda in C++11
-    template<typename T>
-    struct copy_through_move{
-       T value;
-       copy_through_move(T&& g) : value(std::move(g)) {}
-       copy_through_move(copy_through_move&&) = default;
-       copy_through_move(copy_through_move const& lhs) : copy_through_move(std::move(const_cast<copy_through_move&>(lhs))) {}
-    };
-}
 
 namespace cv {
 namespace gapi {
@@ -168,7 +160,7 @@ const char* GAsyncCanceled::what() const noexcept {
 //For now these async functions are simply wrapping serial version of apply/operator() into a functor.
 //These functors are then serialized into single queue, which is processed by a devoted background thread.
 void async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args){
-    //TODO: use copy_through_move for all args except gcomp
+    //TODO: use copy_through_move_t for all args except gcomp
     //TODO: avoid code duplication between versions of "async" functions
     auto l = [=]() mutable {
         auto apply_l = [&](){
@@ -181,7 +173,7 @@ void async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& 
 }
 
 std::future<void> async_apply(GComputation& gcomp, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args){
-    copy_through_move<std::promise<void>> prms{{}};
+    util::copy_through_move_t<std::promise<void>> prms{{}};
     auto f = prms.value.get_future();
     auto l = [=]() mutable {
         auto apply_l = [&](){
@@ -196,7 +188,7 @@ std::future<void> async_apply(GComputation& gcomp, GRunArgs &&ins, GRunArgsP &&o
 }
 
 void async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args, GAsyncContext& ctx){
-    //TODO: use copy_through_move for all args except gcomp
+    //TODO: use copy_through_move_t for all args except gcomp
     auto l = [=, &ctx]() mutable {
         auto apply_l = [&](){
             gcomp.apply(std::move(ins), std::move(outs), std::move(args));
@@ -208,7 +200,7 @@ void async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& 
 }
 
 std::future<void> async_apply(GComputation& gcomp, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args, GAsyncContext& ctx){
-    copy_through_move<std::promise<void>> prms{{}};
+    util::copy_through_move_t<std::promise<void>> prms{{}};
     auto f = prms.value.get_future();
     auto l = [=, &ctx]() mutable {
         auto apply_l = [&](){
@@ -248,7 +240,7 @@ void async(GCompiled& gcmpld, std::function<void(std::exception_ptr)>&& callback
 }
 
 std::future<void> async(GCompiled& gcmpld, GRunArgs &&ins, GRunArgsP &&outs){
-    copy_through_move<std::promise<void>> prms{{}};
+    util::copy_through_move_t<std::promise<void>> prms{{}};
     auto f = prms.value.get_future();
     auto l = [=]() mutable {
         auto apply_l = [&](){
@@ -263,7 +255,7 @@ std::future<void> async(GCompiled& gcmpld, GRunArgs &&ins, GRunArgsP &&outs){
 
 }
 std::future<void> async(GCompiled& gcmpld, GRunArgs &&ins, GRunArgsP &&outs, GAsyncContext& ctx){
-    copy_through_move<std::promise<void>> prms{{}};
+    util::copy_through_move_t<std::promise<void>> prms{{}};
     auto f = prms.value.get_future();
     auto l = [=, &ctx]() mutable {
         auto apply_l = [&](){


### PR DESCRIPTION
GAPI: reuse copy_through_move_t in the gasync.cpp file

opencv#17851 introduced separate header for `copy_through_move_t`. This PR removes it's local duplicate in gasync.cpp to reuse one from the header

<cut/>

<!-- Please describe what your pullrequest is changing -->

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f
```