### PR TITLE
Minor fix in OCL implementation of calcOpticalFlowPyrLK

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -938,7 +938,8 @@ namespace
             {
                 if (!lkSparse_run(prevPyr[level], nextPyr[level], prevPts,
                                   nextPts, status, err,
-                                  prevPts.total(), level))
+                                  static_cast<int>(prevPts.total()),
+                                  level))
                     return false;
             }
             return true;

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -938,7 +938,7 @@ namespace
             {
                 if (!lkSparse_run(prevPyr[level], nextPyr[level], prevPts,
                                   nextPts, status, err,
-                                  prevPts.cols, level))
+                                  prevPts.total(), level))
                     return false;
             }
             return true;


### PR DESCRIPTION
If prevPts size is (N, 1) (which is a default layout for converting `vector<Point2f>` to `UMat`) the `prevPts.cols == 1` and optical flow will be calculated for the first point only.
Getting `prevPts.total()` as in line 1048 is the correct way to get points count.
