### PR TITLE
add images.clear() to opencl Kernel run

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3782,6 +3782,7 @@ bool Kernel::Impl::run(int dims, size_t globalsize[], size_t localsize[],
             }
         }
         cleanupUMats();
+        images.clear();
     }
     else
     {
@@ -3807,6 +3808,7 @@ bool Kernel::runTask(bool sync, const Queue& q)
     {
         CV_OCL_DBG_CHECK(clFinish(qq));
         p->cleanupUMats();
+        p->images.clear();
     }
     else
     {


### PR DESCRIPTION
Fix https://github.com/opencv/opencv/issues/19134 by adding `images.clear` to the two `sync` codepaths for Opencl Kernel run.

Passed all tests in `opencv_test_cored.exe`

```
[----------] Global test environment tear-down
[ SKIPSTAT ] 34 tests skipped
[ SKIPSTAT ] TAG='mem_6gb' skip 1 tests
[ SKIPSTAT ] TAG='skip_bigdata' skip 1 tests
[ SKIPSTAT ] TAG='skip_other' skip 32 tests
[==========] 11608 tests from 245 test cases ran. (420102 ms total)
[  PASSED  ] 11608 tests.

  YOU HAVE 19 DISABLED TESTS
```

Passed all tests in `opencv_test_imgprocd.exe`

```
[----------] Global test environment tear-down
[ SKIPSTAT ] 2 tests skipped
[ SKIPSTAT ] TAG='skip_bigdata' skip 2 tests
[==========] 10239 tests from 202 test cases ran. (377291 ms total)
[  PASSED  ] 10239 tests.

  YOU HAVE 5 DISABLED TESTS
```

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake