### PR TITLE
[ts][summary.py] Extend `-o` to support tabs separated output.

### DIFF
--- a/modules/ts/misc/summary.py
+++ b/modules/ts/misc/summary.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         exit(0)
 
     parser = OptionParser()
-    parser.add_option("-o", "--output", dest="format", help="output results in text format (can be 'txt', 'html', 'markdown' or 'auto' - default)", metavar="FMT", default="auto")
+    parser.add_option("-o", "--output", dest="format", help="output results in text format (can be 'txt', 'html', 'markdown', 'tabs' or 'auto' - default)", metavar="FMT", default="auto")
     parser.add_option("-m", "--metric", dest="metric", help="output metric", metavar="NAME", default="gmean")
     parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), us, ns or ticks)", metavar="UNITS", default="ms")
     parser.add_option("-f", "--filter", dest="filter", help="regex to filter tests", metavar="REGEX", default=None)

--- a/modules/ts/misc/table_formatter.py
+++ b/modules/ts/misc/table_formatter.py
@@ -301,10 +301,8 @@ class table(object):
                 out.write(text + "|")
             out.write(os.linesep)
         elif self.is_tabs:
-            out.write("\t")
-            for c in row.cells:
-                text = ' '.join(self.getValue('text', c) or [])
-                out.write(text + "\t")
+            cols_to_join=[' '.join(self.getValue('text', c) or []) for c in row.cells]
+            out.write('\t'.join(cols_to_join))
             out.write(os.linesep)
         else:
             for ln in range(row.minheight):
@@ -322,8 +320,6 @@ class table(object):
                         i += self.getValue("colspan", cell)
                     if self.is_markdown:
                         out.write("|")
-                    elif self.is_tabs:
-                        out.write("\t")
                 out.write(os.linesep)
 
         if self.is_markdown and row.props.get('header', False):

--- a/modules/ts/misc/table_formatter.py
+++ b/modules/ts/misc/table_formatter.py
@@ -38,6 +38,7 @@ class table(object):
     def __init__(self, caption = None, format=None):
         self.format = format
         self.is_markdown = self.format == 'markdown'
+        self.is_tabs = self.format == 'tabs'
         self.columns = {}
         self.rows = []
         self.ridx = -1;
@@ -253,7 +254,7 @@ class table(object):
 
     def consolePrintTable(self, out):
         columns = self.layoutTable()
-        colrizer = getColorizer(out) if not self.is_markdown else dummyColorizer(out)
+        colrizer = getColorizer(out) if not (self.is_markdown or self.is_tabs) else dummyColorizer(out)
 
         if self.caption:
             out.write("%s%s%s" % ( os.linesep,  os.linesep.join(self.reformatTextValue(self.caption)), os.linesep * 2))
@@ -299,6 +300,12 @@ class table(object):
                 text = ' '.join(self.getValue('text', c) or [])
                 out.write(text + "|")
             out.write(os.linesep)
+        elif self.is_tabs:
+            out.write("\t")
+            for c in row.cells:
+                text = ' '.join(self.getValue('text', c) or [])
+                out.write(text + "\t")
+            out.write(os.linesep)
         else:
             for ln in range(row.minheight):
                 i = 0
@@ -315,6 +322,8 @@ class table(object):
                         i += self.getValue("colspan", cell)
                     if self.is_markdown:
                         out.write("|")
+                    elif self.is_tabs:
+                        out.write("\t")
                 out.write(os.linesep)
 
         if self.is_markdown and row.props.get('header', False):


### PR DESCRIPTION
This PR is related to issue #19267 .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
