### PR TITLE
add cuda::Stream constructor with cuda stream flags

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -656,6 +656,18 @@ public:
     //! creates a new asynchronous stream with custom allocator
     CV_WRAP Stream(const Ptr<GpuMat::Allocator>& allocator);
 
+    /** @brief creates a new Stream using the cudaFlags argument to determine the behaviors of the stream
+
+    @note The cudaFlags parameter is passed to the underlying api cudaStreamCreateWithFlags() and
+    supports the same parameter values.
+    @code
+        // creates an OpenCV cuda::Stream that manages an asynchronous, non-blocking,
+        // non-default CUDA stream
+        cv::cuda::Stream cvStream(cudaStreamNonBlocking);
+    @endcode
+     */
+    CV_WRAP Stream(const size_t cudaFlags);
+
     /** @brief Returns true if the current stream queue is finished. Otherwise, it returns false.
     */
     CV_WRAP bool queryIfComplete() const;

--- a/modules/core/test/test_cuda.cpp
+++ b/modules/core/test/test_cuda.cpp
@@ -1,0 +1,21 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#if defined(HAVE_CUDA)
+
+#include "test_precomp.hpp"
+#include <cuda_runtime.h>
+#include "opencv2/core/cuda.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(CUDA_Stream, construct_cudaFlags)
+{
+    cv::cuda::Stream stream(cudaStreamNonBlocking);
+    EXPECT_NE(stream.cudaPtr(), nullptr);
+}
+
+}} // namespace
+
+#endif

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -33,6 +33,8 @@ class cuda_test(NewOpenCVTests):
         self.assertTrue(cuMat.cudaPtr() != 0)
         stream = cv.cuda_Stream()
         self.assertTrue(stream.cudaPtr() != 0)
+        asyncstream = cv.cuda_Stream(1)  # cudaStreamNonBlocking
+        self.assertTrue(asyncstream.cudaPtr() != 0)
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
adds feature described in issue opencv/opencv#19285
includes code, test, and doc.

TLDR: adds a constructor for cuda::Stream which accepts a raw cudaStream_t and assumes ownership of it including destroying the raw CUDA stream in the Stream's destructor.

<cut/>

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```