### PR TITLE
GAPI: fix build warning

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -461,7 +461,7 @@ void cv::gimpl::ie::GIEExecutable::run(std::vector<InObj>  &&input_objs,
                              return arg.get<cv::gimpl::RcDesc>().shape;
                          });
     // - Output parameters.
-    for (const auto &out_it : ade::util::indexed(op.outs)) {
+    for (const auto out_it : ade::util::indexed(op.outs)) {
         // FIXME: Can the same GArg type resolution mechanism be reused here?
         const auto out_port  = ade::util::index(out_it);
         const auto out_desc  = ade::util::value(out_it);


### PR DESCRIPTION
relates #19050 #18928

[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_openvino-mac/builds/626).

```
force_builders=Custom Mac
build_image:Custom Mac=openvino-2021.2.0
test_modules:Custom Mac=gapi
```