### PR TITLE
[G-API]: Performance tests for kmeans

### DIFF
--- a/modules/gapi/perf/common/gapi_core_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_CORE_PERF_TESTS_HPP
@@ -73,6 +73,12 @@ namespace opencv_test
     class ConcatVertVecPerfTest : public TestPerfParams<tuple<cv::Size, MatType, cv::GCompileArgs>> {};
     class LUTPerfTest : public TestPerfParams<tuple<MatType, MatType, cv::Size, cv::GCompileArgs>> {};
     class ConvertToPerfTest : public TestPerfParams<tuple<compare_f, MatType, int, cv::Size, double, double, cv::GCompileArgs>> {};
+    class KMeansNDPerfTest : public TestPerfParams<tuple<MatType2, cv::Size, CompareMats, int,
+                                                         cv::KmeansFlags, cv::GCompileArgs>> {};
+    class KMeans2DPerfTest : public TestPerfParams<tuple<int, int, cv::KmeansFlags,
+                                                         cv::GCompileArgs>> {};
+    class KMeans3DPerfTest : public TestPerfParams<tuple<int, int, cv::KmeansFlags,
+                                                         cv::GCompileArgs>> {};
     class ResizePerfTest : public TestPerfParams<tuple<compare_f, MatType, int, cv::Size, cv::Size, cv::GCompileArgs>> {};
     class ResizeFxFyPerfTest : public TestPerfParams<tuple<compare_f, MatType, int, cv::Size, double, double, cv::GCompileArgs>> {};
     class ParseSSDBLPerfTest : public TestPerfParams<tuple<cv::Size, float, int, cv::GCompileArgs>>, public ParserSSDTest {};

--- a/modules/gapi/perf/common/gapi_core_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests.hpp
@@ -73,7 +73,7 @@ namespace opencv_test
     class ConcatVertVecPerfTest : public TestPerfParams<tuple<cv::Size, MatType, cv::GCompileArgs>> {};
     class LUTPerfTest : public TestPerfParams<tuple<MatType, MatType, cv::Size, cv::GCompileArgs>> {};
     class ConvertToPerfTest : public TestPerfParams<tuple<compare_f, MatType, int, cv::Size, double, double, cv::GCompileArgs>> {};
-    class KMeansNDPerfTest : public TestPerfParams<tuple<MatType2, cv::Size, CompareMats, int,
+    class KMeansNDPerfTest : public TestPerfParams<tuple<cv::Size, CompareMats, int,
                                                          cv::KmeansFlags, cv::GCompileArgs>> {};
     class KMeans2DPerfTest : public TestPerfParams<tuple<int, int, cv::KmeansFlags,
                                                          cv::GCompileArgs>> {};

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -1909,21 +1909,21 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
 
 PERF_TEST_P_(KMeansNDPerfTest, TestPerformance)
 {
-    MatType2 type = -1;
     cv::Size sz;
     CompareMats cmpF;
     int K = -1;
     cv::KmeansFlags flags = cv::KMEANS_RANDOM_CENTERS;
     cv::GCompileArgs compile_args;
-    std::tie(type, sz, cmpF, K, flags, compile_args) = GetParam();
+    std::tie(sz, cmpF, K, flags, compile_args) = GetParam();
 
+    MatType2 type = CV_32FC1;
     initMatrixRandU(type, sz, -1, false);
 
     double compact_gapi = -1.;
     cv::Mat labels_gapi, centers_gapi;
     if (flags & cv::KMEANS_USE_INITIAL_LABELS)
     {
-        const int amount = sz.height != 1 ? sz.height : sz.width;
+        const int amount = sz.height;
         cv::Mat bestLabels(cv::Size{1, amount}, CV_32SC1);
         cv::randu(bestLabels, 0, K);
 

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_CORE_PERF_TESTS_INL_HPP
@@ -11,6 +11,8 @@
 #include <iostream>
 
 #include "gapi_core_perf_tests.hpp"
+
+#include "../../test/common/gapi_core_tests_common.hpp"
 
 namespace opencv_test
 {
@@ -1900,6 +1902,135 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
     EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
     EXPECT_EQ(out_mat_gapi.size(), sz_in);
 
+    SANITY_CHECK_NOTHING();
+}
+
+//------------------------------------------------------------------------------
+
+PERF_TEST_P_(KMeansNDPerfTest, TestPerformance)
+{
+    MatType2 type = -1;
+    cv::Size sz;
+    CompareMats cmpF;
+    int K = -1;
+    cv::KmeansFlags flags = cv::KMEANS_RANDOM_CENTERS;
+    cv::GCompileArgs compile_args;
+    std::tie(type, sz, cmpF, K, flags, compile_args) = GetParam();
+
+    initMatrixRandU(type, sz, -1, false);
+
+    double compact_gapi = -1.;
+    cv::Mat labels_gapi, centers_gapi;
+    if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+    {
+        const int amount = sz.height != 1 ? sz.height : sz.width;
+        cv::Mat bestLabels(cv::Size{1, amount}, CV_32SC1);
+        cv::randu(bestLabels, 0, K);
+
+        cv::GComputation c(kmeansTestGAPI(in_mat1, bestLabels, K, flags, std::move(compile_args),
+                                          compact_gapi, labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_mat1, bestLabels),
+                    cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestOpenCVCompare(in_mat1, bestLabels, K, flags, compact_gapi, labels_gapi,
+                                centers_gapi, cmpF);
+    }
+    else
+    {
+        cv::GComputation c(kmeansTestGAPI(in_mat1, K, flags, std::move(compile_args), compact_gapi,
+                                          labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_mat1), cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestValidate(sz, type, K, compact_gapi, labels_gapi, centers_gapi);
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(KMeans2DPerfTest, TestPerformance)
+{
+    int amount = -1;
+    int K = -1;
+    cv::KmeansFlags flags = cv::KMEANS_RANDOM_CENTERS;
+    cv::GCompileArgs compile_args;
+    std::tie(amount, K, flags, compile_args) = GetParam();
+
+    std::vector<cv::Point2f> in_vector{};
+    initPointsVectorRandU(amount, in_vector);
+
+    double compact_gapi = -1.;
+    std::vector<int> labels_gapi{};
+    std::vector<cv::Point2f> centers_gapi{};
+    if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+    {
+        std::vector<int> bestLabels(amount);
+        cv::randu(bestLabels, 0, K);
+
+        cv::GComputation c(kmeansTestGAPI(in_vector, bestLabels, K, flags, std::move(compile_args),
+                                          compact_gapi, labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_vector, bestLabels),
+                    cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestOpenCVCompare(in_vector, bestLabels, K, flags, compact_gapi, labels_gapi,
+                                centers_gapi);
+    }
+    else
+    {
+        cv::GComputation c(kmeansTestGAPI(in_vector, K, flags, std::move(compile_args),
+                                          compact_gapi, labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestValidate({-1, amount}, -1, K, compact_gapi, labels_gapi, centers_gapi);
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(KMeans3DPerfTest, TestPerformance)
+{
+    int amount = -1;
+    int K = -1;
+    cv::KmeansFlags flags = cv::KMEANS_RANDOM_CENTERS;
+    cv::GCompileArgs compile_args;
+    std::tie(amount, K, flags, compile_args) = GetParam();
+
+    std::vector<cv::Point3f> in_vector{};
+    initPointsVectorRandU(amount, in_vector);
+
+    double compact_gapi = -1.;
+    std::vector<int> labels_gapi;
+    std::vector<cv::Point3f> centers_gapi;
+    if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+    {
+        std::vector<int> bestLabels(amount);
+        cv::randu(bestLabels, 0, K);
+
+        cv::GComputation c(kmeansTestGAPI(in_vector, bestLabels, K, flags, std::move(compile_args),
+                                          compact_gapi, labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_vector, bestLabels),
+                    cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestOpenCVCompare(in_vector, bestLabels, K, flags, compact_gapi, labels_gapi,
+                                centers_gapi);
+    }
+    else
+    {
+        cv::GComputation c(kmeansTestGAPI(in_vector, K, flags, std::move(compile_args),
+                                          compact_gapi, labels_gapi, centers_gapi));
+        TEST_CYCLE()
+        {
+            c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi));
+        }
+        kmeansTestValidate({-1, amount}, -1, K, compact_gapi, labels_gapi, centers_gapi);
+    }
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
@@ -282,50 +282,32 @@ INSTANTIATE_TEST_CASE_P(ConvertToPerfTestCPU, ConvertToPerfTest,
             Values(0.0),
             Values(cv::compile_args(CORE_CPU))));
 
-INSTANTIATE_TEST_CASE_P(KMeansNDNoInitPerfTestCPU, KMeansNDPerfTest,
-                        Combine(Values(CV_32FC1, CV_32FC3),
-                                Values(cv::Size(1, 20),
-                                       cv::Size(2, 20),
-                                       cv::Size(5, 720)),
+INSTANTIATE_TEST_CASE_P(KMeansNDPerfTestCPU, KMeansNDPerfTest,
+                        Combine(Values(cv::Size(1, 20),
+                                       cv::Size(16, 4096)),
                                 Values(AbsTolerance(0.01).to_compare_obj()),
                                 Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
-                                Values(cv::compile_args(CORE_CPU))));
-
-INSTANTIATE_TEST_CASE_P(KMeansNDInitPerfTestCPU, KMeansNDPerfTest,
-                        Combine(Values(CV_32FC1, CV_32FC3),
-                                Values(cv::Size(1, 20),
-                                       cv::Size(2, 20),
-                                       cv::Size(5, 720)),
-                                Values(AbsTolerance(0.01).to_compare_obj()),
-                                Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                Values(cv::KMEANS_RANDOM_CENTERS,
+                                       cv::KMEANS_PP_CENTERS,
+                                       cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
                                 Values(cv::compile_args(CORE_CPU))));
 
-INSTANTIATE_TEST_CASE_P(KMeans2DNoInitPerfTestCPU, KMeans2DPerfTest,
-                        Combine(Values(20, 720),
+INSTANTIATE_TEST_CASE_P(KMeans2DPerfTestCPU, KMeans2DPerfTest,
+                        Combine(Values(20, 4096),
                                 Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
-                                Values(cv::compile_args(CORE_CPU))));
-
-INSTANTIATE_TEST_CASE_P(KMeans2DInitPerfTestCPU, KMeans2DPerfTest,
-                        Combine(Values(20, 720),
-                                Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                Values(cv::KMEANS_RANDOM_CENTERS,
+                                       cv::KMEANS_PP_CENTERS,
+                                       cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
                                 Values(cv::compile_args(CORE_CPU))));
 
-INSTANTIATE_TEST_CASE_P(KMeans3DNoInitPerfTestCPU, KMeans3DPerfTest,
-                        Combine(Values(20, 720),
+INSTANTIATE_TEST_CASE_P(KMeans3DPerfTestCPU, KMeans3DPerfTest,
+                        Combine(Values(20, 4096),
                                 Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
-                                Values(cv::compile_args(CORE_CPU))));
-
-INSTANTIATE_TEST_CASE_P(KMeans3DInitPerfTestCPU, KMeans3DPerfTest,
-                        Combine(Values(20, 720),
-                                Values(5, 15),
-                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                Values(cv::KMEANS_RANDOM_CENTERS,
+                                       cv::KMEANS_PP_CENTERS,
+                                       cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
                                 Values(cv::compile_args(CORE_CPU))));
 

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #include "../perf_precomp.hpp"
@@ -281,6 +281,53 @@ INSTANTIATE_TEST_CASE_P(ConvertToPerfTestCPU, ConvertToPerfTest,
             Values(2.5, 1.0),
             Values(0.0),
             Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeansNDNoInitPerfTestCPU, KMeansNDPerfTest,
+                        Combine(Values(CV_32FC1, CV_32FC3),
+                                Values(cv::Size(1, 20),
+                                       cv::Size(2, 20),
+                                       cv::Size(5, 720)),
+                                Values(AbsTolerance(0.01).to_compare_obj()),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
+                                Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeansNDInitPerfTestCPU, KMeansNDPerfTest,
+                        Combine(Values(CV_32FC1, CV_32FC3),
+                                Values(cv::Size(1, 20),
+                                       cv::Size(2, 20),
+                                       cv::Size(5, 720)),
+                                Values(AbsTolerance(0.01).to_compare_obj()),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
+                                Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeans2DNoInitPerfTestCPU, KMeans2DPerfTest,
+                        Combine(Values(20, 720),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
+                                Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeans2DInitPerfTestCPU, KMeans2DPerfTest,
+                        Combine(Values(20, 720),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
+                                Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeans3DNoInitPerfTestCPU, KMeans3DPerfTest,
+                        Combine(Values(20, 720),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS),
+                                Values(cv::compile_args(CORE_CPU))));
+
+INSTANTIATE_TEST_CASE_P(KMeans3DInitPerfTestCPU, KMeans3DPerfTest,
+                        Combine(Values(20, 720),
+                                Values(5, 15),
+                                Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
+                                       cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS),
+                                Values(cv::compile_args(CORE_CPU))));
 
 INSTANTIATE_TEST_CASE_P(ResizePerfTestCPU, ResizePerfTest,
     Combine(Values(AbsExact().to_compare_f()),

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_CORE_TESTS_HPP
@@ -151,16 +151,9 @@ GAPI_TEST_FIXTURE(WarpPerspectiveTest, initMatrixRandU,
 GAPI_TEST_FIXTURE(WarpAffineTest, initMatrixRandU,
         FIXTURE_API(CompareMats, double , double, int, int, cv::Scalar),
         6, cmpF, angle, scale, flags, border_mode, border_value)
-GAPI_TEST_FIXTURE(KMeansNDNoInitTest, initMatrixRandU, FIXTURE_API(int, cv::KmeansFlags),
-                  2, K, flags)
-GAPI_TEST_FIXTURE(KMeansNDInitTest, initMatrixRandU,
-                  FIXTURE_API(CompareMats, int, cv::KmeansFlags), 3, cmpF, K, flags)
-GAPI_TEST_FIXTURE(KMeans2DNoInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags),
-                  2, K, flags)
-GAPI_TEST_FIXTURE(KMeans2DInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
-GAPI_TEST_FIXTURE(KMeans3DNoInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags),
-                  2, K, flags)
-GAPI_TEST_FIXTURE(KMeans3DInitTest, initNothing, FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
+GAPI_TEST_FIXTURE(KMeansNDTest, initMatrixRandU, FIXTURE_API(CompareMats, int, cv::KmeansFlags), 3, cmpF, K, flags)
+GAPI_TEST_FIXTURE(KMeans2DTest, initNothing,     FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
+GAPI_TEST_FIXTURE(KMeans3DTest, initNothing,     FIXTURE_API(int, cv::KmeansFlags), 2, K, flags)
 
 GAPI_TEST_EXT_BASE_FIXTURE(ParseSSDBLTest, ParserSSDTest, initNothing,
     FIXTURE_API(float, int), 2, confidence_threshold, filter_label)

--- a/modules/gapi/test/common/gapi_core_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_common.hpp
@@ -126,7 +126,6 @@ void kmeansTestOpenCVCompare(const In& in, const Labels& bestLabels, const int K
 {
     const cv::TermCriteria criteria(cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0);
     const int attempts = 1;
-    double compact_ocv = -1.;
     Labels labels_ocv;
     In centers_ocv;
     { // step to generalize cv::Mat & std::vector cases of bestLabels' types
@@ -134,13 +133,15 @@ void kmeansTestOpenCVCompare(const In& in, const Labels& bestLabels, const int K
         bestLabelsMat.copyTo(labels_ocv);
     }
     // OpenCV code /////////////////////////////////////////////////////////////
-    compact_ocv = cv::kmeans(in, K, labels_ocv, criteria, attempts, flags, centers_ocv);
+    double compact_ocv = cv::kmeans(in, K, labels_ocv, criteria, attempts, flags, centers_ocv);
     // Comparison //////////////////////////////////////////////////////////////
     EXPECT_TRUE(compact_gapi == compact_ocv);
     EXPECT_TRUE(compareKMeansOutputs(labels_gapi, labels_ocv, cmpF));
     EXPECT_TRUE(compareKMeansOutputs(centers_gapi, centers_ocv, cmpF));
 }
 
+// If an input type is cv::Mat, labels' type is also cv::Mat;
+// in other cases, their type has to be std::vector<int>
 template<typename In>
 using KMeansLabelType = typename std::conditional<std::is_same<In, cv::Mat>::value,
                                                   cv::Mat,

--- a/modules/gapi/test/common/gapi_core_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_common.hpp
@@ -1,0 +1,179 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef OPENCV_GAPI_CORE_TESTS_COMMON_HPP
+#define OPENCV_GAPI_CORE_TESTS_COMMON_HPP
+
+#include "gapi_tests_common.hpp"
+#include "../../include/opencv2/gapi/core.hpp"
+
+#include <opencv2/core.hpp>
+
+namespace opencv_test
+{
+namespace
+{
+template <typename Elem, typename CmpF>
+inline bool compareKMeansOutputs(const std::vector<Elem>& outGAPI,
+                                 const std::vector<Elem>& outOCV,
+                                 const CmpF& = AbsExact().to_compare_obj())
+{
+    return AbsExactVector<Elem>().to_compare_f()(outGAPI, outOCV);
+}
+
+inline bool compareKMeansOutputs(const cv::Mat& outGAPI,
+                                 const cv::Mat& outOCV,
+                                 const CompareMats& cmpF)
+{
+    return cmpF(outGAPI, outOCV);
+}
+}
+
+// Overload with initializing the labels
+template<typename Labels, typename In>
+cv::GComputation kmeansTestGAPI(const In& in, const Labels& bestLabels, const int K,
+                                const cv::KmeansFlags flags, cv::GCompileArgs&& args,
+                                double& compact_gapi, Labels& labels_gapi, In& centers_gapi)
+{
+    const cv::TermCriteria criteria(cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0);
+    const int attempts = 1;
+
+    cv::detail::g_type_of_t<In> gIn, centers;
+    cv::GOpaque<double> compactness;
+    cv::detail::g_type_of_t<Labels> inLabels, outLabels;
+    std::tie(compactness, outLabels, centers) =
+        cv::gapi::kmeans(gIn, K, inLabels, criteria, attempts, flags);
+    cv::GComputation c(cv::GIn(gIn, inLabels), cv::GOut(compactness, outLabels, centers));
+    c.apply(cv::gin(in, bestLabels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
+            std::move(args));
+    return c;
+}
+
+// Overload for vector<Point> tests w/o initializing the labels
+template<typename Pt>
+cv::GComputation kmeansTestGAPI(const std::vector<Pt>& in, const int K,
+                                const cv::KmeansFlags flags, cv::GCompileArgs&& args,
+                                double& compact_gapi, std::vector<int>& labels_gapi,
+                                std::vector<Pt>& centers_gapi)
+{
+    const cv::TermCriteria criteria(cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0);
+    const int attempts = 1;
+
+    cv::GArray<Pt> gIn, centers;
+    cv::GOpaque<double> compactness;
+    cv::GArray<int> inLabels(std::vector<int>{}), outLabels;
+    std::tie(compactness, outLabels, centers) =
+        cv::gapi::kmeans(gIn, K, inLabels, criteria, attempts, flags);
+    cv::GComputation c(cv::GIn(gIn), cv::GOut(compactness, outLabels, centers));
+    c.apply(cv::gin(in), cv::gout(compact_gapi, labels_gapi, centers_gapi), std::move(args));
+    return c;
+}
+
+// Overload for Mat tests w/o initializing the labels
+static cv::GComputation kmeansTestGAPI(const cv::Mat& in, const int K,
+                                       const cv::KmeansFlags flags, cv::GCompileArgs&& args,
+                                       double& compact_gapi, cv::Mat& labels_gapi,
+                                       cv::Mat& centers_gapi)
+{
+    const cv::TermCriteria criteria(cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0);
+    const int attempts = 1;
+
+    cv::GMat gIn, centers, labels;
+    cv::GOpaque<double> compactness;
+    std::tie(compactness, labels, centers) = cv::gapi::kmeans(gIn, K, criteria, attempts, flags);
+    cv::GComputation c(cv::GIn(gIn), cv::GOut(compactness, labels, centers));
+    c.apply(cv::gin(in), cv::gout(compact_gapi, labels_gapi, centers_gapi), std::move(args));
+    return c;
+}
+
+template<typename Pt>
+void kmeansTestValidate(const cv::Size& sz, const MatType2&, const int K,
+                        const double compact_gapi, const std::vector<int>& labels_gapi,
+                        const std::vector<Pt>& centers_gapi)
+{
+    const int amount = sz.height;
+    // Validation
+    EXPECT_GE(compact_gapi, 0.);
+    EXPECT_EQ(labels_gapi.size(), static_cast<size_t>(amount));
+    EXPECT_EQ(centers_gapi.size(), static_cast<size_t>(K));
+}
+
+static void kmeansTestValidate(const cv::Size& sz, const MatType2& type, const int K,
+                               const double compact_gapi, const cv::Mat& labels_gapi,
+                               const cv::Mat& centers_gapi)
+{
+    const int chan   = (type >> CV_CN_SHIFT) + 1;
+    const int amount = sz.height != 1 ? sz.height : sz.width;
+    const int dim    = sz.height != 1 ? sz.width * chan : chan;
+    // Validation
+    EXPECT_GE(compact_gapi, 0.);
+    EXPECT_FALSE(labels_gapi.empty());
+    EXPECT_FALSE(centers_gapi.empty());
+    EXPECT_EQ(labels_gapi.rows, amount);
+    EXPECT_EQ(labels_gapi.cols, 1);
+    EXPECT_EQ(centers_gapi.rows, K);
+    EXPECT_EQ(centers_gapi.cols, dim);
+}
+
+template<typename Labels, typename In>
+void kmeansTestOpenCVCompare(const In& in, const Labels& bestLabels, const int K,
+                             const cv::KmeansFlags flags, const double compact_gapi,
+                             const Labels& labels_gapi, const In& centers_gapi,
+                             const CompareMats& cmpF = AbsExact().to_compare_obj())
+{
+    const cv::TermCriteria criteria(cv::TermCriteria::MAX_ITER + cv::TermCriteria::EPS, 30, 0);
+    const int attempts = 1;
+    double compact_ocv = -1.;
+    Labels labels_ocv;
+    In centers_ocv;
+    { // step to generalize cv::Mat & std::vector cases of bestLabels' types
+        cv::Mat bestLabelsMat(bestLabels);
+        bestLabelsMat.copyTo(labels_ocv);
+    }
+    // OpenCV code /////////////////////////////////////////////////////////////
+    compact_ocv = cv::kmeans(in, K, labels_ocv, criteria, attempts, flags, centers_ocv);
+    // Comparison //////////////////////////////////////////////////////////////
+    EXPECT_TRUE(compact_gapi == compact_ocv);
+    EXPECT_TRUE(compareKMeansOutputs(labels_gapi, labels_ocv, cmpF));
+    EXPECT_TRUE(compareKMeansOutputs(centers_gapi, centers_ocv, cmpF));
+}
+
+template<typename In>
+using KMeansLabelType = typename std::conditional<std::is_same<In, cv::Mat>::value,
+                                                  cv::Mat,
+                                                  std::vector<int>
+                                                 >::type;
+template<typename In, typename Labels = KMeansLabelType<In> >
+void kmeansTestBody(const In& in, const cv::Size& sz, const MatType2& type, const int K,
+                    const cv::KmeansFlags flags, cv::GCompileArgs&& args,
+                    const CompareMats& cmpF = AbsExact().to_compare_obj())
+{
+    double compact_gapi = -1.;
+    Labels labels_gapi;
+    In centers_gapi;
+    if (flags & cv::KMEANS_USE_INITIAL_LABELS)
+    {
+        Labels bestLabels;
+        { // step to generalize cv::Mat & std::vector cases of bestLabels' types
+            const int amount = (sz.height != 1 || sz.width == -1) ? sz.height : sz.width;
+            cv::Mat bestLabelsMat(cv::Size{1, amount}, CV_32SC1);
+            cv::randu(bestLabelsMat, 0, K);
+            bestLabelsMat.copyTo(bestLabels);
+        }
+        kmeansTestGAPI(in, bestLabels, K, flags, std::move(args), compact_gapi, labels_gapi,
+                       centers_gapi);
+        kmeansTestOpenCVCompare(in, bestLabels, K, flags, compact_gapi, labels_gapi,
+                                centers_gapi, cmpF);
+    }
+    else
+    {
+        kmeansTestGAPI(in, K, flags, std::move(args), compact_gapi, labels_gapi, centers_gapi);
+        kmeansTestValidate(sz, type, K, compact_gapi, labels_gapi, centers_gapi);
+    }
+}
+} // namespace opencv_test
+
+#endif // OPENCV_GAPI_CORE_TESTS_COMMON_HPP

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_CORE_TESTS_INL_HPP
@@ -12,19 +12,10 @@
 #include <opencv2/gapi/infer/parsers.hpp>
 #include "gapi_core_tests.hpp"
 
+#include "gapi_core_tests_common.hpp"
+
 namespace opencv_test
 {
-
-namespace
-{
-template <typename Elem>
-inline bool compareVectorsAbsExact(const std::vector<Elem>& outGAPI,
-                                   const std::vector<Elem>& outOCV)
-{
-    return AbsExactVector<Elem>().to_compare_f()(outGAPI, outOCV);
-}
-}
-
 TEST_P(MathOpTest, MatricesAccuracyTest)
 {
     // G-API code & corresponding OpenCV code ////////////////////////////////
@@ -1391,185 +1382,25 @@ TEST_P(NormalizeTest, Test)
     }
 }
 
-TEST_P(KMeansNDNoInitTest, AccuracyTest)
+TEST_P(KMeansNDTest, AccuracyTest)
 {
-    const int amount = sz.height != 1 ? sz.height : sz.width,
-              dim    = sz.height != 1 ? sz.width  : (type >> CV_CN_SHIFT) + 1;
-                                                    // amount of channels
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
-    double compact_gapi = -1.;
-    cv::Mat labels_gapi, centers_gapi;
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    cv::GOpaque<double> compactness;
-    cv::GMat outLabels, centers;
-    std::tie(compactness, outLabels, centers) = cv::gapi::kmeans(in, K, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_mat1), cv::gout(compact_gapi, labels_gapi, centers_gapi), getCompileArgs());
-    // Validation //////////////////////////////////////////////////////////////
-    {
-        EXPECT_GE(compact_gapi, 0.);
-        EXPECT_EQ(labels_gapi.cols, 1);
-        EXPECT_EQ(labels_gapi.rows, amount);
-        EXPECT_FALSE(labels_gapi.empty());
-        EXPECT_EQ(centers_gapi.cols, dim);
-        EXPECT_EQ(centers_gapi.rows, K);
-        EXPECT_FALSE(centers_gapi.empty());
-    }
+    kmeansTestBody(in_mat1, sz, type, K, flags, getCompileArgs(), cmpF);
 }
 
-TEST_P(KMeansNDInitTest, AccuracyTest)
-{
-    const int amount = sz.height != 1 ? sz.height : sz.width;
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
-    cv::Mat bestLabels(cv::Size{1, amount}, CV_32SC1);
-    double compact_ocv = -1., compact_gapi = -1.;
-    cv::Mat labels_ocv, labels_gapi, centers_ocv, centers_gapi;
-    cv::randu(bestLabels, 0, K);
-    bestLabels.copyTo(labels_ocv);
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in, inLabels;
-    cv::GOpaque<double> compactness;
-    cv::GMat outLabels, centers;
-    std::tie(compactness, outLabels, centers) =
-        cv::gapi::kmeans(in, K, inLabels, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in, inLabels), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_mat1, bestLabels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
-            getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    compact_ocv = cv::kmeans(in_mat1, K, labels_ocv, criteria, attempts, flags, centers_ocv);
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(compact_gapi == compact_ocv);
-        EXPECT_TRUE(cmpF(labels_gapi, labels_ocv));
-        EXPECT_TRUE(cmpF(centers_gapi, centers_ocv));
-    }
-}
-
-TEST_P(KMeans2DNoInitTest, AccuracyTest)
+TEST_P(KMeans2DTest, AccuracyTest)
 {
     const int amount = sz.height;
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
     std::vector<cv::Point2f> in_vector{};
-    double compact_gapi = -1.;
-    std::vector<int> labels_gapi{};
-    std::vector<cv::Point2f> centers_gapi{};
     initPointsVectorRandU(amount, in_vector);
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2f> in;
-    cv::GArray<int> inLabels(std::vector<int>{});
-    cv::GOpaque<double> compactness;
-    cv::GArray<int> outLabels;
-    cv::GArray<cv::Point2f> centers;
-    std::tie(compactness, outLabels, centers) =
-        cv::gapi::kmeans(in, K, inLabels, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi), getCompileArgs());
-    // Validation //////////////////////////////////////////////////////////////
-    {
-        EXPECT_GE(compact_gapi, 0.);
-        EXPECT_EQ(labels_gapi.size(), static_cast<size_t>(amount));
-        EXPECT_EQ(centers_gapi.size(), static_cast<size_t>(K));
-    }
+    kmeansTestBody(in_vector, sz, type, K, flags, getCompileArgs());
 }
 
-TEST_P(KMeans2DInitTest, AccuracyTest)
+TEST_P(KMeans3DTest, AccuracyTest)
 {
     const int amount = sz.height;
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
-    std::vector<cv::Point2f> in_vector{};
-    std::vector<int> bestLabels(amount);
-    double compact_ocv = -1., compact_gapi = -1.;
-    std::vector<int> labels_ocv{}, labels_gapi{};
-    std::vector<cv::Point2f> centers_ocv{}, centers_gapi{};
-    initPointsVectorRandU(amount, in_vector);
-    cv::randu(bestLabels, 0, K);
-    labels_ocv = bestLabels;
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point2f> in;
-    cv::GArray<int> inLabels;
-    cv::GOpaque<double> compactness;
-    cv::GArray<int> outLabels;
-    cv::GArray<cv::Point2f> centers;
-    std::tie(compactness, outLabels, centers) =
-        cv::gapi::kmeans(in, K, inLabels, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in, inLabels), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_vector, bestLabels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
-            getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    compact_ocv = cv::kmeans(in_vector, K, labels_ocv, criteria, attempts, flags, centers_ocv);
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(compact_gapi == compact_ocv);
-        EXPECT_TRUE(compareVectorsAbsExact(labels_gapi, labels_ocv));
-        EXPECT_TRUE(compareVectorsAbsExact(centers_gapi, centers_ocv));
-    }
-}
-
-TEST_P(KMeans3DNoInitTest, AccuracyTest)
-{
-    const int amount = sz.height;
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
     std::vector<cv::Point3f> in_vector{};
-    double compact_gapi = -1.;
-    std::vector<int> labels_gapi{};
-    std::vector<cv::Point3f> centers_gapi{};
     initPointsVectorRandU(amount, in_vector);
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point3f> in;
-    cv::GArray<int> inLabels(std::vector<int>{});
-    cv::GOpaque<double> compactness;
-    cv::GArray<int> outLabels;
-    cv::GArray<cv::Point3f> centers;
-    std::tie(compactness, outLabels, centers) =
-        cv::gapi::kmeans(in, K, inLabels, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_vector), cv::gout(compact_gapi, labels_gapi, centers_gapi), getCompileArgs());
-    // Validation //////////////////////////////////////////////////////////////
-    {
-        EXPECT_GE(compact_gapi, 0.);
-        EXPECT_EQ(labels_gapi.size(), static_cast<size_t>(amount));
-        EXPECT_EQ(centers_gapi.size(), static_cast<size_t>(K));
-    }
-}
-
-TEST_P(KMeans3DInitTest, AccuracyTest)
-{
-    const int amount = sz.height;
-    const cv::TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 30, 0);
-    const int attempts = 1;
-    std::vector<cv::Point3f> in_vector{};
-    std::vector<int> bestLabels(amount);
-    double compact_ocv = -1., compact_gapi = -1.;
-    std::vector<int> labels_ocv{}, labels_gapi{};
-    std::vector<cv::Point3f> centers_ocv{}, centers_gapi{};
-    initPointsVectorRandU(amount, in_vector);
-    cv::randu(bestLabels, 0, K);
-    labels_ocv = bestLabels;
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GArray<cv::Point3f> in;
-    cv::GArray<int> inLabels;
-    cv::GOpaque<double> compactness;
-    cv::GArray<int> outLabels;
-    cv::GArray<cv::Point3f> centers;
-    std::tie(compactness, outLabels, centers) =
-        cv::gapi::kmeans(in, K, inLabels, criteria, attempts, flags);
-    cv::GComputation c(cv::GIn(in, inLabels), cv::GOut(compactness, outLabels, centers));
-    c.apply(cv::gin(in_vector, bestLabels), cv::gout(compact_gapi, labels_gapi, centers_gapi),
-            getCompileArgs());
-    // OpenCV code /////////////////////////////////////////////////////////////
-    compact_ocv = cv::kmeans(in_vector, K, labels_ocv, criteria, attempts, flags, centers_ocv);
-    // Comparison //////////////////////////////////////////////////////////////
-    {
-        EXPECT_TRUE(compact_gapi == compact_ocv);
-        EXPECT_TRUE(compareVectorsAbsExact(labels_gapi, labels_ocv));
-        EXPECT_TRUE(compareVectorsAbsExact(centers_gapi, centers_ocv));
-    }
+    kmeansTestBody(in_vector, sz, type, K, flags, getCompileArgs());
 }
 
 // PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////

--- a/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_common.hpp
@@ -194,4 +194,4 @@ static void fitLineTestBody(const In& in, const cv::DistanceTypes distType,
 }
 } // namespace opencv_test
 
-#endif // OPENCV_GAPI_VIDEO_TESTS_COMMON_HPP
+#endif // OPENCV_GAPI_IMGPROC_TESTS_COMMON_HPP

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -324,7 +324,7 @@ public:
     }
 
     template <typename T>
-    inline void initPointRandU(cv::RNG& rng, T& pt)
+    inline void initPointRandU(cv::RNG& rng, T& pt) const
     { ::initPointRandU(rng, pt); }
 
 // Disable unreachable code warning for MSVS 2015
@@ -334,7 +334,7 @@ public:
 #endif
     // initialize std::vector<cv::Point_<T>>/std::vector<cv::Point3_<T>>
     template <typename T, template <typename> class Pt>
-    void initPointsVectorRandU(const int sz_in, std::vector<Pt<T>> &vec_)
+    void initPointsVectorRandU(const int sz_in, std::vector<Pt<T>> &vec_) const
     {
         cv::RNG& rng = theRNG();
 

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 
 
 #include "../test_precomp.hpp"
@@ -484,15 +484,16 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
 
-INSTANTIATE_TEST_CASE_P(KMeansNDNoInitTestCPU, KMeansNDNoInitTest,
+INSTANTIATE_TEST_CASE_P(KMeansNDNoInitTestCPU, KMeansNDTest,
                         Combine(Values(CV_32FC1),
                                 Values(cv::Size(2, 20)),
                                 Values(-1),
                                 Values(CORE_CPU),
+                                Values(AbsTolerance(0.01).to_compare_obj()),
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
-INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDInitTest,
+INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDTest,
                         Combine(Values(CV_32FC1, CV_32FC3),
                                 Values(cv::Size(1, 20),
                                        cv::Size(2, 20),
@@ -504,7 +505,7 @@ INSTANTIATE_TEST_CASE_P(KMeansNDInitTestCPU, KMeansNDInitTest,
                                 Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
 
-INSTANTIATE_TEST_CASE_P(KMeansNDInitReverseTestCPU, KMeansNDInitTest,
+INSTANTIATE_TEST_CASE_P(KMeansNDInitReverseTestCPU, KMeansNDTest,
                         Combine(Values(CV_32FC3),
                                 Values(cv::Size(20, 1)),
                                 Values(-1),
@@ -514,7 +515,7 @@ INSTANTIATE_TEST_CASE_P(KMeansNDInitReverseTestCPU, KMeansNDInitTest,
                                 Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
 
-INSTANTIATE_TEST_CASE_P(KMeans2DNoInitTestCPU, KMeans2DNoInitTest,
+INSTANTIATE_TEST_CASE_P(KMeans2DNoInitTestCPU, KMeans2DTest,
                         Combine(Values(-1),
                                 Values(cv::Size(-1, 20)),
                                 Values(-1),
@@ -522,7 +523,7 @@ INSTANTIATE_TEST_CASE_P(KMeans2DNoInitTestCPU, KMeans2DNoInitTest,
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
-INSTANTIATE_TEST_CASE_P(KMeans2DInitTestCPU, KMeans2DInitTest,
+INSTANTIATE_TEST_CASE_P(KMeans2DInitTestCPU, KMeans2DTest,
                         Combine(Values(-1),
                                 Values(cv::Size(-1, 720),
                                        cv::Size(-1, 20)),
@@ -532,7 +533,7 @@ INSTANTIATE_TEST_CASE_P(KMeans2DInitTestCPU, KMeans2DInitTest,
                                 Values(cv::KMEANS_RANDOM_CENTERS | cv::KMEANS_USE_INITIAL_LABELS,
                                        cv::KMEANS_PP_CENTERS     | cv::KMEANS_USE_INITIAL_LABELS)));
 
-INSTANTIATE_TEST_CASE_P(KMeans3DNoInitTestCPU, KMeans3DNoInitTest,
+INSTANTIATE_TEST_CASE_P(KMeans3DNoInitTestCPU, KMeans3DTest,
                         Combine(Values(-1),
                                 Values(cv::Size(-1, 20)),
                                 Values(-1),
@@ -540,7 +541,7 @@ INSTANTIATE_TEST_CASE_P(KMeans3DNoInitTestCPU, KMeans3DNoInitTest,
                                 Values(5),
                                 Values(cv::KMEANS_RANDOM_CENTERS, cv::KMEANS_PP_CENTERS)));
 
-INSTANTIATE_TEST_CASE_P(KMeans3DInitTestCPU, KMeans3DInitTest,
+INSTANTIATE_TEST_CASE_P(KMeans3DInitTestCPU, KMeans3DTest,
                         Combine(Values(-1),
                                 Values(cv::Size(-1, 720),
                                        cv::Size(-1, 20)),


### PR DESCRIPTION
 - Performance tests for kmeans operation added
 - New file created to share common parts between accuracy and performance tests for core kernels
 - Accuracy test bodies refactored
 - Some test typos corrected

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
xbuild_image:Custom Win=openvino-2021.1.0
xbuild_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```