### PR TITLE
python: also catch general c++ exceptions

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -8,6 +8,8 @@
 #include <opencv2/core/async.hpp>
 #include <opencv2/core/detail/async_promise.hpp>
 
+#include <stdexcept>
+
 namespace cv { namespace utils {
 //! @addtogroup core_utils
 //! @{
@@ -111,6 +113,12 @@ String dumpRange(const Range& argument)
     {
         return format("range: (s=%d, e=%d)", argument.start, argument.end);
     }
+}
+
+CV_WRAP static inline
+void testRaiseGeneralException()
+{
+    throw std::runtime_error("exception text");
 }
 
 CV_WRAP static inline

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -206,6 +206,11 @@ catch (const cv::Exception &e) \
 { \
     pyRaiseCVException(e); \
     return 0; \
+} \
+catch (const std::exception &e) \
+{ \
+    PyErr_SetString(opencv_error, e.what()); \
+    return 0; \
 }
 
 using namespace cv;

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -47,6 +47,12 @@ class Bindings(NewOpenCVTests):
         boost.getMaxDepth()  # from ml::DTrees
         boost.isClassifier()  # from ml::StatModel
 
+    def test_raiseGeneralException(self):
+        with self.assertRaises((cv.error,),
+                            msg='C++ exception is not propagated to Python in the right way') as cm:
+            cv.utils.testRaiseGeneralException()
+        self.assertEqual(str(cm.exception), 'exception text')
+
     def test_redirectError(self):
         try:
             cv.imshow("", None)  # This causes an assert


### PR DESCRIPTION
they might be thrown from third-party code (notably Ogre in the ovis
module).
While Linux is kind enough to print them, they cause instant termination
on Windows.
Arguably, they do not origin from OpenCV itself, but still this helps
understanding what went wrong when calling an OpenCV function.

@andy-held 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- n/a There is reference to original bug report and related work
- n/a There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1,linux-4,linux-6
```