### PR TITLE
Fix Darwin collision of Point/Rect/Size types

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -570,7 +570,7 @@ def get_swift_type(ctype):
     return swift_type
 
 def build_swift_extension_decl(name, args, constructor, static, ret_type):
-    extension_decl = ("class " if static else "") + (("func " + name) if not constructor else "convenience init") + "("
+    extension_decl = "@nonobjc " + ("class " if static else "") + (("func " + name) if not constructor else "convenience init") + "("
     swift_args = []
     for a in args:
         if a.ctype not in type_dict:


### PR DESCRIPTION
Splitting this out into a standalone PR, based on the initial work here: https://github.com/opencv/opencv/pull/18925

This patch prevents a symbol conflict between types `Point`/`Rect`/`Size` and those provided by `Darwin`:

```
/Users/chrisbal/Documents/opencv/.build/x86_64-apple-macosx/debug/opencv2.framework/Modules/opencv2.swiftmodule/x86_64-apple-macos.swiftinterface:676:81: error: ambiguous type name 'Rect' in module 'opencv2'
  public func detectMultiScale(img: opencv2.Mat, foundLocations: inout [opencv2.Rect], foundWeights: inout [Swift.Double], hitThreshold: Swift.Double)
                                                                        ~~~~~~~ ^
opencv2.Rect:1:12: note: found candidate with type 'Rect'
open class Rect : NSObject {
           ^
Darwin.Rect:1:15: note: found candidate with type 'Rect'
public struct Rect {
```

I provided backwards compatibility typealiases, which are used by the existing test suite.

This doesn't attempt to solve https://github.com/opencv/opencv/issues/18843, which is still a problem, but would be a bigger undertaking.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=docs,ios,Custom Mac
buildworker:Mac=macosx-1
buildworker:iOS=macosx-2
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-1
```