### PR TITLE
Performance optimization in DirectX and VAAPI interop

### DIFF
--- a/modules/core/src/directx.cpp
+++ b/modules/core/src/directx.cpp
@@ -901,7 +901,7 @@ bool ocl_convert_nv12_to_bgr(
 
     k.args(clImageY, clImageUV, clBuffer, step, cols, rows);
 
-    size_t globalsize[] = { (size_t)cols, (size_t)rows };
+    size_t globalsize[] = { (size_t)cols/2, (size_t)rows/2 };
     return k.run(2, globalsize, 0, false);
 }
 
@@ -922,7 +922,7 @@ bool ocl_convert_bgr_to_nv12(
 
     k.args(clBuffer, step, cols, rows, clImageY, clImageUV);
 
-    size_t globalsize[] = { (size_t)cols, (size_t)rows };
+    size_t globalsize[] = { (size_t)cols/2, (size_t)rows/2 };
     return k.run(2, globalsize, 0, false);
 }
 

--- a/modules/core/src/va_intel.cpp
+++ b/modules/core/src/va_intel.cpp
@@ -158,7 +158,7 @@ static bool ocl_convert_nv12_to_bgr(cl_mem clImageY, cl_mem clImageUV, cl_mem cl
 
     k.args(clImageY, clImageUV, clBuffer, step, cols, rows);
 
-    size_t globalsize[] = { (size_t)cols, (size_t)rows };
+    size_t globalsize[] = { (size_t)cols/2, (size_t)rows/2 };
     return k.run(2, globalsize, 0, false);
 }
 
@@ -171,7 +171,7 @@ static bool ocl_convert_bgr_to_nv12(cl_mem clBuffer, int step, int cols, int row
 
     k.args(clBuffer, step, cols, rows, clImageY, clImageUV);
 
-    size_t globalsize[] = { (size_t)cols, (size_t)rows };
+    size_t globalsize[] = { (size_t)cols/2, (size_t)rows/2 };
     return k.run(2, globalsize, 0, false);
 }
 #endif // HAVE_VA_INTEL && HAVE_OPENCL


### PR DESCRIPTION
(had to close [PR](https://github.com/opencv/opencv/pull/19776/) into master and open this PR into 3.4)

1. Run OpenCL kernels on 4x less work items as each item computes 4 pixels
2. Use float4 vector arithmetic in NV12->BGR kernel

If applied together with [PR19755](https://github.com/opencv/opencv/pull/19755), performance of the following command 
```
example_tapi_video_acceleration -accel=any -opencl=true -i=input.mp4 -o=null
```
increases on my iGPU from ~550fps to ~850fps (H264 1080p input video).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
