### PR TITLE
Init params (StereoSGBMParams) in StereoSGBMImpl constructor init list

### DIFF
--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -2186,19 +2186,21 @@ class StereoSGBMImpl CV_FINAL : public StereoSGBM
 {
 public:
     StereoSGBMImpl()
+        : params()
     {
-        params = StereoSGBMParams();
+        // nothing
     }
 
     StereoSGBMImpl( int _minDisparity, int _numDisparities, int _SADWindowSize,
                     int _P1, int _P2, int _disp12MaxDiff, int _preFilterCap,
                     int _uniquenessRatio, int _speckleWindowSize, int _speckleRange,
                     int _mode )
+        : params(_minDisparity, _numDisparities, _SADWindowSize,
+                 _P1, _P2, _disp12MaxDiff, _preFilterCap,
+                 _uniquenessRatio, _speckleWindowSize, _speckleRange,
+                 _mode)
     {
-        params = StereoSGBMParams( _minDisparity, _numDisparities, _SADWindowSize,
-                                   _P1, _P2, _disp12MaxDiff, _preFilterCap,
-                                   _uniquenessRatio, _speckleWindowSize, _speckleRange,
-                                   _mode );
+        // nothing
     }
 
     void compute( InputArray leftarr, InputArray rightarr, OutputArray disparr ) CV_OVERRIDE


### PR DESCRIPTION
    To improve performance it is better to init the params (StereoSGBMParams) in the
    initialization list.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
