### PR TITLE
release: OpenCV 4.5.1

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    5
 #define CV_VERSION_REVISION 1
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 4.5.1

relates #18825


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world451.dll (vc14)](https://www.virustotal.com/gui/file/6349298e6c189b72c230cf28cc2b289bed73877739888a0c427a8a6e0105c2b1/detection)
[opencv_world451d.dll (vc14)](https://www.virustotal.com/gui/file/44cd5dcf7f4dfdb598c954a647a81bc05713d4bab091d35b54b1e660bb24926b/detection) 
[opencv_world451.dll (vc15)](https://www.virustotal.com/gui/file/3003615e050fe164d5d740de7019d69858436fbcd6cb1e6eed668b640f8757e0/detection)
[opencv_world451d.dll (vc15)](https://www.virustotal.com/gui/file/1297d89e05513cad66f2cba8719b95b6613554ba38507da5940e85c2d4bafc46/detection)

[opencv_ffmpeg451_64.dll](https://www.virustotal.com/gui/file/e5b3be3fa9d73ff07b3b78bb97bab21b8628315a2d8efcdbce36179a11333a4d/detection)

</details>
