### PR TITLE
build: workaround sporadic failures of python binding compilation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gopaque.hpp
+++ b/modules/gapi/include/opencv2/gapi/gopaque.hpp
@@ -21,6 +21,9 @@
 #include <opencv2/gapi/util/type_traits.hpp>
 #include <opencv2/gapi/own/assert.hpp>
 
+#include <opencv2/gapi/gcommon.hpp>  // OpaqueKind
+#include <opencv2/gapi/garray.hpp>  // TypeHintBase
+
 namespace cv
 {
 // Forward declaration; GNode and GOrigin are an internal


### PR DESCRIPTION
Problem is caused by undetermined order of used headers (will be fixed separatelly).

Failed builds due to this problem:
- http://pullrequest.opencv.org/buildbot/builders/precommit_linux64/builds/31078 and others (mostly on linux-5)
- http://pullrequest.opencv.org/buildbot/builders/precommit_linux64_no_opt/builds/28377 and others

```
buildworker:Linux x64=linux-5
```