### PR TITLE
Change type used in points function from RotatedRect

### DIFF
--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -173,8 +173,8 @@ RotatedRect::RotatedRect(const Point2f& _point1, const Point2f& _point2, const P
 void RotatedRect::points(Point2f pt[]) const
 {
     double _angle = angle*CV_PI/180.;
-    float b = (float)cos(_angle)*0.5f;
-    float a = (float)sin(_angle)*0.5f;
+    double b = (double)cos(_angle)*0.5;
+    double a = (double)sin(_angle)*0.5;
 
     pt[0].x = center.x - a*size.height - b*size.width;
     pt[0].y = center.y + b*size.height - a*size.width;


### PR DESCRIPTION
In the function that sets the points of a RotatedRect, the types
should be double in order to keep the precision when dealing with
RotatedRects that are defined far from the origin.

This commit solves the problem in some assertions from
rotatedRectangleIntersection when dealing with rectangles far from
origin.

Original issue: https://github.com/opencv/opencv/issues/19824

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
