### PR TITLE
core(ocl): skip SPIR test on AMD devices if problem detected

### DIFF
--- a/modules/core/test/ocl/test_opencl.cpp
+++ b/modules/core/test/ocl/test_opencl.cpp
@@ -120,6 +120,11 @@ TEST(OpenCL, support_SPIR_programs)
         cv::ocl::ProgramSource src = cv::ocl::ProgramSource::fromSPIR(module_name, "simple_spir", (uchar*)&program_binary_code[0], program_binary_code.size(), "");
         cv::String errmsg;
         cv::ocl::Program program(src, "", errmsg);
+        if (program.ptr() == NULL && device.isAMD())
+        {
+            // https://community.amd.com/t5/opencl/spir-support-in-new-drivers-lost/td-p/170165
+            throw cvtest::SkipTestException("Bypass AMD OpenCL runtime bug: 'cl_khr_spir' extension is declared, but it doesn't really work");
+        }
         ASSERT_TRUE(program.ptr() != NULL);
         k.create("test_kernel", program);
     }


### PR DESCRIPTION
Details: https://community.amd.com/t5/opencl/spir-support-in-new-drivers-lost/td-p/170165

<cut/>

```
Current OpenCL device: 
    Type = dGPU
    Name = Baffin
    ...
    Device extensions:
        ...
        cl_khr_spir

[ RUN      ] OpenCL.support_SPIR_programs
Program SPIR size: 1700 bytes
OpenCL program build log: /simple_spir
Status -11: CL_BUILD_PROGRAM_FAILURE

Error: HSAIL doesn't support OpenCL extension spir.
An invalid binary was detected.
Error: BRIG code generation failed.

/build/3_4_noICV-skx-lin64/opencv/modules/core/test/ocl/test_opencl.cpp:123: Failure
Value of: program.ptr() != NULL
  Actual: false
Expected: true
[  FAILED  ] OpenCL.support_SPIR_programs (0 ms)
```

---

```
force_builders=Custom,Linux OpenCL
build_image:Custom=ubuntu:20.04
buildworker:Custom=linux-3
test_opencl:Custom=ON

build_image:Linux AVX2=ubuntu:18.04
buildworker:Linux AVX2=linux-5
test_opencl:Linux AVX2=ON
```
