### PR TITLE
platforms/android: allow manually selecting the STL to build with

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -238,6 +238,10 @@ class Builder:
             cmd.extend(["-DBUILD_TESTS=ON", "-DINSTALL_TESTS=ON"])
 
         cmake_vars.update(abi.cmake_vars)
+
+        if self.config.stl is not None:
+            cmake_vars['ANDROID_STL'] = self.config.stl
+
         cmd += [ "-D%s='%s'" % (k, v) for (k, v) in cmake_vars.items() if v is not None]
         cmd.append(self.opencvdir)
         execute(cmd)
@@ -376,6 +380,7 @@ if __name__ == "__main__":
     parser.add_argument('--config', default='ndk-10.config.py', type=str, help="Package build configuration", )
     parser.add_argument('--ndk_path', help="Path to Android NDK to use for build")
     parser.add_argument('--sdk_path', help="Path to Android SDK to use for build")
+    parser.add_argument('--stl', help="Manually select the STL to use for build")
     parser.add_argument('--use_android_buildtools', action="store_true", help='Use cmake/ninja build tools from Android SDK')
     parser.add_argument("--modules_list", help="List of  modules to include for build")
     parser.add_argument("--extra_modules_path", help="Path to extra modules to use for build")


### PR DESCRIPTION
The Android NDK allows you to [select one of multiple C++ runtime library (STL) options](https://developer.android.com/ndk/guides/cpp-support). Currently, OpenCV's build_sdk.py script always chooses c++_shared (or gnustl_static for older NDK versions).

This PR adds a flag, `--stl`, which allows the user to select a different STL. This is useful if you want to build OpenCV as a static library, or if you want to integrate the OpenCV library with other code that's using a different STL, since you're only supposed to use one STL for all native libraries of an app.

I targeted the 3.4 branch since it seemed like a small improvement which is still backwards-compatible, but I can rebase it against master if you want, just let me know!

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work - _I didn't make an original bug report for this issue_
- [NA] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
