### PR TITLE
[G-API] Fix bug of GArray<GArray> passing through a graph

### DIFF
--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -246,12 +246,18 @@ namespace detail
 
     public:
         VectorRef() = default;
-        template<typename T> explicit VectorRef(const std::vector<T>& vec) :
-                                            m_ref(new VectorRefT<T>(vec)), m_kind(GOpaqueTraits<T>::kind) {}
-        template<typename T> explicit VectorRef(std::vector<T>& vec)       :
-                                            m_ref(new VectorRefT<T>(vec)), m_kind(GOpaqueTraits<T>::kind) {}
-        template<typename T> explicit VectorRef(std::vector<T>&& vec)      :
-                                            m_ref(new VectorRefT<T>(std::move(vec))), m_kind(GOpaqueTraits<T>::kind) {}
+        template<typename T> explicit VectorRef(const std::vector<T>& vec)
+            : m_ref(new VectorRefT<T>(vec))
+            , m_kind(GOpaqueTraits<T>::kind)
+        {}
+        template<typename T> explicit VectorRef(std::vector<T>& vec)
+            : m_ref(new VectorRefT<T>(vec))
+            , m_kind(GOpaqueTraits<T>::kind)
+        {}
+        template<typename T> explicit VectorRef(std::vector<T>&& vec)
+            : m_ref(new VectorRefT<T>(std::move(vec)))
+            , m_kind(GOpaqueTraits<T>::kind)
+        {}
 
         cv::detail::OpaqueKind getKind() const
         {
@@ -321,9 +327,10 @@ namespace detail
 #  define FLATTEN_NS cv
 #endif
     template<class T> struct flatten_g;
-    template<> struct flatten_g<cv::GMat>    { using type = FLATTEN_NS::Mat; };
-    template<> struct flatten_g<cv::GScalar> { using type = FLATTEN_NS::Scalar; };
-    template<class T> struct flatten_g       { using type = T; };
+    template<> struct flatten_g<cv::GMat>         { using type = FLATTEN_NS::Mat; };
+    template<> struct flatten_g<cv::GScalar>      { using type = FLATTEN_NS::Scalar; };
+    template<class T> struct flatten_g<GArray<T>> { using type = std::vector<T>; };
+    template<class T> struct flatten_g            { using type = T; };
 #undef FLATTEN_NS
     // FIXME: the above mainly duplicates "ProtoToParam" thing from gtyped.hpp
     // but I decided not to include gtyped here - probably worth moving that stuff

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -192,22 +192,19 @@ TEST(GArray, TestIntermediateOutput)
 TEST(GArray, TestGArrayGArrayKernelInput)
 {
     cv::GMat in;
-    cv::GArray<cv::GArray<cv::Point>> contours = cv::gapi::findContours(in, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+    auto contours = cv::gapi::findContours(in, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
     auto out = ThisTest::CountContours::on(contours);
-    cv::GComputation c(GIn(in), GOut(out
-                                    //  ,contours
-                                    ));
+    cv::GComputation c(GIn(in), GOut(out));
 
-    cv::Mat in_mat = cv::Mat::eye(32, 32, CV_8UC1);
+    // Create input - two filled rectangles
+    cv::Mat in_mat = cv::Mat::zeros(50, 50, CV_8UC1);
+    cv::rectangle(in_mat, cv::Point{5,5},   cv::Point{20,20}, 255, cv::FILLED);
+    cv::rectangle(in_mat, cv::Point{25,25}, cv::Point{40,40}, 255, cv::FILLED);
+
     size_t out_count;
-    // std::vector<std::vector<cv::Point>> out_conts;
+    c.apply(gin(in_mat), gout(out_count), cv::compile_args(cv::gapi::kernels<OCVCountContours>()));
 
-    c.apply(gin(in_mat), gout(out_count
-                            //  ,out_conts
-                             ), cv::compile_args(cv::gapi::kernels<OCVCountContours>()));
-
-    // EXPECT_EQ(1u,  out_conts.size());
-    EXPECT_EQ(1u,  out_count);
+    EXPECT_EQ(2u, out_count) << "Two contours must be found";
 }
 
 TEST(GArray, GArrayConstValInitialization)

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -201,7 +201,7 @@ TEST(GArray, TestGArrayGArrayKernelInput)
     cv::rectangle(in_mat, cv::Point{5,5},   cv::Point{20,20}, 255, cv::FILLED);
     cv::rectangle(in_mat, cv::Point{25,25}, cv::Point{40,40}, 255, cv::FILLED);
 
-    size_t out_count;
+    size_t out_count = 0u;
     c.apply(gin(in_mat), gout(out_count), cv::compile_args(cv::gapi::kernels<OCVCountContours>()));
 
     EXPECT_EQ(2u, out_count) << "Two contours must be found";

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -32,6 +32,10 @@ G_TYPED_KERNEL(PointIncrement, <GPointArray(GMat, GPointArray)>, "test.point_inc
 {
     static GArrayDesc outMeta(const GMatDesc&, const GArrayDesc&) { return empty_array_desc(); }
 };
+G_TYPED_KERNEL(CountContours, <GOpaque<size_t>(GArray<GPointArray>)>, "test.array.array.in")
+{
+    static GOpaqueDesc outMeta(const GArrayDesc&) { return empty_gopaque_desc(); }
+};
 } // namespace ThisTest
 
 namespace
@@ -67,6 +71,14 @@ GAPI_OCV_KERNEL(OCVPointIncrement, ThisTest::PointIncrement)
     {
         for (const auto& el : in)
             out.emplace_back(el + Point(1,1));
+    }
+};
+
+GAPI_OCV_KERNEL(OCVCountContours, ThisTest::CountContours)
+{
+    static void run(const std::vector<std::vector<cv::Point>> &contours, size_t &out)
+    {
+        out = contours.size();
     }
 };
 
@@ -175,6 +187,27 @@ TEST(GArray, TestIntermediateOutput)
 
     EXPECT_EQ(10u, out_points.size());
     EXPECT_EQ(10,  out_count[0]);
+}
+
+TEST(GArray, TestGArrayGArrayKernelInput)
+{
+    cv::GMat in;
+    cv::GArray<cv::GArray<cv::Point>> contours = cv::gapi::findContours(in, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+    auto out = ThisTest::CountContours::on(contours);
+    cv::GComputation c(GIn(in), GOut(out
+                                    //  ,contours
+                                    ));
+
+    cv::Mat in_mat = cv::Mat::eye(32, 32, CV_8UC1);
+    size_t out_count;
+    // std::vector<std::vector<cv::Point>> out_conts;
+
+    c.apply(gin(in_mat), gout(out_count
+                            //  ,out_conts
+                             ), cv::compile_args(cv::gapi::kernels<OCVCountContours>()));
+
+    // EXPECT_EQ(1u,  out_conts.size());
+    EXPECT_EQ(1u,  out_count);
 }
 
 TEST(GArray, GArrayConstValInitialization)


### PR DESCRIPTION
If GArray<GArray<U>> wasn't an input or an output of a graph, assertion would fail.

Added test to check the fix works

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*
```