### PR TITLE
GAPI TBB executor integration

### DIFF
--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -443,9 +443,15 @@ cv::GCompiled cv::gimpl::GCompiler::produceCompiled(GPtr &&pg)
     GModel::ConstGraph cgr(*pg);
     const auto &outMetas = GModel::ConstGraph(*pg).metadata()
         .get<OutputMeta>().outMeta;
-    // FIXME: select which executor will be actually used,
-    // make GExecutor abstract.
-    std::unique_ptr<GExecutor> pE(new GExecutor(std::move(pg)));
+
+    // FIXME: Introduce compile argument to select which executor will be actually used,
+    // make GExecutor abstract?.
+#if defined(USE_GAPI_TBB_EXECUTOR)
+    using executor_t = GTBBExecutor;
+#else
+    using executor_t = GExecutor;
+#endif
+    std::unique_ptr<GExecutor> pE(new executor_t(std::move(pg)));
 
     GCompiled compiled;
     compiled.priv().setup(m_metas, outMetas, std::move(pE));

--- a/modules/gapi/src/executor/gexecutor.hpp
+++ b/modules/gapi/src/executor/gexecutor.hpp
@@ -16,10 +16,17 @@
 #include <ade/graph.hpp>
 
 #include "backends/common/gbackend.hpp"
-#define USE_GAPI_TBB_EXECUTOR 0
-#if defined(USE_GAPI_TBB_EXECUTOR)
 #include "gtbbexecutor.hpp"
+
+#ifdef HAVE_TBB
+#if (TBB_INTERFACE_VERSION < 12000)
+// TODO: TBB task API has been deprecated and removed in 12000
+#define USE_GAPI_TBB_EXECUTOR 1
 #endif
+#endif //TBB_INTERFACE_VERSION
+
+
+
 
 namespace cv {
 namespace gimpl {

--- a/modules/gapi/src/executor/gtbbexecutor.cpp
+++ b/modules/gapi/src/executor/gtbbexecutor.cpp
@@ -364,7 +364,7 @@ namespace graph {
 
             ctx.executed++;
             // reset dependecy_count to initial state to simplify re-execution of the same graph
-            node->dependency_count = node->dependencies;
+            node->reset_dependecy_count();
 
             return result;
         }

--- a/modules/gapi/src/executor/gtbbexecutor.hpp
+++ b/modules/gapi/src/executor/gtbbexecutor.hpp
@@ -74,14 +74,19 @@ struct tile_node {
 
     util::variant<sync_task_body, async_task_body>  task_body;
 
-    // number of dependencies according to a dependency graph (i.e. number of "input" edges).
+    // Number of dependency nodes according to a graph
+    // (i.e. Number of unique predecessor nodes which needs to be run before this one.
     size_t                                          dependencies     = 0;
 
-    // number of unsatisfied dependencies. When drops to zero task is ready for execution.
+    // Number of yet unsatisfied dependencies. When drops to zero task is ready for execution.
     // Initially equal to "dependencies"
     atomic_copyable_wrapper<size_t>                 dependency_count = 0;
 
     std::vector<tile_node*>                         dependants;
+
+    void reset_dependecy_count(){
+        dependency_count = dependencies;
+    }
 
     tile_node(decltype(sync_task_body::body)&& f) : task_body(sync_task_body{std::move(f)}) {};
     tile_node(async_tag, decltype(async_task_body::body)&& f) : task_body(async_task_body{std::move(f)}) {};


### PR DESCRIPTION
This patch adds usage of TBB executor in the non-streaming execution GAPI graphs. 

- new virtual function  `GExecutor::runImpl` is added (The function is called by `GExecutor::run`)
- default implementation of the function execute island by island in a serial way 
- new  `GExecutor` inherited class `GTBBExecutor` is added to override it 



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```