### PR TITLE
boost NMS performance

### DIFF
--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -133,6 +133,12 @@ public:
 
     typedef std::map<int, std::vector<util::NormalizedBBox> > LabelBBox;
 
+    inline int getNumOfTargetClasses() {
+        unsigned numBackground =
+            (_backgroundLabelId >= 0 && _backgroundLabelId < _numClasses) ? 1 : 0;
+        return (_numClasses - numBackground);
+    }
+
     bool getParameterDict(const LayerParams &params,
                           const std::string &parameterName,
                           DictValue& result)
@@ -584,12 +590,13 @@ public:
             LabelBBox::const_iterator label_bboxes = decodeBBoxes.find(label);
             if (label_bboxes == decodeBBoxes.end())
                 CV_Error_(cv::Error::StsError, ("Could not find location predictions for label %d", label));
+            int limit = (getNumOfTargetClasses() == 1) ? _keepTopK : std::numeric_limits<int>::max();
             if (_bboxesNormalized)
                 NMSFast_(label_bboxes->second, scores, _confidenceThreshold, _nmsThreshold, 1.0, _topK,
-                         indices[c], util::caffe_norm_box_overlap);
+                         indices[c], util::caffe_norm_box_overlap, limit);
             else
                 NMSFast_(label_bboxes->second, scores, _confidenceThreshold, _nmsThreshold, 1.0, _topK,
-                         indices[c], util::caffe_box_overlap);
+                         indices[c], util::caffe_box_overlap, limit);
             numDetections += indices[c].size();
         }
         if (_keepTopK > -1 && numDetections > (size_t)_keepTopK)


### PR DESCRIPTION
To boost NMS performance, we apply early termination here at this PR.

Notice that **current detection out layer will be used internally by proposal layer.**
In this case, finally, proposal will, ex output top 100 proposals among all candidates.

Typically, **the # of candidates is about more than several thousands**.
Currently flow seriously down-grades performance **by applying NMS for all candidates**.
**However, as we know, to output top K NMS output, we should check if we have picked enough candidates and terminate once we have collected what we need.**

As the table below, to output top K = 100 candidates, we just need to check less than one thousand bboxes
But for current flow, we check all.

pic | # of candidate calculated before | # of candidate calculated after
-- | -- | --
1 | 6000 | 573
2 | 6000 | 371
3 | 6000 | 240



Since NMS is the most time-consuming part of proposal (detection out) layer, it downgrades performance much.
Ex, the experiment shows we will speed up by > x10 times for NMS.  
  | NMS exe time | NMS exe time
-- | -- | --
pic | before(ms) | after (ms)
1 | 16.989 | 1.566
2 | 30.75 | 5.095
3 | 50.68 | 4.446

![image](https://user-images.githubusercontent.com/14846473/108982273-9ba02f80-765b-11eb-99ab-1c1a7f5a6f20.png)



As the result, the inference time for proposal (detection out) layer can speedup by, ex, at x2~x3 times faster than original flow.  

  | infer time | infer time
-- | -- | --
pic | before (ms)| after(ms)
1 | 31.755 | 15.111
2 | 54.335 | 23.932
3 | 69.057 | 23.85

![image](https://user-images.githubusercontent.com/14846473/108982170-7f9c8e00-765b-11eb-966b-f93367e83cbf.png)

Finally, to output top 100, from the table below we understand that original flow does unnecessary work in calculating extra candidates (which > 100). 
By saving it, we can greatly boost layer inference performance.

pic | selected before | selected after
-- | -- | --
1 | 1286 | 100
2 | 1151 | 100
3 | 3369 | 100


test image can be download at following link:

 
[testImage.zip](https://github.com/opencv/opencv/files/6035012/testImage.zip)

test model is:
opencv/opencv_extra/testdata/dnn/mask_rcnn_inception_v2_coco_2018_01_28.pbtxt
mask_rcnn_inception_v2_coco_2018_01_28/frozen_inference_graph.pb

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
