### PR TITLE
Add Neon optimised RGB2Lab conversion

### DIFF
--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1593,17 +1593,16 @@ struct RGB2Lab_b
         const int one_shift_lab_mul_128 = 128*(1 << lab_shift2);
 
         // Helper function for looking up 4 lots of LabCbrtTab_b values at once, returning them as int32x4_t
-        auto LabCbrtTab_b_fnc = [](const int32x4_t& idxvec) -> int32x4_t
-        {
-            int CV_DECL_ALIGNED(32) elems[4] =
-            {
-                LabCbrtTab_b[vgetq_lane_s32(idxvec, 0)],
-                LabCbrtTab_b[vgetq_lane_s32(idxvec, 1)],
-                LabCbrtTab_b[vgetq_lane_s32(idxvec, 2)],
-                LabCbrtTab_b[vgetq_lane_s32(idxvec, 3)]
-            };
-            return vld1q_s32(elems);
-        };
+        #define LAB_CBRT_TAB(x) { \
+            int CV_DECL_ALIGNED(32) elems[4] = \
+            { \
+                LabCbrtTab_b[vgetq_lane_s32(x, 0)], \
+                LabCbrtTab_b[vgetq_lane_s32(x, 1)], \
+                LabCbrtTab_b[vgetq_lane_s32(x, 2)], \
+                LabCbrtTab_b[vgetq_lane_s32(x, 3)]  \
+            }; \
+            x = vld1q_s32(elems); \
+        }
 
         // Convert 2 batches of 4 uint8_t RGBs, which are expanded to 2 batches of int32x4_t, then the resulting Lab is stored as uint8x8x3_t
         // Hence we stride in 8s
@@ -1638,36 +1637,36 @@ struct RGB2Lab_b
             int32x4_t vfX0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C0);
             vfX0 = vmlaq_n_s32(vfX0, vG0, C1);
             vfX0 = vmlaq_n_s32(vfX0, vB0, C2);
-            vfX0 = vshlq_n_s32(vfX0, -lab_shift);
-            vfX0 = LabCbrtTab_b_fnc(vfX0);
+            vfX0 = vshrq_n_s32(vfX0, lab_shift);
+            LAB_CBRT_TAB(vfX0);
 
             // int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)];
             int32x4_t vfY0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C3);
             vfY0 = vmlaq_n_s32(vfY0, vG0, C4);
             vfY0 = vmlaq_n_s32(vfY0, vB0, C5);
-            vfY0 = vshlq_n_s32(vfY0, -lab_shift);
-            vfY0 = LabCbrtTab_b_fnc(vfY0);
+            vfY0 = vshrq_n_s32(vfY0, lab_shift);
+            LAB_CBRT_TAB(vfY0);
 
             // int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];
             int32x4_t vfZ0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C6);
             vfZ0 = vmlaq_n_s32(vfZ0, vG0, C7);
             vfZ0 = vmlaq_n_s32(vfZ0, vB0, C8);
-            vfZ0 = vshlq_n_s32(vfZ0, -lab_shift);
-            vfZ0 = LabCbrtTab_b_fnc(vfZ0);
+            vfZ0 = vshrq_n_s32(vfZ0, lab_shift);
+            LAB_CBRT_TAB(vfZ0);
 
             // int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );
             int32x4_t vL0 = vmlaq_n_s32(vdupq_n_s32(Lshift+one_lsh_by_lab_shift2_sub_one), vfY0, Lscale);
-            vL0 = vshlq_n_s32(vL0, -lab_shift2);
+            vL0 = vshrq_n_s32(vL0, lab_shift2);
 
             // int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );
             int32x4_t va0 = vsubq_s32(vfX0, vfY0);
             va0 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), va0, 500);
-            va0 = vshlq_n_s32(va0, -lab_shift2);
+            va0 = vshrq_n_s32(va0, lab_shift2);
 
             // int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );
             int32x4_t vb0 = vsubq_s32(vfY0, vfZ0);
             vb0 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), vb0, 200);
-            vb0 = vshlq_n_s32(vb0, -lab_shift2);
+            vb0 = vshrq_n_s32(vb0, lab_shift2);
 
             // Second batch
             // ============
@@ -1680,36 +1679,36 @@ struct RGB2Lab_b
             int32x4_t vfX1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C0);
             vfX1 = vmlaq_n_s32(vfX1, vG1, C1);
             vfX1 = vmlaq_n_s32(vfX1, vB1, C2);
-            vfX1 = vshlq_n_s32(vfX1, -lab_shift);
-            vfX1 = LabCbrtTab_b_fnc(vfX1);
+            vfX1 = vshrq_n_s32(vfX1, lab_shift);
+            LAB_CBRT_TAB(vfX1);
 
             // int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)];
             int32x4_t vfY1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C3);
             vfY1 = vmlaq_n_s32(vfY1, vG1, C4);
             vfY1 = vmlaq_n_s32(vfY1, vB1, C5);
-            vfY1 = vshlq_n_s32(vfY1, -lab_shift);
-            vfY1 = LabCbrtTab_b_fnc(vfY1);
+            vfY1 = vshrq_n_s32(vfY1, lab_shift);
+            LAB_CBRT_TAB(vfY1);
 
             // int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];
             int32x4_t vfZ1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C6);
             vfZ1 = vmlaq_n_s32(vfZ1, vG1, C7);
             vfZ1 = vmlaq_n_s32(vfZ1, vB1, C8);
-            vfZ1 = vshlq_n_s32(vfZ1, -lab_shift);
-            vfZ1 = LabCbrtTab_b_fnc(vfZ1);
+            vfZ1 = vshrq_n_s32(vfZ1, lab_shift);
+            LAB_CBRT_TAB(vfZ1);
 
             // int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );
             int32x4_t vL1 = vmlaq_n_s32(vdupq_n_s32(Lshift+one_lsh_by_lab_shift2_sub_one), vfY1, Lscale);
-            vL1 = vshlq_n_s32(vL1, -lab_shift2);
+            vL1 = vshrq_n_s32(vL1, lab_shift2);
 
             // int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );
             int32x4_t va1 = vsubq_s32(vfX1, vfY1);
             va1 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), va1, 500);
-            va1 = vshlq_n_s32(va1, -lab_shift2);
+            va1 = vshrq_n_s32(va1, lab_shift2);
 
             // int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );
             int32x4_t vb1 = vsubq_s32(vfY1, vfZ1);
             vb1 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), vb1, 200);
-            vb1 = vshlq_n_s32(vb1, -lab_shift2);
+            vb1 = vshrq_n_s32(vb1, lab_shift2);
 
             // Saturate, combine and store both batches
             // ========================================

--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1592,15 +1592,17 @@ struct RGB2Lab_b
         const int one_lsh_by_lab_shift2_sub_one = (1 << ((lab_shift2)-1));
         const int one_shift_lab_mul_128 = 128*(1 << lab_shift2);
 
-        // Convert 4 batches of 4 uint8_t RGBs, hence we stride in 16s
-        for(; i <= n - 16; i += 16, src += scn*16, dst += 3*16 )
+        // On each loop, we load nlanes of RGB/A v_uint8s and store nlanes of
+        // Lab v_uint8s
+        for(; i <= n - v_uint8::nlanes; i += v_uint8::nlanes,
+                src += scn*v_uint8::nlanes, dst += 3*v_uint8::nlanes )
         {
             // Load 4 batches of 4 src
             // =======================
-            v_uint8x16 vRi, vGi, vBi;
+            v_uint8 vRi, vGi, vBi;
             if(scn == 4)
             {
-                v_uint8x16 vAi;
+                v_uint8 vAi;
                 v_load_deinterleave(src, vRi, vGi, vBi, vAi);
             }
             else // scn == 3
@@ -1609,49 +1611,51 @@ struct RGB2Lab_b
             }
 
 #define RGB2LAB_BATCH(n) \
-            v_int32x4 vR##n(tab[v_extract_n<4*n+0>(vRi)], tab[v_extract_n<4*n+1>(vRi)], \
-                            tab[v_extract_n<4*n+2>(vRi)], tab[v_extract_n<4*n+3>(vRi)]); \
-            v_int32x4 vG##n(tab[v_extract_n<4*n+0>(vGi)], tab[v_extract_n<4*n+1>(vGi)], \
-                            tab[v_extract_n<4*n+2>(vGi)], tab[v_extract_n<4*n+3>(vGi)]); \
-            v_int32x4 vB##n(tab[v_extract_n<4*n+0>(vBi)], tab[v_extract_n<4*n+1>(vBi)], \
-                            tab[v_extract_n<4*n+2>(vBi)], tab[v_extract_n<4*n+3>(vBi)]); \
+            v_int32 vR##n(tab[v_extract_n<4*n+0>(vRi)], tab[v_extract_n<4*n+1>(vRi)], \
+                          tab[v_extract_n<4*n+2>(vRi)], tab[v_extract_n<4*n+3>(vRi)]); \
+            v_int32 vG##n(tab[v_extract_n<4*n+0>(vGi)], tab[v_extract_n<4*n+1>(vGi)], \
+                          tab[v_extract_n<4*n+2>(vGi)], tab[v_extract_n<4*n+3>(vGi)]); \
+            v_int32 vB##n(tab[v_extract_n<4*n+0>(vBi)], tab[v_extract_n<4*n+1>(vBi)], \
+                          tab[v_extract_n<4*n+2>(vBi)], tab[v_extract_n<4*n+3>(vBi)]); \
             \
             /* int fX = LabCbrtTab_b[CV_DESCALE(R*C0 + G*C1 + B*C2, lab_shift)];*/ \
-            v_int32x4 vfX##n = v_fma(vR##n, v_setall_s32(C0), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
+            v_int32 vfX##n = v_fma(vR##n, v_setall_s32(C0), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
             vfX##n = v_fma(vG##n, v_setall_s32(C1), vfX##n); \
             vfX##n = v_fma(vB##n, v_setall_s32(C2), vfX##n); \
             vfX##n = v_shr<lab_shift>(vfX##n); \
-            vfX##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfX##n)], LabCbrtTab_b[v_extract_n<1>(vfX##n)], \
-                               LabCbrtTab_b[v_extract_n<2>(vfX##n)], LabCbrtTab_b[v_extract_n<3>(vfX##n)]); \
+            vfX##n = v_int32(LabCbrtTab_b[v_extract_n<0>(vfX##n)], LabCbrtTab_b[v_extract_n<1>(vfX##n)], \
+                             LabCbrtTab_b[v_extract_n<2>(vfX##n)], LabCbrtTab_b[v_extract_n<3>(vfX##n)]); \
             \
             /* int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)]; */ \
-            v_int32x4 vfY##n = v_fma(vR##n, v_setall_s32(C3), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
+            v_int32 vfY##n = v_fma(vR##n, v_setall_s32(C3), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
             vfY##n = v_fma(vG##n, v_setall_s32(C4), vfY##n);\
             vfY##n = v_fma(vB##n, v_setall_s32(C5), vfY##n);\
             vfY##n = v_shr<lab_shift>(vfY##n);\
-            vfY##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfY##n)], LabCbrtTab_b[v_extract_n<1>(vfY##n)], \
-                               LabCbrtTab_b[v_extract_n<2>(vfY##n)], LabCbrtTab_b[v_extract_n<3>(vfY##n)]);\
+            vfY##n = v_int32(LabCbrtTab_b[v_extract_n<0>(vfY##n)], LabCbrtTab_b[v_extract_n<1>(vfY##n)], \
+                             LabCbrtTab_b[v_extract_n<2>(vfY##n)], LabCbrtTab_b[v_extract_n<3>(vfY##n)]);\
             \
             /* int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];*/ \
-            v_int32x4 vfZ##n = v_fma(vR##n, v_setall_s32(C6), v_setall_s32(one_lsh_by_lab_shift_sub_one));\
+            v_int32 vfZ##n = v_fma(vR##n, v_setall_s32(C6), v_setall_s32(one_lsh_by_lab_shift_sub_one));\
             vfZ##n = v_fma(vG##n, v_setall_s32(C7), vfZ##n);\
             vfZ##n = v_fma(vB##n, v_setall_s32(C8), vfZ##n);\
             vfZ##n = v_shr<lab_shift>(vfZ##n);\
-            vfZ##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfZ##n)], LabCbrtTab_b[v_extract_n<1>(vfZ##n)], \
-                               LabCbrtTab_b[v_extract_n<2>(vfZ##n)], LabCbrtTab_b[v_extract_n<3>(vfZ##n)]);\
+            vfZ##n = v_int32(LabCbrtTab_b[v_extract_n<0>(vfZ##n)], LabCbrtTab_b[v_extract_n<1>(vfZ##n)], \
+                             LabCbrtTab_b[v_extract_n<2>(vfZ##n)], LabCbrtTab_b[v_extract_n<3>(vfZ##n)]);\
             \
             /* int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );*/ \
-            v_int32x4 vL##n = v_fma(vfY##n, v_setall_s32(Lscale), v_setall_s32(Lshift+one_lsh_by_lab_shift2_sub_one));\
+            v_int32 vL##n = v_fma(vfY##n, v_setall_s32(Lscale), \
+                                  v_setall_s32(Lshift+one_lsh_by_lab_shift2_sub_one));\
             vL##n = v_shr<lab_shift2>(vL##n);\
             \
             /* int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );*/ \
-            v_int32x4 va##n = v_fma(vfX##n - vfY##n, v_setall_s32(500), v_setall_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one));\
+            v_int32 va##n = v_fma(vfX##n - vfY##n, v_setall_s32(500), \
+                                  v_setall_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one));\
             va##n = v_shr<lab_shift2>(va##n);\
             \
             /* int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );*/ \
-            v_int32x4 vb##n = v_fma(vfY##n - vfZ##n, v_setall_s32(200), v_setall_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one));\
+            v_int32 vb##n = v_fma(vfY##n - vfZ##n, v_setall_s32(200), \
+                                  v_setall_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one));\
             vb##n = v_shr<lab_shift2>(vb##n);
-
 
             // Do 4 batches of 4 RGB2Labs
             RGB2LAB_BATCH(0)
@@ -1665,9 +1669,9 @@ struct RGB2Lab_b
             // dst[1] = saturate_cast<uchar>(a);
             // dst[2] = saturate_cast<uchar>(b);
             v_store_interleave(dst,
-                v_pack(v_pack_u(vL0,vL1),v_pack_u(vL2,vL3)),
-                v_pack(v_pack_u(va0,va1),v_pack_u(va2,va3)),
-                v_pack(v_pack_u(vb0,vb1),v_pack_u(vb2,vb3)));
+                v_pack(v_pack_u(vL0, vL1), v_pack_u(vL2, vL3)),
+                v_pack(v_pack_u(va0, va1), v_pack_u(va2, va3)),
+                v_pack(v_pack_u(vb0, vb1), v_pack_u(vb2, vb3)));
         }
 
 #endif

--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1609,30 +1609,36 @@ struct RGB2Lab_b
             }
 
 #define RGB2LAB_BATCH(n) \
-            v_int32x4 vR##n(tab[vRi.val[4*n+0]], tab[vRi.val[4*n+1]], tab[vRi.val[4*n+2]], tab[vRi.val[4*n+3]]); \
-            v_int32x4 vG##n(tab[vGi.val[4*n+0]], tab[vGi.val[4*n+1]], tab[vGi.val[4*n+2]], tab[vGi.val[4*n+3]]); \
-            v_int32x4 vB##n(tab[vBi.val[4*n+0]], tab[vBi.val[4*n+1]], tab[vBi.val[4*n+2]], tab[vBi.val[4*n+3]]); \
+            v_int32x4 vR##n(tab[v_extract_n<4*n+0>(vRi)], tab[v_extract_n<4*n+1>(vRi)], \
+                            tab[v_extract_n<4*n+2>(vRi)], tab[v_extract_n<4*n+3>(vRi)]); \
+            v_int32x4 vG##n(tab[v_extract_n<4*n+0>(vGi)], tab[v_extract_n<4*n+1>(vGi)], \
+                            tab[v_extract_n<4*n+2>(vGi)], tab[v_extract_n<4*n+3>(vGi)]); \
+            v_int32x4 vB##n(tab[v_extract_n<4*n+0>(vBi)], tab[v_extract_n<4*n+1>(vBi)], \
+                            tab[v_extract_n<4*n+2>(vBi)], tab[v_extract_n<4*n+3>(vBi)]); \
             \
             /* int fX = LabCbrtTab_b[CV_DESCALE(R*C0 + G*C1 + B*C2, lab_shift)];*/ \
             v_int32x4 vfX##n = v_fma(vR##n, v_setall_s32(C0), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
             vfX##n = v_fma(vG##n, v_setall_s32(C1), vfX##n); \
             vfX##n = v_fma(vB##n, v_setall_s32(C2), vfX##n); \
             vfX##n = v_shr<lab_shift>(vfX##n); \
-            vfX##n = v_int32x4(LabCbrtTab_b[vfX##n.val[0]], LabCbrtTab_b[vfX##n.val[1]], LabCbrtTab_b[vfX##n.val[2]], LabCbrtTab_b[vfX##n.val[3]]); \
+            vfX##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfX##n)], LabCbrtTab_b[v_extract_n<1>(vfX##n)], \
+                               LabCbrtTab_b[v_extract_n<2>(vfX##n)], LabCbrtTab_b[v_extract_n<3>(vfX##n)]); \
             \
             /* int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)]; */ \
             v_int32x4 vfY##n = v_fma(vR##n, v_setall_s32(C3), v_setall_s32(one_lsh_by_lab_shift_sub_one)); \
             vfY##n = v_fma(vG##n, v_setall_s32(C4), vfY##n);\
             vfY##n = v_fma(vB##n, v_setall_s32(C5), vfY##n);\
             vfY##n = v_shr<lab_shift>(vfY##n);\
-            vfY##n = v_int32x4(LabCbrtTab_b[vfY##n.val[0]], LabCbrtTab_b[vfY##n.val[1]], LabCbrtTab_b[vfY##n.val[2]], LabCbrtTab_b[vfY##n.val[3]]);\
+            vfY##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfY##n)], LabCbrtTab_b[v_extract_n<1>(vfY##n)], \
+                               LabCbrtTab_b[v_extract_n<2>(vfY##n)], LabCbrtTab_b[v_extract_n<3>(vfY##n)]);\
             \
             /* int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];*/ \
             v_int32x4 vfZ##n = v_fma(vR##n, v_setall_s32(C6), v_setall_s32(one_lsh_by_lab_shift_sub_one));\
             vfZ##n = v_fma(vG##n, v_setall_s32(C7), vfZ##n);\
             vfZ##n = v_fma(vB##n, v_setall_s32(C8), vfZ##n);\
             vfZ##n = v_shr<lab_shift>(vfZ##n);\
-            vfZ##n = v_int32x4(LabCbrtTab_b[vfZ##n.val[0]], LabCbrtTab_b[vfZ##n.val[1]], LabCbrtTab_b[vfZ##n.val[2]], LabCbrtTab_b[vfZ##n.val[3]]);\
+            vfZ##n = v_int32x4(LabCbrtTab_b[v_extract_n<0>(vfZ##n)], LabCbrtTab_b[v_extract_n<1>(vfZ##n)], \
+                               LabCbrtTab_b[v_extract_n<2>(vfZ##n)], LabCbrtTab_b[v_extract_n<3>(vfZ##n)]);\
             \
             /* int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );*/ \
             v_int32x4 vL##n = v_fma(vfY##n, v_setall_s32(Lscale), v_setall_s32(Lshift+one_lsh_by_lab_shift2_sub_one));\
@@ -1645,6 +1651,7 @@ struct RGB2Lab_b
             /* int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );*/ \
             v_int32x4 vb##n = v_fma(vfY##n - vfZ##n, v_setall_s32(200), v_setall_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one));\
             vb##n = v_shr<lab_shift2>(vb##n);
+
 
             // Do 4 batches of 4 RGB2Labs
             RGB2LAB_BATCH(0)

--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1623,7 +1623,7 @@ struct RGB2Lab_b
                       LabCbrtTab_b[v_extract_n<2>(vfZ)], LabCbrtTab_b[v_extract_n<3>(vfZ)]);
 
         /* int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );*/
-         vL = v_fma(vfY, v_setall_s32(Lscale), v_setall_s32(Lshift+labDescaleShift));
+        vL = v_fma(vfY, v_setall_s32(Lscale), v_setall_s32(Lshift+labDescaleShift));
         vL = v_shr<lab_shift2>(vL);
 
         /* int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );*/

--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1585,6 +1585,146 @@ struct RGB2Lab_b
 
         i = 0;
 
+#if CV_NEON
+
+        // Define some scalar constants which we will make use of later
+        const int one_lsh_by_lab_shift_sub_one = (1 << ((lab_shift)-1));
+        const int one_lsh_by_lab_shift2_sub_one = (1 << ((lab_shift2)-1));
+        const int one_shift_lab_mul_128 = 128*(1 << lab_shift2);
+
+        // Helper function for looking up 4 lots of LabCbrtTab_b values at once, returning them as int32x4_t
+        auto LabCbrtTab_b_fnc = [](const int32x4_t& idxvec) -> int32x4_t
+        {
+            int CV_DECL_ALIGNED(32) elems[4] =
+            {
+                LabCbrtTab_b[vgetq_lane_s32(idxvec, 0)],
+                LabCbrtTab_b[vgetq_lane_s32(idxvec, 1)],
+                LabCbrtTab_b[vgetq_lane_s32(idxvec, 2)],
+                LabCbrtTab_b[vgetq_lane_s32(idxvec, 3)]
+            };
+            return vld1q_s32(elems);
+        };
+
+        // Convert 2 batches of 4 uint8_t RGBs, which are expanded to 2 batches of int32x4_t, then the resulting Lab is stored as uint8x8x3_t
+        // Hence we stride in 8s
+        for(; i <= n - 8; i += 8, src += scn*8, dst += 3*8 )
+        {
+            // Load two batches of src
+            // =======================
+            uint8x8_t vRi, vGi, vBi;
+            if(scn == 4)
+            {
+                uint8x8x4_t tab_idx = vld4_u8(src);
+                vRi = tab_idx.val[0];
+                vGi = tab_idx.val[1];
+                vBi = tab_idx.val[2];
+            }
+            else // scn == 3
+            {
+                uint8x8x3_t tab_idx = vld3_u8(src);
+                vRi = tab_idx.val[0];
+                vGi = tab_idx.val[1];
+                vBi = tab_idx.val[2];
+            }
+
+            // First batch
+            // ===========
+            // int R = tab[src[0]], G = tab[src[1]], B = tab[src[2]];
+            int32x4_t vR0 = {tab[vget_lane_u8(vRi,0)], tab[vget_lane_u8(vRi,1)], tab[vget_lane_u8(vRi,2)], tab[vget_lane_u8(vRi,3)]};
+            int32x4_t vG0 = {tab[vget_lane_u8(vGi,0)], tab[vget_lane_u8(vGi,1)], tab[vget_lane_u8(vGi,2)], tab[vget_lane_u8(vGi,3)]};
+            int32x4_t vB0 = {tab[vget_lane_u8(vBi,0)], tab[vget_lane_u8(vBi,1)], tab[vget_lane_u8(vBi,2)], tab[vget_lane_u8(vBi,3)]};
+
+            // int fX = LabCbrtTab_b[CV_DESCALE(R*C0 + G*C1 + B*C2, lab_shift)];
+            int32x4_t vfX0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C0);
+            vfX0 = vmlaq_n_s32(vfX0, vG0, C1);
+            vfX0 = vmlaq_n_s32(vfX0, vB0, C2);
+            vfX0 = vshlq_n_s32(vfX0, -lab_shift);
+            vfX0 = LabCbrtTab_b_fnc(vfX0);
+
+            // int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)];
+            int32x4_t vfY0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C3);
+            vfY0 = vmlaq_n_s32(vfY0, vG0, C4);
+            vfY0 = vmlaq_n_s32(vfY0, vB0, C5);
+            vfY0 = vshlq_n_s32(vfY0, -lab_shift);
+            vfY0 = LabCbrtTab_b_fnc(vfY0);
+
+            // int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];
+            int32x4_t vfZ0 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR0, C6);
+            vfZ0 = vmlaq_n_s32(vfZ0, vG0, C7);
+            vfZ0 = vmlaq_n_s32(vfZ0, vB0, C8);
+            vfZ0 = vshlq_n_s32(vfZ0, -lab_shift);
+            vfZ0 = LabCbrtTab_b_fnc(vfZ0);
+
+            // int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );
+            int32x4_t vL0 = vmlaq_n_s32(vdupq_n_s32(Lshift+one_lsh_by_lab_shift2_sub_one), vfY0, Lscale);
+            vL0 = vshlq_n_s32(vL0, -lab_shift2);
+
+            // int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );
+            int32x4_t va0 = vsubq_s32(vfX0, vfY0);
+            va0 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), va0, 500);
+            va0 = vshlq_n_s32(va0, -lab_shift2);
+
+            // int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );
+            int32x4_t vb0 = vsubq_s32(vfY0, vfZ0);
+            vb0 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), vb0, 200);
+            vb0 = vshlq_n_s32(vb0, -lab_shift2);
+
+            // Second batch
+            // ============
+            // int R = tab[src[0]], G = tab[src[1]], B = tab[src[2]];
+            int32x4_t vR1 = {tab[vget_lane_u8(vRi,4)], tab[vget_lane_u8(vRi,5)], tab[vget_lane_u8(vRi,6)], tab[vget_lane_u8(vRi,7)]};
+            int32x4_t vG1 = {tab[vget_lane_u8(vGi,4)], tab[vget_lane_u8(vGi,5)], tab[vget_lane_u8(vGi,6)], tab[vget_lane_u8(vGi,7)]};
+            int32x4_t vB1 = {tab[vget_lane_u8(vBi,4)], tab[vget_lane_u8(vBi,5)], tab[vget_lane_u8(vBi,6)], tab[vget_lane_u8(vBi,7)]};
+
+            // int fX = LabCbrtTab_b[CV_DESCALE(R*C0 + G*C1 + B*C2, lab_shift)];
+            int32x4_t vfX1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C0);
+            vfX1 = vmlaq_n_s32(vfX1, vG1, C1);
+            vfX1 = vmlaq_n_s32(vfX1, vB1, C2);
+            vfX1 = vshlq_n_s32(vfX1, -lab_shift);
+            vfX1 = LabCbrtTab_b_fnc(vfX1);
+
+            // int fY = LabCbrtTab_b[CV_DESCALE(R*C3 + G*C4 + B*C5, lab_shift)];
+            int32x4_t vfY1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C3);
+            vfY1 = vmlaq_n_s32(vfY1, vG1, C4);
+            vfY1 = vmlaq_n_s32(vfY1, vB1, C5);
+            vfY1 = vshlq_n_s32(vfY1, -lab_shift);
+            vfY1 = LabCbrtTab_b_fnc(vfY1);
+
+            // int fZ = LabCbrtTab_b[CV_DESCALE(R*C6 + G*C7 + B*C8, lab_shift)];
+            int32x4_t vfZ1 = vmlaq_n_s32(vdupq_n_s32(one_lsh_by_lab_shift_sub_one), vR1, C6);
+            vfZ1 = vmlaq_n_s32(vfZ1, vG1, C7);
+            vfZ1 = vmlaq_n_s32(vfZ1, vB1, C8);
+            vfZ1 = vshlq_n_s32(vfZ1, -lab_shift);
+            vfZ1 = LabCbrtTab_b_fnc(vfZ1);
+
+            // int L = CV_DESCALE( Lscale*fY + Lshift, lab_shift2 );
+            int32x4_t vL1 = vmlaq_n_s32(vdupq_n_s32(Lshift+one_lsh_by_lab_shift2_sub_one), vfY1, Lscale);
+            vL1 = vshlq_n_s32(vL1, -lab_shift2);
+
+            // int a = CV_DESCALE( 500*(fX - fY) + 128*(1 << lab_shift2), lab_shift2 );
+            int32x4_t va1 = vsubq_s32(vfX1, vfY1);
+            va1 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), va1, 500);
+            va1 = vshlq_n_s32(va1, -lab_shift2);
+
+            // int b = CV_DESCALE( 200*(fY - fZ) + 128*(1 << lab_shift2), lab_shift2 );
+            int32x4_t vb1 = vsubq_s32(vfY1, vfZ1);
+            vb1 = vmlaq_n_s32(vdupq_n_s32(one_shift_lab_mul_128+one_lsh_by_lab_shift2_sub_one), vb1, 200);
+            vb1 = vshlq_n_s32(vb1, -lab_shift2);
+
+            // Saturate, combine and store both batches
+            // ========================================
+            // dst[0] = saturate_cast<uchar>(L);
+            // dst[1] = saturate_cast<uchar>(a);
+            // dst[2] = saturate_cast<uchar>(b);
+            uint8x8x3_t vLab;
+            vLab.val[0] = vqmovn_u16(vcombine_u16(vqmovun_s32(vL0), vqmovun_s32(vL1)));
+            vLab.val[1] = vqmovn_u16(vcombine_u16(vqmovun_s32(va0), vqmovun_s32(va1)));
+            vLab.val[2] = vqmovn_u16(vcombine_u16(vqmovun_s32(vb0), vqmovun_s32(vb1)));
+            vst3_u8(dst, vLab);
+        }
+
+#endif
+
 #if CV_SIMD
         const int vsize = v_uint8::nlanes;
         const int xyzDescaleShift = 1 << (lab_shift - 1);


### PR DESCRIPTION
A Neon specific implementation of RGB2Lab increases single threaded performance by ~25%, here's the numbers run on aws c6gd.4xlarge with gcc 9.3 (numbers are similar using gcc 10)

| Test set   | Test number |    After/before ratio | Speedup with 1/million bounds [%] |
|------------|-------------|----------|-----------------------------------|
| cvtColor8u |           8 |  0.76835 |                        23.2 ± 0.2 |
| cvtColor8u |          34 |  0.76204 |                        23.8 ± 0.2 |
| cvtColor8u |          67 |  0.76667 |                        23.3 ± 0.2 |
| cvtColor8u |          69 |  0.76773 |                        23.2 ± 0.2 |
| cvtColor8u |          71 |  0.76231 |                        23.8 ± 0.2 |
| cvtColor8u |          73 |  0.76184 |                        23.8 ± 0.2 |
| cvtColor8u |          90 |  0.76851 |                        23.1 ± 0.2 |
| cvtColor8u |         103 |  0.76143 |                        23.9 ± 0.2 |
| cvtColor8u |         128 |  0.73870 |                        26.1 ± 0.1 |
| cvtColor8u |         154 |  0.73760 |                        26.2 ± 0.2 |
| cvtColor8u |         187 |  0.73891 |                        26.1 ± 0.1 |
| cvtColor8u |         189 |  0.73889 |                        26.1 ± 0.1 |
| cvtColor8u |         191 |  0.73802 |                        26.2 ± 0.2 |
| cvtColor8u |         193 |  0.73817 |                        26.2 ± 0.2 |
| cvtColor8u |         210 |  0.73879 |                        26.1 ± 0.1 |
| cvtColor8u |         223 |  0.73745 |                        26.3 ± 0.2 |
| cvtColor8u |         248 |  0.73756 |                        26.2 ± 0.1 |
| cvtColor8u |         274 |  0.73613 |                        26.4 ± 0.1 |
| cvtColor8u |         307 |  0.73768 |                        26.2 ± 0.1 |
| cvtColor8u |         309 |  0.73767 |                        26.2 ± 0.1 |
| cvtColor8u |         311 |  0.73676 |                        26.3 ± 0.2 |
| cvtColor8u |         313 |  0.73672 |                        26.3 ± 0.2 |
| cvtColor8u |         330 |  0.73748 |                        26.3 ± 0.1 |
| cvtColor8u |         343 |  0.73591 |                        26.4 ± 0.1 |

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs,ARMv8,ARMv7
```
