### PR TITLE
Fix static analyzer issues

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -936,6 +936,7 @@ struct InferList: public cv::detail::KernelTag {
                                 std::vector<cv::Mat> &out_vec = ctx->outVecR<cv::Mat>(i);
 
                                 IE::Blob::Ptr out_blob = req.GetBlob(ctx->uu.params.output_names[i]);
+                                GAPI_Assert(out_blob);
 
                                 cv::Mat out_mat(cached_dims[i], toCV(out_blob->getTensorDesc().getPrecision()));
                                 // FIXME: Avoid data copy. Not sure if it is possible though
@@ -1103,6 +1104,7 @@ struct InferList2: public cv::detail::KernelTag {
                                     std::vector<cv::Mat> &out_vec = ctx->outVecR<cv::Mat>(i);
 
                                     IE::Blob::Ptr out_blob = req.GetBlob(ctx->uu.params.output_names[i]);
+                                    GAPI_Assert(out_blob);
 
                                     cv::Mat out_mat(cached_dims[i], toCV(out_blob->getTensorDesc().getPrecision()));
                                     // FIXME: Avoid data copy. Not sure if it is possible though

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -615,6 +615,8 @@ protected:
     _ComPtr<IMFDXGIDeviceManager> D3DMgr;
 #endif
     _ComPtr<IMFSourceReader> videoFileSource;
+    _ComPtr<IMFSample> videoSample;
+    _ComPtr<IMFSourceReaderCallback> readCallback;  // non-NULL for "live" streams (camera capture)
     DWORD dwStreamIndex;
     MediaType nativeFormat;
     MediaType captureFormat;
@@ -622,10 +624,8 @@ protected:
     bool convertFormat;
     MFTIME duration;
     LONGLONG frameStep;
-    _ComPtr<IMFSample> videoSample;
     LONGLONG sampleTime;
     bool isOpen;
-    _ComPtr<IMFSourceReaderCallback> readCallback;  // non-NULL for "live" streams (camera capture)
 };
 
 CvCapture_MSMF::CvCapture_MSMF():
@@ -641,8 +641,12 @@ CvCapture_MSMF::CvCapture_MSMF():
 #endif
     videoFileSource(NULL),
     videoSample(NULL),
+    readCallback(NULL),
+    dwStreamIndex(0),
     outputFormat(CV_CAP_MODE_BGR),
     convertFormat(true),
+    duration(0),
+    frameStep(0),
     sampleTime(0),
     isOpen(false)
 {


### PR DESCRIPTION

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
Xbuild_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.2.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi,python3,java
test_modules:Custom Win=gapi,python3,java
test_modules:Custom Mac=gapi,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```