### PR TITLE
[G-API]: Fix coverity warnings

### DIFF
--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -44,7 +44,7 @@ PERF_TEST_P_(BuildOptFlowPyramidPerfTest, TestPerformance)
     outMaxLevelGAPI = static_cast<int>(outMaxLevelSc[0]);
 
     // Comparison //////////////////////////////////////////////////////////////
-    compareOutputPyramids(outOCV, outGAPI);
+    compareOutputPyramids(outGAPI, outOCV);
 
     SANITY_CHECK_NOTHING();
 }
@@ -74,7 +74,7 @@ PERF_TEST_P_(OptFlowLKPerfTest, TestPerformance)
     }
 
     // Comparison //////////////////////////////////////////////////////////////
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 
     SANITY_CHECK_NOTHING();
 }
@@ -109,7 +109,7 @@ PERF_TEST_P_(OptFlowLKForPyrPerfTest, TestPerformance)
     }
 
     // Comparison //////////////////////////////////////////////////////////////
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 
     SANITY_CHECK_NOTHING();
 }
@@ -147,7 +147,7 @@ PERF_TEST_P_(BuildPyr_CalcOptFlow_PipelinePerfTest, TestPerformance)
     }
 
     // Comparison //////////////////////////////////////////////////////////////
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -18,10 +18,10 @@ namespace opencv_test
 namespace
 {
 template <typename Elem>
-inline bool compareVectorsAbsExact(const std::vector<Elem>& outOCV,
-                                   const std::vector<Elem>& outGAPI)
+inline bool compareVectorsAbsExact(const std::vector<Elem>& outGAPI,
+                                   const std::vector<Elem>& outOCV)
 {
-    return AbsExactVector<Elem>().to_compare_f()(outOCV, outGAPI);
+    return AbsExactVector<Elem>().to_compare_f()(outGAPI, outOCV);
 }
 }
 

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -390,26 +390,26 @@ inline GComputation runOCVnGAPIOptFlowPipeline(TestFunctional&,
 
 #endif // HAVE_OPENCV_VIDEO
 
-inline void compareOutputPyramids(const BuildOpticalFlowPyramidTestOutput& outOCV,
-                                  const BuildOpticalFlowPyramidTestOutput& outGAPI)
+inline void compareOutputPyramids(const BuildOpticalFlowPyramidTestOutput& outGAPI,
+                                  const BuildOpticalFlowPyramidTestOutput& outOCV)
 {
     GAPI_Assert(outGAPI.maxLevel == outOCV.maxLevel);
     GAPI_Assert(outOCV.maxLevel >= 0);
     size_t maxLevel = static_cast<size_t>(outOCV.maxLevel);
     for (size_t i = 0; i <= maxLevel; i++)
     {
-        EXPECT_TRUE(AbsExact().to_compare_f()(outOCV.pyramid[i], outGAPI.pyramid[i]));
+        EXPECT_TRUE(AbsExact().to_compare_f()(outGAPI.pyramid[i], outOCV.pyramid[i]));
     }
 }
 
 template <typename Elem>
-inline bool compareVectorsAbsExactForOptFlow(std::vector<Elem> outOCV, std::vector<Elem> outGAPI)
+inline bool compareVectorsAbsExactForOptFlow(std::vector<Elem> outGAPI, std::vector<Elem> outOCV)
 {
-    return AbsExactVector<Elem>().to_compare_f()(outOCV, outGAPI);
+    return AbsExactVector<Elem>().to_compare_f()(outGAPI, outOCV);
 }
 
-inline void compareOutputsOptFlow(const OptFlowLKTestOutput& outOCV,
-                                  const OptFlowLKTestOutput& outGAPI)
+inline void compareOutputsOptFlow(const OptFlowLKTestOutput& outGAPI,
+                                  const OptFlowLKTestOutput& outOCV)
 {
     EXPECT_TRUE(compareVectorsAbsExactForOptFlow(outGAPI.nextPoints, outOCV.nextPoints));
     EXPECT_TRUE(compareVectorsAbsExactForOptFlow(outGAPI.statuses,   outOCV.statuses));

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -27,7 +27,7 @@ TEST_P(BuildOptFlowPyramidTest, AccuracyTest)
 
     runOCVnGAPIBuildOptFlowPyramid(*this, params, outOCV, outGAPI);
 
-    compareOutputPyramids(outOCV, outGAPI);
+    compareOutputPyramids(outGAPI, outOCV);
 }
 
 TEST_P(OptFlowLKTest, AccuracyTest)
@@ -44,7 +44,7 @@ TEST_P(OptFlowLKTest, AccuracyTest)
 
     runOCVnGAPIOptFlowLK(*this, inPts, params, outOCV, outGAPI);
 
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 }
 
 TEST_P(OptFlowLKTestForPyr, AccuracyTest)
@@ -63,7 +63,7 @@ TEST_P(OptFlowLKTestForPyr, AccuracyTest)
 
     runOCVnGAPIOptFlowLKForPyr(*this, in, params, withDeriv, outOCV, outGAPI);
 
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 }
 
 TEST_P(BuildPyr_CalcOptFlow_PipelineTest, AccuracyTest)
@@ -86,7 +86,7 @@ TEST_P(BuildPyr_CalcOptFlow_PipelineTest, AccuracyTest)
 
     runOCVnGAPIOptFlowPipeline(*this, params, outOCV, outGAPI, inPts);
 
-    compareOutputsOptFlow(outOCV, outGAPI);
+    compareOutputsOptFlow(outGAPI, outOCV);
 }
 
 #ifdef HAVE_OPENCV_VIDEO


### PR DESCRIPTION
These changes move G-API output to the first place of arguments in comparison functions in some tests to make them consistent and eliminate warnings from coverity tool.

@alalek 's [comment reference](https://github.com/opencv/opencv/pull/18857#discussion_r537888168).

With the changes in indicated `kmean`'s tests, I'm taking courage to edit older but similar places in code I introduced some time ago.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```