### PR TITLE
Added test for VideoCapture CAP_PROP_FRAME_MSEC option

### DIFF
--- a/modules/videoio/src/cap_mjpeg_decoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_decoder.cpp
@@ -116,6 +116,8 @@ double MotionJpegCapture::getProperty(int property) const
     {
         case CAP_PROP_POS_FRAMES:
             return (double)getFramePos();
+        case CAP_PROP_POS_MSEC:
+            return (double)getFramePos() * (1000. / m_fps);
         case CAP_PROP_POS_AVI_RATIO:
             return double(getFramePos())/m_mjpeg_frames.size();
         case CAP_PROP_FRAME_WIDTH:

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -231,6 +231,34 @@ public:
         else
             std::cout << "Frames counter is not available. Actual frames: " << count_actual << ". SKIP check." << std::endl;
     }
+
+    void doTimestampTest()
+    {
+        if (!isBackendAvailable(apiPref, cv::videoio_registry::getStreamBackends()))
+            throw SkipTestException(cv::String("Backend is not available/disabled: ") + cv::videoio_registry::getBackendName(apiPref));
+
+        if ((apiPref == CAP_MSMF) || ((apiPref == CAP_FFMPEG) && ((ext == "h264") || (ext == "h265"))))
+            throw SkipTestException(cv::String("Backend ") +  cv::videoio_registry::getBackendName(apiPref) +
+                    cv::String(" does not support CAP_PROP_POS_MSEC option"));
+
+        VideoCapture cap;
+        EXPECT_NO_THROW(cap.open(video_file, apiPref));
+        if (!cap.isOpened())
+            throw SkipTestException(cv::String("Backend ") +  cv::videoio_registry::getBackendName(apiPref) +
+                    cv::String(" can't open the video: ")  + video_file);
+
+        Mat img;
+        for(int i = 0; i < 10; i++)
+        {
+            double timestamp = 0;
+            ASSERT_NO_THROW(cap >> img);
+            EXPECT_NO_THROW(timestamp = cap.get(CAP_PROP_POS_MSEC));
+            const double frame_period = 1000.f/bunny_param.getFps();
+            // NOTE: eps == frame_period, because videoCapture returns frame begining timestamp or frame end
+            // timestamp depending on codec and back-end. So the first frame has timestamp 0 or frame_period.
+            EXPECT_NEAR(timestamp, i*frame_period, frame_period);
+        }
+    }
 };
 
 //==================================================================================================
@@ -366,6 +394,8 @@ static const string bunny_params[] = {
 TEST_P(Videoio_Bunny, read_position) { doTest(); }
 
 TEST_P(Videoio_Bunny, frame_count) { doFrameCountTest(); }
+
+TEST_P(Videoio_Bunny, frame_timestamp) { doTimestampTest(); }
 
 INSTANTIATE_TEST_CASE_P(videoio, Videoio_Bunny,
                           testing::Combine(


### PR DESCRIPTION
Relates to: https://github.com/opencv/opencv/pull/18966
<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```