### PR TITLE
build warning (windows 32-bit)

### DIFF
--- a/modules/imgcodecs/test/test_exr.impl.hpp
+++ b/modules/imgcodecs/test/test_exr.impl.hpp
@@ -12,7 +12,7 @@ size_t getFileSize(const string& filename)
     if (ifs.is_open())
     {
         ifs.seekg(0, std::ios::end);
-        return ifs.tellg();
+        return (size_t)ifs.tellg();
     }
     return 0;
 }


### PR DESCRIPTION
relates #19540

```
force_builders=Win32
```