### PR TITLE
Fix build when HAVE_VULKAN is ON

### DIFF
--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -440,9 +440,9 @@ public:
     {
         int padding_mode;
         vkcom::PoolType pool_type;
-        int filter_size[2] = {kernel.height, kernel.width};
-        int pad_size[2] = {pad.height, pad.width};
-        int stride_size[2] = {stride.height, stride.width};
+        int filter_size[2] = {kernel_size[0], kernel_size[1]};
+        int pad_size[2] = {pads_begin[0], pads_begin[1]};
+        int stride_size[2] = {strides[0], strides[1]};
         pool_type = type == MAX ? vkcom::kPoolTypeMax:
                    (type == AVE ? vkcom::kPoolTypeAvg:
                             vkcom::kPoolTypeNum);

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -440,9 +440,9 @@ public:
     {
         int padding_mode;
         vkcom::PoolType pool_type;
-        int filter_size[2] = {kernel_size[0], kernel_size[1]};
-        int pad_size[2] = {pads_begin[0], pads_begin[1]};
-        int stride_size[2] = {strides[0], strides[1]};
+        int filter_size[2] = {static_cast<int>(kernel_size[0]), static_cast<int>(kernel_size[1])};
+        int pad_size[2] = {static_cast<int>(pads_begin[0]), static_cast<int>(pads_begin[1])};
+        int stride_size[2] = {static_cast<int>(strides[0]), static_cast<int>(strides[1])};
         pool_type = type == MAX ? vkcom::kPoolTypeMax:
                    (type == AVE ? vkcom::kPoolTypeAvg:
                             vkcom::kPoolTypeNum);


### PR DESCRIPTION
My previous PR https://github.com/opencv/opencv/pull/18862/ was merged to ```master``` branch and this created problems with enabled ```HAVE_VULKAN``` option, which is not present in ```3.4``` branch

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-vulkan:16.04
```