### PR TITLE
Python: allow to customize Python namespaces

### DIFF
--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -791,5 +791,12 @@ struct PyOpenCV_Converter<cv::GOpaque<T>>
     }
 };
 
+
+// extend cv.gapi.wip. methods
+#define PYOPENCV_EXTRA_METHODS_GAPI_WIP \
+  {"kernels", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_kernels), "kernels(...) -> GKernelPackage"}, \
+  {"op", CV_PY_FN_WITH_KW_(pyopencv_cv_gapi_op, 0), "kernels(...) -> retval\n"}, \
+
+
 #endif  // HAVE_OPENCV_GAPI
 #endif  // OPENCV_GAPI_PYOPENCV_GAPI_HPP

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -73,7 +73,7 @@ def add(g_in1, g_in2, dtype):
     def custom_add_meta(img_desc1, img_desc2, dtype):
         return img_desc1
 
-    return cv.gapi_wip_op('custom.add', custom_add_meta, g_in1, g_in2, dtype).getGMat()
+    return cv.gapi.wip.op('custom.add', custom_add_meta, g_in1, g_in2, dtype).getGMat()
 
 
 # Test multiple output mat
@@ -82,7 +82,7 @@ def split3(g_in):
         out_desc = img_desc.withType(img_desc.depth, 1)
         return out_desc, out_desc, out_desc
 
-    op = cv.gapi_wip_op('custom.split3', custom_split3_meta, g_in)
+    op = cv.gapi.wip.op('custom.split3', custom_split3_meta, g_in)
 
     ch1 = op.getGMat()
     ch2 = op.getGMat()
@@ -95,7 +95,7 @@ def mean(g_in):
     def custom_mean_meta(img_desc):
         return cv.empty_scalar_desc()
 
-    op = cv.gapi_wip_op('custom.mean', custom_mean_meta, g_in)
+    op = cv.gapi.wip.op('custom.mean', custom_mean_meta, g_in)
     return op.getGScalar()
 
 
@@ -104,7 +104,7 @@ def addC(g_in, g_sc, dtype):
     def custom_addC_meta(img_desc, sc_desc, dtype):
         return img_desc
 
-    op = cv.gapi_wip_op('custom.addC', custom_addC_meta, g_in, g_sc, dtype)
+    op = cv.gapi.wip.op('custom.addC', custom_addC_meta, g_in, g_sc, dtype)
     return op.getGMat()
 
 
@@ -113,7 +113,7 @@ def size(g_in):
     def custom_size_meta(img_desc):
         return cv.empty_gopaque_desc()
 
-    op = cv.gapi_wip_op('custom.size', custom_size_meta, g_in)
+    op = cv.gapi.wip.op('custom.size', custom_size_meta, g_in)
     return op.getGOpaque(cv.gapi.CV_SIZE)
 
 
@@ -122,7 +122,7 @@ def sizeR(g_rect):
     def custom_sizeR_meta(opaque_desc):
         return cv.empty_gopaque_desc()
 
-    op = cv.gapi_wip_op('custom.sizeR', custom_sizeR_meta, g_rect)
+    op = cv.gapi.wip.op('custom.sizeR', custom_sizeR_meta, g_rect)
     return op.getGOpaque(cv.gapi.CV_SIZE)
 
 
@@ -131,7 +131,7 @@ def boundingRect(g_array):
     def custom_boundingRect_meta(array_desc):
         return cv.empty_gopaque_desc()
 
-    op = cv.gapi_wip_op('custom.boundingRect', custom_boundingRect_meta, g_array)
+    op = cv.gapi.wip.op('custom.boundingRect', custom_boundingRect_meta, g_array)
     return op.getGOpaque(cv.gapi.CV_RECT)
 
 
@@ -143,7 +143,7 @@ def goodFeaturesToTrack(g_in, max_corners, quality_lvl,
                                         min_distance, mask, block_sz, use_harris_detector, k):
         return cv.empty_array_desc()
 
-    op = cv.gapi_wip_op('custom.goodFeaturesToTrack', custom_goodFeaturesToTrack_meta, g_in,
+    op = cv.gapi.wip.op('custom.goodFeaturesToTrack', custom_goodFeaturesToTrack_meta, g_in,
             max_corners, quality_lvl, min_distance, mask, block_sz, use_harris_detector, k)
     return op.getGArray(cv.gapi.CV_POINT2F)
 
@@ -185,7 +185,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
 
         comp = cv.GComputation(g_in, g_out)
 
-        pkg    = cv.gapi_wip_kernels((custom_mean, 'org.opencv.core.math.mean'))
+        pkg    = cv.gapi.wip.kernels((custom_mean, 'org.opencv.core.math.mean'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         # Comparison
@@ -206,7 +206,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_out = cv.gapi.add(g_in1, g_in2)
         comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
 
-        pkg = cv.gapi_wip_kernels((custom_add, 'org.opencv.core.math.add'))
+        pkg = cv.gapi.wip.kernels((custom_add, 'org.opencv.core.math.add'))
         actual = comp.apply(cv.gin(in_mat1, in_mat2), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -224,7 +224,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_sz = cv.gapi.streaming.size(g_in)
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_sz))
 
-        pkg = cv.gapi_wip_kernels((custom_size, 'org.opencv.streaming.size'))
+        pkg = cv.gapi.wip.kernels((custom_size, 'org.opencv.streaming.size'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -255,7 +255,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
                                             min_distance, mask, block_sz, use_harris_detector, k)
 
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-        pkg = cv.gapi_wip_kernels((custom_goodFeaturesToTrack, 'org.opencv.imgproc.feature.goodFeaturesToTrack'))
+        pkg = cv.gapi.wip.kernels((custom_goodFeaturesToTrack, 'org.opencv.imgproc.feature.goodFeaturesToTrack'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         # NB: OpenCV & G-API have different output types.
@@ -280,7 +280,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_out = cv.gapi.addC(g_in, g_sc)
         comp = cv.GComputation(cv.GIn(g_in, g_sc), cv.GOut(g_out))
 
-        pkg = cv.gapi_wip_kernels((custom_addC, 'org.opencv.core.math.addC'))
+        pkg = cv.gapi.wip.kernels((custom_addC, 'org.opencv.core.math.addC'))
         actual = comp.apply(cv.gin(in_mat, sc), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -297,7 +297,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_sz = cv.gapi.streaming.size(g_r)
         comp = cv.GComputation(cv.GIn(g_r), cv.GOut(g_sz))
 
-        pkg = cv.gapi_wip_kernels((custom_sizeR, 'org.opencv.streaming.sizeR'))
+        pkg = cv.gapi.wip.kernels((custom_sizeR, 'org.opencv.streaming.sizeR'))
         actual = comp.apply(cv.gin(roi), args=cv.compile_args(pkg))
 
         # cv.norm works with tuples ?
@@ -315,7 +315,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_br  = cv.gapi.boundingRect(g_pts)
         comp = cv.GComputation(cv.GIn(g_pts), cv.GOut(g_br))
 
-        pkg = cv.gapi_wip_kernels((custom_boundingRect, 'org.opencv.imgproc.shape.boundingRectVector32S'))
+        pkg = cv.gapi.wip.kernels((custom_boundingRect, 'org.opencv.imgproc.shape.boundingRectVector32S'))
         actual = comp.apply(cv.gin(points), args=cv.compile_args(pkg))
 
         # cv.norm works with tuples ?
@@ -340,7 +340,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_mean))
 
 
-        pkg = cv.gapi_wip_kernels((custom_add   , 'org.opencv.core.math.add'),
+        pkg = cv.gapi.wip.kernels((custom_add   , 'org.opencv.core.math.add'),
                          (custom_mean  , 'org.opencv.core.math.mean'),
                          (custom_split3, 'org.opencv.core.transform.split3'))
 
@@ -364,7 +364,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
 
         comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
 
-        pkg = cv.gapi_wip_kernels((custom_add, 'custom.add'))
+        pkg = cv.gapi.wip.kernels((custom_add, 'custom.add'))
         actual = comp.apply(cv.gin(in_mat1, in_mat2), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -384,7 +384,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
 
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ch1, g_ch2, g_ch3))
 
-        pkg = cv.gapi_wip_kernels((custom_split3, 'custom.split3'))
+        pkg = cv.gapi.wip.kernels((custom_split3, 'custom.split3'))
         ch1, ch2, ch3 = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(in_ch1, ch1, cv.NORM_INF))
@@ -405,7 +405,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
 
         comp = cv.GComputation(g_in, g_out)
 
-        pkg    = cv.gapi_wip_kernels((custom_mean, 'custom.mean'))
+        pkg    = cv.gapi.wip.kernels((custom_mean, 'custom.mean'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         # Comparison
@@ -426,7 +426,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_out = addC(g_in, g_sc, cv.CV_8UC1)
         comp  = cv.GComputation(cv.GIn(g_in, g_sc), cv.GOut(g_out))
 
-        pkg = cv.gapi_wip_kernels((custom_addC, 'custom.addC'))
+        pkg = cv.gapi.wip.kernels((custom_addC, 'custom.addC'))
         actual = comp.apply(cv.gin(in_mat, sc), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -444,7 +444,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_sz = size(g_in)
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_sz))
 
-        pkg = cv.gapi_wip_kernels((custom_size, 'custom.size'))
+        pkg = cv.gapi.wip.kernels((custom_size, 'custom.size'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
@@ -461,7 +461,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_sz = sizeR(g_r)
         comp = cv.GComputation(cv.GIn(g_r), cv.GOut(g_sz))
 
-        pkg = cv.gapi_wip_kernels((custom_sizeR, 'custom.sizeR'))
+        pkg = cv.gapi.wip.kernels((custom_sizeR, 'custom.sizeR'))
         actual = comp.apply(cv.gin(roi), args=cv.compile_args(pkg))
 
         # cv.norm works with tuples ?
@@ -479,7 +479,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_br  = boundingRect(g_pts)
         comp = cv.GComputation(cv.GIn(g_pts), cv.GOut(g_br))
 
-        pkg = cv.gapi_wip_kernels((custom_boundingRect, 'custom.boundingRect'))
+        pkg = cv.gapi.wip.kernels((custom_boundingRect, 'custom.boundingRect'))
         actual = comp.apply(cv.gin(points), args=cv.compile_args(pkg))
 
         # cv.norm works with tuples ?
@@ -511,7 +511,7 @@ class gapi_sample_pipelines(NewOpenCVTests):
                                     min_distance, mask, block_sz, use_harris_detector, k)
 
         comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-        pkg = cv.gapi_wip_kernels((custom_goodFeaturesToTrack, 'custom.goodFeaturesToTrack'))
+        pkg = cv.gapi.wip.kernels((custom_goodFeaturesToTrack, 'custom.goodFeaturesToTrack'))
         actual = comp.apply(cv.gin(in_mat), args=cv.compile_args(pkg))
 
         # NB: OpenCV & G-API have different output types.

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -2198,8 +2198,6 @@ static PyMethodDef special_methods[] = {
 #endif
 #ifdef HAVE_OPENCV_GAPI
   {"GIn", CV_PY_FN_WITH_KW(pyopencv_cv_GIn), "GIn(...) -> GInputProtoArgs"},
-  {"gapi_wip_kernels", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_kernels), "kernels(...) -> GKernelPackage"},
-  {"gapi_wip_op", CV_PY_FN_WITH_KW_(pyopencv_cv_gapi_op, 0), "kernels(...) -> retval\n"},
   {"GOut", CV_PY_FN_WITH_KW(pyopencv_cv_GOut), "GOut(...) -> GOutputProtoArgs"},
   {"gin", CV_PY_FN_WITH_KW(pyopencv_cv_gin), "gin(...) -> ExtractArgsCallback"},
   {"descr_of", CV_PY_FN_WITH_KW(pyopencv_cv_descr_of), "descr_of(...) -> ExtractMetaCallback"},

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -976,6 +976,8 @@ class PythonWrapperGenerator(object):
             if func.isconstructor:
                 continue
             self.code_ns_reg.write(func.get_tab_entry())
+        custom_entries_macro = 'PYOPENCV_EXTRA_METHODS_{}'.format(wname.upper())
+        self.code_ns_reg.write('#ifdef {}\n    {}\n#endif\n'.format(custom_entries_macro, custom_entries_macro))
         self.code_ns_reg.write('    {NULL, NULL}\n};\n\n')
 
         self.code_ns_reg.write('static ConstDef consts_%s[] = {\n'%wname)
@@ -984,6 +986,8 @@ class PythonWrapperGenerator(object):
             compat_name = re.sub(r"([a-z])([A-Z])", r"\1_\2", name).upper()
             if name != compat_name:
                 self.code_ns_reg.write('    {"%s", static_cast<long>(%s)},\n'%(compat_name, cname))
+        custom_entries_macro = 'PYOPENCV_EXTRA_CONSTANTS_{}'.format(wname.upper())
+        self.code_ns_reg.write('#ifdef {}\n    {}\n#endif\n'.format(custom_entries_macro, custom_entries_macro))
         self.code_ns_reg.write('    {NULL, 0}\n};\n\n')
 
     def gen_enum_reg(self, enum_name):


### PR DESCRIPTION
- extra methods through `PYOPENCV_EXTRA_METHODS_<NS_UPPER>` macros
- extra constants through `PYOPENCV_EXTRA_CONSTANTS_<NS_UPPER>` macros
- rename cv.gapi_wip_op => cv.gapi.wip.op
- rename cv.gapi_wip_kernels => cv.gapi.wip.kernels
- Validation: `help(cv.gapi.wip)`

Requested here:
- https://github.com/opencv/opencv/pull/19351#discussion_r603290166
- https://github.com/opencv/opencv/pull/19804#discussion_r604036516

<cut/>

```
Help on module cv2.gapi.wip in cv2.gapi:

NAME
    cv2.gapi.wip

FUNCTIONS
    kernels(...)
        kernels(...) -> GKernelPackage
    
    make_capture_src(...)
        make_capture_src(path) -> retval
        .   * @brief OpenCV's VideoCapture-based streaming source.
        .    *
        .    * This class implements IStreamSource interface.
        .    * Its constructor takes the same parameters as cv::VideoCapture does.
        .    *
        .    * Please make sure that videoio OpenCV module is available before using
        .    * this in your application (G-API doesn't depend on it directly).
        .    *
        .    * @note stream sources are passed to G-API via shared pointers, so
        .    *  please gapi::make_src<> to create objects and ptr() to pass a
        .    *  GCaptureSource to cv::gin().
    
    op(...)
        kernels(...) -> retval

FILE
    (built-in)

(END)
```

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

allow_multiple_commits=1
```
