### PR TITLE
core(parallel): fix JS build, fix OpenMP version dump

### DIFF
--- a/modules/core/include/opencv2/core/parallel/parallel_backend.hpp
+++ b/modules/core/include/opencv2/core/parallel/parallel_backend.hpp
@@ -5,6 +5,7 @@
 #ifndef OPENCV_CORE_PARALLEL_BACKEND_HPP
 #define OPENCV_CORE_PARALLEL_BACKEND_HPP
 
+#include "opencv2/core/cvdef.h"
 #include <memory>
 
 namespace cv { namespace parallel {

--- a/modules/core/misc/plugins/parallel_openmp/CMakeLists.txt
+++ b/modules/core/misc/plugins/parallel_openmp/CMakeLists.txt
@@ -8,5 +8,5 @@ include("${OpenCV_SOURCE_DIR}/cmake/OpenCVPluginStandalone.cmake")
 set(WITH_OPENMP ON)
 include("${OpenCV_SOURCE_DIR}/modules/core/cmake/parallel/init.cmake")
 
-message(STATUS "OpenMP: ${OPENMP_VERSION}")
+message(STATUS "OpenMP: ${OpenMP_CXX_VERSION}")
 ocv_create_plugin(core "opencv_core_parallel_openmp" "ocv.3rdparty.openmp" "OPENMP" "src/parallel/parallel_openmp.cpp")

--- a/modules/core/src/parallel/plugin_parallel_wrapper.impl.hpp
+++ b/modules/core/src/parallel/plugin_parallel_wrapper.impl.hpp
@@ -279,6 +279,7 @@ std::shared_ptr<IParallelBackendFactory> createPluginParallelBackendFactory(cons
 #if OPENCV_HAVE_FILESYSTEM_SUPPORT && defined(PARALLEL_ENABLE_PLUGINS)
     return std::make_shared<impl::PluginParallelBackendFactory>(baseName);
 #else
+    CV_UNUSED(baseName);
     return std::shared_ptr<IParallelBackendFactory>();
 #endif
 }


### PR DESCRIPTION
hotfix #19470

[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master-contrib_docs-lin64/builds/11472).

```
force_builders_only=Docs
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04

build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6
```