### PR TITLE
Fix ransac issue "SolvePnPRansac Fails because calls to solvePnP with less than 6 points"

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -318,7 +318,11 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                       distCoeffs, rvec, tvec, useExtrinsicGuess,
                       (flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P) ? SOLVEPNP_EPNP : flags) ? 1 : -1;
     }
-    catch(...){
+    catch(const cv::Exception& e)
+    {
+        CV_LOG_DEBUG(e.what());
+        CV_LOG_DEBUG(NULL, "Broken implementation for DLT algorithm needs at least 6 points for pose estimation. Fallback to EPnP.");
+
         _rvec.assign(_local_model.col(0));
         _tvec.assign(_local_model.col(1));
 
@@ -332,8 +336,6 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
             }
             _local_inliers.copyTo(_inliers);
         }
-
-        CV_LOG_DEBUG(NULL, "SOLVEPNP_ITERATIVE failed for there is no coplanaer data and DLT algorithm needs at least 6 points. Return EPnP's result.");
 
         return true;
     }

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -311,9 +311,32 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
     opoints_inliers.resize(npoints1);
     ipoints_inliers.resize(npoints1);
-    result = solvePnP(opoints_inliers, ipoints_inliers, cameraMatrix,
+
+    try
+    {
+        result = solvePnP(opoints_inliers, ipoints_inliers, cameraMatrix,
                       distCoeffs, rvec, tvec, useExtrinsicGuess,
                       (flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P) ? SOLVEPNP_EPNP : flags) ? 1 : -1;
+    }
+    catch(...){
+        _rvec.assign(_local_model.col(0));
+        _tvec.assign(_local_model.col(1));
+
+        if(_inliers.needed())
+        {
+            Mat _local_inliers;
+            for (int i = 0; i < npoints; ++i)
+            {
+                if((int)_mask_local_inliers.at<uchar>(i) != 0) // inliers mask
+                    _local_inliers.push_back(i);    // output inliers vector
+            }
+            _local_inliers.copyTo(_inliers);
+        }
+
+        CV_LOG_DEBUG(NULL, "SOLVEPNP_ITERATIVE failed for there is no coplanaer data and DLT algorithm needs at least 6 points. Return EPnP's result.");
+
+        return true;
+    }
 
     if( result <= 0 )
     {

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -2221,4 +2221,48 @@ TEST(Calib3d_SolvePnP, inputShape)
     }
 }
 
+TEST(Calib3d_SolvePnPRansac, badInputPoints)
+{
+    // https://github.com/opencv/opencv/issues/17799
+    vector<Point3f> pts3ds;
+    vector<Point2f> pts2ds;
+    Mat rvec_est_iterative, tvec_est_iterative;
+    Mat rvec_est_epnp, tvec_est_epnp;
+    Mat camera_mat = Mat::zeros(3, 3, CV_32FC1);
+    camera_mat.at<float>(0, 0) = 741.341;
+    camera_mat.at<float>(0, 2) = 484.054;
+    camera_mat.at<float>(1, 1) = 741.341;
+    camera_mat.at<float>(1, 2) = 353.712;
+    camera_mat.at<float>(2, 2) = 1.f;
+
+    pts3ds = {
+        {-2.38359, -1.8294, 5.84055},{0.269438, -3.55329, 6.38706},
+        {1.32004, -3.59713, 6.26518},{0.653517, -3.20692, 6.36725},
+        {1.14937, -3.42034, 5.69143},{1.33856, -3.34351, 5.82228},
+        {1.3699, -3.35232, 5.66638},{-0.128751, -2.37403, 5.87024},
+        {-0.192395, -2.26672, 5.77338},{0.248772, -2.42177, 5.80129},
+        {-0.0280549, -2.16775, 5.59574},{-0.186872, -2.00519, 5.98443},
+        {-0.0836972, -1.8935, 5.96695},{0.128314, -1.84086, 5.91907},
+        {1.80947, -4.24816, 6.70636}
+    };
+
+    pts2ds = {
+        {95, 130},{539, 134},
+        {650, 184},{555, 198},
+        {642, 208},{660, 223},
+        {668, 224},{409, 287},
+        {392, 304},{466, 305},
+        {57, 334},{39, 335},
+        {403, 360},{415, 366},
+        {913, 473}
+    };
+
+    vector<int> inliers;
+    solvePnPRansac(pts3ds, pts2ds, cv::InputArray(camera_mat), cv::Mat(), rvec_est_iterative, tvec_est_iterative, false, 1000, 2, 0.99, inliers);
+    solvePnPRansac(pts3ds, pts2ds, cv::InputArray(camera_mat), cv::Mat(), rvec_est_epnp, tvec_est_epnp, false, 1000, 2, 0.99, inliers, SOLVEPNP_EPNP);
+
+    EXPECT_LE(cvtest::norm(rvec_est_iterative, rvec_est_epnp, NORM_INF), 1e-3);
+    EXPECT_LE(cvtest::norm(tvec_est_iterative, tvec_est_epnp, NORM_INF), 1e-3);
+}
+
 }} // namespace


### PR DESCRIPTION
Firstly, I proposed this issue in there.   [issue #17799](https://github.com/opencv/opencv/issues/17799)
I did some amendment based on this [PR](https://github.com/opencv/opencv/pull/19253).

### My solutions:
- return "true" and the EPnP's result when SolvePnPRansac Fails due to there is no coplanaer data and DLT with less than 6 points. Because I think the result of EPnP may be correct, we should leave the right for user to choose whether use or not use the result.
- provide a test data
- provide a log for user

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=linux,docs
```