### PR TITLE
Remove redundant "if" condition and unused variables in libjasper and…

### DIFF
--- a/3rdparty/libjasper/jas_malloc.c
+++ b/3rdparty/libjasper/jas_malloc.c
@@ -145,8 +145,6 @@ void *jas_alloc2(size_t nmemb, size_t size)
 
 void *jas_alloc3(size_t a, size_t b, size_t c)
 {
-    size_t n;
-
     if (a && SIZE_MAX / a < b) {
         errno = ENOMEM;
         return NULL;

--- a/3rdparty/libjasper/jpc_enc.c
+++ b/3rdparty/libjasper/jpc_enc.c
@@ -1806,7 +1806,7 @@ if (jas_getdbglevel()) {
             if (pos > cumlen) {
                 /* The rate is too high. */
                 lo = thresh;
-            } else if (pos <= cumlen) {
+            } else {
                 /* The rate is low enough, so try higher. */
                 hi = thresh;
                 if (!success || thresh < goodthresh) {

--- a/3rdparty/libjasper/jpc_t1dec.c
+++ b/3rdparty/libjasper/jpc_t1dec.c
@@ -239,7 +239,7 @@ static int jpc_dec_decodecblk(jpc_dec_t *dec, jpc_dec_tile_t *tile, jpc_dec_tcom
         for (i = 0; i < seg->numpasses; ++i) {
             if (cblk->numimsbs > band->numbps) {
                 ccp = &tile->cp->ccps[compno];
-                if (ccp->roishift <= 0) {
+                if (ccp->roishift == 0) {
                     jas_eprintf("warning: corrupt code stream\n");
                 } else {
                     if (cblk->numimsbs < ccp->roishift - band->numbps) {

--- a/3rdparty/libjpeg-turbo/src/jdatasrc.c
+++ b/3rdparty/libjpeg-turbo/src/jdatasrc.c
@@ -106,7 +106,7 @@ fill_input_buffer(j_decompress_ptr cinfo)
 
   nbytes = JFREAD(src->infile, src->buffer, INPUT_BUF_SIZE);
 
-  if (nbytes <= 0) {
+  if (nbytes == 0) {
     if (src->start_of_file)     /* Treat empty input file as fatal error */
       ERREXIT(cinfo, JERR_INPUT_EMPTY);
     WARNMS(cinfo, JWRN_JPEG_EOF);

--- a/3rdparty/libjpeg-turbo/src/jdmarker.c
+++ b/3rdparty/libjpeg-turbo/src/jdmarker.c
@@ -267,7 +267,7 @@ get_sof(j_decompress_ptr cinfo, boolean is_prog, boolean is_arith)
   /* We don't support files in which the image height is initially specified */
   /* as 0 and is later redefined by DNL.  As long as we have to check that,  */
   /* might as well have a general sanity check. */
-  if (cinfo->image_height <= 0 || cinfo->image_width <= 0 ||
+  if (cinfo->image_height == 0 || cinfo->image_width == 0 ||
       cinfo->num_components <= 0)
     ERREXIT(cinfo, JERR_EMPTY_IMAGE);
 
@@ -709,7 +709,7 @@ get_interesting_appn(j_decompress_ptr cinfo)
 /* Process an APP0 or APP14 marker without saving it */
 {
   JLONG length;
-  JOCTET b[APPN_DATA_LEN];
+  JOCTET b[APPN_DATA_LEN] = {{0}};
   unsigned int i, numtoread;
   INPUT_VARS(cinfo);
 

--- a/3rdparty/libjpeg-turbo/src/jdmarker.c
+++ b/3rdparty/libjpeg-turbo/src/jdmarker.c
@@ -709,8 +709,11 @@ get_interesting_appn(j_decompress_ptr cinfo)
 /* Process an APP0 or APP14 marker without saving it */
 {
   JLONG length;
-  JOCTET b[APPN_DATA_LEN] = {{0}};
+  JOCTET b[APPN_DATA_LEN];
   unsigned int i, numtoread;
+
+  MEMZERO(b, sizeof(b));
+
   INPUT_VARS(cinfo);
 
   INPUT_2BYTES(cinfo, length, return FALSE);


### PR DESCRIPTION
1. Improve and simplify if statement by reducing condition that is not needed.
2. Remove unused variables function.
3. Fix uninitialized  char array.

Signed-off-by: Dan Ben Yosef danbey@gmail.com

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
