### PR TITLE
fix for #19870

### DIFF
--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -93,7 +93,9 @@ CV_IMPL void cvSetWindowProperty(const char* name, int prop_id, double prop_valu
     break;
 
     case cv::WND_PROP_VSYNC:
-        #if defined (HAVE_WIN32UI)
+        #if defined (HAVE_QT)
+            // nothing
+        #elif defined (HAVE_WIN32UI)
             cvSetPropVsync_W32(name, (prop_value != 0));
         #else
             // not implemented yet for other toolkits
@@ -191,7 +193,9 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
     break;
 
     case cv::WND_PROP_VSYNC:
-        #if defined (HAVE_WIN32UI)
+        #if defined (HAVE_QT)
+            return -1;
+        #elif defined (HAVE_WIN32UI)
             return cvGetPropVsync_W32(name);
         #else
             return -1;


### PR DESCRIPTION
this fixes issue #19870

`HAVE_QT` and `HAVE_WIN32UI` can both be true at the same time
if `HAVE_QT`, `window_w32.cpp` is not included in the build, see `CMakeLists.txt`
code for `HAVE_WIN32UI` must be inactive if `HAVE_QT`
empty cases added to implement this