### PR TITLE
Add reading of specific images from multipage tiff

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -225,7 +225,7 @@ The function imreadmulti loads a specified range from a multi-page image from th
 @param mats A vector of Mat objects holding each page, if more than one.
 @sa cv::imread
 */
-CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, size_t start, size_t count, int flags = IMREAD_ANYCOLOR);
+CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, int start, int count, int flags = IMREAD_ANYCOLOR);
 
 /** @brief Returns the number of images inside the give file
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -220,7 +220,7 @@ CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& m
 The function imreadmulti loads a specified range from a multi-page image from the specified file into a vector of Mat objects.
 @param filename Name of file to be loaded.
 @param start Start index of the image to load
-@param end Count number of images to load
+@param count Count number of images to load
 @param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
 @param mats A vector of Mat objects holding each page, if more than one.
 @sa cv::imread
@@ -232,7 +232,7 @@ CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& m
 The function imcount will return the number of pages in a multi-page image, or 1 for single-page images
 @param filename Name of file to be loaded.
 */
-CV_EXPORTS_W int imcount(const String& filename);
+CV_EXPORTS_W size_t imcount(const String& filename);
 
 /** @brief Saves an image to a specified file.
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -215,6 +215,25 @@ The function imreadmulti loads a multi-page image from the specified file into a
 */
 CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, int flags = IMREAD_ANYCOLOR);
 
+/** @brief Loads a of images of a multi-page image from a file.
+
+The function imreadmulti loads a specified range from a multi-page image from the specified file into a vector of Mat objects.
+@param filename Name of file to be loaded.
+@param start Start index of the image to load
+@param end Count number of images to load
+@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
+@param mats A vector of Mat objects holding each page, if more than one.
+@sa cv::imread
+*/
+CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, size_t start, size_t count, int flags = IMREAD_ANYCOLOR);
+
+/** @brief Returns the number of images inside the give file
+
+The function imcount will return the number of pages in a multi-page image, or 1 for single-page images
+@param filename Name of file to be loaded.
+*/
+CV_EXPORTS_W int imcount(const String& filename);
+
 /** @brief Saves an image to a specified file.
 
 The function imwrite saves the image to the specified file. The image format is chosen based on the

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -231,8 +231,9 @@ CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& m
 
 The function imcount will return the number of pages in a multi-page image, or 1 for single-page images
 @param filename Name of file to be loaded.
+@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
 */
-CV_EXPORTS_W size_t imcount(const String& filename);
+CV_EXPORTS_W size_t imcount(const String& filename, int flags = IMREAD_ANYCOLOR);
 
 /** @brief Saves an image to a specified file.
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -769,7 +769,8 @@ bool imreadmulti(const String& filename, std::vector<Mat>& mats, size_t start, s
     return imreadmulti_(filename, flags, mats, start, count);
 }
 
-int imcount_(const String& filename)
+static
+size_t imcount_(const String& filename)
 {
     /// Search for the relevant decoder to handle the imagery
     ImageDecoder decoder;
@@ -811,7 +812,7 @@ int imcount_(const String& filename)
         return 0;
     }
 
-    int result = 1;
+    size_t result = 1;
 
 
     while (decoder->nextPage())
@@ -822,7 +823,7 @@ int imcount_(const String& filename)
     return result;
 }
 
-int imcount(const String& filename)
+size_t imcount(const String& filename)
 {
     CV_TRACE_FUNCTION();
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -770,7 +770,7 @@ bool imreadmulti(const String& filename, std::vector<Mat>& mats, size_t start, s
 }
 
 static
-size_t imcount_(const String& filename)
+size_t imcount_(const String& filename, int flags)
 {
     /// Search for the relevant decoder to handle the imagery
     ImageDecoder decoder;
@@ -823,11 +823,11 @@ size_t imcount_(const String& filename)
     return result;
 }
 
-size_t imcount(const String& filename)
+size_t imcount(const String& filename, int flags)
 {
     CV_TRACE_FUNCTION();
 
-    return imcount_(filename);
+    return imcount_(filename, flags);
 }
 
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -496,7 +496,7 @@ imread_( const String& filename, int flags, Mat& mat )
 
 
 static bool
-imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, size_t start, size_t count)
+imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, int start, int count)
 {
     /// Search for the relevant decoder to handle the imagery
     ImageDecoder decoder;
@@ -515,6 +515,14 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, size_t s
     /// if no decoder was found, return nothing.
     if (!decoder) {
         return 0;
+    }
+
+    if (start < 0) {
+        return 0;
+    }
+
+    if (count < 0) {
+        count = std::numeric_limits<int>::max();
     }
 
     /// set the filename in the driver
@@ -640,11 +648,11 @@ bool imreadmulti(const String& filename, std::vector<Mat>& mats, int flags)
 {
     CV_TRACE_FUNCTION();
 
-    return imreadmulti_(filename, flags, mats, 0, std::numeric_limits<size_t>::max());
+    return imreadmulti_(filename, flags, mats, 0, -1);
 }
 
 
-bool imreadmulti(const String& filename, std::vector<Mat>& mats, size_t start, size_t count, int flags)
+bool imreadmulti(const String& filename, std::vector<Mat>& mats, int start, int count, int flags)
 {
     CV_TRACE_FUNCTION();
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -501,6 +501,8 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, int star
     /// Search for the relevant decoder to handle the imagery
     ImageDecoder decoder;
 
+    CV_CheckGE(start, 0, "Start index cannont be < 0");
+
 #ifdef HAVE_GDAL
     if (flags != IMREAD_UNCHANGED && (flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL) {
         decoder = GdalDecoder().newDecoder();
@@ -514,10 +516,6 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, int star
 
     /// if no decoder was found, return nothing.
     if (!decoder) {
-        return 0;
-    }
-
-    if (start < 0) {
         return 0;
     }
 
@@ -695,12 +693,12 @@ size_t imcount_(const String& filename, int flags)
     }
     catch (const cv::Exception& e)
     {
-        std::cerr << "imreadmulti_('" << filename << "'): can't read header: " << e.what() << std::endl << std::flush;
+        std::cerr << "imcount_('" << filename << "'): can't read header: " << e.what() << std::endl << std::flush;
         return 0;
     }
     catch (...)
     {
-        std::cerr << "imreadmulti_('" << filename << "'): can't read header: unknown exception" << std::endl << std::flush;
+        std::cerr << "imcount_('" << filename << "'): can't read header: unknown exception" << std::endl << std::flush;
         return 0;
     }
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -546,7 +546,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, int star
         return 0;
     }
 
-    size_t current = start;
+    int current = start;
 
     while (current > 0)
     {

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -780,6 +780,8 @@ size_t imcount_(const String& filename, int flags)
         decoder = GdalDecoder().newDecoder();
     }
     else {
+#else
+        CV_UNUSED(flags);
 #endif
         decoder = findDecoder(filename);
 #ifdef HAVE_GDAL

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -495,111 +495,6 @@ imread_( const String& filename, int flags, Mat& mat )
 }
 
 
-/**
-* Read an image into memory and return the information
-*
-* @param[in] filename File to load
-* @param[in] flags Flags
-* @param[in] mats Reference to C++ vector<Mat> object to hold the images
-*
-*/
-static bool
-imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats)
-{
-    /// Search for the relevant decoder to handle the imagery
-    ImageDecoder decoder;
-
-#ifdef HAVE_GDAL
-    if (flags != IMREAD_UNCHANGED && (flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL){
-        decoder = GdalDecoder().newDecoder();
-    }
-    else{
-#endif
-        decoder = findDecoder(filename);
-#ifdef HAVE_GDAL
-    }
-#endif
-
-    /// if no decoder was found, return nothing.
-    if (!decoder){
-        return 0;
-    }
-
-    /// set the filename in the driver
-    decoder->setSource(filename);
-
-    // read the header to make sure it succeeds
-    try
-    {
-        // read the header to make sure it succeeds
-        if( !decoder->readHeader() )
-            return 0;
-    }
-    catch (const cv::Exception& e)
-    {
-        std::cerr << "imreadmulti_('" << filename << "'): can't read header: " << e.what() << std::endl << std::flush;
-        return 0;
-    }
-    catch (...)
-    {
-        std::cerr << "imreadmulti_('" << filename << "'): can't read header: unknown exception" << std::endl << std::flush;
-        return 0;
-    }
-
-    for (;;)
-    {
-        // grab the decoded type
-        int type = decoder->type();
-        if( (flags & IMREAD_LOAD_GDAL) != IMREAD_LOAD_GDAL && flags != IMREAD_UNCHANGED )
-        {
-            if ((flags & IMREAD_ANYDEPTH) == 0)
-                type = CV_MAKETYPE(CV_8U, CV_MAT_CN(type));
-
-            if ((flags & CV_LOAD_IMAGE_COLOR) != 0 ||
-                ((flags & IMREAD_ANYCOLOR) != 0 && CV_MAT_CN(type) > 1))
-                type = CV_MAKETYPE(CV_MAT_DEPTH(type), 3);
-            else
-                type = CV_MAKETYPE(CV_MAT_DEPTH(type), 1);
-        }
-
-        // established the required input image size
-        Size size = validateInputImageSize(Size(decoder->width(), decoder->height()));
-
-        // read the image data
-        Mat mat(size.height, size.width, type);
-        bool success = false;
-        try
-        {
-            if (decoder->readData(mat))
-                success = true;
-        }
-        catch (const cv::Exception& e)
-        {
-            std::cerr << "imreadmulti_('" << filename << "'): can't read data: " << e.what() << std::endl << std::flush;
-        }
-        catch (...)
-        {
-            std::cerr << "imreadmulti_('" << filename << "'): can't read data: unknown exception" << std::endl << std::flush;
-        }
-        if (!success)
-            break;
-
-        // optionally rotate the data if EXIF' orientation flag says so
-        if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
-        {
-            ApplyExifOrientation(decoder->getExifTag(ORIENTATION), mat);
-        }
-
-        mats.push_back(mat);
-        if (!decoder->nextPage())
-        {
-            break;
-        }
-    }
-
-    return !mats.empty();
-}
-
 static bool
 imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, size_t start, size_t count)
 {
@@ -643,19 +538,18 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, size_t s
         return 0;
     }
 
-    size_t current = 0;
-    size_t end = start + count;
+    size_t current = start;
 
-    while (current < start)
+    while (current > 0)
     {
         if (!decoder->nextPage())
         {
             return false;
         }
-        ++current;
+        --current;
     }
 
-    while (current < end)
+    while (current < count)
     {
         // grab the decoded type
         int type = decoder->type();
@@ -746,22 +640,10 @@ bool imreadmulti(const String& filename, std::vector<Mat>& mats, int flags)
 {
     CV_TRACE_FUNCTION();
 
-    return imreadmulti_(filename, flags, mats);
+    return imreadmulti_(filename, flags, mats, 0, std::numeric_limits<size_t>::max());
 }
 
 
-/**
-* Read parts of a multi-page image
-*
-*  This function merely calls the actual implementation above and returns itself.
-*
-* @param[in] filename File to load
-* @param[in] mats Reference to C++ vector<Mat> object to hold the images
-* @param[in] start Start index for the sequence to load
-* @param[in] count number of images to load
-* @param[in] flags Flags you wish to set.
-*
-*/
 bool imreadmulti(const String& filename, std::vector<Mat>& mats, size_t start, size_t count, int flags)
 {
     CV_TRACE_FUNCTION();

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -363,11 +363,11 @@ TEST(Imgcodecs_Tiff, count_multipage)
     const string root = cvtest::TS::ptr()->get_data_path();
     {
         const string filename = root + "readwrite/multipage.tif";
-        ASSERT_EQ(6, imcount(filename));
+        ASSERT_EQ((size_t)6, imcount(filename));
     }
     {
         const string filename = root + "readwrite/test32FC3_raw.tiff";
-        ASSERT_EQ(1, imcount(filename));
+        ASSERT_EQ((size_t)1, imcount(filename));
     }
 }
 
@@ -397,11 +397,11 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
         vector<Mat> multi_pages;
         bool res = imreadmulti(filename, multi_pages, 0, 0);
         // If we asked for 0 images and we successfully read 0 images should this be false ?
-        ASSERT_TRUE(res == false); 
-        ASSERT_EQ(0, multi_pages.size());
+        ASSERT_TRUE(res == false);
+        ASSERT_EQ((size_t)0, multi_pages.size());
         res = imreadmulti(filename, multi_pages, 0, 123123);
         ASSERT_TRUE(res == true);
-        ASSERT_EQ(6, multi_pages.size());
+        ASSERT_EQ((size_t)6, multi_pages.size());
     }
 
     {
@@ -423,7 +423,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
         {
             bool res = imreadmulti(filename, multi_pages, i, 1);
             ASSERT_TRUE(res == true);
-            ASSERT_EQ(1, multi_pages.size());
+            ASSERT_EQ((size_t)1, multi_pages.size());
             EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), multi_pages[0], single_pages[i]);
             multi_pages.clear();
         }
@@ -436,7 +436,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
         {
             bool res = imreadmulti(filename, multi_pages, i*2, 2);
             ASSERT_TRUE(res == true);
-            ASSERT_EQ(2, multi_pages.size());
+            ASSERT_EQ((size_t)2, multi_pages.size());
             EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), multi_pages[0], single_pages[i * 2]) << i;
             EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), multi_pages[1], single_pages[i * 2 + 1]);
             multi_pages.clear();

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -383,15 +383,15 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
         "readwrite/multipage_p5.tif",
         "readwrite/multipage_p6.tif"
     };
-    const size_t page_count = sizeof(page_files) / sizeof(page_files[0]);
+    const int page_count = sizeof(page_files) / sizeof(page_files[0]);
     vector<Mat> single_pages;
-    for (size_t i = 0; i < page_count; i++)
+    for (int i = 0; i < page_count; i++)
     {
         // imread and imreadmulti have different default values for the flag
         const Mat page = imread(root + page_files[i], IMREAD_ANYCOLOR);
         single_pages.push_back(page);
     }
-    ASSERT_EQ(page_count, single_pages.size());
+    ASSERT_EQ((size_t)page_count, single_pages.size());
 
     {
         SCOPED_TRACE("Edge Cases");
@@ -410,8 +410,8 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
         vector<Mat> multi_pages;
         bool res = imreadmulti(filename, multi_pages, 0, 6);
         ASSERT_TRUE(res == true);
-        ASSERT_EQ(page_count, multi_pages.size());
-        for (size_t i = 0; i < page_count; i++)
+        ASSERT_EQ((size_t)page_count, multi_pages.size());
+        for (int i = 0; i < page_count; i++)
         {
             EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), multi_pages[i], single_pages[i]);
         }

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -387,13 +387,14 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     vector<Mat> single_pages;
     for (size_t i = 0; i < page_count; i++)
     {
-        const Mat page = imread(root + page_files[i]);
+        // imread and imreadmulti have different default values for the flag
+        const Mat page = imread(root + page_files[i], IMREAD_ANYCOLOR);
         single_pages.push_back(page);
     }
     ASSERT_EQ(page_count, single_pages.size());
 
     {
-        // Edge cases
+        SCOPED_TRACE("Edge Cases");
         vector<Mat> multi_pages;
         bool res = imreadmulti(filename, multi_pages, 0, 0);
         // If we asked for 0 images and we successfully read 0 images should this be false ?
@@ -405,7 +406,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     }
 
     {
-        // Read all
+        SCOPED_TRACE("Read all with indices");
         vector<Mat> multi_pages;
         bool res = imreadmulti(filename, multi_pages, 0, 6);
         ASSERT_TRUE(res == true);
@@ -417,7 +418,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     }
 
     {
-        // Read one by one
+        SCOPED_TRACE("Read one by one");
         vector<Mat> multi_pages;
         for (size_t i = 0; i < page_count; i++)
         {
@@ -430,7 +431,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     }
 
     {
-        // Pairs of two
+        SCOPED_TRACE("Read multiple at a time");
         vector<Mat> multi_pages;
         for (size_t i = 0; i < page_count/2; i++)
         {

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -420,7 +420,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     {
         SCOPED_TRACE("Read one by one");
         vector<Mat> multi_pages;
-        for (size_t i = 0; i < page_count; i++)
+        for (int i = 0; i < page_count; i++)
         {
             bool res = imreadmulti(filename, multi_pages, i, 1);
             ASSERT_TRUE(res == true);
@@ -433,7 +433,7 @@ TEST(Imgcodecs_Tiff, read_multipage_indexed)
     {
         SCOPED_TRACE("Read multiple at a time");
         vector<Mat> multi_pages;
-        for (size_t i = 0; i < page_count/2; i++)
+        for (int i = 0; i < page_count/2; i++)
         {
             bool res = imreadmulti(filename, multi_pages, i*2, 2);
             ASSERT_TRUE(res == true);


### PR DESCRIPTION
The current implementation of `imreadmulti` reads all images from the multipage file, sometimes this is not the required functionality, for example due to memory contraints, or really just wanting to target a specific subrange of the multipage file. This PR allows any subsequence to be read . 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
