### PR TITLE
core(opencl): add version check before clCreateFromGLTexture() call

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -720,7 +720,12 @@ public:
 
     String name() const;
     String vendor() const;
+
+    /// See CL_PLATFORM_VERSION
     String version() const;
+    int versionMajor() const;
+    int versionMinor() const;
+
     int deviceNumber() const;
     void getDevice(Device& device, int d) const;
 


### PR DESCRIPTION
- to avoid crash with old OpenCL runtimes

resolves #5209