### PR TITLE
Added TF add behaviour alignment

### DIFF
--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -235,6 +235,23 @@ Range normalize_axis_range(const Range& r, int axisSize)
     return clamped;
 }
 
+static inline
+bool isAllOnes(const MatShape &inputShape, int startPos, int endPos)
+{
+    CV_Assert(!inputShape.empty());
+
+    CV_CheckGE((int) inputShape.size(), startPos, "");
+    CV_CheckGE(startPos, 0, "");
+    CV_CheckLE(startPos, endPos, "");
+    CV_CheckLE((size_t)endPos, inputShape.size(), "");
+
+    for (size_t i = startPos; i < endPos; i++)
+    {
+        if (inputShape[i] != 1)
+            return false;
+    }
+    return true;
+}
 CV__DNN_EXPERIMENTAL_NS_END
 }
 }

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -207,11 +207,6 @@ TEST_P(Test_TensorFlow_layers, eltwise)
 
 TEST_P(Test_TensorFlow_layers, eltwise_add_vec)
 {
-    if (target == DNN_TARGET_OPENCL_FP16)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
-    if (target == DNN_TARGET_OPENCL)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
-
     runTensorFlowNet("eltwise_add_vec");
 }
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -205,6 +205,16 @@ TEST_P(Test_TensorFlow_layers, eltwise)
     runTensorFlowNet("eltwise_sub");
 }
 
+TEST_P(Test_TensorFlow_layers, eltwise_add_vec)
+{
+    if (target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
+    runTensorFlowNet("eltwise_add_vec");
+}
+
 TEST_P(Test_TensorFlow_layers, channel_broadcast)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)


### PR DESCRIPTION
**Merge with extra**: opencv/opencv_extra#849

**Fixes** #17364: inappropriate OpenCV processing of specific tensor summation case in [LaneNet](https://github.com/MaybeShewill-CV/lanenet-lane-detection) BiseNetv2 front end.

Added [tf.math.add](https://www.tensorflow.org/api_docs/python/tf/math/add) and OCV [`eltwise_layer` ](https://github.com/opencv/opencv/blob/master/modules/dnn/src/layers/eltwise_layer.cpp)behaviour alignment.

The initial problem problem is incorrect processing of the case, when, for example, there are two tensors: `a` (shape: [1,1,1,n] ) and `b`  (shape: [1,<some_val_1>,<some_val_2>,n]  ). [ `tf.math.add`](https://www.tensorflow.org/api_docs/python/tf/math/add) returns the result `c` (shape: [1,<some_val_1>,<some_val_2>,n] ), whereas OpenCV compares `1` vs ` <some_val_1>` and  `1` vs` <some_val_2>`, throws exception in ``getMemoryShapes()`` and that's all.
The solution for such cases (for example, for tensor shape ``1x10x1x1 (NxCxHxW)`` +``1x10x5x5 (NxCxHxW)``) was:
1. choose the correct output resultant shape: ``1x10x5x5 (NxCxHxW)``
2. expand ``1x10x1x1 (NxCxHxW)`` for further correct summation with ``1x10x5x5 (NxCxHxW)``.
The initial problem problem is incorrect processing of the case, when, for example, there are two tensors: `a` (shape: [1,1,1,n] ) and `b`  (shape: [1,<some_val_1>,<some_val_2>,n]  ). [ `tf.math.add`](https://www.tensorflow.org/api_docs/python/tf/math/add) returns the result `c` (shape: [1,<some_val_1>,<some_val_2>,n] ), whereas OpenCV compares `1` vs ` <some_val_1>` and  `1` vs` <some_val_2>`, throws exception in ``getMemoryShapes()`` and that's all.
The solution for such cases (for example, for tensor shape ``1x10x1x1 (NxCxHxW)`` +``1x10x5x5 (NxCxHxW)``) was:
1. choose the correct output resultant shape: ``1x10x5x5 (NxCxHxW)``
2. expand ``1x10x1x1 (NxCxHxW)`` for further correct summation with ``1x10x5x5 (NxCxHxW)``.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```