### PR TITLE
Disable thread sanitization check when CV_USE_GLOBAL_WORKERS_COND_VAR is not set.

### DIFF
--- a/modules/core/src/parallel_impl.cpp
+++ b/modules/core/src/parallel_impl.cpp
@@ -382,6 +382,16 @@ public:
 };
 
 
+// Disable thread sanitization check when CV_USE_GLOBAL_WORKERS_COND_VAR is not
+// set because it triggers as the main thread reads isActive while the children
+// thread writes it (but it all works out because a mutex is locked in the main
+// thread and isActive re-checked).
+// This is to solve issue #19463.
+#if !defined(CV_USE_GLOBAL_WORKERS_COND_VAR) && defined(__clang__) && defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+__attribute__((no_sanitize("thread")))
+#endif
+#endif
 void WorkerThread::thread_body()
 {
     (void)cv::utils::getThreadID(); // notify OpenCV about new thread


### PR DESCRIPTION
This fixes #19463

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

```
force_builders=linux,docs,mac,ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1,linux-4,linux-6
```