### PR TITLE
github(actions): manual trigger for arm64-build-checks.yml

### DIFF
--- a/.github/workflows/arm64-build-checks.yml
+++ b/.github/workflows/arm64-build-checks.yml
@@ -1,6 +1,6 @@
 name: arm64 build checks
 
-on: [pull_request]
+on: workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
relates #17989

This is just an example, no need to run it always.

- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#manual-events

<!-- **WIP** -->