### PR TITLE
Check for CMake 3.19 if Xcode version is 12.2 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,7 @@ endif()
 
 include(cmake/OpenCVMinDepVersions.cmake)
 
-if(CMAKE_GENERATOR MATCHES Xcode AND XCODE_VERSION VERSION_GREATER 4.3)
-  cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-elseif(CMAKE_SYSTEM_NAME MATCHES WindowsPhone OR CMAKE_SYSTEM_NAME MATCHES WindowsStore)
+if(CMAKE_SYSTEM_NAME MATCHES WindowsPhone OR CMAKE_SYSTEM_NAME MATCHES WindowsStore)
   cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
   #Required to resolve linker error issues due to incompatibility with CMake v3.0+ policies.
   #CMake fails to find _fseeko() which leads to subsequent linker error.

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -37,7 +37,7 @@ from subprocess import check_call, check_output, CalledProcessError
 from distutils.dir_util import copy_tree
 
 sys.path.insert(0, os.path.abspath(os.path.abspath(os.path.dirname(__file__))+'/../apple'))
-from cv_build_utils import execute, print_error, get_xcode_major, get_xcode_setting
+from cv_build_utils import execute, print_error, get_xcode_major, get_xcode_setting, get_xcode_version, get_cmake_version
 
 IPHONEOS_DEPLOYMENT_TARGET='9.0'  # default, can be changed via command line options or environment variable
 
@@ -64,6 +64,12 @@ class Builder:
         self.run_tests = run_tests
         self.build_docs = build_docs
 
+    def checkCMakeVersion(self):
+        if get_xcode_version() >= (12, 2):
+            assert get_cmake_version() >= (3, 19), "CMake 3.19 or later is required when building with Xcode 12.2 or greater. Current version is {}".format(get_cmake_version())
+        else:
+            assert get_cmake_version() >= (3, 17), "CMake 3.17 or later is required. Current version is {}".format(get_cmake_version())
+
     def getBuildDir(self, parent, target):
 
         res = os.path.join(parent, 'build-%s-%s' % (target[0].lower(), target[1].lower()))
@@ -73,6 +79,7 @@ class Builder:
         return os.path.abspath(res)
 
     def _build(self, outdir):
+        self.checkCMakeVersion()
         outdir = os.path.abspath(outdir)
         if not os.path.isdir(outdir):
             os.makedirs(outdir)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -10,11 +10,14 @@ import os, os.path, sys, argparse, traceback, multiprocessing
 sys.path.insert(0, os.path.abspath(os.path.abspath(os.path.dirname(__file__))+'/../ios'))
 from build_framework import Builder
 sys.path.insert(0, os.path.abspath(os.path.abspath(os.path.dirname(__file__))+'/../apple'))
-from cv_build_utils import print_error
+from cv_build_utils import print_error, get_cmake_version
 
 MACOSX_DEPLOYMENT_TARGET='10.12'  # default, can be changed via command line options or environment variable
 
 class OSXBuilder(Builder):
+
+    def checkCMakeVersion(self):
+        assert get_cmake_version() >= (3, 17), "CMake 3.17 or later is required. Current version is {}".format(get_cmake_version())
 
     def getObjcTarget(self, target):
         # Obj-C generation target


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

This PR addresses #19014 

- remove obsolete check for Cmake version 3.0 or greater when using Xcode 4.3 or greater
- add .py script check for Cmake version 3.19 or greater when build for iOS with Xcode 12.2 or greater
- add .py script check for Cmake version 3.17 or greater when build for macOS or build for iOS with Xcode 12.1 or lower 
