### PR TITLE
G-API: Removing ParseSSD overload.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/parsers.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/parsers.hpp
@@ -9,6 +9,7 @@
 #define OPENCV_GAPI_PARSERS_HPP
 
 #include <utility> // std::tuple
+
 #include <opencv2/gapi/gmat.hpp>
 #include <opencv2/gapi/gkernel.hpp>
 

--- a/modules/gapi/include/opencv2/gapi/infer/parsers.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/parsers.hpp
@@ -9,7 +9,6 @@
 #define OPENCV_GAPI_PARSERS_HPP
 
 #include <utility> // std::tuple
-
 #include <opencv2/gapi/gmat.hpp>
 #include <opencv2/gapi/gkernel.hpp>
 
@@ -69,7 +68,8 @@ GAPI_EXPORTS std::tuple<GArray<Rect>, GArray<int>> parseSSD(const GMat& in,
                                                             const float confidenceThreshold = 0.5f,
                                                             const int   filterLabel = -1);
 
-/** @overload
+/** @brief Parses output of SSD network.
+
 Extracts detection information (box, confidence) from SSD output and
 filters it by given confidence and by going out of bounds.
 
@@ -87,9 +87,9 @@ the larger side of the rectangle.
 */
 GAPI_EXPORTS_W GArray<Rect> parseSSD(const GMat& in,
                                      const GOpaque<Size>& inSz,
-                                     const float confidenceThreshold = 0.5f,
-                                     const bool alignmentToSquare = false,
-                                     const bool filterOutOfBounds = false);
+                                     const float confidenceThreshold,
+                                     const bool alignmentToSquare,
+                                     const bool filterOutOfBounds);
 
 /** @brief Parses output of Yolo network.
 

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -652,7 +652,12 @@ GAPI_OCV_KERNEL(GCPUParseSSDBL, cv::gapi::nn::parsers::GParseSSDBL)
                     std::vector<cv::Rect>& out_boxes,
                     std::vector<int>&      out_labels)
     {
-        cv::parseSSDBL(in_ssd_result, in_size, confidence_threshold, filter_label, out_boxes, out_labels);
+        cv::unitedParseSSD(in_ssd_result, in_size,
+                           confidence_threshold,
+                           filter_label,
+                           false,
+                           false,
+                           out_boxes, out_labels);
     }
 };
 
@@ -665,7 +670,13 @@ GAPI_OCV_KERNEL(GOCVParseSSD, cv::gapi::nn::parsers::GParseSSD)
                     const bool      filter_out_of_bounds,
                     std::vector<cv::Rect>& out_boxes)
     {
-        cv::parseSSD(in_ssd_result, in_size, confidence_threshold, alignment_to_square, filter_out_of_bounds, out_boxes);
+        std::vector<int> unused_labels;
+        cv::unitedParseSSD(in_ssd_result, in_size,
+                           confidence_threshold,
+                           -1,
+                           alignment_to_square,
+                           filter_out_of_bounds,
+                           out_boxes, unused_labels);
     }
 };
 

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -652,12 +652,12 @@ GAPI_OCV_KERNEL(GCPUParseSSDBL, cv::gapi::nn::parsers::GParseSSDBL)
                     std::vector<cv::Rect>& out_boxes,
                     std::vector<int>&      out_labels)
     {
-        cv::unitedParseSSD(in_ssd_result, in_size,
-                           confidence_threshold,
-                           filter_label,
-                           false,
-                           false,
-                           out_boxes, out_labels);
+        cv::ParseSSD(in_ssd_result, in_size,
+                     confidence_threshold,
+                     filter_label,
+                     false,
+                     false,
+                     out_boxes, out_labels);
     }
 };
 
@@ -671,12 +671,12 @@ GAPI_OCV_KERNEL(GOCVParseSSD, cv::gapi::nn::parsers::GParseSSD)
                     std::vector<cv::Rect>& out_boxes)
     {
         std::vector<int> unused_labels;
-        cv::unitedParseSSD(in_ssd_result, in_size,
-                           confidence_threshold,
-                           -1,
-                           alignment_to_square,
-                           filter_out_of_bounds,
-                           out_boxes, unused_labels);
+        cv::ParseSSD(in_ssd_result, in_size,
+                     confidence_threshold,
+                     -1,
+                     alignment_to_square,
+                     filter_out_of_bounds,
+                     out_boxes, unused_labels);
     }
 };
 

--- a/modules/gapi/src/backends/cpu/gnnparsers.cpp
+++ b/modules/gapi/src/backends/cpu/gnnparsers.cpp
@@ -170,12 +170,14 @@ private:
 } // namespace nn
 } // namespace gapi
 
-void parseSSDBL(const cv::Mat&  in_ssd_result,
-                const cv::Size& in_size,
-                const float     confidence_threshold,
-                const int       filter_label,
-                std::vector<cv::Rect>& out_boxes,
-                std::vector<int>&      out_labels)
+void unitedParseSSD(const cv::Mat&  in_ssd_result,
+                    const cv::Size& in_size,
+                    const float     confidence_threshold,
+                    const int       filter_label,
+                    const bool      alignment_to_square,
+                    const bool      filter_out_of_bounds,
+                    std::vector<cv::Rect>& out_boxes,
+                    std::vector<int>&      out_labels)
 {
     cv::gapi::nn::SSDParser parser(in_ssd_result.size, in_size, in_ssd_result.ptr<float>());
     out_boxes.clear();
@@ -192,48 +194,18 @@ void parseSSDBL(const cv::Mat&  in_ssd_result,
         {
             break;    // marks end-of-detections
         }
-
-        if (confidence < confidence_threshold ||
-            (filter_label != -1 && label != filter_label))
-        {
-            continue; // filter out object classes if filter is specified
-        }             // and skip objects with low confidence
-        out_boxes.emplace_back(rc & parser.getSurface());
-        out_labels.emplace_back(label);
-    }
-}
-
-void parseSSD(const cv::Mat&  in_ssd_result,
-              const cv::Size& in_size,
-              const float     confidence_threshold,
-              const bool      alignment_to_square,
-              const bool      filter_out_of_bounds,
-              std::vector<cv::Rect>& out_boxes)
-{
-    cv::gapi::nn::SSDParser parser(in_ssd_result.size, in_size, in_ssd_result.ptr<float>());
-    out_boxes.clear();
-    cv::Rect rc;
-    float image_id, confidence;
-    int label;
-    const size_t range = parser.getMaxProposals();
-    for (size_t i = 0; i < range; ++i)
-    {
-        std::tie(rc, image_id, confidence, label) = parser.extract(i);
-
-        if (image_id < 0.f)
-        {
-            break;    // marks end-of-detections
-        }
         if (confidence < confidence_threshold)
         {
             continue; // skip objects with low confidence
         }
-
+        if((filter_label != -1) && (label != filter_label))
+        {
+            continue; // filter out object classes if filter is specified
+        }
         if (alignment_to_square)
         {
             parser.adjustBoundingBox(rc);
         }
-
         const auto clipped_rc = rc & parser.getSurface();
         if (filter_out_of_bounds)
         {
@@ -243,6 +215,7 @@ void parseSSD(const cv::Mat&  in_ssd_result,
             }
         }
         out_boxes.emplace_back(clipped_rc);
+        out_labels.emplace_back(label);
     }
 }
 

--- a/modules/gapi/src/backends/cpu/gnnparsers.cpp
+++ b/modules/gapi/src/backends/cpu/gnnparsers.cpp
@@ -170,14 +170,14 @@ private:
 } // namespace nn
 } // namespace gapi
 
-void unitedParseSSD(const cv::Mat&  in_ssd_result,
-                    const cv::Size& in_size,
-                    const float     confidence_threshold,
-                    const int       filter_label,
-                    const bool      alignment_to_square,
-                    const bool      filter_out_of_bounds,
-                    std::vector<cv::Rect>& out_boxes,
-                    std::vector<int>&      out_labels)
+void ParseSSD(const cv::Mat&  in_ssd_result,
+              const cv::Size& in_size,
+              const float     confidence_threshold,
+              const int       filter_label,
+              const bool      alignment_to_square,
+              const bool      filter_out_of_bounds,
+              std::vector<cv::Rect>& out_boxes,
+              std::vector<int>&      out_labels)
 {
     cv::gapi::nn::SSDParser parser(in_ssd_result.size, in_size, in_ssd_result.ptr<float>());
     out_boxes.clear();

--- a/modules/gapi/src/backends/cpu/gnnparsers.hpp
+++ b/modules/gapi/src/backends/cpu/gnnparsers.hpp
@@ -11,14 +11,14 @@
 
 namespace cv
 {
-void unitedParseSSD(const cv::Mat&  in_ssd_result,
-                    const cv::Size& in_size,
-                    const float     confidence_threshold,
-                    const int       filter_label,
-                    const bool      alignment_to_square,
-                    const bool      filter_out_of_bounds,
-                    std::vector<cv::Rect>& out_boxes,
-                    std::vector<int>&      out_labels);
+void ParseSSD(const cv::Mat&  in_ssd_result,
+              const cv::Size& in_size,
+              const float     confidence_threshold,
+              const int       filter_label,
+              const bool      alignment_to_square,
+              const bool      filter_out_of_bounds,
+              std::vector<cv::Rect>& out_boxes,
+              std::vector<int>&      out_labels);
 
 void parseYolo(const cv::Mat&  in_yolo_result,
                const cv::Size& in_size,

--- a/modules/gapi/src/backends/cpu/gnnparsers.hpp
+++ b/modules/gapi/src/backends/cpu/gnnparsers.hpp
@@ -11,19 +11,14 @@
 
 namespace cv
 {
-void parseSSDBL(const cv::Mat&  in_ssd_result,
-                const cv::Size& in_size,
-                const float     confidence_threshold,
-                const int       filter_label,
-                std::vector<cv::Rect>& out_boxes,
-                std::vector<int>&      out_labels);
-
-void parseSSD(const cv::Mat&  in_ssd_result,
-              const cv::Size& in_size,
-              const float     confidence_threshold,
-              const bool      alignment_to_square,
-              const bool      filter_out_of_bounds,
-              std::vector<cv::Rect>& out_boxes);
+void unitedParseSSD(const cv::Mat&  in_ssd_result,
+                    const cv::Size& in_size,
+                    const float     confidence_threshold,
+                    const int       filter_label,
+                    const bool      alignment_to_square,
+                    const bool      filter_out_of_bounds,
+                    std::vector<cv::Rect>& out_boxes,
+                    std::vector<int>&      out_labels);
 
 void parseYolo(const cv::Mat&  in_yolo_result,
                const cv::Size& in_size,


### PR DESCRIPTION
### parseSSD overload is ambiguous.

Added specialization for ParseSSD functions with different return values. Unfortunately needs call `cv::gapi::parseSSD<GArray<Rect>>` for second version of ParseSSD. But all samples use first version of ParseSSD with tuple in return value. 

Returned overloads, removed defaults from second function variant.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Magic commands:
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

