### PR TITLE
Added Steps support in DNN Slice layer

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -364,6 +364,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
          * Inner vector has slice ranges for the first number of input dimensions.
          */
         std::vector<std::vector<Range> > sliceRanges;
+        std::vector<std::vector<int> > sliceSteps;
         int axis;
         int num_split;
 

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -64,6 +64,7 @@ public:
     SliceLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
+        hasSteps = false;
         axis = params.get<int>("axis", 1);
         num_split = params.get<int>("num_split", 0);
         hasDynamicShapes = params.get<bool>("has_dynamic_shapes", false);
@@ -112,6 +113,22 @@ public:
                     sliceRanges[0][i].end = end;  // We'll finalize a negative value later.
                 }
             }
+
+            if (params.has("steps"))
+            {
+                const DictValue &steps = params.get("steps");
+                sliceSteps.resize(1);
+                sliceSteps[0].resize(steps.size());
+
+                for (int i = 0; i < steps.size(); ++i)
+                {
+                    int step = steps.get<int>(i);
+                    CV_Assert(step >= 1);
+                    if (step > 1)
+                        hasSteps = true;
+                    sliceSteps[0][i] = step;
+                }
+            }
         }
     }
 
@@ -120,11 +137,11 @@ public:
 #ifdef HAVE_DNN_IE_NN_BUILDER_2019
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
             return INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2019R1) &&
-                sliceRanges.size() == 1 && sliceRanges[0].size() == 4;
+                sliceRanges.size() == 1 && sliceRanges[0].size() == 4 && !hasSteps;
 #endif
 #ifdef HAVE_DNN_NGRAPH
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-            return sliceRanges.size() == 1;
+            return sliceRanges.size() == 1 && !hasSteps;
 #endif
         return backendId == DNN_BACKEND_OPENCV;
     }
@@ -147,6 +164,9 @@ public:
                 {
                     if (shapesInitialized || inpShape[j] > 0)
                         outputs[i][j] = normalize_axis_range(sliceRanges[i][j], inpShape[j]).size();
+
+                    if (! sliceSteps.empty() && sliceSteps[i][j] > 1)
+                        outputs[i][j] = (outputs[i][j] + sliceSteps[i][j] - 1) / sliceSteps[i][j];
                 }
             }
         }
@@ -181,6 +201,7 @@ public:
         const MatSize& inpShape = inputs[0].size;
 
         finalSliceRanges = sliceRanges;
+
         if (sliceRanges.empty())
         {
             // Divide input blob on equal parts by axis.
@@ -212,6 +233,9 @@ public:
                 finalSliceRanges[i][j] = normalize_axis_range(finalSliceRanges[i][j], inpShape[j]);
             }
         }
+
+        if (!sliceSteps.empty() && sliceSteps[0].size() != inputs[0].dims)
+            sliceSteps[0].resize(inputs[0].dims, 1);
 
 #if 0
         std::cout << "DEBUG: DNN/Slice: " << outputs.size() << " inpShape=" << inpShape << std::endl;
@@ -478,9 +502,24 @@ public:
 
         const Mat& inpMat = inputs[0];
         CV_Assert(outputs.size() == finalSliceRanges.size());
-        for (size_t i = 0; i < outputs.size(); i++)
+
+        if (!hasSteps)
         {
-            inpMat(finalSliceRanges[i]).copyTo(outputs[i]);
+            for (size_t i = 0; i < outputs.size(); i++)
+            {
+                inpMat(finalSliceRanges[i]).copyTo(outputs[i]);
+            }
+        }
+        else
+        {
+            int dimsNum = inpMat.dims;
+
+            for (size_t i = 0; i < outputs.size(); i++)
+            {
+                std::vector<int> inpIdx(dimsNum, 0);
+                std::vector<int> outIdx(dimsNum, 0);
+                getSliceRecursive(inpMat, inpIdx, finalSliceRanges[i], sliceSteps[i], 0, dimsNum, outputs[i], outIdx);
+            }
         }
     }
 
@@ -570,11 +609,34 @@ public:
     }
 #endif  // HAVE_DNN_NGRAPH
 
+private:
+    void getSliceRecursive(const Mat &inpMat, std::vector<int> &inpIdx,
+                           const std::vector<Range> &sliceRanges,
+                           const std::vector<int> &sliceSteps, int dim, int dimsNum,
+                           Mat &outputs, std::vector<int> &outIdx)
+    {
+        int begin = sliceRanges[dim].start;
+        int end = sliceRanges[dim].end;
+        int step = !sliceSteps.empty() ? sliceSteps[dim] : 1;
+
+        for (int k = begin, j = 0; k < end; k += step, j++)
+        {
+            inpIdx[dim] = k;
+            outIdx[dim] = j;
+
+            if (dim + 1 < dimsNum)
+                getSliceRecursive(inpMat, inpIdx, sliceRanges, sliceSteps, dim + 1, dimsNum, outputs, outIdx);
+            else
+                outputs.at<float>(outIdx.data()) = inpMat.at<float>(inpIdx.data());
+        }
+    }
+
 protected:
     // The actual non-negative values determined from @p sliceRanges depends on input size.
     std::vector<std::vector<Range> > finalSliceRanges;
     bool hasDynamicShapes;
     bool shapesInitialized;
+    bool hasSteps;
 };
 
 class CropLayerImpl CV_FINAL : public SliceLayerImpl

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -165,7 +165,7 @@ public:
                     if (shapesInitialized || inpShape[j] > 0)
                         outputs[i][j] = normalize_axis_range(sliceRanges[i][j], inpShape[j]).size();
 
-                    if (! sliceSteps.empty() && sliceSteps[i][j] > 1)
+                    if (!sliceSteps.empty() && (i < sliceSteps.size()) && (j < sliceSteps[i].size()) && (sliceSteps[i][j] > 1))
                         outputs[i][j] = (outputs[i][j] + sliceSteps[i][j] - 1) / sliceSteps[i][j];
                 }
             }

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -444,6 +444,9 @@ public:
     {
         CV_TRACE_FUNCTION();
 
+        if (hasSteps)
+            return false;  // TODO not implemented yet: https://github.com/opencv/opencv/pull/19546
+
         std::vector<UMat> inputs;
         std::vector<UMat> outputs;
 
@@ -619,6 +622,9 @@ private:
         int end = sliceRanges[dim].end;
         int step = !sliceSteps.empty() ? sliceSteps[dim] : 1;
 
+        const bool is32F = inpMat.depth() == CV_32F;
+
+        // TODO optimization is required (for 2D tail case at least)
         for (int k = begin, j = 0; k < end; k += step, j++)
         {
             inpIdx[dim] = k;
@@ -627,7 +633,12 @@ private:
             if (dim + 1 < dimsNum)
                 getSliceRecursive(inpMat, inpIdx, sliceRanges, sliceSteps, dim + 1, dimsNum, outputs, outIdx);
             else
-                outputs.at<float>(outIdx.data()) = inpMat.at<float>(inpIdx.data());
+            {
+                if (is32F)
+                    outputs.at<float>(outIdx.data()) = inpMat.at<float>(inpIdx.data());
+                else
+                    outputs.at<short>(outIdx.data()) = inpMat.at<short>(inpIdx.data());  // 16F emulation
+            }
         }
     }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -646,17 +646,6 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto_)
 
             if (inp_size == 1)
             {
-                if (layerParams.has("steps"))
-                {
-                    DictValue steps_dict = layerParams.get("steps");
-                    for (int i = 0; i < steps_dict.size(); ++i)
-                    {
-                        if (steps_dict.get<int>(i) != 1) {
-                            CV_Error(Error::StsNotImplemented,
-                                "Slice layer only supports steps = 1");
-                        }
-                    }
-                }
                 if (layerParams.has("axes")) {
                     DictValue axes = layerParams.get("axes");
                     for (int i = 1; i < axes.size(); ++i) {

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -629,61 +629,21 @@ TEST_P(Test_ONNX_layers, Slice)
 
 TEST_P(Test_ONNX_layers, Slice_Steps_2DInput)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-    {
-        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
-    }
-    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
-    {
-        if (backend == DNN_BACKEND_OPENCV)
-            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
-    }
-
     testONNXModels("slice_opset_11_steps_2d");
 }
 
 TEST_P(Test_ONNX_layers, Slice_Steps_3DInput)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-    {
-        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
-    }
-    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
-    {
-        if (backend == DNN_BACKEND_OPENCV)
-            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
-    }
-
     testONNXModels("slice_opset_11_steps_3d");
 }
 
 TEST_P(Test_ONNX_layers, Slice_Steps_4DInput)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-    {
-        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
-    }
-    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
-    {
-        if (backend == DNN_BACKEND_OPENCV)
-            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
-    }
-
     testONNXModels("slice_opset_11_steps_4d");
 }
 
 TEST_P(Test_ONNX_layers, Slice_Steps_5DInput)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-    {
-        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
-    }
-    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
-    {
-        if (backend == DNN_BACKEND_OPENCV)
-            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
-    }
-
     testONNXModels("slice_opset_11_steps_5d");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -627,6 +627,66 @@ TEST_P(Test_ONNX_layers, Slice)
 #endif
 }
 
+TEST_P(Test_ONNX_layers, Slice_Steps_2DInput)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
+    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
+    {
+        if (backend == DNN_BACKEND_OPENCV)
+            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    }
+
+    testONNXModels("slice_opset_11_steps_2d");
+}
+
+TEST_P(Test_ONNX_layers, Slice_Steps_3DInput)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
+    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
+    {
+        if (backend == DNN_BACKEND_OPENCV)
+            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    }
+
+    testONNXModels("slice_opset_11_steps_3d");
+}
+
+TEST_P(Test_ONNX_layers, Slice_Steps_4DInput)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
+    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
+    {
+        if (backend == DNN_BACKEND_OPENCV)
+            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    }
+
+    testONNXModels("slice_opset_11_steps_4d");
+}
+
+TEST_P(Test_ONNX_layers, Slice_Steps_5DInput)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+    {
+        if (target == DNN_TARGET_MYRIAD) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    }
+    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_OPENCL)
+    {
+        if (backend == DNN_BACKEND_OPENCV)
+            applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_OPENCL : CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    }
+
+    testONNXModels("slice_opset_11_steps_5d");
+}
+
 TEST_P(Test_ONNX_layers, Softmax)
 {
     testONNXModels("softmax");


### PR DESCRIPTION
**Merge with extra**: opencv/opencv_extra#854

**Fixes** #18920: added ``steps`` parameter support for Slice layer

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.2.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```