### PR TITLE
core(IPP): disable some ippsMagnitude_32f calls

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2376,4 +2376,16 @@ TEST(Core_MinMaxIdx, rows_overflow)
 }
 
 
+TEST(Core_Magnitude, regression_19506)
+{
+    for (int N = 1; N <= 64; ++N)
+    {
+        Mat a(1, N, CV_32FC1, Scalar::all(1e-20));
+        Mat res;
+        magnitude(a, a, res);
+        EXPECT_LE(cvtest::norm(res, NORM_L1), 1e-15) << N;
+    }
+}
+
+
 }} // namespace


### PR DESCRIPTION
resolves #19506

Looks like the problem relates to `ippsMagnitude_32f` only. ippsMagnitude_64f works fine.

<cut/>

/cc @eplankin

```
build_image:Custom=ubuntu:18.04
buildworker:Custom=linux-3
```