### PR TITLE
Increased Photo_CalibrateDebevec.regression test tolerance to pass on arm64 with gcc 9.3.

### DIFF
--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -227,7 +227,11 @@ TEST(Photo_CalibrateDebevec, regression)
     diff = diff.mul(1.0f / response);
     double max;
     minMaxLoc(diff, NULL, &max);
-    ASSERT_FALSE(max > 0.1);
+#if defined(__arm__) || defined(__aarch64__)
+    ASSERT_LT(max, 0.131);
+#else
+    ASSERT_LT(max, 0.1);
+#endif
 }
 
 TEST(Photo_CalibrateRobertson, regression)


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/issues/19124

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
