### PR TITLE
videoio(build): eliminate inconsistent 'override' warnings

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -90,13 +90,14 @@ class CvCaptureCAM : public CvCapture {
     public:
         CvCaptureCAM(int cameraNum = -1) ;
         ~CvCaptureCAM();
-        virtual bool grabFrame();
-        virtual IplImage* retrieveFrame(int);
-        virtual IplImage* queryFrame();
-        virtual double getProperty(int property_id) const;
-        virtual bool setProperty(int property_id, double value);
-        virtual int didStart();
+        bool grabFrame() CV_OVERRIDE;
+        IplImage* retrieveFrame(int) CV_OVERRIDE;
+        double getProperty(int property_id) const CV_OVERRIDE;
+        bool setProperty(int property_id, double value) CV_OVERRIDE;
         int getCaptureDomain() /*const*/ CV_OVERRIDE { return cv::CAP_AVFOUNDATION; }
+
+        virtual IplImage* queryFrame();
+        virtual int didStart();
     private:
         AVCaptureSession            *mCaptureSession;
         AVCaptureDeviceInput        *mCaptureDeviceInput;
@@ -132,12 +133,13 @@ class CvCaptureFile : public CvCapture {
 public:
     CvCaptureFile(const char* filename) ;
     ~CvCaptureFile();
-    virtual bool grabFrame();
-    virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id) const;
-    virtual bool setProperty(int property_id, double value);
-    virtual int didStart();
+    bool grabFrame() CV_OVERRIDE;
+    IplImage* retrieveFrame(int) CV_OVERRIDE;
+    double getProperty(int property_id) const CV_OVERRIDE;
+    bool setProperty(int property_id, double value) CV_OVERRIDE;
     int getCaptureDomain() /*const*/ CV_OVERRIDE { return cv::CAP_AVFOUNDATION; }
+
+    virtual int didStart();
 private:
     AVAsset                  *mAsset;
     AVAssetTrack             *mAssetTrack;

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -94,12 +94,13 @@ class CvCaptureCAM : public CvCapture {
 public:
     CvCaptureCAM(int cameraNum = -1) ;
     ~CvCaptureCAM();
-    virtual bool grabFrame();
-    virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id) const;
-    virtual bool setProperty(int property_id, double value);
-    virtual int didStart();
+    bool grabFrame() CV_OVERRIDE;
+    IplImage* retrieveFrame(int) CV_OVERRIDE;
+    double getProperty(int property_id) const CV_OVERRIDE;
+    bool setProperty(int property_id, double value) CV_OVERRIDE;
     int getCaptureDomain() /*const*/ CV_OVERRIDE { return cv::CAP_AVFOUNDATION; }
+
+    virtual int didStart();
 
 private:
     AVCaptureSession            *mCaptureSession;
@@ -136,12 +137,13 @@ class CvCaptureFile : public CvCapture {
 public:
     CvCaptureFile(const char* filename) ;
     ~CvCaptureFile();
-    virtual bool grabFrame();
-    virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id) const;
-    virtual bool setProperty(int property_id, double value);
-    virtual int didStart();
+    bool grabFrame() CV_OVERRIDE;
+    IplImage* retrieveFrame(int) CV_OVERRIDE;
+    double getProperty(int property_id) const CV_OVERRIDE;
+    bool setProperty(int property_id, double value) CV_OVERRIDE;
     int getCaptureDomain() /*const*/ CV_OVERRIDE { return cv::CAP_AVFOUNDATION; }
+
+    virtual int didStart();
 
 private:
     AVAsset                  *mAsset;


### PR DESCRIPTION
backport changes from #19821
relates #19809