### PR TITLE
remove g_isOpenCVActivated errant assign and clarify variable

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1150,7 +1150,7 @@ void OpenCLExecutionContext::release()
 
 
 // true if we have initialized OpenCL subsystem with available platforms
-static bool g_isOpenCVActivated = false;
+static bool g_isOpenCLActivated = false;
 
 bool haveOpenCL()
 {
@@ -1178,7 +1178,7 @@ bool haveOpenCL()
         {
             cl_uint n = 0;
             g_isOpenCLAvailable = ::clGetPlatformIDs(0, NULL, &n) == CL_SUCCESS;
-            g_isOpenCVActivated = n > 0;
+            g_isOpenCLActivated = n > 0;
             CV_LOG_INFO(NULL, "OpenCL: found " << n << " platforms");
         }
         catch (...)
@@ -1214,7 +1214,7 @@ bool useOpenCL()
 
 bool isOpenCLActivated()
 {
-    if (!g_isOpenCVActivated)
+    if (!g_isOpenCLActivated)
         return false; // prevent unnecessary OpenCL activation via useOpenCL()->haveOpenCL() calls
     return useOpenCL();
 }
@@ -6370,7 +6370,6 @@ public:
 static OpenCLAllocator* getOpenCLAllocator_() // call once guarantee
 {
     static OpenCLAllocator* g_allocator = new OpenCLAllocator(); // avoid destructor call (using of this object is too wide)
-    g_isOpenCVActivated = true;
     return g_allocator;
 }
 MatAllocator* getOpenCLAllocator()


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/19132

* Remove errant assignment in `getOpenCLAllocator_()`
* Rename variable in the 4 places from g_isOpenCVActivated to g_isOpenCLActivated

Tests are successful. Here is output of `opencv_test_cored.exe`. The 4 test fails are unrelated.

```
[----------] Global test environment tear-down
[ SKIPSTAT ] 34 tests skipped
[ SKIPSTAT ] TAG='mem_6gb' skip 1 tests
[ SKIPSTAT ] TAG='skip_bigdata' skip 1 tests
[ SKIPSTAT ] TAG='skip_other' skip 32 tests
[==========] 11608 tests from 245 test cases ran. (417470 ms total)
[  PASSED  ] 11604 tests.
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] Core_InputOutput.filestorage_base64_basic_read_XML
[  FAILED  ] Core_InputOutput.filestorage_base64_basic_read_YAML
[  FAILED  ] Core_InputOutput.filestorage_base64_basic_read_JSON
[  FAILED  ] Core_globbing.accuracy

 4 FAILED TESTS
  YOU HAVE 19 DISABLED TESTS
```

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
