### PR TITLE
Added ONNX NormalizeL2 subgraph

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -249,6 +249,40 @@ public:
     }
 };
 
+class NormalizeSubgraph4 : public NormalizeSubgraphBase
+{
+public:
+    NormalizeSubgraph4() : NormalizeSubgraphBase(1)
+    {
+        int input = addNodeToMatch("");
+        int mul = addNodeToMatch("Mul", input, input);
+        int sum = addNodeToMatch("ReduceSum", mul);
+        int eps = addNodeToMatch("");
+        int max = addNodeToMatch("Max", sum, eps);
+        int sqrt = addNodeToMatch("Sqrt", max);
+        int reciprocal = addNodeToMatch("Reciprocal", sqrt);
+        addNodeToMatch("Mul", input, reciprocal);
+        setFusedNode("Normalize", input);
+    }
+};
+
+class NormalizeSubgraph5 : public NormalizeSubgraphBase
+{
+public:
+    NormalizeSubgraph5() : NormalizeSubgraphBase(1)
+    {
+        int input = addNodeToMatch("");
+        int mul = addNodeToMatch("Mul", input, input);
+        int sum = addNodeToMatch("ReduceSum", mul);
+        int clip = addNodeToMatch("Clip", sum);
+        int sqrt = addNodeToMatch("Sqrt", clip);
+        int one = addNodeToMatch("Constant");
+        int div = addNodeToMatch("Div", one, sqrt);
+        addNodeToMatch("Mul", input, div);
+        setFusedNode("Normalize", input);
+    }
+};
+
 class GatherCastSubgraph : public Subgraph
 {
 public:
@@ -526,6 +560,8 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<BatchNormalizationSubgraph2>());
     subgraphs.push_back(makePtr<ExpandSubgraph>());
     subgraphs.push_back(makePtr<MishSubgraph>());
+    subgraphs.push_back(makePtr<NormalizeSubgraph4>());
+    subgraphs.push_back(makePtr<NormalizeSubgraph5>());
 
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -403,6 +403,11 @@ TEST_P(Test_ONNX_layers, BatchNormalizationSubgraph)
     testONNXModels("batch_norm_subgraph");
 }
 
+TEST_P(Test_ONNX_layers, NormalizeFusionSubgraph)
+{
+    testONNXModels("normalize_fusion");
+}
+
 TEST_P(Test_ONNX_layers, Transpose)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves: #18876
merge with extra opencv/opencv_extra#842

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```