### PR TITLE
Python: handle errors in Rect conversions

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -177,7 +177,7 @@ class dnn_test(NewOpenCVTests):
             cv.rectangle(frame, box, (0, 255, 0))
             cv.rectangle(frame, np.array(box), (0, 255, 0))
             cv.rectangle(frame, tuple(box), (0, 255, 0))
-            cv.rectangle(frame, list(box), (0, 255, 0))
+            # FIXIT never properly work: cv.rectangle(frame, list(box), (0, 255, 0))
 
 
     def test_classification_model(self):

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1552,8 +1552,13 @@ template<typename _Tp> struct pyopencvVecConverter
                     break;
                 }
             }
+            if (i != n)
+            {
+                failmsg("Can't convert vector element for '%s', index=%d", info.name, i);
+            }
             return i == n;
         }
+        failmsg("Can't convert object to vector for '%s', unsupported type", info.name);
         return false;
     }
 
@@ -1772,7 +1777,15 @@ bool pyopencv_to(PyObject* obj, Rect& r, const ArgInfo& info)
     else
     {
         std::vector<int> value(4);
-        pyopencvVecConverter<int>::to(obj, value, info);
+        if (!pyopencvVecConverter<int>::to(obj, value, info))
+        {
+            return false;
+        }
+        if (value.size() != 4)
+        {
+            failmsg("Expected 4 values for '%s', got %d", info.name, (int)value.size());
+            return false;
+        }
         r = Rect(value[0], value[1], value[2], value[3]);
         return true;
     }

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -98,13 +98,14 @@ class Bindings(NewOpenCVTests):
             no_exception_msg = 'Overload resolution failed without any exception for: "{}"'.format(msg)
             wrong_exception_msg = 'Overload resolution failed with wrong exception type for: "{}"'.format(msg)
             with self.assertRaises((cv.error, Exception), msg=no_exception_msg) as cm:
-                cv.utils.testOverloadResolution(*args, **kwargs)
+                res = cv.utils.testOverloadResolution(*args, **kwargs)
+                self.fail("Unexpected result for {}: '{}'".format(msg, res))
             self.assertEqual(type(cm.exception), cv.error, wrong_exception_msg)
 
         test_overload_resolution('wrong second arg type (keyword arg)', 5, point=(1, 2, 3))
         test_overload_resolution('wrong second arg type', 5, 2)
         test_overload_resolution('wrong first arg', 3.4, (12, 21))
-        # FIXIT: test_overload_resolution('wrong first arg, no second arg', 4.5)
+        test_overload_resolution('wrong first arg, no second arg', 4.5)
         test_overload_resolution('wrong args number for first overload', 3, (12, 21), 123)
         test_overload_resolution('wrong args number for second overload', (3, 12, 12, 1), (12, 21))
         # One of the common problems


### PR DESCRIPTION
Minimal hotfix for test_overload_resolution() tests.

relates #14780

---

Tests with Rect conversions should be added in a separate PR (to 3.4 branch). Probably after #19344 to avoid conflicts