### PR TITLE
Fixed Vulnerabilities in Two libpng files 

### DIFF
--- a/3rdparty/libpng/pngpread.c
+++ b/3rdparty/libpng/pngpread.c
@@ -224,6 +224,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+    
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/3rdparty/libpng/pngrutil.c
+++ b/3rdparty/libpng/pngrutil.c
@@ -182,8 +182,21 @@ png_read_chunk_header(png_structrp png_ptr)
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
    /* Check for too-large chunk length */
-   png_check_chunk_length(png_ptr, length);
-
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+    
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Fixed vulnerabilities in files pngpread.c and pngrutil.c in the following path:
3rdparty/libpng/pngpread.c and pngrutil.c

libpng is a popular graphics library.
libpng is subject to CVE-2017-12652.
The vulnerability was fixed by commit 347538efbdc21b8df684ebd92d37400b3ce85d55.
The fix is in two files: pngpread.c and pngrutil.c.

https://github.com/glennrp/libpng/commit/347538efbdc21b8df684ebd92d37400b3ce85d55 