### PR TITLE
Reduce if statement as it has the same expression on both sides of '&&'

### DIFF
--- a/3rdparty/carotene/src/resize.cpp
+++ b/3rdparty/carotene/src/resize.cpp
@@ -758,7 +758,7 @@ inline void resizeAreaRounding(const Size2D &ssize, const Size2D &dsize,
     }
     else if (channels == 3)
     {
-        if ((wr == 2.0f) && (wr == 2.0f))
+        if (wr == 2.0f)
         {
 #ifndef __ANDROID__
             size_t roiw16 = dsize.width >= 15 ? (dsize.width - 15) * 3 : 0;

--- a/3rdparty/carotene/src/resize.cpp
+++ b/3rdparty/carotene/src/resize.cpp
@@ -758,7 +758,7 @@ inline void resizeAreaRounding(const Size2D &ssize, const Size2D &dsize,
     }
     else if (channels == 3)
     {
-        if (wr == 2.0f)
+        if ((wr == 2.0f) && (hr == 2.0f))
         {
 #ifndef __ANDROID__
             size_t roiw16 = dsize.width >= 15 ? (dsize.width - 15) * 3 : 0;


### PR DESCRIPTION
If statement has the same expression on both sides so this can be reduce

Signed-off-by: Dan Ben Yosef <danbey@gmail.com>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
