### PR TITLE
Fix bug with predictions in RTrees/Boost

### DIFF
--- a/modules/ml/src/boost.cpp
+++ b/modules/ml/src/boost.cpp
@@ -490,6 +490,7 @@ public:
 
     float predict( InputArray samples, OutputArray results, int flags ) const CV_OVERRIDE
     {
+        CV_Assert( samples.cols() == getVarCount() && samples.type() == CV_32F );
         return impl.predict(samples, results, flags);
     }
 

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -479,6 +479,7 @@ public:
     float predict( InputArray samples, OutputArray results, int flags ) const CV_OVERRIDE
     {
         CV_TRACE_FUNCTION();
+        CV_Assert( samples.cols() == getVarCount() && samples.type() == CV_32F );
         return impl.predict(samples, results, flags);
     }
 

--- a/modules/ml/test/test_rtrees.cpp
+++ b/modules/ml/test/test_rtrees.cpp
@@ -99,15 +99,10 @@ TEST(ML_RTrees, bug_12974_throw_exception_when_predict_different_feature_count)
 {
     // create a simple 2 feature dataset and train + save the model
     cv::Ptr<RTrees> model = RTrees::create();
-    Mat samples(2, 2, CV_32FC1);
-    samples.at<float>(0,0) = 0;
-    samples.at<float>(0,1) = 0;
-    samples.at<float>(1,0) = 1;
-    samples.at<float>(1,1) = 1;
-    Mat responses(2, 1, CV_32S);
-    responses.at<float>(0) = 0;
-    responses.at<float>(1) = 1;
-    cv::Ptr<TrainData> trainData = TrainData::create(samples, cv::ml::ROW_SAMPLE, responses);
+    Mat samples(2, 2, CV_32F);
+    randu(samples, 0, 10);
+    Mat labels = (Mat_<int>(2,1) << 0,1);
+    cv::Ptr<TrainData> trainData = TrainData::create(samples, cv::ml::ROW_SAMPLE, labels);
     model->train(trainData);
     // load the model and try to predict on a 1 feature sample
     Mat test(1, 1, CV_32FC1);

--- a/modules/ml/test/test_rtrees.cpp
+++ b/modules/ml/test/test_rtrees.cpp
@@ -97,16 +97,22 @@ TEST(ML_RTrees, 11142_sample_weights_classification)
 
 TEST(ML_RTrees, bug_12974_throw_exception_when_predict_different_feature_count)
 {
-    // create a simple 2 feature dataset and train + save the model
+    int numFeatures = 5;
+    // create a 5 feature dataset and train the model
     cv::Ptr<RTrees> model = RTrees::create();
-    Mat samples(2, 2, CV_32F);
+    Mat samples(10, numFeatures, CV_32F);
     randu(samples, 0, 10);
-    Mat labels = (Mat_<int>(2,1) << 0,1);
+    Mat labels = (Mat_<int>(10,1) << 0,0,0,0,0,1,1,1,1,1);
     cv::Ptr<TrainData> trainData = TrainData::create(samples, cv::ml::ROW_SAMPLE, labels);
     model->train(trainData);
-    // load the model and try to predict on a 1 feature sample
-    Mat test(1, 1, CV_32FC1);
-    ASSERT_THROW(model -> predict(test), Exception);
+    // try to predict on data which have fewer features - this should throw an exception
+    for(int i = 1; i < numFeatures - 1; ++i) {
+        Mat test(1, i, CV_32FC1);
+        ASSERT_THROW(model->predict(test), Exception);
+    }
+    // try to predict on data which have more features - this should also throw an exception
+    Mat test(1, numFeatures + 1, CV_32FC1);
+    ASSERT_THROW(model->predict(test), Exception);
 }
 
 

--- a/modules/ml/test/test_rtrees.cpp
+++ b/modules/ml/test/test_rtrees.cpp
@@ -95,6 +95,24 @@ TEST(ML_RTrees, 11142_sample_weights_classification)
     EXPECT_GE(error_with_weights, error_without_weights);
 }
 
+TEST(ML_RTrees, bug_12974_throw_exception_when_predict_different_feature_count)
+{
+    // create a simple 2 feature dataset and train + save the model
+    cv::Ptr<RTrees> model = RTrees::create();
+    Mat samples(2, 2, CV_32FC1);
+    samples.at<float>(0,0) = 0;
+    samples.at<float>(0,1) = 0;
+    samples.at<float>(1,0) = 1;
+    samples.at<float>(1,1) = 1;
+    Mat responses(2, 1, CV_32S);
+    responses.at<float>(0) = 0;
+    responses.at<float>(1) = 1;
+    cv::Ptr<TrainData> trainData = TrainData::create(samples, cv::ml::ROW_SAMPLE, responses);
+    model->train(trainData);
+    // load the model and try to predict on a 1 feature sample
+    Mat test(1, 1, CV_32FC1);
+    ASSERT_THROW(model -> predict(test), Exception);
+}
 
 
 }} // namespace


### PR DESCRIPTION
Addresses https://github.com/opencv/opencv/issues/12974, although that issue incorrectly mentions the saving/loading of the model, which is not relevant. The source of the issue is no validation when calling the `predict` method, which we have in other models i.e;
- https://github.com/opencv/opencv/blob/master/modules/ml/src/svm.cpp#L2013
- https://github.com/opencv/opencv/blob/master/modules/ml/src/knearest.cpp#L370
- https://github.com/opencv/opencv/blob/master/modules/ml/src/nbayes.cpp#L314

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
