### PR TITLE
JavaScript: fix Python 3 support in make_umd.py

### DIFF
--- a/modules/js/src/make_umd.py
+++ b/modules/js/src/make_umd.py
@@ -69,13 +69,16 @@
 import os, sys, re, json, shutil
 from subprocess import Popen, PIPE, STDOUT
 
+PY3 = sys.version_info >= (3, 0)
+
 def make_umd(opencvjs, cvjs):
-    src = open(opencvjs, 'r+b')
-    dst = open(cvjs, 'w+b')
-    content = src.read()
-    dst.seek(0)
-    # inspired by https://github.com/umdjs/umd/blob/95563fd6b46f06bda0af143ff67292e7f6ede6b7/templates/returnExportsGlobal.js
-    dst.write(("""
+    with open(opencvjs, 'r+b') as src:
+        content = src.read()
+    if PY3:  # content is bytes
+        content = content.decode('utf-8')
+    with open(cvjs, 'w+b') as dst:
+        # inspired by https://github.com/umdjs/umd/blob/95563fd6b46f06bda0af143ff67292e7f6ede6b7/templates/returnExportsGlobal.js
+        dst.write(("""
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
@@ -103,7 +106,8 @@ def make_umd(opencvjs, cvjs):
     Module = {};
   return cv(Module);
 }));
-    """ % (content)).lstrip().encode())
+        """ % (content)).lstrip().encode('utf-8'))
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 2:


### PR DESCRIPTION
resolves #19198

```
force_builders=docs,Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
```