### PR TITLE
stitching: workaround the ExposureCompensate.SimilarityThreshold failure

### DIFF
--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -154,7 +154,11 @@ void GainCompensator::singleFeed(const std::vector<Point> &corners, const std::v
                 {
                     CV_Assert(similarity_it != similarities_.end());
                     UMat similarity = *similarity_it++;
-                    bitwise_and(intersect, similarity, intersect);
+                    // in-place operation has an issue. don't remove the swap
+                    // detail https://github.com/opencv/opencv/issues/19184
+                    Mat_<uchar> intersect_updated;
+                    bitwise_and(intersect, similarity, intersect_updated);
+                    std::swap(intersect, intersect_updated);
                 }
 
                 int intersect_count = countNonZero(intersect);


### PR DESCRIPTION
Closes #19184 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### before
```
[ RUN      ] ExposureCompensate.SimilarityThreshold
/opencv/modules/stitching/test/test_exposure_compensate.cpp:69: Failure
Expected: (psnr_similarity_mask) > (300), actual: 38.0114 vs 300
[  FAILED  ] ExposureCompensate.SimilarityThreshold (56824 ms)
```
### after
```
[ RUN      ] ExposureCompensate.SimilarityThreshold
[       OK ] ExposureCompensate.SimilarityThreshold (115807 ms)
```