### PR TITLE
G-API: Extend GKernelPackage API

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -517,6 +517,13 @@ namespace gapi {
         const std::vector<GTransform>& get_transformations() const;
 
         /**
+         * @brief Returns vector of kernel ids included in the package
+         *
+         * @return vector of kernel ids included in the package
+         */
+        std::vector<std::string> get_kernel_ids() const;
+
+        /**
          * @brief Test if a particular kernel _implementation_ KImpl is
          * included in this kernel package.
          *
@@ -603,6 +610,18 @@ namespace gapi {
         void include()
         {
             includeHelper<KImpl>();
+        }
+
+        void include(cv::gapi::GBackend bck, const std::string& id)
+        {
+            static auto kernel_helper = []() { return 42; };
+
+            cv::gapi::GBackend backend     = bck;
+            auto kernel_id   = id;
+            auto kernel_impl = GKernelImpl{kernel_helper/*, &KImpl::API::getOutMeta*/};
+            removeAPI(kernel_id);
+
+            m_id_kernels[kernel_id] = std::make_pair(backend, kernel_impl);
         }
 
         /**

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -55,6 +55,16 @@ const std::vector<cv::GTransform> &cv::gapi::GKernelPackage::get_transformations
     return m_transformations;
 }
 
+std::vector<std::string> cv::gapi::GKernelPackage::get_kernel_ids() const
+{
+    std::vector<std::string> ids;
+    for (const auto& id : m_id_kernels)
+    {
+        ids.push_back(id.first);
+    }
+    return ids;
+}
+
 cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,
                                            const GKernelPackage  &rhs)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.1.0

Xtest_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*
```