### PR TITLE
getDefaultName() isn't overloaded in SparseOpticalFlow

### DIFF
--- a/modules/cudaoptflow/src/brox.cpp
+++ b/modules/cudaoptflow/src/brox.cpp
@@ -64,6 +64,8 @@ namespace {
         {
         }
 
+        virtual String getDefaultName() const { return "DenseOpticalFlow.BroxOpticalFlow"; }
+
         virtual void calc(InputArray I0, InputArray I1, InputOutputArray flow, Stream& stream);
 
         virtual double getFlowSmoothness() const { return alpha_; }

--- a/modules/cudaoptflow/src/farneback.cpp
+++ b/modules/cudaoptflow/src/farneback.cpp
@@ -129,6 +129,8 @@ namespace
 
         virtual void calc(InputArray I0, InputArray I1, InputOutputArray flow, Stream& stream);
 
+        virtual String getDefaultName() const { return "DenseOpticalFlow.FarnebackOpticalFlow"; }
+
     private:
         int numLevels_;
         double pyrScale_;

--- a/modules/cudaoptflow/src/pyrlk.cpp
+++ b/modules/cudaoptflow/src/pyrlk.cpp
@@ -347,6 +347,8 @@ namespace
                 sparse(prevImg, nextImg, prevPts, nextPts, status, err, stream);
             }
         }
+
+        virtual String getDefaultName() const { return "SparseOpticalFlow.SparsePyrLKOpticalFlow"; }
     };
 
     class DensePyrLKOpticalFlowImpl : public DensePyrLKOpticalFlow, private PyrLKOpticalFlowBase
@@ -388,6 +390,8 @@ namespace
             GpuMat flows[] = {u, v};
             cuda::merge(flows, 2, _flow, stream);
         }
+
+        virtual String getDefaultName() const { return "DenseOpticalFlow.DensePyrLKOpticalFlow"; }
     };
 }
 

--- a/modules/cudaoptflow/src/tvl1flow.cpp
+++ b/modules/cudaoptflow/src/tvl1flow.cpp
@@ -119,6 +119,9 @@ namespace
 
         virtual void calc(InputArray I0, InputArray I1, InputOutputArray flow, Stream& stream);
 
+        virtual String getDefaultName() const { return "DenseOpticalFlow.OpticalFlowDual_TVL1"; }
+
+
     private:
         double tau_;
         double lambda_;

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -867,6 +867,8 @@ namespace
                           OutputArray status,
                           OutputArray err = cv::noArray()) CV_OVERRIDE;
 
+        virtual String getDefaultName() const CV_OVERRIDE { return "SparseOpticalFlow.SparsePyrLKOpticalFlow"; }
+
     private:
 #ifdef HAVE_OPENCL
         bool checkParam()

--- a/modules/video/src/optflowgf.cpp
+++ b/modules/video/src/optflowgf.cpp
@@ -618,6 +618,8 @@ public:
 
     virtual void calc(InputArray I0, InputArray I1, InputOutputArray flow) CV_OVERRIDE;
 
+    virtual String getDefaultName() const CV_OVERRIDE { return "DenseOpticalFlow.FarnebackOpticalFlow"; }
+
 private:
     int numLevels_;
     double pyrScale_;

--- a/modules/video/src/tvl1flow.cpp
+++ b/modules/video/src/tvl1flow.cpp
@@ -102,6 +102,8 @@ public:
     }
     OpticalFlowDual_TVL1();
 
+    virtual String getDefaultName() const CV_OVERRIDE { return "DenseOpticalFlow.DualTVL1OpticalFlow"; }
+
     void calc(InputArray I0, InputArray I1, InputOutputArray flow) CV_OVERRIDE;
     void collectGarbage() CV_OVERRIDE;
 


### PR DESCRIPTION
fixes https://github.com/opencv/opencv/issues/17960

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake