### PR TITLE
release: OpenCV 3.4.13

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 13
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.13

relates #18824


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3413.dll (vc14)](https://www.virustotal.com/gui/file/6c5578b9774d1c659db300091b4a8e159535a878df6861e81d2fcdfa8b8dc0af/detection)
[opencv_world3413d.dll (vc14)](https://www.virustotal.com/gui/file/ec470aba9a856908c9336955bad526d2b8f02d8db43aaa9689b6f79101f75b02/detection)
[opencv_world3413.dll (vc15)](https://www.virustotal.com/gui/file/195c972e39e4df9901405d5edfbe4a5826f642d4c64afbe14aca4e10e73af588/detection)
[opencv_world3413d.dll (vc15)](https://www.virustotal.com/gui/file/0a03d40e96f6435154e3d45dbeca823f6af68641cef6ccb95d688193dd42b0c1/detection)

[opencv_ffmpeg3413_64.dll](https://www.virustotal.com/gui/file/2abd4c09ef76e913bde03929d8a0c31b5515772f682551acb43a2914d4bd42d0/detection)

</details>
