### PR TITLE
highgui: expose VSYNC window property for OpenGL on W32

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -202,7 +202,8 @@ enum WindowPropertyFlags {
        WND_PROP_ASPECT_RATIO = 2, //!< window's aspect ration (can be set to WINDOW_FREERATIO or WINDOW_KEEPRATIO).
        WND_PROP_OPENGL       = 3, //!< opengl support.
        WND_PROP_VISIBLE      = 4, //!< checks whether the window exists and is visible
-       WND_PROP_TOPMOST      = 5  //!< property to toggle normal window being topmost or not
+       WND_PROP_TOPMOST      = 5, //!< property to toggle normal window being topmost or not
+       WND_PROP_VSYNC        = 6  //!< enable or disable VSYNC (in OpenGL mode)
      };
 
 //! Mouse Events see cv::MouseCallback

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -115,6 +115,9 @@ double cvGetPropTopmost_COCOA(const char* name);
 void cvSetPropTopmost_W32(const char* name, const bool topmost);
 void cvSetPropTopmost_COCOA(const char* name, const bool topmost);
 
+double cvGetPropVsync_W32(const char* name);
+void cvSetPropVsync_W32(const char* name, const bool enabled);
+
 //for QT
 #if defined (HAVE_QT)
 CvRect cvGetWindowRect_QT(const char* name);

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -92,6 +92,14 @@ CV_IMPL void cvSetWindowProperty(const char* name, int prop_id, double prop_valu
         #endif
     break;
 
+    case cv::WND_PROP_VSYNC:
+        #if defined (HAVE_WIN32UI)
+            cvSetPropVsync_W32(name, (prop_value != 0));
+        #else
+            // not implemented yet for other toolkits
+        #endif
+    break;
+
     default:;
     }
 }
@@ -177,6 +185,14 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
             return cvGetPropTopmost_W32(name);
         #elif defined(HAVE_COCOA)
             return cvGetPropTopmost_COCOA(name);
+        #else
+            return -1;
+        #endif
+    break;
+
+    case cv::WND_PROP_VSYNC:
+        #if defined (HAVE_WIN32UI)
+            return cvGetPropVsync_W32(name);
         #else
             return -1;
         #endif


### PR DESCRIPTION
combined with the proposed zero-delay `pollKey` alternative to waitKey (separate pull request), disabling VSYNC can *drastically* speed up display of images. I can get close to 1000 fps for a trivial example (see below), whereas with VSYNC it's nailed to 60 fps (for my screen) and with mandatory `Sleep()` in `waitKey` it's throttled to a jittery 100 FPS depending on OS scheduler.

~~I hope I based this on the right branch. it's not a bug fix.~~ I think I managed to retarget this to the master branch.

I took the implementation of the TOPMOST property as a template and tried to emulate the code structure.

please let me know if I can improve or if this isn't the right way to get such code introduced.

<cut/>

```python
#!/usr/bin/env python3
import time
import numpy as np
import cv2 as cv

cv.namedWindow("window", cv.WINDOW_OPENGL)
print("VSYNC is", cv.getWindowProperty("window", cv.WND_PROP_VSYNC))
cv.setWindowProperty("window", cv.WND_PROP_VSYNC, 0)
print("VSYNC is", cv.getWindowProperty("window", cv.WND_PROP_VSYNC))

i = np.eye(60, dtype=np.uint8) * 255 # cheap barber pole
cnt = 0
t0 = t1 = time.perf_counter()
while True:
	t1 = time.perf_counter()
	if t1 - t0 >= 1.0:
		t0 = t1
		print(cnt, "fps")
		cnt = 0
	i = np.roll(i, shift=1, axis=1) # roll by one column
	cv.imshow("window", i)
	cnt += 1
	key = cv.waitKey(1)
	if key in (13, 27): break
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Win32,Custom
buildworker:Custom=linux-1,linux-4,linux-6
build_image:Custom=qt:16.04
```