### PR TITLE
relative to https://forum.opencv.org/t/cv2-findtransformecc-sometimes…

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -339,7 +339,7 @@ CV_EXPORTS_W double findTransformECC( InputArray templateImage, InputArray input
                                       InputArray inputMask, int gaussFiltSize);
 
 /** @overload */
-CV_EXPORTS
+CV_EXPORTS_W
 double findTransformECC(InputArray templateImage, InputArray inputImage,
     InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),


### PR DESCRIPTION
relative to https://forum.opencv.org/t/cv2-findtransformecc-sometimes-missing-defaults/1870
Something weird There is pythong binding for cv.findTransformECC  but I cannot use it n python. There is two functions for findTransformECC   in python but only one with CV_EXPORTS_W

I think This pr needs t be tested on linux with python 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
