### PR TITLE
[G-API] Async infer request hotfix

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -859,6 +859,14 @@ struct InferList: public cv::detail::KernelTag {
             // by some resetInternalData(), etc? (Probably at the GExecutor level)
         }
 
+        // NB: If list of roi is empty need to post output data anyway.
+        if (in_roi_vec.empty()) {
+            for (auto i : ade::util::iota(ctx->uu.params.num_out)) {
+                 ctx->out.post(ctx->output(i));
+            }
+            return;
+        }
+
         for (auto&& rc : in_roi_vec) {
             // NB: Only single async request is supported now,
             // so need to wait until previos iteration is over.
@@ -982,6 +990,14 @@ struct InferList2: public cv::detail::KernelTag {
             ctx->outVecR<cv::Mat>(i).clear();
             // FIXME: Isn't this should be done automatically
             // by some resetInternalData(), etc? (Probably at the GExecutor level)
+        }
+
+        // NB: If list of roi is empty need to post output data anyway.
+        if (list_size == 0u) {
+            for (auto i : ade::util::iota(ctx->uu.params.num_out)) {
+                 ctx->out.post(ctx->output(i));
+            }
+            return;
         }
 
         for (const auto &list_idx : ade::util::iota(list_size)) {

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -293,12 +293,12 @@ public:
     }
 
     // Syntax sugar
-          cv::GShape      inShape(int i)             const;
-    const cv::Mat&        inMat(std::size_t input)   const;
+          cv::GShape      inShape(std::size_t input) const;
+    const cv::Mat&        inMat  (std::size_t input) const;
     const cv::MediaFrame& inFrame(std::size_t input) const;
 
     cv::Mat&     outMatR(std::size_t idx);
-    cv::GRunArgP output(int idx);
+    cv::GRunArgP output (std::size_t idx);
 
     const IEUnit                          &uu;
     cv::gimpl::GIslandExecutable::IOutput &out;
@@ -367,7 +367,7 @@ const cv::GArgs& IECallContext::inArgs() const {
     return m_args;
 }
 
-cv::GShape IECallContext::inShape(int i) const {
+cv::GShape IECallContext::inShape(std::size_t i) const {
     return m_in_shapes[i];
 }
 
@@ -383,7 +383,7 @@ cv::Mat& IECallContext::outMatR(std::size_t idx) {
     return *cv::util::get<cv::Mat*>(m_results.at(idx));
 }
 
-cv::GRunArgP IECallContext::output(int idx) {
+cv::GRunArgP IECallContext::output(std::size_t idx) {
     return m_output_objs[idx].second;
 };
 
@@ -522,8 +522,7 @@ void cv::gimpl::ie::GIEExecutable::run(cv::gimpl::GIslandExecutable::IInput  &in
     //        wait until it is over and start collecting new data.
     //     2. Collect island inputs/outputs.
     //     3. Create kernel context. (Every kernel has his own context.)
-    //     4. Without waiting for the completion of the asynchronous request
-    //        started by kernel go to the next frame (1)
+    //     4. Go to the next frame without waiting until the async request is over (1)
     //
     //     5. If graph is compiled in non-streaming mode, wait until request is over.
 

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -1286,6 +1286,122 @@ TEST(Infer2, TestStreamingInfer)
     pipeline.stop();
 }
 
+TEST(InferEmptyList, TestStreamingInfer)
+{
+    initTestDataPath();
+    initDLDTDataPath();
+
+    std::string filepath = findDataFile("cv/video/768x576.avi");
+
+    cv::gapi::ie::detail::ParamDesc params;
+    params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
+    params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
+    params.device_id = "CPU";
+
+    // Load IE network, initialize input data using that.
+    cv::Mat in_mat;
+    std::vector<cv::Mat> ie_ages;
+    std::vector<cv::Mat> ie_genders;
+    std::vector<cv::Mat> gapi_ages;
+    std::vector<cv::Mat> gapi_genders;
+
+    // NB: Empty list of roi
+    std::vector<cv::Rect> roi_list;
+
+    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
+    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+
+    cv::GMat in;
+    cv::GArray<cv::Rect> roi;
+    cv::GArray<GMat> age, gender;
+
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(roi, in);
+    cv::GComputation comp(cv::GIn(in, roi), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
+
+
+    std::size_t num_frames = 0u;
+    std::size_t max_frames = 1u;
+
+    cv::VideoCapture cap;
+    cap.open(filepath);
+    if (!cap.isOpened())
+        throw SkipTestException("Video file can not be opened");
+
+    cap >> in_mat;
+    auto pipeline = comp.compileStreaming(cv::compile_args(cv::gapi::networks(pp)));
+    pipeline.setSource(
+            cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(filepath), roi_list));
+
+    pipeline.start();
+    while (num_frames < max_frames && pipeline.pull(cv::gout(gapi_ages, gapi_genders)))
+    {
+        EXPECT_TRUE(gapi_ages.empty());
+        EXPECT_TRUE(gapi_genders.empty());
+    }
+}
+
+TEST(Infer2EmptyList, TestStreamingInfer)
+{
+    initTestDataPath();
+    initDLDTDataPath();
+
+    std::string filepath = findDataFile("cv/video/768x576.avi");
+
+    cv::gapi::ie::detail::ParamDesc params;
+    params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
+    params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
+    params.device_id = "CPU";
+
+    // Load IE network, initialize input data using that.
+    cv::Mat in_mat;
+    std::vector<cv::Mat> ie_ages;
+    std::vector<cv::Mat> ie_genders;
+    std::vector<cv::Mat> gapi_ages;
+    std::vector<cv::Mat> gapi_genders;
+
+    // NB: Empty list of roi
+    std::vector<cv::Rect> roi_list;
+
+    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
+    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+
+    cv::GArray<cv::Rect> rr;
+    cv::GMat in;
+    cv::GArray<cv::GMat> age, gender;
+    std::tie(age, gender) = cv::gapi::infer2<AgeGender>(in, rr);
+
+    cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
+
+
+    std::size_t num_frames = 0u;
+    std::size_t max_frames = 1u;
+
+    cv::VideoCapture cap;
+    cap.open(filepath);
+    if (!cap.isOpened())
+        throw SkipTestException("Video file can not be opened");
+
+    cap >> in_mat;
+    auto pipeline = comp.compileStreaming(cv::compile_args(cv::gapi::networks(pp)));
+    pipeline.setSource(
+            cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(filepath), roi_list));
+
+    pipeline.start();
+    while (num_frames < max_frames && pipeline.pull(cv::gout(gapi_ages, gapi_genders)))
+    {
+        EXPECT_TRUE(gapi_ages.empty());
+        EXPECT_TRUE(gapi_genders.empty());
+    }
+}
+
 } // namespace opencv_test
 
 #endif //  HAVE_INF_ENGINE

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -1112,10 +1112,7 @@ TEST(InferList, TestStreamingInfer)
 
     // Load IE network, initialize input data using that.
     cv::Mat in_mat;
-    std::vector<cv::Mat> ie_ages;
-    std::vector<cv::Mat> ie_genders;
-    std::vector<cv::Mat> gapi_ages;
-    std::vector<cv::Mat> gapi_genders;
+    std::vector<cv::Mat> ie_ages, ie_genders, gapi_ages, gapi_genders;
 
     std::vector<cv::Rect> roi_list = {
         cv::Rect(cv::Point{64, 60}, cv::Size{ 96,  96}),
@@ -1206,10 +1203,7 @@ TEST(Infer2, TestStreamingInfer)
 
     // Load IE network, initialize input data using that.
     cv::Mat in_mat;
-    std::vector<cv::Mat> ie_ages;
-    std::vector<cv::Mat> ie_genders;
-    std::vector<cv::Mat> gapi_ages;
-    std::vector<cv::Mat> gapi_genders;
+    std::vector<cv::Mat> ie_ages, ie_genders, gapi_ages, gapi_genders;
 
     std::vector<cv::Rect> roi_list = {
         cv::Rect(cv::Point{64, 60}, cv::Size{ 96,  96}),
@@ -1300,10 +1294,7 @@ TEST(InferEmptyList, TestStreamingInfer)
 
     // Load IE network, initialize input data using that.
     cv::Mat in_mat;
-    std::vector<cv::Mat> ie_ages;
-    std::vector<cv::Mat> ie_genders;
-    std::vector<cv::Mat> gapi_ages;
-    std::vector<cv::Mat> gapi_genders;
+    std::vector<cv::Mat> ie_ages, ie_genders, gapi_ages, gapi_genders;
 
     // NB: Empty list of roi
     std::vector<cv::Rect> roi_list;
@@ -1358,10 +1349,7 @@ TEST(Infer2EmptyList, TestStreamingInfer)
 
     // Load IE network, initialize input data using that.
     cv::Mat in_mat;
-    std::vector<cv::Mat> ie_ages;
-    std::vector<cv::Mat> ie_genders;
-    std::vector<cv::Mat> gapi_ages;
-    std::vector<cv::Mat> gapi_genders;
+    std::vector<cv::Mat> ie_ages, ie_genders, gapi_ages, gapi_genders;
 
     // NB: Empty list of roi
     std::vector<cv::Rect> roi_list;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Overview
* In case empty roi list for `InferROIList` & `Infer2` data will be got from `StreamingOutput` but not post back, due the list is empty, it cause hanging.
* Since the async request and collecting data for the next frame work asynchronously, there is a data race on `StreamingOutput` object, because callback can call `StreamingOutput::post` method while the `StreamingOutput::get` is working. 


### Build configuration
```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

Xtest_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*
```