### PR TITLE
dnn : Added Spatial Attention Module in Darknet Importer

### DIFF
--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -770,6 +770,11 @@ TEST_P(Test_Darknet_layers, relu)
     testDarknetLayer("relu");
 }
 
+TEST_P(Test_Darknet_layers, sam)
+{
+    testDarknetLayer("sam", true);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_Darknet_layers, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
Spatial Attention Module in YOLOv4.  
From https://github.com/AlexeyAB/darknet/wiki/CFG-Parameters-in-the-different-layers
![sam description](https://user-images.githubusercontent.com/47391270/109850475-90ab5780-7c78-11eb-9de1-7008d7c16730.png)

resolves : #18988 
merge with extra : opencv/opencv_extra#861

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.2.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```