### PR TITLE
videoio: av_frame_unref compilation fix

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1469,9 +1469,12 @@ bool CvCapture_FFMPEG::retrieveFrame(int, unsigned char** data, int* step, int* 
     *height = frame.height;
     *cn = frame.cn;
 
-    if (sw_picture != picture) {
+#if USE_AV_HW_CODECS
+    if (sw_picture != picture)
+    {
         av_frame_unref(sw_picture);
     }
+#endif
     return true;
 }
 


### PR DESCRIPTION
related #19460

Compilation fix for older FFmpeg versions (< 2.0.0, >9 years old)

