### PR TITLE
doc(windows): update how to handle MSVS 2019

### DIFF
--- a/doc/tutorials/introduction/windows_install/windows_install.markdown
+++ b/doc/tutorials/introduction/windows_install/windows_install.markdown
@@ -48,12 +48,12 @@ cd /c/lib
 @code{.bash}
 #!/bin/bash -e
 myRepo=$(pwd)
-CMAKE_CONFIG_GENERATOR="Visual Studio 14 2015 Win64"
+CMAKE_GENERATOR_OPTIONS=-G"Visual Studio 16 2019"
+#CMAKE_GENERATOR_OPTIONS=-G"Visual Studio 15 2017 Win64"
+#CMAKE_GENERATOR_OPTIONS=(-G"Visual Studio 16 2019" -A x64)  # CMake 3.14+ is required
 if [  ! -d "$myRepo/opencv"  ]; then
     echo "cloning opencv"
     git clone https://github.com/opencv/opencv.git
-    mkdir -p Build/opencv
-    mkdir -p Install/opencv
 else
     cd opencv
     git pull --rebase
@@ -62,16 +62,17 @@ fi
 if [  ! -d "$myRepo/opencv_contrib"  ]; then
     echo "cloning opencv_contrib"
     git clone https://github.com/opencv/opencv_contrib.git
-    mkdir -p Build/opencv_contrib
 else
     cd opencv_contrib
     git pull --rebase
     cd ..
 fi
 RepoSource=opencv
-pushd Build/$RepoSource
-CMAKE_OPTIONS='-DBUILD_PERF_TESTS:BOOL=OFF -DBUILD_TESTS:BOOL=OFF -DBUILD_DOCS:BOOL=OFF  -DWITH_CUDA:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DINSTALL_CREATE_DISTRIB=ON'
-cmake -G"$CMAKE_CONFIG_GENERATOR" $CMAKE_OPTIONS -DOPENCV_EXTRA_MODULES_PATH="$myRepo"/opencv_contrib/modules -DCMAKE_INSTALL_PREFIX="$myRepo"/install/"$RepoSource" "$myRepo/$RepoSource"
+mkdir -p build_opencv
+pushd build_opencv
+CMAKE_OPTIONS=(-DBUILD_PERF_TESTS:BOOL=OFF -DBUILD_TESTS:BOOL=OFF -DBUILD_DOCS:BOOL=OFF  -DWITH_CUDA:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DINSTALL_CREATE_DISTRIB=ON)
+set -x
+cmake "${CMAKE_GENERATOR_OPTIONS[@]}" "${CMAKE_OPTIONS[@]}" -DOPENCV_EXTRA_MODULES_PATH="$myRepo"/opencv_contrib/modules -DCMAKE_INSTALL_PREFIX="$myRepo/install/$RepoSource" "$myRepo/$RepoSource"
 echo "************************* $Source_DIR -->debug"
 cmake --build .  --config debug
 echo "************************* $Source_DIR -->release"
@@ -82,15 +83,15 @@ popd
 @endcode
     In this script I suppose you use VS 2015 in 64 bits
 @code{.bash}
-CMAKE_CONFIG_GENERATOR="Visual Studio 14 2015 Win64"
+CMAKE_GENERATOR_OPTIONS=-G"Visual Studio 14 2015 Win64"
 @endcode
-    and opencv will be installed in c:/lib/install
+    and opencv will be installed in c:/lib/install/opencv
 @code{.bash}
--DCMAKE_INSTALL_PREFIX="$myRepo"/install/"$RepoSource" "$myRepo/$RepoSource"
+-DCMAKE_INSTALL_PREFIX="$myRepo/install/$RepoSource"
 @endcode
     with no Perf tests, no tests, no doc, no CUDA and no example
 @code{.bash}
-CMAKE_OPTIONS='-DBUILD_PERF_TESTS:BOOL=OFF -DBUILD_TESTS:BOOL=OFF -DBUILD_DOCS:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF'
+CMAKE_OPTIONS=(-DBUILD_PERF_TESTS:BOOL=OFF -DBUILD_TESTS:BOOL=OFF -DBUILD_DOCS:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF)
 @endcode
 -#  In git command line enter following command :
 @code{.bash}


### PR DESCRIPTION
Ref: https://forum.opencv.org/t/install-error-for-visual-studio-2019-cmake-error-could-not-create-named-generator-visual-studio-16-2019-win64/144

relates #9514

/cc @LaurentBerger 

```
force_builders_only=docs
```