### PR TITLE
TanH darknet and test

### DIFF
--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -241,6 +241,10 @@ namespace cv {
                     {
                         activation_param.type = "Sigmoid";
                     }
+                    else if (type == "tanh")
+                    {
+                        activation_param.type = "TanH";
+                    }
                     else
                     {
                         CV_Error(cv::Error::StsParseError, "Unsupported activation: " + type);

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -702,6 +702,11 @@ TEST_P(Test_Darknet_layers, mish)
     testDarknetLayer("mish", true);
 }
 
+TEST_P(Test_Darknet_layers, tanh)
+{
+    testDarknetLayer("tanh");
+}
+
 TEST_P(Test_Darknet_layers, avgpool_softmax)
 {
     testDarknetLayer("avgpool_softmax");


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/847

This PR resolves the issue  #19393  and the test data is added in opencv_extra through PR[ #opencv/opencv_extra/pull/847](https://github.com/opencv/opencv_extra/pull/847)

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
opencv_extra=tanh_darlnet_testdata

force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.2.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```