### PR TITLE
use opencl GPU:0 (1st gpu) in OpenCLExecutionContext test cases

### DIFF
--- a/modules/core/test/test_opencl.cpp
+++ b/modules/core/test/test_opencl.cpp
@@ -120,12 +120,12 @@ TEST(OCL_OpenCLExecutionContext, createGPU)
 
     ASSERT_FALSE(ctx.empty());
 
-    ocl::Context context = ocl::Context::create(":GPU:1");
+    ocl::Context context = ocl::Context::create(":GPU:0");
     if (context.empty())
     {
         context = ocl::Context::create(":CPU:");
         if (context.empty())
-            throw SkipTestException("OpenCL GPU1/CPU devices are not available");
+            throw SkipTestException("OpenCL GPU0/CPU devices are not available");
     }
 
     ocl::Device device = context.device(0);
@@ -161,7 +161,7 @@ TEST(OCL_OpenCLExecutionContext, ScopeTest)
 
     ASSERT_FALSE(ctx.empty());
 
-    ocl::Context context = ocl::Context::create(":GPU:1");
+    ocl::Context context = ocl::Context::create(":GPU:0");
     if (context.empty())
     {
         context = ocl::Context::create(":CPU:");


### PR DESCRIPTION
Fix opencv/opencv#18917 by using GPU:0 instead of GPU:1 in two OpenCLExecutionContext test cases. Otherwise, those test cases are using the 2nd GPU *or* silently fall-back to using a CPU-based OpenCL runtime.

If the opencv test pipeline and its multiple test platforms do not have 2 GPUs in them, then it is possible all the previous results of these two test cases are results of a fallback CPU device. It is important to check the test results of these two test cases on all the test platforms -- it might be the first time these two test cases run on a GPU.

It successfully runs on my two test machines. However, these two machines have two GPUs each.

```
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from OCL_OpenCLExecutionContext
[ RUN      ] OCL_OpenCLExecutionContext.basic
[       OK ] OCL_OpenCLExecutionContext.basic (1 ms)
[ RUN      ] OCL_OpenCLExecutionContext.createAndBind
[       OK ] OCL_OpenCLExecutionContext.createAndBind (45 ms)
[ RUN      ] OCL_OpenCLExecutionContext.createGPU
[       OK ] OCL_OpenCLExecutionContext.createGPU (102 ms)
[ RUN      ] OCL_OpenCLExecutionContext.ScopeTest
[       OK ] OCL_OpenCLExecutionContext.ScopeTest (2 ms)
[----------] 4 tests from OCL_OpenCLExecutionContext (162 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (194 ms total)
[  PASSED  ] 4 tests.
```

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake