### PR TITLE
GAPI: fix Clang warning for dangling references in for loop variable

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -38,10 +38,6 @@ if(MSVC)
   endif()
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")  # don't add Clang here: issue should be investigated and fixed (workaround for Apple only)
-  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wrange-loop-analysis)  # https://github.com/opencv/opencv/issues/18928
-endif()
-
 file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/*.hpp"

--- a/modules/gapi/src/backends/common/gcompoundkernel.cpp
+++ b/modules/gapi/src/backends/common/gcompoundkernel.cpp
@@ -16,7 +16,7 @@
 cv::detail::GCompoundContext::GCompoundContext(const cv::GArgs& in_args)
 {
     m_args.resize(in_args.size());
-    for (const auto& it : ade::util::indexed(in_args))
+    for (const auto it : ade::util::indexed(in_args))
     {
         const auto& i      = ade::util::index(it);
         const auto& in_arg = ade::util::value(it);

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -71,7 +71,7 @@ void linkNodes(ade::Graph& g) {
     for (const auto& nh : g.nodes()) {
         if (gm.metadata(nh).get<cv::gimpl::NodeType>().t == cv::gimpl::NodeType::OP) {
             const auto& op = gm.metadata(nh).get<gimpl::Op>();
-            for (const auto& in : ade::util::indexed(op.args)) {
+            for (const auto in : ade::util::indexed(op.args)) {
                 const auto& arg = ade::util::value(in);
                 if (arg.kind == cv::detail::ArgKind::GOBJREF) {
                     const auto idx = ade::util::index(in);
@@ -82,9 +82,9 @@ void linkNodes(ade::Graph& g) {
                 }
             }
 
-            for (const auto& out : ade::util::indexed(op.outs)) {
-                const auto idx = ade::util::index(out);
-                const auto rc  = ade::util::value(out);
+            for (const auto out : ade::util::indexed(op.outs)) {
+                const auto  idx = ade::util::index(out);
+                const auto& rc  = ade::util::value(out);
                 const auto& out_nh = dataNodes.at(rc);
                 const auto& out_eh = g.link(nh, out_nh);
                 gm.metadata(out_eh).set(cv::gimpl::Output{idx});

--- a/modules/gapi/src/backends/cpu/gcpubackend.cpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.cpp
@@ -237,11 +237,11 @@ void cv::gimpl::GCPUExecutable::run(std::vector<InObj>  &&input_objs,
 
         // - Output parameters.
         // FIXME: pre-allocate internal Mats, etc, according to the known meta
-        for (const auto &out_it : ade::util::indexed(op.outs))
+        for (const auto out_it : ade::util::indexed(op.outs))
         {
             // FIXME: Can the same GArg type resolution mechanism be reused here?
-            const auto out_port  = ade::util::index(out_it);
-            const auto out_desc  = ade::util::value(out_it);
+            const auto  out_port  = ade::util::index(out_it);
+            const auto& out_desc  = ade::util::value(out_it);
             context.m_results[out_port] = magazine::getObjPtr(m_res, out_desc);
         }
 
@@ -259,10 +259,10 @@ void cv::gimpl::GCPUExecutable::run(std::vector<InObj>  &&input_objs,
         //FIXME: unify with cv::detail::ensure_out_mats_not_reallocated
         //FIXME: when it's done, remove can_describe(const GMetaArg&, const GRunArgP&)
         //and descr_of(const cv::GRunArgP &argp)
-        for (const auto &out_it : ade::util::indexed(op_info.expected_out_metas))
+        for (const auto out_it : ade::util::indexed(op_info.expected_out_metas))
         {
-            const auto out_index      = ade::util::index(out_it);
-            const auto expected_meta  = ade::util::value(out_it);
+            const auto  out_index      = ade::util::index(out_it);
+            const auto& expected_meta  = ade::util::value(out_it);
 
             if (!can_describe(expected_meta, context.m_results[out_index]))
             {

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -232,7 +232,7 @@ void cv::gimpl::FluidAgent::reset()
 {
     m_producedLines = 0;
 
-    for (const auto& it : ade::util::indexed(in_views))
+    for (const auto it : ade::util::indexed(in_views))
     {
         auto& v = ade::util::value(it);
         if (v)
@@ -505,7 +505,7 @@ void cv::gimpl::FluidAgent::doWork()
 
     k.m_f(in_args, out_buffers);
 
-    for (const auto& it : ade::util::indexed(in_views))
+    for (const auto it : ade::util::indexed(in_views))
     {
         auto& in_view = ade::util::value(it);
 
@@ -517,7 +517,7 @@ void cv::gimpl::FluidAgent::doWork()
         };
     }
 
-    for (auto out_buf : out_buffers)
+    for (auto* out_buf : out_buffers)
     {
         out_buf->priv().writeDone();
         // FIXME WARNING: Scratch buffers rotated here too!
@@ -571,10 +571,10 @@ void cv::gimpl::GFluidExecutable::initBufferRois(std::vector<int>& readStarts,
     }
 
     // First, initialize rois for output nodes, add them to traversal stack
-    for (const auto& it : ade::util::indexed(proto.out_nhs))
+    for (const auto it : ade::util::indexed(proto.out_nhs))
     {
         const auto idx = ade::util::index(it);
-        const auto nh  = ade::util::value(it);
+        const auto& nh  = ade::util::value(it);
 
         const auto &d  = m_gm.metadata(nh).get<Data>();
 
@@ -927,7 +927,7 @@ std::size_t cv::gimpl::GFluidExecutable::total_buffers_size() const
 {
     GConstFluidModel fg(m_g);
     std::size_t total_size = 0;
-    for (const auto &i : ade::util::indexed(m_buffers))
+    for (const auto i : ade::util::indexed(m_buffers))
     {
         // Check that all internal and scratch buffers are allocated
         const auto  idx = ade::util::index(i);
@@ -1310,7 +1310,7 @@ void cv::gimpl::GFluidExecutable::run(std::vector<InObj>  &input_objs,
         agent->reset();
         // Pass input cv::Scalar's to agent argument
         const auto& op = m_gm.metadata(agent->op_handle).get<Op>();
-        for (const auto& it : ade::util::indexed(op.args))
+        for (const auto it : ade::util::indexed(op.args))
         {
             const auto& arg = ade::util::value(it);
             packArg(agent->in_args[ade::util::index(it)], arg);

--- a/modules/gapi/src/backends/ocl/goclbackend.cpp
+++ b/modules/gapi/src/backends/ocl/goclbackend.cpp
@@ -231,21 +231,21 @@ void cv::gimpl::GOCLExecutable::run(std::vector<InObj>  &&input_objs,
 
         // - Output parameters.
         // FIXME: pre-allocate internal Mats, etc, according to the known meta
-        for (const auto &out_it : ade::util::indexed(op.outs))
+        for (const auto out_it : ade::util::indexed(op.outs))
         {
             // FIXME: Can the same GArg type resolution mechanism be reused here?
-            const auto out_port  = ade::util::index(out_it);
-            const auto out_desc  = ade::util::value(out_it);
+            const auto  out_port  = ade::util::index(out_it);
+            const auto& out_desc  = ade::util::value(out_it);
             context.m_results[out_port] = magazine::getObjPtr(m_res, out_desc, true);
         }
 
         // Now trigger the executable unit
         k.apply(context);
 
-        for (const auto &out_it : ade::util::indexed(op_info.expected_out_metas))
+        for (const auto out_it : ade::util::indexed(op_info.expected_out_metas))
         {
-            const auto out_index      = ade::util::index(out_it);
-            const auto expected_meta  = ade::util::value(out_it);
+            const auto  out_index      = ade::util::index(out_it);
+            const auto& expected_meta  = ade::util::value(out_it);
 
             if (!can_describe(expected_meta, context.m_results[out_index]))
             {
@@ -262,8 +262,8 @@ void cv::gimpl::GOCLExecutable::run(std::vector<InObj>  &&input_objs,
 
     for (auto &it : output_objs)
     {
-        auto& rc = it.first;
-        auto& g_arg = it.second;
+        const auto& rc    = it.first;
+              auto& g_arg = it.second;
         magazine::writeBack(m_res, rc, g_arg);
         if (rc.shape == GShape::GMAT)
         {

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -338,7 +338,7 @@ void cv::gimpl::GCompiler::validateInputMeta()
         return false; // should never happen
     };
 
-    for (const auto &meta_arg_idx : ade::util::indexed(ade::util::zip(m_metas, c_expr.m_ins)))
+    for (const auto meta_arg_idx : ade::util::indexed(ade::util::zip(m_metas, c_expr.m_ins)))
     {
         const auto &meta  = std::get<0>(ade::util::value(meta_arg_idx));
         const auto &proto = std::get<1>(ade::util::value(meta_arg_idx));
@@ -365,7 +365,7 @@ void cv::gimpl::GCompiler::validateOutProtoArgs()
         return;
     }
     const auto &c_expr = util::get<cv::GComputation::Priv::Expr>(m_c.priv().m_shape);
-    for (const auto &out_pos : ade::util::indexed(c_expr.m_outs))
+    for (const auto out_pos : ade::util::indexed(c_expr.m_outs))
     {
         const auto &node = proto::origin_of(ade::util::value(out_pos)).node;
         if (node.shape() != cv::GNode::NodeShape::CALL)

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -135,7 +135,7 @@ cv::gimpl::Unrolled cv::gimpl::unrollExpr(const GProtoArgs &ins,
                 // Put the outputs object description of the node
                 // so that they are not lost if they are not consumed by other operations
                 GAPI_Assert(call_p.m_k.outCtors.size() == call_p.m_k.outShapes.size());
-                for (const auto &it : ade::util::indexed(call_p.m_k.outShapes))
+                for (const auto it : ade::util::indexed(call_p.m_k.outShapes))
                 {
                     std::size_t port  = ade::util::index(it);
                     GShape shape      = ade::util::value(it);
@@ -212,7 +212,7 @@ cv::gimpl::GModelBuilder::put(const GProtoArgs &ins, const GProtoArgs &outs)
         const GCall::Priv&  call_p  = call.priv();
         ade::NodeHandle     call_h  = put_OpNode(op_expr_node);
 
-        for (const auto &it : ade::util::indexed(call_p.m_args))
+        for (const auto it : ade::util::indexed(call_p.m_args))
         {
             const auto  in_port = ade::util::index(it);
             const auto& in_arg  = ade::util::value(it);

--- a/modules/gapi/src/compiler/passes/kernels.cpp
+++ b/modules/gapi/src/compiler/passes/kernels.cpp
@@ -94,7 +94,7 @@ namespace
 
         // Reconnect expanded kernels from graph data objects
         // to subgraph data objects, then drop that graph data objects
-        for (const auto& it : ade::util::zip(in_nhs, sorted_in_nhs))
+        for (const auto it : ade::util::zip(in_nhs, sorted_in_nhs))
         {
             const auto& subgr_in_nh = std::get<0>(it);
             const auto& comp_in_nh  = std::get<1>(it);
@@ -105,7 +105,7 @@ namespace
 
         gr.erase(nh);
 
-        for (const auto& it : ade::util::zip(out_nhs, sorted_out_nhs))
+        for (const auto it : ade::util::zip(out_nhs, sorted_out_nhs))
         {
             const auto& subgr_out_nh = std::get<0>(it);
             const auto& comp_out_nh  = std::get<1>(it);

--- a/modules/gapi/src/compiler/passes/meta.cpp
+++ b/modules/gapi/src/compiler/passes/meta.cpp
@@ -24,7 +24,7 @@ void cv::gimpl::passes::initMeta(ade::passes::PassContext &ctx, const GMetaArgs 
 
     const auto &proto = gr.metadata().get<Protocol>();
 
-    for (const auto& it : ade::util::indexed(proto.in_nhs))
+    for (const auto it : ade::util::indexed(proto.in_nhs))
     {
         auto& data = gr.metadata(ade::util::value(it)).get<Data>();
         data.meta = metas.at(ade::util::index(it));
@@ -125,7 +125,7 @@ void cv::gimpl::passes::storeResultingMeta(ade::passes::PassContext &ctx)
     const auto &proto = gr.metadata().get<Protocol>();
     GMetaArgs output_metas(proto.out_nhs.size());
 
-    for (const auto& it : ade::util::indexed(proto.out_nhs))
+    for (const auto it : ade::util::indexed(proto.out_nhs))
     {
         auto& data = gr.metadata(ade::util::value(it)).get<Data>();
         output_metas[ade::util::index(it)] = data.meta;

--- a/modules/gapi/test/gapi_gcomputation_tests.cpp
+++ b/modules/gapi/test/gapi_gcomputation_tests.cpp
@@ -81,7 +81,7 @@ namespace opencv_test
 
           void check(const std::vector<cv::Mat>& out_mats)
           {
-              for (const auto& it : ade::util::zip(ref_mats, out_mats))
+              for (const auto it : ade::util::zip(ref_mats, out_mats))
               {
                   const auto& ref_mat = std::get<0>(it);
                   const auto& out_mat = std::get<1>(it);

--- a/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
@@ -213,7 +213,7 @@ TEST(GModelBuilder, Check_Multiple_Outputs)
     EXPECT_EQ(0u, gm.metadata(p.out_nhs[1]->inEdges().front()).get<cv::gimpl::Output>().port);
     EXPECT_EQ(1u, gm.metadata(p.out_nhs[2]->inEdges().front()).get<cv::gimpl::Output>().port);
     EXPECT_EQ(0u, gm.metadata(p.out_nhs[3]->inEdges().front()).get<cv::gimpl::Output>().port);
-    for (const auto& it : ade::util::indexed(p.out_nhs))
+    for (const auto it : ade::util::indexed(p.out_nhs))
     {
         const auto& out_nh = ade::util::value(it);
 


### PR DESCRIPTION
Clang complains that the code in question binds a temporary value (returned by `indexed`) to a (`const`) reference.  While technically assigning a temporary value to `const` reference is OK (as it extends a lifetime of the temporary to lifetime of the reference), let\s please the compiler :)   

resolves #18928

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
buildworker:Mac=macosx-1
buildworker:iOS=macosx-1

force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```