### PR TITLE
release: OpenCV 3.4.14

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 14
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.14

relates #19656

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3414.dll (vc14)](https://www.virustotal.com/gui/file/b87ee686227781321fcd99294499c84e8cf4091edcc8672eda17d9528aa11706/detection)
[opencv_world3414d.dll (vc14)](https://www.virustotal.com/gui/file/2c78cbb32d8d6b1604a908128235b962065b789bf89d231510a04d720cdc9497/detection)
[opencv_world3414.dll (vc15)](https://www.virustotal.com/gui/file/b0637e5738b272351a78b126f8e57f5b32846bad92cded6abb6fccc6db3ff491/detection)
[opencv_world3414d.dll (vc15)](https://www.virustotal.com/gui/file/58b8d4a99409f51e80e7026df88fec366ba085317a762e224b0fa3c5133b6447/detection)

[opencv_ffmpeg3414_64.dll](https://www.virustotal.com/gui/file/3f61eaff916f22b95a444ccde7d30c75423b1b8bfbbdb6b6f3e987fafed9d77e/detection)

</details>
