### PR TITLE
Added Exif parsing for PNG Issue 16579

### DIFF
--- a/modules/imgcodecs/src/exif.hpp
+++ b/modules/imgcodecs/src/exif.hpp
@@ -54,24 +54,6 @@
 
 namespace cv
 {
-/**
- * @brief Jpeg markers that can encounter in Jpeg file
- */
-enum AppMarkerTypes
-{
-    SOI   = 0xD8, SOF0  = 0xC0, SOF2  = 0xC2, DHT   = 0xC4,
-    DQT   = 0xDB, DRI   = 0xDD, SOS   = 0xDA,
-
-    RST0  = 0xD0, RST1  = 0xD1, RST2  = 0xD2, RST3  = 0xD3,
-    RST4  = 0xD4, RST5  = 0xD5, RST6  = 0xD6, RST7  = 0xD7,
-
-    APP0  = 0xE0, APP1  = 0xE1, APP2  = 0xE2, APP3  = 0xE3,
-    APP4  = 0xE4, APP5  = 0xE5, APP6  = 0xE6, APP7  = 0xE7,
-    APP8  = 0xE8, APP9  = 0xE9, APP10 = 0xEA, APP11 = 0xEB,
-    APP12 = 0xEC, APP13 = 0xED, APP14 = 0xEE, APP15 = 0xEF,
-
-    COM   = 0xFE, EOI   = 0xD9
-};
 
 /**
  * @brief Base Exif tags used by IFD0 (main image)
@@ -168,19 +150,22 @@ class ExifReader
 public:
     /**
      * @brief ExifReader constructor. Constructs an object of exif reader
-     *
-     * @param [in]stream An istream to look for EXIF bytes from
      */
-    explicit ExifReader( std::istream& stream );
+    ExifReader();
     ~ExifReader();
 
 
     /**
      * @brief Parse the file with exif info
      *
-     * @return true if parsing was successful and exif information exists in JpegReader object
+     * @param [in] data The data buffer to read EXIF data starting with endianness
+     * @param [in] size The size of the data buffer
+     *
+     * @return true if successful parsing
+     *         false if parsing error
      */
-    bool parse();
+
+    bool parseExif(unsigned char* data, const size_t size);
 
     /**
      * @brief Get tag info by tag number
@@ -188,10 +173,10 @@ public:
      * @param [in] tag The tag number
      * @return ExifEntru_t structure. Caller has to know what tag it calls in order to extract proper field from the structure ExifEntry_t
      */
-    ExifEntry_t getTag( const ExifTagName tag );
+    ExifEntry_t getTag( const ExifTagName tag ) const;
+
 
 private:
-    std::istream& m_stream;
     std::vector<unsigned char> m_data;
     std::map<int, ExifEntry_t > m_exif;
     Endianess_t m_format;
@@ -199,7 +184,6 @@ private:
     void parseExif();
     bool checkTagMark() const;
 
-    size_t getFieldSize ();
     size_t getNumDirEntry( const size_t offsetNumDir ) const;
     uint32_t getStartOffset() const;
     uint16_t getExifTag( const size_t offset ) const;
@@ -215,7 +199,6 @@ private:
 
     u_rational_t getURational( const size_t offset ) const;
 
-    std::map<int, ExifEntry_t > getExif();
     std::string getString( const size_t offset ) const;
     std::vector<u_rational_t> getResolution( const size_t offset ) const;
     std::vector<u_rational_t> getWhitePoint( const size_t offset ) const;

--- a/modules/imgcodecs/src/grfmt_base.cpp
+++ b/modules/imgcodecs/src/grfmt_base.cpp
@@ -55,6 +55,11 @@ BaseImageDecoder::BaseImageDecoder()
     m_scale_denom = 1;
 }
 
+
+ExifEntry_t BaseImageDecoder::getExifTag(const ExifTagName tag) const
+{
+    return m_exif.getTag(tag);
+}
 bool BaseImageDecoder::setSource( const String& filename )
 {
     m_filename = filename;

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -45,6 +45,7 @@
 
 #include "utils.hpp"
 #include "bitstrm.hpp"
+#include "exif.hpp"
 
 namespace cv
 {
@@ -65,6 +66,7 @@ public:
     int height() const { return m_height; }
     virtual int type() const { return m_type; }
 
+    ExifEntry_t getExifTag(const ExifTagName tag) const;
     virtual bool setSource( const String& filename );
     virtual bool setSource( const Mat& buf );
     virtual int setScale( const int& scale_denom );
@@ -87,6 +89,7 @@ protected:
     String m_signature;
     Mat m_buf;
     bool m_buf_supported;
+    ExifReader m_exif;
 };
 
 

--- a/modules/imgcodecs/src/grfmt_jpeg.hpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.hpp
@@ -52,6 +52,25 @@
 
 namespace cv
 {
+/**
+* @brief Jpeg markers that can be encountered in a Jpeg file
+*/
+enum AppMarkerTypes
+{
+    SOI = 0xD8, SOF0 = 0xC0, SOF2 = 0xC2, DHT = 0xC4,
+    DQT = 0xDB, DRI = 0xDD, SOS = 0xDA,
+
+    RST0 = 0xD0, RST1 = 0xD1, RST2 = 0xD2, RST3 = 0xD3,
+    RST4 = 0xD4, RST5 = 0xD5, RST6 = 0xD6, RST7 = 0xD7,
+
+    APP0 = 0xE0, APP1 = 0xE1, APP2 = 0xE2, APP3 = 0xE3,
+    APP4 = 0xE4, APP5 = 0xE5, APP6 = 0xE6, APP7 = 0xE7,
+    APP8 = 0xE8, APP9 = 0xE9, APP10 = 0xEA, APP11 = 0xEB,
+    APP12 = 0xEC, APP13 = 0xED, APP14 = 0xEE, APP15 = 0xEF,
+
+    COM = 0xFE, EOI = 0xD9
+};
+
 
 class JpegDecoder CV_FINAL : public BaseImageDecoder
 {

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -284,6 +284,22 @@ bool  PngDecoder::readData( Mat& img )
             png_read_image( png_ptr, buffer );
             png_read_end( png_ptr, end_info );
 
+#ifdef PNG_eXIf_SUPPORTED
+            png_uint_32 num_exif = 0;
+            png_bytep exif = 0;
+
+            // Exif info could be in info_ptr (intro_info) or end_info per specification
+            if( png_get_valid(png_ptr, info_ptr, PNG_INFO_eXIf) )
+                png_get_eXIf_1(png_ptr, info_ptr, &num_exif, &exif);
+            else if( png_get_valid(png_ptr, end_info, PNG_INFO_eXIf) )
+                png_get_eXIf_1(png_ptr, end_info, &num_exif, &exif);
+
+            if( exif && num_exif > 0 )
+            {
+                m_exif.parseExif(exif, num_exif);
+            }
+#endif
+
             result = true;
         }
     }

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -354,48 +354,15 @@ static void ExifTransform(int orientation, Mat& img)
     }
 }
 
-static void ApplyExifOrientation(const String& filename, Mat& img)
+static void ApplyExifOrientation(ExifEntry_t orientationTag, Mat& img)
 {
     int orientation = IMAGE_ORIENTATION_TL;
 
-    if (filename.size() > 0)
+    if (orientationTag.tag != INVALID_TAG)
     {
-        std::ifstream stream( filename.c_str(), std::ios_base::in | std::ios_base::binary );
-        ExifReader reader( stream );
-        if( reader.parse() )
-        {
-            ExifEntry_t entry = reader.getTag( ORIENTATION );
-            if (entry.tag != INVALID_TAG)
-            {
-                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-            }
-        }
-        stream.close();
+        orientation = orientationTag.field_u16; //orientation is unsigned short, so check field_u16
+        ExifTransform(orientation, img);
     }
-
-    ExifTransform(orientation, img);
-}
-
-static void ApplyExifOrientation(const Mat& buf, Mat& img)
-{
-    int orientation = IMAGE_ORIENTATION_TL;
-
-    if( buf.isContinuous() )
-    {
-        ByteStreamBuffer bsb( reinterpret_cast<char*>(buf.data), buf.total() * buf.elemSize() );
-        std::istream stream( &bsb );
-        ExifReader reader( stream );
-        if( reader.parse() )
-        {
-            ExifEntry_t entry = reader.getTag( ORIENTATION );
-            if (entry.tag != INVALID_TAG)
-            {
-                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-            }
-        }
-    }
-
-    ExifTransform(orientation, img);
 }
 
 /**
@@ -537,6 +504,12 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0 )
         resize( *mat, *mat, Size( size.width / scale_denom, size.height / scale_denom ), 0, 0, INTER_LINEAR_EXACT);
     }
 
+    /// optionally rotate the data if EXIF orientation flag says so
+    if( mat && !mat->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    {
+        ApplyExifOrientation(decoder->getExifTag(ORIENTATION), *mat);
+    }
+
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
         hdrtype == LOAD_IMAGE ? (void*)image : (void*)mat;
 }
@@ -634,7 +607,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats)
         // optionally rotate the data if EXIF' orientation flag says so
         if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
         {
-            ApplyExifOrientation(filename, mat);
+            ApplyExifOrientation(decoder->getExifTag(ORIENTATION), mat);
         }
 
         mats.push_back(mat);
@@ -664,12 +637,6 @@ Mat imread( const String& filename, int flags )
 
     /// load the data
     imread_( filename, flags, LOAD_MAT, &img );
-
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(filename, img);
-    }
 
     /// return a reference to the data
     return img;
@@ -932,6 +899,12 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
         resize( *mat, *mat, Size( size.width / scale_denom, size.height / scale_denom ), 0, 0, INTER_LINEAR_EXACT);
     }
 
+    /// optionally rotate the data if EXIF' orientation flag says so
+    if (!mat->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED)
+    {
+        ApplyExifOrientation(decoder->getExifTag(ORIENTATION), *mat);
+    }
+
     decoder.release();
 
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
@@ -946,12 +919,6 @@ Mat imdecode( InputArray _buf, int flags )
     Mat buf = _buf.getMat(), img;
     imdecode_( buf, flags, LOAD_MAT, &img );
 
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(buf, img);
-    }
-
     return img;
 }
 
@@ -962,12 +929,6 @@ Mat imdecode( InputArray _buf, int flags, Mat* dst )
     Mat buf = _buf.getMat(), img;
     dst = dst ? dst : &img;
     imdecode_( buf, flags, LOAD_MAT, dst );
-
-    /// optionally rotate the data if EXIF' orientation flag says so
-    if( !dst->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-    {
-        ApplyExifOrientation(buf, *dst);
-    }
 
     return *dst;
 }

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -7,6 +7,12 @@ namespace opencv_test { namespace {
 
 #ifdef HAVE_PNG
 
+#ifdef HAVE_LIBPNG_PNG_H
+#include <libpng/png.h>
+#else
+#include <png.h>
+#endif
+
 TEST(Imgcodecs_Png, write_big)
 {
     const string root = cvtest::TS::ptr()->get_data_path();
@@ -92,6 +98,97 @@ TEST(Imgcodecs_Png, read_color_palette_with_alpha)
     EXPECT_EQ(img.at<Vec3b>(0, 0), Vec3b(0, 0, 255));
     EXPECT_EQ(img.at<Vec3b>(0, 1), Vec3b(0, 0, 255));
 }
+
+#ifdef PNG_eXIf_SUPPORTED
+/**
+ * Test for check whether reading exif orientation tag was processed successfully or not
+ * The test info is the set of 8 images named testExifRotate_{1 to 8}.png
+ * The test image is the square 10x10 points divided by four sub-squares:
+ * (R corresponds to Red, G to Green, B to Blue, W to white)
+ * ---------             ---------
+ * | R | G |             | G | R |
+ * |-------| - (tag 1)   |-------| - (tag 2)
+ * | B | W |             | W | B |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | W | B |             | B | W |
+ * |-------| - (tag 3)   |-------| - (tag 4)
+ * | G | R |             | R | G |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | R | B |             | G | W |
+ * |-------| - (tag 5)   |-------| - (tag 6)
+ * | G | W |             | R | B |
+ * ---------             ---------
+ *
+ * ---------             ---------
+ * | W | G |             | B | R |
+ * |-------| - (tag 7)   |-------| - (tag 8)
+ * | B | R |             | W | G |
+ * ---------             ---------
+ *
+ *
+ * Every image contains exif field with orientation tag (0x112)
+ * After reading each image and applying the orientation tag,
+ * the resulting image should be:
+ * ---------
+ * | R | G |
+ * |-------|
+ * | B | W |
+ * ---------
+ *
+ */
+
+typedef testing::TestWithParam<string> Imgcodecs_PNG_Exif;
+
+// Solution to issue 16579: PNG read doesn't support Exif orientation data
+TEST_P(Imgcodecs_PNG_Exif, exif_orientation)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + GetParam();
+    const int colorThresholdHigh = 250;
+    const int colorThresholdLow = 5;
+
+    Mat m_img = imread(filename);
+    ASSERT_FALSE(m_img.empty());
+    Vec3b vec;
+
+    //Checking the first quadrant (with supposed red)
+    vec = m_img.at<Vec3b>(2, 2); //some point inside the square
+    EXPECT_LE(vec.val[0], colorThresholdLow);
+    EXPECT_LE(vec.val[1], colorThresholdLow);
+    EXPECT_GE(vec.val[2], colorThresholdHigh);
+
+    //Checking the second quadrant (with supposed green)
+    vec = m_img.at<Vec3b>(2, 7);  //some point inside the square
+    EXPECT_LE(vec.val[0], colorThresholdLow);
+    EXPECT_GE(vec.val[1], colorThresholdHigh);
+    EXPECT_LE(vec.val[2], colorThresholdLow);
+
+    //Checking the third quadrant (with supposed blue)
+    vec = m_img.at<Vec3b>(7, 2);  //some point inside the square
+    EXPECT_GE(vec.val[0], colorThresholdHigh);
+    EXPECT_LE(vec.val[1], colorThresholdLow);
+    EXPECT_LE(vec.val[2], colorThresholdLow);
+}
+
+const string exif_files[] =
+{
+    "readwrite/testExifOrientation_1.png",
+    "readwrite/testExifOrientation_2.png",
+    "readwrite/testExifOrientation_3.png",
+    "readwrite/testExifOrientation_4.png",
+    "readwrite/testExifOrientation_5.png",
+    "readwrite/testExifOrientation_6.png",
+    "readwrite/testExifOrientation_7.png",
+    "readwrite/testExifOrientation_8.png"
+};
+
+INSTANTIATE_TEST_CASE_P(ExifFiles, Imgcodecs_PNG_Exif,
+    testing::ValuesIn(exif_files));
+#endif // PNG_eXIf_SUPPORTED
 
 #endif // HAVE_PNG
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/843

Added Exif parsing for PNG files to support Exif orientation tag.  Moved decoder specific Exif parsing to JPEG and PNG decoders, respectively. Issue 16579

resolves #16579

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X ] I agree to contribute to the project under Apache 2 License.
- [X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X ] The PR is proposed to proper branch
- [X ] There is reference to original bug report and related work
- [X ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X ] The feature is well documented and sample code can be built with the project CMake

```
opencv_extra=raaldrid-exif_PNG_test_files
```