### PR TITLE
Increase testing IPHONEOS_DEPLOYMENT_TARGET to 9.0

### DIFF
--- a/platforms/ios/run_tests.py
+++ b/platforms/ios/run_tests.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import glob, re, os, os.path, shutil, string, sys, argparse, traceback, multiprocessing
 from subprocess import check_call, check_output, CalledProcessError
 
-IPHONEOS_DEPLOYMENT_TARGET='8.0'  # default, can be changed via command line options or environment variable
+IPHONEOS_DEPLOYMENT_TARGET='9.0'  # default, can be changed via command line options or environment variable
 
 def execute(cmd, cwd = None):
     print("Executing: %s in %s" % (cmd, cwd), file=sys.stderr)


### PR DESCRIPTION
Splitting this out into a standalone PR, based on the initial work here: https://github.com/opencv/opencv/pull/18925

Xcode 12 no longer supports building to deployment targets earlier than 9.0, which triggers a warning, and possible failure when treating warnings as errors.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
