### PR TITLE
cmake(TBB): fix target_compile_definitions() with "UNKNOWN" target

### DIFF
--- a/cmake/OpenCVDetectTBB.cmake
+++ b/cmake/OpenCVDetectTBB.cmake
@@ -85,7 +85,11 @@ function(ocv_tbb_env_guess _found)
     if(NOT (TBB_INTERFACE_VERSION LESS 12000))  # >= 12000, oneTBB 2021+
       # avoid "defaultlib" requirement of tbb12.lib (we are using absolute path to 'tbb.lib' only)
       # https://github.com/oneapi-src/oneTBB/blame/2dba2072869a189b9fdab3ffa431d3ea49059a19/include/oneapi/tbb/detail/_config.h#L334
-      target_compile_definitions(tbb INTERFACE "__TBB_NO_IMPLICIT_LINKAGE=1")
+      if(NOT (CMAKE_VERSION VERSION_LESS "3.16.0"))  # https://gitlab.kitware.com/cmake/cmake/-/issues/19434
+        target_compile_definitions(tbb INTERFACE "__TBB_NO_IMPLICIT_LINKAGE=1")
+      else()
+        set_target_properties(tbb PROPERTIES INTERFACE_COMPILE_OPTIONS "__TBB_NO_IMPLICIT_LINKAGE=1")
+      endif()
     endif()
     message(STATUS "Found TBB (env): ${TBB_ENV_LIB}")
     set(${_found} TRUE PARENT_SCOPE)


### PR DESCRIPTION
relates #19447

- https://gitlab.kitware.com/cmake/cmake/-/issues/19434 (requires CMake 3.16+)

To support Ubuntu 16.04 (CMake 3.5.x) / 18.04 (CMake 3.10.x).
Ubuntu 20.04 has CMake 3.16.3.

Error message:
```
target_compile_definitions called with non-compilable target type
```

<cut/>

-------

```
build_image:Custom Win=oneapi_tbb-2021.1.1
```