### PR TITLE
Added JUnit-style package name to XML reports

### DIFF
--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -777,8 +777,27 @@ std::string findDataDirectory(const std::string& relative_path, bool required = 
 
 class SystemInfoCollector : public testing::EmptyTestEventListener
 {
+public:
+    explicit SystemInfoCollector(const char* executable):
+        testing::EmptyTestEventListener()
+    {
+        std::string tmp(executable);
+        size_t last_slash1 = tmp.find_last_of('/');
+        size_t last_slash2 = tmp.find_last_of('\\');
+        if(last_slash1 == std::string::npos)
+           last_slash1 = 0;
+        if(last_slash2 == std::string::npos)
+           last_slash2 = 0;
+
+        size_t last_slash = std::max(last_slash1, last_slash2);
+        size_t last_dot = tmp.find_last_of('.');
+        if(last_dot < last_slash)
+            last_dot = std::string::npos;
+        module = tmp.substr(last_slash+1, last_dot);
+    }
 private:
     virtual void OnTestProgramStart(const testing::UnitTest&);
+    std::string module;
 };
 
 #ifndef __CV_TEST_EXEC_ARGS
@@ -807,7 +826,7 @@ int main(int argc, char **argv) \
     ts->init(resourcesubdir); \
     __CV_TEST_EXEC_ARGS(CV_TEST_INIT0_ ## INIT0) \
     ::testing::InitGoogleTest(&argc, argv); \
-    ::testing::UnitTest::GetInstance()->listeners().Append(new SystemInfoCollector); \
+    ::testing::UnitTest::GetInstance()->listeners().Append(new SystemInfoCollector(argv[0])); \
     __CV_TEST_EXEC_ARGS(__VA_ARGS__) \
     parseCustomOptions(argc, argv); \
     } \

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -653,7 +653,7 @@ void PrintTo(const Size& sz, ::std::ostream* os);
     ::perf::TestBase::Init(std::vector<std::string>(impls, impls + sizeof impls / sizeof *impls), \
                            argc, argv); \
     ::testing::InitGoogleTest(&argc, argv); \
-    ::testing::UnitTest::GetInstance()->listeners().Append(new cvtest::SystemInfoCollector); \
+    ::testing::UnitTest::GetInstance()->listeners().Append(new cvtest::SystemInfoCollector(argv[0])); \
     ::testing::Test::RecordProperty("cv_module_name", #modulename); \
     ::perf::TestBase::RecordRunParameters(); \
     __CV_TEST_EXEC_ARGS(__VA_ARGS__) \

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -1118,6 +1118,7 @@ inline static void recordPropertyVerbose(const std::string & property,
 void SystemInfoCollector::OnTestProgramStart(const testing::UnitTest&)
 {
     std::cout << "CTEST_FULL_OUTPUT" << std::endl; // Tell CTest not to discard any output
+    recordPropertyVerbose("package", "OpenCV module", module);
     recordPropertyVerbose("cv_version", "OpenCV version", cv::getVersionString(), CV_VERSION);
     recordPropertyVerbose("cv_vcs_version", "OpenCV VCS version", getSnippetFromConfig("Version control:", "\n"));
     recordPropertyVerbose("cv_build_type", "Build type", getSnippetFromConfig("Configuration:", "\n"), CV_TEST_BUILD_CONFIG);


### PR DESCRIPTION
The option helps to organize test reports hierarchy in Jenkins.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
