### PR TITLE
 update xrange() to range(), as Python 2 has been deprecate

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_pyramids/py_pyramids.markdown
+++ b/doc/py_tutorials/py_imgproc/py_pyramids/py_pyramids.markdown
@@ -88,27 +88,27 @@ B = cv.imread('orange.jpg')
 # generate Gaussian pyramid for A
 G = A.copy()
 gpA = [G]
-for i in xrange(6):
+for i in range(6):
     G = cv.pyrDown(G)
     gpA.append(G)
 
 # generate Gaussian pyramid for B
 G = B.copy()
 gpB = [G]
-for i in xrange(6):
+for i in range(6):
     G = cv.pyrDown(G)
     gpB.append(G)
 
 # generate Laplacian Pyramid for A
 lpA = [gpA[5]]
-for i in xrange(5,0,-1):
+for i in range(5,0,-1):
     GE = cv.pyrUp(gpA[i])
     L = cv.subtract(gpA[i-1],GE)
     lpA.append(L)
 
 # generate Laplacian Pyramid for B
 lpB = [gpB[5]]
-for i in xrange(5,0,-1):
+for i in range(5,0,-1):
     GE = cv.pyrUp(gpB[i])
     L = cv.subtract(gpB[i-1],GE)
     lpB.append(L)
@@ -122,7 +122,7 @@ for la,lb in zip(lpA,lpB):
 
 # now reconstruct
 ls_ = LS[0]
-for i in xrange(1,6):
+for i in range(1,6):
     ls_ = cv.pyrUp(ls_)
     ls_ = cv.add(ls_, LS[i])
 

--- a/doc/py_tutorials/py_imgproc/py_thresholding/py_thresholding.markdown
+++ b/doc/py_tutorials/py_imgproc/py_thresholding/py_thresholding.markdown
@@ -47,7 +47,7 @@ ret,thresh5 = cv.threshold(img,127,255,cv.THRESH_TOZERO_INV)
 titles = ['Original Image','BINARY','BINARY_INV','TRUNC','TOZERO','TOZERO_INV']
 images = [img, thresh1, thresh2, thresh3, thresh4, thresh5]
 
-for i in xrange(6):
+for i in range(6):
     plt.subplot(2,3,i+1),plt.imshow(images[i],'gray',vmin=0,vmax=255)
     plt.title(titles[i])
     plt.xticks([]),plt.yticks([])
@@ -98,7 +98,7 @@ titles = ['Original Image', 'Global Thresholding (v = 127)',
             'Adaptive Mean Thresholding', 'Adaptive Gaussian Thresholding']
 images = [img, th1, th2, th3]
 
-for i in xrange(4):
+for i in range(4):
     plt.subplot(2,2,i+1),plt.imshow(images[i],'gray')
     plt.title(titles[i])
     plt.xticks([]),plt.yticks([])
@@ -153,7 +153,7 @@ titles = ['Original Noisy Image','Histogram','Global Thresholding (v=127)',
           'Original Noisy Image','Histogram',"Otsu's Thresholding",
           'Gaussian filtered Image','Histogram',"Otsu's Thresholding"]
 
-for i in xrange(3):
+for i in range(3):
     plt.subplot(3,3,i*3+1),plt.imshow(images[i*3],'gray')
     plt.title(titles[i*3]), plt.xticks([]), plt.yticks([])
     plt.subplot(3,3,i*3+2),plt.hist(images[i*3].ravel(),256)
@@ -196,7 +196,7 @@ bins = np.arange(256)
 fn_min = np.inf
 thresh = -1
 
-for i in xrange(1,256):
+for i in range(1,256):
     p1,p2 = np.hsplit(hist_norm,[i]) # probabilities
     q1,q2 = Q[i],Q[255]-Q[i] # cum sum of classes
     if q1 < 1.e-6 or q2 < 1.e-6:

--- a/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
+++ b/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
@@ -268,7 +268,7 @@ fft_filters = [np.fft.fft2(x) for x in filters]
 fft_shift = [np.fft.fftshift(y) for y in fft_filters]
 mag_spectrum = [np.log(np.abs(z)+1) for z in fft_shift]
 
-for i in xrange(6):
+for i in range(6):
     plt.subplot(2,3,i+1),plt.imshow(mag_spectrum[i],cmap = 'gray')
     plt.title(filter_name[i]), plt.xticks([]), plt.yticks([])
 

--- a/doc/py_tutorials/py_photo/py_non_local_means/py_non_local_means.markdown
+++ b/doc/py_tutorials/py_photo/py_non_local_means/py_non_local_means.markdown
@@ -108,7 +108,7 @@ from matplotlib import pyplot as plt
 cap = cv.VideoCapture('vtest.avi')
 
 # create a list of first 5 frames
-img = [cap.read()[1] for i in xrange(5)]
+img = [cap.read()[1] for i in range(5)]
 
 # convert all to grayscale
 gray = [cv.cvtColor(i, cv.COLOR_BGR2GRAY) for i in img]


### PR DESCRIPTION
update `xrange()` to `range()`, as Python 2 has been deprecate, more info:
1.  Python 2 has been no longer supported officially since January 1, 2020.  Check  https://www.python.org/doc/sunset-python-2
2.  xrange() was renamed to range() in Python 3. Check  https://stackoverflow.com/questions/17192158/nameerror-global-name-xrange-is-not-defined-in-python-3/17192181#17192181

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
