### PR TITLE
ABI: exclude quaternion header from ABI/API check

### DIFF
--- a/cmake/templates/opencv_abi.xml.in
+++ b/cmake/templates/opencv_abi.xml.in
@@ -27,6 +27,7 @@
     opencv2/core/cuda*
     opencv2/core/opencl*
     opencv2/core/private*
+    opencv2/core/quaternion*
     opencv/cxeigen.hpp
     opencv2/core/eigen.hpp
     opencv2/flann/hdf5.h


### PR DESCRIPTION
- this API is experimental for now (under active development)

- [x] Validated: Added Symbols 124 => [61](http://pullrequest.opencv.org/buildbot/builders/precommit_linux64/builds/29623/steps/Compare%20ABI%20dumps/logs/report-html)