### PR TITLE
Add GitHub Actions for building XCFramework artifacts

### DIFF
--- a/.github/workflows/apple-build-checks.yml
+++ b/.github/workflows/apple-build-checks.yml
@@ -1,0 +1,101 @@
+name: Apple CI
+
+on:  
+  push:
+    branches:
+      - master
+      - '3.4'
+      - next
+    tags:
+      - '**'
+  pull_request: # Run on every pull request, regardless of target branch
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
+
+jobs:
+  dynamic-xcframework:
+    runs-on: macos-11.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: CMake Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/xcframework
+            !build/xcframework/**/opencv2.framework
+            !build/xcframework/opencv2.xcframework
+            !build/xcframework/opencv2-*.xcframework.zip
+          key: ${{ runner.os }}-xcframework-${{ hashFiles('build/xcframework/**/**/version_string.tmp') }}
+          restore-keys: |
+            ${{ runner.os }}-xcframework-
+      - name: Swift Package Manager Cache
+        uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      - name: Remove Stale Items from Cache
+        run: |
+          rm -r build/xcframework/opencv2-static.xcframework.zip || true
+          rm -r build/xcframework/opencv2-dynamic.xcframework.zip || true
+          rm -r build/xcframework/opencv2.xcframework || true
+      - name: Update CMake 3.19+
+        run: brew update && (brew upgrade cmake || true) # Need CMake 3.19 or higher https://gitlab.kitware.com/cmake/cmake/-/issues/21425
+      - name: Build Dynamic XCFramework
+        run: python3 platforms/apple/build_xcframework.py build/xcframework --dynamic
+      - name: Zip Dynamic XCFramework
+        run: cd build/xcframework/ && zip -r opencv2-dynamic.xcframework.zip opencv2.xcframework
+      - name: Compute Swift Package binary checksum
+        run: swift package compute-checksum build/xcframework/opencv2-dynamic.xcframework.zip
+      - name: Upload Dynamic XCFramework
+        uses: actions/upload-artifact@v2
+        with:
+          name: opencv2-dynamic.xcframework.zip
+          path: |
+            build/xcframework/opencv2-dynamic.xcframework.zip
+
+  static-xcframework:
+    runs-on: macos-11.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: CMake Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/xcframework
+            !build/xcframework/**/opencv2.framework
+            !build/xcframework/opencv2.xcframework
+            !build/xcframework/opencv2-*.xcframework.zip
+          key: ${{ runner.os }}-xcframework-${{ hashFiles('build/xcframework/**/**/version_string.tmp') }}
+          restore-keys: |
+            ${{ runner.os }}-xcframework-
+      - name: Swift Package Manager Cache
+        uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      - name: Remove Stale Items from Cache
+        run: |
+          rm -r build/xcframework/opencv2-static.xcframework.zip || true
+          rm -r build/xcframework/opencv2-dynamic.xcframework.zip || true
+          rm -r build/xcframework/opencv2.xcframework || true
+      - name: Update CMake 3.19+
+        run: brew update && (brew upgrade cmake || true) # Need CMake 3.19 or higher https://gitlab.kitware.com/cmake/cmake/-/issues/21425
+      - name: Build Static XCFramework
+        run: python3 platforms/apple/build_xcframework.py build/xcframework
+      - name: Zip Static XCFramework
+        run: cd build/xcframework/ && zip -r opencv2-static.xcframework.zip opencv2.xcframework
+      - name: Compute Swift Package binary checksum
+        run: swift package compute-checksum build/xcframework/opencv2-static.xcframework.zip
+      - name: Upload Static XCFramework
+        uses: actions/upload-artifact@v2
+        with:
+          name: opencv2-static.xcframework.zip
+          path: |
+            build/xcframework/opencv2-static.xcframework.zip


### PR DESCRIPTION
Splitting this out into a standalone PR, based on the initial work here: https://github.com/opencv/opencv/pull/18925

Someone will need to enable GitHub Actions support for this repository, it seems to be disabled: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository

After this is merged and GitHub Actions is enabled, whenever new code is merged to master, someone creates a pull request, or a tag is created, a new static and dynamic XCFramework build for Apple platforms will be created and the artifacts stored. There is a 5 GB artifact limit so older artifacts will be purged periodically. 

Areas for possible future improvement:
* Perhaps it would be better to only store the artifacts after merging to master, and skipping the storage for pull requests
* It's possible to also automatically upload these artifacts to new GitHub Releases after a tag is created, but perhaps a more manual release process is preferred here
* General cleanup of the job steps (removal of temporary workarounds, deduplication, etc)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
