### PR TITLE
save allocation of memory for fake image

### DIFF
--- a/modules/dnn/src/layers/proposal_layer.cpp
+++ b/modules/dnn/src/layers/proposal_layer.cpp
@@ -286,7 +286,8 @@ public:
 
         CV_Assert(imInfo.total() >= 2);
         // We've chosen the smallest data type because we need just a shape from it.
-        fakeImageBlob.create(shape(1, 1, imInfo.at<float>(0), imInfo.at<float>(1)), CV_8UC1);
+        // We don't allocate memory but just need the shape is correct.
+        Mat fakeImageBlob(shape(1, 1, imInfo.at<float>(0), imInfo.at<float>(1)), CV_8UC1, nullptr);
 
         // Generate prior boxes.
         std::vector<Mat> layerInputs(2), layerOutputs(1, priorBoxes);
@@ -427,7 +428,6 @@ private:
     Ptr<PermuteLayer> deltasPermute;
     Ptr<PermuteLayer> scoresPermute;
     uint32_t keepTopBeforeNMS, keepTopAfterNMS, featStride, baseSize;
-    Mat fakeImageBlob;
     float nmsThreshold;
     DictValue ratios, scales;
 #ifdef HAVE_OPENCL


### PR DESCRIPTION
In ProposalLayerImpl layer, there is a fake image. For now, we actually allocate memory for it.
```
// We've chosen the smallest data type because we need just a shape from it.
 fakeImageBlob.create(shape(1, 1, imInfo.at<float>(0), imInfo.at<float>(1)), CV_8UC1);
```
For example, if the input image has [N, C, H, W] = [1, 3, 1024, 1024], it will create a memory space of 1024*1024 = 1MB.
**For edge devices, allocate 1MB unnecessary memory indeed consumes too much system resource.**
Also notice that fakeImageBlob is a class member variable so its life scope is the same as dnn net.

However, this fake mat is used at:

- prior box layer and
- detection out layer.

In both of the layers, we don't access the content but merely request the shape info.
Instead, in the PR, we make fakeImageBlob as local variable. Also, it carries correct shape info but point to nulptr data(since it will NOT be used at all). So we can save, ex 1MB when doing inference for a model with ProposalLayer.

The figure below shows the result of memory usage probe (by valgrind --tool=massif) for ProposalLayerImpl fake image. in this case the input image is of [N, C, H, W] = [1, 3, 650, 650].
Originally the peak usage of memory is about 486.8 KB (650 * 650 ~ 422,5K plus alignment and other system memory ). 

```
    KB
486.8^                                    #                                   
     |                                    #:::::::::::::::::::::::::::::      
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |                                    #                                   
     |     @::::::::::::::::::::::::::::::#                             :     
     |     @                              #                             ::::: 
     |     @                              #                             :     
   0 +----------------------------------------------------------------------->KB
     0                                                                   974.
```
With this PR the peak usage of memory is only~ 72.04KB  (only system memory ). 

```
    KB
74.02^                                     :                                  
     |                                  @@#:::::::::::::::::::::::::::::::::: 
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
     |                                  @@#:                                  
   0 +----------------------------------------------------------------------->KB
     0                                                                   149.0
```
**Notice that for HAVE_OPENCL, we may apply the same optimization also.**


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
