### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2021.03

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/master_20200908
-# Binaries were created for OpenCV: f445b826d084188077a5e9d204c4c33d1589f380
-ocv_update(FFMPEG_BINARIES_COMMIT "6152e132572dfdaa32887eabeb7199bef49b14dc")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "37e2dadf776631acc8856e281f29cf42")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "cf5dba83edf8619f57ccff4edb989c62")
+# Binaries branch name: ffmpeg/master_20210303
+# Binaries were created for OpenCV: 7ac6abe02a33bef445a5b77214ad31964e2c5cc1
+ocv_update(FFMPEG_BINARIES_COMMIT "629590c3ba09fb0c8eaa9ab858ff13d3a84ca1aa")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "638065d5a0dab8a828879942375dcac4")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "7f10ae2e6a080ba3714f7a38ee03ae15")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "f8e65dbe4a3b4eedc0d2997e07c3f3fd")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -721,10 +721,6 @@ TEST_P(videocapture_acceleration, read)
     VideoAccelerationType actual_va = static_cast<VideoAccelerationType>(static_cast<int>(hw_reader.get(CAP_PROP_HW_ACCELERATION)));
     if (va_type != VIDEO_ACCELERATION_ANY && va_type != VIDEO_ACCELERATION_NONE)
     {
-#ifdef _WIN32  // FIXIT FFmpeg wrapper upgrade is required
-        if (actual_va == static_cast<VideoAccelerationType>(0))
-            throw SkipTestException(backend_name + " VideoCapture on " + filename + " not supported with HW acceleration (legacy FFmpeg wrapper), skipping");
-#endif
         ASSERT_EQ((int)actual_va, (int)va_type) << "actual_va=" << actual_va << ", va_type=" << va_type;
     }
     std::cout << "VideoCapture " << backend_name << ":" << actual_va << std::endl << std::flush;
@@ -880,10 +876,6 @@ TEST_P(videowriter_acceleration, write)
         actual_va = static_cast<VideoAccelerationType>(static_cast<int>(hw_writer.get(VIDEOWRITER_PROP_HW_ACCELERATION)));
         if (va_type != VIDEO_ACCELERATION_ANY && va_type != VIDEO_ACCELERATION_NONE)
         {
-#ifdef _WIN32  // FIXIT FFmpeg wrapper upgrade is required
-            if (actual_va == static_cast<VideoAccelerationType>(-1))
-                throw SkipTestException(backend_name + " VideoWriter on " + filename + " not supported with HW acceleration (legacy FFmpeg wrapper), skipping");
-#endif
             ASSERT_EQ((int)actual_va, (int)va_type) << "actual_va=" << actual_va << ", va_type=" << va_type;
         }
         std::cout << "VideoWriter " << backend_name << ":" << actual_va << std::endl << std::flush;


### PR DESCRIPTION
**Merge with 3rdparty**: https://github.com/opencv/opencv_3rdparty/pull/62

- FFmpeg 4.3.2

previous update: #18290
