### PR TITLE
videoio(ffmpeg): fix VIDEO_ACCELERATION_ANY handling

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_hw.hpp
+++ b/modules/videoio/src/cap_ffmpeg_hw.hpp
@@ -486,7 +486,7 @@ public:
         if (va_type == VIDEO_ACCELERATION_ANY)
         {
             if (!accel_list.empty())
-                accel_list = ",";  // add no-acceleration case to the end of the list
+                accel_list += ",";  // add no-acceleration case to the end of the list
         }
         CV_LOG_DEBUG(NULL, "FFMPEG: allowed acceleration types (" << getVideoAccelerationName(va_type) << "): '" << accel_list << "'");
 

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -572,7 +572,7 @@ void CvCapture_FFMPEG::init()
     memset(&packet_filtered, 0, sizeof(packet_filtered));
     av_init_packet(&packet_filtered);
     bsfc = NULL;
-    va_type = cv::VIDEO_ACCELERATION_ANY;
+    va_type = cv::VIDEO_ACCELERATION_NONE;  // TODO OpenCV 5.0: change to _ANY?
     hw_device = -1;
 }
 


### PR DESCRIPTION
relates #19460

thanks to @mikhail-nikolskiy

<cut/>

```
force_builders=Custom Win
build_image:Custom Win=ffmpeg-plugin
buildworker:Custom Win=windows-2
test_modules:Custom Win=videoio,python3,java
test_opencl:Custom Win=ON

Xtest_modules=videoio,python3,java

buildworker:Win64 OpenCL=windows-1

build_image:Win64=ffmpeg-plugin-msvs2015
buildworker:Win64=windows-2
test_opencl:Win64=ON
```