### PR TITLE
core(cuda.hpp): fix GpuMatND compilation with GCC < 5

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -452,8 +452,16 @@ public:
     GpuMatND(const GpuMatND&) = default;
     GpuMatND& operator=(const GpuMatND&) = default;
 
+#if defined(__GNUC__) && __GNUC__ < 5
+    // error: function '...' defaulted on its first declaration with an exception-specification
+    // that differs from the implicit declaration '...'
+
+    GpuMatND(GpuMatND&&) = default;
+    GpuMatND& operator=(GpuMatND&&) = default;
+#else
     GpuMatND(GpuMatND&&) noexcept = default;
     GpuMatND& operator=(GpuMatND&&) noexcept = default;
+#endif
 
     void upload(InputArray src);
     void upload(InputArray src, Stream& stream);


### PR DESCRIPTION
relates #19259

Probably relates: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59526

<cut/>

Failed ARMv7 builder (GCC 4.8.x)
```
/build/precommit_armv7/opencv/modules/core/include/opencv2/core/cuda.hpp:456:15: error: function 'cv::cuda::GpuMatND& cv::cuda::GpuMatND::operator=(cv::cuda::GpuMatND&&)' defaulted on its first declaration with an exception-specification that differs from the implicit declaration 'cv::cuda::GpuMatND& cv::cuda::GpuMatND::operator=(cv::cuda::GpuMatND&&)'
     GpuMatND& operator=(GpuMatND&&) noexcept = default;
               ^
```

Failed CentOS 7:
```
/build/precommit_custom_linux/opencv/modules/core/include/opencv2/core/cuda.hpp:456:15: error: function 'cv::cuda::GpuMatND& cv::cuda::GpuMatND::operator=(cv::cuda::GpuMatND&&)' defaulted on its first declaration with an exception-specification that differs from the implicit declaration 'cv::cuda::GpuMatND& cv::cuda::GpuMatND::operator=(cv::cuda::GpuMatND&&)'
     GpuMatND& operator=(GpuMatND&&) noexcept = default;
               ^
```

---

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1,linux-4,linux-6
```