### PR TITLE
JavaScript(build): reuse Python executable used to run main script

### DIFF
--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -77,7 +77,9 @@ class Builder:
             rm_one(d)
 
     def get_cmake_cmd(self):
-        cmd = ["cmake",
+        cmd = [
+            "cmake",
+            "-DPYTHON_DEFAULT_EXECUTABLE=%s" % sys.executable,
                "-DENABLE_PIC=FALSE", # To workaround emscripten upstream backend issue https://github.com/emscripten-core/emscripten/issues/8761
                "-DCMAKE_BUILD_TYPE=Release",
                "-DCMAKE_TOOLCHAIN_FILE='%s'" % self.get_toolchain_file(),


### PR DESCRIPTION
- don't switch between Python versions in the middle of the build

relates #19207

<cut/>

```
force_builders=linux,docs,Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
```