### PR TITLE
(3.4) add noexcept to default constructors of cv::ocl

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -70,7 +70,7 @@ class CV_EXPORTS Image2D;
 class CV_EXPORTS_W_SIMPLE Device
 {
 public:
-    CV_WRAP Device();
+    CV_WRAP Device() CV_NOEXCEPT;
     explicit Device(void* d);
     Device(const Device& d);
     Device& operator = (const Device& d);
@@ -238,7 +238,7 @@ protected:
 class CV_EXPORTS Context
 {
 public:
-    Context();
+    Context() CV_NOEXCEPT;
     explicit Context(int dtype);
     ~Context();
     Context(const Context& c);
@@ -269,7 +269,7 @@ public:
 class CV_EXPORTS Platform
 {
 public:
-    Platform();
+    Platform() CV_NOEXCEPT;
     ~Platform();
     Platform(const Platform& p);
     Platform& operator = (const Platform& p);
@@ -324,7 +324,7 @@ void initializeContextFromHandle(Context& ctx, void* platform, void* context, vo
 class CV_EXPORTS Queue
 {
 public:
-    Queue();
+    Queue() CV_NOEXCEPT;
     explicit Queue(const Context& c, const Device& d=Device());
     ~Queue();
     Queue(const Queue& q);
@@ -350,7 +350,7 @@ class CV_EXPORTS KernelArg
 public:
     enum { LOCAL=1, READ_ONLY=2, WRITE_ONLY=4, READ_WRITE=6, CONSTANT=8, PTR_ONLY = 16, NO_SIZE=256 };
     KernelArg(int _flags, UMat* _m, int wscale=1, int iwscale=1, const void* _obj=0, size_t _sz=0);
-    KernelArg();
+    KernelArg() CV_NOEXCEPT;
 
     static KernelArg Local(size_t localMemSize)
     { return KernelArg(LOCAL, 0, 1, 1, 0, localMemSize); }
@@ -387,7 +387,7 @@ public:
 class CV_EXPORTS Kernel
 {
 public:
-    Kernel();
+    Kernel() CV_NOEXCEPT;
     Kernel(const char* kname, const Program& prog);
     Kernel(const char* kname, const ProgramSource& prog,
            const String& buildopts = String(), String* errmsg=0);
@@ -597,7 +597,7 @@ protected:
 class CV_EXPORTS Program
 {
 public:
-    Program();
+    Program() CV_NOEXCEPT;
     Program(const ProgramSource& src,
             const String& buildflags, String& errmsg);
     Program(const Program& prog);
@@ -642,7 +642,7 @@ class CV_EXPORTS ProgramSource
 public:
     typedef uint64 hash_t; // deprecated
 
-    ProgramSource();
+    ProgramSource() CV_NOEXCEPT;
     explicit ProgramSource(const String& module, const String& name, const String& codeStr, const String& codeHash);
     explicit ProgramSource(const String& prog); // deprecated
     explicit ProgramSource(const char* prog); // deprecated
@@ -711,7 +711,7 @@ protected:
 class CV_EXPORTS PlatformInfo
 {
 public:
-    PlatformInfo();
+    PlatformInfo() CV_NOEXCEPT;
     explicit PlatformInfo(void* id);
     ~PlatformInfo();
 
@@ -776,7 +776,7 @@ CV_EXPORTS void buildOptionsAddMatrixDescription(String& buildOptions, const Str
 class CV_EXPORTS Image2D
 {
 public:
-    Image2D();
+    Image2D() CV_NOEXCEPT;
 
     /**
     @param src UMat object from which to get image properties and data

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1114,7 +1114,7 @@ struct Platform::Impl
     bool initialized;
 };
 
-Platform::Platform()
+Platform::Platform() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -1310,7 +1310,7 @@ struct Device::Impl
 };
 
 
-Device::Device()
+Device::Device() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -2283,7 +2283,7 @@ struct Context::Impl
 };
 
 
-Context::Context()
+Context::Context() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -2654,7 +2654,7 @@ struct Queue::Impl
     cv::ocl::Queue profiling_queue_;
 };
 
-Queue::Queue()
+Queue::Queue() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -2734,7 +2734,7 @@ static cl_command_queue getQueue(const Queue& q)
 
 /////////////////////////////////////////// KernelArg /////////////////////////////////////////////
 
-KernelArg::KernelArg()
+KernelArg::KernelArg() CV_NOEXCEPT
     : flags(0), m(0), obj(0), sz(0), wscale(1), iwscale(1)
 {
 }
@@ -2876,7 +2876,7 @@ static void CL_CALLBACK oclCleanupCallback(cl_event e, cl_int, void *p)
 
 namespace cv { namespace ocl {
 
-Kernel::Kernel()
+Kernel::Kernel() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -3466,7 +3466,7 @@ struct ProgramSource::Impl
 };
 
 
-ProgramSource::ProgramSource()
+ProgramSource::ProgramSource() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -3975,7 +3975,10 @@ struct Program::Impl
 };
 
 
-Program::Program() { p = 0; }
+Program::Program() CV_NOEXCEPT
+{
+    p = 0;
+}
 
 Program::Program(const ProgramSource& src,
         const String& buildflags, String& errmsg)
@@ -5999,7 +6002,7 @@ struct PlatformInfo::Impl
     int versionMinor_;
 };
 
-PlatformInfo::PlatformInfo()
+PlatformInfo::PlatformInfo() CV_NOEXCEPT
 {
     p = 0;
 }
@@ -6566,7 +6569,7 @@ struct Image2D::Impl
     cl_mem handle;
 };
 
-Image2D::Image2D()
+Image2D::Image2D() CV_NOEXCEPT
 {
     p = NULL;
 }

--- a/modules/core/src/ocl_disabled.impl.hpp
+++ b/modules/core/src/ocl_disabled.impl.hpp
@@ -34,7 +34,7 @@ CV_EXPORTS_W void finish() { /* nothing */ }
 
 CV_EXPORTS bool haveSVM() { return false; }
 
-Device::Device() : p(NULL) { }
+Device::Device() CV_NOEXCEPT : p(NULL) { }
 Device::Device(void* d) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Device::Device(const Device& d) : p(NULL) { }
 Device& Device::operator=(const Device& d) { return *this; }
@@ -145,7 +145,7 @@ const Device& Device::getDefault()
 }
 
 
-Context::Context() : p(NULL) { }
+Context::Context() CV_NOEXCEPT : p(NULL) { }
 Context::Context(int dtype) : p(NULL) { }
 Context::~Context() { }
 Context::Context(const Context& c) : p(NULL) { }
@@ -169,7 +169,7 @@ void* Context::ptr() const { return NULL; }
 bool Context::useSVM() const { return false; }
 void Context::setUseSVM(bool enabled) { }
 
-Platform::Platform() : p(NULL) { }
+Platform::Platform() CV_NOEXCEPT : p(NULL) { }
 Platform::~Platform() { }
 Platform::Platform(const Platform&) : p(NULL) { }
 Platform& Platform::operator=(const Platform&) { return *this; }
@@ -189,7 +189,7 @@ void convertFromImage(void* cl_mem_image, UMat& dst) { OCL_NOT_AVAILABLE(); }
 
 void initializeContextFromHandle(Context& ctx, void* platform, void* context, void* device) { OCL_NOT_AVAILABLE(); }
 
-Queue::Queue() : p(NULL) { }
+Queue::Queue() CV_NOEXCEPT : p(NULL) { }
 Queue::Queue(const Context& c, const Device& d) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Queue::~Queue() { }
 Queue::Queue(const Queue& q) {}
@@ -209,7 +209,7 @@ Queue& Queue::getDefault()
 const Queue& Queue::getProfilingQueue() const { OCL_NOT_AVAILABLE(); }
 
 
-KernelArg::KernelArg()
+KernelArg::KernelArg() CV_NOEXCEPT
     : flags(0), m(0), obj(0), sz(0), wscale(1), iwscale(1)
 {
 }
@@ -226,7 +226,7 @@ KernelArg KernelArg::Constant(const Mat& m)
 }
 
 
-Kernel::Kernel() : p(NULL) { }
+Kernel::Kernel() CV_NOEXCEPT : p(NULL) { }
 Kernel::Kernel(const char* kname, const Program& prog) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Kernel::Kernel(const char* kname, const ProgramSource& prog, const String& buildopts, String* errmsg) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Kernel::~Kernel() { }
@@ -255,7 +255,7 @@ size_t Kernel::localMemSize() const { OCL_NOT_AVAILABLE(); }
 void* Kernel::ptr() const { return NULL; }
 
 
-Program::Program() : p(NULL) { }
+Program::Program() CV_NOEXCEPT : p(NULL) { }
 Program::Program(const ProgramSource& src, const String& buildflags, String& errmsg) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Program::Program(const Program& prog) : p(NULL) { }
 Program& Program::operator=(const Program& prog) { return *this; }
@@ -274,7 +274,7 @@ String Program::getPrefix() const { OCL_NOT_AVAILABLE(); }
 /* static */ String Program::getPrefix(const String& buildflags) { OCL_NOT_AVAILABLE(); }
 
 
-ProgramSource::ProgramSource() : p(NULL) { }
+ProgramSource::ProgramSource() CV_NOEXCEPT : p(NULL) { }
 ProgramSource::ProgramSource(const String& module, const String& name, const String& codeStr, const String& codeHash) : p(NULL) { }
 ProgramSource::ProgramSource(const String& prog) : p(NULL) { }
 ProgramSource::ProgramSource(const char* prog) : p(NULL) { }
@@ -289,7 +289,7 @@ ProgramSource::hash_t ProgramSource::hash() const { OCL_NOT_AVAILABLE(); }
 /* static */ ProgramSource ProgramSource::fromSPIR(const String& module, const String& name, const unsigned char* binary, const size_t size, const cv::String& buildOptions) { OCL_NOT_AVAILABLE(); }
 
 
-PlatformInfo::PlatformInfo() : p(NULL) { }
+PlatformInfo::PlatformInfo() CV_NOEXCEPT : p(NULL) { }
 PlatformInfo::PlatformInfo(void* id) : p(NULL) { OCL_NOT_AVAILABLE(); }
 PlatformInfo::~PlatformInfo() { }
 
@@ -332,7 +332,7 @@ int predictOptimalVectorWidthMax(InputArray src1, InputArray src2, InputArray sr
 void buildOptionsAddMatrixDescription(String& buildOptions, const String& name, InputArray _m) { OCL_NOT_AVAILABLE(); }
 
 
-Image2D::Image2D() : p(NULL) { }
+Image2D::Image2D() CV_NOEXCEPT : p(NULL) { }
 Image2D::Image2D(const UMat &src, bool norm, bool alias) { OCL_NOT_AVAILABLE(); }
 Image2D::Image2D(const Image2D & i) : p(NULL) { OCL_NOT_AVAILABLE(); }
 Image2D::~Image2D() { }


### PR DESCRIPTION
backport #19572

- handled KernelArg, Image2D
