### PR TITLE
dnn(caffe): add DetectionOutputParameter.clip to .proto file

### DIFF
--- a/modules/dnn/src/caffe/opencv-caffe.proto
+++ b/modules/dnn/src/caffe/opencv-caffe.proto
@@ -181,6 +181,8 @@ message DetectionOutputParameter {
   optional float confidence_threshold = 9;
   // If prior boxes are normalized to [0, 1] or not.
   optional bool normalized_bbox = 10 [default = true];
+  // OpenCV custom parameter
+  optional bool clip = 1000 [default = false];
 }
 
 message Datum {


### PR DESCRIPTION
Allow to load `opencv_face_detector` model with external protobuf.
Builtin protobuf has patch with support for "custom" properties.

Validation instructions:
- `cmake -DBUILD_PROTOBUF=OFF -DPROTOBUF_UPDATE_FILES=ON ...`
- `./bin/opencv_test_dnn --gtest_filter=*opencv_face*`

**Note**: .pb.cc / .pb.h files are not updated (not necessary and this update is large enough)

relates #18702