### PR TITLE
[G-API] Change memory measurement statistic in Fluid tests

### DIFF
--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -863,7 +863,6 @@ uint64_t currMemoryConsumption()
     std::string stat_line;
     std::getline(proc_stat, stat_line);
     uint64_t unused, data_and_stack;
-    // using resident set size
     std::istringstream(stat_line) >> unused >> unused >> unused >> unused >> unused
                                   >> data_and_stack;
     CV_Assert(data_and_stack != 0);

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -862,11 +862,12 @@ uint64_t currMemoryConsumption()
     }
     std::string stat_line;
     std::getline(proc_stat, stat_line);
-    uint64_t unused, rss;
+    uint64_t unused, data_and_stack;
     // using resident set size
-    std::istringstream(stat_line) >> unused >> rss;
-    CV_Assert(rss != 0);
-    return rss;
+    std::istringstream(stat_line) >> unused >> unused >> unused >> unused >> unused
+                                  >> data_and_stack;
+    CV_Assert(data_and_stack != 0);
+    return data_and_stack;
 }
 #else
 // FIXME: implement this part (at least for Windows?), right now it's enough to check Linux only


### PR DESCRIPTION
Based on recent discussion in a related bug report (#19434), let's change the statistic used to measure the "memory consumption" 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=centos:7
buildworker:Custom=linux-1,linux-4,linux-6
test_modules:Custom=gapi
```
