### PR TITLE
VideoCapture/DSHOW : Allow to set CAP_PROP_CONVERT_RGB before FOURCC/FPS/CHANNEL/WIDTH/HEIGHT.

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3485,7 +3485,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
     case CV_CAP_PROP_CONVERT_RGB:
     {
         const bool convertRgb = cvRound(propVal) == 1;
-        const bool success = g_VI.setConvertRGB(m_index, m_convertRGBSet);
+        const bool success = g_VI.setConvertRGB(m_index, convertRgb);
         if(success)
             m_convertRGBSet = convertRgb;
         return success;

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3341,6 +3341,7 @@ VideoCapture_DShow::VideoCapture_DShow(int index)
     , m_fourcc(-1)
     , m_widthSet(-1)
     , m_heightSet(-1)
+    , m_convertRGBSet(true)
 {
     CoInitialize(0);
     open(index);
@@ -3450,6 +3451,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
             break;
         g_VI.stopDevice(m_index);
         g_VI.setupDevice(m_index,  cvFloor(propVal));
+        g_VI.setConvertRGB(m_index, m_convertRGBSet);
         break;
 
     case CV_CAP_PROP_FPS:
@@ -3463,6 +3465,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
                 g_VI.setupDevice(m_index, m_widthSet, m_heightSet);
             else
                 g_VI.setupDevice(m_index);
+            g_VI.setConvertRGB(m_index, m_convertRGBSet);
         }
         return g_VI.isDeviceSetup(m_index);
     }
@@ -3481,7 +3484,11 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
 
     case CV_CAP_PROP_CONVERT_RGB:
     {
-        return g_VI.setConvertRGB(m_index, cvRound(propVal) == 1);
+        const bool convertRgb = cvRound(propVal) == 1;
+        const bool success = g_VI.setConvertRGB(m_index, m_convertRGBSet);
+        if(success)
+            m_convertRGBSet = convertRgb;
+        return success;
     }
 
     }
@@ -3497,6 +3504,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
                 g_VI.stopDevice(m_index);
                 g_VI.setIdealFramerate(m_index, fps);
                 g_VI.setupDeviceFourcc(m_index, m_width, m_height, m_fourcc);
+                g_VI.setConvertRGB(m_index, m_convertRGBSet);
             }
 
             bool success = g_VI.isDeviceSetup(m_index);
@@ -3602,6 +3610,7 @@ void VideoCapture_DShow::close()
         m_index = -1;
     }
     m_widthSet = m_heightSet = m_width = m_height = -1;
+    m_convertRGBSet = true;
 }
 
 Ptr<IVideoCapture> create_DShow_capture(int index)

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -37,6 +37,7 @@ protected:
 
     int m_index, m_width, m_height, m_fourcc;
     int m_widthSet, m_heightSet;
+    bool m_convertRGBSet;
     static videoInput g_VI;
 };
 

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -78,18 +78,18 @@ TEST(DISABLED_videoio_camera, dshow_convert_rgb_persistency)
 {
     VideoCapture capture(CAP_DSHOW);
     ASSERT_TRUE(capture.isOpened());
-    ASSERT_TRUE(capture.set(CAP_PROP_CONVERT_RGB, false));
-    ASSERT_FALSE(static_cast<bool>(capture.get(CAP_PROP_CONVERT_RGB)));
+    ASSERT_TRUE(capture.set(CAP_PROP_CONVERT_RGB, 0));
+    ASSERT_DOUBLE_EQ(capture.get(CAP_PROP_CONVERT_RGB), 0);
     capture.set(CAP_PROP_FRAME_WIDTH, 641);
     capture.set(CAP_PROP_FRAME_HEIGHT, 481);
     capture.set(CAP_PROP_FPS, 31);
-    capture.set(CAP_PROP_CHANNEL, 1);
+    capture.set(CAP_PROP_CHANNEL, 1); 
     capture.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y', '1', '6', ' '));
     std::cout << "Camera 0 via " << capture.getBackendName() << " backend" << std::endl;
     std::cout << "Frame width: " << capture.get(CAP_PROP_FRAME_WIDTH) << std::endl;
     std::cout << "     height: " << capture.get(CAP_PROP_FRAME_HEIGHT) << std::endl;
     std::cout << "Capturing FPS: " << capture.get(CAP_PROP_FPS) << std::endl;
-    ASSERT_FALSE(static_cast<bool>(capture.get(CAP_PROP_CONVERT_RGB)));
+    ASSERT_DOUBLE_EQ(capture.get(CAP_PROP_CONVERT_RGB), 0);
     capture.release();
 }
 

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -72,6 +72,27 @@ TEST(DISABLED_videoio_camera, basic)
     capture.release();
 }
 
+// Test that CAP_PROP_CONVERT_RGB remain to false (default is true) after other supported property are set.
+// The test use odd value to be almost sure to trigger code responsible for recreating the device.
+TEST(DISABLED_videoio_camera, dshow_convert_rgb_persistency)
+{
+    VideoCapture capture(CAP_DSHOW);
+    ASSERT_TRUE(capture.isOpened());
+    ASSERT_TRUE(capture.set(CAP_PROP_CONVERT_RGB, false));
+    ASSERT_FALSE(static_cast<bool>(capture.get(CAP_PROP_CONVERT_RGB)));
+    capture.set(CAP_PROP_FRAME_WIDTH, 641);
+    capture.set(CAP_PROP_FRAME_HEIGHT, 481);
+    capture.set(CAP_PROP_FPS, 31);
+    capture.set(CAP_PROP_CHANNEL, 1);
+    capture.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y', '1', '6', ' '));
+    std::cout << "Camera 0 via " << capture.getBackendName() << " backend" << std::endl;
+    std::cout << "Frame width: " << capture.get(CAP_PROP_FRAME_WIDTH) << std::endl;
+    std::cout << "     height: " << capture.get(CAP_PROP_FRAME_HEIGHT) << std::endl;
+    std::cout << "Capturing FPS: " << capture.get(CAP_PROP_FPS) << std::endl;
+    ASSERT_FALSE(static_cast<bool>(capture.get(CAP_PROP_CONVERT_RGB)));
+    capture.release();
+}
+
 TEST(DISABLED_videoio_camera, v4l_read_mjpg)
 {
     VideoCapture capture(CAP_V4L2);

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -83,7 +83,7 @@ TEST(DISABLED_videoio_camera, dshow_convert_rgb_persistency)
     capture.set(CAP_PROP_FRAME_WIDTH, 641);
     capture.set(CAP_PROP_FRAME_HEIGHT, 481);
     capture.set(CAP_PROP_FPS, 31);
-    capture.set(CAP_PROP_CHANNEL, 1); 
+    capture.set(CAP_PROP_CHANNEL, 1);
     capture.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y', '1', '6', ' '));
     std::cout << "Camera 0 via " << capture.getBackendName() << " backend" << std::endl;
     std::cout << "Frame width: " << capture.get(CAP_PROP_FRAME_WIDTH) << std::endl;


### PR DESCRIPTION
Related issue : https://github.com/opencv/opencv/issues/19367

The PR fixed it the case to set FOURCC/FPS/CHANNEL & CONVERT_RGB in any order.
Every time `stopDevice` is called, `setConvertRgb` should be called again with correct value.
For example settings `FPS` after CONVERT_RGB:
https://github.com/opencv/opencv/blob/ea41f89b40392fc0c5bdfe0f0c43c4820c4b2eac/modules/videoio/src/cap_dshow.cpp#L3455-L3467
Same for `CHANNEL`
https://github.com/opencv/opencv/blob/ea41f89b40392fc0c5bdfe0f0c43c4820c4b2eac/modules/videoio/src/cap_dshow.cpp#L3447-L3453
And when settings `FOURCC`/`WIDTH`/`HEIGHT`
https://github.com/opencv/opencv/blob/ea41f89b40392fc0c5bdfe0f0c43c4820c4b2eac/modules/videoio/src/cap_dshow.cpp#L3494-L3500

<cut/>

##### Detailed description

I'm using Boson camera from FLIR. I'm interested in Y16 format video. I'm using DSHOW backend on windows.
I noticed that setting `CAP_PROP_CONVERT_RGB` then something like `CAP_PROP_FOURCC` will revert `CAP_PROP_CONVERT_RGB` to the default value.

##### Steps to reproduce

```cpp
#include <opencv2/videoio.hpp>

// ...

cv::VideoCapture cap;
cap.open(0, cv::CAP_DSHOW);
f(!cap.isOpened())
    return;

// Print true, that is ok, default expected behavior.
std::cout << "CAP_PROP_CONVERT_RGB: " << cap.get(cv::CAP_PROP_CONVERT_RGB) << std::endl; 

cap.set(cv::CAP_PROP_CONVERT_RGB, false);
cap.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y', '1', '6', ' '));

// Print true, should print false.
std::cout << "CAP_PROP_CONVERT_RGB: " << cap.get(cv::CAP_PROP_CONVERT_RGB) << std::endl; 
```

##### Proposed solution

I fixed it into a [fork](https://github.com/OlivierLDff/opencv/commit/a6ecf9da52fd537c467cb4722038b7d362970516).
I introduced a `m_convertRGBSet` boolean value inside `VideoCapture_DShow` that is updated when `CAP_PROP_CONVERT_RGB` is set.
Then i call `g_VI.setConvertRGB` when g_VI get reinitialized with the saved value.

##### Current workaround

I believe what everyone is doing right now is first set `CAP_PROP_FOURCC` then `CAP_PROP_CONVERT_RGB`.
Especially boson user, like it is shown on [FLIR website](https://flir.custhelp.com/app/answers/detail/a_id/3387/kw/boson%20opencv)

I believe it should work in both order. Or it should be documented somewhere.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builder=Win32
```