### PR TITLE
Corrected DNN elementwise multiplication

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -306,7 +306,7 @@ bool hasAllOnes(const Mat &inputs, int startPos, int endPos)
 
     for (int i = startPos; i < endPos; i++)
     {
-        if (inputs.at<int>(i) != 1 || inputs.at<int>(i)!= -1)
+        if (inputs.at<int>(i) != 1 && inputs.at<int>(i) != -1)
             return false;
     }
     return true;

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -12,6 +12,7 @@ Implementation of Tensorflow models parser
 #include "../precomp.hpp"
 
 #include <opencv2/core/utils/logger.defines.hpp>
+#include <opencv2/dnn/shape_utils.hpp>
 #undef CV_LOG_STRIP_LEVEL
 #define CV_LOG_STRIP_LEVEL CV_LOG_LEVEL_DEBUG + 1
 #include <opencv2/core/utils/logger.hpp>
@@ -1825,6 +1826,7 @@ void TFImporter::parseNode(const tensorflow::NodeDef& layer_)
             {
                 // Check if all the inputs have the same shape.
                 bool equalInpShapes = true;
+                bool isShapeOnes = false;
                 MatShape outShape0;
                 for (int ii = 0; ii < num_inputs && !netInputShapes.empty(); ii++)
                 {
@@ -1845,12 +1847,14 @@ void TFImporter::parseNode(const tensorflow::NodeDef& layer_)
                     else if (outShape != outShape0)
                     {
                         equalInpShapes = false;
+                        isShapeOnes = isAllOnes(outShape, 2, outShape.size()) ||
+                                      isAllOnes(outShape0, 2, outShape0.size());
                         break;
                     }
                 }
 
                 int id;
-                if (equalInpShapes || netInputShapes.empty())
+                if (equalInpShapes || netInputShapes.empty() || (!equalInpShapes && isShapeOnes))
                 {
                     layerParams.set("operation", type == "RealDiv" ? "div" : "prod");
                     id = dstNet.addLayer(name, "Eltwise", layerParams);

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -210,6 +210,12 @@ TEST_P(Test_TensorFlow_layers, eltwise_add_vec)
     runTensorFlowNet("eltwise_add_vec");
 }
 
+TEST_P(Test_TensorFlow_layers, eltwise_mul_vec)
+{
+    runTensorFlowNet("eltwise_mul_vec");
+}
+
+
 TEST_P(Test_TensorFlow_layers, channel_broadcast)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -478,6 +478,11 @@ TEST_P(Test_TensorFlow_layers, reshape_nchw)
     runTensorFlowNet("reshape_nchw");
 }
 
+TEST_P(Test_TensorFlow_layers, reshape_conv)
+{
+    runTensorFlowNet("reshape_conv");
+}
+
 TEST_P(Test_TensorFlow_layers, leaky_relu)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2018050000)


### PR DESCRIPTION
Merge with extra: opencv/opencv_extra#865
Fixes [#18214](https://github.com/opencv/opencv/issues/18214#issuecomment-683894976): 
* issue 1:  aligned OCV and [TF multiplication](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Multiply?hl=ru) layer behaviour for the following case: inputs **a** (shape: [1,1,1, C] ) and **b** (shape: [1, H, W, C] ), OCV **a** mul **b** returns [1,1,1, C], whereas TF mul - [1, H, W, C].
* issue 2: MobileNetV3 reshape problem (before Conv layer): ``number of input channels should be multiple of 72 but got 1 in getMemoryShapes()``

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.2.0:20.04
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

allow_multiple_commits=1
```