### PR TITLE
[G-API] Adding GMat operators to the standalone mode

### DIFF
--- a/modules/gapi/cmake/standalone.cmake
+++ b/modules/gapi/cmake/standalone.cmake
@@ -15,6 +15,8 @@ file(GLOB FLUID_includes "${FLUID_ROOT}/include/opencv2/*.hpp"
                          "${FLUID_ROOT}/include/opencv2/gapi/own/*.hpp"
                          "${FLUID_ROOT}/include/opencv2/gapi/fluid/*.hpp")
 file(GLOB FLUID_sources  "${FLUID_ROOT}/src/api/g*.cpp"
+                         "${FLUID_ROOT}/src/api/kernels_core.cpp"
+                         "${FLUID_ROOT}/src/api/operators.cpp"
                          "${FLUID_ROOT}/src/api/rmat.cpp"
                          "${FLUID_ROOT}/src/api/media.cpp"
                          "${FLUID_ROOT}/src/compiler/*.cpp"

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -12,8 +12,6 @@
 
 #include <utility> // std::tuple
 
-#include <opencv2/imgproc.hpp>
-
 #include <opencv2/gapi/gmat.hpp>
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/gkernel.hpp>
@@ -505,6 +503,8 @@ namespace core {
         }
     };
 
+
+#if !defined(GAPI_STANDALONE)
     G_TYPED_KERNEL(
         GKMeansND,
         <std::tuple<GOpaque<double>,GMat,GMat>(GMat,int,GMat,TermCriteria,int,KmeansFlags)>,
@@ -575,6 +575,8 @@ namespace core {
             return std::make_tuple(empty_gopaque_desc(), empty_array_desc(), empty_array_desc());
         }
     };
+
+#endif //!defined(GAPI_STANDALONE)
 } // namespace core
 
 namespace streaming {
@@ -1392,6 +1394,7 @@ CV_64F.
  */
 GAPI_EXPORTS std::tuple<GMat, GMat> integral(const GMat& src, int sdepth = -1, int sqdepth = -1);
 
+#if !defined(GAPI_STANDALONE)
 /** @brief Applies a fixed-level threshold to each matrix element.
 
 The function applies fixed-level thresholding to a single- or multiple-channel matrix.
@@ -1441,6 +1444,8 @@ Input and output matrices must be CV_8UC1.
 
 @sa threshold
  */
+#endif //!defined(GAPI_STANDALONE)
+
 GAPI_EXPORTS GMat inRange(const GMat& src, const GScalar& threshLow, const GScalar& threshUp);
 
 //! @} gapi_matrixop
@@ -1848,6 +1853,7 @@ GAPI_EXPORTS GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, i
                              int borderMode = cv::BORDER_CONSTANT, const Scalar& borderValue = Scalar());
 //! @} gapi_transform
 
+#if !defined(GAPI_STANDALONE)
 /** @brief Finds centers of clusters and groups input samples around the clusters.
 
 The function kmeans implements a k-means algorithm that finds the centers of K clusters
@@ -1941,6 +1947,7 @@ Gets dimensions from rectangle.
 */
 GAPI_EXPORTS GOpaque<Size> size(const GOpaque<Rect>& r);
 } //namespace streaming
+#endif //!defined(GAPI_STANDALONE)
 } //namespace gapi
 } //namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -209,6 +209,8 @@ namespace cv { namespace gapi { namespace own {
          */
         int depth() const           {return CV_MAT_DEPTH(flags);}
 
+        Size size() const { return Size{rows, cols};}
+
         /** @brief Returns the number of matrix channels.
 
         The method returns the number of matrix channels.

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -264,6 +264,7 @@ std::tuple<GMat, GMat> integral(const GMat& src, int sdepth, int sqdepth)
     return core::GIntegral::on(src, sdepth, sqdepth);
 }
 
+#if !defined(GAPI_STANDALONE)
 GMat threshold(const GMat& src, const GScalar& thresh, const GScalar& maxval, int type)
 {
     GAPI_Assert(type != cv::THRESH_TRIANGLE && type != cv::THRESH_OTSU);
@@ -275,6 +276,7 @@ std::tuple<GMat, GScalar> threshold(const GMat& src, const GScalar& maxval, int 
     GAPI_Assert(type == cv::THRESH_TRIANGLE || type == cv::THRESH_OTSU);
     return core::GThresholdOT::on(src, maxval, type);
 }
+#endif //!defined(GAPI_STANDALONE)
 
 GMat inRange(const GMat& src, const GScalar& threshLow, const GScalar& threshUp)
 {
@@ -383,6 +385,7 @@ GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, int flags,
     return core::GWarpAffine::on(src, M, dsize, flags, borderMode, borderValue);
 }
 
+#if !defined(GAPI_STANDALONE)
 std::tuple<GOpaque<double>,GMat,GMat> kmeans(const GMat& data, const int K, const GMat& bestLabels,
                                              const TermCriteria& criteria, const int attempts,
                                              const KmeansFlags flags)
@@ -426,6 +429,7 @@ GOpaque<Size> streaming::size(const GOpaque<Rect>& r)
 {
     return streaming::GSizeR::on(r);
 }
+#endif //!defined(GAPI_STANDALONE)
 
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/api/operators.cpp
+++ b/modules/gapi/src/api/operators.cpp
@@ -7,7 +7,6 @@
 
 #include "precomp.hpp"
 
-#include <opencv2/gapi/imgproc.hpp>
 #include <opencv2/gapi/core.hpp>
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/operators.hpp>


### PR DESCRIPTION
Current stand-alone mode miss `GMat` operators (e.g. like `/` or `+`). 

This patch address this shortcoming.  

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```