### PR TITLE
highgui(pollKey): properly handle no-GUI case

### DIFF
--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -297,7 +297,17 @@ int cv::waitKey(int delay)
     return (code != -1) ? (code & 0xff) : -1;
 }
 
-// NOTE: cv::pollKey has no C API equivalent. it is implemented in each backend source file.
+#if defined(HAVE_WIN32UI)
+// pollKey() implemented in window_w32.cpp
+#elif defined(HAVE_GTK) || defined(HAVE_COCOA) || defined(HAVE_QT) || (defined (WINRT) && !defined (WINRT_8_0))
+// pollKey() fallback implementation
+int cv::pollKey()
+{
+    CV_TRACE_FUNCTION();
+    // fallback. please implement a proper polling function
+    return cvWaitKey(1);
+}
+#endif
 
 int cv::createTrackbar(const String& trackbarName, const String& winName,
                    int* value, int count, TrackbarCallback callback,
@@ -789,6 +799,10 @@ CV_IMPL int cvCreateButton(const char*, void (*)(int, void*), void*, int, int)
     CV_NO_GUI_ERROR("cvCreateButton");
 }
 
+int cv::pollKey()
+{
+    CV_NO_GUI_ERROR("cv::pollKey()");
+}
 
 #endif
 

--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -382,13 +382,6 @@ CV_IMPL int cvWaitKey(int delay)
 }
 
 
-int cv::pollKey()
-{
-    CV_TRACE_FUNCTION();
-    // fallback. please implement a proper polling function
-    return cvWaitKey(1);
-}
-
 //Yannick Verdie
 //This function is experimental and some functions (such as cvSet/getWindowProperty will not work)
 //We recommend not using this function for now

--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -632,13 +632,6 @@ CV_IMPL int cvWaitKey (int maxWait)
     return returnCode;
 }
 
-int cv::pollKey()
-{
-    CV_TRACE_FUNCTION();
-    // fallback. please implement a proper polling function
-    return cvWaitKey(1);
-}
-
 CvRect cvGetWindowRect_COCOA( const char* name )
 {
     CvRect result = cvRect(-1, -1, -1, -1);

--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -1950,13 +1950,6 @@ CV_IMPL int cvWaitKey( int delay )
     return last_key;
 }
 
-int cv::pollKey()
-{
-    CV_TRACE_FUNCTION();
-    // fallback. please implement a proper polling function
-    return cvWaitKey(1);
-}
-
 
 #endif  // HAVE_GTK
 #endif  // _WIN32

--- a/modules/highgui/src/window_winrt.cpp
+++ b/modules/highgui/src/window_winrt.cpp
@@ -205,14 +205,6 @@ CV_IMPL int cvGetTrackbarPos(const char* trackbar_name, const char* window_name)
 
 /********************************** Not YET implemented API ****************************************************/
 
-int cv::pollKey()
-{
-    CV_TRACE_FUNCTION();
-    CV_WINRT_NO_GUI_ERROR("cvPollKey");
-
-    // TODO: implement appropriate logic here
-}
-
 CV_IMPL int cvWaitKey(int delay)
 {
     CV_WINRT_NO_GUI_ERROR("cvWaitKey");


### PR DESCRIPTION
relates #19411

Fix missing `pollKey()` definition in case of no-GUI builds

[ARMv7 builder](http://pullrequest.opencv.org/buildbot/builders/precommit_armv7/builds/12983):
```
    import cv2 as cv
ImportError: /home/build/work/master/build/lib/cv2.so: undefined symbol: _ZN2cv7pollKeyEv
```