### PR TITLE
QRCodeDetector::decodeMulti() fixed invalid usage fixedType()

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3642,15 +3642,16 @@ bool QRCodeDetector::decodeMulti(
     }
     else if(straight_qrcode.needed())
     {
+        int straight_qrcode_type = straight_qrcode.fixedType() ?
+                                   straight_qrcode.type() : CV_8UC1;
         vector<Mat> tmp_straight_qrcodes(straight_barcode.size());
         for (size_t i = 0; i < straight_barcode.size(); i++)
         {
             straight_barcode[i].convertTo(tmp_straight_qrcodes[i],
-                                          straight_qrcode.fixedType() ?
-                                          straight_qrcode.type() : CV_8UC1);
+                                          straight_qrcode_type);
         }
-        straight_qrcode.create(OutputArray(tmp_straight_qrcodes).size(),
-                               OutputArray(tmp_straight_qrcodes).type());
+        straight_qrcode.create(Size(tmp_straight_qrcodes.size(), 1),
+                               straight_qrcode_type);
         straight_qrcode.assign(tmp_straight_qrcodes);
     }
     decoded_info.clear();

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2486,24 +2486,18 @@ cv::String QRCodeDetector::decode(InputArray in, InputArray points,
     CV_Assert(src_points.size() == 4);
     CV_CheckGT(contourArea(src_points), 0.0, "Invalid QR code source points");
 
-    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
-                                      straight_qrcode.channels() : 1;
-    CV_Assert(straight_qrcode_channels == 1);
-
     QRDecode qrdec;
     qrdec.init(inarr, src_points);
     bool ok = qrdec.straightDecodingProcess();
 
     std::string decoded_info = qrdec.getDecodeInformation();
-    if(!ok && straight_qrcode.needed())
+    if (!ok && straight_qrcode.needed())
     {
         straight_qrcode.release();
     }
     else if (straight_qrcode.needed())
     {
-        qrdec.getStraightBarcode().convertTo(straight_qrcode,
-                                             straight_qrcode.fixedType() ?
-                                             straight_qrcode.type() : CV_8UC1);
+        qrdec.getStraightBarcode().convertTo(straight_qrcode, CV_8UC1);
     }
 
     return ok ? decoded_info : std::string();
@@ -2521,25 +2515,19 @@ cv::String QRCodeDetector::decodeCurved(InputArray in, InputArray points,
     CV_Assert(src_points.size() == 4);
     CV_CheckGT(contourArea(src_points), 0.0, "Invalid QR code source points");
 
-    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
-                                      straight_qrcode.channels() : 1;
-    CV_Assert(straight_qrcode_channels == 1);
-
     QRDecode qrdec;
     qrdec.init(inarr, src_points);
     bool ok = qrdec.curvedDecodingProcess();
 
     std::string decoded_info = qrdec.getDecodeInformation();
 
-    if(!ok && straight_qrcode.needed())
+    if (!ok && straight_qrcode.needed())
     {
         straight_qrcode.release();
     }
     else if (straight_qrcode.needed())
     {
-        qrdec.getStraightBarcode().convertTo(straight_qrcode,
-                                             straight_qrcode.fixedType() ?
-                                             straight_qrcode.type() : CV_8UC1);
+        qrdec.getStraightBarcode().convertTo(straight_qrcode, CV_8UC1);
     }
 
     return ok ? decoded_info : std::string();
@@ -3618,11 +3606,6 @@ bool QRCodeDetector::decodeMulti(
         }
     }
     CV_Assert(src_points.size() > 0);
-
-    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
-                         straight_qrcode.channels() : 1;
-    CV_Assert(straight_qrcode_channels == 1);
-
     vector<QRDecode> qrdec(src_points.size());
     vector<Mat> straight_barcode(src_points.size());
     vector<std::string> info(src_points.size());
@@ -3635,23 +3618,18 @@ bool QRCodeDetector::decodeMulti(
             for_copy.push_back(straight_barcode[i]);
     }
     straight_barcode = for_copy;
-    if (straight_qrcode.needed() &&
-       (straight_barcode.size() == 0))
+    if (straight_qrcode.needed() && straight_barcode.size() == 0)
     {
         straight_qrcode.release();
     }
-    else if(straight_qrcode.needed())
+    else if (straight_qrcode.needed())
     {
-        int straight_qrcode_type = straight_qrcode.fixedType() ?
-                                   straight_qrcode.type() : CV_8UC1;
+        straight_qrcode.create(Size((int)straight_barcode.size(), 1), CV_8UC1);
         vector<Mat> tmp_straight_qrcodes(straight_barcode.size());
         for (size_t i = 0; i < straight_barcode.size(); i++)
         {
-            straight_barcode[i].convertTo(tmp_straight_qrcodes[i],
-                                          straight_qrcode_type);
+            straight_barcode[i].convertTo(tmp_straight_qrcodes[i], CV_8UC1);
         }
-        straight_qrcode.create(Size(int(tmp_straight_qrcodes.size()), 1),
-                               straight_qrcode_type);
         straight_qrcode.assign(tmp_straight_qrcodes);
     }
     decoded_info.clear();

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2486,17 +2486,24 @@ cv::String QRCodeDetector::decode(InputArray in, InputArray points,
     CV_Assert(src_points.size() == 4);
     CV_CheckGT(contourArea(src_points), 0.0, "Invalid QR code source points");
 
+    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
+                                      straight_qrcode.channels() : 1;
+    CV_Assert(straight_qrcode_channels == 1);
+
     QRDecode qrdec;
     qrdec.init(inarr, src_points);
     bool ok = qrdec.straightDecodingProcess();
 
     std::string decoded_info = qrdec.getDecodeInformation();
-
-    if (ok && straight_qrcode.needed())
+    if(!ok && straight_qrcode.needed())
+    {
+        straight_qrcode.release();
+    }
+    else if (straight_qrcode.needed())
     {
         qrdec.getStraightBarcode().convertTo(straight_qrcode,
                                              straight_qrcode.fixedType() ?
-                                             straight_qrcode.type() : CV_32FC2);
+                                             straight_qrcode.type() : CV_8UC1);
     }
 
     return ok ? decoded_info : std::string();
@@ -2514,17 +2521,25 @@ cv::String QRCodeDetector::decodeCurved(InputArray in, InputArray points,
     CV_Assert(src_points.size() == 4);
     CV_CheckGT(contourArea(src_points), 0.0, "Invalid QR code source points");
 
+    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
+                                      straight_qrcode.channels() : 1;
+    CV_Assert(straight_qrcode_channels == 1);
+
     QRDecode qrdec;
     qrdec.init(inarr, src_points);
     bool ok = qrdec.curvedDecodingProcess();
 
     std::string decoded_info = qrdec.getDecodeInformation();
 
-    if (ok && straight_qrcode.needed())
+    if(!ok && straight_qrcode.needed())
+    {
+        straight_qrcode.release();
+    }
+    else if (straight_qrcode.needed())
     {
         qrdec.getStraightBarcode().convertTo(straight_qrcode,
                                              straight_qrcode.fixedType() ?
-                                             straight_qrcode.type() : CV_32FC2);
+                                             straight_qrcode.type() : CV_8UC1);
     }
 
     return ok ? decoded_info : std::string();
@@ -3603,6 +3618,11 @@ bool QRCodeDetector::decodeMulti(
         }
     }
     CV_Assert(src_points.size() > 0);
+
+    size_t straight_qrcode_channels = straight_qrcode.fixedType() ?
+                         straight_qrcode.channels() : 1;
+    CV_Assert(straight_qrcode_channels == 1);
+
     vector<QRDecode> qrdec(src_points.size());
     vector<Mat> straight_barcode(src_points.size());
     vector<std::string> info(src_points.size());
@@ -3615,18 +3635,22 @@ bool QRCodeDetector::decodeMulti(
             for_copy.push_back(straight_barcode[i]);
     }
     straight_barcode = for_copy;
-    vector<Mat> tmp_straight_qrcodes;
-    if (straight_qrcode.needed())
+    if (straight_qrcode.needed() &&
+       (straight_barcode.size() == 0))
     {
+        straight_qrcode.release();
+    }
+    else if(straight_qrcode.needed())
+    {
+        vector<Mat> tmp_straight_qrcodes(straight_barcode.size());
         for (size_t i = 0; i < straight_barcode.size(); i++)
         {
-            Mat tmp_straight_qrcode;
-            tmp_straight_qrcodes.push_back(tmp_straight_qrcode);
-            straight_barcode[i].convertTo(((OutputArray)tmp_straight_qrcodes[i]),
-                                             ((OutputArray)tmp_straight_qrcodes[i]).fixedType() ?
-                                             ((OutputArray)tmp_straight_qrcodes[i]).type() : CV_32FC2);
+            straight_barcode[i].convertTo(tmp_straight_qrcodes[i],
+                                          straight_qrcode.fixedType() ?
+                                          straight_qrcode.type() : CV_8UC1);
         }
-        straight_qrcode.createSameSize(tmp_straight_qrcodes, CV_32FC2);
+        straight_qrcode.create(OutputArray(tmp_straight_qrcodes).size(),
+                               OutputArray(tmp_straight_qrcodes).type());
         straight_qrcode.assign(tmp_straight_qrcodes);
     }
     decoded_info.clear();

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3650,7 +3650,7 @@ bool QRCodeDetector::decodeMulti(
             straight_barcode[i].convertTo(tmp_straight_qrcodes[i],
                                           straight_qrcode_type);
         }
-        straight_qrcode.create(Size(tmp_straight_qrcodes.size(), 1),
+        straight_qrcode.create(Size(int(tmp_straight_qrcodes.size()), 1),
                                straight_qrcode_type);
         straight_qrcode.assign(tmp_straight_qrcodes);
     }

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -635,11 +635,13 @@ TEST(Objdetect_QRCode_decodeMulti, check_output_parameters_type_19363)
     QRCodeDetector qrcode;
     std::vector<Point> corners;
     std::vector<cv::String> decoded_info;
-    std::vector<Mat2s> straight_barcode_nchannels;
+#if 0  // FIXIT: OutputArray::create() type check
+    std::vector<Mat2b> straight_barcode_nchannels;
     EXPECT_ANY_THROW(qrcode.detectAndDecodeMulti(src, decoded_info, corners, straight_barcode_nchannels));
+#endif
 
-    int expected_barcode_type = CV_16SC1;
-    std::vector<Mat1s> straight_barcode;
+    int expected_barcode_type = CV_8UC1;
+    std::vector<Mat1b> straight_barcode;
     EXPECT_TRUE(qrcode.detectAndDecodeMulti(src, decoded_info, corners, straight_barcode));
     ASSERT_FALSE(corners.empty());
     for(size_t i = 0; i < straight_barcode.size(); i++)

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -252,6 +252,8 @@ TEST_P(Objdetect_QRCode, regression)
     decoded_info = qrcode.detectAndDecode(src, corners, straight_barcode);
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
+    int expected_barcode_type = CV_8UC1;
+    EXPECT_EQ(expected_barcode_type, straight_barcode.type());
 #else
     ASSERT_TRUE(qrcode.detect(src, corners));
 #endif
@@ -317,6 +319,8 @@ TEST_P(Objdetect_QRCode_Close, regression)
     decoded_info = qrcode.detectAndDecode(barcode, corners, straight_barcode);
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
+    int expected_barcode_type = CV_8UC1;
+    EXPECT_EQ(expected_barcode_type, straight_barcode.type());
 #else
     ASSERT_TRUE(qrcode.detect(barcode, corners));
 #endif
@@ -382,6 +386,8 @@ TEST_P(Objdetect_QRCode_Monitor, regression)
     decoded_info = qrcode.detectAndDecode(barcode, corners, straight_barcode);
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
+    int expected_barcode_type = CV_8UC1;
+    EXPECT_EQ(expected_barcode_type, straight_barcode.type());
 #else
     ASSERT_TRUE(qrcode.detect(barcode, corners));
 #endif
@@ -442,6 +448,8 @@ TEST_P(Objdetect_QRCode_Curved, regression)
     decoded_info = qrcode.detectAndDecodeCurved(src, corners, straight_barcode);
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
+    int expected_barcode_type = CV_8UC1;
+    EXPECT_EQ(expected_barcode_type, straight_barcode.type());
 #else
     ASSERT_TRUE(qrcode.detect(src, corners));
 #endif
@@ -502,6 +510,9 @@ TEST_P(Objdetect_QRCode_Multi, regression)
     EXPECT_TRUE(qrcode.detectAndDecodeMulti(src, decoded_info, corners, straight_barcode));
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
+    int expected_barcode_type = CV_8UC1;
+    for(size_t i = 0; i < straight_barcode.size(); i++)
+        EXPECT_EQ(expected_barcode_type, straight_barcode[i].type());
 #else
     ASSERT_TRUE(qrcode.detectMulti(src, corners));
 #endif
@@ -610,6 +621,30 @@ TEST(Objdetect_QRCode_detectMulti, detect_regression_16961)
     ASSERT_FALSE(corners.empty());
     size_t expect_corners_size = 36;
     EXPECT_EQ(corners.size(), expect_corners_size);
+}
+
+TEST(Objdetect_QRCode_decodeMulti, check_output_parameters_type_19363)
+{
+    const std::string name_current_image = "9_qrcodes.jpg";
+    const std::string root = "qrcode/multiple/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat src = imread(image_path);
+    ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
+#ifdef HAVE_QUIRC
+    QRCodeDetector qrcode;
+    std::vector<Point> corners;
+    std::vector<cv::String> decoded_info;
+    std::vector<Mat2s> straight_barcode_nchannels;
+    EXPECT_ANY_THROW(qrcode.detectAndDecodeMulti(src, decoded_info, corners, straight_barcode_nchannels));
+
+    int expected_barcode_type = CV_16SC1;
+    std::vector<Mat1s> straight_barcode;
+    EXPECT_TRUE(qrcode.detectAndDecodeMulti(src, decoded_info, corners, straight_barcode));
+    ASSERT_FALSE(corners.empty());
+    for(size_t i = 0; i < straight_barcode.size(); i++)
+        EXPECT_EQ(expected_barcode_type, straight_barcode[i].type());
+#endif
 }
 
 TEST(Objdetect_QRCode_basic, not_found_qrcode)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/845

fix #19363

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
