### PR TITLE
Minimal implementation of GpuMatND

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -389,6 +389,13 @@ public:
     */
     GpuMatND(SizeArray size, int type, void* data, StepArray step = StepArray());
 
+    /** @brief Allocates GPU memory.
+    Suppose there is some GPU memory already allocated. In that case, this method may choose to reuse that
+    GPU memory under the specific condition: it must be of the same size and type, not externally allocated,
+    the GPU memory is continuous(i.e., isContinuous() is true), and is not a sub-matrix of another GpuMatND
+    (i.e., isSubmatrix() is false). In other words, this method guarantees that the GPU memory allocated by
+    this method is always continuous and is not a sub-region of another GpuMatND.
+    */
     void create(SizeArray size, int type);
 
     void release();

--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -362,33 +362,34 @@ public:
     using StepArray = std::vector<size_t>;
     using IndexArray = std::vector<int>;
 
-    ~GpuMatND() = default;
+    //! destructor
+    ~GpuMatND();
 
     //! default constructor
     GpuMatND();
 
     /** @overload
-    @param _size Array of integers specifying an n-dimensional array shape.
-    @param _type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
+    @param size Array of integers specifying an n-dimensional array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
     CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
     */
-    GpuMatND(SizeArray _size, int _type);
+    GpuMatND(SizeArray size, int type);
 
     /** @overload
-    @param _size Array of integers specifying an n-dimensional array shape.
-    @param _type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
+    @param size Array of integers specifying an n-dimensional array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
     CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
-    @param _data Pointer to the user data. Matrix constructors that take data and step parameters do not
+    @param data Pointer to the user data. Matrix constructors that take data and step parameters do not
     allocate matrix data. Instead, they just initialize the matrix header that points to the specified
     data, which means that no data is copied. This operation is very efficient and can be used to
     process external data using OpenCV functions. The external data is not automatically deallocated, so
     you should take care of it.
-    @param _step Array of _size.size()-1 steps in case of a multi-dimensional array (the last step is always
+    @param step Array of _size.size()-1 steps in case of a multi-dimensional array (the last step is always
     set to the element size). If not specified, the matrix is assumed to be continuous.
     */
-    GpuMatND(SizeArray _size, int _type, void* _data, StepArray _step = StepArray());
+    GpuMatND(SizeArray size, int type, void* data, StepArray step = StepArray());
 
-    void create(SizeArray _size, int _type);
+    void create(SizeArray size, int type);
 
     void release();
 
@@ -402,6 +403,7 @@ public:
     GpuMatND clone() const;
 
     /** @overload
+    This overload is non-blocking, so it may return even if the copy operation is not finished.
     */
     GpuMatND clone(Stream& stream) const;
 
@@ -484,7 +486,7 @@ public:
 
 private:
     //! internal use
-    void setFields(SizeArray _size, int _type, StepArray _step = StepArray());
+    void setFields(SizeArray size, int type, StepArray step = StepArray());
 
 public:
     /*! includes several bit-fields:

--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -367,7 +367,6 @@ public:
     GpuMatND();
 
     /** @overload
-
     @param _size Array of integers specifying an n-dimensional array shape.
     @param _type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
     CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
@@ -375,7 +374,6 @@ public:
     GpuMatND(SizeArray _size, int _type);
 
     /** @overload
-
     @param _size Array of integers specifying an n-dimensional array shape.
     @param _type Array type. Use CV_8UC1, ..., CV_16FC4 to create 1-4 channel matrices, or
     CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
@@ -396,26 +394,49 @@ public:
     void swap(GpuMatND& m) noexcept;
 
     /** @brief Creates a full copy of the array and the underlying data.
-
     The method creates a full copy of the array. It mimics the behavior of Mat::clone(), i.e.
     the original step is not taken into account. So, the array copy is a continuous array
     occupying total()\*elemSize() bytes.
     */
     GpuMatND clone() const;
+
+    /** @overload
+    */
     GpuMatND clone(Stream& stream) const;
 
-    /** @brief Extracts a submatrix.
-
+    /** @brief Extracts a sub-matrix.
     The operator makes a new header for the specified sub-array of \*this.
     The operator is an O(1) operation, that is, no matrix data is copied.
     @param ranges Array of selected ranges along each dimension.
     */
     GpuMatND operator()(const std::vector<Range>& ranges) const;
 
-    //! creates a GpuMat header for a part of the bigger matrix
+    /** @brief Creates a GpuMat header for a 2D plane part of an n-dim matrix.
+    @note The returned GpuMat is constructed with the constructor for user-allocated data.
+    That is, It does not perform reference counting.
+    @note This function does not increment this GpuMatND's reference counter.
+    */
+    GpuMat createGpuMatHeader(IndexArray idx, Range rowRange, Range colRange) const;
+
+    /** @overload
+    Creates a GpuMat header if this GpuMatND is effectively 2D.
+    @note The returned GpuMat is constructed with the constructor for user-allocated data.
+    That is, It does not perform reference counting.
+    @note This function does not increment this GpuMatND's reference counter.
+    */
+    GpuMat createGpuMatHeader() const;
+
+    /** @brief Extracts a 2D plane part of an n-dim matrix.
+    It differs from createGpuMatHeader(IndexArray, Range, Range) in that it clones a part of this
+    GpuMatND to the returned GpuMat.
+    @note This operator does not increment this GpuMatND's reference counter;
+    */
     GpuMat operator()(IndexArray idx, Range rowRange, Range colRange) const;
 
-    //! creates a GpuMat header if this GpuMatND is effectively 2D
+    /** @brief Extracts a 2D plane part of an n-dim matrix if this GpuMatND is effectively 2D.
+    It differs from createGpuMatHeader() in that it clones a part of this GpuMatND.
+    @note This operator does not increment this GpuMatND's reference counter;
+    */
     operator GpuMat() const;
 
     GpuMatND(const GpuMatND&) = default;

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -384,6 +384,86 @@ void swap(GpuMat& a, GpuMat& b)
 }
 
 //===================================================================================
+// GpuMatND
+//===================================================================================
+
+inline
+GpuMatND::GpuMatND() :
+    flags(0), dims(0), data(nullptr)
+{
+}
+
+inline
+GpuMatND::GpuMatND(SizeArray _size, int _type) :
+    flags(0), dims(0), data(nullptr)
+{
+    create(std::move(_size), _type);
+}
+
+inline
+void GpuMatND::swap(GpuMatND& m) noexcept
+{
+    std::swap(*this, m);
+}
+
+inline
+bool GpuMatND::isContinuous() const
+{
+    return (flags & Mat::CONTINUOUS_FLAG) != 0;
+}
+
+inline
+bool GpuMatND::isSubmatrix() const
+{
+    return (flags & Mat::SUBMATRIX_FLAG) != 0;
+}
+
+inline
+size_t GpuMatND::elemSize() const
+{
+    return CV_ELEM_SIZE(flags);
+}
+
+inline
+size_t GpuMatND::elemSize1() const
+{
+    return CV_ELEM_SIZE1(flags);
+}
+
+inline
+bool GpuMatND::empty() const
+{
+    return data == nullptr;
+}
+
+inline
+bool GpuMatND::external() const
+{
+    return !empty() && data_.use_count() == 0;
+}
+
+inline
+size_t GpuMatND::total() const
+{
+    size_t p = 1;
+    for(auto s : size)
+        p *= s;
+    return p;
+}
+
+inline
+size_t GpuMatND::totalMemSize() const
+{
+    return size[0] * step[0];
+}
+
+inline
+int GpuMatND::type() const
+{
+    return CV_MAT_TYPE(flags);
+}
+
+//===================================================================================
 // HostMem
 //===================================================================================
 

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -389,13 +389,13 @@ void swap(GpuMat& a, GpuMat& b)
 
 inline
 GpuMatND::GpuMatND() :
-    flags(0), dims(0), data(nullptr)
+    flags(0), dims(0), data(nullptr), offset(0)
 {
 }
 
 inline
 GpuMatND::GpuMatND(SizeArray _size, int _type) :
-    flags(0), dims(0), data(nullptr)
+    flags(0), dims(0), data(nullptr), offset(0)
 {
     create(std::move(_size), _type);
 }
@@ -440,6 +440,12 @@ inline
 bool GpuMatND::external() const
 {
     return !empty() && data_.use_count() == 0;
+}
+
+inline
+uchar* GpuMatND::getDevicePtr() const
+{
+    return data + offset;
 }
 
 inline

--- a/modules/core/src/cuda/gpu_mat_nd.cu
+++ b/modules/core/src/cuda/gpu_mat_nd.cu
@@ -1,0 +1,280 @@
+#include "opencv2/opencv_modules.hpp"
+
+#ifndef HAVE_OPENCV_CUDEV
+
+#error "opencv_cudev is required"
+
+#else
+
+#include "opencv2/core/cuda.hpp"
+#include "opencv2/cudev.hpp"
+
+using namespace cv;
+using namespace cv::cuda;
+
+GpuMatND::DevicePtr::DevicePtr(const size_t _size)
+    : data(nullptr)
+{
+    CV_CUDEV_SAFE_CALL(cudaMalloc(&data, _size));
+}
+
+GpuMatND::DevicePtr::~DevicePtr()
+{
+    CV_CUDEV_SAFE_CALL(cudaFree(data));
+}
+
+/////////////////////////////////////////////////////
+/// create
+
+void GpuMatND::create(SizeArray _size, int _type)
+{
+    {
+        auto elements_nonzero = [](SizeArray& v)
+        {
+            return std::all_of(v.begin(), v.end(),
+                [](unsigned u){ return u > 0; });
+        };
+        CV_Assert(!_size.empty());
+        CV_Assert(elements_nonzero(_size));
+    }
+
+    if (size == _size && type() == _type && !external())
+        return;
+
+    release();
+
+    setFields(std::move(_size), _type);
+
+    data_ = std::make_shared<DevicePtr>(totalMemSize());
+    data = data_->data;
+}
+
+/////////////////////////////////////////////////////
+/// release
+
+void GpuMatND::release()
+{
+    data = nullptr;
+    data_.reset();
+
+    flags = dims = 0;
+    size.clear();
+    step.clear();
+}
+
+/////////////////////////////////////////////////////
+/// clone
+
+GpuMatND GpuMatND::clone() const
+{
+    GpuMatND ret(size, type());
+
+    if (isContinuous())
+    {
+        CV_CUDEV_SAFE_CALL(cudaMemcpy(ret.data, data, totalMemSize(), cudaMemcpyDeviceToDevice));
+    }
+    else
+    {
+        // 1D arrays are always continuous
+
+        if (dims == 2)
+        {
+            CV_CUDEV_SAFE_CALL(
+                cudaMemcpy2D(ret.data, ret.step[0], data, step[0],
+                    size[1]*step[1], size[0], cudaMemcpyDeviceToDevice)
+            );
+        }
+        else
+        {
+            std::vector<int> idx(dims-2, 0);
+
+            bool end = false;
+
+            uchar* d = ret.data;
+            uchar* s = data;
+
+            // iterate each 2D plane
+            do
+            {
+                CV_CUDEV_SAFE_CALL(
+                    cudaMemcpy2D(
+                        d, ret.step[dims-2], s, step[dims-2],
+                        size[dims-1]*step[dims-1], size[dims-2], cudaMemcpyDeviceToDevice)
+                );
+
+                int inc = dims-3;
+                while (true)
+                {
+                    if (idx[inc] == size[inc] - 1)
+                    {
+                        if (inc == 0)
+                        {
+                            end = true;
+                            break;
+                        }
+
+                        idx[inc] = 0;
+                        d -= (ret.size[inc] - 1) * ret.step[inc];
+                        s -= (size[inc] - 1) * step[inc];
+                        inc--;
+                    }
+                    else
+                    {
+                        idx[inc]++;
+                        d += ret.step[inc];
+                        s += step[inc];
+                        break;
+                    }
+                }
+            }
+            while (!end);
+        }
+    }
+
+    return ret;
+}
+
+GpuMatND GpuMatND::clone(Stream& stream) const
+{
+    GpuMatND ret(size, type());
+
+    cudaStream_t _stream = StreamAccessor::getStream(stream);
+
+    if (isContinuous())
+    {
+        CV_CUDEV_SAFE_CALL(cudaMemcpyAsync(ret.data, data, totalMemSize(), cudaMemcpyDeviceToDevice, _stream));
+    }
+    else
+    {
+        // 1D arrays are always continuous
+
+        if (dims == 2)
+        {
+            CV_CUDEV_SAFE_CALL(
+                cudaMemcpy2DAsync(ret.data, ret.step[0], data, step[0],
+                    size[1]*step[1], size[0], cudaMemcpyDeviceToDevice, _stream)
+            );
+        }
+        else
+        {
+            std::vector<int> idx(dims-2, 0);
+
+            bool end = false;
+
+            uchar* d = ret.data;
+            uchar* s = data;
+
+            // iterate each 2D plane
+            do
+            {
+                CV_CUDEV_SAFE_CALL(
+                    cudaMemcpy2DAsync(
+                        d, ret.step[dims-2], s, step[dims-2],
+                        size[dims-1]*step[dims-1], size[dims-2], cudaMemcpyDeviceToDevice, _stream)
+                );
+
+                int inc = dims-3;
+                while (true)
+                {
+                    if (idx[inc] == size[inc] - 1)
+                    {
+                        if (inc == 0)
+                        {
+                            end = true;
+                            break;
+                        }
+
+                        idx[inc] = 0;
+                        d -= (ret.size[inc] - 1) * ret.step[inc];
+                        s -= (size[inc] - 1) * step[inc];
+                        inc--;
+                    }
+                    else
+                    {
+                        idx[inc]++;
+                        d += ret.step[inc];
+                        s += step[inc];
+                        break;
+                    }
+                }
+            }
+            while (!end);
+        }
+    }
+
+    return ret;
+}
+
+/////////////////////////////////////////////////////
+/// upload
+
+void GpuMatND::upload(InputArray src)
+{
+    Mat mat = src.getMat();
+
+    CV_DbgAssert(!mat.empty());
+
+    if (!mat.isContinuous())
+        mat = mat.clone();
+
+    SizeArray _size(mat.dims);
+    std::copy_n(mat.size.p, mat.dims, _size.data());
+
+    create(std::move(_size), mat.type());
+
+    CV_CUDEV_SAFE_CALL(cudaMemcpy(data, mat.data, totalMemSize(), cudaMemcpyHostToDevice));
+}
+
+void GpuMatND::upload(InputArray src, Stream& stream)
+{
+    Mat mat = src.getMat();
+
+    CV_DbgAssert(!mat.empty());
+
+    if (!mat.isContinuous())
+        mat = mat.clone();
+
+    SizeArray _size(mat.dims);
+    std::copy_n(mat.size.p, mat.dims, _size.data());
+
+    create(std::move(_size), mat.type());
+
+    cudaStream_t _stream = StreamAccessor::getStream(stream);
+    CV_CUDEV_SAFE_CALL(cudaMemcpyAsync(data, mat.data, totalMemSize(), cudaMemcpyHostToDevice, _stream));
+}
+
+/////////////////////////////////////////////////////
+/// download
+
+void GpuMatND::download(OutputArray dst) const
+{
+    CV_DbgAssert(!empty());
+
+    dst.create(dims, size.data(), type());
+    Mat mat = dst.getMat();
+
+    GpuMatND gmat = *this;
+
+    if (!gmat.isContinuous())
+        gmat = gmat.clone();
+
+    CV_CUDEV_SAFE_CALL(cudaMemcpy(mat.data, gmat.data, gmat.totalMemSize(), cudaMemcpyDeviceToHost));
+}
+
+void GpuMatND::download(OutputArray dst, Stream& stream) const
+{
+    CV_DbgAssert(!empty());
+
+    dst.create(dims, size.data(), type());
+    Mat mat = dst.getMat();
+
+    GpuMatND gmat = *this;
+
+    if (!gmat.isContinuous())
+        gmat = gmat.clone(stream);
+
+    cudaStream_t _stream = StreamAccessor::getStream(stream);
+    CV_CUDEV_SAFE_CALL(cudaMemcpyAsync(mat.data, gmat.data, gmat.totalMemSize(), cudaMemcpyDeviceToHost, _stream));
+}
+
+#endif

--- a/modules/core/src/cuda_gpu_mat_nd.cpp
+++ b/modules/core/src/cuda_gpu_mat_nd.cpp
@@ -7,6 +7,8 @@
 using namespace cv;
 using namespace cv::cuda;
 
+GpuMatND::~GpuMatND() = default;
+
 GpuMatND::GpuMatND(SizeArray _size, int _type, void* _data, StepArray _step) :
     flags(0), dims(0), data(static_cast<uchar*>(_data)), offset(0)
 {

--- a/modules/core/src/cuda_gpu_mat_nd.cpp
+++ b/modules/core/src/cuda_gpu_mat_nd.cpp
@@ -39,8 +39,7 @@ GpuMatND GpuMatND::operator()(const std::vector<Range>& ranges) const
     return ret;
 }
 
-
-GpuMat GpuMatND::operator()(IndexArray idx, Range rowRange, Range colRange) const
+GpuMat GpuMatND::createGpuMatHeader(IndexArray idx, Range rowRange, Range colRange) const
 {
     CV_Assert((int)idx.size() == dims - 2);
 
@@ -50,10 +49,10 @@ GpuMat GpuMatND::operator()(IndexArray idx, Range rowRange, Range colRange) cons
     ranges.push_back(rowRange);
     ranges.push_back(colRange);
 
-    return (*this)(ranges);
+    return (*this)(ranges).createGpuMatHeader();
 }
 
-GpuMatND::operator GpuMat() const
+GpuMat GpuMatND::createGpuMatHeader() const
 {
     auto Effectively2D = [](GpuMatND m)
     {
@@ -65,6 +64,16 @@ GpuMatND::operator GpuMat() const
     CV_Assert(Effectively2D(*this));
 
     return GpuMat(size[dims-2], size[dims-1], type(), data, step[dims-2]);
+}
+
+GpuMat GpuMatND::operator()(IndexArray idx, Range rowRange, Range colRange) const
+{
+    return createGpuMatHeader(idx, rowRange, colRange).clone();
+}
+
+GpuMatND::operator GpuMat() const
+{
+    return createGpuMatHeader().clone();
 }
 
 void GpuMatND::setFields(SizeArray _size, int _type, StepArray _step)

--- a/modules/core/src/cuda_gpu_mat_nd.cpp
+++ b/modules/core/src/cuda_gpu_mat_nd.cpp
@@ -1,0 +1,134 @@
+#include "precomp.hpp"
+
+using namespace cv;
+using namespace cv::cuda;
+
+GpuMatND::GpuMatND(SizeArray _size, int _type, void* _data, StepArray _step) :
+    flags(0), dims(0), data(static_cast<uchar*>(_data))
+{
+    CV_Assert(_step.empty() || _size.size() == _step.size() + 1);
+
+    setFields(std::move(_size), _type, std::move(_step));
+}
+
+GpuMatND GpuMatND::operator()(const std::vector<Range>& ranges) const
+{
+    CV_Assert(dims == (int)ranges.size());
+
+    for (int i = 0; i < dims; ++i)
+    {
+        Range r = ranges[i];
+        CV_Assert(r == Range::all() || (0 <= r.start && r.start < r.end && r.end <= size[i]));
+    }
+
+    GpuMatND ret = *this;
+
+    for (int i = 0; i < dims; ++i)
+    {
+        Range r = ranges[i];
+        if (r != Range::all() && r != Range(0, ret.size[i]))
+        {
+            ret.data += r.start * ret.step[i];
+            ret.size[i] = r.size();
+            ret.flags |= Mat::SUBMATRIX_FLAG;
+        }
+    }
+
+    ret.flags = cv::updateContinuityFlag(ret.flags, dims, ret.size.data(), ret.step.data());
+
+    return ret;
+}
+
+
+GpuMat GpuMatND::operator()(IndexArray idx, Range rowRange, Range colRange) const
+{
+    CV_Assert((int)idx.size() == dims - 2);
+
+    std::vector<Range> ranges;
+    for (int i : idx)
+        ranges.emplace_back(i, i+1);
+    ranges.push_back(rowRange);
+    ranges.push_back(colRange);
+
+    return (*this)(ranges);
+}
+
+GpuMatND::operator GpuMat() const
+{
+    auto Effectively2D = [](GpuMatND m)
+    {
+        for (int i = 0; i < m.dims - 2; ++i)
+            if (m.size[i] > 1)
+                return false;
+        return true;
+    };
+    CV_Assert(Effectively2D(*this));
+
+    return GpuMat(size[dims-2], size[dims-1], type(), data, step[dims-2]);
+}
+
+void GpuMatND::setFields(SizeArray _size, int _type, StepArray _step)
+{
+    _type &= Mat::TYPE_MASK;
+
+    flags = Mat::MAGIC_VAL + _type;
+    dims = static_cast<int>(_size.size());
+    size = std::move(_size);
+
+    if (_step.empty())
+    {
+        step = StepArray(dims);
+
+        step.back() = elemSize();
+        for (int _i = dims - 2; _i >= 0; --_i)
+        {
+            const size_t i = _i;
+            step[i] = step[i+1] * size[i+1];
+        }
+
+        flags |= Mat::CONTINUOUS_FLAG;
+    }
+    else
+    {
+        step = std::move(_step);
+        step.push_back(elemSize());
+
+        flags = cv::updateContinuityFlag(flags, dims, size.data(), step.data());
+    }
+
+    CV_Assert(size.size() == step.size());
+    CV_Assert(step.back() == elemSize());
+}
+
+#ifndef HAVE_CUDA
+
+void GpuMatND::create(SizeArray _size, int _type)
+{
+    CV_UNUSED(_size);
+    CV_UNUSED(_type);
+    throw_no_cuda();
+}
+
+void GpuMatND::release()
+{
+    throw_no_cuda();
+}
+
+GpuMatND GpuMatND::clone() const
+{
+    throw_no_cuda();
+}
+
+void GpuMatND::upload(InputArray src)
+{
+    CV_UNUSED(src);
+    throw_no_cuda();
+}
+
+void GpuMatND::download(OutputArray dst) const
+{
+    CV_UNUSED(dst);
+    throw_no_cuda();
+}
+
+#endif


### PR DESCRIPTION
For the first step to resolving #15897 and #16433, this PR tries to implement a minimal set of functions and entities that a `GpuMatND` class should have.

This PR includes:
* Constructor with internally managed memory with reference counting
* Constructor with external memory
* Default destructor, default copy, and move operations
* `clone()` for deep copying, with the resulting array being always continuous
* N-dim submatrix extraction (shallow copy)
* Uploading from and downloading to `Mat`
* Converting operator to `GpuMat`

<cut/>

Tests are in https://github.com/opencv/opencv_contrib/pull/2805
The following leak check was performed with the test.
```
cuda-memcheck --leak-check full opencv_test_cudev.exe --gtest_filter=*GpuMatND*
```

I hope this PR could be accepted as a minimal implementation.

Further things that should be added include:
* Add `GpuMatND` to the list of classes handled by the proxy classes(`InputArray` and `OutputArray`)
* Add asynchronous APIs with `cuda::Stream`
* Add `copyTo`, `convertTo`, `setTo`, as in `GpuMat`

I'm guessing that these can be made as a separate PR.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```