### PR TITLE
VA sample: device autodetection changed

### DIFF
--- a/samples/va_intel/display.cpp.inc
+++ b/samples/va_intel/display.cpp.inc
@@ -87,7 +87,6 @@ static unsigned readId(const char* devName, const char* idName)
 static int findAdapter(unsigned desiredVendorId)
 {
     int adapterIndex = -1;
-    int numAdapters = 0;
 
     Directory dir(VA_INTEL_PCI_DIR);
 
@@ -101,10 +100,18 @@ static int findAdapter(unsigned desiredVendorId)
             unsigned vendorId = readId(name, "vendor");
             if (vendorId == desiredVendorId)
             {
-                adapterIndex = numAdapters;
+                char subdirName[256];
+                snprintf(subdirName, sizeof(subdirName), "%s/%s/%s", VA_INTEL_PCI_DIR, name, "drm");
+                Directory subdir(subdirName);
+                for (int j = 0; j < subdir.count(); ++j)
+                {
+                    if (!strncmp(subdir[j]->d_name, "card", 4))
+                    {
+                        adapterIndex = strtoul(subdir[j]->d_name + 4, NULL, 10);
+                    }
+                }
                 break;
             }
-            ++numAdapters;
         }
     }
 


### PR DESCRIPTION
The code worked with assumption that PCI devices sorted by name match DRI devices order, i.e. device with ID 0000:00:02 should be represented by `card0/renderD128` and device 0000:01:00 by `card1/renderD129`. But in reality this is wrong:
```
$ ls -l /dev/dri/by-path/
lrwxrwxrwx. 1 root root  8 Feb 18 16:30 pci-0000:00:02.0-card -> ../card1
lrwxrwxrwx. 1 root root 13 Feb 18 16:30 pci-0000:00:02.0-render -> ../renderD129
lrwxrwxrwx. 1 root root  8 Feb 18 16:30 pci-0000:01:00.0-card -> ../card0
lrwxrwxrwx. 1 root root 13 Feb 18 16:30 pci-0000:01:00.0-render -> ../renderD128
```

Instead we probe `drm` endpoint as it seem to contain correct DRI device names:
```
$ ls  /sys/bus/pci/devices/0000\:01\:00.0/drm
card0  controlD64  renderD128
$ ls  /sys/bus/pci/devices/0000\:00\:02.0/drm
card1  controlD65  renderD129
```