### PR TITLE
add thread-safe startup of fastMalloc and fastFree

### DIFF
--- a/modules/core/perf/perf_allocation.cpp
+++ b/modules/core/perf/perf_allocation.cpp
@@ -1,5 +1,9 @@
-#include <array>
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
 #include "perf_precomp.hpp"
+#include <array>
 
 using namespace perf;
 
@@ -14,7 +18,7 @@ namespace opencv_test
 
 typedef perf::TestBaseWithParam<MatType> MatDepth_tb;
 
-PERF_TEST_P(MatDepth_tb, Allocation_Aligned,
+PERF_TEST_P(MatDepth_tb, DISABLED_Allocation_Aligned,
     testing::Values(CV_8UC1, CV_16SC1, CV_8UC3, CV_8UC4))
 {
     const int matType = GetParam();

--- a/modules/core/perf/perf_allocation.cpp
+++ b/modules/core/perf/perf_allocation.cpp
@@ -1,0 +1,44 @@
+#include <array>
+#include "perf_precomp.hpp"
+
+using namespace perf;
+
+#define ALLOC_MAT_SIZES ::perf::szSmall24, ::perf::szSmall32, ::perf::szSmall64, \
+    ::perf::sz5MP, ::perf::sz2K, ::perf::szSmall128, ::perf::szODD, ::perf::szQVGA, \
+    ::perf::szVGA, ::perf::szSVGA, ::perf::sz720p, ::perf::sz1080p, ::perf::sz2160p, \
+    ::perf::sz4320p, ::perf::sz3MP, ::perf::szXGA, ::perf::szSXGA, ::perf::szWQHD, \
+    ::perf::sznHD, ::perf::szqHD
+
+namespace opencv_test
+{
+
+typedef perf::TestBaseWithParam<MatType> MatDepth_tb;
+
+PERF_TEST_P(MatDepth_tb, Allocation_Aligned,
+    testing::Values(CV_8UC1, CV_16SC1, CV_8UC3, CV_8UC4))
+{
+    const int matType = GetParam();
+    const cv::Mat utility(1, 1, matType);
+    const size_t elementBytes = utility.elemSize();
+
+    const std::array<cv::Size, 20> sizes{ALLOC_MAT_SIZES};
+    std::array<size_t, 20> bytes;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        bytes[i] = sizes[i].width * sizes[i].height * elementBytes;
+    }
+
+    declare.time(60)
+           .iterations(100);
+
+    TEST_CYCLE()
+    {
+        for (int i = 0; i < 100000; ++i)
+        {
+            fastFree(fastMalloc(bytes[i % sizes.size()]));
+        }
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+};

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -100,25 +100,24 @@ static bool readMemoryAlignmentParameter()
     // TODO add checks for valgrind, ASAN if value == false
     return value;
 }
+
+#if defined _MSC_VER
+#pragma warning(suppress:4714)  // preventive: const marked as __forceinline not inlined
+static __forceinline
+#else
 static inline
+#endif
 bool isAlignedAllocationEnabled()
 {
-    static bool initialized = false;
-    static bool useMemalign = true;
-    if (!initialized)
-    {
-        initialized = true;  // trick to avoid stuck in acquire (works only if allocations are scope based)
-        useMemalign = readMemoryAlignmentParameter();
-    }
+    // use construct on first use idiom https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
+    // details: https://github.com/opencv/opencv/issues/15691
+    static bool useMemalign
+    #if defined __GNUC__
+        __attribute__((unused))
+    #endif
+        = readMemoryAlignmentParameter();
     return useMemalign;
 }
-// do not use variable directly, details: https://github.com/opencv/opencv/issues/15691
-static const bool g_force_initialization_memalign_flag
-#if defined __GNUC__
-    __attribute__((unused))
-#endif
-    = isAlignedAllocationEnabled();
-
 #endif
 
 #ifdef OPENCV_ALLOC_ENABLE_STATISTICS

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -111,13 +111,16 @@ bool isAlignedAllocationEnabled()
 {
     // use construct on first use idiom https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
     // details: https://github.com/opencv/opencv/issues/15691
-    static bool useMemalign
-    #if defined __GNUC__
-        __attribute__((unused))
-    #endif
-        = readMemoryAlignmentParameter();
+    static bool useMemalign = readMemoryAlignmentParameter();
     return useMemalign;
 }
+
+// need for this static const is disputed; retaining as it doesn't cause harm
+static const bool g_force_initialization_memalign_flag
+#if defined __GNUC__
+    __attribute__((unused))
+#endif
+    = isAlignedAllocationEnabled();
 #endif
 
 #ifdef OPENCV_ALLOC_ENABLE_STATISTICS


### PR DESCRIPTION
Fixes program startup unsafe thread behavior of the core memory allocator `fastMalloc()` and
deallocator `fastFree()` from issue https://github.com/opencv/opencv/issues/19004 and adds performance test case.

Summary: The code works as expected on below tested platforms. I do not see any
consistent performance gains or losses.

🚨Please note: this PR is *only* for OpenCV 4 and newer. This fix *requires*
a C++11 compliant compiler. Do not apply this exact code to the 3.x codebase since
that code might be compiled on an older C++98 compiler. Only C++11 or newer
promises thread-safe initialization of static local variables
https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables.
Such a variable is low cost, will only initialize once, handles exceptions, and
threads block if they try to pass through the same declaration if another thread
is initializing.

### Unit functionality testing

It is difficult with the current test harness to unit test this fix in isolation
since the easiest failure would only appear at startup and other failures would
occur randomly seconds, minutes, or hours later. Instead, most OpenCV test cases
will indirectly test this since most allocate memory. If random or widespread
memory violations appear after this PR, it suggests there is an issue that needs
investigation. If anyone has an idea how to reliably unit test this, please contact
me and I'll write the test.

Meanwhile, I have run the core unit tests `opencv_test_core`. Test was compiled
with code that includes this fix and the performance test case. All unit tests
passed.

```
[----------] Global test environment tear-down
[ SKIPSTAT ] 40 tests skipped
[ SKIPSTAT ] TAG='mem_6gb' skip 1 tests
[ SKIPSTAT ] TAG='skip_bigdata' skip 1 tests
[ SKIPSTAT ] TAG='skip_other' skip 38 tests
[==========] 11608 tests from 245 test cases ran. (58634 ms total)
[  PASSED  ] 11608 tests.
```

### Performance testing

Code changes of this type have very small changes; often in the low micro or innanoseconds.
In an effort to see any patterns of poor performance, 100000 iterations are run and multiple
samples collected. Code was compiled on two separate computers and the test run afterwards with
`run.py . -t core --configuration Release --gtest_filter=*Allocation* --perf_min_samples=50`

Absolute results are not useful as they will different on all machines/vm. Relative results will
slightly vary due to variations of resource availability on the test machine/vm at the time of
the test.

1. i7-3720QM 4C/8T w/ 16GB ram, Win 10, Windows x64 Release build via VS2019 v16.8.2
2. i7-10875H 8C/16T w/ 32GB ram, Ubuntu 18.04, ELF64 Release build via g++ 7.5.0
   This Ubuntu is running in a Docker within WSL2 running on host Win10.

Code `master` is commit e726ff3296b9e382371a778ad807d37a2e49b979 + the performance test case.
Code `fix` is above code + this fix.
Summary is generated with `summary.py *.xml`

#### Windows build

4 tests with the fix, 4 tests with master

MatType | 1-fix | 1-master | 2-fix | 2-master | 3-fix | 3-master | 4-fix | 4-master
-- | -- | -- | -- | -- | -- | -- | -- | --
8UC1 | 803.41 | 1108.649 | 1096.648 | 1069.492 | 1030.315 | 962.789 | 1071.768 | 1016.982
16SC1 | 1049.798 | 1451.937 | 1383.221 | 1377.024 | 1308.098 | 1293.132 | 1413.328 | 1155.163
8UC3 | 1231.156 | 1446.758 | 1433.7 | 1202.575 | 1361.586 | 1291.419 | 1217.747 | 1359.528
8UC4 | 1308.182 | 1528.312 | 1449.753 | 1276.084 | 1482.031 | 1405.05 | 1292.891 | 1458.997

![image](https://user-images.githubusercontent.com/679350/101299252-cedbdb00-3831-11eb-9641-0d7b18e2ebf8.png)

#### Ubuntu build

3 tests with fix, 3 tests with master


MatType | 1-fix | 1-master | 2-fix | 2-master | 3-fix | 3-master
-- | -- | -- | -- | -- | -- | --
8UC1 | 3.719 | 3.772 | 3.715 | 3.681 | 3.714 | 3.643
16SC1 | 17.87 | 18.15 | 17.112 | 17.043 | 17.309 | 17.26
8UC3 | 17.93 | 17.894 | 17.282 | 17.481 | 17.357 | 17.615
8UC4 | 18.211 | 18.105 | 17.709 | 17.722 | 17.46 | 17.806

![image](https://user-images.githubusercontent.com/679350/101299271-e2874180-3831-11eb-8719-6156fa21cd12.png)

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
