### PR TITLE
[imgcodecs] Support unicode filenames on Windows.

### DIFF
--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -620,7 +620,7 @@ FILE *fopen(const char *in, const char *mode)
     if (f)
         return f;
     // try unicode path assuming utf8 was passed
-    static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     auto s = converter.from_bytes(in);
     auto m = converter.from_bytes(mode);
     if (s.size() >= 255)

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -138,6 +138,8 @@ CV_INLINE bool  isBigEndian( void )
     return (((const int*)"\0\x1\x2\x3\x4\x5\x6\x7")[0] & 255) != 0;
 }
 
+FILE *fopen(const char *fn, const char *mode);
+
 }  // namespace
 
 #endif/*_UTILS_H_*/


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

---

Hi,

This PR enables unicode file name support for imgcodecs on Windows. With it opencv can read and write to files with unicode file names given utf8 file name is provided.
It also adds long path support (see PR condition `if (s.size() >= 255)`).

Custom `cv::fopen()` is added to utils.hpp, so all codecs will see it.
On windows it performs utf8 to wstring conversion and `_wfopen_s()` call.
On other systems libc fopen is called.

There is fast path if we open ascii filename. If it fails, conversion code path is used.
