### PR TITLE
cudalegacy: fix wrong index

### DIFF
--- a/modules/cudalegacy/src/calib3d.cpp
+++ b/modules/cudalegacy/src/calib3d.cpp
@@ -283,7 +283,7 @@ void cv::cuda::solvePnPRansac(const Mat& object, const Mat& image, const Mat& ca
             p_transf.z = rot[6] * p.x + rot[7] * p.y + rot[8] * p.z + transl[2];
             p_proj.x = p_transf.x / p_transf.z;
             p_proj.y = p_transf.y / p_transf.z;
-            if (norm(p_proj - image_normalized.at<Point2f>(0, i)) < max_dist)
+            if (norm(p_proj - image_normalized.at<Point2f>(i)) < max_dist)
                 inliers->push_back(i);
         }
     }


### PR DESCRIPTION
This `image_normalized` is created as a single column vector.
https://github.com/opencv/opencv/blob/bbad38b2c51c78e71d3364814e58b1e6e887705a/modules/imgproc/src/undistort.dispatch.cpp#L476

This part should scan in `(i, 0)` and not `(0, i)`

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```