### PR TITLE
fix core module android arm64 build

### DIFF
--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -60,6 +60,10 @@
     #include "emmintrin.h"
 #endif
 
+#if defined __ARM_NEON && defined __aarch64__
+    #include <arm_neon.h>
+#endif
+
 namespace cv
 {
 

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -60,10 +60,6 @@
     #include "emmintrin.h"
 #endif
 
-#if defined __ARM_NEON && defined __aarch64__
-    #include <arm_neon.h>
-#endif
-
 namespace cv
 {
 
@@ -247,7 +243,7 @@ static void randf_32f( float* arr, int len, uint64* state, const Vec2f* p, bool 
         __m128 p1 = _mm_unpackhi_ps(q01l, q01h);
 
         _mm_storeu_ps(arr + i, _mm_add_ps(_mm_mul_ps(_mm_loadu_ps(f), p0), p1));
-#elif defined __ARM_NEON && defined __aarch64__
+#elif CV_NEON && defined __aarch64__
         // handwritten NEON is required not for performance but for numerical stability!
         // 64bit gcc tends to use fmadd instead of separate multiply and add
         // use volatile to ensure to separate the multiply and add
@@ -282,7 +278,7 @@ static void randf_32f( float* arr, int len, uint64* state, const Vec2f* p, bool 
                 _mm_mul_ss(_mm_set_ss((float)(int)temp), _mm_set_ss(p[i][0])),
                 _mm_set_ss(p[i][1]))
                 );
-#elif defined __ARM_NEON && defined __aarch64__
+#elif CV_NEON && defined __aarch64__
         float32x2_t t = vadd_f32(vmul_f32(
                 vdup_n_f32((float)(int)temp), vdup_n_f32(p[i][0])),
                 vdup_n_f32(p[i][1]));


### PR DESCRIPTION
This PR fix 3.4 branch's core module failure build on android arm64, by determine and including `arm_neon.h` header file.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
