### PR TITLE
Relax accuracy requirements in the OpenCL sqrt perf arithmetic test.

### DIFF
--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -678,7 +678,12 @@ OCL_PERF_TEST_P(SqrtFixture, Sqrt, ::testing::Combine(
 
     OCL_TEST_CYCLE() cv::sqrt(src, dst);
 
-    if (CV_MAT_DEPTH(type) >= CV_32F)
+    // To square root 32 bit floats we use native_sqrt, which has implementation
+    // defined accuracy. We know intel devices have accurate native_sqrt, but
+    // otherwise stick to a relaxed sanity check. For types larger than 32 bits
+    // we can do the accuracy check for all devices as normal.
+    if (CV_MAT_DEPTH(type) > CV_32F || !ocl::useOpenCL() ||
+        ocl::Device::getDefault().isIntel())
         SANITY_CHECK(dst, 1e-5, ERROR_RELATIVE);
     else
         SANITY_CHECK(dst, 1);

--- a/modules/imgproc/perf/opencl/perf_imgproc.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgproc.cpp
@@ -166,7 +166,17 @@ OCL_PERF_TEST_P(CornerMinEigenValFixture, CornerMinEigenVal,
 
     OCL_TEST_CYCLE() cv::cornerMinEigenVal(src, dst, blockSize, apertureSize, borderType);
 
-    SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
+#ifdef HAVE_OPENCL
+    bool strictCheck = !ocl::useOpenCL() || ocl::Device::getDefault().isIntel();
+#else
+    bool strictCheck = true;
+#endif
+
+    // using native_* OpenCL functions on non-intel devices may lose accuracy
+    if (strictCheck)
+        SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
+    else
+        SANITY_CHECK(dst, 0.1, ERROR_RELATIVE);
 }
 
 ///////////// CornerHarris ////////////////////////

--- a/modules/imgproc/test/ocl/test_imgproc.cpp
+++ b/modules/imgproc/test/ocl/test_imgproc.cpp
@@ -234,10 +234,12 @@ OCL_TEST_P(CornerMinEigenVal, Mat)
         OCL_OFF(cv::cornerMinEigenVal(src_roi, dst_roi, blockSize, apertureSize, borderType));
         OCL_ON(cv::cornerMinEigenVal(usrc_roi, udst_roi, blockSize, apertureSize, borderType));
 
-        if (ocl::Device::getDefault().isIntel())
-          Near(1e-5, true);
+        // The corner kernel uses native_sqrt() which has implementation defined accuracy.
+        // If we're using a CL implementation that isn't intel, test with relaxed accuracy.
+        if (!ocl::useOpenCL() || ocl::Device::getDefault().isIntel())
+            Near(1e-5, true);
         else
-          Near(0.1, true);  // using native_* OpenCL functions may lose accuracy
+            Near(0.1, true);
     }
 }
 


### PR DESCRIPTION
Also bring perf_imgproc CornerMinEigenVal accuracy requirements in line with
the test_imgproc accuracy requirements on that test and fix indentation on
the latter.

Partially addresses issue #9821

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
