### PR TITLE
apps(model_diagnostics): fix invalid callback

### DIFF
--- a/apps/model-diagnostics/model_diagnostics.cpp
+++ b/apps/model-diagnostics/model_diagnostics.cpp
@@ -12,11 +12,14 @@ using namespace cv;
 using namespace dnn;
 
 
-static void diagnosticsErrorCallback(const Exception& exc)
+static
+int diagnosticsErrorCallback(int /*status*/, const char* /*func_name*/,
+                             const char* /*err_msg*/, const char* /*file_name*/,
+                             int /*line*/, void* /*userdata*/)
 {
-    CV_UNUSED(exc);
     fflush(stdout);
     fflush(stderr);
+    return 0;
 }
 
 static std::string checkFileExists(const std::string& fileName)
@@ -54,7 +57,7 @@ int main( int argc, const char** argv )
     CV_Assert(!model.empty());
 
     enableModelDiagnostics(true);
-    redirectError((ErrorCallback)diagnosticsErrorCallback, NULL);
+    redirectError(diagnosticsErrorCallback, NULL);
 
     Net ocvNet = readNet(model, config, frameworkId);
 


### PR DESCRIPTION
relates #19693

<cut/>

Compiler message (Ubuntu 20.04):

> /build/master_openvino-skl-lin64/opencv/apps/model-diagnostics/model_diagnostics.cpp:57:34: warning: cast between incompatible function types from 'void (*)(const cv::Exception&)' to 'cv::ErrorCallback' {aka 'int (*)(int, const char*, const char*, const char*, int, void*)'} [-Wcast-function-type]

```
   57 |     redirectError((ErrorCallback)diagnosticsErrorCallback, NULL);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~
```

```
buildworker:Custom=linux-1
build_image:Custom=ubuntu-openvino-2021.3.0:20.04
test_modules:Custom=dnn,gapi,python2,python3,java
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
