### PR TITLE
valgrind: filter out hardware-accelerated videoio tests

### DIFF
--- a/modules/ts/misc/run_long.py
+++ b/modules/ts/misc/run_long.py
@@ -46,6 +46,8 @@ LONG_TESTS_DEBUG_VALGRIND = [
     ('tracking', '*DistanceAndOverlap*/2', 1000.0), # faceocc2
     ('videoio', 'videoio/videoio_ffmpeg.write_big*', 1000),
     ('videoio', 'videoio_ffmpeg.parallel', 1000),
+    ('videoio', '*videocapture_acceleration*', 1000), # valgrind can't track HW buffers: Conditional jump or move depends on uninitialised value(s)
+    ('videoio', '*videowriter_acceleration*', 1000), # valgrind crash: set_mempolicy: Operation not permitted
     ('xfeatures2d', 'Features2d_RotationInvariance_Descriptor_BoostDesc_LBGM.regression', 1124.51),
     ('xfeatures2d', 'Features2d_RotationInvariance_Descriptor_VGG120.regression', 2198.1),
     ('xfeatures2d', 'Features2d_RotationInvariance_Descriptor_VGG48.regression', 1958.52),


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_valgrind-lin64-debug/builds/10287).

- [x] [Validation build](http://pullrequest.opencv.org/buildbot/builders/master_valgrind-lin64-debug/builds/10290)