### PR TITLE
add noexcept to default constructors of cv::ocl

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -70,7 +70,7 @@ class CV_EXPORTS Image2D;
 class CV_EXPORTS_W_SIMPLE Device
 {
 public:
-    CV_WRAP Device();
+    CV_WRAP Device() CV_NOEXCEPT;
     explicit Device(void* d);
     Device(const Device& d);
     Device& operator = (const Device& d);
@@ -245,7 +245,7 @@ protected:
 class CV_EXPORTS Context
 {
 public:
-    Context();
+    Context() CV_NOEXCEPT;
     explicit Context(int dtype);  //!< @deprecated
     ~Context();
     Context(const Context& c);
@@ -298,7 +298,7 @@ public:
 class CV_EXPORTS Platform
 {
 public:
-    Platform();
+    Platform() CV_NOEXCEPT;
     ~Platform();
     Platform(const Platform& p);
     Platform& operator = (const Platform& p);
@@ -357,7 +357,7 @@ void initializeContextFromHandle(Context& ctx, void* platform, void* context, vo
 class CV_EXPORTS Queue
 {
 public:
-    Queue();
+    Queue() CV_NOEXCEPT;
     explicit Queue(const Context& c, const Device& d=Device());
     ~Queue();
     Queue(const Queue& q);
@@ -421,7 +421,7 @@ public:
 class CV_EXPORTS Kernel
 {
 public:
-    Kernel();
+    Kernel() CV_NOEXCEPT;
     Kernel(const char* kname, const Program& prog);
     Kernel(const char* kname, const ProgramSource& prog,
            const String& buildopts = String(), String* errmsg=0);
@@ -498,7 +498,7 @@ protected:
 class CV_EXPORTS Program
 {
 public:
-    Program();
+    Program() CV_NOEXCEPT;
     Program(const ProgramSource& src,
             const String& buildflags, String& errmsg);
     Program(const Program& prog);
@@ -544,7 +544,7 @@ class CV_EXPORTS ProgramSource
 public:
     typedef uint64 hash_t; // deprecated
 
-    ProgramSource();
+    ProgramSource() CV_NOEXCEPT;
     explicit ProgramSource(const String& module, const String& name, const String& codeStr, const String& codeHash);
     explicit ProgramSource(const String& prog); // deprecated
     explicit ProgramSource(const char* prog); // deprecated
@@ -614,7 +614,7 @@ protected:
 class CV_EXPORTS PlatformInfo
 {
 public:
-    PlatformInfo();
+    PlatformInfo() CV_NOEXCEPT;
     /**
      * @param id pointer cl_platform_id (cl_platform_id*)
      */

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1451,7 +1451,7 @@ struct Platform::Impl
     bool initialized;
 };
 
-Platform::Platform()
+Platform::Platform() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -1677,7 +1677,7 @@ struct Device::Impl
 };
 
 
-Device::Device()
+Device::Device() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -2834,7 +2834,7 @@ public:
 };
 
 
-Context::Context()
+Context::Context() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -3231,7 +3231,7 @@ struct Queue::Impl
     cv::ocl::Queue profiling_queue_;
 };
 
-Queue::Queue()
+Queue::Queue() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -3457,7 +3457,7 @@ static void CL_CALLBACK oclCleanupCallback(cl_event e, cl_int, void *p)
 
 namespace cv { namespace ocl {
 
-Kernel::Kernel()
+Kernel::Kernel() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -4047,7 +4047,7 @@ struct ProgramSource::Impl
 };
 
 
-ProgramSource::ProgramSource()
+ProgramSource::ProgramSource() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -4556,7 +4556,10 @@ struct Program::Impl
 };
 
 
-Program::Program() { p = 0; }
+Program::Program() CV_NOEXCEPT
+{
+    p = 0;
+}
 
 Program::Program(const ProgramSource& src,
         const String& buildflags, String& errmsg)
@@ -6608,7 +6611,7 @@ struct PlatformInfo::Impl
     int versionMinor_;
 };
 
-PlatformInfo::PlatformInfo()
+PlatformInfo::PlatformInfo() CV_NOEXCEPT
 {
     p = 0;
 }

--- a/modules/core/src/ocl_disabled.impl.hpp
+++ b/modules/core/src/ocl_disabled.impl.hpp
@@ -34,7 +34,7 @@ CV_EXPORTS_W void finish() { /* nothing */ }
 
 CV_EXPORTS bool haveSVM() { return false; }
 
-Device::Device() : p(NULL) { }
+Device::Device() CV_NOEXCEPT : p(NULL) { }
 Device::Device(void* d) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Device::Device(const Device& d) : p(NULL) { }
 Device& Device::operator=(const Device& d) { return *this; }
@@ -147,7 +147,7 @@ const Device& Device::getDefault()
 /* static */ Device Device::fromHandle(void* d) { OCL_NOT_AVAILABLE(); }
 
 
-Context::Context() : p(NULL) { }
+Context::Context() CV_NOEXCEPT : p(NULL) { }
 Context::Context(int dtype) : p(NULL) { }
 Context::~Context() { }
 Context::Context(const Context& c) : p(NULL) { }
@@ -178,7 +178,7 @@ void Context::setUseSVM(bool enabled) { }
 void Context::release() { }
 
 
-Platform::Platform() : p(NULL) { }
+Platform::Platform() CV_NOEXCEPT : p(NULL) { }
 Platform::~Platform() { }
 Platform::Platform(const Platform&) : p(NULL) { }
 Platform& Platform::operator=(const Platform&) { return *this; }
@@ -198,7 +198,7 @@ void convertFromImage(void* cl_mem_image, UMat& dst) { OCL_NOT_AVAILABLE(); }
 
 void initializeContextFromHandle(Context& ctx, void* platform, void* context, void* device) { OCL_NOT_AVAILABLE(); }
 
-Queue::Queue() : p(NULL) { }
+Queue::Queue() CV_NOEXCEPT : p(NULL) { }
 Queue::Queue(const Context& c, const Device& d) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Queue::~Queue() { }
 Queue::Queue(const Queue& q) {}
@@ -235,7 +235,7 @@ KernelArg KernelArg::Constant(const Mat& m)
 }
 
 
-Kernel::Kernel() : p(NULL) { }
+Kernel::Kernel() CV_NOEXCEPT : p(NULL) { }
 Kernel::Kernel(const char* kname, const Program& prog) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Kernel::Kernel(const char* kname, const ProgramSource& prog, const String& buildopts, String* errmsg) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Kernel::~Kernel() { }
@@ -264,7 +264,7 @@ size_t Kernel::localMemSize() const { OCL_NOT_AVAILABLE(); }
 void* Kernel::ptr() const { return NULL; }
 
 
-Program::Program() : p(NULL) { }
+Program::Program() CV_NOEXCEPT : p(NULL) { }
 Program::Program(const ProgramSource& src, const String& buildflags, String& errmsg) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Program::Program(const Program& prog) : p(NULL) { }
 Program& Program::operator=(const Program& prog) { return *this; }
@@ -283,7 +283,7 @@ String Program::getPrefix() const { OCL_NOT_AVAILABLE(); }
 /* static */ String Program::getPrefix(const String& buildflags) { OCL_NOT_AVAILABLE(); }
 
 
-ProgramSource::ProgramSource() : p(NULL) { }
+ProgramSource::ProgramSource() CV_NOEXCEPT : p(NULL) { }
 ProgramSource::ProgramSource(const String& module, const String& name, const String& codeStr, const String& codeHash) : p(NULL) { }
 ProgramSource::ProgramSource(const String& prog) : p(NULL) { }
 ProgramSource::ProgramSource(const char* prog) : p(NULL) { }
@@ -298,7 +298,7 @@ ProgramSource::hash_t ProgramSource::hash() const { OCL_NOT_AVAILABLE(); }
 /* static */ ProgramSource ProgramSource::fromSPIR(const String& module, const String& name, const unsigned char* binary, const size_t size, const cv::String& buildOptions) { OCL_NOT_AVAILABLE(); }
 
 
-PlatformInfo::PlatformInfo() : p(NULL) { }
+PlatformInfo::PlatformInfo() CV_NOEXCEPT : p(NULL) { }
 PlatformInfo::PlatformInfo(void* id) : p(NULL) { OCL_NOT_AVAILABLE(); }
 PlatformInfo::~PlatformInfo() { }
 


### PR DESCRIPTION
fixes https://github.com/opencv/opencv/issues/19571
This is only for OpenCV 4.x. It requires C++11 or newer.

- follows iso c++ guideline C.44
- enables default compiler-created constructors to also be noexcept

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] The feature is well documented and sample code can be built with the project CMake
