### PR TITLE
JavaScript(build): fix generator with Python3

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -820,7 +820,7 @@ class JSWrapperGenerator(object):
 
 
             # Generate bindings for properties
-            for property in sorted(class_info.props):
+            for property in class_info.props:
                 _class_property = class_property_enum_template if property.tp in type_dict else class_property_template
                 class_bindings.append(_class_property.substitute(js_name=property.name, cpp_name='::'.join(
                     [class_info.cname, property.name])))


### PR DESCRIPTION
- class_info.props is a 'list'

relates #19161

Error message:

```
TypeError: '<' not supported between instances of 'ClassProp' and 'ClassProp'
```

<cut/>

```
force_builders=docs,Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
```
