### PR TITLE
Added Exif parsing for PNG format Issue 16579

### DIFF
--- a/modules/imgcodecs/src/exif.cpp
+++ b/modules/imgcodecs/src/exif.cpp
@@ -62,7 +62,7 @@ ExifEntry_t::ExifEntry_t() :
 /**
  * @brief ExifReader constructor
  */
-ExifReader::ExifReader(std::istream& stream) : m_stream(stream), m_format(NONE)
+ExifReader::ExifReader() : m_format(NONE)
 {
 }
 
@@ -71,25 +71,6 @@ ExifReader::ExifReader(std::istream& stream) : m_stream(stream), m_format(NONE)
  */
 ExifReader::~ExifReader()
 {
-}
-
-/**
- * @brief Parsing the file and prepare (internally) exif directory structure
- * @return  true if parsing was successful and exif information exists in JpegReader object
- *          false in case of unsuccessful parsing
- */
-bool ExifReader::parse()
-{
-    try {
-        m_exif = getExif();
-        if( !m_exif.empty() )
-        {
-            return true;
-        }
-        return false;
-    } catch (ExifParsingError&) {
-        return false;
-    }
 }
 
 
@@ -115,100 +96,37 @@ ExifEntry_t ExifReader::getTag(const ExifTagName tag)
 
 
 /**
- * @brief Get exif directory structure contained in file (if any)
- *          This is internal function and is not exposed to client
+ * @brief Parsing the exif data buffer and prepare (internal) exif directory
  *
- *  @return Map where key is tag number and value is ExifEntry_t structure
- */
-std::map<int, ExifEntry_t > ExifReader::getExif()
-{
-    const std::streamsize markerSize = 2;
-    const std::streamsize offsetToTiffHeader = 6; //bytes from Exif size field to the first TIFF header
-    unsigned char appMarker[markerSize];
-    m_exif.erase( m_exif.begin(), m_exif.end() );
-
-    std::streamsize count;
-
-    bool exifFound = false, stopSearch = false;
-    while( ( !m_stream.eof() ) && !exifFound && !stopSearch )
-    {
-        m_stream.read( reinterpret_cast<char*>(appMarker), markerSize );
-        count = m_stream.gcount();
-        if( count < markerSize )
-        {
-            break;
-        }
-        unsigned char marker = appMarker[1];
-        size_t bytesToSkip;
-        size_t exifSize;
-        switch( marker )
-        {
-            //For all the markers just skip bytes in file pointed by followed two bytes (field size)
-            case SOF0: case SOF2: case DHT: case DQT: case DRI: case SOS:
-            case RST0: case RST1: case RST2: case RST3: case RST4: case RST5: case RST6: case RST7:
-            case APP0: case APP2: case APP3: case APP4: case APP5: case APP6: case APP7: case APP8:
-            case APP9: case APP10: case APP11: case APP12: case APP13: case APP14: case APP15:
-            case COM:
-                bytesToSkip = getFieldSize();
-                if (bytesToSkip < markerSize) {
-                    throw ExifParsingError();
-                }
-                m_stream.seekg( static_cast<long>( bytesToSkip - markerSize ), m_stream.cur );
-                if ( m_stream.fail() ) {
-                    throw ExifParsingError();
-                }
-                break;
-
-            //SOI and EOI don't have the size field after the marker
-            case SOI: case EOI:
-                break;
-
-            case APP1: //actual Exif Marker
-                exifSize = getFieldSize();
-                if (exifSize <= offsetToTiffHeader) {
-                    throw ExifParsingError();
-                }
-                m_data.resize( exifSize - offsetToTiffHeader );
-                m_stream.seekg( static_cast<long>( offsetToTiffHeader ), m_stream.cur );
-                if ( m_stream.fail() ) {
-                    throw ExifParsingError();
-                }
-                m_stream.read( reinterpret_cast<char*>(&m_data[0]), exifSize - offsetToTiffHeader );
-                exifFound = true;
-                break;
-
-            default: //No other markers are expected according to standard. May be a signal of error
-                stopSearch = true;
-                break;
-        }
-    }
-
-    if( !exifFound )
-    {
-        return m_exif;
-    }
-
-    parseExif();
-
-    return m_exif;
-}
-
-/**
- * @brief Get the size of exif field (required to properly ready whole exif from the file)
- *          This is internal function and is not exposed to client
+ * @param [in] data The data buffer to read EXIF data starting with endianness
+ * @param [in] size The size of the data buffer
  *
- *  @return size of exif field in the file
+ * @return  true if parsing was successful
+ *          false in case of unsuccessful parsing
  */
-size_t ExifReader::getFieldSize ()
+bool ExifReader::parseExif(unsigned char* data, const size_t size)
 {
-    unsigned char fieldSize[2];
-    m_stream.read( reinterpret_cast<char*>(fieldSize), 2 );
-    std::streamsize count = m_stream.gcount();
-    if (count < 2)
+    // Populate m_data, then call parseExif() (private)
+    if( data && size > 0 )
     {
-        return 0;
+        m_data.assign(data, data + size);
     }
-    return ( fieldSize[0] << 8 ) + fieldSize[1];
+    else
+    {
+        return false;
+    }
+
+    try {
+        parseExif();
+        if( !m_exif.empty() )
+        {
+            return true;
+        }
+        return false;
+    }
+    catch( ExifParsingError& ) {
+        return false;
+    }
 }
 
 /**

--- a/modules/imgcodecs/src/exif.hpp
+++ b/modules/imgcodecs/src/exif.hpp
@@ -168,19 +168,22 @@ class ExifReader
 public:
     /**
      * @brief ExifReader constructor. Constructs an object of exif reader
-     *
-     * @param [in]stream An istream to look for EXIF bytes from
      */
-    explicit ExifReader( std::istream& stream );
+    ExifReader();
     ~ExifReader();
 
 
     /**
      * @brief Parse the file with exif info
      *
-     * @return true if parsing was successful and exif information exists in JpegReader object
+     * @param [in] data The data buffer to read EXIF data starting with endianness
+     * @param [in] size The size of the data buffer
+     *
+     * @return true if successful parsing
+     *         false if parsing error
      */
-    bool parse();
+
+    bool parseExif(unsigned char* data, const size_t size);
 
     /**
      * @brief Get tag info by tag number
@@ -190,8 +193,8 @@ public:
      */
     ExifEntry_t getTag( const ExifTagName tag );
 
+
 private:
-    std::istream& m_stream;
     std::vector<unsigned char> m_data;
     std::map<int, ExifEntry_t > m_exif;
     Endianess_t m_format;
@@ -199,7 +202,6 @@ private:
     void parseExif();
     bool checkTagMark() const;
 
-    size_t getFieldSize ();
     size_t getNumDirEntry( const size_t offsetNumDir ) const;
     uint32_t getStartOffset() const;
     uint16_t getExifTag( const size_t offset ) const;
@@ -215,7 +217,6 @@ private:
 
     u_rational_t getURational( const size_t offset ) const;
 
-    std::map<int, ExifEntry_t > getExif();
     std::string getString( const size_t offset ) const;
     std::vector<u_rational_t> getResolution( const size_t offset ) const;
     std::vector<u_rational_t> getWhitePoint( const size_t offset ) const;

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -45,6 +45,7 @@
 
 #include "utils.hpp"
 #include "bitstrm.hpp"
+#include "exif.hpp"
 
 namespace cv
 {
@@ -64,6 +65,7 @@ public:
     int width() const { return m_width; }
     int height() const { return m_height; }
     virtual int type() const { return m_type; }
+    ExifReader exif() const { return m_exif; }
 
     virtual bool setSource( const String& filename );
     virtual bool setSource( const Mat& buf );
@@ -87,6 +89,7 @@ protected:
     String m_signature;
     Mat m_buf;
     bool m_buf_supported;
+    ExifReader m_exif;
 };
 
 

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -244,6 +244,7 @@ bool  JpegDecoder::readHeader()
 
         if (state->cinfo.src != 0)
         {
+            jpeg_save_markers(&state->cinfo, AppMarkerTypes::APP1, 0xffff);
             jpeg_read_header( &state->cinfo, TRUE );
 
             state->cinfo.scale_num=1;
@@ -455,6 +456,29 @@ bool  JpegDecoder::readData( Mat& img )
                     cinfo->out_color_components = 4;
                 }
             }
+
+            // Check for Exif marker APP1
+            jpeg_saved_marker_ptr exif_marker = NULL;
+            jpeg_saved_marker_ptr cmarker = cinfo->marker_list;
+            while( cmarker && exif_marker == NULL )
+            {
+                if (cmarker->marker == AppMarkerTypes::APP1)
+                    exif_marker = cmarker;
+
+                cmarker = cmarker->next;
+            }
+
+            // Parse Exif data
+            if( exif_marker )
+            {
+                const std::streamsize offsetToTiffHeader = 6; //bytes from Exif size field to the first TIFF header
+
+                if (exif_marker->data_length > offsetToTiffHeader)
+                {
+                    m_exif.parseExif(exif_marker->data + offsetToTiffHeader, exif_marker->data_length - offsetToTiffHeader);
+                }
+            }
+
 
             jpeg_start_decompress( cinfo );
 

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -284,6 +284,20 @@ bool  PngDecoder::readData( Mat& img )
             png_read_image( png_ptr, buffer );
             png_read_end( png_ptr, end_info );
 
+            png_uint_32 num_exif = 0;
+            png_bytep exif = nullptr;
+
+            // Exif info could be in info_ptr (intro_info) or end_info!!
+            if( png_get_valid(png_ptr, info_ptr, PNG_INFO_eXIf) )
+                png_get_eXIf_1(png_ptr, info_ptr, &num_exif, &exif);
+            else if( png_get_valid(png_ptr, end_info, PNG_INFO_eXIf) )
+                png_get_eXIf_1(png_ptr, end_info, &num_exif, &exif);
+
+            if( exif && num_exif > 0 )
+            {
+                m_exif.parseExif(exif, num_exif);
+            }
+
             result = true;
         }
     }

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -354,48 +354,16 @@ static void ExifTransform(int orientation, Mat& img)
     }
 }
 
-static void ApplyExifOrientation(const String& filename, Mat& img)
+static void ApplyExifOrientation(ExifReader& exif, Mat& img)
 {
     int orientation = IMAGE_ORIENTATION_TL;
 
-    if (filename.size() > 0)
+    ExifEntry_t entry = exif.getTag( ORIENTATION );
+    if (entry.tag != INVALID_TAG)
     {
-        std::ifstream stream( filename.c_str(), std::ios_base::in | std::ios_base::binary );
-        ExifReader reader( stream );
-        if( reader.parse() )
-        {
-            ExifEntry_t entry = reader.getTag( ORIENTATION );
-            if (entry.tag != INVALID_TAG)
-            {
-                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-            }
-        }
-        stream.close();
+        orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+        ExifTransform(orientation, img);
     }
-
-    ExifTransform(orientation, img);
-}
-
-static void ApplyExifOrientation(const Mat& buf, Mat& img)
-{
-    int orientation = IMAGE_ORIENTATION_TL;
-
-    if( buf.isContinuous() )
-    {
-        ByteStreamBuffer bsb( reinterpret_cast<char*>(buf.data), buf.total() * buf.elemSize() );
-        std::istream stream( &bsb );
-        ExifReader reader( stream );
-        if( reader.parse() )
-        {
-            ExifEntry_t entry = reader.getTag( ORIENTATION );
-            if (entry.tag != INVALID_TAG)
-            {
-                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-            }
-        }
-    }
-
-    ExifTransform(orientation, img);
 }
 
 /**
@@ -537,6 +505,12 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0 )
         resize( *mat, *mat, Size( size.width / scale_denom, size.height / scale_denom ), 0, 0, INTER_LINEAR_EXACT);
     }
 
+    /// optionally rotate the data if EXIF orientation flag says so
+    if( mat && !mat->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    {
+        ApplyExifOrientation(decoder->exif(), *mat);
+    }
+
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
         hdrtype == LOAD_IMAGE ? (void*)image : (void*)mat;
 }
@@ -634,7 +608,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats)
         // optionally rotate the data if EXIF' orientation flag says so
         if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
         {
-            ApplyExifOrientation(filename, mat);
+            ApplyExifOrientation(decoder->exif(), mat);
         }
 
         mats.push_back(mat);
@@ -664,12 +638,6 @@ Mat imread( const String& filename, int flags )
 
     /// load the data
     imread_( filename, flags, LOAD_MAT, &img );
-
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(filename, img);
-    }
 
     /// return a reference to the data
     return img;
@@ -932,6 +900,12 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
         resize( *mat, *mat, Size( size.width / scale_denom, size.height / scale_denom ), 0, 0, INTER_LINEAR_EXACT);
     }
 
+    /// optionally rotate the data if EXIF' orientation flag says so
+    if (!mat->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED)
+    {
+        ApplyExifOrientation(decoder->exif(), *mat);
+    }
+
     decoder.release();
 
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
@@ -946,12 +920,6 @@ Mat imdecode( InputArray _buf, int flags )
     Mat buf = _buf.getMat(), img;
     imdecode_( buf, flags, LOAD_MAT, &img );
 
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(buf, img);
-    }
-
     return img;
 }
 
@@ -962,12 +930,6 @@ Mat imdecode( InputArray _buf, int flags, Mat* dst )
     Mat buf = _buf.getMat(), img;
     dst = dst ? dst : &img;
     imdecode_( buf, flags, LOAD_MAT, dst );
-
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !dst->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(buf, *dst);
-    }
 
     return *dst;
 }

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -93,6 +93,95 @@ TEST(Imgcodecs_Png, read_color_palette_with_alpha)
     EXPECT_EQ(img.at<Vec3b>(0, 1), Vec3b(0, 0, 255));
 }
 
+/**
+ * Test for check whether reading exif orientation tag was processed successfully or not
+ * The test info is the set of 8 images named testExifRotate_{1 to 8}.png
+ * The test image is the square 10x10 points divided by four sub-squares:
+ * (R corresponds to Red, G to Green, B to Blue, W to white)
+ * ---------             ---------
+ * | R | G |             | G | R |
+ * |-------| - (tag 1)   |-------| - (tag 2)
+ * | B | W |             | W | B |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | W | B |             | B | W |
+ * |-------| - (tag 3)   |-------| - (tag 4)
+ * | G | R |             | R | G |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | R | B |             | G | W |
+ * |-------| - (tag 5)   |-------| - (tag 6)
+ * | G | W |             | R | B |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | W | G |             | B | R |
+ * |-------| - (tag 7)   |-------| - (tag 8)
+ * | B | R |             | W | G |
+ * ---------             ---------
+ *
+ *
+ * Every image contains exif field with orientation tag (0x112)
+ * After reading each image and applying the orientation tag,
+ * the resulting image should be:
+ * ---------
+ * | R | G |
+ * |-------|
+ * | B | W |
+ * ---------
+ *
+ */
+
+typedef testing::TestWithParam<string> Imgcodecs_PNG_Exif;
+
+// Solution to issue 16579: PNG read doesn't support Exif orientation data
+TEST_P(Imgcodecs_PNG_Exif, exif_orientation)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + GetParam();
+    const int colorThresholdHigh = 250;
+    const int colorThresholdLow = 5;
+
+    Mat m_img = imread(filename);
+    ASSERT_FALSE(m_img.empty());
+    Vec3b vec;
+
+    //Checking the first quadrant (with supposed red)
+    vec = m_img.at<Vec3b>(2, 2); //some point inside the square
+    EXPECT_LE(vec.val[0], colorThresholdLow);
+    EXPECT_LE(vec.val[1], colorThresholdLow);
+    EXPECT_GE(vec.val[2], colorThresholdHigh);
+
+    //Checking the second quadrant (with supposed green)
+    vec = m_img.at<Vec3b>(2, 7);  //some point inside the square
+    EXPECT_LE(vec.val[0], colorThresholdLow);
+    EXPECT_GE(vec.val[1], colorThresholdHigh);
+    EXPECT_LE(vec.val[2], colorThresholdLow);
+
+    //Checking the third quadrant (with supposed blue)
+    vec = m_img.at<Vec3b>(7, 2);  //some point inside the square
+    EXPECT_GE(vec.val[0], colorThresholdHigh);
+    EXPECT_LE(vec.val[1], colorThresholdLow);
+    EXPECT_LE(vec.val[2], colorThresholdLow);
+}
+
+const string exif_files[] =
+{
+    "readwrite/testExifOrientation_1.png",
+    "readwrite/testExifOrientation_2.png",
+    "readwrite/testExifOrientation_3.png",
+    "readwrite/testExifOrientation_4.png",
+    "readwrite/testExifOrientation_5.png",
+    "readwrite/testExifOrientation_6.png",
+    "readwrite/testExifOrientation_7.png",
+    "readwrite/testExifOrientation_8.png"
+};
+
+INSTANTIATE_TEST_CASE_P(ExifFiles, Imgcodecs_PNG_Exif,
+    testing::ValuesIn(exif_files));
+
 #endif // HAVE_PNG
 
 }} // namespace


### PR DESCRIPTION
Added Exif parsing for PNG files to support Exif orientation tag.  Moved decoder specific Exif parsing to JPEG and PNG decoders, respectively. Issue 16579

https://github.com/opencv/opencv/issues/16579

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X ] I agree to contribute to the project under Apache 2 License.
- [X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X ] The PR is proposed to proper branch
- [X ] There is reference to original bug report and related work
- [X ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X ] The feature is well documented and sample code can be built with the project CMake
