### PR TITLE
android: use gradle 5.6.4

### DIFF
--- a/platforms/android/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
resolves #19047

Upgrade to the latest Gradle 6.7.1 failed with build errors:

<cut/>

```
Failed to notify project evaluation listener.
  'org.gradle.api.file.RegularFileProperty org.gradle.api.file.ProjectLayout.fileProperty(org.gradle.api.provider.Provider)'

java.lang.NoSuchMethodError: 'org.gradle.api.file.RegularFileProperty org.gradle.api.file.ProjectLayout.fileProperty(org.gradle.api.provider.Provider)
```
