### PR TITLE
[G-API] Fix streaming kernels in standalone 

### DIFF
--- a/modules/gapi/cmake/standalone.cmake
+++ b/modules/gapi/cmake/standalone.cmake
@@ -21,6 +21,7 @@ file(GLOB FLUID_sources  "${FLUID_ROOT}/src/api/g*.cpp"
                          "${FLUID_ROOT}/src/compiler/passes/*.cpp"
                          "${FLUID_ROOT}/src/executor/*.cpp"
                          "${FLUID_ROOT}/src/backends/fluid/*.cpp"
+                         "${FLUID_ROOT}/src/backends/streaming/*.cpp"
                          "${FLUID_ROOT}/src/backends/common/*.cpp")
 
 add_library(${FLUID_TARGET} STATIC ${FLUID_includes} ${FLUID_sources})

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -4,7 +4,10 @@
 //
 // Copyright (C) 2020 Intel Corporation
 
+#if !defined(GAPI_STANDALONE)
 #include <opencv2/imgproc.hpp>
+#endif // !defined(GAPI_STANDALONE)
+
 #include <opencv2/gapi/util/throw.hpp> // throw_error
 #include <opencv2/gapi/streaming/format.hpp> // kernels
 

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -32,7 +32,6 @@ using ConstStreamingGraph = ade::ConstTypedGraph
     , StreamingCreateFunction
     >;
 
-
 class GStreamingIntrinExecutable final: public cv::gimpl::GIslandExecutable
 {
     virtual void run(std::vector<InObj>  &&,
@@ -135,18 +134,30 @@ cv::gapi::GBackend cv::gapi::streaming::backend()
     return this_backend;
 }
 
-cv::gapi::GKernelPackage cv::gapi::streaming::kernels()
+struct Copy: public cv::detail::KernelTag
 {
-    return cv::gapi::kernels<cv::gimpl::BGR>();
-}
+    using API = cv::gimpl::streaming::GCopy;
 
-cv::gapi::GKernelPackage cv::gimpl::streaming::kernels()
-{
-    return cv::gapi::kernels<cv::gimpl::Copy>();
-}
+    static cv::gapi::GBackend backend() { return cv::gapi::streaming::backend(); }
 
-void cv::gimpl::Copy::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
-                                 cv::gimpl::GIslandExecutable::IOutput &out)
+    class Actor final: public cv::gapi::streaming::IActor
+    {
+        public:
+            explicit Actor(const cv::GCompileArgs&) {}
+            virtual void run(cv::gimpl::GIslandExecutable::IInput  &in,
+                             cv::gimpl::GIslandExecutable::IOutput &out) override;
+    };
+
+    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
+    {
+        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
+    }
+
+    static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
+};
+
+void Copy::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
+                      cv::gimpl::GIslandExecutable::IOutput &out)
 {
     const auto in_msg = in.get();
     if (cv::util::holds_alternative<cv::gimpl::EndOfStream>(in_msg))
@@ -176,8 +187,34 @@ void cv::gimpl::Copy::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
     out.post(std::move(out_arg));
 }
 
-void cv::gimpl::BGR::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
-                                cv::gimpl::GIslandExecutable::IOutput &out)
+cv::gapi::GKernelPackage cv::gimpl::streaming::kernels()
+{
+    return cv::gapi::kernels<Copy>();
+}
+
+#if !defined(GAPI_STANDALONE)
+
+struct GOCVBGR: public cv::detail::KernelTag
+{
+    using API = cv::gapi::streaming::GBGR;
+    static cv::gapi::GBackend backend() { return cv::gapi::streaming::backend(); }
+
+    class Actor final: public cv::gapi::streaming::IActor {
+        public:
+            explicit Actor(const cv::GCompileArgs&) {}
+            virtual void run(cv::gimpl::GIslandExecutable::IInput &in,
+                             cv::gimpl::GIslandExecutable::IOutput&out) override;
+    };
+
+    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
+    {
+        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
+    }
+    static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
+};
+
+void GOCVBGR::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
+                     cv::gimpl::GIslandExecutable::IOutput &out)
 {
     const auto in_msg = in.get();
     if (cv::util::holds_alternative<cv::gimpl::EndOfStream>(in_msg))
@@ -215,6 +252,21 @@ void cv::gimpl::BGR::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
     }
     out.post(std::move(out_arg));
 }
+
+cv::gapi::GKernelPackage cv::gapi::streaming::kernels()
+{
+    return cv::gapi::kernels<GOCVBGR>();
+}
+
+#else
+
+cv::gapi::GKernelPackage cv::gapi::streaming::kernels()
+{
+    // Still provide this symbol to avoid linking issues
+    util::throw_error(std::runtime_error("cv::gapi::streaming::kernels() isn't supported in standalone"));
+}
+
+#endif // !defined(GAPI_STANDALONE)
 
 cv::GMat cv::gapi::copy(const cv::GMat& in) {
     return cv::gimpl::streaming::GCopy::on<cv::GMat>(in);

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
@@ -12,13 +12,6 @@
 #include "gstreamingkernel.hpp"
 
 namespace cv {
-namespace gapi {
-namespace streaming {
-
-cv::gapi::GBackend backend();
-
-}} // namespace gapi::streaming
-
 namespace gimpl {
 namespace streaming {
 
@@ -39,48 +32,6 @@ struct GCopy final : public cv::detail::NoTag
 };
 
 } // namespace streaming
-
-struct Copy: public cv::detail::KernelTag
-{
-    using API = streaming::GCopy;
-
-    static gapi::GBackend backend() { return cv::gapi::streaming::backend(); }
-
-    class Actor final: public cv::gapi::streaming::IActor
-    {
-        public:
-            explicit Actor(const cv::GCompileArgs&) {}
-            virtual void run(cv::gimpl::GIslandExecutable::IInput  &in,
-                             cv::gimpl::GIslandExecutable::IOutput &out) override;
-    };
-
-    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
-    {
-        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
-    }
-
-    static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
-};
-
-struct BGR: public cv::detail::KernelTag
-{
-    using API = cv::gapi::streaming::GBGR;
-    static gapi::GBackend backend() { return cv::gapi::streaming::backend(); }
-
-    class Actor final: public cv::gapi::streaming::IActor {
-        public:
-            explicit Actor(const cv::GCompileArgs&) {}
-            virtual void run(cv::gimpl::GIslandExecutable::IInput &in,
-                             cv::gimpl::GIslandExecutable::IOutput&out) override;
-    };
-
-    static cv::gapi::streaming::IActor::Ptr create(const cv::GCompileArgs& args)
-    {
-        return cv::gapi::streaming::IActor::Ptr(new Actor(args));
-    }
-    static cv::gapi::streaming::GStreamingKernel kernel() { return {&create}; };
-};
-
 } // namespace gimpl
 } // namespace cv
 

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -36,7 +36,7 @@
 #include "executor/gstreamingexecutor.hpp"
 #include "backends/common/gbackend.hpp"
 #include "backends/common/gmetabackend.hpp"
-#include "backends/streaming/gstreamingbackend.hpp"
+#include "backends/streaming/gstreamingbackend.hpp" // cv::gimpl::streaming::kernels()
 
 // <FIXME:>
 #if !defined(GAPI_STANDALONE)
@@ -44,7 +44,6 @@
 #include <opencv2/gapi/cpu/imgproc.hpp> // ...Imgproc
 #include <opencv2/gapi/cpu/video.hpp>   // ...and Video kernel implementations
 #include <opencv2/gapi/render/render.hpp>   // render::ocv::backend()
-#include <opencv2/gapi/streaming/format.hpp> // streaming::kernels()
 #endif // !defined(GAPI_STANDALONE)
 // </FIXME:>
 

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1005,12 +1005,10 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
                     // In the current implementation, such islands
                     // _must_ start with copy
                     GAPI_Assert(isl->in_ops().size() == 1u);
-#if !defined(GAPI_STANDALONE)
                     GAPI_Assert(GModel::Graph(*m_orig_graph)
                                 .metadata(*isl->in_ops().begin())
                                 .get<cv::gimpl::Op>()
                                 .k.name == cv::gimpl::streaming::GCopy::id());
-#endif // GAPI_STANDALONE
                     for (auto out_nh : nh->outNodes()) {
                         for (auto out_eh : out_nh->outEdges()) {
                             qgr.metadata(out_eh).set(DesyncSpecialCase{});


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```