### PR TITLE
Error Message for SURF if not implemented

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -29,8 +29,9 @@ BA_COST_CHOICES['no'] = cv.detail_NoBundleAdjuster
 
 FEATURES_FIND_CHOICES = OrderedDict()
 try:
+    cv.xfeatures2d_SURF.create()
     FEATURES_FIND_CHOICES['surf'] = cv.xfeatures2d_SURF.create
-except AttributeError:
+except (AttributeError, cv.error) as e:
     print("SURF not available")
 # if SURF not available, ORB is default
 FEATURES_FIND_CHOICES['orb'] = cv.ORB.create


### PR DESCRIPTION
In OpenCV 4.5.1 

```
import cv2 as cv
cv.xfeatures2d_SURF.create
```

will not create an AttributeError, even if the function is excluded (no nonfree option)

In Line 305 (now 306) however 

`finder = FEATURES_FIND_CHOICES[args.features]()` 
aka
`
cv.xfeatures2d_SURF.create()`

will raise an 

`error: OpenCV(4.5.1) ..\opencv_contrib\modules\xfeatures2d\src\surf.cpp:1029: error: (-213:The function/feature is not implemented) This algorithm is patented and is excluded in this configuration; Set OPENCV_ENABLE_NONFREE CMake option and rebuild the library in function 'cv::xfeatures2d::SURF::create'`

So we should check with cv.xfeatures2d_SURF.create() correctly if SURF is available

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x ] I agree to contribute to the project under Apache 2 License.
- [x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
