### PR TITLE
Add Media Frame size function and corresponding tests

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -591,6 +591,12 @@ G_TYPED_KERNEL(GSizeR, <GOpaque<Size>(GOpaque<Rect>)>, "org.opencv.streaming.siz
         return empty_gopaque_desc();
     }
 };
+
+G_TYPED_KERNEL(GSizeMF, <GOpaque<Size>(GFrame)>, "org.opencv.streaming.sizeMF") {
+    static GOpaqueDesc outMeta(const GFrameDesc&) {
+        return empty_gopaque_desc();
+    }
+};
 } // namespace streaming
 
 //! @addtogroup gapi_math
@@ -1940,6 +1946,15 @@ Gets dimensions from rectangle.
 @return Size (rectangle dimensions).
 */
 GAPI_EXPORTS GOpaque<Size> size(const GOpaque<Rect>& r);
+
+/** @brief Gets dimensions from MediaFrame.
+
+@note Function textual ID is "org.opencv.streaming.sizeMF"
+
+@param src Input frame
+@return Size (frame dimensions).
+*/
+GAPI_EXPORTS GOpaque<Size> size(const GFrame& src);
 } //namespace streaming
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -427,5 +427,10 @@ GOpaque<Size> streaming::size(const GOpaque<Rect>& r)
     return streaming::GSizeR::on(r);
 }
 
+GOpaque<Size> streaming::size(const GFrame& src)
+{
+    return streaming::GSizeMF::on(src);
+}
+
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -692,6 +692,16 @@ GAPI_OCV_KERNEL(GCPUSizeR, cv::gapi::streaming::GSizeR)
     }
 };
 
+GAPI_OCV_KERNEL(GCPUSizeMF, cv::gapi::streaming::GSizeMF)
+{
+    static void run(const cv::MediaFrame& in, cv::Size& out)
+    {
+        cv::GFrameDesc desc = in.desc();
+        out.width = desc.size.width;
+        out.height = desc.size.height;
+    }
+};
+
 cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
@@ -771,6 +781,7 @@ cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
          , GCPUParseYolo
          , GCPUSize
          , GCPUSizeR
-         >();
+         , GCPUSizeMF
+        >();
     return pkg;
 }

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -696,9 +696,7 @@ GAPI_OCV_KERNEL(GCPUSizeMF, cv::gapi::streaming::GSizeMF)
 {
     static void run(const cv::MediaFrame& in, cv::Size& out)
     {
-        cv::GFrameDesc desc = in.desc();
-        out.width = desc.size.width;
-        out.height = desc.size.height;
+        out = in.desc().size;
     }
 };
 

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -170,6 +170,7 @@ GAPI_TEST_EXT_BASE_FIXTURE(ParseYoloTest, ParserYoloTest, initNothing,
     FIXTURE_API(float, float, int, std::pair<bool,int>), 4, confidence_threshold, nms_threshold, num_classes, dims_config)
 GAPI_TEST_FIXTURE(SizeTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(SizeRTest, initNothing, <>, 0)
+GAPI_TEST_FIXTURE(SizeMFTest, initNothing, <>, 0)
 } // opencv_test
 
 #endif //OPENCV_GAPI_CORE_TESTS_HPP

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1909,12 +1909,10 @@ TEST_P(SizeRTest, ParseTest)
 namespace {
     class TestMediaBGR final : public cv::MediaFrame::IAdapter {
         cv::Mat m_mat;
-        using Cb = cv::MediaFrame::View::Callback;
-        Cb m_cb;
 
     public:
-        explicit TestMediaBGR(cv::Mat m, Cb cb = []() {})
-            : m_mat(m), m_cb(cb) {
+        explicit TestMediaBGR(cv::Mat m)
+            : m_mat(m) {
         }
         cv::GFrameDesc meta() const override {
             return cv::GFrameDesc{ cv::MediaFormat::BGR, cv::Size(m_mat.cols, m_mat.rows) };
@@ -1922,19 +1920,18 @@ namespace {
         cv::MediaFrame::View access(cv::MediaFrame::Access) override {
             cv::MediaFrame::View::Ptrs pp = { m_mat.ptr(), nullptr, nullptr, nullptr };
             cv::MediaFrame::View::Strides ss = { m_mat.step, 0u, 0u, 0u };
-            return cv::MediaFrame::View(std::move(pp), std::move(ss), Cb{ m_cb });
+            return cv::MediaFrame::View(std::move(pp), std::move(ss));
         }
     };
 };
 
 TEST_P(SizeMFTest, ParseTest)
 {
-    cv::GFrame in;
     cv::Size out_sz;
-    int counter = 0;
     cv::Mat bgr = cv::Mat::eye(sz.height, sz.width, CV_8UC3);
-    cv::MediaFrame frame = cv::MediaFrame::Create<TestMediaBGR>(bgr, [&counter]() {counter++; });
+    cv::MediaFrame frame = cv::MediaFrame::Create<TestMediaBGR>(bgr);
 
+    cv::GFrame in;
     auto out = cv::gapi::streaming::size(in);
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
     c.apply(cv::gin(frame), cv::gout(out_sz), getCompileArgs());

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -617,4 +617,11 @@ INSTANTIATE_TEST_CASE_P(SizeRTestCPU, SizeRTest,
                                        cv::Size(640, 320)),
                                 Values(-1),
                                 Values(CORE_CPU)));
+
+INSTANTIATE_TEST_CASE_P(SizeMFTestCPU, SizeMFTest,
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_32FC1),
+                                Values(cv::Size(32, 32),
+                                       cv::Size(640, 320)),
+                                Values(-1),
+                                Values(CORE_CPU)));
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

``` 
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
// disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```