### PR TITLE
videoio(plugins): support VideoCaptureParameters, CAPTURE_API_VERSION=1

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -76,7 +76,7 @@ VideoCapture::VideoCapture(const String& filename, int apiPreference) : throwOnF
 }
 
 VideoCapture::VideoCapture(const String& filename, int apiPreference, const std::vector<int>& params)
-    : throwOnFail(true)
+    : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
     open(filename, apiPreference, params);
@@ -89,7 +89,7 @@ VideoCapture::VideoCapture(int index, int apiPreference) : throwOnFail(false)
 }
 
 VideoCapture::VideoCapture(int index, int apiPreference, const std::vector<int>& params)
-    : throwOnFail(true)
+    : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
     open(index, apiPreference, params);

--- a/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
+++ b/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
@@ -24,7 +24,7 @@ extern "C"
 typedef struct CvCapture_FFMPEG CvCapture_FFMPEG;
 typedef struct CvVideoWriter_FFMPEG CvVideoWriter_FFMPEG;
 
-OPENCV_FFMPEG_API struct CvCapture_FFMPEG* cvCreateFileCapture_FFMPEG(const char* filename);
+//OPENCV_FFMPEG_API struct CvCapture_FFMPEG* cvCreateFileCapture_FFMPEG(const char* filename);
 OPENCV_FFMPEG_API int cvSetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap,
                                                   int prop, double value);
 OPENCV_FFMPEG_API double cvGetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap, int prop);

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -82,6 +82,15 @@ public:
         }
     }
 
+    VideoParameters(int* params, unsigned n_params)
+    {
+        params_.reserve(n_params);
+        for (unsigned i = 0; i < n_params; ++i)
+        {
+            add(params[2*i], params[2*i + 1]);
+        }
+    }
+
     void add(int key, int value)
     {
         params_.emplace_back(key, value);
@@ -190,17 +199,13 @@ private:
 class VideoWriterParameters : public VideoParameters
 {
 public:
-    VideoWriterParameters() = default;
-
-    explicit VideoWriterParameters(const std::vector<int>& params) : VideoParameters(params) {};
+    using VideoParameters::VideoParameters;  // reuse constructors
 };
 
 class VideoCaptureParameters : public VideoParameters
 {
 public:
-    VideoCaptureParameters() = default;
-
-    explicit VideoCaptureParameters(const std::vector<int>& params) : VideoParameters(params) {};
+    using VideoParameters::VideoParameters;  // reuse constructors
 };
 
 class IVideoCapture

--- a/modules/videoio/src/plugin_capture_api.hpp
+++ b/modules/videoio/src/plugin_capture_api.hpp
@@ -13,7 +13,7 @@
 /// increased for backward-compatible changes, e.g. add new function
 /// Caller API <= Plugin API -> plugin is fully compatible
 /// Caller API > Plugin API -> plugin is not fully compatible, caller should use extra checks to use plugins with older API
-#define CAPTURE_API_VERSION 0
+#define CAPTURE_API_VERSION 1
 
 /// increased for incompatible changes, e.g. remove function argument
 /// Caller ABI == Plugin ABI -> plugin is compatible
@@ -103,18 +103,23 @@ struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries
     CvResult (CV_API_CALL *Capture_retreive)(CvPluginCapture handle, int stream_idx, cv_videoio_capture_retrieve_cb_t callback, void* userdata);
 }; // OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries
 
-#if 0
 struct OpenCV_VideoIO_Capture_Plugin_API_v1_1_api_entries
 {
-    /** @brief TBD
+    /** @brief Open video capture with parameters
 
-    @note API-CALL XXX, API-Version == YYY
+    @param filename File name or NULL to use camera_index instead
+    @param camera_index Camera index (used if filename == NULL)
+    @param params pointer on 2*n_params array of 'key,value' pairs
+    @param n_params number of passed parameters
+    @param[out] handle pointer on Capture handle
+
+    @note API-CALL 8, API-Version == 1
      */
-    CvResult (CV_API_CALL* zzz)(
-        ...
-    );
+    CvResult (CV_API_CALL *Capture_open_with_params)(
+        const char* filename, int camera_index,
+        int* params, unsigned n_params,
+        CV_OUT CvPluginCapture* handle);
 }; // OpenCV_VideoIO_Capture_Plugin_API_v1_1_api_entries
-#endif
 
 typedef struct OpenCV_VideoIO_Capture_Plugin_API_v1_0
 {
@@ -122,16 +127,14 @@ typedef struct OpenCV_VideoIO_Capture_Plugin_API_v1_0
     struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries v0;
 } OpenCV_VideoIO_Capture_Plugin_API_v1_0;
 
-#if 0
 typedef struct OpenCV_VideoIO_Capture_Plugin_API_v1_1
 {
     OpenCV_API_Header api_header;
     struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries v0;
     struct OpenCV_VideoIO_Capture_Plugin_API_v1_1_api_entries v1;
 } OpenCV_VideoIO_Capture_Plugin_API_v1_1;
-#endif
 
-#if 0 //CAPTURE_ABI_VERSION == 1 && CAPTURE_API_VERSION == 1
+#if CAPTURE_ABI_VERSION == 1 && CAPTURE_API_VERSION == 1
 typedef struct OpenCV_VideoIO_Capture_Plugin_API_v1_1 OpenCV_VideoIO_Capture_Plugin_API;
 #elif CAPTURE_ABI_VERSION == 1 && CAPTURE_API_VERSION == 0
 typedef struct OpenCV_VideoIO_Capture_Plugin_API_v1_0 OpenCV_VideoIO_Capture_Plugin_API;

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -509,12 +509,10 @@ TEST(videoio_ffmpeg, create_with_property_badarg)
         throw SkipTestException("FFmpeg backend was not found");
 
     string video_file = findDataFile("video/big_buck_bunny.mp4");
-    EXPECT_ANY_THROW(
-    {
-        VideoCapture cap(video_file, CAP_FFMPEG, {
-            CAP_PROP_FORMAT, -2  // invalid
-        });
+    VideoCapture cap(video_file, CAP_FFMPEG, {
+        CAP_PROP_FORMAT, -2  // invalid
     });
+    EXPECT_FALSE(cap.isOpened());
 }
 
 


### PR DESCRIPTION
relates #19394
relates #16766

Validation:
- `--gtest_filter=*ffmpeg*with_property*`
- with/without `cmake ... -DVIDEOIO_PLUGIN_LIST=all`

Note: FFmpeg Windows wrapper is not updated.

<cut/>

```
force_builders=Linux32,Win32,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```