### PR TITLE
core: update handling of allocator stats type

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -82,16 +82,24 @@ option(OPENCV_ENABLE_ALLOCATOR_STATS "Enable Allocator metrics" ON)
 
 if(NOT OPENCV_ENABLE_ALLOCATOR_STATS)
   add_definitions(-DOPENCV_DISABLE_ALLOCATOR_STATS=1)
-else()
+elseif(HAVE_CXX11 OR DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
   if(NOT DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
     if(HAVE_ATOMIC_LONG_LONG AND OPENCV_ENABLE_ATOMIC_LONG_LONG)
-      set(OPENCV_ALLOCATOR_STATS_COUNTER_TYPE "long long")
+      if(MINGW)
+        # command-line generation issue due to space in value, int/int64_t should be used instead
+        # https://github.com/opencv/opencv/issues/16990
+        message(STATUS "Consider adding OPENCV_ALLOCATOR_STATS_COUNTER_TYPE=int/int64_t according to your build configuration")
+      else()
+        set(OPENCV_ALLOCATOR_STATS_COUNTER_TYPE "long long")
+      endif()
     else()
       set(OPENCV_ALLOCATOR_STATS_COUNTER_TYPE "int")
     endif()
   endif()
-  message(STATUS "Allocator metrics storage type: '${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}'")
-  add_definitions("-DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}")
+  if(DEFINED OPENCV_ALLOCATOR_STATS_COUNTER_TYPE)
+    message(STATUS "Allocator metrics storage type: '${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}'")
+    add_definitions("-DOPENCV_ALLOCATOR_STATS_COUNTER_TYPE=${OPENCV_ALLOCATOR_STATS_COUNTER_TYPE}")
+  endif()
 endif()
 
 

--- a/modules/core/include/opencv2/core/utils/allocator_stats.impl.hpp
+++ b/modules/core/include/opencv2/core/utils/allocator_stats.impl.hpp
@@ -7,13 +7,11 @@
 
 #include "./allocator_stats.hpp"
 
-#ifdef CV_CXX11
-#include <atomic>
-#endif
-
 //#define OPENCV_DISABLE_ALLOCATOR_STATS
 
-namespace cv { namespace utils {
+#ifdef CV_CXX11
+
+#include <atomic>
 
 #ifndef OPENCV_ALLOCATOR_STATS_COUNTER_TYPE
 #if defined(__GNUC__) && (\
@@ -27,6 +25,16 @@ namespace cv { namespace utils {
 #ifndef OPENCV_ALLOCATOR_STATS_COUNTER_TYPE
 #define OPENCV_ALLOCATOR_STATS_COUNTER_TYPE long long
 #endif
+
+#else  // CV_CXX11
+
+#ifndef OPENCV_ALLOCATOR_STATS_COUNTER_TYPE
+#define OPENCV_ALLOCATOR_STATS_COUNTER_TYPE int  // CV_XADD supports int only
+#endif
+
+#endif  // CV_CXX11
+
+namespace cv { namespace utils {
 
 #ifdef CV__ALLOCATOR_STATS_LOG
 namespace {


### PR DESCRIPTION
- don't use OPENCV_ALLOCATOR_STATS_COUNTER_TYPE definition in non C++11 builds
- don't use with MinGW: #16990 and duplicates

relates #16786