### PR TITLE
JavaScript: robust code generation

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -776,15 +776,13 @@ class JSWrapperGenerator(object):
                     self.bindings+=binding
 
         # generate code for the classes and their methods
-        class_list = list(self.classes.items())
-
-        for name, class_info in class_list:
+        for name, class_info in sorted(self.classes.items()):
             class_bindings = []
             if not name in white_list:
                 continue
 
             # Generate bindings for methods
-            for method_name, method in class_info.methods.items():
+            for method_name, method in sorted(class_info.methods.items()):
                 if method.cname in ignore_list:
                     continue
                 if not method.name in white_list[method.class_name]:
@@ -822,7 +820,7 @@ class JSWrapperGenerator(object):
 
 
             # Generate bindings for properties
-            for property in class_info.props:
+            for property in sorted(class_info.props):
                 _class_property = class_property_enum_template if property.tp in type_dict else class_property_template
                 class_bindings.append(_class_property.substitute(js_name=property.name, cpp_name='::'.join(
                     [class_info.cname, property.name])))


### PR DESCRIPTION
- avoid randomized output due to unpredictable dict/set order

```
force_builders_only=docs,Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
```