### PR TITLE
videoio: fix API/ABI_VERSION macros before plugin_api.hpp

### DIFF
--- a/modules/videoio/src/cap_mfx_plugin.cpp
+++ b/modules/videoio/src/cap_mfx_plugin.cpp
@@ -7,6 +7,9 @@
 #include <string>
 #include "cap_mfx_reader.hpp"
 #include "cap_mfx_writer.hpp"
+
+#define ABI_VERSION 0
+#define API_VERSION 0
 #include "plugin_api.hpp"
 
 using namespace std;

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -16,8 +16,6 @@
 #include "cap_mfx_writer.hpp"
 #endif
 
-#include "plugin_api.hpp"
-
 // All WinRT versions older than 8.0 should provide classes used for video support
 #if defined(WINRT) && !defined(WINRT_8_0) && defined(__cplusplus_winrt)
 #   include "cap_winrt_capture.hpp"


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/pull/19027#issuecomment-760060435