### PR TITLE
[G-API]: Performance tests for BackgroundSubtractor

### DIFF
--- a/modules/gapi/perf/common/gapi_video_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests.hpp
@@ -27,8 +27,8 @@ class BuildPyr_CalcOptFlow_PipelinePerfTest : public TestPerfParams<tuple<std::s
                                                                           cv::GCompileArgs>> {};
 
 class BackgroundSubtractorPerfTest:
-    public TestPerfParams<tuple<cv::gapi::video::BackgroundSubtractorType, bool, double,
-                                std::string, std::size_t, cv::GCompileArgs, CompareMats>> {};
+    public TestPerfParams<tuple<cv::gapi::video::BackgroundSubtractorType, std::string,
+                                bool, double, std::size_t, cv::GCompileArgs, CompareMats>> {};
 } // opencv_test
 
 #endif // OPENCV_GAPI_VIDEO_PERF_TESTS_HPP

--- a/modules/gapi/perf/common/gapi_video_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests.hpp
@@ -26,6 +26,9 @@ class OptFlowLKForPyrPerfTest : public TestPerfParams<tuple<std::string,int,tupl
 class BuildPyr_CalcOptFlow_PipelinePerfTest : public TestPerfParams<tuple<std::string,int,int,bool,
                                                                           cv::GCompileArgs>> {};
 
+class BackgroundSubtractorPerfTest:
+    public TestPerfParams<tuple<cv::gapi::video::BackgroundSubtractorType, bool, double,
+                                std::string, std::size_t, cv::GCompileArgs, CompareMats>> {};
 } // opencv_test
 
 #endif // OPENCV_GAPI_VIDEO_PERF_TESTS_HPP

--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -206,13 +206,12 @@ PERF_TEST_P_(BackgroundSubtractorPerfTest, TestPerformance)
     std::size_t frames = 1u;
 
     // Processing `testNumFrames` amount of frames without measurements:
-    while (frames <= testNumFrames && cap.grab())
+    while (frames++ <= testNumFrames && cap.grab())
     {
         cap.retrieve(frame);
         c.apply(frame, gapiForeground);
         pOCVBackSub->apply(frame, ocvForeground, learningRate);
         EXPECT_TRUE(cmpF(gapiForeground, ocvForeground));
-        frames++;
     }
 
     // ...and then measuring the G-API subtractor performance on the single frame

--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -205,7 +205,7 @@ PERF_TEST_P_(BackgroundSubtractorPerfTest, TestPerformance)
             frames.push_back(frame);
         }
     }
-    testNumFrames = frames.size();
+    GAPI_Assert(testNumFrames == frames.size() && "Can't read required number of frames");
 
     // G-API graph declaration
     cv::GMat in;

--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -172,13 +172,13 @@ PERF_TEST_P_(BackgroundSubtractorPerfTest, TestPerformance)
     std::tie(opType, detectShadows, learningRate, filePath, testNumFrames,
              compileArgs, cmpF) = GetParam();
 
-    int histLength = 500;
+    const int histLength = 500;
     double thr = -1;
     if (opType == gvideo::TYPE_BS_MOG2)
         thr = 16.;
     else if (opType == gvideo::TYPE_BS_KNN)
         thr = 400.;
-    gvideo::BackgroundSubtractorParams bsp(opType, histLength, thr, detectShadows, learningRate);
+    const gvideo::BackgroundSubtractorParams bsp(opType, histLength, thr, detectShadows, learningRate);
 
     // Video source declaration
     cv::VideoCapture cap;

--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -174,10 +174,21 @@ PERF_TEST_P_(BackgroundSubtractorPerfTest, TestPerformance)
 
     const int histLength = 500;
     double thr = -1;
-    if (opType == gvideo::TYPE_BS_MOG2)
-        thr = 16.;
-    else if (opType == gvideo::TYPE_BS_KNN)
-        thr = 400.;
+    switch (opType)
+    {
+        case gvideo::TYPE_BS_MOG2:
+        {
+            thr = 16.;
+            break;
+        }
+        case gvideo::TYPE_BS_KNN:
+        {
+            thr = 400.;
+            break;
+        }
+        default:
+            FAIL() << "unsupported type of BackgroundSubtractor";
+    }
     const gvideo::BackgroundSubtractorParams bsp(opType, histLength, thr, detectShadows,
                                                  learningRate);
 

--- a/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
@@ -105,11 +105,10 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackgroundSubtractorPerfTestCPU),
                               BackgroundSubtractorPerfTest,
                               Combine(Values(cv::gapi::video::TYPE_BS_MOG2,
                                              cv::gapi::video::TYPE_BS_KNN),
+                                      Values("cv/video/768x576.avi", "cv/video/1920x1080.avi"),
                                       testing::Bool(),
                                       Values(0., 0.5, 1.),
-                                      Values("cv/video/768x576.avi", "cv/video/1920x1080.avi"),
-                                      Values(1, 10),
+                                      Values(5),
                                       Values(cv::compile_args(VIDEO_CPU)),
                                       Values(AbsExact().to_compare_obj())));
-
 } // opencv_test

--- a/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
@@ -100,4 +100,16 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTe
                                       Values(3),
                                       Values(true),
                                       Values(cv::compile_args(VIDEO_CPU))));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackgroundSubtractorPerfTestCPU),
+                              BackgroundSubtractorPerfTest,
+                              Combine(Values(cv::gapi::video::TYPE_BS_MOG2,
+                                             cv::gapi::video::TYPE_BS_KNN),
+                                      Values(true, false),
+                                      Values(0., 0.5, 1),
+                                      Values("cv/video/768x576.avi", "cv/video/1920x1080.avi"),
+                                      Values(1, 10),
+                                      Values(cv::compile_args(VIDEO_CPU)),
+                                      Values(AbsExact().to_compare_obj())));
+
 } // opencv_test

--- a/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
@@ -70,7 +70,7 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKForPyrPerfTestCPU), OptFlowLKF
                                       Values(cv::TermCriteria(cv::TermCriteria::COUNT |
                                                               cv::TermCriteria::EPS,
                                                               30, 0.01)),
-                                      Values(true, false),
+                                      testing::Bool(),
                                       Values(cv::compile_args(VIDEO_CPU))));
 
 INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKInternalPerfTestCPU),
@@ -90,7 +90,7 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelinePerfTestCP
                               Combine(Values("cv/optflow/frames/1080p_%02d.png"),
                                       Values(7, 11),
                                       Values(1000),
-                                      Values(true, false),
+                                      testing::Bool(),
                                       Values(cv::compile_args(VIDEO_CPU))));
 
 INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTestPerfCPU),
@@ -105,8 +105,8 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackgroundSubtractorPerfTestCPU),
                               BackgroundSubtractorPerfTest,
                               Combine(Values(cv::gapi::video::TYPE_BS_MOG2,
                                              cv::gapi::video::TYPE_BS_KNN),
-                                      Values(true, false),
-                                      Values(0., 0.5, 1),
+                                      testing::Bool(),
+                                      Values(0., 0.5, 1.),
                                       Values("cv/video/768x576.avi", "cv/video/1920x1080.avi"),
                                       Values(1, 10),
                                       Values(cv::compile_args(VIDEO_CPU)),

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -132,7 +132,7 @@ inline void compareOutputPyramids(const BuildOpticalFlowPyramidTestOutput& outGA
 {
     GAPI_Assert(outGAPI.maxLevel == outOCV.maxLevel);
     GAPI_Assert(outOCV.maxLevel >= 0);
-    size_t maxLevel = static_cast<size_t>(outOCV.maxLevel);
+    const size_t maxLevel = static_cast<size_t>(outOCV.maxLevel);
     for (size_t i = 0; i <= maxLevel; i++)
     {
         EXPECT_TRUE(AbsExact().to_compare_f()(outGAPI.pyramid[i], outOCV.pyramid[i]));
@@ -140,7 +140,8 @@ inline void compareOutputPyramids(const BuildOpticalFlowPyramidTestOutput& outGA
 }
 
 template <typename Elem>
-inline bool compareVectorsAbsExactForOptFlow(std::vector<Elem> outGAPI, std::vector<Elem> outOCV)
+inline bool compareVectorsAbsExactForOptFlow(const std::vector<Elem>& outGAPI,
+                                             const std::vector<Elem>& outOCV)
 {
     return AbsExactVector<Elem>().to_compare_f()(outGAPI, outOCV);
 }
@@ -442,7 +443,7 @@ inline GComputation runOCVnGAPIOptFlowPipeline(TestFunctional&,
 // Note: namespace must match the namespace of the type of the printed object
 namespace cv { namespace gapi { namespace video
 {
-inline std::ostream& operator<<(std::ostream& os, BackgroundSubtractorType op)
+inline std::ostream& operator<<(std::ostream& os, const BackgroundSubtractorType op)
 {
 #define CASE(v) case BackgroundSubtractorType::v: os << #v; break
     switch (op)

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -359,7 +359,7 @@ inline void testBackgroundSubtractorStreaming(cv::GStreamingCompiled& gapiBackSu
 } // namespace opencv_test
 
 // Note: namespace must match the namespace of the type of the printed object
-namespace cv::gapi::video
+namespace cv { namespace gapi { namespace video
 {
 inline std::ostream& operator<<(std::ostream& os, BackgroundSubtractorType op)
 {
@@ -373,7 +373,7 @@ inline std::ostream& operator<<(std::ostream& os, BackgroundSubtractorType op)
 #undef CASE
     return os;
 }
-} // namespace cv::gapi::video
+}}} // namespace cv::gapi::video
 
 #else // !HAVE_OPENCV_VIDEO
 

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -127,9 +127,15 @@ struct OptFlowLKTestParams
     cv::GCompileArgs compileArgs;
     int flags                     = 0;
 };
+} // namespace
+} // namespace opencv_test
 
 #ifdef HAVE_OPENCV_VIDEO
 
+namespace opencv_test
+{
+namespace
+{
 inline GComputation runOCVnGAPIBuildOptFlowPyramid(TestFunctional& testInst,
                                                    const BuildOpticalFlowPyramidTestParams& params,
                                                    BuildOpticalFlowPyramidTestOutput& outOCV,
@@ -349,9 +355,32 @@ inline void testBackgroundSubtractorStreaming(cv::GStreamingCompiled& gapiBackSu
     EXPECT_LT(0u, frames);
     EXPECT_FALSE(gapiBackSub.running());
 }
+} // namespace
+} // namespace opencv_test
+
+// Note: namespace must match the namespace of the type of the printed object
+namespace cv::gapi::video
+{
+inline std::ostream& operator<<(std::ostream& os, BackgroundSubtractorType op)
+{
+#define CASE(v) case BackgroundSubtractorType::v: os << #v; break
+    switch (op)
+    {
+        CASE(TYPE_BS_MOG2);
+        CASE(TYPE_BS_KNN);
+        default: GAPI_Assert(false && "unknown BackgroundSubtractor type");
+    }
+#undef CASE
+    return os;
+}
+} // namespace cv::gapi::video
 
 #else // !HAVE_OPENCV_VIDEO
 
+namespace opencv_test
+{
+namespace
+{
 inline cv::GComputation runOCVnGAPIBuildOptFlowPyramid(TestFunctional&,
                                                        const BuildOpticalFlowPyramidTestParams&,
                                                        BuildOpticalFlowPyramidTestOutput&,
@@ -387,9 +416,15 @@ inline GComputation runOCVnGAPIOptFlowPipeline(TestFunctional&,
 {
     GAPI_Assert(0 && "This function shouldn't be called without opencv_video");
 }
+} // namespace
+} // namespace opencv_test
 
 #endif // HAVE_OPENCV_VIDEO
 
+namespace opencv_test
+{
+namespace
+{
 inline void compareOutputPyramids(const BuildOpticalFlowPyramidTestOutput& outGAPI,
                                   const BuildOpticalFlowPyramidTestOutput& outOCV)
 {

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -111,7 +111,7 @@ TEST_P(BackgroundSubtractorTest, AccuracyTest)
     auto gapiBackSub = c.compileStreaming(getCompileArgs());
 
     // Testing G-API Background Substractor in streaming mode
-    auto path = findDataFile(filePath);
+    const auto path = findDataFile(filePath);
     try
     {
         gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -111,7 +111,7 @@ TEST_P(BackgroundSubtractorTest, AccuracyTest)
     auto gapiBackSub = c.compileStreaming(getCompileArgs());
 
     // Testing G-API Background Substractor in streaming mode
-    auto path = findDataFile("cv/video/768x576.avi");
+    auto path = findDataFile(filePath);
     try
     {
         gapiBackSub.setSource(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path));

--- a/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
@@ -107,7 +107,7 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BackgroundSubtractorTestCPU),
                                              std::make_tuple(cv::gapi::video::TYPE_BS_KNN, 400),
                                              std::make_tuple(cv::gapi::video::TYPE_BS_KNN, 200)),
                                              Values(500, 50),
-                                             Values(true, false),
+                                             testing::Bool(),
                                              Values(-1, 0, 0.5, 1),
                                              Values("cv/video/768x576.avi"),
                                              Values(3)));


### PR DESCRIPTION
 - Performance tests for BackgroundSubtractor stateful operation added
 - Accuracy test misprint fixed

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
xbuild_image:Custom Win=openvino-2021.1.0
xbuild_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```