### PR TITLE
cmake: update MKL library searching

### DIFF
--- a/cmake/OpenCVFindMKL.cmake
+++ b/cmake/OpenCVFindMKL.cmake
@@ -3,7 +3,14 @@
 # installation/package
 #
 # Parameters:
-# MKL_WITH_TBB
+# MKL_ROOT_DIR / ENV{MKLROOT}
+# MKL_INCLUDE_DIR
+# MKL_LIBRARIES
+# MKL_USE_SINGLE_DYNAMIC_LIBRARY - use single dynamic library mkl_rt.lib / libmkl_rt.so
+# MKL_WITH_TBB / MKL_WITH_OPENMP
+#
+# Extra:
+# MKL_LIB_FIND_PATHS
 #
 # On return this will define:
 #
@@ -12,12 +19,6 @@
 # MKL_INCLUDE_DIRS  - MKL include folder
 # MKL_LIBRARIES     - MKL libraries that are used by OpenCV
 #
-
-macro (mkl_find_lib VAR NAME DIRS)
-    find_path(${VAR} ${NAME} ${DIRS} NO_DEFAULT_PATH)
-    set(${VAR} ${${VAR}}/${NAME})
-    unset(${VAR} CACHE)
-endmacro()
 
 macro(mkl_fail)
     set(HAVE_MKL OFF)
@@ -39,43 +40,50 @@ macro(get_mkl_version VERSION_FILE)
     set(MKL_VERSION_STR "${MKL_VERSION_MAJOR}.${MKL_VERSION_MINOR}.${MKL_VERSION_UPDATE}" CACHE STRING "MKL version" FORCE)
 endmacro()
 
+OCV_OPTION(MKL_USE_SINGLE_DYNAMIC_LIBRARY "Use MKL Single Dynamic Library thorugh mkl_rt.lib / libmkl_rt.so" OFF)
+OCV_OPTION(MKL_WITH_TBB "Use MKL with TBB multithreading" OFF)#ON IF WITH_TBB)
+OCV_OPTION(MKL_WITH_OPENMP "Use MKL with OpenMP multithreading" OFF)#ON IF WITH_OPENMP)
 
-if(NOT DEFINED MKL_USE_MULTITHREAD)
-    OCV_OPTION(MKL_WITH_TBB "Use MKL with TBB multithreading" OFF)#ON IF WITH_TBB)
-    OCV_OPTION(MKL_WITH_OPENMP "Use MKL with OpenMP multithreading" OFF)#ON IF WITH_OPENMP)
+if(NOT MKL_ROOT_DIR AND DEFINED MKL_INCLUDE_DIR AND EXISTS "${MKL_INCLUDE_DIR}/mkl.h")
+  file(TO_CMAKE_PATH "${MKL_INCLUDE_DIR}" MKL_INCLUDE_DIR)
+  get_filename_component(MKL_ROOT_DIR "${MKL_INCLUDE_DIR}/.." ABSOLUTE)
+endif()
+if(NOT MKL_ROOT_DIR)
+  file(TO_CMAKE_PATH "${MKL_ROOT_DIR}" mkl_root_paths)
+  if(DEFINED ENV{MKLROOT})
+      file(TO_CMAKE_PATH "$ENV{MKLROOT}" path)
+      list(APPEND mkl_root_paths "${path}")
+  endif()
+
+  if(WITH_MKL AND NOT mkl_root_paths)
+    if(WIN32)
+      set(ProgramFilesx86 "ProgramFiles(x86)")
+      file(TO_CMAKE_PATH "$ENV{${ProgramFilesx86}}" path)
+      list(APPEND mkl_root_paths ${path}/IntelSWTools/compilers_and_libraries/windows/mkl)
+    endif()
+    if(UNIX)
+      list(APPEND mkl_root_paths "/opt/intel/mkl")
+    endif()
+  endif()
+
+  find_path(MKL_ROOT_DIR include/mkl.h PATHS ${mkl_root_paths})
 endif()
 
-#check current MKL_ROOT_DIR
 if(NOT MKL_ROOT_DIR OR NOT EXISTS "${MKL_ROOT_DIR}/include/mkl.h")
-    set(mkl_root_paths "${MKL_ROOT_DIR}")
-    if(DEFINED ENV{MKLROOT})
-        list(APPEND mkl_root_paths "$ENV{MKLROOT}")
-    endif()
-
-    if(WITH_MKL AND NOT mkl_root_paths)
-      if(WIN32)
-        set(ProgramFilesx86 "ProgramFiles(x86)")
-        list(APPEND mkl_root_paths $ENV{${ProgramFilesx86}}/IntelSWTools/compilers_and_libraries/windows/mkl)
-      endif()
-      if(UNIX)
-        list(APPEND mkl_root_paths "/opt/intel/mkl")
-      endif()
-    endif()
-
-    find_path(MKL_ROOT_DIR include/mkl.h PATHS ${mkl_root_paths})
+  mkl_fail()
 endif()
 
-set(MKL_INCLUDE_DIRS "${MKL_ROOT_DIR}/include" CACHE PATH "Path to MKL include directory")
+set(MKL_INCLUDE_DIR "${MKL_ROOT_DIR}/include" CACHE PATH "Path to MKL include directory")
 
 if(NOT MKL_ROOT_DIR
     OR NOT EXISTS "${MKL_ROOT_DIR}"
-    OR NOT EXISTS "${MKL_INCLUDE_DIRS}"
-    OR NOT EXISTS "${MKL_INCLUDE_DIRS}/mkl_version.h"
+    OR NOT EXISTS "${MKL_INCLUDE_DIR}"
+    OR NOT EXISTS "${MKL_INCLUDE_DIR}/mkl_version.h"
 )
-    mkl_fail()
+  mkl_fail()
 endif()
 
-get_mkl_version(${MKL_INCLUDE_DIRS}/mkl_version.h)
+get_mkl_version(${MKL_INCLUDE_DIR}/mkl_version.h)
 
 #determine arch
 if(CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8)
@@ -95,52 +103,66 @@ else()
     set(MKL_ARCH_SUFFIX "c")
 endif()
 
-if(MKL_VERSION_STR VERSION_GREATER "11.3.0" OR MKL_VERSION_STR VERSION_EQUAL "11.3.0")
-    set(mkl_lib_find_paths
-        ${MKL_ROOT_DIR}/lib)
-    foreach(MKL_ARCH ${MKL_ARCH_LIST})
-      list(APPEND mkl_lib_find_paths
-        ${MKL_ROOT_DIR}/lib/${MKL_ARCH}
-        ${MKL_ROOT_DIR}/../tbb/lib/${MKL_ARCH}
-        ${MKL_ROOT_DIR}/${MKL_ARCH})
-    endforeach()
+set(mkl_lib_find_paths ${MKL_LIB_FIND_PATHS} ${MKL_ROOT_DIR}/lib)
+foreach(MKL_ARCH ${MKL_ARCH_LIST})
+  list(APPEND mkl_lib_find_paths
+    ${MKL_ROOT_DIR}/lib/${MKL_ARCH}
+    ${MKL_ROOT_DIR}/${MKL_ARCH}
+  )
+endforeach()
 
-    set(mkl_lib_list "mkl_intel_${MKL_ARCH_SUFFIX}")
+if(MKL_USE_SINGLE_DYNAMIC_LIBRARY AND NOT (MKL_VERSION_STR VERSION_LESS "10.3.0"))
 
-    if(MKL_WITH_TBB)
-        list(APPEND mkl_lib_list mkl_tbb_thread tbb)
-    elseif(MKL_WITH_OPENMP)
-        if(MSVC)
-            list(APPEND mkl_lib_list mkl_intel_thread libiomp5md)
-        else()
-            list(APPEND mkl_lib_list mkl_gnu_thread)
-        endif()
+  # https://software.intel.com/content/www/us/en/develop/articles/a-new-linking-model-single-dynamic-library-mkl_rt-since-intel-mkl-103.html
+  set(mkl_lib_list "mkl_rt")
+
+elseif(NOT (MKL_VERSION_STR VERSION_LESS "11.3.0"))
+
+  foreach(MKL_ARCH ${MKL_ARCH_LIST})
+    list(APPEND mkl_lib_find_paths
+      ${MKL_ROOT_DIR}/../tbb/lib/${MKL_ARCH}
+    )
+  endforeach()
+
+  set(mkl_lib_list "mkl_intel_${MKL_ARCH_SUFFIX}")
+
+  if(MKL_WITH_TBB)
+    list(APPEND mkl_lib_list mkl_tbb_thread tbb)
+  elseif(MKL_WITH_OPENMP)
+    if(MSVC)
+      list(APPEND mkl_lib_list mkl_intel_thread libiomp5md)
     else()
-        list(APPEND mkl_lib_list mkl_sequential)
+      list(APPEND mkl_lib_list mkl_gnu_thread)
     endif()
+  else()
+    list(APPEND mkl_lib_list mkl_sequential)
+  endif()
 
-    list(APPEND mkl_lib_list mkl_core)
+  list(APPEND mkl_lib_list mkl_core)
 else()
-    message(STATUS "MKL version ${MKL_VERSION_STR} is not supported")
-    mkl_fail()
+  message(STATUS "MKL version ${MKL_VERSION_STR} is not supported")
+  mkl_fail()
 endif()
 
-set(MKL_LIBRARIES "")
-foreach(lib ${mkl_lib_list})
-    find_library(${lib} NAMES ${lib} ${lib}_dll HINTS ${mkl_lib_find_paths})
-    mark_as_advanced(${lib})
-    if(NOT ${lib})
-        mkl_fail()
+if(NOT MKL_LIBRARIES)
+  set(MKL_LIBRARIES "")
+  foreach(lib ${mkl_lib_list})
+    set(lib_var_name MKL_LIBRARY_${lib})
+    find_library(${lib_var_name} NAMES ${lib} ${lib}_dll HINTS ${mkl_lib_find_paths})
+    mark_as_advanced(${lib_var_name})
+    if(NOT ${lib_var_name})
+      mkl_fail()
     endif()
-    list(APPEND MKL_LIBRARIES ${${lib}})
-endforeach()
+    list(APPEND MKL_LIBRARIES ${${lib_var_name}})
+  endforeach()
+endif()
 
 message(STATUS "Found MKL ${MKL_VERSION_STR} at: ${MKL_ROOT_DIR}")
 set(HAVE_MKL ON)
 set(MKL_ROOT_DIR "${MKL_ROOT_DIR}" CACHE PATH "Path to MKL directory")
-set(MKL_INCLUDE_DIRS "${MKL_INCLUDE_DIRS}" CACHE PATH "Path to MKL include directory")
-set(MKL_LIBRARIES "${MKL_LIBRARIES}" CACHE STRING "MKL libraries")
-if(UNIX AND NOT MKL_LIBRARIES_DONT_HACK)
+set(MKL_INCLUDE_DIRS "${MKL_INCLUDE_DIR}")
+set(MKL_LIBRARIES "${MKL_LIBRARIES}")
+if(UNIX AND NOT MKL_USE_SINGLE_DYNAMIC_LIBRARY AND NOT MKL_LIBRARIES_DONT_HACK)
     #it's ugly but helps to avoid cyclic lib problem
     set(MKL_LIBRARIES ${MKL_LIBRARIES} ${MKL_LIBRARIES} ${MKL_LIBRARIES} "-lpthread" "-lm" "-ldl")
 endif()


### PR DESCRIPTION
- allow to specify `MKL_LIBRARIES` through command-line (to support custom cases)
- added `MKL_USE_SINGLE_DYNAMIC_LIBRARY=ON` mode

resolves #17870

- [x] Validated with oneAPI on Linux
- [x] Validated with [standalone oneAPI MKL](https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html#onemkl) on Windows