### PR TITLE
Guard non-free usage in stitching as contrib can be built without it

### DIFF
--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -44,7 +44,7 @@
 
 namespace opencv_test { namespace {
 
-#ifdef HAVE_OPENCV_XFEATURES2D
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 
 TEST(SurfFeaturesFinder, CanFindInROIs)
 {
@@ -74,7 +74,7 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
     ASSERT_EQ(bad_count, 0);
 }
 
-#endif // HAVE_OPENCV_XFEATURES2D
+#endif // HAVE_OPENCV_XFEATURES2D && OPENCV_ENABLE_NONFREE
 
 TEST(ParallelFeaturesFinder, IsSameWithSerial)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
