### PR TITLE
Fix path resolution bugs for XCFramework builds

### DIFF
--- a/platforms/apple/build_xcframework.py
+++ b/platforms/apple/build_xcframework.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
             xcframework_path,
         ]
         for folder in build_folders:
-            xcframework_build_command += ["-framework", xcframework_path]
+            xcframework_build_command += ["-framework", "{}/{}.framework".format(folder, args.framework_name)]
         execute(xcframework_build_command, cwd=os.getcwd())
 
         print("")

--- a/platforms/apple/build_xcframework.py
+++ b/platforms/apple/build_xcframework.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         build_folders = []
 
         def get_or_create_build_folder(base_dir, platform):
-            build_folder = "./{}/{}".format(base_dir, platform).replace(" ", "\\ ")  # Escape spaces in output path
+            build_folder = "{}/{}".format(base_dir, platform).replace(" ", "\\ ")  # Escape spaces in output path
             pathlib.Path(build_folder).mkdir(parents=True, exist_ok=True)
             return build_folder
 


### PR DESCRIPTION
This PR fixes a bug found by @vade [here](https://github.com/opencv/opencv/pull/18826#issuecomment-742748803). It was introduced in 69e1167882a8145bfcc2ba3a89fcdc23ee8b7913. This PR fixes that bug.

I also found another issue that prevents the use of absolute paths when assembling the xcframework, so I've also included a fix for that.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=docs,ios,Custom Mac
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-2
```