### PR TITLE
improve map allocation check

### DIFF
--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -844,20 +844,19 @@ public:
             CV_Assert(numLocClasses == 1);
         }
         locPreds.resize(num);
-        int label;
         for (int i = 0; i < num; ++i, locData += numPredsPerClass * numLocClasses * 4)
         {
             LabelBBox& labelBBox = locPreds[i];
-            label = shareLocation ? -1 : 0;
+            int start = shareLocation ? -1 : 0;
             for (int c = 0; c < numLocClasses; ++c) {
-                labelBBox[label++].resize(numPredsPerClass);
+                labelBBox[start++].resize(numPredsPerClass);
             }
             for (int p = 0; p < numPredsPerClass; ++p)
             {
                 int startIdx = p * numLocClasses * 4;
                 for (int c = 0; c < numLocClasses; ++c)
                 {
-                    label = shareLocation ? -1 : c;
+                    int label = shareLocation ? -1 : c;
                     util::NormalizedBBox& bbox = labelBBox[label][p];
                     if (locPredTransposed)
                     {

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -844,19 +844,20 @@ public:
             CV_Assert(numLocClasses == 1);
         }
         locPreds.resize(num);
+        int label;
         for (int i = 0; i < num; ++i, locData += numPredsPerClass * numLocClasses * 4)
         {
             LabelBBox& labelBBox = locPreds[i];
+            label = shareLocation ? -1 : 0;
+            for (int c = 0; c < numLocClasses; ++c) {
+                labelBBox[label++].resize(numPredsPerClass);
+            }
             for (int p = 0; p < numPredsPerClass; ++p)
             {
                 int startIdx = p * numLocClasses * 4;
                 for (int c = 0; c < numLocClasses; ++c)
                 {
-                    int label = shareLocation ? -1 : c;
-                    if (labelBBox.find(label) == labelBBox.end())
-                    {
-                        labelBBox[label].resize(numPredsPerClass);
-                    }
+                    label = shareLocation ? -1 : c;
                     util::NormalizedBBox& bbox = labelBBox[label][p];
                     if (locPredTransposed)
                     {

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -844,20 +844,19 @@ public:
             CV_Assert(numLocClasses == 1);
         }
         locPreds.resize(num);
-        int label;
         for (int i = 0; i < num; ++i, locData += numPredsPerClass * numLocClasses * 4)
         {
             LabelBBox& labelBBox = locPreds[i];
-            label = shareLocation ? -1 : 0;
-            for (int c = 0; c < numLocClasses; ++c) {
-                labelBBox[label++].resize(numPredsPerClass);
-            }
             for (int p = 0; p < numPredsPerClass; ++p)
             {
                 int startIdx = p * numLocClasses * 4;
                 for (int c = 0; c < numLocClasses; ++c)
                 {
-                    label = shareLocation ? -1 : c;
+                    int label = shareLocation ? -1 : c;
+                    if (labelBBox.find(label) == labelBBox.end())
+                    {
+                        labelBBox[label].resize(numPredsPerClass);
+                    }
                     util::NormalizedBBox& bbox = labelBBox[label][p];
                     if (locPredTransposed)
                     {


### PR DESCRIPTION
Move map resize to the beginning of loop to avoid unnecessary check within inner loop.

**Google benchmark test:**
Vgg16 Faster RCNN model, detection output layer is used by
1. proposal output; where we have 1 location class and 9 * 14 * 14 = 1764 prediction per class.
2. Output layer: where we have 21 location classes and 100 prediction per class.

According to test on VGG16 faster RCNN, there are speedup of:
65.38% (17000ns  / 10279 ns)
45.22% (30308 / 20870 ns)

<cut/>

the benchmark program is at the link and compiled by:
https://drive.google.com/file/d/1sBzXPuCLEekjoWh85k4ZUKlgqQrJcXsU/view?usp=sharing
```
g++ test.cpp -std=c++14 -O3 -I<benchmark>/benchmark/include -L<benchmark>/build/src -lbenchmark -lpthread -o 
benchmark
```
```
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.22, 0.33, 0.54
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.

1x1764
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_FasterRCNNProposl            10279 ns        10279 ns        70308
BM_FasterRCNNProposlOrigin      17001 ns        17000 ns        41550

21x100
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_FasterRCNNProposl            20871 ns        20870 ns        35424
BM_FasterRCNNProposlOrigin      30309 ns        30308 ns        23321


```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [V] I agree to contribute to the project under Apache 2 License.
- [V] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [V] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [V] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=linux,docs
```