### PR TITLE
[G-API]: Fix new streaming tests for CI

### DIFF
--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -1704,7 +1704,11 @@ TEST(GAPI_Streaming, CopyFrame)
     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
 
     auto cc = comp.compileStreaming();
-    cc.setSource<BGRSource>(filepath);
+    try {
+        cc.setSource<BGRSource>(filepath);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     cv::VideoCapture cap;
     cap.open(filepath);
@@ -1739,7 +1743,11 @@ TEST(GAPI_Streaming, Reshape)
     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
 
     auto cc = comp.compileStreaming();
-    cc.setSource<BGRSource>(filepath);
+    try {
+        cc.setSource<BGRSource>(filepath);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     cv::VideoCapture cap;
     cap.open(filepath);
@@ -1765,7 +1773,11 @@ TEST(GAPI_Streaming, Reshape)
     // Reshape the graph meta
     filepath = findDataFile("cv/video/1920x1080.avi");
     cc.stop();
-    cc.setSource<BGRSource>(filepath);
+    try {
+        cc.setSource<BGRSource>(filepath);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     cap.open(filepath);
     if (!cap.isOpened())
@@ -1799,7 +1811,11 @@ TEST(GAPI_Streaming, AccessBGRFromBGRFrame)
     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
 
     auto cc = comp.compileStreaming();
-    cc.setSource<BGRSource>(filepath);
+    try {
+        cc.setSource<BGRSource>(filepath);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     cv::VideoCapture cap;
     cap.open(filepath);
@@ -1831,7 +1847,11 @@ TEST(GAPI_Streaming, AccessBGRFromNV12Frame)
     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
 
     auto cc = comp.compileStreaming();
-    cc.setSource<NV12Source>(filepath);
+    try {
+        cc.setSource<NV12Source>(filepath);
+    } catch(...) {
+        throw SkipTestException("Video file can not be opened");
+    }
 
     cv::VideoCapture cap;
     cap.open(filepath);


### PR DESCRIPTION
Relates to: [#19009](https://github.com/opencv/opencv/pull/19009)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```