### PR TITLE
build warnings

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -247,6 +247,7 @@ inline DictValue & DictValue::operator=(const DictValue &r)
 }
 
 inline DictValue::DictValue(const DictValue &r)
+    : pv(NULL)
 {
     type = r.type;
 

--- a/modules/gapi/include/opencv2/gapi/util/optional.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/optional.hpp
@@ -35,9 +35,9 @@ namespace util
         // instead {}
         optional() {};
         optional(const optional&) = default;
-        explicit optional(T &&value) noexcept;
-        explicit optional(const T &value) noexcept;
-        optional(optional &&) noexcept;
+        explicit optional(T&&) noexcept;
+        explicit optional(const T&) noexcept;
+        optional(optional&&) noexcept;
         // TODO: optional(nullopt_t) noexcept;
         // TODO: optional(const optional<U> &)
         // TODO: optional(optional<U> &&)
@@ -46,8 +46,8 @@ namespace util
         // TODO: optional(U&& value);
 
         // Assignment
-        optional& operator=(const optional& rhs) = default;
-        optional& operator=(optional&& rhs);
+        optional& operator=(const optional&) = default;
+        optional& operator=(optional&&);
 
         // Observers
         T* operator-> ();


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/2775

- GCC 4.8.5 / CentOS 7

[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_etc-centos-lin64/builds/44)

<cut/>

```
/build/master_etc-centos-lin64/opencv/modules/core/include/opencv2/core/utility.hpp:1004:9: warning: 'paramCoeff.cv::dnn::dnn4_v20201117::DictValue::<anonymous>.cv::dnn::dnn4_v20201117::DictValue::<anonymous union>::pi' may be used uninitialized in this function [-Wmaybe-uninitialized]
/build/master_etc-centos-lin64/opencv/modules/core/include/opencv2/core/utility.hpp:1004:9: warning: 'param.cv::dnn::dnn4_v20201117::DictValue::<anonymous>.cv::dnn::dnn4_v20201117::DictValue::<anonymous union>::pi' may be used uninitialized in this function [-Wmaybe-uninitialized]
/build/master_etc-centos-lin64/opencv/modules/core/include/opencv2/core/utility.hpp:1004:9: warning: 'paramOrder.cv::dnn::dnn4_v20201117::DictValue::<anonymous>.cv::dnn::dnn4_v20201117::DictValue::<anonymous union>::pi' may be used uninitialized in this function [-Wmaybe-uninitialized]
/build/master_etc-centos-lin64/opencv/modules/gapi/include/opencv2/gapi/util/optional.hpp:30:32: warning: unused parameter 'rhs' [-Wunused-parameter]
/build/master_etc-centos-lin64/opencv/modules/gapi/include/opencv2/gapi/util/optional.hpp:30:32: warning: unused parameter 'rhs' [-Wunused-parameter]
```

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
test_modules:Custom=none
```