### PR TITLE
[G-API]: IE tests pluginConfig fix & refactoring

### DIFF
--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -508,10 +508,8 @@ TEST(TestAgeGenderIE, GenericInfer)
 
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    cv::gapi::ie::Params<cv::gapi::Generic> pp{"age-gender-generic",
-                                                params.model_path,
-                                                params.weights_path,
-                                                params.device_id};
+    cv::gapi::ie::Params<cv::gapi::Generic> pp{
+        "age-gender-generic", params.model_path, params.weights_path, params.device_id};
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));
@@ -539,10 +537,9 @@ TEST(TestAgeGenderIE, InvalidConfigGeneric)
     auto gender  = outputs.at("prob");
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{"age-gender-generic",
-                                                       model_path,
-                                                       weights_path,
-                                                       device_id}.pluginConfig({{"unsupported_config", "some_value"}});
+    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{
+        "age-gender-generic", model_path, weights_path, device_id
+    }.pluginConfig({{"unsupported_config", "some_value"}});
 
     EXPECT_ANY_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                      cv::compile_args(cv::gapi::networks(pp))));
@@ -566,10 +563,10 @@ TEST(TestAgeGenderIE, CPUConfigGeneric)
     auto gender  = outputs.at("prob");
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    auto pp = cv::gapi::ie::Params<cv::gapi::Generic>{"age-gender-generic",
-                                                       model_path,
-                                                       weights_path,
-                                                       device_id}.pluginConfig({{"ENFORCE_BF16", "NO"}});
+    auto pp = cv::gapi::ie::Params<cv::gapi::Generic> {
+        "age-gender-generic", model_path, weights_path, device_id
+    }.pluginConfig({{IE::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,
+                     IE::PluginConfigParams::CPU_THROUGHPUT_NUMA}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));
@@ -593,7 +590,8 @@ TEST(TestAgeGenderIE, InvalidConfig)
 
     auto pp = cv::gapi::ie::Params<AgeGender> {
         model_path, weights_path, device_id
-    }.cfgOutputLayers({ "age_conv3", "prob" }).pluginConfig({{"unsupported_config", "some_value"}});
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .pluginConfig({{"unsupported_config", "some_value"}});
 
     EXPECT_ANY_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                      cv::compile_args(cv::gapi::networks(pp))));
@@ -617,7 +615,9 @@ TEST(TestAgeGenderIE, CPUConfig)
 
     auto pp = cv::gapi::ie::Params<AgeGender> {
         model_path, weights_path, device_id
-    }.cfgOutputLayers({ "age_conv3", "prob" }).pluginConfig({{"ENFORCE_BF16", "NO"}});
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .pluginConfig({{IE::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,
+                     IE::PluginConfigParams::CPU_THROUGHPUT_NUMA}});
 
     EXPECT_NO_THROW(comp.compile(cv::GMatDesc{CV_8U,3,cv::Size{320, 240}},
                     cv::compile_args(cv::gapi::networks(pp))));


### PR DESCRIPTION
Reopen of https://github.com/opencv/opencv/pull/18913
These changes:
- Replace plugin config parameters with the working ones
- Refactor for consistency

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```