### PR TITLE
[G-API]: Performance tests for boundingRect

### DIFF
--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -42,11 +42,11 @@ class GoodFeaturesPerfTest    : public TestPerfParams<tuple<compare_vector_f<cv:
                                                             int,int,double,double,int,bool,
                                                             cv::GCompileArgs>> {};
 class BoundingRectMatPerfTest       :
-    public TestPerfParams<tuple<compare_rect_f, MatType2,cv::Size,bool, cv::GCompileArgs>> {};
+    public TestPerfParams<tuple<CompareRects, MatType2,cv::Size,bool, cv::GCompileArgs>> {};
 class BoundingRectVector32SPerfTest :
-    public TestPerfParams<tuple<compare_rect_f, cv::Size, cv::GCompileArgs>> {};
+    public TestPerfParams<tuple<CompareRects, cv::Size, cv::GCompileArgs>> {};
 class BoundingRectVector32FPerfTest :
-    public TestPerfParams<tuple<compare_rect_f, cv::Size, cv::GCompileArgs>> {};
+    public TestPerfParams<tuple<CompareRects, cv::Size, cv::GCompileArgs>> {};
 class EqHistPerfTest      : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class BGR2RGBPerfTest     : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class RGB2GrayPerfTest    : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -41,6 +41,12 @@ class CannyPerfTest           : public TestPerfParams<tuple<compare_f, MatType,c
 class GoodFeaturesPerfTest    : public TestPerfParams<tuple<compare_vector_f<cv::Point2f>, std::string,
                                                             int,int,double,double,int,bool,
                                                             cv::GCompileArgs>> {};
+class BoundingRectMatPerfTest       :
+    public TestPerfParams<tuple<compare_rect_f, MatType2,cv::Size,bool, cv::GCompileArgs>> {};
+class BoundingRectVector32SPerfTest :
+    public TestPerfParams<tuple<compare_rect_f, cv::Size, cv::GCompileArgs>> {};
+class BoundingRectVector32FPerfTest :
+    public TestPerfParams<tuple<compare_rect_f, cv::Size, cv::GCompileArgs>> {};
 class EqHistPerfTest      : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class BGR2RGBPerfTest     : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class RGB2GrayPerfTest    : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -42,7 +42,7 @@ class GoodFeaturesPerfTest    : public TestPerfParams<tuple<compare_vector_f<cv:
                                                             int,int,double,double,int,bool,
                                                             cv::GCompileArgs>> {};
 class BoundingRectMatPerfTest       :
-    public TestPerfParams<tuple<CompareRects, MatType2,cv::Size,bool, cv::GCompileArgs>> {};
+    public TestPerfParams<tuple<CompareRects, MatType,cv::Size,bool, cv::GCompileArgs>> {};
 class BoundingRectVector32SPerfTest :
     public TestPerfParams<tuple<CompareRects, cv::Size, cv::GCompileArgs>> {};
 class BoundingRectVector32FPerfTest :

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -756,7 +756,7 @@ PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
 {
     CompareRects cmpF;
     cv::Size sz;
-    MatType2 type;
+    MatType type;
     bool initByVector = false;
     cv::GCompileArgs compile_args;
     std::tie(cmpF, type, sz, initByVector, compile_args) = GetParam();

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -11,6 +11,8 @@
 
 #include "gapi_imgproc_perf_tests.hpp"
 
+#include "../../test/common/gapi_imgproc_tests_common.hpp"
+
 namespace opencv_test
 {
 
@@ -746,6 +748,87 @@ PERF_TEST_P_(GoodFeaturesPerfTest, TestPerformance)
 
     SANITY_CHECK_NOTHING();
 
+}
+
+//------------------------------------------------------------------------------
+
+PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
+{
+    compare_rect_f cmpF;
+    cv::Size sz;
+    MatType2 type;
+    bool initByVector = false;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, sz, initByVector, compile_args) = GetParam();
+
+    if (initByVector)
+    {
+        initMatByPointsVectorRandU<cv::Point_>(type, sz, -1);
+    }
+    else
+    {
+        initMatrixRandU(type, sz, -1, false);
+    }
+
+    cv::Rect out_rect_gapi;
+    cv::GComputation c(boundingRectTestGAPI<cv::GMat>(in_mat1, std::move(compile_args),
+                                                      out_rect_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_mat1), cv::gout(out_rect_gapi));
+    }
+
+    boundingRectTestOpenCVCompare(in_mat1, out_rect_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BoundingRectVector32SPerfTest, TestPerformance)
+{
+    compare_rect_f cmpF;
+    cv::Size sz;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, compile_args) = GetParam();
+
+    std::vector<cv::Point2i> in_vectorS;
+    initPointsVectorRandU(sz.width, in_vectorS);
+
+    cv::Rect out_rect_gapi;
+    cv::GComputation c(
+        boundingRectTestGAPI<cv::GArray<cv::Point2i>>(in_vectorS, std::move(compile_args),
+                                                      out_rect_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vectorS), cv::gout(out_rect_gapi));
+    }
+
+    boundingRectTestOpenCVCompare(in_vectorS, out_rect_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BoundingRectVector32FPerfTest, TestPerformance)
+{
+    compare_rect_f cmpF;
+    cv::Size sz;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, compile_args) = GetParam();
+
+    std::vector<cv::Point2f> in_vectorF;
+    initPointsVectorRandU(sz.width, in_vectorF);
+
+    cv::Rect out_rect_gapi;
+    cv::GComputation c(
+        boundingRectTestGAPI<cv::GArray<cv::Point2f>>(in_vectorF, std::move(compile_args),
+                                                      out_rect_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vectorF), cv::gout(out_rect_gapi));
+    }
+
+    boundingRectTestOpenCVCompare(in_vectorF, out_rect_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
 }
 
 //------------------------------------------------------------------------------

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -771,8 +771,7 @@ PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
     }
 
     cv::Rect out_rect_gapi;
-    cv::GComputation c(boundingRectTestGAPI<cv::GMat>(in_mat1, std::move(compile_args),
-                                                      out_rect_gapi));
+    cv::GComputation c(boundingRectTestGAPI(in_mat1, std::move(compile_args), out_rect_gapi));
 
     TEST_CYCLE()
     {
@@ -794,9 +793,7 @@ PERF_TEST_P_(BoundingRectVector32SPerfTest, TestPerformance)
     initPointsVectorRandU(sz.width, in_vectorS);
 
     cv::Rect out_rect_gapi;
-    cv::GComputation c(
-        boundingRectTestGAPI<cv::GArray<cv::Point2i>>(in_vectorS, std::move(compile_args),
-                                                      out_rect_gapi));
+    cv::GComputation c(boundingRectTestGAPI(in_vectorS, std::move(compile_args), out_rect_gapi));
 
     TEST_CYCLE()
     {
@@ -818,9 +815,7 @@ PERF_TEST_P_(BoundingRectVector32FPerfTest, TestPerformance)
     initPointsVectorRandU(sz.width, in_vectorF);
 
     cv::Rect out_rect_gapi;
-    cv::GComputation c(
-        boundingRectTestGAPI<cv::GArray<cv::Point2f>>(in_vectorF, std::move(compile_args),
-                                                      out_rect_gapi));
+    cv::GComputation c(boundingRectTestGAPI(in_vectorF, std::move(compile_args), out_rect_gapi));
 
     TEST_CYCLE()
     {

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -754,7 +754,7 @@ PERF_TEST_P_(GoodFeaturesPerfTest, TestPerformance)
 
 PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
 {
-    compare_rect_f cmpF;
+    CompareRects cmpF;
     cv::Size sz;
     MatType2 type;
     bool initByVector = false;
@@ -784,7 +784,7 @@ PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
 
 PERF_TEST_P_(BoundingRectVector32SPerfTest, TestPerformance)
 {
-    compare_rect_f cmpF;
+    CompareRects cmpF;
     cv::Size sz;
     cv::GCompileArgs compile_args;
     std::tie(cmpF, sz, compile_args) = GetParam();
@@ -806,7 +806,7 @@ PERF_TEST_P_(BoundingRectVector32SPerfTest, TestPerformance)
 
 PERF_TEST_P_(BoundingRectVector32FPerfTest, TestPerformance)
 {
-    compare_rect_f cmpF;
+    CompareRects cmpF;
     cv::Size sz;
     cv::GCompileArgs compile_args;
     std::tie(cmpF, sz, compile_args) = GetParam();

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -789,18 +789,18 @@ PERF_TEST_P_(BoundingRectVector32SPerfTest, TestPerformance)
     cv::GCompileArgs compile_args;
     std::tie(cmpF, sz, compile_args) = GetParam();
 
-    std::vector<cv::Point2i> in_vectorS;
-    initPointsVectorRandU(sz.width, in_vectorS);
+    std::vector<cv::Point2i> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
 
     cv::Rect out_rect_gapi;
-    cv::GComputation c(boundingRectTestGAPI(in_vectorS, std::move(compile_args), out_rect_gapi));
+    cv::GComputation c(boundingRectTestGAPI(in_vector, std::move(compile_args), out_rect_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_vectorS), cv::gout(out_rect_gapi));
+        c.apply(cv::gin(in_vector), cv::gout(out_rect_gapi));
     }
 
-    boundingRectTestOpenCVCompare(in_vectorS, out_rect_gapi, cmpF);
+    boundingRectTestOpenCVCompare(in_vector, out_rect_gapi, cmpF);
     SANITY_CHECK_NOTHING();
 }
 
@@ -811,18 +811,18 @@ PERF_TEST_P_(BoundingRectVector32FPerfTest, TestPerformance)
     cv::GCompileArgs compile_args;
     std::tie(cmpF, sz, compile_args) = GetParam();
 
-    std::vector<cv::Point2f> in_vectorF;
-    initPointsVectorRandU(sz.width, in_vectorF);
+    std::vector<cv::Point2f> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
 
     cv::Rect out_rect_gapi;
-    cv::GComputation c(boundingRectTestGAPI(in_vectorF, std::move(compile_args), out_rect_gapi));
+    cv::GComputation c(boundingRectTestGAPI(in_vector, std::move(compile_args), out_rect_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_vectorF), cv::gout(out_rect_gapi));
+        c.apply(cv::gin(in_vector), cv::gout(out_rect_gapi));
     }
 
-    boundingRectTestOpenCVCompare(in_vectorF, out_rect_gapi, cmpF);
+    boundingRectTestOpenCVCompare(in_vector, out_rect_gapi, cmpF);
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
@@ -182,7 +182,7 @@ INSTANTIATE_TEST_CASE_P(BoundingRectMatPerfTestCPU, BoundingRectMatPerfTest,
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectMatVectorPerfTestCPU, BoundingRectMatPerfTest,
-                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(1e-5).to_compare_f()),
                                 Values(CV_32S, CV_32F),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(true),
@@ -194,7 +194,7 @@ INSTANTIATE_TEST_CASE_P(BoundingRectVector32SPerfTestCPU, BoundingRectVector32SP
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectVector32FPerfTestCPU, BoundingRectVector32FPerfTest,
-                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(1e-5).to_compare_f()),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
@@ -174,6 +174,30 @@ INSTANTIATE_TEST_CASE_P(GoodFeaturesInternalPerfTestCPU, GoodFeaturesPerfTest,
             Values(true),
             Values(cv::compile_args(IMGPROC_CPU))));
 
+INSTANTIATE_TEST_CASE_P(BoundingRectMatPerfTestCPU, BoundingRectMatPerfTest,
+                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                                Values(CV_8UC1),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(false),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(BoundingRectMatVectorPerfTestCPU, BoundingRectMatPerfTest,
+                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                                Values(CV_32S, CV_32F),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(true),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(BoundingRectVector32SPerfTestCPU, BoundingRectVector32SPerfTest,
+                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(BoundingRectVector32FPerfTestCPU, BoundingRectVector32FPerfTest,
+                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
 INSTANTIATE_TEST_CASE_P(EqHistPerfTestCPU, EqHistPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
         Values(szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
@@ -175,26 +175,26 @@ INSTANTIATE_TEST_CASE_P(GoodFeaturesInternalPerfTestCPU, GoodFeaturesPerfTest,
             Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectMatPerfTestCPU, BoundingRectMatPerfTest,
-                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(0).to_compare_obj()),
                                 Values(CV_8UC1),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(false),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectMatVectorPerfTestCPU, BoundingRectMatPerfTest,
-                        Combine(Values(IoUToleranceRect(1e-5).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(1e-5).to_compare_obj()),
                                 Values(CV_32S, CV_32F),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(true),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectVector32SPerfTestCPU, BoundingRectVector32SPerfTest,
-                        Combine(Values(IoUToleranceRect(0).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(0).to_compare_obj()),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectVector32FPerfTestCPU, BoundingRectVector32FPerfTest,
-                        Combine(Values(IoUToleranceRect(1e-5).to_compare_f()),
+                        Combine(Values(IoUToleranceRect(1e-5).to_compare_obj()),
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -76,9 +76,8 @@ GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursHNoOffsetTest,
                                           cv::ContourApproximationModes),
                               4, sz, type, mode, method)
 GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursHOffsetTest, <>, 0)
-GAPI_TEST_FIXTURE(BoundingRectMatTest, initMatrixRandU, FIXTURE_API(CompareRects), 1, cmpF)
-GAPI_TEST_FIXTURE(BoundingRectMatVector32STest, initNothing, FIXTURE_API(CompareRects), 1, cmpF)
-GAPI_TEST_FIXTURE(BoundingRectMatVector32FTest, initNothing, FIXTURE_API(CompareRects), 1, cmpF)
+GAPI_TEST_FIXTURE(BoundingRectMatTest, initNothing, FIXTURE_API(CompareRects,bool),
+                  2, cmpF, initByVector)
 GAPI_TEST_FIXTURE(BoundingRectVector32STest, initNothing, FIXTURE_API(CompareRects), 1, cmpF)
 GAPI_TEST_FIXTURE(BoundingRectVector32FTest, initNothing, FIXTURE_API(CompareRects), 1, cmpF)
 GAPI_TEST_FIXTURE(FitLine2DMatVectorTest, initMatByPointsVectorRandU<cv::Point_>,

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -1,0 +1,52 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+#ifndef OPENCV_GAPI_IMGPROC_TESTS_COMMON_HPP
+#define OPENCV_GAPI_IMGPROC_TESTS_COMMON_HPP
+
+#include "gapi_tests_common.hpp"
+#include "../../include/opencv2/gapi/imgproc.hpp"
+
+#include <opencv2/imgproc.hpp>
+
+namespace opencv_test
+{
+template<typename G_In, typename In>
+static cv::GComputation boundingRectTestGAPI(const In& in, cv::GCompileArgs&& args,
+                                             cv::Rect& out_rect_gapi)
+{
+    G_In g_in;
+    auto out = cv::gapi::boundingRect(g_in);
+    cv::GComputation c(cv::GIn(g_in), cv::GOut(out));
+    c.apply(cv::gin(in), cv::gout(out_rect_gapi), std::move(args));
+    return c;
+}
+
+template<typename In>
+static void boundingRectTestOpenCVCompare(const In& in, const cv::Rect& out_rect_gapi,
+                                          const compare_rect_f& cmpF)
+{
+    // OpenCV code /////////////////////////////////////////////////////////////
+    cv::Rect out_rect_ocv = cv::boundingRect(in);
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
+    }
+}
+
+template<typename G_In, typename In>
+static void boundingRectTestBody(const In& in, const CompareRects& cmpF_, cv::GCompileArgs&& args)
+{
+    cv::Rect out_rect_gapi;
+    boundingRectTestGAPI<G_In>(in, std::move(args), out_rect_gapi);
+
+    compare_rect_f cmpF = [cmpF_](const cv::Rect& a, const cv::Rect& b){ return cmpF_(a, b); };
+    boundingRectTestOpenCVCompare(in, out_rect_gapi, cmpF);
+}
+
+} // namespace opencv_test
+
+#endif // OPENCV_GAPI_VIDEO_TESTS_COMMON_HPP

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -27,7 +27,7 @@ static cv::GComputation boundingRectTestGAPI(const In& in, cv::GCompileArgs&& ar
 
 template<typename In>
 static void boundingRectTestOpenCVCompare(const In& in, const cv::Rect& out_rect_gapi,
-                                          const compare_rect_f& cmpF)
+                                          const CompareRects& cmpF)
 {
     // OpenCV code /////////////////////////////////////////////////////////////
     cv::Rect out_rect_ocv = cv::boundingRect(in);
@@ -36,12 +36,11 @@ static void boundingRectTestOpenCVCompare(const In& in, const cv::Rect& out_rect
 }
 
 template<typename In>
-static void boundingRectTestBody(const In& in, const CompareRects& cmpF_, cv::GCompileArgs&& args)
+static void boundingRectTestBody(const In& in, const CompareRects& cmpF, cv::GCompileArgs&& args)
 {
     cv::Rect out_rect_gapi;
     boundingRectTestGAPI(in, std::move(args), out_rect_gapi);
 
-    compare_rect_f cmpF = [cmpF_](const cv::Rect& a, const cv::Rect& b) { return cmpF_(a, b); };
     boundingRectTestOpenCVCompare(in, out_rect_gapi, cmpF);
 }
 

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -14,11 +14,11 @@
 
 namespace opencv_test
 {
-template<typename G_In, typename In>
+template<typename In>
 static cv::GComputation boundingRectTestGAPI(const In& in, cv::GCompileArgs&& args,
                                              cv::Rect& out_rect_gapi)
 {
-    G_In g_in;
+    cv::detail::g_type_of_t<In> g_in;
     auto out = cv::gapi::boundingRect(g_in);
     cv::GComputation c(cv::GIn(g_in), cv::GOut(out));
     c.apply(cv::gin(in), cv::gout(out_rect_gapi), std::move(args));
@@ -37,11 +37,11 @@ static void boundingRectTestOpenCVCompare(const In& in, const cv::Rect& out_rect
     }
 }
 
-template<typename G_In, typename In>
+template<typename In>
 static void boundingRectTestBody(const In& in, const CompareRects& cmpF_, cv::GCompileArgs&& args)
 {
     cv::Rect out_rect_gapi;
-    boundingRectTestGAPI<G_In>(in, std::move(args), out_rect_gapi);
+    boundingRectTestGAPI(in, std::move(args), out_rect_gapi);
 
     compare_rect_f cmpF = [cmpF_](const cv::Rect& a, const cv::Rect& b){ return cmpF_(a, b); };
     boundingRectTestOpenCVCompare(in, out_rect_gapi, cmpF);

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -32,9 +32,7 @@ static void boundingRectTestOpenCVCompare(const In& in, const cv::Rect& out_rect
     // OpenCV code /////////////////////////////////////////////////////////////
     cv::Rect out_rect_ocv = cv::boundingRect(in);
     // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
+    EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
 }
 
 template<typename In>
@@ -43,7 +41,7 @@ static void boundingRectTestBody(const In& in, const CompareRects& cmpF_, cv::GC
     cv::Rect out_rect_gapi;
     boundingRectTestGAPI(in, std::move(args), out_rect_gapi);
 
-    compare_rect_f cmpF = [cmpF_](const cv::Rect& a, const cv::Rect& b){ return cmpF_(a, b); };
+    compare_rect_f cmpF = [cmpF_](const cv::Rect& a, const cv::Rect& b) { return cmpF_(a, b); };
     boundingRectTestOpenCVCompare(in, out_rect_gapi, cmpF);
 }
 

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -623,6 +623,14 @@ TEST_P(FindContoursHOffsetTest, AccuracyTest)
 
 TEST_P(BoundingRectMatTest, AccuracyTest)
 {
+    if (initByVector)
+    {
+        initMatByPointsVectorRandU<cv::Point_>(type, sz, dtype);
+    }
+    else
+    {
+        initMatrixRandU(type, sz, dtype);
+    }
     cv::Rect out_rect_gapi, out_rect_ocv;
 
     // G-API code //////////////////////////////////////////////////////////////
@@ -640,69 +648,13 @@ TEST_P(BoundingRectMatTest, AccuracyTest)
         EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
     }
 }
-
-TEST_P(BoundingRectMatVector32STest, AccuracyTest)
-{
-    cv::Rect out_rect_gapi, out_rect_ocv;
-
-    std::vector<cv::Point2i> in_vectorS(sz.width);
-    cv::randu(in_vectorS, cv::Scalar::all(0), cv::Scalar::all(255));
-    in_mat1 = cv::Mat(in_vectorS);
-
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    auto out = cv::gapi::boundingRect(in);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_mat1), cv::gout(out_rect_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        out_rect_ocv = cv::boundingRect(in_mat1);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
-}
-
-TEST_P(BoundingRectMatVector32FTest, AccuracyTest)
-{
-    cv::RNG& rng = theRNG();
-    cv::Rect out_rect_gapi, out_rect_ocv;
-
-    std::vector<cv::Point2f> in_vectorF(sz.width);
-    const int fscale = 256;  // avoid bits near ULP, generate stable test input
-    for (int i = 0; i < sz.width; i++)
-    {
-        cv::Point2f pt(rng.uniform(0, 255 * fscale) / static_cast<float>(fscale),
-                       rng.uniform(0, 255 * fscale) / static_cast<float>(fscale));
-        in_vectorF.push_back(pt);
-    }
-    in_mat1 = cv::Mat(in_vectorF);
-
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    auto out = cv::gapi::boundingRect(in);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_mat1), cv::gout(out_rect_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        out_rect_ocv = cv::boundingRect(in_mat1);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
-}
-
 
 TEST_P(BoundingRectVector32STest, AccuracyTest)
 {
     cv::Rect out_rect_gapi, out_rect_ocv;
 
-    std::vector<cv::Point2i> in_vectorS(sz.width);
-    cv::randu(in_vectorS, cv::Scalar::all(0), cv::Scalar::all(255));
+    std::vector<cv::Point2i> in_vectorS;
+    initPointsVectorRandU(sz.width, in_vectorS);
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GArray<cv::Point2i> in;
@@ -714,7 +666,6 @@ TEST_P(BoundingRectVector32STest, AccuracyTest)
     {
         out_rect_ocv = cv::boundingRect(in_vectorS);
     }
-
     // Comparison //////////////////////////////////////////////////////////////
     {
         EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
@@ -723,17 +674,10 @@ TEST_P(BoundingRectVector32STest, AccuracyTest)
 
 TEST_P(BoundingRectVector32FTest, AccuracyTest)
 {
-    cv::RNG& rng = theRNG();
     cv::Rect out_rect_gapi, out_rect_ocv;
 
-    std::vector<cv::Point2f> in_vectorF(sz.width);
-    const int fscale = 256;  // avoid bits near ULP, generate stable test input
-    for (int i = 0; i < sz.width; i++)
-    {
-        cv::Point2f pt(rng.uniform(0, 255 * fscale) / static_cast<float>(fscale),
-                       rng.uniform(0, 255 * fscale) / static_cast<float>(fscale));
-        in_vectorF.push_back(pt);
-    }
+    std::vector<cv::Point2f> in_vectorF;
+    initPointsVectorRandU(sz.width, in_vectorF);
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GArray<cv::Point2f> in;

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -11,6 +11,8 @@
 #include <opencv2/gapi/imgproc.hpp>
 #include "gapi_imgproc_tests.hpp"
 
+#include "gapi_imgproc_tests_common.hpp"
+
 namespace opencv_test
 {
 
@@ -631,69 +633,24 @@ TEST_P(BoundingRectMatTest, AccuracyTest)
     {
         initMatrixRandU(type, sz, dtype);
     }
-    cv::Rect out_rect_gapi, out_rect_ocv;
-
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    auto out = cv::gapi::boundingRect(in);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_mat1), cv::gout(out_rect_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        out_rect_ocv = cv::boundingRect(in_mat1);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
+    boundingRectTestBody<cv::GMat>(in_mat1, cmpF, getCompileArgs());
 }
 
 TEST_P(BoundingRectVector32STest, AccuracyTest)
-{
-    cv::Rect out_rect_gapi, out_rect_ocv;
 
+{
     std::vector<cv::Point2i> in_vectorS;
     initPointsVectorRandU(sz.width, in_vectorS);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2i> in;
-    auto out = cv::gapi::boundingRect(in);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vectorS), cv::gout(out_rect_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        out_rect_ocv = cv::boundingRect(in_vectorS);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
+    boundingRectTestBody<cv::GArray<cv::Point2i>>(in_vectorS, cmpF, getCompileArgs());
 }
 
 TEST_P(BoundingRectVector32FTest, AccuracyTest)
 {
-    cv::Rect out_rect_gapi, out_rect_ocv;
-
     std::vector<cv::Point2f> in_vectorF;
     initPointsVectorRandU(sz.width, in_vectorF);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2f> in;
-    auto out = cv::gapi::boundingRect(in);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vectorF), cv::gout(out_rect_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        out_rect_ocv = cv::boundingRect(in_vectorF);
-    }
-
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_rect_gapi, out_rect_ocv));
-    }
+    boundingRectTestBody<cv::GArray<cv::Point2f>>(in_vectorF, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DMatVectorTest, AccuracyTest)

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -639,18 +639,18 @@ TEST_P(BoundingRectMatTest, AccuracyTest)
 TEST_P(BoundingRectVector32STest, AccuracyTest)
 
 {
-    std::vector<cv::Point2i> in_vectorS;
-    initPointsVectorRandU(sz.width, in_vectorS);
+    std::vector<cv::Point2i> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
 
-    boundingRectTestBody(in_vectorS, cmpF, getCompileArgs());
+    boundingRectTestBody(in_vector, cmpF, getCompileArgs());
 }
 
 TEST_P(BoundingRectVector32FTest, AccuracyTest)
 {
-    std::vector<cv::Point2f> in_vectorF;
-    initPointsVectorRandU(sz.width, in_vectorF);
+    std::vector<cv::Point2f> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
 
-    boundingRectTestBody(in_vectorF, cmpF, getCompileArgs());
+    boundingRectTestBody(in_vector, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DMatVectorTest, AccuracyTest)

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -633,7 +633,7 @@ TEST_P(BoundingRectMatTest, AccuracyTest)
     {
         initMatrixRandU(type, sz, dtype);
     }
-    boundingRectTestBody<cv::GMat>(in_mat1, cmpF, getCompileArgs());
+    boundingRectTestBody(in_mat1, cmpF, getCompileArgs());
 }
 
 TEST_P(BoundingRectVector32STest, AccuracyTest)
@@ -642,7 +642,7 @@ TEST_P(BoundingRectVector32STest, AccuracyTest)
     std::vector<cv::Point2i> in_vectorS;
     initPointsVectorRandU(sz.width, in_vectorS);
 
-    boundingRectTestBody<cv::GArray<cv::Point2i>>(in_vectorS, cmpF, getCompileArgs());
+    boundingRectTestBody(in_vectorS, cmpF, getCompileArgs());
 }
 
 TEST_P(BoundingRectVector32FTest, AccuracyTest)
@@ -650,7 +650,7 @@ TEST_P(BoundingRectVector32FTest, AccuracyTest)
     std::vector<cv::Point2f> in_vectorF;
     initPointsVectorRandU(sz.width, in_vectorF);
 
-    boundingRectTestBody<cv::GArray<cv::Point2f>>(in_vectorF, cmpF, getCompileArgs());
+    boundingRectTestBody(in_vectorF, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DMatVectorTest, AccuracyTest)

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -593,6 +593,8 @@ using compare_vec_f = std::function<bool(const cv::Vec<Elem, cn> &a, const cv::V
 template<typename T1, typename T2>
 struct CompareF
 {
+    CompareF() = default;
+
     using callable_t = std::function<bool(const T1& a, const T2& b)>;
     CompareF(callable_t&& cmp, std::string&& cmp_name) :
         _comparator(std::move(cmp)), _name(std::move(cmp_name)) {}

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -303,23 +303,17 @@ INSTANTIATE_TEST_CASE_P(BoundingRectMatTestCPU, BoundingRectMatTest,
                                        cv::Size(128, 128)),
                                 Values(-1),
                                 Values(IMGPROC_CPU),
-                                Values(IoUToleranceRect(0).to_compare_obj())));
+                                Values(IoUToleranceRect(0).to_compare_obj()),
+                                Values(false)));
 
-INSTANTIATE_TEST_CASE_P(BoundingRectMatVector32STestCPU, BoundingRectMatVector32STest,
-                        Combine(Values(-1),
+INSTANTIATE_TEST_CASE_P(BoundingRectMatVectorTestCPU, BoundingRectMatTest,
+                        Combine(Values(CV_32S, CV_32F),
                                 Values(cv::Size(1280, 1),
                                        cv::Size(128, 1)),
                                 Values(-1),
                                 Values(IMGPROC_CPU),
-                                Values(IoUToleranceRect(0).to_compare_obj())));
-
- INSTANTIATE_TEST_CASE_P(BoundingRectMatVector32FTestCPU, BoundingRectMatVector32FTest,
-                         Combine(Values(-1),
-                                 Values(cv::Size(1280, 1),
-                                        cv::Size(128, 1)),
-                                 Values(-1),
-                                 Values(IMGPROC_CPU),
-                                 Values(IoUToleranceRect(1e-5).to_compare_obj())));
+                                Values(IoUToleranceRect(0).to_compare_obj()),
+                                Values(true)));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectVector32STestCPU, BoundingRectVector32STest,
                         Combine(Values(-1),

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -312,7 +312,7 @@ INSTANTIATE_TEST_CASE_P(BoundingRectMatVectorTestCPU, BoundingRectMatTest,
                                        cv::Size(128, 1)),
                                 Values(-1),
                                 Values(IMGPROC_CPU),
-                                Values(IoUToleranceRect(0).to_compare_obj()),
+                                Values(IoUToleranceRect(1e-5).to_compare_obj()),
                                 Values(true)));
 
 INSTANTIATE_TEST_CASE_P(BoundingRectVector32STestCPU, BoundingRectVector32STest,


### PR DESCRIPTION
 - Performance tests for `boundingRect` operation added
 - Accuracy test bodies merged/refactored using initialization functions which have been added recently
 - new file created to share similar code between acc. and perf. tests

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
xbuild_image:Custom Win=openvino-2021.1.0
xbuild_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```