### PR TITLE
Not not test stitiching with SURF, if NONFREE is disabled

### DIFF
--- a/modules/stitching/perf/opencl/perf_stitch.cpp
+++ b/modules/stitching/perf/opencl/perf_stitch.cpp
@@ -19,7 +19,7 @@ namespace ocl {
 
 typedef TestBaseWithParam<string> stitch;
 
-#ifdef HAVE_OPENCV_XFEATURES2D
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 #define TEST_DETECTORS testing::Values("surf", "orb", "akaze")
 #else
 #define TEST_DETECTORS testing::Values("orb", "akaze")

--- a/modules/stitching/perf/perf_estimators.cpp
+++ b/modules/stitching/perf/perf_estimators.cpp
@@ -8,7 +8,7 @@ using namespace perf;
 
 typedef TestBaseWithParam<tuple<string, string> > bundleAdjuster;
 
-#ifdef HAVE_OPENCV_XFEATURES2D
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 #define TEST_DETECTORS testing::Values("surf", "orb")
 #else
 #define TEST_DETECTORS testing::Values<string>("orb")

--- a/modules/stitching/perf/perf_matchers.cpp
+++ b/modules/stitching/perf/perf_matchers.cpp
@@ -17,7 +17,7 @@ typedef TestBaseWithParam<matchVector_t> matchVector;
 #define ORB_MATCH_CONFIDENCE  0.3f
 #define WORK_MEGAPIX 0.6
 
-#ifdef HAVE_OPENCV_XFEATURES2D
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 #define TEST_DETECTORS testing::Values("surf", "orb")
 #else
 #define TEST_DETECTORS testing::Values<string>("orb")

--- a/modules/stitching/perf/perf_precomp.hpp
+++ b/modules/stitching/perf/perf_precomp.hpp
@@ -11,8 +11,10 @@ static inline Ptr<detail::FeaturesFinder> getFeatureFinder(const std::string& na
 {
     if (name == "orb")
         return makePtr<detail::OrbFeaturesFinder>();
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
     else if (name == "surf")
         return makePtr<detail::SurfFeaturesFinder>();
+#endif
     else if (name == "akaze")
         return makePtr<detail::AKAZEFeaturesFinder>();
     else

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -16,7 +16,7 @@ typedef TestBaseWithParam<string> stitch;
 typedef TestBaseWithParam<int> stitchExposureCompensation;
 typedef TestBaseWithParam<tuple<string, string> > stitchDatasets;
 
-#ifdef HAVE_OPENCV_XFEATURES2D
+#if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 #define TEST_DETECTORS testing::Values("surf", "orb", "akaze")
 #else
 #define TEST_DETECTORS testing::Values("orb", "akaze")


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
