### PR TITLE
core: include version.hpp in cvdef.h, fix precomp.hpp usage

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -50,7 +50,6 @@
 #endif
 
 #include "opencv2/core/cvdef.h"
-#include "opencv2/core/version.hpp"
 #include "opencv2/core/base.hpp"
 #include "opencv2/core/cvstd.hpp"
 #include "opencv2/core/traits.hpp"

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -45,6 +45,8 @@
 #ifndef OPENCV_CORE_CVDEF_H
 #define OPENCV_CORE_CVDEF_H
 
+#include "opencv2/core/version.hpp"
+
 //! @addtogroup core_utils
 //! @{
 

--- a/modules/core/include/opencv2/core/simd_intrinsics.hpp
+++ b/modules/core/include/opencv2/core/simd_intrinsics.hpp
@@ -40,7 +40,6 @@ Notes:
 #endif
 
 #include "opencv2/core/cvdef.h"
-#include "opencv2/core/version.hpp"
 
 #ifdef OPENCV_SIMD_CONFIG_HEADER
 #include CVAUX_STR(OPENCV_SIMD_CONFIG_HEADER)

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -42,6 +42,7 @@
 //
 //M*/
 
+#include "precomp.hpp"
 #include "hal_internal.hpp"
 
 #ifdef HAVE_LAPACK

--- a/modules/core/src/hal_internal.hpp
+++ b/modules/core/src/hal_internal.hpp
@@ -45,8 +45,6 @@
 #ifndef OPENCV_CORE_HAL_INTERNAL_HPP
 #define OPENCV_CORE_HAL_INTERNAL_HPP
 
-#include "precomp.hpp"
-
 #ifdef HAVE_LAPACK
 
 int lapack_LU32f(float* a, size_t a_step, int m, float* b, size_t b_step, int n, int* info);

--- a/modules/core/src/intel_gpu_gemm.inl.hpp
+++ b/modules/core/src/intel_gpu_gemm.inl.hpp
@@ -25,7 +25,6 @@
 #ifdef HAVE_OPENCL
 
 #include <sstream>
-#include "precomp.hpp"
 #include "opencl_kernels_core.hpp"
 #include "opencv2/core/opencl/runtime/opencl_clamdblas.hpp"
 #include "opencv2/core/opencl/runtime/opencl_core.hpp"

--- a/modules/core/src/matrix_c.cpp
+++ b/modules/core/src/matrix_c.cpp
@@ -1,6 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "precomp.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/core/types_c.h"
-#include "precomp.hpp"
 
 // glue
 

--- a/modules/core/src/matrix_iterator.cpp
+++ b/modules/core/src/matrix_iterator.cpp
@@ -2,9 +2,8 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
-
-#include "opencv2/core/mat.hpp"
 #include "precomp.hpp"
+#include "opencv2/core/mat.hpp"
 
 namespace cv {
 

--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -2,11 +2,10 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
-
+#include "precomp.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/core/types_c.h"
 #include "opencl_kernels_core.hpp"
-#include "precomp.hpp"
 
 #undef HAVE_IPP
 #undef CV_IPP_RUN_FAST

--- a/modules/core/src/matrix_sparse.cpp
+++ b/modules/core/src/matrix_sparse.cpp
@@ -2,10 +2,9 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
-
+#include "precomp.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/core/types_c.h"
-#include "precomp.hpp"
 
 namespace cv {
 

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -2,9 +2,8 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
-
-#include "opencv2/core/mat.hpp"
 #include "precomp.hpp"
+#include "opencv2/core/mat.hpp"
 
 namespace cv {
 


### PR DESCRIPTION
Compatibility impact: Low

approved at technical meeting.