### PR TITLE
G-API: Adding a skip for failed streaming test

### DIFF
--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -1108,22 +1108,20 @@ TEST(GAPI_Streaming, TestTwoVideosDifferentLength)
 {
     initTestDataPath();
     auto desc = cv::GMatDesc{CV_8U,3,{768,576}};
-    std::string path1, path2;
-    try {
-        path1 = findDataFile("cv/video/768x576.avi");
-        path2 = findDataFile("highgui/video/big_buck_bunny.avi");
-    } catch(...) {
-        throw SkipTestException("Video file can not be found");
-    }
+    auto path1 = findDataFile("cv/video/768x576.avi");
+    auto path2 = findDataFile("highgui/video/big_buck_bunny.avi");
 
     cv::GMat in1, in2;
     auto out = in1 + cv::gapi::resize(in2, desc.size);
 
     cv::GComputation cc(cv::GIn(in1, in2), cv::GOut(out));
     auto sc = cc.compileStreaming();
-
-    sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path1),
-                         gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path2)));
+    try {
+        sc.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path1),
+                             gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(path2)));
+    } catch(...) {
+        throw SkipTestException("Video file can not be found");
+    }
     sc.start();
 
     cv::Mat out_mat;


### PR DESCRIPTION
Problem: TestTwoVideosDifferentLength has incorrect skip for setSource().

relates #19844

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake



### Magic CentOS commands:

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```