### PR TITLE
 G-API: ONNX. Adding INT64-32 conversion for output.

### DIFF
--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -209,6 +209,12 @@ inline cv::util::optional<T> getCompileArg(const cv::GCompileArgs &args)
 
 void GAPI_EXPORTS createMat(const cv::GMatDesc& desc, cv::Mat& mat);
 
+inline void convertInt64ToInt32(const int64_t* src, int* dst, int size)
+{
+    std::transform(src, src + size, dst,
+                   [](int64_t el) { return static_cast<int>(el); });
+}
+
 }} // cv::gimpl
 
 #endif // OPENCV_GAPI_GBACKEND_HPP

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -209,7 +209,7 @@ inline cv::util::optional<T> getCompileArg(const cv::GCompileArgs &args)
 
 void GAPI_EXPORTS createMat(const cv::GMatDesc& desc, cv::Mat& mat);
 
-inline void convertInt64ToInt32(const int64_t* src, int* dst, int size)
+inline void convertInt64ToInt32(const int64_t* src, int* dst, size_t size)
 {
     std::transform(src, src + size, dst,
                    [](int64_t el) { return static_cast<int>(el); });

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -106,7 +106,7 @@ inline IE::Precision toIE(int depth) {
     case CV_8U:  return IE::Precision::U8;
     case CV_32S: return IE::Precision::I32;
     case CV_32F: return IE::Precision::FP32;
-    default:     GAPI_Assert(false && "Unsupported data type");
+    default:     GAPI_Assert(false && "IE. Unsupported data type");
     }
     return IE::Precision::UNSPECIFIED;
 }
@@ -116,7 +116,7 @@ inline int toCV(IE::Precision prec) {
     case IE::Precision::FP32: return CV_32F;
     case IE::Precision::I32:  return CV_32S;
     case IE::Precision::I64:  return CV_32S;
-    default:     GAPI_Assert(false && "Unsupported data type");
+    default:     GAPI_Assert(false && "IE. Unsupported data type");
     }
     return -1;
 }
@@ -159,7 +159,7 @@ inline IE::Blob::Ptr wrapIE(const cv::Mat &mat, cv::gapi::ie::TraitAs hint) {
         HANDLE(32F, float);
         HANDLE(32S, int);
 #undef HANDLE
-    default: GAPI_Assert(false && "Unsupported data type");
+    default: GAPI_Assert(false && "IE. Unsupported data type");
     }
     return IE::Blob::Ptr{};
 }
@@ -196,12 +196,13 @@ inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
         HANDLE(I32, int);
 #undef HANDLE
         case IE::Precision::I64: {
+            GAPI_LOG_WARNING(NULL, "INT64 isn't supported for cv::Mat. Conversion to INT32 is used.");
             cv::gimpl::convertInt64ToInt32(blob->buffer().as<int64_t*>(),
                                            reinterpret_cast<int*>(mat.data),
                                            mat.total());
             break;
         }
-    default: GAPI_Assert(false && "Unsupported data type");
+    default: GAPI_Assert(false && "IE. Unsupported data type");
     }
 }
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -115,6 +115,7 @@ inline int toCV(IE::Precision prec) {
     case IE::Precision::U8:   return CV_8U;
     case IE::Precision::FP32: return CV_32F;
     case IE::Precision::I32:  return CV_32S;
+    case IE::Precision::I64:  return CV_32S;
     default:     GAPI_Assert(false && "Unsupported data type");
     }
     return -1;
@@ -194,6 +195,14 @@ inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
         HANDLE(FP32, float);
         HANDLE(I32, int);
 #undef HANDLE
+        case IE::Precision::I64: {
+            const auto dims = blob->getTensorDesc().getDims();
+            const auto total = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
+            cv::gimpl::convertInt64ToInt32(blob->buffer().as<int64_t*>(),
+                                           reinterpret_cast<int*>(mat.data),
+                                           total);
+            break;
+        }
     default: GAPI_Assert(false && "Unsupported data type");
     }
 }

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -196,11 +196,9 @@ inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
         HANDLE(I32, int);
 #undef HANDLE
         case IE::Precision::I64: {
-            const auto dims = blob->getTensorDesc().getDims();
-            const auto total = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
             cv::gimpl::convertInt64ToInt32(blob->buffer().as<int64_t*>(),
                                            reinterpret_cast<int*>(mat.data),
-                                           total);
+                                           mat.total());
             break;
         }
     default: GAPI_Assert(false && "Unsupported data type");

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -199,7 +199,7 @@ inline cv::Mat toCV(Ort::Value &v) {
                        type,
                        reinterpret_cast<void*>(v.GetTensorMutableData<uint8_t*>()));
     }
-    const int total = std::accumulate(shape.begin(), shape.end(), 0);
+    const int total = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int>());
     cv::Mat mt(shape, CV_32S);
     int64_t* ptr = v.GetTensorMutableData<int64_t>();
     int* mt_ptr = mt.ptr<int>();

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -200,11 +200,10 @@ inline cv::Mat toCV(Ort::Value &v) {
                        reinterpret_cast<void*>(v.GetTensorMutableData<uint8_t*>()));
     }
     cv::Mat mt(shape, CV_32S);
-    const int64_t* ptr = v.GetTensorMutableData<int64_t>();
-    int* mt_ptr = mt.ptr<int>();
     GAPI_Assert(mt.isContinuous());
-    std::transform(ptr, ptr + mt.total(), mt_ptr,
-                   [](int64_t el) { return static_cast<int>(el); });
+    cv::gimpl::convertInt64ToInt32(v.GetTensorMutableData<int64_t>(),
+                                   mt.ptr<int>(),
+                                   mt.total());
     return mt;
 }
 

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -86,7 +86,6 @@ struct TensorInfo {
 
     bool is_dynamic = false;
     bool is_grayscale = false;
-    bool is_postproc = false;
 
     struct MeanStdev {
         cv::Scalar mean;

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -202,7 +202,7 @@ inline cv::Mat toCV(Ort::Value &v) {
     cv::Mat mt(shape, CV_32S);
     GAPI_Assert(mt.isContinuous());
     cv::gimpl::convertInt64ToInt32(v.GetTensorMutableData<int64_t>(),
-                                   mt.ptr<int>(),
+                                   reinterpret_cast<int*>(mt.data),
                                    mt.total());
     return mt;
 }

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -189,7 +189,7 @@ inline void copyFromONNX(Ort::Value &v, cv::Mat& mat) {
     const auto info = v.GetTensorTypeAndShapeInfo();
     const auto prec = info.GetElementType();
     const auto shape = toCV(info.GetShape());
-    mat = cv::Mat(shape, toCV(prec));
+    mat.create(shape, toCV(prec));
     switch (prec) {
 #define HANDLE(E,T)                                          \
         case E: std::copy_n(v.GetTensorMutableData<T>(),     \

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -205,6 +205,7 @@ inline cv::Mat toCV(Ort::Value &v) {
     int* mt_ptr = mt.ptr<int>();
     std::transform(ptr, ptr + total, mt_ptr,
                    [](int64_t el) { return static_cast<int>(el); });
+    GAPI_Assert(mt.isContinuous());
     return mt;
 }
 

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -176,7 +176,7 @@ std::tuple<int, bool> toCV(ONNXTensorElementDataType prec) {
     }
     default: GAPI_Assert(false && "Unsupported data type");
     }
-    return  std::make_tuple(-1, false);;
+    return std::make_tuple(-1, false);
 }
 
 inline std::vector<int> toCV(const std::vector<int64_t> &vsz) {

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -170,7 +170,10 @@ inline int toCV(ONNXTensorElementDataType prec) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8: return CV_8U;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: return CV_32F;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32: return CV_32S;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: return -1;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: {
+        GAPI_LOG_WARNING(NULL, "INT64 isn't supported for cv::Mat. Conversion to INT32 is used.");
+        return -1;
+    }
     default: GAPI_Assert(false && "Unsupported data type");
     }
     return -1;
@@ -198,7 +201,7 @@ inline cv::Mat toCV(Ort::Value &v) {
     const int64_t* ptr = v.GetTensorMutableData<int64_t>();
     cv::Mat mt({total}, CV_32S);
     for (int i = 0; i < total; ++i) {
-        mt.at<int>(i) = (static_cast<int>(ptr[i]));
+        mt.at<int>(i) = static_cast<int>(ptr[i]);
     }
     return mt.reshape(1, shape);
 }

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -199,13 +199,12 @@ inline cv::Mat toCV(Ort::Value &v) {
                        type,
                        reinterpret_cast<void*>(v.GetTensorMutableData<uint8_t*>()));
     }
-    const int total = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int>());
     cv::Mat mt(shape, CV_32S);
-    int64_t* ptr = v.GetTensorMutableData<int64_t>();
+    const int64_t* ptr = v.GetTensorMutableData<int64_t>();
     int* mt_ptr = mt.ptr<int>();
-    std::transform(ptr, ptr + total, mt_ptr,
-                   [](int64_t el) { return static_cast<int>(el); });
     GAPI_Assert(mt.isContinuous());
+    std::transform(ptr, ptr + mt.total(), mt_ptr,
+                   [](int64_t el) { return static_cast<int>(el); });
     return mt;
 }
 

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -242,8 +242,7 @@ inline void preprocess(const cv::Mat& src,
         const bool with_batch = ti.dims.size() == 4u ? true : false;
         const int shift = with_batch ? 0 : 1;
 
-        const auto ddepth = type;
-        GAPI_Assert((ddepth == CV_8U || ddepth == CV_32F)
+        GAPI_Assert((type == CV_8U || type == CV_32F)
                     && "Only 8U and 32F model input is supported for 8U data");
 
         // Assess the expected input layout
@@ -278,8 +277,8 @@ inline void preprocess(const cv::Mat& src,
 
         cv::Mat rsz, pp;
         cv::resize(csc, rsz, cv::Size(new_w, new_h));
-        if (src.depth() == CV_8U && ddepth == CV_32F) {
-            rsz.convertTo(pp, ddepth, ti.normalize ? 1.f / 255 : 1.f);
+        if (src.depth() == CV_8U && type == CV_32F) {
+            rsz.convertTo(pp, type, ti.normalize ? 1.f / 255 : 1.f);
             if (ti.mstd.has_value()) {
                 pp -= ti.mstd->mean;
                 pp /= ti.mstd->stdev;
@@ -290,7 +289,7 @@ inline void preprocess(const cv::Mat& src,
 
         if (!is_hwc && new_c > 1) {
             // Convert to CHW
-            dst.create(cv::Size(new_w, new_h * new_c), ddepth);
+            dst.create(cv::Size(new_w, new_h * new_c), type);
             std::vector<cv::Mat> planes(new_c);
             for (int ch = 0; ch < new_c; ++ch) {
                 planes[ch] = dst.rowRange(ch * new_h, (ch + 1) * new_h);

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -334,10 +334,9 @@ public:
                         reinterpret_cast<void*>(result[i].GetTensorMutableData<uint8_t*>()))
                 .copyTo(outs.back());
             } else {
-                const size_t total = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
                 const int64_t* ptr = result[i].GetTensorMutableData<int64_t>();
                 int* mt_ptr = outs.back().ptr<int>();
-                std::transform(ptr, ptr + total, mt_ptr,
+                std::transform(ptr, ptr + outs.back().total(), mt_ptr,
                                [](int64_t el) { return static_cast<int>(el); });
             }
         }

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -326,9 +326,11 @@ public:
         for (size_t i = 0; i < num_out; ++i) {
             const auto info = result[i].GetTensorTypeAndShapeInfo();
             const auto shape = info.GetShape();
-            const auto type = toCV(info.GetElementType());
+            const auto type = toCV(info.GetElementType()) != -1
+                ? toCV(info.GetElementType())
+                : CV_32S;
             const std::vector<int> dims(shape.begin(), shape.end());
-            if (type != -1){
+            if (type != -1) {
                 cv::Mat(dims, type,
                         reinterpret_cast<void*>(result[i].GetTensorMutableData<uint8_t*>()))
                 .copyTo(outs[i]);

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -973,7 +973,7 @@ TEST_F(ONNXYoloV3MultiInput, InferBSConstInput)
     validate();
 }
 
-TEST_F(ONNXRCNN, InferRCNN64to32)
+TEST_F(ONNXRCNN, ConversionInt64to32)
 {
     useModel("object_detection_segmentation/faster-rcnn/model/FasterRCNN-10");
     cv::Mat dst;

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -481,8 +481,8 @@ public:
         rsz.convertTo(cvt, CV_32F, 1.f);
         toCHW(cvt, chw);
         mn = chw - rcnn_mean;
-        int padded_h = std::ceil(new_h / 32.f) * 32;
-        int padded_w = std::ceil(new_w / 32.f) * 32;
+        const int padded_h = std::ceil(new_h / 32.f) * 32;
+        const int padded_w = std::ceil(new_w / 32.f) * 32;
         cv::Mat pad_im(cv::Size(padded_w, 3 * padded_h), CV_32F, 0.f);
         pad_im(cv::Rect(0, 0, mn.cols, mn.rows)) += mn;
         dst = pad_im.reshape(1, {3, padded_h, padded_w});

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -326,9 +326,7 @@ public:
         for (size_t i = 0; i < num_out; ++i) {
             const auto info = result[i].GetTensorTypeAndShapeInfo();
             const auto shape = info.GetShape();
-            const auto type = toCV(info.GetElementType()) != -1
-                ? toCV(info.GetElementType())
-                : CV_32S;
+            const auto type = toCV(info.GetElementType());
             const std::vector<int> dims(shape.begin(), shape.end());
             if (type != -1) {
                 cv::Mat(dims, type,
@@ -341,7 +339,7 @@ public:
                 for (size_t l = 0; l < total; ++l) {
                     out_vec.push_back(static_cast<int>(ptr[l]));
                 }
-                cv::Mat (dims, CV_32S, out_vec.data()).copyTo(outs[i]);
+                cv::Mat(dims, CV_32S, out_vec.data()).copyTo(outs[i]);
             }
         }
     }
@@ -463,8 +461,8 @@ public:
 class ONNXRCNN : public ONNXWithRemap {
 private:
     const cv::Scalar rcnn_mean = { 102.9801, 115.9465, 122.7717 };
-    float range_max = 1333;
-    float range_min = 800;
+    const float range_max = 1333;
+    const float range_min = 800;
 public:
     void preprocess(const cv::Mat& src, cv::Mat& dst) {
         cv::Mat rsz, cvt, chw, mn;
@@ -983,7 +981,7 @@ TEST_F(ONNXYoloV3MultiInput, InferBSConstInput)
     validate();
 }
 
-TEST_F(ONNXRCNN, InferRCNN)
+TEST_F(ONNXRCNN, InferRCNN64to32)
 {
     useModel("object_detection_segmentation/faster-rcnn/model/FasterRCNN-10");
     cv::Mat dst;

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -130,7 +130,7 @@ std::tuple<int, bool> toCV(ONNXTensorElementDataType prec) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: return std::make_tuple(CV_32S, true);
     default: GAPI_Assert(false && "Unsupported data type");
     }
-    return  std::make_tuple(-1, false);;
+    return std::make_tuple(-1, false);
 }
 
 inline std::vector<int64_t> toORT(const cv::MatSize &sz) {


### PR DESCRIPTION
### Adding INT64-32 conversion for output.
ONNX's RCNN contains output (labels) with [INT64 type](https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/faster-rcnn).
INT64 type isn't supported for cv::Mat. Conversion to INT32 is used for this output.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


### Custom build:

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
Xbuild_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1

build_image:Custom=ubuntu-onnx:20.04
```
