### PR TITLE
Swift(test): fix minAreaRect test

### DIFF
--- a/modules/imgproc/misc/objc/test/ImgprocTest.swift
+++ b/modules/imgproc/misc/objc/test/ImgprocTest.swift
@@ -1128,8 +1128,8 @@ class ImgprocTest: OpenCVTestCase {
 
         let rrect = Imgproc.minAreaRect(points: points)
 
-        XCTAssertEqual(Size2f(width: 2, height: 5), rrect.size)
-        XCTAssertEqual(-90.0, rrect.angle)
+        XCTAssertEqual(Size2f(width: 5, height: 2), rrect.size)
+        XCTAssertEqual(0.0, rrect.angle)
         XCTAssertEqual(Point2f(x: 3.5, y: 2), rrect.center)
     }
 


### PR DESCRIPTION
relates #19068

<cut/>

Failed test messages:
> Test Case '-[OpenCVTestTests.ImgprocTest testMinAreaRect]' started.
/Volumes/build-storage/build/precommit_custom_mac/build/osx/build/build-x86_64-macosx/modules/objc_bindings_generator/osx/test/test/ImgprocTest.swift:1131: error: -[OpenCVTestTests.ImgprocTest testMinAreaRect] : XCTAssertEqual failed: ("Size2f {2.000000,5.000000}") is not equal to ("Size2f {5.000000,2.000000}")
/Volumes/build-storage/build/precommit_custom_mac/build/osx/build/build-x86_64-macosx/modules/objc_bindings_generator/osx/test/test/ImgprocTest.swift:1132: error: -[OpenCVTestTests.ImgprocTest testMinAreaRect] : XCTAssertEqual failed: ("-90.0") is not equal to ("0.0")

---

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-1
```