### PR TITLE
[G-API] GStreamingBackend hotfix

### DIFF
--- a/modules/gapi/include/opencv2/gapi/streaming/format.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/format.hpp
@@ -13,8 +13,7 @@ namespace cv {
 namespace gapi {
 namespace streaming {
 
-cv::gapi::GKernelPackage kernels();
-cv::gapi::GBackend backend();
+GAPI_EXPORTS cv::gapi::GKernelPackage kernels();
 
 // FIXME: Make a generic kernel
 G_API_OP(GCopy, <GFrame(GFrame)>, "org.opencv.streaming.copy")

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -58,9 +58,9 @@ namespace gimpl {
     struct Data;
     struct RcDesc;
 
-    struct RMatMediaBGRAdapter final: public cv::RMat::Adapter
+    struct GAPI_EXPORTS RMatMediaAdapterBGR final: public cv::RMat::Adapter
     {
-        RMatMediaBGRAdapter(cv::MediaFrame frame) : m_frame(frame) { };
+        explicit RMatMediaAdapterBGR(const cv::MediaFrame& frame) : m_frame(frame) { };
 
         virtual cv::RMat::View access(cv::RMat::Access a) override
         {

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -58,6 +58,35 @@ namespace gimpl {
     struct Data;
     struct RcDesc;
 
+    struct RMatMediaBGRAdapter final: public cv::RMat::Adapter
+    {
+        RMatMediaBGRAdapter(cv::MediaFrame frame) : m_frame(frame) { };
+
+        virtual cv::RMat::View access(cv::RMat::Access a) override
+        {
+            auto view = m_frame.access(a == cv::RMat::Access::W ? cv::MediaFrame::Access::W
+                                                                : cv::MediaFrame::Access::R);
+            auto ptr = reinterpret_cast<uchar*>(view.ptr[0]);
+            auto stride = view.stride[0];
+
+            std::shared_ptr<cv::MediaFrame::View> view_ptr =
+                std::make_shared<cv::MediaFrame::View>(std::move(view));
+            auto callback = [view_ptr]() mutable { view_ptr.reset(); };
+
+            return cv::RMat::View(desc(), ptr, stride, callback);
+        }
+
+        virtual cv::GMatDesc desc() const override
+        {
+            const auto& desc = m_frame.desc();
+            GAPI_Assert(desc.fmt == cv::MediaFormat::BGR);
+            return cv::GMatDesc{CV_8U, 3, desc.size};
+        }
+
+        cv::MediaFrame m_frame;
+    };
+
+
 namespace magazine {
     template<typename... Ts> struct Class
     {

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -55,6 +55,7 @@ class GStreamingIntrinExecutable final: public cv::gimpl::GIslandExecutable
 
 public:
     GStreamingIntrinExecutable(const ade::Graph                   &,
+                               const cv::GCompileArgs             &,
                                const std::vector<ade::NodeHandle> &);
 
     const ade::Graph& m_g;
@@ -80,10 +81,10 @@ class GStreamingBackendImpl final: public cv::gapi::GBackend::Priv
     }
 
     virtual EPtr compile(const ade::Graph &graph,
-                         const cv::GCompileArgs &,
+                         const cv::GCompileArgs &args,
                          const std::vector<ade::NodeHandle> &nodes) const override
     {
-        return EPtr{new GStreamingIntrinExecutable(graph, nodes)};
+        return EPtr{new GStreamingIntrinExecutable(graph, args, nodes)};
     }
 
     virtual bool controlsMerge() const override
@@ -101,6 +102,7 @@ class GStreamingBackendImpl final: public cv::gapi::GBackend::Priv
 };
 
 GStreamingIntrinExecutable::GStreamingIntrinExecutable(const ade::Graph& g,
+                                                       const cv::GCompileArgs& args,
                                                        const std::vector<ade::NodeHandle>& nodes)
     : m_g(g), m_gm(m_g)
 {
@@ -114,7 +116,7 @@ GStreamingIntrinExecutable::GStreamingIntrinExecutable(const ade::Graph& g,
     GAPI_Assert(it != nodes.end() && "No operators found for this island?!");
 
     ConstStreamingGraph cag(m_g);
-    m_actor = cag.metadata(*it).get<StreamingCreateFunction>().createActorFunction();
+    m_actor = cag.metadata(*it).get<StreamingCreateFunction>().createActorFunction(args);
 
     // Ensure this the only op in the graph
     if (std::any_of(it+1, nodes.end(), is_op))

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -184,7 +184,7 @@ void cv::gimpl::BGR::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
         switch (desc.fmt)
         {
             case cv::MediaFormat::BGR:
-                rmat = cv::make_rmat<cv::gimpl::RMatMediaBGRAdapter>(frame);
+                rmat = cv::make_rmat<cv::gimpl::RMatMediaAdapterBGR>(frame);
                 break;
             case cv::MediaFormat::NV12:
             {

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -190,8 +190,8 @@ void cv::gimpl::BGR::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
             {
                 cv::Mat bgr;
                 auto view = frame.access(cv::MediaFrame::Access::R);
-                cv::Mat y_plane (desc.size,     CV_8UC1, view.ptr[0]);
-                cv::Mat uv_plane(desc.size / 2, CV_8UC2, view.ptr[1]);
+                cv::Mat y_plane (desc.size,     CV_8UC1, view.ptr[0], view.stride[0]);
+                cv::Mat uv_plane(desc.size / 2, CV_8UC2, view.ptr[1], view.stride[1]);
                 cv::cvtColorTwoPlane(y_plane, uv_plane, bgr, cv::COLOR_YUV2BGR_NV12);
                 rmat = cv::make_rmat<cv::gimpl::RMatAdapter>(bgr);
                 break;

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
@@ -14,34 +14,6 @@
 namespace cv {
 namespace gimpl {
 
-struct RMatMediaBGRAdapter final: public cv::RMat::Adapter
-{
-    RMatMediaBGRAdapter(cv::MediaFrame frame) : m_frame(frame) { };
-
-    virtual cv::RMat::View access(cv::RMat::Access a) override
-    {
-        auto view = m_frame.access(a == cv::RMat::Access::W ? cv::MediaFrame::Access::W
-                                                            : cv::MediaFrame::Access::R);
-        auto ptr = reinterpret_cast<uchar*>(view.ptr[0]);
-        auto stride = view.stride[0];
-
-        std::shared_ptr<cv::MediaFrame::View> view_ptr =
-            std::make_shared<cv::MediaFrame::View>(std::move(view));
-        auto callback = [view_ptr]() mutable { view_ptr.reset(); };
-
-        return cv::RMat::View(desc(), ptr, stride, callback);
-    }
-
-    virtual cv::GMatDesc desc() const override
-    {
-        const auto& desc = m_frame.desc();
-        GAPI_Assert(desc.fmt == cv::MediaFormat::BGR);
-        return cv::GMatDesc{CV_8U, 3, desc.size};
-    }
-
-    cv::MediaFrame m_frame;
-};
-
 struct Copy: public cv::detail::KernelTag
 {
     using API = cv::gapi::streaming::GCopy;
@@ -51,14 +23,14 @@ struct Copy: public cv::detail::KernelTag
     class Actor final: public cv::gapi::streaming::IActor
     {
         public:
-            explicit Actor() {}
+            explicit Actor(const cv::GCompileArgs&) {}
             virtual void run(cv::gimpl::GIslandExecutable::IInput  &in,
                              cv::gimpl::GIslandExecutable::IOutput &out) override;
     };
 
-    static cv::gapi::streaming::IActor::Ptr create()
+    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
     {
-        return cv::gapi::streaming::IActor::Ptr(new Actor());
+        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
     }
 
     static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
@@ -71,14 +43,14 @@ struct BGR: public cv::detail::KernelTag
 
     class Actor final: public cv::gapi::streaming::IActor {
         public:
-            explicit Actor() {}
+            explicit Actor(const cv::GCompileArgs&) {}
             virtual void run(cv::gimpl::GIslandExecutable::IInput &in,
                              cv::gimpl::GIslandExecutable::IOutput&out) override;
     };
 
-    static cv::gapi::streaming::IActor::Ptr create()
+    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
     {
-        return cv::gapi::streaming::IActor::Ptr(new Actor());
+        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
     }
     static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
 };

--- a/modules/gapi/src/backends/streaming/gstreamingkernel.hpp
+++ b/modules/gapi/src/backends/streaming/gstreamingkernel.hpp
@@ -14,6 +14,8 @@ namespace cv {
 namespace gapi {
 namespace streaming {
 
+GAPI_EXPORTS cv::gapi::GBackend backend();
+
 class IActor {
 public:
     using Ptr = std::shared_ptr<IActor>;
@@ -24,7 +26,7 @@ public:
     virtual ~IActor() = default;
 };
 
-using CreateActorFunction = std::function<IActor::Ptr()>;
+using CreateActorFunction = std::function<IActor::Ptr(const cv::GCompileArgs&)>;
 struct GStreamingKernel
 {
     CreateActorFunction createActorFunction;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

## Overview
* `cv::gapi::streaming::backend()` moved to `gstreamingkernel.hpp`
* Added `cv::GCompileArgs` to `Actor` ctor 
* Exported `cv::gapi::streaming::kernels` & `cv::gapi::streaming::backend`
* `RMatMediaBGRAdapter` moved to `common/gbackend.hpp`