### PR TITLE
GAPI: fix C++17 compilation errors in GNetPackage 

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -418,8 +418,8 @@ struct GAPI_EXPORTS GNetParam {
  * @sa cv::gapi::networks
  */
 struct GAPI_EXPORTS_W_SIMPLE GNetPackage {
-    GAPI_WRAP GNetPackage() : GNetPackage({}) {}
-    explicit GNetPackage(std::initializer_list<GNetParam> &&ii);
+    GAPI_WRAP GNetPackage() = default;
+    explicit GNetPackage(std::initializer_list<GNetParam> ii);
     std::vector<GBackend> backends() const;
     std::vector<GNetParam> networks;
 };

--- a/modules/gapi/src/api/ginfer.cpp
+++ b/modules/gapi/src/api/ginfer.cpp
@@ -16,8 +16,8 @@
 
 #include <opencv2/gapi/infer.hpp>
 
-cv::gapi::GNetPackage::GNetPackage(std::initializer_list<GNetParam> &&ii)
-    : networks(std::move(ii)) {
+cv::gapi::GNetPackage::GNetPackage(std::initializer_list<GNetParam> ii)
+    : networks(ii) {
 }
 
 std::vector<cv::gapi::GBackend> cv::gapi::GNetPackage::backends() const {


### PR DESCRIPTION

- explicitly declared default constructor
- made initilizer_list  constructor to accept the list by copy
   -- as it is  more canonical (and as copying the initializer_list does
not force copy of the list items)
   -- current version anyway does not do what it is intended to

(fixes #17385)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f