### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/modules/python/bindings/CMakeLists.txt
+++ b/modules/python/bindings/CMakeLists.txt
@@ -29,12 +29,15 @@ foreach(m ${OPENCV_PYTHON_MODULES})
 
   # both wrapping and C++ implementation
   file(GLOB hdr2 ${OPENCV_MODULE_${m}_LOCATION}/misc/python/python_*.hpp)
+  list(SORT hdr2)
   list(APPEND opencv_hdrs ${hdr2})
   list(APPEND opencv_userdef_hdrs ${hdr2})
 
   file(GLOB hdr ${OPENCV_MODULE_${m}_LOCATION}/misc/python/shadow*.hpp)
+  list(SORT hdr)
   list(APPEND opencv_hdrs ${hdr})
   file(GLOB userdef_hdrs ${OPENCV_MODULE_${m}_LOCATION}/misc/python/pyopencv*.hpp)
+  list(SORT userdef_hdrs)
   list(APPEND opencv_userdef_hdrs ${userdef_hdrs})
 endforeach(m)
 

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2741,6 +2741,7 @@ int videoInput::start(int deviceID, videoDevice *VD){
     }
 
     VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
+    CV_Assert(pVih);
     int currentWidth    =  HEADER(pVih)->biWidth;
     int currentHeight    =  HEADER(pVih)->biHeight;
 


### PR DESCRIPTION
~~#19822 from alalek:core_wui_backward_compatibility~~ (backport)
~~#19823 from alalek:issue_contrib_2895~~ (moved to contrib)
#19825 from alalek:cmake_fix_headers_order_python_3.4
~~#19827 from alalek:build_videoio_macosx_override_3.4~~ (backport)
#19830 from alalek:issue_19368
~~#19831 from alalek:backport_19771~~ (backport)

Previous "Merge 3.4": #19821

<cut/>

<details>

```
buildworker:Win64 OpenCL=windows-2
#buildworker:Custom=linux-1,linux-2,linux-4,linux-6
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6
Xbuild_image:Custom=javascript-simd
#build_image:Custom=powerpc64le
#build_image:Custom=ubuntu-openvino-2019r3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.4.0:16.04
#build_image:Custom=ubuntu-openvino-2021.1.0:20.04
#build_image:Custom=ubuntu-openvino-2021.2.0:20.04
#build_image:Custom=ubuntu-openvino-2021.3.0:20.04
#buildworker:Custom=linux-1
#build_image:Custom=ubuntu-vulkan:16.04
#buildworker:Custom=linux-4
#build_image:Custom=fedora:28
#build_image:Custom=ubuntu-cuda:16.04
#build_image:Custom=ubuntu-clang:18.04
#build_image:Custom=ubuntu:20.04
#buildworker:Custom=linux-1
#build_image:Custom=javascript-simd
#build_image:Custom=mips64el
#build_image:Custom Mac=openvino-2019r3.0
#build_image:Custom Mac=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.4.0
Xbuild_image:Custom Mac=openvino-2021.1.0
Xbuild_image:Custom Mac=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.3.0
#build_image:Custom Win=openvino-2019r3.0
#build_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Win=openvino-2020.4.0
Xbuild_image:Custom Win=openvino-2021.1.0
Xbuild_image:Custom Win=openvino-2021.2.0
build_image:Custom Win=openvino-2021.3.0
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules=dnn,python2,python3,java
test_opencl:Custom Win=OFF
build_contrib:Custom Win=OFF
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```

</details>
