### PR TITLE
[Minor PR] Change Keymap wording for gray image in curve mode

### DIFF
--- a/samples/python/hist.py
+++ b/samples/python/hist.py
@@ -76,7 +76,7 @@ def main():
     a - show histogram for color image in curve mode \n
     b - show histogram in bin mode \n
     c - show equalized histogram (always in bin mode) \n
-    d - show histogram for color image in curve mode \n
+    d - show histogram for gray image in curve mode \n
     e - show histogram for a normalized image in curve mode \n
     Esc - exit \n
     ''')


### PR DESCRIPTION
Instead of being a copy of line 76, line 79 instead correctly indicates that it will show a histogram for a gray image in curve mode, as given by the code block at line 103 referencing image "gray" instead of image "im".

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
