### PR TITLE
[cv::transform] Enable CV_SIMD for the 16U case on AArch64.

### DIFF
--- a/modules/core/src/matmul.simd.hpp
+++ b/modules/core/src/matmul.simd.hpp
@@ -1537,7 +1537,7 @@ transform_8u( const uchar* src, uchar* dst, const float* m, int len, int scn, in
 static void
 transform_16u( const ushort* src, ushort* dst, const float* m, int len, int scn, int dcn )
 {
-#if CV_SIMD && !defined(__aarch64__) && !defined(_M_ARM64)
+#if CV_SIMD
     if( scn == 3 && dcn == 3 )
     {
         int x = 0;


### PR DESCRIPTION
Performance uplift (x-factor) ranges from 2.20 to 2.50, on the following perf tests of the core module:

1. `Mat_Transform::Size_MatType`
2. `Transform::OCL_TransformFixture`

The associated issue is #19163.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ X ] I agree to contribute to the project under Apache 2 License.
- [ X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ X ] The PR is proposed to proper branch
- [ X ] There is reference to original bug report and related work