### PR TITLE
fix cmake includes for ipp static standalone libraries

### DIFF
--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -142,12 +142,12 @@ macro(ipp_detect_version)
         # When using dynamic libraries from standalone Intel IPP it is your responsibility to install those on the target system
         list(APPEND IPP_LIBRARIES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX})
       else ()
-        add_library(ipp${name} STATIC IMPORTED)
-        set_target_properties(ipp${name} PROPERTIES
+        add_library(ipp${name}${IPP_SUFFIX} STATIC IMPORTED)
+        set_target_properties(ipp${name}${IPP_SUFFIX} PROPERTIES
           IMPORTED_LINK_INTERFACE_LIBRARIES ""
           IMPORTED_LOCATION ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
         )
-        list(APPEND IPP_LIBRARIES ipp${name})
+        list(APPEND IPP_LIBRARIES ipp${name}${IPP_SUFFIX})
         if (NOT BUILD_SHARED_LIBS AND (HAVE_IPP_ICV OR ";${OPENCV_INSTALL_EXTERNAL_DEPENDENCIES};" MATCHES ";ipp;"))
           # CMake doesn't support "install(TARGETS ${IPP_PREFIX}${name} " command with imported targets
           install(FILES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}


### PR DESCRIPTION
fixes opencv/opencv#19282 with details in that issue.

TLDR: fixes opencv static libraries with windows IPP standalone static library list in `OpenCVModules.cmake` 

This has been tested locally on the current `4.5` branch (specifically 4.5.1). I have not tested it on the legacy `3` branch.
I diff'd the `OpenCVModules.cmake` file changed in this PR and it is the same in both `4.5.1` and `3` branches.
Therefore, it should apply cleanly to the legacy branch.
Caution: I have no knowledge about the viability of this change on legacy `3` opencv, its static support, its IPP support, etc. I do not have the os, compilers, harness, etc for that legacy setup.

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] The feature is well documented and sample code can be built with the project CMake
