### PR TITLE
Fix UB in CopyMakeConstBoder_8u

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -1325,13 +1325,12 @@ void copyMakeConstBorder_8u( const uchar* src, size_t srcstep, cv::Size srcroi,
         memcpy( dstInner + srcroi.width, constBuf, right );
     }
 
-    dst += dststep*top;
-
     for( i = 0; i < top; i++ )
-        memcpy(dst + (i - top)*dststep, constBuf, dstroi.width);
+        memcpy(dst + i * dststep, constBuf, dstroi.width);
 
+    dst += (top + srcroi.height) * dststep;
     for( i = 0; i < bottom; i++ )
-        memcpy(dst + (i + srcroi.height)*dststep, constBuf, dstroi.width);
+        memcpy(dst + i * dststep, constBuf, dstroi.width);
 }
 
 }


### PR DESCRIPTION
**Problem**: addition of unsigned offset to 0x000007ff0362 overflowed to 0x000007fefac0

In `third_party/opencv/modules/core/src/copy.cpp ` the function `copyMakeConstBorder_8u` receives the step of a cv::Mat, namely `dststep` of type `size_t`. When offsetting the destination matrix pointer to start copying data, `memcpy(dst + (i - top) * dststep, constBuf, dstroi.width)` the result of `(i - top)` could be negative, then, when applying the arithmetic operator * because of [arithmetic operator conversion](https://en.cppreference.com/w/cpp/language/operator_arithmetic) the int is converted to size_t, resulting pointer overflow.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
