### PR TITLE
[G-API]: Performance tests for fitLine and findContours

### DIFF
--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -57,6 +57,30 @@ class BoundingRectVector32SPerfTest :
     public TestPerfParams<tuple<CompareRects, cv::Size, cv::GCompileArgs>> {};
 class BoundingRectVector32FPerfTest :
     public TestPerfParams<tuple<CompareRects, cv::Size, cv::GCompileArgs>> {};
+class FitLine2DMatVectorPerfTest : public TestPerfParams<tuple<CompareVecs<float, 4>,
+                                                               MatType,cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine2DVector32SPerfTest : public TestPerfParams<tuple<CompareVecs<float, 4>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine2DVector32FPerfTest : public TestPerfParams<tuple<CompareVecs<float, 4>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine2DVector64FPerfTest : public TestPerfParams<tuple<CompareVecs<float, 4>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine3DMatVectorPerfTest : public TestPerfParams<tuple<CompareVecs<float, 6>,
+                                                               MatType,cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine3DVector32SPerfTest : public TestPerfParams<tuple<CompareVecs<float, 6>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine3DVector32FPerfTest : public TestPerfParams<tuple<CompareVecs<float, 6>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
+class FitLine3DVector64FPerfTest : public TestPerfParams<tuple<CompareVecs<float, 6>,
+                                                               cv::Size,cv::DistanceTypes,
+                                                               cv::GCompileArgs>> {};
 class EqHistPerfTest      : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class BGR2RGBPerfTest     : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};
 class RGB2GrayPerfTest    : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs>> {};

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -43,6 +43,14 @@ class CannyPerfTest           : public TestPerfParams<tuple<compare_f, MatType,c
 class GoodFeaturesPerfTest    : public TestPerfParams<tuple<compare_vector_f<cv::Point2f>, std::string,
                                                             int,int,double,double,int,bool,
                                                             cv::GCompileArgs>> {};
+class FindContoursPerfTest    : public TestPerfParams<tuple<CompareMats, MatType,cv::Size,
+                                                            cv::RetrievalModes,
+                                                            cv::ContourApproximationModes,
+                                                            cv::GCompileArgs>> {};
+class FindContoursHPerfTest   : public TestPerfParams<tuple<CompareMats, MatType,cv::Size,
+                                                            cv::RetrievalModes,
+                                                            cv::ContourApproximationModes,
+                                                            cv::GCompileArgs>> {};
 class BoundingRectMatPerfTest       :
     public TestPerfParams<tuple<CompareRects, MatType,cv::Size,bool, cv::GCompileArgs>> {};
 class BoundingRectVector32SPerfTest :

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -839,17 +839,15 @@ PERF_TEST_P_(FindContoursHPerfTest, TestPerformance)
 
     std::vector<std::vector<cv::Point>> out_cnts_gapi;
     std::vector<cv::Vec4i>              out_hier_gapi;
-    cv::GComputation c(findContoursTestGAPI<WITH_HIERARCHY>(in, mode, method,
-                                                            std::move(compile_args),
-                                                            out_cnts_gapi, out_hier_gapi, offset));
+    cv::GComputation c(findContoursTestGAPI<HIERARCHY>(in, mode, method, std::move(compile_args),
+                                                       out_cnts_gapi, out_hier_gapi, offset));
 
     TEST_CYCLE()
     {
         c.apply(gin(in, offset), gout(out_cnts_gapi, out_hier_gapi));
     }
 
-    findContoursTestOpenCVCompare<WITH_HIERARCHY>(in, mode, method, out_cnts_gapi, out_hier_gapi,
-                                                  cmpF);
+    findContoursTestOpenCVCompare<HIERARCHY>(in, mode, method, out_cnts_gapi, out_hier_gapi, cmpF);
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -795,6 +795,63 @@ PERF_TEST_P_(GoodFeaturesPerfTest, TestPerformance)
 
 //------------------------------------------------------------------------------
 
+PERF_TEST_P_(FindContoursPerfTest, TestPerformance)
+{
+    CompareMats cmpF;
+    MatType type;
+    cv::Size sz;
+    cv::RetrievalModes mode;
+    cv::ContourApproximationModes method;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, sz, mode, method, compile_args) = GetParam();
+
+    cv::Mat in;
+    initMatForFindingContours(in, sz, type);
+    cv::Point offset = cv::Point();
+
+    std::vector<std::vector<cv::Point>> out_cnts_gapi;
+    cv::GComputation c(findContoursTestGAPI(in, mode, method, std::move(compile_args),
+                                            out_cnts_gapi, offset));
+
+    TEST_CYCLE()
+    {
+        c.apply(gin(in, offset), gout(out_cnts_gapi));
+    }
+
+    findContoursTestOpenCVCompare(in, mode, method, out_cnts_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FindContoursHPerfTest, TestPerformance)
+{
+    CompareMats cmpF;
+    MatType type;
+    cv::Size sz;
+    cv::RetrievalModes mode;
+    cv::ContourApproximationModes method;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, sz, mode, method, compile_args) = GetParam();
+
+    cv::Mat in;
+    initMatForFindingContours(in, sz, type);
+    cv::Point offset = cv::Point();
+
+    std::vector<std::vector<cv::Point>> out_cnts_gapi;
+    std::vector<cv::Vec4i>              out_hier_gapi;
+    cv::GComputation c(findContoursTestGAPI(in, mode, method, std::move(compile_args),
+                                            out_cnts_gapi, out_hier_gapi, offset));
+
+    TEST_CYCLE()
+    {
+        c.apply(gin(in, offset), gout(out_cnts_gapi, out_hier_gapi));
+    }
+
+    findContoursTestOpenCVCompare(in, mode, method, out_cnts_gapi, out_hier_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+//------------------------------------------------------------------------------
+
 PERF_TEST_P_(BoundingRectMatPerfTest, TestPerformance)
 {
     CompareRects cmpF;

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -808,17 +808,18 @@ PERF_TEST_P_(FindContoursPerfTest, TestPerformance)
     cv::Mat in;
     initMatForFindingContours(in, sz, type);
     cv::Point offset = cv::Point();
+    std::vector<cv::Vec4i> out_hier_gapi = std::vector<cv::Vec4i>();
 
     std::vector<std::vector<cv::Point>> out_cnts_gapi;
     cv::GComputation c(findContoursTestGAPI(in, mode, method, std::move(compile_args),
-                                            out_cnts_gapi, offset));
+                                            out_cnts_gapi, out_hier_gapi, offset));
 
     TEST_CYCLE()
     {
         c.apply(gin(in, offset), gout(out_cnts_gapi));
     }
 
-    findContoursTestOpenCVCompare(in, mode, method, out_cnts_gapi, cmpF);
+    findContoursTestOpenCVCompare(in, mode, method, out_cnts_gapi, out_hier_gapi, cmpF);
     SANITY_CHECK_NOTHING();
 }
 
@@ -838,15 +839,17 @@ PERF_TEST_P_(FindContoursHPerfTest, TestPerformance)
 
     std::vector<std::vector<cv::Point>> out_cnts_gapi;
     std::vector<cv::Vec4i>              out_hier_gapi;
-    cv::GComputation c(findContoursTestGAPI(in, mode, method, std::move(compile_args),
-                                            out_cnts_gapi, out_hier_gapi, offset));
+    cv::GComputation c(findContoursTestGAPI<WITH_HIERARCHY>(in, mode, method,
+                                                            std::move(compile_args),
+                                                            out_cnts_gapi, out_hier_gapi, offset));
 
     TEST_CYCLE()
     {
         c.apply(gin(in, offset), gout(out_cnts_gapi, out_hier_gapi));
     }
 
-    findContoursTestOpenCVCompare(in, mode, method, out_cnts_gapi, out_hier_gapi, cmpF);
+    findContoursTestOpenCVCompare<WITH_HIERARCHY>(in, mode, method, out_cnts_gapi, out_hier_gapi,
+                                                  cmpF);
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -928,6 +928,198 @@ PERF_TEST_P_(BoundingRectVector32FPerfTest, TestPerformance)
 
 //------------------------------------------------------------------------------
 
+PERF_TEST_P_(FitLine2DMatVectorPerfTest, TestPerformance)
+{
+    CompareVecs<float, 4> cmpF;
+    cv::Size sz;
+    MatType type;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, sz, distType, compile_args) = GetParam();
+
+    initMatByPointsVectorRandU<cv::Point_>(type, sz, -1);
+
+    cv::Vec4f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_mat1, distType, std::move(compile_args), out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_mat1, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine2DVector32SPerfTest, TestPerformance)
+{
+    CompareVecs<float, 4> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point2i> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec4f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine2DVector32FPerfTest, TestPerformance)
+{
+    CompareVecs<float, 4> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point2f> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec4f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine2DVector64FPerfTest, TestPerformance)
+{
+    CompareVecs<float, 4> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point2d> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec4f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine3DMatVectorPerfTest, TestPerformance)
+{
+    CompareVecs<float, 6> cmpF;
+    cv::Size sz;
+    MatType type;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, sz, distType, compile_args) = GetParam();
+
+    initMatByPointsVectorRandU<cv::Point3_>(type, sz, -1);
+
+    cv::Vec6f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_mat1, distType, std::move(compile_args), out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_mat1, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine3DVector32SPerfTest, TestPerformance)
+{
+    CompareVecs<float, 6> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point3i> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec6f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine3DVector32FPerfTest, TestPerformance)
+{
+    CompareVecs<float, 6> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point3f> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec6f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(FitLine3DVector64FPerfTest, TestPerformance)
+{
+    CompareVecs<float, 6> cmpF;
+    cv::Size sz;
+    cv::DistanceTypes distType;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, sz, distType, compile_args) = GetParam();
+
+    std::vector<cv::Point3d> in_vector;
+    initPointsVectorRandU(sz.width, in_vector);
+
+    cv::Vec6f out_vec_gapi;
+    cv::GComputation c(fitLineTestGAPI(in_vector, distType, std::move(compile_args),
+                                       out_vec_gapi));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_vector), cv::gout(out_vec_gapi));
+    }
+
+    fitLineTestOpenCVCompare(in_vector, distType, out_vec_gapi, cmpF);
+    SANITY_CHECK_NOTHING();
+}
+
+//------------------------------------------------------------------------------
+
 PERF_TEST_P_(EqHistPerfTest, TestPerformance)
 {
     compare_f cmpF = get<0>(GetParam());

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
@@ -254,6 +254,66 @@ INSTANTIATE_TEST_CASE_P(BoundingRectVector32FPerfTestCPU, BoundingRectVector32FP
                                 Values(szVGA, sz720p, sz1080p),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
+INSTANTIATE_TEST_CASE_P(FitLine2DMatVectorPerfTestCPU, FitLine2DMatVectorPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S,
+                                       CV_32S, CV_32F, CV_64F),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine2DVector32SPerfTestCPU, FitLine2DVector32SPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine2DVector32FPerfTestCPU, FitLine2DVector32FPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine2DVector64FPerfTestCPU, FitLine2DVector64FPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 4>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine3DMatVectorPerfTestCPU, FitLine3DMatVectorPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(CV_8U, CV_8S, CV_16U, CV_16S,
+                                       CV_32S, CV_32F, CV_64F),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine3DVector32SPerfTestCPU, FitLine3DVector32SPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine3DVector32FPerfTestCPU, FitLine3DVector32FPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FitLine3DVector64FPerfTestCPU, FitLine3DVector64FPerfTest,
+                        Combine(Values(RelDiffToleranceVec<float, 6>(0.01).to_compare_obj()),
+                                Values(cv::Size(8, 0), cv::Size(1024, 0)),
+                                Values(DIST_L1, DIST_L2, DIST_L12, DIST_FAIR,
+                                       DIST_WELSCH, DIST_HUBER),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
 INSTANTIATE_TEST_CASE_P(EqHistPerfTestCPU, EqHistPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
         Values(szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_cpu.cpp
@@ -194,6 +194,42 @@ INSTANTIATE_TEST_CASE_P(GoodFeaturesInternalPerfTestCPU, GoodFeaturesPerfTest,
             Values(true),
             Values(cv::compile_args(IMGPROC_CPU))));
 
+INSTANTIATE_TEST_CASE_P(FindContoursPerfTestCPU, FindContoursPerfTest,
+                        Combine(Values(AbsExact().to_compare_obj()),
+                                Values(CV_8UC1),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(RETR_EXTERNAL, RETR_LIST, RETR_CCOMP, RETR_TREE),
+                                Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FindContours32SPerfTestCPU, FindContoursPerfTest,
+                        Combine(Values(AbsExact().to_compare_obj()),
+                                Values(CV_32SC1),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(RETR_CCOMP, RETR_FLOODFILL),
+                                Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FindContoursHPerfTestCPU, FindContoursHPerfTest,
+                        Combine(Values(AbsExact().to_compare_obj()),
+                                Values(CV_8UC1),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(RETR_EXTERNAL, RETR_LIST, RETR_CCOMP, RETR_TREE),
+                                Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(FindContoursH32SPerfTestCPU, FindContoursHPerfTest,
+                        Combine(Values(AbsExact().to_compare_obj()),
+                                Values(CV_32SC1),
+                                Values(szVGA, sz720p, sz1080p),
+                                Values(RETR_CCOMP, RETR_FLOODFILL),
+                                Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
 INSTANTIATE_TEST_CASE_P(BoundingRectMatPerfTestCPU, BoundingRectMatPerfTest,
                         Combine(Values(IoUToleranceRect(0).to_compare_obj()),
                                 Values(CV_8UC1),

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -68,13 +68,13 @@ GAPI_TEST_FIXTURE_SPEC_PARAMS(GoodFeaturesTest,
                               blockSize, useHarrisDetector)
 GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursNoOffsetTest,
                               FIXTURE_API(cv::Size,MatType2,cv::RetrievalModes,
-                                          cv::ContourApproximationModes),
-                              4, sz, type, mode, method)
+                                          cv::ContourApproximationModes, CompareMats),
+                              5, sz, type, mode, method, cmpF)
 GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursOffsetTest, <>, 0)
 GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursHNoOffsetTest,
                               FIXTURE_API(cv::Size,MatType2,cv::RetrievalModes,
-                                          cv::ContourApproximationModes),
-                              4, sz, type, mode, method)
+                                          cv::ContourApproximationModes, CompareMats),
+                              5, sz, type, mode, method, cmpF)
 GAPI_TEST_FIXTURE_SPEC_PARAMS(FindContoursHOffsetTest, <>, 0)
 GAPI_TEST_FIXTURE(BoundingRectMatTest, initNothing, FIXTURE_API(CompareRects,bool),
                   2, cmpF, initByVector)

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -174,6 +174,57 @@ static void boundingRectTestBody(const In& in, const CompareRects& cmpF, cv::GCo
     boundingRectTestGAPI(in, std::move(args), out_rect_gapi);
     boundingRectTestOpenCVCompare(in, out_rect_gapi, cmpF);
 }
+
+//-------------------------------------------------------------------------------------------------
+
+template<typename In>
+static cv::GComputation fitLineTestGAPI(const In& in, const cv::DistanceTypes distType,
+                                        cv::GCompileArgs&& args, cv::Vec4f& out_vec_gapi)
+{
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    cv::detail::g_type_of_t<In> g_in;
+    auto out = cv::gapi::fitLine2D(g_in, distType, paramDefault, repsDefault, aepsDefault);
+    cv::GComputation c(cv::GIn(g_in), cv::GOut(out));
+    c.apply(cv::gin(in), cv::gout(out_vec_gapi), std::move(args));
+    return c;
+}
+
+template<typename In>
+static cv::GComputation fitLineTestGAPI(const In& in, const cv::DistanceTypes distType,
+                                        cv::GCompileArgs&& args, cv::Vec6f& out_vec_gapi)
+{
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    cv::detail::g_type_of_t<In> g_in;
+    auto out = cv::gapi::fitLine3D(g_in, distType, paramDefault, repsDefault, aepsDefault);
+    cv::GComputation c(cv::GIn(g_in), cv::GOut(out));
+    c.apply(cv::gin(in), cv::gout(out_vec_gapi), std::move(args));
+    return c;
+}
+
+template<typename In, int dim>
+static void fitLineTestOpenCVCompare(const In& in, const cv::DistanceTypes distType,
+                                     const cv::Vec<float, dim>& out_vec_gapi,
+                                     const CompareVecs<float, dim>& cmpF)
+{
+    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
+
+    // OpenCV code /////////////////////////////////////////////////////////////
+    cv::Vec<float, dim> out_vec_ocv;
+    cv::fitLine(in, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
+    // Comparison //////////////////////////////////////////////////////////////
+    EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
+}
+
+template<typename In, int dim>
+static void fitLineTestBody(const In& in, const cv::DistanceTypes distType,
+                            const CompareVecs<float, dim>& cmpF, cv::GCompileArgs&& args)
+{
+    cv::Vec<float, dim> out_vec_gapi;
+    fitLineTestGAPI(in, distType, std::move(args), out_vec_gapi);
+    fitLineTestOpenCVCompare(in, distType, out_vec_gapi, cmpF);
+}
 } // namespace opencv_test
 
 #endif // OPENCV_GAPI_VIDEO_TESTS_COMMON_HPP

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -491,7 +491,7 @@ TEST_P(FindContoursOffsetTest, AccuracyTest)
 
 TEST_P(FindContoursHNoOffsetTest, AccuracyTest)
 {
-    findContoursTestBody<WITH_HIERARCHY>(sz, type, mode, method, cmpF, getCompileArgs());
+    findContoursTestBody<HIERARCHY>(sz, type, mode, method, cmpF, getCompileArgs());
 }
 
 TEST_P(FindContoursHOffsetTest, AccuracyTest)
@@ -505,7 +505,7 @@ TEST_P(FindContoursHOffsetTest, AccuracyTest)
     std::vector<std::vector<cv::Point>> outCtsOCV,  outCtsGAPI;
     std::vector<cv::Vec4i>              outHierOCV, outHierGAPI;
 
-    findContoursTestBody<WITH_HIERARCHY>(sz, type, mode, method, cmpF, getCompileArgs(), offset);
+    findContoursTestBody<HIERARCHY>(sz, type, mode, method, cmpF, getCompileArgs(), offset);
 }
 
 TEST_P(BoundingRectMatTest, AccuracyTest)

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -540,188 +540,60 @@ TEST_P(BoundingRectVector32FTest, AccuracyTest)
 
 TEST_P(FitLine2DMatVectorTest, AccuracyTest)
 {
-    cv::Vec4f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_mat1, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_mat1, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DVector32STest, AccuracyTest)
 {
-    cv::Vec4f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point2i> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2i> in;
-    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DVector32FTest, AccuracyTest)
 {
-    cv::Vec4f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point2f> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2f> in;
-    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine2DVector64FTest, AccuracyTest)
 {
-    cv::Vec4f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point2d> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2d> in;
-    auto out = cv::gapi::fitLine2D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine3DMatVectorTest, AccuracyTest)
 {
-    cv::Vec6f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_mat1), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_mat1, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_mat1, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine3DVector32STest, AccuracyTest)
 {
-    cv::Vec6f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point3i> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point3i> in;
-    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine3DVector32FTest, AccuracyTest)
 {
-    cv::Vec6f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point3f> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point3f> in;
-    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(FitLine3DVector64FTest, AccuracyTest)
 {
-    cv::Vec6f out_vec_gapi, out_vec_ocv;
-    double paramDefault = 0., repsDefault = 0., aepsDefault = 0.;
-
     std::vector<cv::Point3d> in_vec;
     initPointsVectorRandU(sz.width, in_vec);
 
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point3d> in;
-    auto out = cv::gapi::fitLine3D(in, distType, paramDefault, repsDefault, aepsDefault);
-
-    cv::GComputation c(cv::GIn(in), cv::GOut(out));
-    c.apply(cv::gin(in_vec), cv::gout(out_vec_gapi), getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    {
-        cv::fitLine(in_vec, out_vec_ocv, distType, paramDefault, repsDefault, aepsDefault);
-    }
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(cmpF(out_vec_gapi, out_vec_ocv));
-    }
+    fitLineTestBody(in_vec, distType, cmpF, getCompileArgs());
 }
 
 TEST_P(BGR2RGBTest, AccuracyTest)

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -270,7 +270,8 @@ INSTANTIATE_TEST_CASE_P(FindContoursNoOffsetTestCPU, FindContoursNoOffsetTest,
                                 Values(cv::Size(1280, 720)),
                                 Values(CV_8UC1),
                                 Values(RETR_EXTERNAL),
-                                Values(CHAIN_APPROX_NONE)));
+                                Values(CHAIN_APPROX_NONE),
+                                Values(AbsExact().to_compare_obj())));
 
 INSTANTIATE_TEST_CASE_P(FindContoursOffsetTestCPU, FindContoursOffsetTest,
                         Values(IMGPROC_CPU));
@@ -282,7 +283,8 @@ INSTANTIATE_TEST_CASE_P(FindContoursHNoOffsetTestCPU, FindContoursHNoOffsetTest,
                                 Values(CV_8UC1),
                                 Values(RETR_EXTERNAL, RETR_LIST, RETR_CCOMP, RETR_TREE),
                                 Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
-                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS)));
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(AbsExact().to_compare_obj())));
 
 INSTANTIATE_TEST_CASE_P(FindContoursHNoOffset32STestCPU, FindContoursHNoOffsetTest,
                         Combine(Values(IMGPROC_CPU),
@@ -291,7 +293,8 @@ INSTANTIATE_TEST_CASE_P(FindContoursHNoOffset32STestCPU, FindContoursHNoOffsetTe
                                 Values(CV_32SC1),
                                 Values(RETR_CCOMP, RETR_FLOODFILL),
                                 Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE,
-                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS)));
+                                       CHAIN_APPROX_TC89_L1, CHAIN_APPROX_TC89_KCOS),
+                                Values(AbsExact().to_compare_obj())));
 
 INSTANTIATE_TEST_CASE_P(FindContoursHOffsetTestCPU, FindContoursHOffsetTest,
                         Values(IMGPROC_CPU));


### PR DESCRIPTION
 - Performance tests for `fitLine` and `findContours` operations added
 - new file created to share similar code between acc. and perf. tests
 - Accuracy test bodies refactored

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
xbuild_image:Custom Win=openvino-2021.1.0
xbuild_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```