### PR TITLE
core(IPP): disable SSE4.2 code path in countNonZero()

### DIFF
--- a/modules/core/src/count_non_zero.dispatch.cpp
+++ b/modules/core/src/count_non_zero.dispatch.cpp
@@ -62,11 +62,9 @@ static bool ipp_countNonZero( Mat &src, int &res )
 {
     CV_INSTRUMENT_REGION_IPP();
 
-#if defined __APPLE__ || (defined _MSC_VER && defined _M_IX86)
     // see https://github.com/opencv/opencv/issues/17453
-    if (src.dims <= 2 && src.step > 520000)
+    if (src.dims <= 2 && src.step > 520000 && cv::ipp::getIppTopFeatures() == ippCPUID_SSE42)
         return false;
-#endif
 
 #if IPP_VERSION_X100 < 201801
     // Poor performance of SSE42


### PR DESCRIPTION
resolves #17453
relates #17455

Reproduced even on Linux with `OPENCV_IPP=sse42`
(MacOSX and Win32 platforms doesn't have AVX2 IPP optimizations)

/cc @eplankin