### PR TITLE
gapi: avoid global static initializers

### DIFF
--- a/modules/gapi/src/compiler/passes/kernels.cpp
+++ b/modules/gapi/src/compiler/passes/kernels.cpp
@@ -25,15 +25,18 @@
 #include "logger.hpp"    // GAPI_LOG
 #include "api/gproto_priv.hpp" // is_dynamic, rewrap
 
-namespace
+static
+const std::vector<std::string>& getKnownIntrinsics()
 {
     // FIXME: This may be not the right design choice, but so far it works
-    const std::vector<std::string> known_intrinsics = {
+    static const std::vector<std::string> known_intrinsics = {
         cv::gapi::streaming::detail::GDesync::id()
     };
+    return known_intrinsics;
 }
 bool cv::gimpl::is_intrinsic(const std::string &s) {
     // FIXME: This search might be better in time once we start using string
+    const std::vector<std::string>& known_intrinsics = getKnownIntrinsics();
     return std::find(known_intrinsics.begin(),
                      known_intrinsics.end(),
                      s) != known_intrinsics.end();


### PR DESCRIPTION
- use lazy on-demand initialization

continues #19326