### PR TITLE
Fix building opencv using gcc 11.x #19244

### DIFF
--- a/modules/gapi/test/test_precomp.hpp
+++ b/modules/gapi/test/test_precomp.hpp
@@ -11,6 +11,7 @@
 #define __OPENCV_GAPI_TEST_PRECOMP_HPP__
 
 #include <cstdint>
+#include <thread>
 #include <vector>
 
 #include <opencv2/ts.hpp>


### PR DESCRIPTION
Add missing `#include <thread>` in modules/gapi/test/test_precomp.hpp

Fix #19244
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
