### PR TITLE
Init params (StereoBMParams) in StereoBMImpl constructor initialization list

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1147,15 +1147,10 @@ protected:
 class StereoBMImpl CV_FINAL : public StereoBM
 {
 public:
-    StereoBMImpl()
-    {
-        params = StereoBMParams();
-    }
+    StereoBMImpl():params() {}
 
-    StereoBMImpl( int _numDisparities, int _SADWindowSize )
-    {
-        params = StereoBMParams(_numDisparities, _SADWindowSize);
-    }
+    StereoBMImpl( int _numDisparities, int _SADWindowSize ):
+        params(StereoBMParams(_numDisparities, _SADWindowSize)) {}
 
     void compute( InputArray leftarr, InputArray rightarr, OutputArray disparr ) CV_OVERRIDE
     {

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1154,7 +1154,7 @@ public:
     }
 
     StereoBMImpl( int _numDisparities, int _SADWindowSize )
-        : params(StereoBMParams(_numDisparities, _SADWindowSize))
+        : params(_numDisparities, _SADWindowSize)
     {
         // nothing
     }

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1147,10 +1147,17 @@ protected:
 class StereoBMImpl CV_FINAL : public StereoBM
 {
 public:
-    StereoBMImpl():params() {}
+    StereoBMImpl()
+        : params()
+    {
+        // nothing
+    }
 
-    StereoBMImpl( int _numDisparities, int _SADWindowSize ):
-        params(StereoBMParams(_numDisparities, _SADWindowSize)) {}
+    StereoBMImpl( int _numDisparities, int _SADWindowSize )
+        : params(StereoBMParams(_numDisparities, _SADWindowSize))
+    {
+        // nothing
+    }
 
     void compute( InputArray leftarr, InputArray rightarr, OutputArray disparr ) CV_OVERRIDE
     {


### PR DESCRIPTION
To improve preformence it is better to init the params (StereoBMImpl) in the
initialization list.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
