### PR TITLE
release: OpenCV 4.5.2

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    5
 #define CV_VERSION_REVISION 2
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 4.5.2

relates #19657

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world451.dll (vc14)](https://www.virustotal.com/gui/file/f72879b346bebdf89daea53674a9bebc7f40806b6d76ec6fb71bfb6be4493ce3/detection)
[opencv_world451d.dll (vc14)](https://www.virustotal.com/gui/file/162588e825258c56e7df72e65de4a52404030ce12c761d566372b98ea4020b72/detection) 
[opencv_world451.dll (vc15)](https://www.virustotal.com/gui/file/420fb5da01508fa860b8b525afad68b47e1f29e87c83b7ed0acf834c2ed25d09/detection)
[opencv_world451d.dll (vc15)](https://www.virustotal.com/gui/file/35850a521dfce4eae91d21f9e9c09ed9b11b7e3b99a8cb11f4a9954026a02cda/detection)

[opencv_ffmpeg451_64.dll](https://www.virustotal.com/gui/file/8f373e1ab44860c125e93471e916a08180c0921c12b485d62f1158ec0026cc9c/detection)

</details>
