### PR TITLE
[G-API] Support RMat for PlaidML backend

### DIFF
--- a/modules/gapi/src/backends/plaidml/gplaidmlbackend.cpp
+++ b/modules/gapi/src/backends/plaidml/gplaidmlbackend.cpp
@@ -198,9 +198,6 @@ void cv::gimpl::GPlaidMLExecutable::run(std::vector<InObj>  &&input_objs,
     exec_->run();
 
     for (auto& it : output_objs) bindOutArg(it.first, it.second);
-
-    // FIXME:
-    // PlaidML backend haven't been updated with RMat support
 }
 
 void cv::gimpl::GPlaidMLExecutable::bindInArg(const RcDesc &rc, const GRunArg  &arg)
@@ -215,10 +212,12 @@ void cv::gimpl::GPlaidMLExecutable::bindInArg(const RcDesc &rc, const GRunArg  &
 
         switch (arg.index())
         {
-        case GRunArg::index_of<cv::Mat>() :
+        case GRunArg::index_of<cv::RMat>():
         {
-            auto& arg_mat = util::get<cv::Mat>(arg);
-            binder_->input(it->second).copy_from(arg_mat.data);
+            auto& rmat = cv::util::get<cv::RMat>(arg);
+            auto  view = rmat.access(cv::RMat::Access::R);
+            auto  mat  = cv::gimpl::asMat(view);
+            binder_->input(it->second).copy_from(mat.data);
         }
         break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
@@ -243,10 +242,12 @@ void cv::gimpl::GPlaidMLExecutable::bindOutArg(const RcDesc &rc, const GRunArgP 
 
         switch (arg.index())
         {
-        case GRunArgP::index_of<cv::Mat*>() :
+        case GRunArgP::index_of<cv::RMat*>() :
         {
-            auto& arg_mat = *util::get<cv::Mat*>(arg);
-            binder_->output(it->second).copy_into(arg_mat.data);
+            auto& rmat = *cv::util::get<cv::RMat*>(arg);
+            auto  view = rmat.access(cv::RMat::Access::W);
+            auto  mat  = cv::gimpl::asMat(view);
+            binder_->output(it->second).copy_into(mat.data);
         }
         break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration
```
Xforce_builders_only=linux,docs
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

Xforce_builders=Custom
Xbuildworker:Custom=linux-1
build_image:Custom=plaidml2
Xtest_modules:Custom=gapi
test_filter:Custom=*ML*
```
