### PR TITLE
Added TF resize_bilinear behaviour alignment

### DIFF
--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -42,6 +42,7 @@ public:
         CV_Check(interpolation, interpolation == "nearest" || interpolation == "opencv_linear" || interpolation == "bilinear", "");
 
         alignCorners = params.get<bool>("align_corners", false);
+        halfPixelCenters = params.get<bool>("half_pixel_centers", false);
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,
@@ -114,7 +115,7 @@ public:
 
         Mat& inp = inputs[0];
         Mat& out = outputs[0];
-        if (interpolation == "nearest" || interpolation == "opencv_linear")
+        if (interpolation == "nearest" || interpolation == "opencv_linear" || (interpolation == "bilinear" && halfPixelCenters))
         {
             InterpolationFlags mode = interpolation == "nearest" ? INTER_NEAREST : INTER_LINEAR;
             for (size_t n = 0; n < inputs[0].size[0]; ++n)
@@ -236,6 +237,7 @@ protected:
     String interpolation;
     float scaleWidth, scaleHeight;
     bool alignCorners;
+    bool halfPixelCenters;
 };
 
 

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1962,6 +1962,9 @@ void TFImporter::populateNet(Net dstNet)
             if (hasLayerAttr(layer, "align_corners"))
                 layerParams.set("align_corners", getLayerAttr(layer, "align_corners").b());
 
+            if (hasLayerAttr(layer, "half_pixel_centers"))
+                layerParams.set("half_pixel_centers", getLayerAttr(layer, "half_pixel_centers").b());
+
             int id = dstNet.addLayer(name, "Resize", layerParams);
             layer_id[name] = id;
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -81,12 +81,12 @@ class Test_TensorFlow_layers : public DNNTestLayer
 {
 public:
     void runTensorFlowNet(const std::string& prefix, bool hasText = false,
-                          double l1 = 0.0, double lInf = 0.0, bool memoryLoad = false)
+                          double l1 = 0.0, double lInf = 0.0, bool memoryLoad = false, const std::string& groupPrefix = "")
     {
-        std::string netPath = path(prefix + "_net.pb");
-        std::string netConfig = (hasText ? path(prefix + "_net.pbtxt") : "");
+        std::string netPath = path(prefix + groupPrefix + "_net.pb");
+        std::string netConfig = (hasText ? path(prefix + groupPrefix + "_net.pbtxt") : "");
         std::string inpPath = path(prefix + "_in.npy");
-        std::string outPath = path(prefix + "_out.npy");
+        std::string outPath = path(prefix + groupPrefix + "_out.npy");
 
         cv::Mat input = blobFromNPY(inpPath);
         cv::Mat ref = blobFromNPY(outPath);
@@ -975,10 +975,53 @@ TEST_P(Test_TensorFlow_layers, keras_mobilenet_head)
     runTensorFlowNet("keras_learning_phase");
 }
 
+// TF case: align_corners=False, half_pixel_centers=False
 TEST_P(Test_TensorFlow_layers, resize_bilinear)
 {
     runTensorFlowNet("resize_bilinear");
+}
+
+// TF case: align_corners=True, half_pixel_centers=False
+TEST_P(Test_TensorFlow_layers, resize_bilinear_align_corners)
+{
+    runTensorFlowNet("resize_bilinear",
+                     false, 0.0, 0.0, false, // default parameters
+                     "_align_corners");
+}
+
+// TF case: align_corners=False, half_pixel_centers=True
+TEST_P(Test_TensorFlow_layers, resize_bilinear_half_pixel)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+
+    runTensorFlowNet("resize_bilinear", false, 0.0, 0.0, false, "_half_pixel");
+}
+
+// TF case: align_corners=False, half_pixel_centers=False
+TEST_P(Test_TensorFlow_layers, resize_bilinear_factor)
+{
     runTensorFlowNet("resize_bilinear_factor");
+}
+
+// TF case: align_corners=False, half_pixel_centers=True
+TEST_P(Test_TensorFlow_layers, resize_bilinear_factor_half_pixel)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+
+    runTensorFlowNet("resize_bilinear_factor", false, 0.0, 0.0, false, "_half_pixel");
+}
+
+// TF case: align_corners=True, half_pixel_centers=False
+TEST_P(Test_TensorFlow_layers, resize_bilinear_factor_align_corners)
+{
+    runTensorFlowNet("resize_bilinear_factor", false, 0.0, 0.0, false, "_align_corners");
+}
+
+// TF case: align_corners=False, half_pixel_centers=False
+TEST_P(Test_TensorFlow_layers, resize_bilinear_down)
+{
     runTensorFlowNet("resize_bilinear_down");
 }
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/825

Fixes #18721: TF resize bilinear upsampling layer shift

Added ``half_pixel_centers`` parameter to cover ``align_corners=False, half_pixel_centers=True`` case for TF  [resize_bilinear](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/image/resize_bilinear).

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```