### PR TITLE
Corrected SSD text graph generation in accordance with preprocessing block order 

### DIFF
--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -122,7 +122,6 @@ def createSSDGraph(modelPath, configPath, outputPath):
     print('Input image size: %dx%d' % (image_width, image_height))
 
     # Read the graph.
-    _inpNames = ['image_tensor']
     outNames = ['num_detections', 'detection_scores', 'detection_boxes', 'detection_classes']
 
     writeTextGraph(modelPath, outputPath, outNames)
@@ -246,6 +245,15 @@ def createSSDGraph(modelPath, configPath, outputPath):
         graph_def.node[1].input.pop()
     graph_def.node[1].input.append(graph_def.node[0].name)
     graph_def.node[1].input.append(weights)
+
+    # check and correct the case when preprocessing block is after input
+    preproc_id = "Preprocessor/"
+    if graph_def.node[2].name.startswith(preproc_id) and \
+        graph_def.node[2].input[0].startswith(preproc_id):
+
+        if not any(preproc_id in inp for inp in graph_def.node[3].input):
+            graph_def.node[3].input.insert(0, graph_def.node[2].name)
+
 
     # Create SSD postprocessing head ###############################################
 


### PR DESCRIPTION
Resolves: #19354

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
