### PR TITLE
videoio(test): skip GStreamer in 'frame_timestamp' tests

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1062,6 +1062,8 @@ double GStreamerCapture::getProperty(int propId) const
     switch(propId)
     {
     case CV_CAP_PROP_POS_MSEC:
+        CV_LOG_ONCE_WARNING(NULL, "OpenCV | GStreamer: CAP_PROP_POS_MSEC property result may be unrealiable: "
+                                  "https://github.com/opencv/opencv/issues/19025");
         format = GST_FORMAT_TIME;
         status = gst_element_query_position(sink.get(), CV_GST_FORMAT(format), &value);
         if(!status) {


### PR DESCRIPTION
- CAP_PROP_POS_MSEC is not reliable

resolves #19025

<cut/>

```
force_builders=Linux AVX2,Custom
build_image:Custom=gstreamer:16.04
buildworker:Custom=linux-1,linux-2
test_modules:Custom=videoio,python2,python3,java
```