### PR TITLE
gapi(test): avoid compilation failure with GCC11

### DIFF
--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -356,7 +356,12 @@ template<typename case_t>
 struct cancel : ::testing::Test{};
 TYPED_TEST_CASE_P(cancel);
 
-TYPED_TEST_P(cancel, basic){
+TYPED_TEST_P(cancel, basic)
+{
+#if defined(__GNUC__) && __GNUC__ >= 11
+    // std::vector<TypeParam> requests can't handle type with ctor parameter (SelfCanceling)
+    FAIL() << "Test code is not available due to compilation error with GCC 11";
+#else
     constexpr int num_tasks = 100;
     cancel_struct cancel_struct_ {num_tasks};
     std::vector<TypeParam> requests; requests.reserve(num_tasks);
@@ -378,6 +383,7 @@ TYPED_TEST_P(cancel, basic){
         }
     }
     ASSERT_GT(canceled, 0u);
+#endif
 }
 
 namespace {


### PR DESCRIPTION
relates #19678

unlock code compilation, but tests will fail with error message