### PR TITLE
getCacheDirectory binding for Python

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -144,7 +144,10 @@ AsyncArray testAsyncException()
     return p.getArrayResult();
 }
 
+namespace fs {
+    CV_EXPORTS_AS(getCacheDirectory) cv::String getCacheDirectoryForDownloads();
+}
 //! @}
-}} // namespace
+}} // namespace fs
 
 #endif // OPENCV_CORE_BINDINGS_UTILS_HPP

--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -145,9 +145,9 @@ AsyncArray testAsyncException()
 }
 
 namespace fs {
-    CV_EXPORTS_AS(getCacheDirectory) cv::String getCacheDirectoryForDownloads();
-}
+    CV_EXPORTS_W cv::String getCacheDirectoryForDownloads();
+} // namespace fs
 //! @}
-}} // namespace fs
+}} // namespaces cv /  utils
 
 #endif // OPENCV_CORE_BINDINGS_UTILS_HPP

--- a/modules/core/src/bindings_utils.cpp
+++ b/modules/core/src/bindings_utils.cpp
@@ -5,6 +5,7 @@
 #include "precomp.hpp"
 #include "opencv2/core/bindings_utils.hpp"
 #include <sstream>
+#include <opencv2/core/utils/filesystem.hpp>
 
 namespace cv { namespace utils {
 
@@ -207,5 +208,12 @@ CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argume
     }
     return ss.str();
 }
+
+namespace fs {
+cv::String getCacheDirectoryForDownloads()
+{
+    return cv::utils::fs::getCacheDirectory("downloads", "OPENCV_DOWNLOADS_CACHE_DIR");
+}
+} // namespace fs
 
 }} // namespace

--- a/modules/core/src/bindings_utils.cpp
+++ b/modules/core/src/bindings_utils.cpp
@@ -6,6 +6,7 @@
 #include "opencv2/core/bindings_utils.hpp"
 #include <sstream>
 #include <opencv2/core/utils/filesystem.hpp>
+#include <opencv2/core/utils/filesystem.private.hpp>
 
 namespace cv { namespace utils {
 
@@ -212,7 +213,11 @@ CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argume
 namespace fs {
 cv::String getCacheDirectoryForDownloads()
 {
+#if OPENCV_HAVE_FILESYSTEM_SUPPORT
     return cv::utils::fs::getCacheDirectory("downloads", "OPENCV_DOWNLOADS_CACHE_DIR");
+#else
+    CV_Error(Error::StsNotImplemented, "File system support is disabled in this OpenCV build!");
+#endif
 }
 } // namespace fs
 

--- a/modules/python/test/test_fs_cache_dir.py
+++ b/modules/python/test/test_fs_cache_dir.py
@@ -1,0 +1,24 @@
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import cv2 as cv
+import os
+import datetime
+
+from tests_common import NewOpenCVTests
+
+class get_cache_dir_test(NewOpenCVTests):
+    def test_get_cache_dir(self):
+        #New binding
+        path = cv.utils.fs.getCacheDirectory()
+        try:
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(os.path.isdir(path))
+            os.rmdir(path)
+        except:
+            print("Tried to create cache directory ", path)
+            pass
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/python/test/test_fs_cache_dir.py
+++ b/modules/python/test/test_fs_cache_dir.py
@@ -1,6 +1,7 @@
 # Python 2/3 compatibility
 from __future__ import print_function
 
+import numpy as np
 import cv2 as cv
 import os
 import datetime
@@ -10,15 +11,31 @@ from tests_common import NewOpenCVTests
 class get_cache_dir_test(NewOpenCVTests):
     def test_get_cache_dir(self):
         #New binding
-        path = cv.utils.fs.getCacheDirectory()
-        try:
-            self.assertTrue(os.path.exists(path))
-            self.assertTrue(os.path.isdir(path))
-            os.rmdir(path)
-        except:
-            print("Tried to create cache directory ", path)
-            pass
+        path = cv.utils.fs.getCacheDirectoryForDownloads()
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.isdir(path))
 
+    def get_cache_dir_imread_interop(self, ext):
+        path = cv.utils.fs.getCacheDirectoryForDownloads()
+        gold_image = np.ones((16, 16, 3), np.uint8)
+        read_from_file = np.zeros((16, 16, 3), np.uint8)
+        test_file_name = os.path.join(path, "test." + ext)
+        try:
+            cv.imwrite(test_file_name, gold_image)
+            read_from_file = cv.imread(test_file_name)
+        finally:
+            os.remove(test_file_name)
+
+        self.assertEqual(cv.norm(gold_image, read_from_file), 0)
+
+    def test_get_cache_dir_imread_interop_png(self):
+        self.get_cache_dir_imread_interop("png")
+
+    def test_get_cache_dir_imread_interop_jpeg(self):
+        self.get_cache_dir_imread_interop("jpg")
+
+    def test_get_cache_dir_imread_interop_tiff(self):
+        self.get_cache_dir_imread_interop("tif")
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Replaces https://github.com/opencv/opencv/pull/18931 and adds more test for imgcodecs interop.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
