### PR TITLE
Remove virtual inheritance from Feature2D

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -141,11 +141,7 @@ public:
 
 /** @brief Abstract base class for 2D image feature detectors and descriptor extractors
 */
-#ifdef __EMSCRIPTEN__
 class CV_EXPORTS_W Feature2D : public Algorithm
-#else
-class CV_EXPORTS_W Feature2D : public virtual Algorithm
-#endif
 {
 public:
     virtual ~Feature2D();


### PR DESCRIPTION
Related to https://github.com/opencv/opencv/issues/12976, removes virtual inheritance from Features2D, as it no longer appears to be necessary (there is no longer a diamond inheritance structure).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
