### PR TITLE
dnn(OpenCL): fix gemm kernel scheduling

### DIFF
--- a/modules/dnn/src/ocl4dnn/src/math_functions.cpp
+++ b/modules/dnn/src/ocl4dnn/src/math_functions.cpp
@@ -112,14 +112,14 @@ ocl::Image2D ocl4dnnGEMMCopyBufferToImage(UMat buffer, int offset,
             global_copy[0] = padded_width;
             global_copy[1] = padded_height;
 
-            oclk_gemm_copy
+            bool res = oclk_gemm_copy
                 .args(
                     ocl::KernelArg::PtrReadOnly(buffer),
                     image, offset,
                     width, height,
                     ld)
                 .run(2, global_copy, NULL, false);
-            oclk_gemm_copy.run(2, global_copy, NULL, false);
+            CV_Assert(res);
         }
     }
 


### PR DESCRIPTION
fixup #19114

Fixes error message:

```
[ RUN      ] Test_ONNX_layers.GatherMultiOutput/0, where GetParam() = OCV/OCL
[ERROR:0] OpenCL kernel can't be reused in async mode: gemm_buffer_copy_image_no_transpose_float
[       OK ] Test_ONNX_layers.GatherMultiOutput/0 (1 ms)
```