### PR TITLE
Fix cv save image

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 13
-#define CV_VERSION_STATUS   "-dev"
+#define CV_VERSION_STATUS   "-pre"
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -1065,7 +1065,9 @@ cvSaveImage( const char* filename, const CvArr* arr, const int* _params )
         for( ; _params[i] > 0; i += 2 )
             CV_Assert(static_cast<size_t>(i) < cv::CV_IO_MAX_IMAGE_PARAMS*2); // Limit number of params for security reasons
     }
-    return cv::imwrite_(filename, cv::cvarrToMat(arr),
+    std::vector<cv::Mat> img_vec;
+    img_vec.emplace_back(cv::cvarrToMat(arr));
+    return cv::imwrite_(filename, img_vec,
         i > 0 ? std::vector<int>(_params, _params+i) : std::vector<int>(),
         CV_IS_IMAGE(arr) && ((const IplImage*)arr)->origin == IPL_ORIGIN_BL );
 }


### PR DESCRIPTION
Hi, OpenCV Team

This PR tries to fix https://github.com/opencv/opencv/issues/12818 on branch 3.4.

Though labled as `won't fix`, there are still some programs using `cvSaveImage( )`, and I just happen to migrate a project with many OpenCV C API calls to C++ API calls, encounter opencv 3.4 latest version (3.4.13)'s `cvSaveImage( )` still crash on Windows platform.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


Apart from this PR's fix method, people could also write a simple function as alternative to the bug `cvSaveImage`:
```c++
void mySaveImage(const char* filename, IplImage* dst)
{
    cv::Mat img = cv::cvarrToMat(dst);
    cv::imwrite(filename, img);
}
```