### PR TITLE
fix link order: put zlib after png/tiff/openexr

### DIFF
--- a/modules/imgcodecs/CMakeLists.txt
+++ b/modules/imgcodecs/CMakeLists.txt
@@ -13,11 +13,6 @@ if(HAVE_WINRT_CX AND NOT WINRT)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
 endif()
 
-if(HAVE_PNG OR HAVE_TIFF OR HAVE_OPENEXR)
-  ocv_include_directories(${ZLIB_INCLUDE_DIRS})
-  list(APPEND GRFMT_LIBS ${ZLIB_LIBRARIES})
-endif()
-
 if(HAVE_JPEG)
   ocv_include_directories(${JPEG_INCLUDE_DIR} ${${JPEG_LIBRARY}_BINARY_DIR})
   list(APPEND GRFMT_LIBS ${JPEG_LIBRARIES})
@@ -56,6 +51,11 @@ endif()
 if(HAVE_OPENEXR)
   include_directories(SYSTEM ${OPENEXR_INCLUDE_PATHS})
   list(APPEND GRFMT_LIBS ${OPENEXR_LIBRARIES})
+endif()
+
+if(HAVE_PNG OR HAVE_TIFF OR HAVE_OPENEXR)
+  ocv_include_directories(${ZLIB_INCLUDE_DIRS})
+  list(APPEND GRFMT_LIBS ${ZLIB_LIBRARIES})
 endif()
 
 if(HAVE_GDAL)


### PR DESCRIPTION
Previous link dependency: imgcodecs --> zlib --> libpng
this can generate imgcodecs shared lib, until Visual Studio integrated
with vcpkg, which will additionally specify LIBPATH, pointing to vcpkg
installed zlib (if any), which links the wrong zlib.

Fixed link dependency: imgcodecs --> libpng --> zlib
in this fixed case, symbols in zlib referenced in libpng will be found
in the build-from-source static zlib, instead of the vcpkg one.

related discussion:
- https://github.com/microsoft/vcpkg/issues/16165
- https://github.com/opencv/opencv/issues/17051
- https://github.com/opencv/opencv/issues/10576

MSVC linking order reference pages:
- https://docs.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-160
  for link order
- https://docs.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-160
  LIB environment variable, for library file searching
- https://docs.microsoft.com/en-us/cpp/build/reference/libpath-additional-libpath?view=msvc-160
  LIBPATH option, for library file searching

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
