### PR TITLE
[hal][neon] Optimize the v_dotprod_fast intrinsics for aarch64.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -74,6 +74,8 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 // [2] https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
 #if defined(__ARM_64BIT_STATE) || defined(_M_ARM64)
 #define CV_NEON_AARCH64 1
+#else
+#define CV_NEON_AARCH64 0
 #endif
 
 // TODO

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -726,41 +726,61 @@ inline v_float64x2 v_dotprod_expand(const v_int32x4& a,   const v_int32x4& b,
 // 16 >> 32
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b)
 {
+#ifdef CV_SIMD128_64F
+    int32x4_t p = vmull_s16(vget_low_s16(a.val), vget_low_s16(b.val));
+    return v_int32x4(vmlal_high_s16(p, a.val, b.val));
+#else
     int16x4_t a0 = vget_low_s16(a.val);
     int16x4_t a1 = vget_high_s16(a.val);
     int16x4_t b0 = vget_low_s16(b.val);
     int16x4_t b1 = vget_high_s16(b.val);
     int32x4_t p = vmull_s16(a0, b0);
     return v_int32x4(vmlal_s16(p, a1, b1));
+#endif
 }
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b, const v_int32x4& c)
 {
+#ifdef CV_SIMD128_64F
+    int32x4_t p = vmlal_s16(c.val, vget_low_s16(a.val), vget_low_s16(b.val));
+    return v_int32x4(vmlal_high_s16(p, a.val, b.val));
+#else
     int16x4_t a0 = vget_low_s16(a.val);
     int16x4_t a1 = vget_high_s16(a.val);
     int16x4_t b0 = vget_low_s16(b.val);
     int16x4_t b1 = vget_high_s16(b.val);
     int32x4_t p = vmlal_s16(c.val, a0, b0);
     return v_int32x4(vmlal_s16(p, a1, b1));
+#endif
 }
 
 // 32 >> 64
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 {
+#ifdef CV_SIMD128_64F
+    int64x2_t p = vmull_s32(vget_low_s32(a.val), vget_low_s32(b.val));
+    return v_int64x2(vmlal_high_s32(p, a.val, b.val));
+#else
     int32x2_t a0 = vget_low_s32(a.val);
     int32x2_t a1 = vget_high_s32(a.val);
     int32x2_t b0 = vget_low_s32(b.val);
     int32x2_t b1 = vget_high_s32(b.val);
     int64x2_t p = vmull_s32(a0, b0);
     return v_int64x2(vmlal_s32(p, a1, b1));
+#endif
 }
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b, const v_int64x2& c)
 {
+#ifdef CV_SIMD128_64F
+  int64x2_t p = vmlal_s32(c.val, vget_low_s32(a.val), vget_low_s32(b.val));
+  return v_int64x2(vmlal_high_s32(p, a.val, b.val));
+#else
     int32x2_t a0 = vget_low_s32(a.val);
     int32x2_t a1 = vget_high_s32(a.val);
     int32x2_t b0 = vget_low_s32(b.val);
     int32x2_t b1 = vget_high_s32(b.val);
     int64x2_t p = vmlal_s32(c.val, a0, b0);
     return v_int64x2(vmlal_s32(p, a1, b1));
+#endif
 }
 
 // 8 >> 32
@@ -1292,7 +1312,11 @@ inline int64 v_reduce_sum(const v_int64x2& a)
 #if CV_SIMD128_64F
 inline double v_reduce_sum(const v_float64x2& a)
 {
+#ifdef __aarch64__
+  return vaddvq_f64(a.val);
+#else
     return vgetq_lane_f64(a.val, 0) + vgetq_lane_f64(a.val, 1);
+#endif
 }
 #endif
 

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -726,7 +726,7 @@ inline v_float64x2 v_dotprod_expand(const v_int32x4& a,   const v_int32x4& b,
 // 16 >> 32
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b)
 {
-#ifdef CV_SIMD128_64F
+#if CV_SIMD128_64F
     int32x4_t p = vmull_s16(vget_low_s16(a.val), vget_low_s16(b.val));
     return v_int32x4(vmlal_high_s16(p, a.val, b.val));
 #else
@@ -740,7 +740,7 @@ inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b)
 }
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b, const v_int32x4& c)
 {
-#ifdef CV_SIMD128_64F
+#if CV_SIMD128_64F
     int32x4_t p = vmlal_s16(c.val, vget_low_s16(a.val), vget_low_s16(b.val));
     return v_int32x4(vmlal_high_s16(p, a.val, b.val));
 #else
@@ -756,7 +756,7 @@ inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b, const v_
 // 32 >> 64
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 {
-#ifdef CV_SIMD128_64F
+#if CV_SIMD128_64F
     int64x2_t p = vmull_s32(vget_low_s32(a.val), vget_low_s32(b.val));
     return v_int64x2(vmlal_high_s32(p, a.val, b.val));
 #else
@@ -770,7 +770,7 @@ inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 }
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b, const v_int64x2& c)
 {
-#ifdef CV_SIMD128_64F
+#if CV_SIMD128_64F
   int64x2_t p = vmlal_s32(c.val, vget_low_s32(a.val), vget_low_s32(b.val));
   return v_int64x2(vmlal_high_s32(p, a.val, b.val));
 #else

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -771,8 +771,8 @@ inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b, const v_int64x2& c)
 {
 #if CV_SIMD128_64F
-  int64x2_t p = vmlal_s32(c.val, vget_low_s32(a.val), vget_low_s32(b.val));
-  return v_int64x2(vmlal_high_s32(p, a.val, b.val));
+    int64x2_t p = vmlal_s32(c.val, vget_low_s32(a.val), vget_low_s32(b.val));
+    return v_int64x2(vmlal_high_s32(p, a.val, b.val));
 #else
     int32x2_t a0 = vget_low_s32(a.val);
     int32x2_t a1 = vget_high_s32(a.val);
@@ -1312,11 +1312,7 @@ inline int64 v_reduce_sum(const v_int64x2& a)
 #if CV_SIMD128_64F
 inline double v_reduce_sum(const v_float64x2& a)
 {
-#ifdef __aarch64__
-  return vaddvq_f64(a.val);
-#else
-    return vgetq_lane_f64(a.val, 0) + vgetq_lane_f64(a.val, 1);
-#endif
+    return vaddvq_f64(a.val);
 }
 #endif
 

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -62,6 +62,20 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 #define CV_SIMD128_64F 0
 #endif
 
+// The following macro checks if the code is being compiled for the
+// AArch64 execution state of Armv8, to enable the 128-bit
+// intrinsics. The macro `__ARM_64BIT_STATE` is the one recommended by
+// the Arm C Language Extension (ACLE) specifications [1] to check the
+// availability of 128-bit intrinsics, and it is supporrted by clang
+// and gcc. The macro `_M_ARM64` is the equivalent one for Microsoft
+// Visual Studio [2] .
+//
+// [1] https://developer.arm.com/documentation/101028/0012/13--Advanced-SIMD--Neon--intrinsics
+// [2] https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+#if defined(__ARM_64BIT_STATE) || defined(_M_ARM64)
+#define CV_NEON_AARCH64 1
+#endif
+
 // TODO
 #define CV_NEON_DOT 0
 
@@ -726,7 +740,7 @@ inline v_float64x2 v_dotprod_expand(const v_int32x4& a,   const v_int32x4& b,
 // 16 >> 32
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b)
 {
-#if CV_SIMD128_64F
+#if CV_NEON_AARCH64
     int32x4_t p = vmull_s16(vget_low_s16(a.val), vget_low_s16(b.val));
     return v_int32x4(vmlal_high_s16(p, a.val, b.val));
 #else
@@ -740,7 +754,7 @@ inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b)
 }
 inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b, const v_int32x4& c)
 {
-#if CV_SIMD128_64F
+#if CV_NEON_AARCH64
     int32x4_t p = vmlal_s16(c.val, vget_low_s16(a.val), vget_low_s16(b.val));
     return v_int32x4(vmlal_high_s16(p, a.val, b.val));
 #else
@@ -756,7 +770,7 @@ inline v_int32x4 v_dotprod_fast(const v_int16x8& a, const v_int16x8& b, const v_
 // 32 >> 64
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 {
-#if CV_SIMD128_64F
+#if CV_NEON_AARCH64
     int64x2_t p = vmull_s32(vget_low_s32(a.val), vget_low_s32(b.val));
     return v_int64x2(vmlal_high_s32(p, a.val, b.val));
 #else
@@ -770,7 +784,7 @@ inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b)
 }
 inline v_int64x2 v_dotprod_fast(const v_int32x4& a, const v_int32x4& b, const v_int64x2& c)
 {
-#if CV_SIMD128_64F
+#if CV_NEON_AARCH64
     int64x2_t p = vmlal_s32(c.val, vget_low_s32(a.val), vget_low_s32(b.val));
     return v_int64x2(vmlal_high_s32(p, a.val, b.val));
 #else


### PR DESCRIPTION
On Armv8 in AArch64 execution mode, we can skip the sequence

```
   v<op>_<ty>(vget_high_<ty>(x), vget_high_<ty>(y))
```

in favour of

```
   v<op>_high_<ty>(x, y)
```

This has better changes for recent compilers to use less data movement
operations and better register allocation. See for example:

   https://godbolt.org/z/bPq7vd

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ X ] I agree to contribute to the project under Apache 2 License.
- [ X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ X ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs,ARMv8,ARMv7
```