### PR TITLE
cmake: fix processing order of <wrapper>_bindings_generator

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -98,15 +98,6 @@ macro(ocv_add_dependencies full_modname)
   endforeach()
   unset(__depsvar)
 
-  # hack for python
-  set(__python_idx)
-  list(FIND OPENCV_MODULE_${full_modname}_WRAPPERS "python" __python_idx)
-  if (NOT __python_idx EQUAL -1)
-    list(REMOVE_ITEM OPENCV_MODULE_${full_modname}_WRAPPERS "python")
-    list(APPEND OPENCV_MODULE_${full_modname}_WRAPPERS "python_bindings_generator" "python2" "python3")
-  endif()
-  unset(__python_idx)
-
   ocv_list_unique(OPENCV_MODULE_${full_modname}_REQ_DEPS)
   ocv_list_unique(OPENCV_MODULE_${full_modname}_OPT_DEPS)
   ocv_list_unique(OPENCV_MODULE_${full_modname}_PRIVATE_REQ_DEPS)
@@ -209,9 +200,17 @@ macro(ocv_add_module _name)
       set(OPENCV_MODULES_DISABLED_USER ${OPENCV_MODULES_DISABLED_USER} "${the_module}" CACHE INTERNAL "List of OpenCV modules explicitly disabled by user")
     endif()
 
-    # add reverse wrapper dependencies
+    # add reverse wrapper dependencies (BINDINDS)
     foreach (wrapper ${OPENCV_MODULE_${the_module}_WRAPPERS})
-      ocv_add_dependencies(opencv_${wrapper} OPTIONAL ${the_module})
+      if(wrapper STREQUAL "python")  # hack for python (BINDINDS)
+        ocv_add_dependencies(opencv_python2 OPTIONAL ${the_module})
+        ocv_add_dependencies(opencv_python3 OPTIONAL ${the_module})
+      else()
+        ocv_add_dependencies(opencv_${wrapper} OPTIONAL ${the_module})
+      endif()
+      if(DEFINED OPENCV_MODULE_opencv_${wrapper}_bindings_generator_CLASS)
+        ocv_add_dependencies(opencv_${wrapper}_bindings_generator OPTIONAL ${the_module})
+      endif()
     endforeach()
 
     # stop processing of current file

--- a/modules/python/bindings/CMakeLists.txt
+++ b/modules/python/bindings/CMakeLists.txt
@@ -11,7 +11,7 @@ set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../")
 # get list of modules to wrap
 set(OPENCV_PYTHON_MODULES)
 foreach(m ${OPENCV_MODULES_BUILD})
-  if (";${OPENCV_MODULE_${m}_WRAPPERS};" MATCHES ";${MODULE_NAME};" AND HAVE_${m})
+  if (";${OPENCV_MODULE_${m}_WRAPPERS};" MATCHES ";python;" AND HAVE_${m})
     list(APPEND OPENCV_PYTHON_MODULES ${m})
     #message(STATUS "\t${m}")
   endif()


### PR DESCRIPTION
Currently only `python_bindings_generator` is properly handled.

Other cases (java, obj, +added js) may not work.
In case of #18965 (js) we have this order:
```
OPENCV_MODULES_BUILD=opencv_core;opencv_imgproc;opencv_js_bindings_generator;opencv_python_tests;opencv_video;opencv_dnn;opencv_features2d;opencv_calib3d;opencv_objdetect;opencv_js
```
(dnn module is not processed before `opencv_js_bindings_generator` - this is necessary to fill `*_opencv_dnn_HEADERS` variable)

<cut/>

```
force_builders_only=linux
#,Custom,Custom Mac
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
build_image:Custom Mac=osx_framework
buildworker:Custom Mac=macosx-2
```