### PR TITLE
WIP: [G-API]: Support MediaFrame as output in graph

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -101,6 +101,7 @@ public:
 
     const cv::Scalar& inVal(int input);
     cv::Scalar& outValR(int output); // FIXME: Avoid cv::Scalar s = ctx.outValR()
+    cv::MediaFrame& outFrame(int output);
     template<typename T> std::vector<T>& outVecR(int output) // FIXME: the same issue
     {
         return outVecRef(output).wref<T>();
@@ -256,6 +257,13 @@ template<> struct get_out<cv::GScalar>
     static cv::Scalar& get(GCPUContext &ctx, int idx)
     {
         return ctx.outValR(idx);
+    }
+};
+template<> struct get_out<cv::GFrame>
+{
+    static cv::MediaFrame& get(GCPUContext &ctx, int idx)
+    {
+        return ctx.outFrame(idx);
     }
 };
 template<typename U> struct get_out<cv::GArray<U>>

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -210,6 +210,7 @@ using GRunArgP = util::variant<
     cv::Mat*,
     cv::RMat*,
     cv::Scalar*,
+    cv::MediaFrame*,
     cv::detail::VectorRef,
     cv::detail::OpaqueRef
     >;

--- a/modules/gapi/include/opencv2/gapi/gcall.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcall.hpp
@@ -11,6 +11,7 @@
 #include <opencv2/gapi/garg.hpp>      // GArg
 #include <opencv2/gapi/gmat.hpp>      // GMat
 #include <opencv2/gapi/gscalar.hpp>   // GScalar
+#include <opencv2/gapi/gframe.hpp>    // GFrame
 #include <opencv2/gapi/garray.hpp>    // GArray<T>
 #include <opencv2/gapi/gopaque.hpp>   // GOpaque<T>
 
@@ -41,6 +42,7 @@ public:
     GMat    yield      (int output = 0);
     GMatP   yieldP     (int output = 0);
     GScalar yieldScalar(int output = 0);
+    GFrame  yieldFrame (int output = 0);
 
     template<class T> GArray<T> yieldArray(int output = 0)
     {

--- a/modules/gapi/include/opencv2/gapi/gframe.hpp
+++ b/modules/gapi/include/opencv2/gapi/gframe.hpp
@@ -62,6 +62,9 @@ struct GAPI_EXPORTS GFrameDesc
 static inline GFrameDesc empty_gframe_desc() { return GFrameDesc{}; }
 /** @} */
 
+class MediaFrame;
+GAPI_EXPORTS GFrameDesc descr_of(const MediaFrame &frame);
+
 GAPI_EXPORTS std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &desc);
 
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -82,6 +82,10 @@ namespace detail
     {
         static inline cv::GScalar yield(cv::GCall &call, int i) { return call.yieldScalar(i); }
     };
+    template<> struct Yield<cv::GFrame>
+    {
+        static inline cv::GFrame yield(cv::GCall &call, int i) { return call.yieldFrame(i); }
+    };
     template<typename U> struct Yield<cv::GArray<U> >
     {
         static inline cv::GArray<U> yield(cv::GCall &call, int i) { return call.yieldArray<U>(i); }
@@ -238,8 +242,6 @@ class GKernelType<K, std::function<R(Args...)> >
 public:
     using InArgs  = std::tuple<Args...>;
     using OutArgs = std::tuple<R>;
-
-    static_assert(!cv::detail::contains<GFrame, OutArgs>::value, "Values of GFrame type can't be used as operation outputs");
 
     static R on(Args... args)
     {

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -211,6 +211,11 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, HandleRMat hand
         }
         break;
     }
+    case GShape::GFRAME:
+    {
+        mag.template slot<cv::MediaFrame>()[rc.id] = *util::get<cv::MediaFrame*>(arg);
+        break;
+    }
     case GShape::GARRAY:
         mag.template slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg);
         break;
@@ -301,6 +306,7 @@ cv::GRunArgP getObjPtr(Mag& mag, const RcDesc &rc, bool is_umat)
         else
             return GRunArgP(&mag.template slot<cv::Mat>()[rc.id]);
     case GShape::GSCALAR: return GRunArgP(&mag.template slot<cv::Scalar>()[rc.id]);
+    case GShape::GFRAME: return GRunArgP(&mag.template slot<cv::MediaFrame>()[rc.id]);
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructor by either bindIn/Out or resetInternal)
     case GShape::GARRAY:
@@ -342,6 +348,12 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg)
         case GRunArgP::index_of<cv::Scalar*>() : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
+        break;
+    }
+
+    case GShape::GFRAME:
+    {
+        *util::get<cv::MediaFrame*>(g_arg) = mag.template slot<cv::MediaFrame>().at(rc.id);
         break;
     }
 

--- a/modules/gapi/src/api/gcall.cpp
+++ b/modules/gapi/src/api/gcall.cpp
@@ -59,6 +59,11 @@ cv::GScalar cv::GCall::yieldScalar(int output)
     return cv::GScalar(m_priv->m_node, output);
 }
 
+cv::GFrame cv::GCall::yieldFrame(int output)
+{
+    return cv::GFrame(m_priv->m_node, output);
+}
+
 cv::detail::GArrayU cv::GCall::yieldArray(int output)
 {
     return cv::detail::GArrayU(m_priv->m_node, output);

--- a/modules/gapi/src/api/gframe.cpp
+++ b/modules/gapi/src/api/gframe.cpp
@@ -8,6 +8,7 @@
 #include "precomp.hpp"
 
 #include <opencv2/gapi/gframe.hpp>
+#include <opencv2/gapi/media.hpp>
 
 #include "api/gorigin.hpp"
 
@@ -32,6 +33,10 @@ namespace cv {
 
 bool GFrameDesc::operator== (const GFrameDesc &rhs) const {
     return fmt == rhs.fmt && size == rhs.size;
+}
+
+GFrameDesc descr_of(const cv::MediaFrame &frame) {
+    return frame.desc();
 }
 
 std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &d) {

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -146,6 +146,7 @@ cv::GMetaArg cv::descr_of(const cv::GRunArgP &argp)
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(cv::descr_of(*util::get<cv::Mat*>(argp)));
     case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::MediaFrame*>():        return GMetaArg(descr_of(*util::get<cv::MediaFrame*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -163,6 +164,7 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArgP& argp)
     case GRunArgP::index_of<cv::Mat*>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::Mat*>(argp));
     case GRunArgP::index_of<cv::Scalar*>():            return meta == GMetaArg(cv::descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::MediaFrame*>():        return meta == GMetaArg(cv::descr_of(*util::get<cv::MediaFrame*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return meta == GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return meta == GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -282,6 +284,8 @@ const void* cv::gimpl::proto::ptr(const GRunArgP &arg)
         return static_cast<const void*>(cv::util::get<cv::Mat*>(arg));
     case GRunArgP::index_of<cv::Scalar*>():
         return static_cast<const void*>(cv::util::get<cv::Scalar*>(arg));
+    case GRunArgP::index_of<cv::MediaFrame*>():
+        return static_cast<const void*>(cv::util::get<cv::MediaFrame*>(arg));
     case GRunArgP::index_of<cv::RMat*>():
         return static_cast<const void*>(cv::util::get<cv::RMat*>(arg));
     case GRunArgP::index_of<cv::detail::VectorRef>():

--- a/modules/gapi/src/backends/cpu/gcpukernel.cpp
+++ b/modules/gapi/src/backends/cpu/gcpukernel.cpp
@@ -41,6 +41,11 @@ cv::detail::OpaqueRef& cv::GCPUContext::outOpaqueRef(int output)
     return util::get<cv::detail::OpaqueRef>(m_results.at(output));
 }
 
+cv::MediaFrame& cv::GCPUContext::outFrame(int output)
+{
+    return *util::get<cv::MediaFrame*>(m_results.at(output));
+}
+
 cv::GCPUKernel::GCPUKernel()
 {
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This PR doesn't introduce brand-new functionality nor new tests. It's just some extension to MediaFrame which will be used somewhere else. Related PR: https://github.com/opencv/opencv/pull/18780

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
