### PR TITLE
WIP Keypoint Abstraction

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -2203,7 +2203,7 @@ bool findCirclesGrid2(InputArray _image, Size patternSize,
     std::vector<Point2f> points;
     if (blobDetector)
     {
-        std::vector<KeyPoint> keypoints;
+        KeyPointCollection keypoints;
         blobDetector->detect(_image, keypoints);
         for (size_t i = 0; i < keypoints.size(); i++)
         {

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -722,7 +722,7 @@ CV_EXPORTS void write( FileStorage& fs, const String& name, const String& value 
 CV_EXPORTS void write( FileStorage& fs, const String& name, const Mat& value );
 CV_EXPORTS void write( FileStorage& fs, const String& name, const SparseMat& value );
 #ifdef CV__LEGACY_PERSISTENCE
-CV_EXPORTS void write( FileStorage& fs, const String& name, const std::vector<KeyPoint>& value);
+CV_EXPORTS void write( FileStorage& fs, const String& name, const KeyPointCollection& value);
 CV_EXPORTS void write( FileStorage& fs, const String& name, const std::vector<DMatch>& value);
 #endif
 
@@ -744,7 +744,7 @@ CV_EXPORTS void read(const FileNode& node, std::string& value, const std::string
 CV_EXPORTS void read(const FileNode& node, Mat& mat, const Mat& default_mat = Mat() );
 CV_EXPORTS void read(const FileNode& node, SparseMat& mat, const SparseMat& default_mat = SparseMat() );
 #ifdef CV__LEGACY_PERSISTENCE
-CV_EXPORTS void read(const FileNode& node, std::vector<KeyPoint>& keypoints);
+CV_EXPORTS void read(const FileNode& node, KeyPointCollection& keypoints);
 CV_EXPORTS void read(const FileNode& node, std::vector<DMatch>& matches);
 #endif
 CV_EXPORTS void read(const FileNode& node, KeyPoint& value, const KeyPoint& default_value);
@@ -1093,7 +1093,7 @@ void write( FileStorage& fs, const String& name, const std::vector< std::vector<
 // Implementation is similar to templates instantiations
 static inline void write(FileStorage& fs, const KeyPoint& kpt) { write(fs, String(), kpt); }
 static inline void write(FileStorage& fs, const DMatch& m) { write(fs, String(), m); }
-static inline void write(FileStorage& fs, const std::vector<KeyPoint>& vec)
+static inline void write(FileStorage& fs, const KeyPointCollection& vec)
 {
     cv::internal::VecWriterProxy<KeyPoint, 0> w(&fs);
     w(vec);
@@ -1171,7 +1171,7 @@ void read( const FileNode& node, std::vector<_Tp>& vec, const std::vector<_Tp>& 
 }
 
 static inline
-void read( const FileNode& node, std::vector<KeyPoint>& vec, const std::vector<KeyPoint>& default_value )
+void read( const FileNode& node, KeyPointCollection& vec, const KeyPointCollection& default_value )
 {
     if(!node.node)
         vec = default_value;
@@ -1282,7 +1282,7 @@ void operator >> (const FileNode& n, KeyPoint& kpt)
 
 #ifdef CV__LEGACY_PERSISTENCE
 static inline
-void operator >> (const FileNode& n, std::vector<KeyPoint>& vec)
+void operator >> (const FileNode& n, KeyPointCollection& vec)
 {
     read(n, vec);
 }

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -826,7 +826,7 @@ namespace internal
     {
     public:
         VecWriterProxy( FileStorage* _fs ) : fs(_fs) {}
-        void operator()(const std::vector<_Tp>& vec) const
+        void operator()(KeyPointCollection vec) const
         {
             size_t count = vec.size();
             for (size_t i = 0; i < count; i++)
@@ -1098,7 +1098,7 @@ static inline void write(FileStorage& fs, const KeyPointCollection& vec)
     cv::internal::VecWriterProxy<KeyPoint, 0> w(&fs);
     w(vec);
 }
-static inline void write(FileStorage& fs, const std::vector<DMatch>& vec)
+static inline void write(FileStorage& fs, KeyPointCollection vec)
 {
     cv::internal::VecWriterProxy<DMatch, 0> w(&fs);
     w(vec);

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -826,7 +826,7 @@ namespace internal
     {
     public:
         VecWriterProxy( FileStorage* _fs ) : fs(_fs) {}
-        void operator()(KeyPointCollection vec) const
+        void operator()(const std::vector<_Tp>& vec) const
         {
             size_t count = vec.size();
             for (size_t i = 0; i < count; i++)
@@ -1093,12 +1093,12 @@ void write( FileStorage& fs, const String& name, const std::vector< std::vector<
 // Implementation is similar to templates instantiations
 static inline void write(FileStorage& fs, const KeyPoint& kpt) { write(fs, String(), kpt); }
 static inline void write(FileStorage& fs, const DMatch& m) { write(fs, String(), m); }
-static inline void write(FileStorage& fs, const KeyPointCollection& vec)
+static inline void write(FileStorage& fs, const std::vector<KeyPoint>& vec)
 {
     cv::internal::VecWriterProxy<KeyPoint, 0> w(&fs);
     w(vec);
 }
-static inline void write(FileStorage& fs, KeyPointCollection vec)
+static inline void write(FileStorage& fs, const std::vector<DMatch>& vec)
 {
     cv::internal::VecWriterProxy<DMatch, 0> w(&fs);
     w(vec);

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -688,7 +688,7 @@ class CV_EXPORTS_W_SIMPLE KeyPointCollection {
 public:
     using KeyPoints = std::vector<KeyPoint>;
     KeyPointCollection() { keypoints = std::vector<KeyPoint>(); }
-    KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(1); }
+    KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(n); }
     KeyPointCollection(const int n, const KeyPoint& kp) { keypoints = std::vector<KeyPoint>(n, kp); }
 
     KeyPoints::iterator begin() { return keypoints.begin(); }
@@ -701,6 +701,7 @@ public:
     void push_back(const KeyPoint& kp) {  keypoints.push_back(kp); }
     void clear() { keypoints.clear(); }
     bool empty() const { return keypoints.empty(); }
+    void swap(KeyPointCollection& kp) { keypoints.swap(kp.keypoints); }
     size_t size() const { return keypoints.size(); }
     void resize(const size_t size) { keypoints.resize(size); }
     const KeyPoint& operator[] (const int index) const { return keypoints[index]; }

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -802,7 +802,7 @@ public:
     CV_PROP_RW float response; //!< the response by which the most strong keypoints have been selected. Can be used for the further sorting or subsampling
     CV_PROP_RW int octave; //!< octave (pyramid layer) from which the keypoint has been extracted
     CV_PROP_RW int class_id; //!< object class (if the keypoints need to be clustered by an object they belong to)
-    CV_PROP_RW float layer; //!< layer >
+    CV_PROP_RW int layer; //!< layer of the octave (0 if not applicable) >
 };
 
 #ifdef OPENCV_TRAITS_ENABLE_DEPRECATED

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -52,6 +52,7 @@
 #include <cfloat>
 #include <vector>
 #include <limits>
+#include <functional>
 
 #include "opencv2/core/cvdef.h"
 #include "opencv2/core/cvstd.hpp"
@@ -688,9 +689,10 @@ class CV_EXPORTS_W_SIMPLE KeyPointCollection {
 public:
     using KeyPoints = std::vector<KeyPoint>;
     using value_type = KeyPoints::value_type;
+    using Lambda = std::function<float(const KeyPoint&)>;
     KeyPointCollection() { keypoints = std::vector<KeyPoint>(); }
-    KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(n); }
     KeyPointCollection(const int n, const KeyPoint& kp) { keypoints = std::vector<KeyPoint>(n, kp); }
+    KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(n); }
 
     KeyPoints::iterator begin() { return keypoints.begin(); }
     KeyPoints::iterator end()   { return keypoints.end(); }
@@ -714,10 +716,14 @@ public:
                 KeyPoints::const_iterator iterator1,
                 KeyPoints::const_iterator iterator2) { keypoints.insert(iterator, iterator1, iterator2); }
     void erase(KeyPoints::iterator first, KeyPoints::iterator last) {keypoints.erase(first, last); }
-    void erase(KeyPoints::iterator iterator) {keypoints.erase(iterator); }
+    void erase(KeyPoints::iterator iterator) { keypoints.erase(iterator); }
+    void setScaleFactorCallable(const Lambda& lambda){ scaleFactorCallable = lambda; }
+    const Lambda& getScaleFactorCallable() const { return scaleFactorCallable; }
+    float getScaleFactor(const KeyPoint& kp) const { return scaleFactorCallable(kp); }
 
 private:
     KeyPoints keypoints;
+    Lambda scaleFactorCallable;
 };
 
 

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -687,6 +687,7 @@ struct Type< Scalar_<_Tp> > { enum { value = CV_MAKETYPE(Depth<_Tp>::value, 4) }
 class CV_EXPORTS_W_SIMPLE KeyPointCollection {
 public:
     using KeyPoints = std::vector<KeyPoint>;
+    using value_type = KeyPoints::value_type;
     KeyPointCollection() { keypoints = std::vector<KeyPoint>(); }
     KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(n); }
     KeyPointCollection(const int n, const KeyPoint& kp) { keypoints = std::vector<KeyPoint>(n, kp); }

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -683,6 +683,31 @@ struct Type< Scalar_<_Tp> > { enum { value = CV_MAKETYPE(Depth<_Tp>::value, 4) }
 } // namespace
 
 
+
+class CV_EXPORTS_W_SIMPLE KeyPointCollection {
+public:
+    using KeyPoints = std::vector<KeyPoint>;
+
+    KeyPoints::iterator begin() { return keypoints.begin(); }
+    KeyPoints::iterator end()   { return keypoints.end(); }
+    void push_back(KeyPoint& kp) {  keypoints.push_back(kp); }
+    void clear() { keypoints.clear(); }
+    bool empty() { return keypoints.empty(); }
+    size_t size() const { return keypoints.size(); }
+    void resize(const size_t size) { keypoints.resize(size); }
+    const KeyPoint& operator[] (const int index) const { return keypoints[index]; }
+    KeyPoint& operator[] (const int index) { return keypoints[index]; }
+    void insert(KeyPoints::iterator iterator,
+                KeyPoints::iterator iterator1,
+                KeyPoints::iterator iterator2) { keypoints.insert(iterator, iterator1, iterator2); }
+    void erase(KeyPoints::iterator first, KeyPoints::iterator last) {keypoints.erase(first, last); }
+    void erase(KeyPoints::iterator iterator) {keypoints.erase(iterator); }
+
+private:
+    KeyPoints keypoints;
+};
+
+
 /////////////////////////////// KeyPoint ////////////////////////////////
 
 /** @brief Data structure for salient point detectors.
@@ -732,7 +757,7 @@ public:
     @param keypointIndexes Array of indexes of keypoints to be converted to points. (Acts like a mask to
     convert only specified keypoints)
     */
-    CV_WRAP static void convert(const std::vector<KeyPoint>& keypoints,
+    CV_WRAP static void convert(const KeyPointCollection& keypoints,
                                 CV_OUT std::vector<Point2f>& points2f,
                                 const std::vector<int>& keypointIndexes=std::vector<int>());
     /** @overload
@@ -744,7 +769,7 @@ public:
     @param class_id object id
     */
     CV_WRAP static void convert(const std::vector<Point2f>& points2f,
-                                CV_OUT std::vector<KeyPoint>& keypoints,
+                                CV_OUT KeyPointCollection& keypoints,
                                 float size=1, float response=1, int octave=0, int class_id=-1);
 
     /**
@@ -784,7 +809,6 @@ public:
     typedef Vec<channel_type, channels> vec_type;
 };
 #endif
-
 
 //////////////////////////////// DMatch /////////////////////////////////
 

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -802,6 +802,7 @@ public:
     CV_PROP_RW float response; //!< the response by which the most strong keypoints have been selected. Can be used for the further sorting or subsampling
     CV_PROP_RW int octave; //!< octave (pyramid layer) from which the keypoint has been extracted
     CV_PROP_RW int class_id; //!< object class (if the keypoints need to be clustered by an object they belong to)
+    CV_PROP_RW float layer; //!< layer >
 };
 
 #ifdef OPENCV_TRAITS_ENABLE_DEPRECATED

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -688,10 +688,11 @@ class CV_EXPORTS_W_SIMPLE KeyPointCollection {
 public:
     using KeyPoints = std::vector<KeyPoint>;
 
+
     KeyPoints::iterator begin() { return keypoints.begin(); }
     KeyPoints::iterator end()   { return keypoints.end(); }
-    KeyPoints::const_iterator begin() const {return keypoints.begin();}
-    KeyPoints::const_iterator end() const {return keypoints.end();}
+    KeyPoints::const_iterator begin() const { return keypoints.begin(); }
+    KeyPoints::const_iterator end() const { return keypoints.end(); }
     KeyPoint* data() { return keypoints.data(); }
     void reserve(const int n) { keypoints.reserve(n); }
     size_t capacity() const { return keypoints.capacity(); }

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -808,7 +808,8 @@ public:
     CV_PROP_RW float response; //!< the response by which the most strong keypoints have been selected. Can be used for the further sorting or subsampling
     CV_PROP_RW int octave; //!< octave (pyramid layer) from which the keypoint has been extracted
     CV_PROP_RW int class_id; //!< object class (if the keypoints need to be clustered by an object they belong to)
-    CV_PROP_RW int layer; //!< layer of the octave (0 if not applicable) >
+    CV_PROP_RW int layer; //!< layer of the octave (0 if not applicable). Primarily for SIFT >
+    CV_PROP_RW int level; //!< evolution level (0 if not applicable). Primarily for KAZE/AKAZE >
 };
 
 #ifdef OPENCV_TRAITS_ENABLE_DEPRECATED

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -690,9 +690,14 @@ public:
 
     KeyPoints::iterator begin() { return keypoints.begin(); }
     KeyPoints::iterator end()   { return keypoints.end(); }
-    void push_back(KeyPoint& kp) {  keypoints.push_back(kp); }
+    KeyPoints::const_iterator begin() const {return keypoints.begin();}
+    KeyPoints::const_iterator end() const {return keypoints.end();}
+    KeyPoint* data() { return keypoints.data(); }
+    void reserve(const int n) { keypoints.reserve(n); }
+    size_t capacity() const { return keypoints.capacity(); }
+    void push_back(const KeyPoint& kp) {  keypoints.push_back(kp); }
     void clear() { keypoints.clear(); }
-    bool empty() { return keypoints.empty(); }
+    bool empty() const { return keypoints.empty(); }
     size_t size() const { return keypoints.size(); }
     void resize(const size_t size) { keypoints.resize(size); }
     const KeyPoint& operator[] (const int index) const { return keypoints[index]; }
@@ -700,6 +705,9 @@ public:
     void insert(KeyPoints::iterator iterator,
                 KeyPoints::iterator iterator1,
                 KeyPoints::iterator iterator2) { keypoints.insert(iterator, iterator1, iterator2); }
+    void insert(KeyPoints::iterator iterator,
+                KeyPoints::const_iterator iterator1,
+                KeyPoints::const_iterator iterator2) { keypoints.insert(iterator, iterator1, iterator2); }
     void erase(KeyPoints::iterator first, KeyPoints::iterator last) {keypoints.erase(first, last); }
     void erase(KeyPoints::iterator iterator) {keypoints.erase(iterator); }
 

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -687,7 +687,9 @@ struct Type< Scalar_<_Tp> > { enum { value = CV_MAKETYPE(Depth<_Tp>::value, 4) }
 class CV_EXPORTS_W_SIMPLE KeyPointCollection {
 public:
     using KeyPoints = std::vector<KeyPoint>;
-
+    KeyPointCollection() { keypoints = std::vector<KeyPoint>(); }
+    KeyPointCollection(const int n) { keypoints = std::vector<KeyPoint>(1); }
+    KeyPointCollection(const int n, const KeyPoint& kp) { keypoints = std::vector<KeyPoint>(n, kp); }
 
     KeyPoints::iterator begin() { return keypoints.begin(); }
     KeyPoints::iterator end()   { return keypoints.end(); }

--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -679,7 +679,7 @@
             "j_type": "MatOfKeyPoint",
             "jn_type": "long",
             "jni_type": "jlong",
-            "jni_var": "std::vector<KeyPoint> %(n)s",
+            "jni_var": "KeyPointCollection %(n)s",
             "suffix": "J",
             "v_type": "Mat",
             "j_import": "org.opencv.core.MatOfKeyPoint"
@@ -867,7 +867,7 @@
             "j_type": "List<MatOfKeyPoint>",
             "jn_type": "long",
             "jni_type": "jlong",
-            "jni_var": "std::vector< std::vector<KeyPoint> > %(n)s",
+            "jni_var": "std::vector< KeyPointCollection > %(n)s",
             "v_type": "vector_Mat",
             "j_import": "org.opencv.core.MatOfKeyPoint"
         },

--- a/modules/core/src/persistence_cpp.cpp
+++ b/modules/core/src/persistence_cpp.cpp
@@ -597,14 +597,14 @@ CV_EXPORTS void read(const FileNode& node, DMatch& value, const DMatch& default_
 }
 
 #ifdef CV__LEGACY_PERSISTENCE
-void write( FileStorage& fs, const String& name, const std::vector<KeyPoint>& vec)
+void write( FileStorage& fs, const String& name, const KeyPointCollection& vec)
 {
     // from template implementation
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ);
     write(fs, vec);
 }
 
-void read(const FileNode& node, std::vector<KeyPoint>& keypoints)
+void read(const FileNode& node, KeyPointCollection& keypoints)
 {
     FileNode first_node = *(node.begin());
     if (first_node.isSeq())

--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -62,7 +62,7 @@ size_t KeyPoint::hash() const
     return _Val;
 }
 
-void KeyPoint::convert(const std::vector<KeyPoint>& keypoints, std::vector<Point2f>& points2f,
+void KeyPoint::convert(const KeyPointCollection& keypoints, std::vector<Point2f>& points2f,
                        const std::vector<int>& keypointIndexes)
 {
     CV_INSTRUMENT_REGION();
@@ -90,7 +90,7 @@ void KeyPoint::convert(const std::vector<KeyPoint>& keypoints, std::vector<Point
     }
 }
 
-void KeyPoint::convert( const std::vector<Point2f>& points2f, std::vector<KeyPoint>& keypoints,
+void KeyPoint::convert( const std::vector<Point2f>& points2f, KeyPointCollection& keypoints,
                         float size, float response, int octave, int class_id )
 {
     CV_INSTRUMENT_REGION();

--- a/modules/cudafeatures2d/include/opencv2/cudafeatures2d.hpp
+++ b/modules/cudafeatures2d/include/opencv2/cudafeatures2d.hpp
@@ -414,7 +414,7 @@ public:
 
     /** Converts keypoints array from internal representation to standard vector. */
     virtual void convert(InputArray gpu_keypoints,
-                         std::vector<KeyPoint>& keypoints) = 0;
+                         KeyPointCollection& keypoints) = 0;
 };
 
 //

--- a/modules/cudafeatures2d/src/fast.cpp
+++ b/modules/cudafeatures2d/src/fast.cpp
@@ -67,10 +67,10 @@ namespace
     public:
         FAST_Impl(int threshold, bool nonmaxSuppression, int max_npoints);
 
-        virtual void detect(InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask);
+        virtual void detect(InputArray _image, KeyPointCollection& keypoints, InputArray _mask);
         virtual void detectAsync(InputArray _image, OutputArray _keypoints, InputArray _mask, Stream& stream);
 
-        virtual void convert(InputArray _gpu_keypoints, std::vector<KeyPoint>& keypoints);
+        virtual void convert(InputArray _gpu_keypoints, KeyPointCollection& keypoints);
 
         virtual void setThreshold(int threshold) { threshold_ = threshold; }
         virtual int getThreshold() const { return threshold_; }
@@ -97,7 +97,7 @@ namespace
     {
     }
 
-    void FAST_Impl::detect(InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask)
+    void FAST_Impl::detect(InputArray _image, KeyPointCollection& keypoints, InputArray _mask)
     {
         if (_image.empty())
         {
@@ -169,7 +169,7 @@ namespace
         cudaSafeCall( cudaFree(d_counter) );
     }
 
-    void FAST_Impl::convert(InputArray _gpu_keypoints, std::vector<KeyPoint>& keypoints)
+    void FAST_Impl::convert(InputArray _gpu_keypoints, KeyPointCollection& keypoints)
     {
         if (_gpu_keypoints.empty())
         {

--- a/modules/cudafeatures2d/src/orb.cpp
+++ b/modules/cudafeatures2d/src/orb.cpp
@@ -349,10 +349,10 @@ namespace
                  int fastThreshold,
                  bool blurForDescriptor);
 
-        virtual void detectAndCompute(InputArray _image, InputArray _mask, std::vector<KeyPoint>& keypoints, OutputArray _descriptors, bool useProvidedKeypoints);
+        virtual void detectAndCompute(InputArray _image, InputArray _mask, KeyPointCollection& keypoints, OutputArray _descriptors, bool useProvidedKeypoints);
         virtual void detectAndComputeAsync(InputArray _image, InputArray _mask, OutputArray _keypoints, OutputArray _descriptors, bool useProvidedKeypoints, Stream& stream);
 
-        virtual void convert(InputArray _gpu_keypoints, std::vector<KeyPoint>& keypoints);
+        virtual void convert(InputArray _gpu_keypoints, KeyPointCollection& keypoints);
 
         virtual int descriptorSize() const { return kBytes; }
         virtual int descriptorType() const { return CV_8U; }
@@ -575,7 +575,7 @@ namespace
         return pow(scaleFactor, level - firstLevel);
     }
 
-    void ORB_Impl::detectAndCompute(InputArray _image, InputArray _mask, std::vector<KeyPoint>& keypoints, OutputArray _descriptors, bool useProvidedKeypoints)
+    void ORB_Impl::detectAndCompute(InputArray _image, InputArray _mask, KeyPointCollection& keypoints, OutputArray _descriptors, bool useProvidedKeypoints)
     {
         using namespace cv::cuda::device::orb;
         if (useProvidedKeypoints)
@@ -592,7 +592,7 @@ namespace
                 nLevels_ = std::max(nLevels_, level);
             }
             nLevels_ ++;
-            std::vector<std::vector<KeyPoint> > oKeypoints(nLevels_);
+            std::vector<KeyPointCollection > oKeypoints(nLevels_);
             for( j = 0; j < nkeypoints; j++ )
             {
                 level = keypoints[j].octave;
@@ -604,7 +604,7 @@ namespace
                 keyPointsCount_.resize(nLevels_);
                 int t;
                 for(t = 0; t < nLevels_; t++) {
-                    const std::vector<KeyPoint>& ks = oKeypoints[t];
+                    const KeyPointCollection& ks = oKeypoints[t];
                     if (!ks.empty()){
 
                         Mat h_keypoints(ROWS_COUNT, static_cast<int>(ks.size()), CV_32FC1);
@@ -865,7 +865,7 @@ namespace
         }
     }
 
-    void ORB_Impl::convert(InputArray _gpu_keypoints, std::vector<KeyPoint>& keypoints)
+    void ORB_Impl::convert(InputArray _gpu_keypoints, KeyPointCollection& keypoints)
     {
         if (_gpu_keypoints.empty())
         {

--- a/modules/features2d/doc/agast.txt
+++ b/modules/features2d/doc/agast.txt
@@ -52,7 +52,7 @@ The references are:
 namespace cv
 {
 
-static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_5_8(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
 
     cv::Mat img;
@@ -815,7 +815,7 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     }
 }
 
-static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12d(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -3261,7 +3261,7 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     }
 }
 
-static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12s(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -5344,7 +5344,7 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     }
 }
 
-static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void OAST_9_16(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -7472,7 +7472,7 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
 }
 
 
-void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression)
+void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression)
 {
     AGAST(_img, keypoints, threshold, nonmax_suppression, AgastFeatureDetector::OAST_9_16);
 }
@@ -7485,7 +7485,7 @@ public:
     : threshold(_threshold), nonmaxSuppression(_nonmaxSuppression), type((short)_type)
     {}
 
-    void detect( InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask )
+    void detect( InputArray _image, KeyPointCollection& keypoints, InputArray _mask )
     {
         Mat mask = _mask.getMat(), grayImage;
         UMat ugrayImage;
@@ -7539,10 +7539,10 @@ Ptr<AgastFeatureDetector> AgastFeatureDetector::create( int threshold, bool nonm
     return makePtr<AgastFeatureDetector_Impl>(threshold, nonmaxSuppression, type);
 }
 
-void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression, int type)
+void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression, int type)
 {
 
-    std::vector<KeyPoint> kpts;
+    KeyPointCollection kpts;
 
     // detect
     switch(type) {
@@ -7566,7 +7566,7 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
     int pixel_[16];
     makeAgastOffsets(pixel_, (int)img.step, type);
 
-    std::vector<KeyPoint>::iterator kpt;
+    KeyPointCollection::iterator kpt;
     for(kpt = kpts.begin(); kpt != kpts.end(); kpt++)
     {
         switch(type) {
@@ -7599,8 +7599,8 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
         size_t lastRowCorner_ind = 0, next_lastRowCorner_ind = 0;
 
         std::vector<int> nmsFlags;
-        std::vector<KeyPoint>::iterator currCorner_nms;
-        std::vector<KeyPoint>::const_iterator currCorner;
+        KeyPointCollection::iterator currCorner_nms;
+        KeyPointCollection::const_iterator currCorner;
 
         currCorner = kpts.begin();
 

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -94,9 +94,9 @@ namespace cv
 //! @{
 
 // //! writes vector of keypoints to the file storage
-// CV_EXPORTS void write(FileStorage& fs, const String& name, const std::vector<KeyPoint>& keypoints);
+// CV_EXPORTS void write(FileStorage& fs, const String& name, const KeyPointCollection& keypoints);
 // //! reads vector of keypoints from the specified file storage node
-// CV_EXPORTS void read(const FileNode& node, CV_OUT std::vector<KeyPoint>& keypoints);
+// CV_EXPORTS void read(const FileNode& node, CV_OUT KeyPointCollection& keypoints);
 
 /** @brief A class filters a vector of keypoints.
 
@@ -111,29 +111,29 @@ public:
     /*
      * Remove keypoints within borderPixels of an image edge.
      */
-    static void runByImageBorder( std::vector<KeyPoint>& keypoints, Size imageSize, int borderSize );
+    static void runByImageBorder( KeyPointCollection& keypoints, Size imageSize, int borderSize );
     /*
      * Remove keypoints of sizes out of range.
      */
-    static void runByKeypointSize( std::vector<KeyPoint>& keypoints, float minSize,
+    static void runByKeypointSize( KeyPointCollection& keypoints, float minSize,
                                    float maxSize=FLT_MAX );
     /*
      * Remove keypoints from some image by mask for pixels of this image.
      */
-    static void runByPixelsMask( std::vector<KeyPoint>& keypoints, const Mat& mask );
+    static void runByPixelsMask( KeyPointCollection& keypoints, const Mat& mask );
     /*
      * Remove duplicated keypoints.
      */
-    static void removeDuplicated( std::vector<KeyPoint>& keypoints );
+    static void removeDuplicated( KeyPointCollection& keypoints );
     /*
      * Remove duplicated keypoints and sort the remaining keypoints
      */
-    static void removeDuplicatedSorted( std::vector<KeyPoint>& keypoints );
+    static void removeDuplicatedSorted( KeyPointCollection& keypoints );
 
     /*
      * Retain the specified number of the best keypoints (according to the response)
      */
-    static void retainBest( std::vector<KeyPoint>& keypoints, int npoints );
+    static void retainBest( KeyPointCollection& keypoints, int npoints );
 };
 
 
@@ -159,7 +159,7 @@ public:
     matrix with non-zero values in the region of interest.
      */
     CV_WRAP virtual void detect( InputArray image,
-                                 CV_OUT std::vector<KeyPoint>& keypoints,
+                                 CV_OUT KeyPointCollection& keypoints,
                                  InputArray mask=noArray() );
 
     /** @overload
@@ -170,7 +170,7 @@ public:
     masks[i] is a mask for images[i].
     */
     CV_WRAP virtual void detect( InputArrayOfArrays images,
-                         CV_OUT std::vector<std::vector<KeyPoint> >& keypoints,
+                         CV_OUT std::vector<KeyPointCollection >& keypoints,
                          InputArrayOfArrays masks=noArray() );
 
     /** @brief Computes the descriptors for a set of keypoints detected in an image (first variant) or image set
@@ -185,7 +185,7 @@ public:
     descriptor for keypoint j-th keypoint.
      */
     CV_WRAP virtual void compute( InputArray image,
-                                  CV_OUT CV_IN_OUT std::vector<KeyPoint>& keypoints,
+                                  CV_OUT CV_IN_OUT KeyPointCollection& keypoints,
                                   OutputArray descriptors );
 
     /** @overload
@@ -199,12 +199,12 @@ public:
     descriptor for keypoint j-th keypoint.
     */
     CV_WRAP virtual void compute( InputArrayOfArrays images,
-                          CV_OUT CV_IN_OUT std::vector<std::vector<KeyPoint> >& keypoints,
+                          CV_OUT CV_IN_OUT std::vector<KeyPointCollection >& keypoints,
                           OutputArrayOfArrays descriptors );
 
     /** Detects keypoints and computes the descriptors */
     CV_WRAP virtual void detectAndCompute( InputArray image, InputArray mask,
-                                           CV_OUT std::vector<KeyPoint>& keypoints,
+                                           CV_OUT KeyPointCollection& keypoints,
                                            OutputArray descriptors,
                                            bool useProvidedKeypoints=false );
 
@@ -517,7 +517,7 @@ public:
 };
 
 /** @overload */
-CV_EXPORTS void FAST( InputArray image, CV_OUT std::vector<KeyPoint>& keypoints,
+CV_EXPORTS void FAST( InputArray image, CV_OUT KeyPointCollection& keypoints,
                       int threshold, bool nonmaxSuppression=true );
 
 /** @brief Detects corners using the FAST algorithm
@@ -538,7 +538,7 @@ Detects corners using the FAST algorithm by @cite Rosten06 .
 cv2.FAST_FEATURE_DETECTOR_TYPE_7_12 and cv2.FAST_FEATURE_DETECTOR_TYPE_9_16. For corner
 detection, use cv2.FAST.detect() method.
  */
-CV_EXPORTS void FAST( InputArray image, CV_OUT std::vector<KeyPoint>& keypoints,
+CV_EXPORTS void FAST( InputArray image, CV_OUT KeyPointCollection& keypoints,
                       int threshold, bool nonmaxSuppression, int type );
 
 //! @} features2d_main
@@ -573,7 +573,7 @@ public:
 };
 
 /** @overload */
-CV_EXPORTS void AGAST( InputArray image, CV_OUT std::vector<KeyPoint>& keypoints,
+CV_EXPORTS void AGAST( InputArray image, CV_OUT KeyPointCollection& keypoints,
                       int threshold, bool nonmaxSuppression=true );
 
 /** @brief Detects corners using the AGAST algorithm
@@ -594,7 +594,7 @@ The perl script and examples of tree generation are placed in features2d/doc fol
 Detects corners using the AGAST algorithm by @cite mair2010_agast .
 
  */
-CV_EXPORTS void AGAST( InputArray image, CV_OUT std::vector<KeyPoint>& keypoints,
+CV_EXPORTS void AGAST( InputArray image, CV_OUT KeyPointCollection& keypoints,
                       int threshold, bool nonmaxSuppression, int type );
 //! @} features2d_main
 
@@ -1299,7 +1299,7 @@ For Python API, flags are modified as cv2.DRAW_MATCHES_FLAGS_DEFAULT,
 cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS, cv2.DRAW_MATCHES_FLAGS_DRAW_OVER_OUTIMG,
 cv2.DRAW_MATCHES_FLAGS_NOT_DRAW_SINGLE_POINTS
  */
-CV_EXPORTS_W void drawKeypoints( InputArray image, const std::vector<KeyPoint>& keypoints, InputOutputArray outImage,
+CV_EXPORTS_W void drawKeypoints( InputArray image, const KeyPointCollection& keypoints, InputOutputArray outImage,
                                const Scalar& color=Scalar::all(-1), int flags=DrawMatchesFlags::DEFAULT );
 
 /** @brief Draws the found matches of keypoints from two images.
@@ -1324,15 +1324,15 @@ DrawMatchesFlags.
 This function draws matches of keypoints from two images in the output image. Match is a line
 connecting two keypoints (circles). See cv::DrawMatchesFlags.
  */
-CV_EXPORTS_W void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
-                             InputArray img2, const std::vector<KeyPoint>& keypoints2,
+CV_EXPORTS_W void drawMatches( InputArray img1, const KeyPointCollection& keypoints1,
+                             InputArray img2, const KeyPointCollection& keypoints2,
                              const std::vector<DMatch>& matches1to2, InputOutputArray outImg,
                              const Scalar& matchColor=Scalar::all(-1), const Scalar& singlePointColor=Scalar::all(-1),
                              const std::vector<char>& matchesMask=std::vector<char>(), int flags=DrawMatchesFlags::DEFAULT );
 
 /** @overload */
-CV_EXPORTS_AS(drawMatchesKnn) void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
-                             InputArray img2, const std::vector<KeyPoint>& keypoints2,
+CV_EXPORTS_AS(drawMatchesKnn) void drawMatches( InputArray img1, const KeyPointCollection& keypoints1,
+                             InputArray img2, const KeyPointCollection& keypoints2,
                              const std::vector<std::vector<DMatch> >& matches1to2, InputOutputArray outImg,
                              const Scalar& matchColor=Scalar::all(-1), const Scalar& singlePointColor=Scalar::all(-1),
                              const std::vector<std::vector<char> >& matchesMask=std::vector<std::vector<char> >(), int flags=DrawMatchesFlags::DEFAULT );
@@ -1344,7 +1344,7 @@ CV_EXPORTS_AS(drawMatchesKnn) void drawMatches( InputArray img1, const std::vect
 \****************************************************************************************/
 
 CV_EXPORTS void evaluateFeatureDetector( const Mat& img1, const Mat& img2, const Mat& H1to2,
-                                         std::vector<KeyPoint>* keypoints1, std::vector<KeyPoint>* keypoints2,
+                                         KeyPointCollection* keypoints1, KeyPointCollection* keypoints2,
                                          float& repeatability, int& correspCount,
                                          const Ptr<FeatureDetector>& fdetector=Ptr<FeatureDetector>() );
 
@@ -1483,7 +1483,7 @@ public:
     returned if it is non-zero.
     @param descriptors Descriptors of the image keypoints that are returned if they are non-zero.
      */
-    void compute( InputArray image, std::vector<KeyPoint>& keypoints, OutputArray imgDescriptor,
+    void compute( InputArray image, KeyPointCollection& keypoints, OutputArray imgDescriptor,
                   std::vector<std::vector<int> >* pointIdxsOfClusters=0, Mat* descriptors=0 );
     /** @overload
     @param keypointDescriptors Computed descriptors to match with vocabulary.
@@ -1496,7 +1496,7 @@ public:
                   std::vector<std::vector<int> >* pointIdxsOfClusters=0 );
     // compute() is not constant because DescriptorMatcher::match is not constant
 
-    CV_WRAP_AS(compute) void compute2( const Mat& image, std::vector<KeyPoint>& keypoints, CV_OUT Mat& imgDescriptor )
+    CV_WRAP_AS(compute) void compute2( const Mat& image, KeyPointCollection& keypoints, CV_OUT Mat& imgDescriptor )
     { compute(image,keypoints,imgDescriptor); }
 
     /** @brief Returns an image descriptor size if the vocabulary is set. Otherwise, it returns 0.

--- a/modules/features2d/misc/java/src/cpp/features2d_converters.cpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_converters.cpp
@@ -8,7 +8,7 @@ using namespace cv;
 
 
 //vector_KeyPoint
-void Mat_to_vector_KeyPoint(Mat& mat, std::vector<KeyPoint>& v_kp)
+void Mat_to_vector_KeyPoint(Mat& mat, KeyPointCollection& v_kp)
 {
     v_kp.clear();
     CHECK_MAT(mat.type()==CV_32FC(7) && mat.cols==1);
@@ -22,7 +22,7 @@ void Mat_to_vector_KeyPoint(Mat& mat, std::vector<KeyPoint>& v_kp)
 }
 
 
-void vector_KeyPoint_to_Mat(std::vector<KeyPoint>& v_kp, Mat& mat)
+void vector_KeyPoint_to_Mat(KeyPointCollection& v_kp, Mat& mat)
 {
     int count = (int)v_kp.size();
     mat.create(count, 1, CV_32FC(7));
@@ -66,7 +66,7 @@ void Mat_to_vector_vector_KeyPoint(Mat& mat, std::vector< std::vector< KeyPoint 
     Mat_to_vector_Mat(mat, vm);
     for(size_t i=0; i<vm.size(); i++)
     {
-        std::vector<KeyPoint> vkp;
+        KeyPointCollection vkp;
         Mat_to_vector_KeyPoint(vm[i], vkp);
         vv_kp.push_back(vkp);
     }

--- a/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
@@ -18,10 +18,10 @@ namespace cv
 class CV_EXPORTS_AS(FeatureDetector) javaFeatureDetector
 {
 public:
-    CV_WRAP void detect( const Mat& image, CV_OUT std::vector<KeyPoint>& keypoints, const Mat& mask=Mat() ) const
+    CV_WRAP void detect( const Mat& image, CV_OUT KeyPointCollection& keypoints, const Mat& mask=Mat() ) const
     { return wrapped->detect(image, keypoints, mask); }
 
-    CV_WRAP void detect( const std::vector<Mat>& images, CV_OUT std::vector<std::vector<KeyPoint> >& keypoints, const std::vector<Mat>& masks=std::vector<Mat>() ) const
+    CV_WRAP void detect( const std::vector<Mat>& images, CV_OUT std::vector<KeyPointCollection >& keypoints, const std::vector<Mat>& masks=std::vector<Mat>() ) const
     { return wrapped->detect(images, keypoints, masks); }
 
     CV_WRAP bool empty() const
@@ -191,10 +191,10 @@ private:
 class CV_EXPORTS_AS(DescriptorExtractor) javaDescriptorExtractor
 {
 public:
-    CV_WRAP void compute( const Mat& image, CV_IN_OUT std::vector<KeyPoint>& keypoints, Mat& descriptors ) const
+    CV_WRAP void compute( const Mat& image, CV_IN_OUT KeyPointCollection& keypoints, Mat& descriptors ) const
     { return wrapped->compute(image, keypoints, descriptors); }
 
-    CV_WRAP void compute( const std::vector<Mat>& images, CV_IN_OUT std::vector<std::vector<KeyPoint> >& keypoints, CV_OUT std::vector<Mat>& descriptors ) const
+    CV_WRAP void compute( const std::vector<Mat>& images, CV_IN_OUT std::vector<KeyPointCollection >& keypoints, CV_OUT std::vector<Mat>& descriptors ) const
     { return wrapped->compute(images, keypoints, descriptors); }
 
     CV_WRAP int descriptorSize() const
@@ -305,8 +305,8 @@ enum
                                   // orientation will be drawn.
 };
 
-CV_EXPORTS_AS(drawMatches2) void drawMatches( const Mat& img1, const std::vector<KeyPoint>& keypoints1,
-                             const Mat& img2, const std::vector<KeyPoint>& keypoints2,
+CV_EXPORTS_AS(drawMatches2) void drawMatches( const Mat& img1, const KeyPointCollection& keypoints1,
+                             const Mat& img2, const KeyPointCollection& keypoints2,
                              const std::vector<std::vector<DMatch> >& matches1to2, Mat& outImg,
                              const Scalar& matchColor=Scalar::all(-1), const Scalar& singlePointColor=Scalar::all(-1),
                              const std::vector<std::vector<char> >& matchesMask=std::vector<std::vector<char> >(), int flags=0);

--- a/modules/features2d/src/affine_feature.cpp
+++ b/modules/features2d/src/affine_feature.cpp
@@ -70,15 +70,15 @@ public:
         return backend_->defaultNorm();
     }
 
-    void detectAndCompute(InputArray image, InputArray mask, std::vector<KeyPoint>& keypoints,
+    void detectAndCompute(InputArray image, InputArray mask, KeyPointCollection& keypoints,
             OutputArray descriptors, bool useProvidedKeypoints=false) CV_OVERRIDE;
 
     void setViewParams(const std::vector<float>& tilts, const std::vector<float>& rolls) CV_OVERRIDE;
     void getViewParams(std::vector<float>& tilts, std::vector<float>& rolls) const CV_OVERRIDE;
 
 protected:
-    void splitKeypointsByView(const std::vector<KeyPoint>& keypoints_,
-            std::vector< std::vector<KeyPoint> >& keypointsByView) const;
+    void splitKeypointsByView(const KeyPointCollection& keypoints_,
+            std::vector< KeyPointCollection >& keypointsByView) const;
 
     const Ptr<Feature2D> backend_;
     int maxTilt_;
@@ -138,8 +138,8 @@ void AffineFeature_Impl::getViewParams(std::vector<float>& tilts,
     rolls = rolls_;
 }
 
-void AffineFeature_Impl::splitKeypointsByView(const std::vector<KeyPoint>& keypoints_,
-        std::vector< std::vector<KeyPoint> >& keypointsByView) const
+void AffineFeature_Impl::splitKeypointsByView(const KeyPointCollection& keypoints_,
+        std::vector< KeyPointCollection >& keypointsByView) const
 {
     for( size_t i = 0; i < keypoints_.size(); i++ )
     {
@@ -155,7 +155,7 @@ public:
     skewedDetectAndCompute(
         const std::vector<float>& _tilts,
         const std::vector<float>& _rolls,
-        std::vector< std::vector<KeyPoint> >& _keypointsCollection,
+        std::vector< KeyPointCollection >& _keypointsCollection,
         std::vector<Mat>& _descriptorCollection,
         const Mat& _image,
         const Mat& _mask,
@@ -186,11 +186,11 @@ public:
             affineSkew(tilts[a], rolls[a], warpedImage, warpedMask, pose);
             invertAffineTransform(pose, invPose);
 
-            std::vector<KeyPoint> wKeypoints;
+            KeyPointCollection wKeypoints;
             Mat wDescriptors;
             if( !do_keypoints )
             {
-                const std::vector<KeyPoint>& keypointsInView = keypointsCollection[a];
+                const KeyPointCollection& keypointsInView = keypointsCollection[a];
                 if( keypointsInView.size() == 0 ) // when there are no keypoints in this affine view
                     continue;
 
@@ -281,7 +281,7 @@ private:
 
     const std::vector<float>& tilts;
     const std::vector<float>& rolls;
-    std::vector< std::vector<KeyPoint> >& keypointsCollection;
+    std::vector< KeyPointCollection >& keypointsCollection;
     std::vector<Mat>& descriptorCollection;
     const Mat& image;
     const Mat& mask;
@@ -291,7 +291,7 @@ private:
 };
 
 void AffineFeature_Impl::detectAndCompute(InputArray _image, InputArray _mask,
-        std::vector<KeyPoint>& keypoints,
+        KeyPointCollection& keypoints,
         OutputArray _descriptors,
         bool useProvidedKeypoints)
 {
@@ -305,7 +305,7 @@ void AffineFeature_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     if( (!do_keypoints && !do_descriptors) || _image.empty() )
         return;
 
-    std::vector< std::vector<KeyPoint> > keypointsCollection(tilts_.size());
+    std::vector< KeyPointCollection > keypointsCollection(tilts_.size());
     std::vector< Mat > descriptorCollection(tilts_.size());
 
     if( do_keypoints )
@@ -319,7 +319,7 @@ void AffineFeature_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     if( do_keypoints )
         for( size_t i = 0; i < keypointsCollection.size(); i++ )
         {
-            const std::vector<KeyPoint>& keys = keypointsCollection[i];
+            const KeyPointCollection& keys = keypointsCollection[i];
             keypoints.insert(keypoints.end(), keys.begin(), keys.end());
         }
 

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -50,7 +50,7 @@ namespace cv
 
 #if (defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64))
 
-static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_5_8(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
 
     cv::Mat img;
@@ -813,7 +813,7 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     }
 }
 
-static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12d(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -3258,7 +3258,7 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
 }
 
 
-static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12s(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -5339,7 +5339,7 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     }
 }
 
-static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void OAST_9_16(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -7446,7 +7446,7 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
 
 #else // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64))
 
-static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, int agasttype)
+static void AGAST_ALL(InputArray _img, KeyPointCollection& keypoints, int threshold, int agasttype)
 {
     cv::Mat img;
     if(!_img.getMat().isContinuous())
@@ -7912,29 +7912,29 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     }
 }
 
-static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_5_8(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     AGAST_ALL(_img, keypoints, threshold, AgastFeatureDetector::AGAST_5_8);
 }
 
-static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12d(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     AGAST_ALL(_img, keypoints, threshold, AgastFeatureDetector::AGAST_7_12d);
 }
 
-static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void AGAST_7_12s(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     AGAST_ALL(_img, keypoints, threshold, AgastFeatureDetector::AGAST_7_12s);
 }
 
-static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
+static void OAST_9_16(InputArray _img, KeyPointCollection& keypoints, int threshold)
 {
     AGAST_ALL(_img, keypoints, threshold, AgastFeatureDetector::OAST_9_16);
 }
 
 #endif // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64))
 
-void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression)
+void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression)
 {
     CV_INSTRUMENT_REGION();
 
@@ -7948,7 +7948,7 @@ public:
     : threshold(_threshold), nonmaxSuppression(_nonmaxSuppression), type((short)_type)
     {}
 
-    void detect( InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask ) CV_OVERRIDE
+    void detect( InputArray _image, KeyPointCollection& keypoints, InputArray _mask ) CV_OVERRIDE
     {
         CV_INSTRUMENT_REGION();
 
@@ -8011,11 +8011,11 @@ Ptr<AgastFeatureDetector> AgastFeatureDetector::create( int threshold, bool nonm
     return makePtr<AgastFeatureDetector_Impl>(threshold, nonmaxSuppression, type);
 }
 
-void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression, int type)
+void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression, int type)
 {
     CV_INSTRUMENT_REGION();
 
-    std::vector<KeyPoint> kpts;
+    KeyPointCollection kpts;
 
     // detect
     switch(type) {
@@ -8039,7 +8039,7 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
     int pixel_[16];
     makeAgastOffsets(pixel_, (int)img.step, type);
 
-    std::vector<KeyPoint>::iterator kpt;
+    KeyPointCollection::iterator kpt;
     for(kpt = kpts.begin(); kpt != kpts.end(); ++kpt)
     {
         switch(type) {
@@ -8072,7 +8072,7 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
         size_t lastRowCorner_ind = 0, next_lastRowCorner_ind = 0;
 
         std::vector<int> nmsFlags;
-        std::vector<KeyPoint>::const_iterator currCorner;
+        KeyPointCollection::const_iterator currCorner;
 
         currCorner = kpts.begin();
 

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -8039,7 +8039,7 @@ void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool n
     int pixel_[16];
     makeAgastOffsets(pixel_, (int)img.step, type);
 
-    KeyPointCollection::iterator kpt;
+    std::vector<KeyPoint>::iterator kpt;
     for(kpt = kpts.begin(); kpt != kpts.end(); ++kpt)
     {
         switch(type) {
@@ -8072,7 +8072,7 @@ void AGAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool n
         size_t lastRowCorner_ind = 0, next_lastRowCorner_ind = 0;
 
         std::vector<int> nmsFlags;
-        KeyPointCollection::const_iterator currCorner;
+        std::vector<KeyPoint>::const_iterator currCorner;
 
         currCorner = kpts.begin();
 

--- a/modules/features2d/src/akaze.cpp
+++ b/modules/features2d/src/akaze.cpp
@@ -163,7 +163,7 @@ namespace cv
         }
 
         void detectAndCompute(InputArray image, InputArray mask,
-                              std::vector<KeyPoint>& keypoints,
+                              KeyPointCollection& keypoints,
                               OutputArray descriptors,
                               bool useProvidedKeypoints) CV_OVERRIDE
         {

--- a/modules/features2d/src/bagofwords.cpp
+++ b/modules/features2d/src/bagofwords.cpp
@@ -140,7 +140,7 @@ const Mat& BOWImgDescriptorExtractor::getVocabulary() const
     return vocabulary;
 }
 
-void BOWImgDescriptorExtractor::compute( InputArray image, std::vector<KeyPoint>& keypoints, OutputArray imgDescriptor,
+void BOWImgDescriptorExtractor::compute( InputArray image, KeyPointCollection& keypoints, OutputArray imgDescriptor,
                                          std::vector<std::vector<int> >* pointIdxsOfClusters, Mat* descriptors )
 {
     CV_INSTRUMENT_REGION();

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -71,7 +71,7 @@ protected:
       double confidence;
   };
 
-  virtual void detect( InputArray image, std::vector<KeyPoint>& keypoints, InputArray mask=noArray() ) CV_OVERRIDE;
+  virtual void detect( InputArray image, KeyPointCollection& keypoints, InputArray mask=noArray() ) CV_OVERRIDE;
   virtual void findBlobs(InputArray image, InputArray binaryImage, std::vector<Center> &centers) const;
 
   Params params;
@@ -301,7 +301,7 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
 #endif
 }
 
-void SimpleBlobDetectorImpl::detect(InputArray image, std::vector<cv::KeyPoint>& keypoints, InputArray mask)
+void SimpleBlobDetectorImpl::detect(InputArray image, KeyPointCollection& keypoints, InputArray mask)
 {
     CV_INSTRUMENT_REGION();
 

--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -167,7 +167,7 @@ public:
 
   // Agast without non-max suppression
   void
-  getAgastPoints(int threshold, std::vector<cv::KeyPoint>& keypoints);
+  getAgastPoints(int threshold, KeyPointCollection& keypoints);
 
   // get scores - attention, this is in layer coordinates, not scale=1 coordinates!
   inline int
@@ -912,7 +912,7 @@ BriskScaleSpace::getKeypoints(const int threshold_, KeyPointCollection& keypoint
 
   // assign thresholds
   int safeThreshold_ = (int)(threshold_ * safetyFactor_);
-  std::vector<std::vector<cv::KeyPoint> > agastPoints;
+  std::vector<KeyPointCollection> agastPoints;
   agastPoints.resize(layers_);
 
   // go through the octaves and intra layers and calculate agast corner scores:

--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -88,14 +88,14 @@ public:
         const std::vector<int> &indexChange=std::vector<int>());
 
     void detectAndCompute( InputArray image, InputArray mask,
-                     CV_OUT std::vector<KeyPoint>& keypoints,
+                     CV_OUT KeyPointCollection& keypoints,
                      OutputArray descriptors,
                      bool useProvidedKeypoints ) CV_OVERRIDE;
 
 protected:
 
-    void computeKeypointsNoOrientation(InputArray image, InputArray mask, std::vector<KeyPoint>& keypoints) const;
-    void computeDescriptorsAndOrOrientation(InputArray image, InputArray mask, std::vector<KeyPoint>& keypoints,
+    void computeKeypointsNoOrientation(InputArray image, InputArray mask, KeyPointCollection& keypoints) const;
+    void computeDescriptorsAndOrOrientation(InputArray image, InputArray mask, KeyPointCollection& keypoints,
                                        OutputArray descriptors, bool doDescriptors, bool doOrientation,
                                        bool useProvidedKeypoints) const;
 
@@ -236,7 +236,7 @@ public:
 
   // get Keypoints
   void
-  getKeypoints(const int _threshold, std::vector<cv::KeyPoint>& keypoints);
+  getKeypoints(const int _threshold, KeyPointCollection& keypoints);
 
 protected:
   // nonmax suppression:
@@ -657,7 +657,7 @@ RoiPredicate(const float minX, const float minY, const float maxX, const float m
 
 // computes the descriptor
 void
-BRISK_Impl::detectAndCompute( InputArray _image, InputArray _mask, std::vector<KeyPoint>& keypoints,
+BRISK_Impl::detectAndCompute( InputArray _image, InputArray _mask, KeyPointCollection& keypoints,
                               OutputArray _descriptors, bool useProvidedKeypoints)
 {
   bool doOrientation=true;
@@ -670,7 +670,7 @@ BRISK_Impl::detectAndCompute( InputArray _image, InputArray _mask, std::vector<K
 }
 
 void
-BRISK_Impl::computeDescriptorsAndOrOrientation(InputArray _image, InputArray _mask, std::vector<KeyPoint>& keypoints,
+BRISK_Impl::computeDescriptorsAndOrOrientation(InputArray _image, InputArray _mask, KeyPointCollection& keypoints,
                                      OutputArray _descriptors, bool doDescriptors, bool doOrientation,
                                      bool useProvidedKeypoints) const
 {
@@ -854,7 +854,7 @@ BRISK_Impl::~BRISK_Impl()
 }
 
 void
-BRISK_Impl::computeKeypointsNoOrientation(InputArray _image, InputArray _mask, std::vector<KeyPoint>& keypoints) const
+BRISK_Impl::computeKeypointsNoOrientation(InputArray _image, InputArray _mask, KeyPointCollection& keypoints) const
 {
   Mat image = _image.getMat(), mask = _mask.getMat();
   if( image.type() != CV_8UC1 )
@@ -904,7 +904,7 @@ BriskScaleSpace::constructPyramid(const cv::Mat& image)
 }
 
 void
-BriskScaleSpace::getKeypoints(const int threshold_, std::vector<cv::KeyPoint>& keypoints)
+BriskScaleSpace::getKeypoints(const int threshold_, KeyPointCollection& keypoints)
 {
   // make sure keypoints is empty
   keypoints.resize(0);
@@ -2143,7 +2143,7 @@ BriskLayer::BriskLayer(const BriskLayer& layer, int mode)
 // Agast
 // wraps the agast class
 void
-BriskLayer::getAgastPoints(int threshold, std::vector<KeyPoint>& keypoints)
+BriskLayer::getAgastPoints(int threshold, KeyPointCollection& keypoints)
 {
   oast_9_16_->setThreshold(threshold);
   oast_9_16_->detect(img_, keypoints);

--- a/modules/features2d/src/draw.cpp
+++ b/modules/features2d/src/draw.cpp
@@ -88,7 +88,7 @@ static inline void _drawKeypoint( InputOutputArray img, const KeyPoint& p, const
     }
 }
 
-void drawKeypoints( InputArray image, const std::vector<KeyPoint>& keypoints, InputOutputArray outImage,
+void drawKeypoints( InputArray image, const KeyPointCollection& keypoints, InputOutputArray outImage,
                     const Scalar& _color, int flags )
 {
     CV_INSTRUMENT_REGION();
@@ -113,7 +113,7 @@ void drawKeypoints( InputArray image, const std::vector<KeyPoint>& keypoints, In
     bool isRandColor = _color == Scalar::all(-1);
 
     CV_Assert( !outImage.empty() );
-    std::vector<KeyPoint>::const_iterator it = keypoints.begin(),
+    KeyPointCollection::const_iterator it = keypoints.begin(),
                                      end = keypoints.end();
     for( ; it != end; ++it )
     {
@@ -141,8 +141,8 @@ static void _prepareImage(InputArray src, const Mat& dst)
         CV_Error(Error::StsInternal, "");
 }
 
-static void _prepareImgAndDrawKeypoints( InputArray img1, const std::vector<KeyPoint>& keypoints1,
-                                         InputArray img2, const std::vector<KeyPoint>& keypoints2,
+static void _prepareImgAndDrawKeypoints( InputArray img1, const KeyPointCollection& keypoints1,
+                                         InputArray img2, const KeyPointCollection& keypoints2,
                                          InputOutputArray _outImg, Mat& outImg1, Mat& outImg2,
                                          const Scalar& singlePointColor, int flags )
 {
@@ -202,8 +202,8 @@ static inline void _drawMatch( InputOutputArray outImg, InputOutputArray outImg1
           color, 1, LINE_AA, draw_shift_bits );
 }
 
-void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
-                  InputArray img2, const std::vector<KeyPoint>& keypoints2,
+void drawMatches( InputArray img1, const KeyPointCollection& keypoints1,
+                  InputArray img2, const KeyPointCollection& keypoints2,
                   const std::vector<DMatch>& matches1to2, InputOutputArray outImg,
                   const Scalar& matchColor, const Scalar& singlePointColor,
                   const std::vector<char>& matchesMask, int flags )
@@ -231,8 +231,8 @@ void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
     }
 }
 
-void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
-                  InputArray img2, const std::vector<KeyPoint>& keypoints2,
+void drawMatches( InputArray img1, const KeyPointCollection& keypoints1,
+                  InputArray img2, const KeyPointCollection& keypoints2,
                   const std::vector<std::vector<DMatch> >& matches1to2, InputOutputArray outImg,
                   const Scalar& matchColor, const Scalar& singlePointColor,
                   const std::vector<std::vector<char> >& matchesMask, int flags )

--- a/modules/features2d/src/draw.cpp
+++ b/modules/features2d/src/draw.cpp
@@ -113,7 +113,7 @@ void drawKeypoints( InputArray image, const KeyPointCollection& keypoints, Input
     bool isRandColor = _color == Scalar::all(-1);
 
     CV_Assert( !outImage.empty() );
-    KeyPointCollection::const_iterator it = keypoints.begin(),
+    std::vector<KeyPoint>::const_iterator it = keypoints.begin(),
                                      end = keypoints.end();
     for( ; it != end; ++it )
     {

--- a/modules/features2d/src/evaluation.cpp
+++ b/modules/features2d/src/evaluation.cpp
@@ -116,8 +116,8 @@ public:
     EllipticKeyPoint();
     EllipticKeyPoint( const Point2f& _center, const Scalar& _ellipse );
 
-    static void convert( const std::vector<KeyPoint>& src, std::vector<EllipticKeyPoint>& dst );
-    static void convert( const std::vector<EllipticKeyPoint>& src, std::vector<KeyPoint>& dst );
+    static void convert( const KeyPointCollection& src, std::vector<EllipticKeyPoint>& dst );
+    static void convert( const std::vector<EllipticKeyPoint>& src, KeyPointCollection& dst );
 
     static Mat_<double> getSecondMomentsMatrix( const Scalar& _ellipse );
     Mat_<double> getSecondMomentsMatrix() const;
@@ -177,7 +177,7 @@ void EllipticKeyPoint::calcProjection( const Mat_<double>& H, EllipticKeyPoint& 
     projection = EllipticKeyPoint( dstCenter, Scalar(dstM(0,0), dstM(0,1), dstM(1,1)) );
 }
 
-void EllipticKeyPoint::convert( const std::vector<KeyPoint>& src, std::vector<EllipticKeyPoint>& dst )
+void EllipticKeyPoint::convert( const KeyPointCollection& src, std::vector<EllipticKeyPoint>& dst )
 {
     CV_INSTRUMENT_REGION();
 
@@ -194,7 +194,7 @@ void EllipticKeyPoint::convert( const std::vector<KeyPoint>& src, std::vector<El
     }
 }
 
-void EllipticKeyPoint::convert( const std::vector<EllipticKeyPoint>& src, std::vector<KeyPoint>& dst )
+void EllipticKeyPoint::convert( const std::vector<EllipticKeyPoint>& src, KeyPointCollection& dst )
 {
     CV_INSTRUMENT_REGION();
 
@@ -393,7 +393,7 @@ static void computeOneToOneMatchedOverlaps( const std::vector<EllipticKeyPoint>&
 }
 
 static void calculateRepeatability( const Mat& img1, const Mat& img2, const Mat& H1to2,
-                                    const std::vector<KeyPoint>& _keypoints1, const std::vector<KeyPoint>& _keypoints2,
+                                    const KeyPointCollection& _keypoints1, const KeyPointCollection& _keypoints2,
                                     float& repeatability, int& correspondencesCount,
                                     Mat* thresholdedOverlapMask=0  )
 {
@@ -456,14 +456,14 @@ static void calculateRepeatability( const Mat& img1, const Mat& img2, const Mat&
 }
 
 void cv::evaluateFeatureDetector( const Mat& img1, const Mat& img2, const Mat& H1to2,
-                              std::vector<KeyPoint>* _keypoints1, std::vector<KeyPoint>* _keypoints2,
+                              KeyPointCollection* _keypoints1, KeyPointCollection* _keypoints2,
                               float& repeatability, int& correspCount,
                               const Ptr<FeatureDetector>& _fdetector )
 {
     CV_INSTRUMENT_REGION();
 
     Ptr<FeatureDetector> fdetector(_fdetector);
-    std::vector<KeyPoint> *keypoints1, *keypoints2, buf1, buf2;
+    KeyPointCollection *keypoints1, *keypoints2, buf1, buf2;
     keypoints1 = _keypoints1 != 0 ? _keypoints1 : &buf1;
     keypoints2 = _keypoints2 != 0 ? _keypoints2 : &buf2;
 

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -55,7 +55,7 @@ namespace cv
 {
 
 template<int patternSize>
-void FAST_t(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression)
+void FAST_t(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression)
 {
     Mat img = _img.getMat();
     const int K = patternSize/2, N = patternSize + K + 1;
@@ -298,7 +298,7 @@ struct cmp_pt
     bool operator ()(const pt& a, const pt& b) const { return a.y < b.y || (a.y == b.y && a.x < b.x); }
 };
 
-static bool ocl_FAST( InputArray _img, std::vector<KeyPoint>& keypoints,
+static bool ocl_FAST( InputArray _img, KeyPointCollection& keypoints,
                      int threshold, bool nonmax_suppression, int maxKeypoints )
 {
     UMat img = _img.getUMat();
@@ -375,7 +375,7 @@ static bool ocl_FAST( InputArray _img, std::vector<KeyPoint>& keypoints,
 namespace ovx {
     template <> inline bool skipSmallImages<VX_KERNEL_FAST_CORNERS>(int w, int h) { return w*h < 800 * 600; }
 }
-static bool openvx_FAST(InputArray _img, std::vector<KeyPoint>& keypoints,
+static bool openvx_FAST(InputArray _img, KeyPointCollection& keypoints,
                         int _threshold, bool nonmaxSuppression, int type)
 {
     using namespace ivx;
@@ -436,7 +436,7 @@ static bool openvx_FAST(InputArray _img, std::vector<KeyPoint>& keypoints,
 
 #endif
 
-static inline int hal_FAST(cv::Mat& src, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression, int type)
+static inline int hal_FAST(cv::Mat& src, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression, int type)
 {
     if (threshold > 20)
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
@@ -493,7 +493,7 @@ static inline int hal_FAST(cv::Mat& src, std::vector<KeyPoint>& keypoints, int t
     return CV_HAL_ERROR_OK;
 }
 
-void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression, int type)
+void FAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression, int type)
 {
     CV_INSTRUMENT_REGION();
 
@@ -528,7 +528,7 @@ void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool
 }
 
 
-void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression)
+void FAST(InputArray _img, KeyPointCollection& keypoints, int threshold, bool nonmax_suppression)
 {
     CV_INSTRUMENT_REGION();
 
@@ -543,7 +543,7 @@ public:
     : threshold(_threshold), nonmaxSuppression(_nonmaxSuppression), type((short)_type)
     {}
 
-    void detect( InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask ) CV_OVERRIDE
+    void detect( InputArray _image, KeyPointCollection& keypoints, InputArray _mask ) CV_OVERRIDE
     {
         CV_INSTRUMENT_REGION();
 

--- a/modules/features2d/src/feature2d.cpp
+++ b/modules/features2d/src/feature2d.cpp
@@ -57,7 +57,7 @@ Feature2D::~Feature2D() {}
  *              matrix with non-zero values in the region of interest.
  */
 void Feature2D::detect( InputArray image,
-                        std::vector<KeyPoint>& keypoints,
+                        KeyPointCollection& keypoints,
                         InputArray mask )
 {
     CV_INSTRUMENT_REGION();
@@ -72,7 +72,7 @@ void Feature2D::detect( InputArray image,
 
 
 void Feature2D::detect( InputArrayOfArrays _images,
-                        std::vector<std::vector<KeyPoint> >& keypoints,
+                        std::vector<KeyPointCollection>& keypoints,
                         InputArrayOfArrays _masks )
 {
     CV_INSTRUMENT_REGION();
@@ -103,7 +103,7 @@ void Feature2D::detect( InputArrayOfArrays _images,
  * descriptors  Copmputed descriptors. Row i is the descriptor for keypoint i.
  */
 void Feature2D::compute( InputArray image,
-                         std::vector<KeyPoint>& keypoints,
+                         KeyPointCollection& keypoints,
                          OutputArray descriptors )
 {
     CV_INSTRUMENT_REGION();
@@ -117,7 +117,7 @@ void Feature2D::compute( InputArray image,
 }
 
 void Feature2D::compute( InputArrayOfArrays _images,
-                         std::vector<std::vector<KeyPoint> >& keypoints,
+                         std::vector<KeyPointCollection>& keypoints,
                          OutputArrayOfArrays _descriptors )
 {
     CV_INSTRUMENT_REGION();
@@ -145,7 +145,7 @@ void Feature2D::compute( InputArrayOfArrays _images,
 
 /* Detects keypoints and computes the descriptors */
 void Feature2D::detectAndCompute( InputArray, InputArray,
-                                  std::vector<KeyPoint>&,
+                                  KeyPointCollection&,
                                   OutputArray,
                                   bool )
 {

--- a/modules/features2d/src/gftt.cpp
+++ b/modules/features2d/src/gftt.cpp
@@ -76,7 +76,7 @@ public:
     void setK(double k_) CV_OVERRIDE { k = k_; }
     double getK() const CV_OVERRIDE { return k; }
 
-    void detect( InputArray _image, std::vector<KeyPoint>& keypoints, InputArray _mask ) CV_OVERRIDE
+    void detect( InputArray _image, KeyPointCollection& keypoints, InputArray _mask ) CV_OVERRIDE
     {
         CV_INSTRUMENT_REGION();
 

--- a/modules/features2d/src/kaze.cpp
+++ b/modules/features2d/src/kaze.cpp
@@ -106,7 +106,7 @@ namespace cv
         }
 
         void detectAndCompute(InputArray image, InputArray mask,
-                              std::vector<KeyPoint>& keypoints,
+                              KeyPointCollection& keypoints,
                               OutputArray descriptors,
                               bool useProvidedKeypoints) CV_OVERRIDE
         {

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -897,7 +897,7 @@ void AKAZEFeatures::Do_Subpixel_Refinement(
         kp.angle = -1;
         kp.response = ldet[j];
         kp.octave = e.octave;
-        kp.class_id = static_cast<int>(i);
+        kp.level = static_cast<int>(i);
 
         // Compute the gradient
         float Dx = 0.5f * (ldet[ y     *cols + x + 1] - ldet[ y     *cols + x - 1]);
@@ -1189,7 +1189,7 @@ void AKAZEFeatures::Compute_Descriptors(KeyPointCollection& kpts, OutputArray de
 
   for(size_t i = 0; i < kpts.size(); i++)
   {
-      CV_Assert(0 <= kpts[i].class_id && kpts[i].class_id < static_cast<int>(evolution_.size()));
+      CV_Assert(0 <= kpts[i].level && kpts[i].level < static_cast<int>(evolution_.size()));
   }
 
   // Allocate memory for the matrix with the descriptors
@@ -1362,7 +1362,7 @@ static inline
 void Compute_Main_Orientation(KeyPoint& kpt, const Pyramid& evolution)
 {
   // get the right evolution level for this keypoint
-  const MEvolution& e = evolution[kpt.class_id];
+  const MEvolution& e = evolution[kpt.level];
   // Get the information from the keypoint
   int scale = cvRound(0.5f * kpt.size / e.octave_ratio);
   int x0 = cvRound(kpt.pt.x / e.octave_ratio);
@@ -1507,7 +1507,7 @@ void MSURF_Upright_Descriptor_64_Invoker::Get_MSURF_Upright_Descriptor_64(const 
   // Get the information from the keypoint
   ratio = (float)(1 << kpt.octave);
   scale = cvRound(0.5f*kpt.size / ratio);
-  const int level = kpt.class_id;
+  const int level = kpt.level;
   const Mat Lx = evolution[level].Lx;
   const Mat Ly = evolution[level].Ly;
   yf = kpt.pt.y / ratio;
@@ -1641,7 +1641,7 @@ void MSURF_Descriptor_64_Invoker::Get_MSURF_Descriptor_64(const KeyPoint& kpt, f
   ratio = (float)(1 << kpt.octave);
   scale = cvRound(0.5f*kpt.size / ratio);
   angle = kpt.angle * static_cast<float>(CV_PI / 180.f);
-  const int level = kpt.class_id;
+  const int level = kpt.level;
   const Mat Lx = evolution[level].Lx;
   const Mat Ly = evolution[level].Ly;
   yf = kpt.pt.y / ratio;
@@ -1762,7 +1762,7 @@ void Upright_MLDB_Full_Descriptor_Invoker::Get_Upright_MLDB_Full_Descriptor(cons
   // Get the information from the keypoint
   const float ratio = (float)(1 << kpt.octave);
   const int scale = cvRound(0.5f*kpt.size / ratio);
-  const int level = kpt.class_id;
+  const int level = kpt.level;
   const Mat Lx = evolution[level].Lx;
   const Mat Ly = evolution[level].Ly;
   const Mat Lt = evolution[level].Lt;
@@ -1979,7 +1979,7 @@ void MLDB_Full_Descriptor_Invoker::Get_MLDB_Full_Descriptor(const KeyPoint& kpt,
   for(int lvl = 0; lvl < 3; lvl++)
   {
       int val_count = (lvl + 2) * (lvl + 2);
-      MLDB_Fill_Values(values, sample_step[lvl], kpt.class_id, xf, yf, co, si, scale);
+      MLDB_Fill_Values(values, sample_step[lvl], kpt.level, xf, yf, co, si, scale);
       MLDB_Binary_Comparisons(values, desc, val_count, dpos);
   }
 
@@ -2007,7 +2007,7 @@ void MLDB_Descriptor_Subset_Invoker::Get_MLDB_Descriptor_Subset(const KeyPoint& 
   float ratio = (float)(1 << kpt.octave);
   int scale = cvRound(0.5f*kpt.size / ratio);
   float angle = kpt.angle * static_cast<float>(CV_PI / 180.f);
-  const int level = kpt.class_id;
+  const int level = kpt.level;
   const Mat Lx = evolution[level].Lx;
   const Mat Ly = evolution[level].Ly;
   const Mat Lt = evolution[level].Lt;
@@ -2115,7 +2115,7 @@ void Upright_MLDB_Descriptor_Subset_Invoker::Get_Upright_MLDB_Descriptor_Subset(
   // Get the information from the keypoint
   float ratio = (float)(1 << kpt.octave);
   int scale = cvRound(0.5f*kpt.size / ratio);
-  const int level = kpt.class_id;
+  const int level = kpt.level;
   const Mat Lx = evolution[level].Lx;
   const Mat Ly = evolution[level].Ly;
   const Mat Lt = evolution[level].Lt;

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -671,7 +671,7 @@ Compute_Determinant_Hessian_Response(Pyramid &evolution) {
  * @brief This method selects interesting keypoints through the nonlinear scale space
  * @param kpts Vector of detected keypoints
  */
-void AKAZEFeatures::Feature_Detection(std::vector<KeyPoint>& kpts)
+void AKAZEFeatures::Feature_Detection(KeyPointCollection& kpts)
 {
   CV_INSTRUMENT_REGION();
 
@@ -870,7 +870,7 @@ void AKAZEFeatures::Find_Scale_Space_Extrema(std::vector<Mat>& keypoints_by_laye
  * @param kpts Output vector of the final refined keypoints
  */
 void AKAZEFeatures::Do_Subpixel_Refinement(
-  std::vector<Mat>& keypoints_by_layers, std::vector<KeyPoint>& output_keypoints)
+  std::vector<Mat>& keypoints_by_layers, KeyPointCollection& output_keypoints)
 {
   CV_INSTRUMENT_REGION();
 
@@ -941,7 +941,7 @@ void AKAZEFeatures::Do_Subpixel_Refinement(
 class SURF_Descriptor_Upright_64_Invoker : public ParallelLoopBody
 {
 public:
-  SURF_Descriptor_Upright_64_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, const Pyramid& evolution)
+  SURF_Descriptor_Upright_64_Invoker(KeyPointCollection& kpts, Mat& desc, const Pyramid& evolution)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -959,7 +959,7 @@ public:
   void Get_SURF_Descriptor_Upright_64(const KeyPoint& kpt, float* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   const Pyramid*   evolution_;
 };
@@ -967,7 +967,7 @@ private:
 class SURF_Descriptor_64_Invoker : public ParallelLoopBody
 {
 public:
-  SURF_Descriptor_64_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, Pyramid& evolution)
+  SURF_Descriptor_64_Invoker(KeyPointCollection& kpts, Mat& desc, Pyramid& evolution)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -985,7 +985,7 @@ public:
   void Get_SURF_Descriptor_64(const KeyPoint& kpt, float* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
 };
@@ -993,7 +993,7 @@ private:
 class MSURF_Upright_Descriptor_64_Invoker : public ParallelLoopBody
 {
 public:
-  MSURF_Upright_Descriptor_64_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, Pyramid& evolution)
+  MSURF_Upright_Descriptor_64_Invoker(KeyPointCollection& kpts, Mat& desc, Pyramid& evolution)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -1011,7 +1011,7 @@ public:
   void Get_MSURF_Upright_Descriptor_64(const KeyPoint& kpt, float* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
 };
@@ -1019,7 +1019,7 @@ private:
 class MSURF_Descriptor_64_Invoker : public ParallelLoopBody
 {
 public:
-  MSURF_Descriptor_64_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, Pyramid& evolution)
+  MSURF_Descriptor_64_Invoker(KeyPointCollection& kpts, Mat& desc, Pyramid& evolution)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -1037,7 +1037,7 @@ public:
   void Get_MSURF_Descriptor_64(const KeyPoint& kpt, float* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
 };
@@ -1045,7 +1045,7 @@ private:
 class Upright_MLDB_Full_Descriptor_Invoker : public ParallelLoopBody
 {
 public:
-  Upright_MLDB_Full_Descriptor_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, Pyramid& evolution, AKAZEOptions& options)
+  Upright_MLDB_Full_Descriptor_Invoker(KeyPointCollection& kpts, Mat& desc, Pyramid& evolution, AKAZEOptions& options)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -1064,7 +1064,7 @@ public:
   void Get_Upright_MLDB_Full_Descriptor(const KeyPoint& kpt, unsigned char* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
   AKAZEOptions*              options_;
@@ -1073,7 +1073,7 @@ private:
 class Upright_MLDB_Descriptor_Subset_Invoker : public ParallelLoopBody
 {
 public:
-  Upright_MLDB_Descriptor_Subset_Invoker(std::vector<KeyPoint>& kpts,
+  Upright_MLDB_Descriptor_Subset_Invoker(KeyPointCollection& kpts,
                                          Mat& desc,
                                          Pyramid& evolution,
                                          AKAZEOptions& options,
@@ -1099,7 +1099,7 @@ public:
   void Get_Upright_MLDB_Descriptor_Subset(const KeyPoint& kpt, unsigned char* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
   AKAZEOptions*              options_;
@@ -1111,7 +1111,7 @@ private:
 class MLDB_Full_Descriptor_Invoker : public ParallelLoopBody
 {
 public:
-  MLDB_Full_Descriptor_Invoker(std::vector<KeyPoint>& kpts, Mat& desc, Pyramid& evolution, AKAZEOptions& options)
+  MLDB_Full_Descriptor_Invoker(KeyPointCollection& kpts, Mat& desc, Pyramid& evolution, AKAZEOptions& options)
     : keypoints_(&kpts)
     , descriptors_(&desc)
     , evolution_(&evolution)
@@ -1134,7 +1134,7 @@ public:
                                int count, int& dpos) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
   AKAZEOptions*              options_;
@@ -1143,7 +1143,7 @@ private:
 class MLDB_Descriptor_Subset_Invoker : public ParallelLoopBody
 {
 public:
-  MLDB_Descriptor_Subset_Invoker(std::vector<KeyPoint>& kpts,
+  MLDB_Descriptor_Subset_Invoker(KeyPointCollection& kpts,
                                  Mat& desc,
                                  Pyramid& evolution,
                                  AKAZEOptions& options,
@@ -1169,7 +1169,7 @@ public:
   void Get_MLDB_Descriptor_Subset(const KeyPoint& kpt, unsigned char* desc, int desc_size) const;
 
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   Mat*                   descriptors_;
   Pyramid*   evolution_;
   AKAZEOptions*              options_;
@@ -1183,7 +1183,7 @@ private:
  * @param kpts Vector of detected keypoints
  * @param desc Matrix to store the descriptors
  */
-void AKAZEFeatures::Compute_Descriptors(std::vector<KeyPoint>& kpts, OutputArray descriptors)
+void AKAZEFeatures::Compute_Descriptors(KeyPointCollection& kpts, OutputArray descriptors)
 {
   CV_INSTRUMENT_REGION();
 
@@ -1442,7 +1442,7 @@ void Compute_Main_Orientation(KeyPoint& kpt, const Pyramid& evolution)
 class ComputeKeypointOrientation : public ParallelLoopBody
 {
 public:
-  ComputeKeypointOrientation(std::vector<KeyPoint>& kpts,
+  ComputeKeypointOrientation(KeyPointCollection& kpts,
                              const Pyramid& evolution)
     : keypoints_(&kpts)
     , evolution_(&evolution)
@@ -1457,7 +1457,7 @@ public:
     }
   }
 private:
-  std::vector<KeyPoint>* keypoints_;
+  KeyPointCollection* keypoints_;
   const Pyramid* evolution_;
 };
 
@@ -1465,7 +1465,7 @@ private:
  * @brief This method computes the main orientation for a given keypoints
  * @param kpts Input keypoints
  */
-void AKAZEFeatures::Compute_Keypoints_Orientation(std::vector<KeyPoint>& kpts) const
+void AKAZEFeatures::Compute_Keypoints_Orientation(KeyPointCollection& kpts) const
 {
   CV_INSTRUMENT_REGION();
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -92,17 +92,17 @@ private:
   void Allocate_Memory_Evolution();
   void Find_Scale_Space_Extrema(std::vector<Mat>& keypoints_by_layers);
   void Do_Subpixel_Refinement(std::vector<Mat>& keypoints_by_layers,
-    std::vector<KeyPoint>& kpts);
+    KeyPointCollection& kpts);
 
   /// Feature description methods
-  void Compute_Keypoints_Orientation(std::vector<cv::KeyPoint>& kpts) const;
+  void Compute_Keypoints_Orientation(KeyPointCollection& kpts) const;
 
 public:
   /// Constructor with input arguments
   AKAZEFeatures(const AKAZEOptions& options);
   void Create_Nonlinear_Scale_Space(InputArray img);
-  void Feature_Detection(std::vector<cv::KeyPoint>& kpts);
-  void Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, OutputArray desc);
+  void Feature_Detection(KeyPointCollection& kpts);
+  void Compute_Descriptors(KeyPointCollection& kpts, OutputArray desc);
 };
 
 /* ************************************************************************* */

--- a/modules/features2d/src/kaze/KAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/KAZEFeatures.cpp
@@ -319,10 +319,10 @@ void KAZEFeatures::Determinant_Hessian(KeyPointCollection& kpts)
     // Delete the memory of the vector of keypoints vectors
     // In case we use the same kaze object for multiple images
     for (size_t i = 0; i < kpts_par_.size(); i++) {
-        vector<KeyPoint>().swap(kpts_par_[i]);
+        KeyPointCollection().swap(kpts_par_[i]);
     }
     kpts_par_.clear();
-    vector<KeyPoint> aux;
+    KeyPointCollection aux;
 
     // Allocate memory for the vector of vectors
     for (size_t i = 1; i < evolution_.size() - 1; i++) {
@@ -402,7 +402,7 @@ void KAZEFeatures::Do_Subpixel_Refinement(KeyPointCollection &kpts) {
     Mat b = Mat::zeros(3, 1, CV_32F);
     Mat dst = Mat::zeros(3, 1, CV_32F);
 
-    vector<KeyPoint> kpts_(kpts);
+    KeyPointCollection kpts_(kpts);
 
     for (size_t i = 0; i < kpts_.size(); i++) {
 

--- a/modules/features2d/src/kaze/KAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/KAZEFeatures.cpp
@@ -180,7 +180,7 @@ void KAZEFeatures::Compute_Detector_Response(void)
  * @brief This method selects interesting keypoints through the nonlinear scale space
  * @param kpts Vector of keypoints
  */
-void KAZEFeatures::Feature_Detection(std::vector<KeyPoint>& kpts)
+void KAZEFeatures::Feature_Detection(KeyPointCollection& kpts)
 {
     kpts.clear();
         Compute_Detector_Response();
@@ -234,7 +234,7 @@ void KAZEFeatures::Compute_Multiscale_Derivatives(void)
 class FindExtremumKAZEInvoker : public ParallelLoopBody
 {
 public:
-    explicit FindExtremumKAZEInvoker(std::vector<TEvolution>& ev, std::vector<std::vector<KeyPoint> >& kpts_par,
+    explicit FindExtremumKAZEInvoker(std::vector<TEvolution>& ev, std::vector<KeyPointCollection >& kpts_par,
                                                                      const KAZEOptions& options) : evolution_(&ev), kpts_par_(&kpts_par), options_(options)
     {
     }
@@ -242,7 +242,7 @@ public:
     void operator()(const Range& range) const CV_OVERRIDE
     {
         std::vector<TEvolution>& evolution = *evolution_;
-        std::vector<std::vector<KeyPoint> >& kpts_par = *kpts_par_;
+        std::vector<KeyPointCollection >& kpts_par = *kpts_par_;
         for (int i = range.start; i < range.end; i++)
         {
             float value = 0.0;
@@ -297,7 +297,7 @@ public:
 
 private:
     std::vector<TEvolution>*  evolution_;
-    std::vector<std::vector<KeyPoint> >* kpts_par_;
+    std::vector<KeyPointCollection >* kpts_par_;
     KAZEOptions options_;
 };
 
@@ -308,7 +308,7 @@ private:
  * @param kpts Vector of keypoints
  * @note We compute features for each of the nonlinear scale space level in a different processing thread
  */
-void KAZEFeatures::Determinant_Hessian(std::vector<KeyPoint>& kpts)
+void KAZEFeatures::Determinant_Hessian(KeyPointCollection& kpts)
 {
     int level = 0;
     float dist = 0.0, smax = 3.0;
@@ -392,7 +392,7 @@ void KAZEFeatures::Determinant_Hessian(std::vector<KeyPoint>& kpts)
  * @brief This method performs subpixel refinement of the detected keypoints
  * @param kpts Vector of detected keypoints
  */
-void KAZEFeatures::Do_Subpixel_Refinement(std::vector<KeyPoint> &kpts) {
+void KAZEFeatures::Do_Subpixel_Refinement(KeyPointCollection &kpts) {
 
     int step = 1;
     int x = 0, y = 0;
@@ -489,7 +489,7 @@ void KAZEFeatures::Do_Subpixel_Refinement(std::vector<KeyPoint> &kpts) {
 class KAZE_Descriptor_Invoker : public ParallelLoopBody
 {
 public:
-        KAZE_Descriptor_Invoker(std::vector<KeyPoint> &kpts, Mat &desc, std::vector<TEvolution>& evolution, const KAZEOptions& options)
+        KAZE_Descriptor_Invoker(KeyPointCollection &kpts, Mat &desc, std::vector<TEvolution>& evolution, const KAZEOptions& options)
                 : kpts_(&kpts)
                 , desc_(&desc)
                 , evolution_(&evolution)
@@ -503,7 +503,7 @@ public:
 
     void operator() (const Range& range) const CV_OVERRIDE
     {
-        std::vector<KeyPoint> &kpts      = *kpts_;
+        KeyPointCollection &kpts      = *kpts_;
         Mat                   &desc      = *desc_;
         std::vector<TEvolution>   &evolution = *evolution_;
 
@@ -535,7 +535,7 @@ private:
     void Get_KAZE_Upright_Descriptor_128(const KeyPoint& kpt, float* desc) const;
     void Get_KAZE_Descriptor_128(const KeyPoint& kpt, float *desc) const;
 
-        std::vector<KeyPoint> * kpts_;
+        KeyPointCollection * kpts_;
         Mat                   * desc_;
         std::vector<TEvolution>   * evolution_;
         KAZEOptions                 options_;
@@ -547,7 +547,7 @@ private:
  * @param kpts Vector of keypoints
  * @param desc Matrix with the feature descriptors
  */
-void KAZEFeatures::Feature_Description(std::vector<KeyPoint> &kpts, Mat &desc)
+void KAZEFeatures::Feature_Description(KeyPointCollection &kpts, Mat &desc)
 {
     for(size_t i = 0; i < kpts.size(); i++)
     {

--- a/modules/features2d/src/kaze/KAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/KAZEFeatures.cpp
@@ -283,7 +283,7 @@ public:
                         point.response = fabs(value);
                         point.size = evolution[i].esigma;
                         point.octave = (int)evolution[i].octave;
-                        point.class_id = i;
+                        point.level = i;
 
                         // We use the angle field for the sublevel value
                         // Then, we will replace this angle field with the main orientation
@@ -344,7 +344,7 @@ void KAZEFeatures::Determinant_Hessian(KeyPointCollection& kpts)
 
             // Check in case we have the same point as maxima in previous evolution levels
             for (int ik = 0; ik < (int)kpts.size(); ik++) {
-                if (kpts[ik].class_id == level || kpts[ik].class_id == level + 1 || kpts[ik].class_id == level - 1) {
+                if (kpts[ik].level == level || kpts[ik].level == level + 1 || kpts[ik].level == level - 1) {
                     dist = pow(kpts_par_[i][j].pt.x - kpts[ik].pt.x, 2) + pow(kpts_par_[i][j].pt.y - kpts[ik].pt.y, 2);
 
                     if (dist < evolution_[level].sigma_size*evolution_[level].sigma_size) {
@@ -410,40 +410,40 @@ void KAZEFeatures::Do_Subpixel_Refinement(KeyPointCollection &kpts) {
         y = static_cast<int>(kpts_[i].pt.y);
 
         // Compute the gradient
-        Dx = (1.0f / (2.0f*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x + step)
-            - *(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x - step));
-        Dy = (1.0f / (2.0f*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y + step) + x)
-            - *(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y - step) + x));
-        Ds = 0.5f*(*(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y)+x)
-            - *(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y)+x));
+        Dx = (1.0f / (2.0f*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x + step)
+            - *(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x - step));
+        Dy = (1.0f / (2.0f*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y + step) + x)
+            - *(evolution_[kpts_[i].level].Ldet.ptr<float>(y - step) + x));
+        Ds = 0.5f*(*(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y)+x)
+            - *(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y)+x));
 
         // Compute the Hessian
-        Dxx = (1.0f / (step*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x + step)
-            + *(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x - step)
-            - 2.0f*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x)));
+        Dxx = (1.0f / (step*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x + step)
+            + *(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x - step)
+            - 2.0f*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x)));
 
-        Dyy = (1.0f / (step*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y + step) + x)
-            + *(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y - step) + x)
-            - 2.0f*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x)));
+        Dyy = (1.0f / (step*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y + step) + x)
+            + *(evolution_[kpts_[i].level].Ldet.ptr<float>(y - step) + x)
+            - 2.0f*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x)));
 
-        Dss = *(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y)+x)
-            + *(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y)+x)
-            - 2.0f*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y)+x));
+        Dss = *(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y)+x)
+            + *(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y)+x)
+            - 2.0f*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y)+x));
 
-        Dxy = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y + step) + x + step)
-            + (*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y - step) + x - step)))
-            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y - step) + x + step)
-            + (*(evolution_[kpts_[i].class_id].Ldet.ptr<float>(y + step) + x - step)));
+        Dxy = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y + step) + x + step)
+            + (*(evolution_[kpts_[i].level].Ldet.ptr<float>(y - step) + x - step)))
+            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level].Ldet.ptr<float>(y - step) + x + step)
+            + (*(evolution_[kpts_[i].level].Ldet.ptr<float>(y + step) + x - step)));
 
-        Dxs = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y)+x + step)
-            + (*(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y)+x - step)))
-            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y)+x - step)
-            + (*(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y)+x + step)));
+        Dxs = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y)+x + step)
+            + (*(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y)+x - step)))
+            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y)+x - step)
+            + (*(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y)+x + step)));
 
-        Dys = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y + step) + x)
-            + (*(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y - step) + x)))
-            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].class_id + 1].Ldet.ptr<float>(y - step) + x)
-            + (*(evolution_[kpts_[i].class_id - 1].Ldet.ptr<float>(y + step) + x)));
+        Dys = (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y + step) + x)
+            + (*(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y - step) + x)))
+            - (1.0f / (4.0f*step))*(*(evolution_[kpts_[i].level + 1].Ldet.ptr<float>(y - step) + x)
+            + (*(evolution_[kpts_[i].level - 1].Ldet.ptr<float>(y + step) + x)));
 
         // Solve the linear system
         *(A.ptr<float>(0)) = Dxx;
@@ -551,7 +551,7 @@ void KAZEFeatures::Feature_Description(KeyPointCollection &kpts, Mat &desc)
 {
     for(size_t i = 0; i < kpts.size(); i++)
     {
-        CV_Assert(0 <= kpts[i].class_id && kpts[i].class_id < static_cast<int>(evolution_.size()));
+        CV_Assert(0 <= kpts[i].level && kpts[i].level < static_cast<int>(evolution_.size()));
     }
 
     // Allocate memory for the matrix of descriptors
@@ -584,7 +584,7 @@ void KAZEFeatures::Compute_Main_Orientation(KeyPoint &kpt, const std::vector<TEv
     // Get the information from the keypoint
     xf = kpt.pt.x;
     yf = kpt.pt.y;
-    level = kpt.class_id;
+    level = kpt.level;
     s = cvRound(kpt.size / 2.0f);
 
     // Calculate derivatives responses for points within radius of 6*scale
@@ -675,7 +675,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Upright_Descriptor_64(const KeyPoint &kpt
     yf = kpt.pt.y;
     xf = kpt.pt.x;
     scale = cvRound(kpt.size / 2.0f);
-    level = kpt.class_id;
+    level = kpt.level;
 
     i = -8;
 
@@ -804,7 +804,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Descriptor_64(const KeyPoint &kpt, float 
     xf = kpt.pt.x;
     scale = cvRound(kpt.size / 2.0f);
     angle = kpt.angle * static_cast<float>(CV_PI / 180.f);
-    level = kpt.class_id;
+    level = kpt.level;
     co = cos(angle);
     si = sin(angle);
 
@@ -934,7 +934,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Upright_Descriptor_128(const KeyPoint &kp
     yf = kpt.pt.y;
     xf = kpt.pt.x;
     scale = cvRound(kpt.size / 2.0f);
-    level = kpt.class_id;
+    level = kpt.level;
 
     i = -8;
 
@@ -1087,7 +1087,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Descriptor_128(const KeyPoint &kpt, float
     xf = kpt.pt.x;
     scale = cvRound(kpt.size / 2.0f);
     angle = kpt.angle * static_cast<float>(CV_PI / 180.f);
-    level = kpt.class_id;
+    level = kpt.level;
     co = cos(angle);
     si = sin(angle);
 

--- a/modules/features2d/src/kaze/KAZEFeatures.h
+++ b/modules/features2d/src/kaze/KAZEFeatures.h
@@ -31,7 +31,7 @@ private:
     std::vector<TEvolution> evolution_;    ///< Vector of nonlinear diffusion evolution
 
     /// Vector of keypoint vectors for finding extrema in multiple threads
-    std::vector<std::vector<cv::KeyPoint> > kpts_par_;
+    std::vector<KeyPointCollection> kpts_par_;
 
     /// FED parameters
     int ncycles_;                  ///< Number of cycles

--- a/modules/features2d/src/kaze/KAZEFeatures.h
+++ b/modules/features2d/src/kaze/KAZEFeatures.h
@@ -47,16 +47,16 @@ public:
     /// Public methods for KAZE interface
     void Allocate_Memory_Evolution(void);
     int Create_Nonlinear_Scale_Space(const cv::Mat& img);
-    void Feature_Detection(std::vector<cv::KeyPoint>& kpts);
-    void Feature_Description(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc);
+    void Feature_Detection(KeyPointCollection& kpts);
+    void Feature_Description(KeyPointCollection& kpts, cv::Mat& desc);
     static void Compute_Main_Orientation(cv::KeyPoint& kpt, const std::vector<TEvolution>& evolution_, const KAZEOptions& options);
 
     /// Feature Detection Methods
     void Compute_KContrast(const cv::Mat& img, const float& kper);
     void Compute_Multiscale_Derivatives(void);
     void Compute_Detector_Response(void);
-    void Determinant_Hessian(std::vector<cv::KeyPoint>& kpts);
-    void Do_Subpixel_Refinement(std::vector<cv::KeyPoint>& kpts);
+    void Determinant_Hessian(KeyPointCollection& kpts);
+    void Do_Subpixel_Refinement(KeyPointCollection& kpts);
 };
 
 }

--- a/modules/features2d/src/keypoint.cpp
+++ b/modules/features2d/src/keypoint.cpp
@@ -66,7 +66,7 @@ struct KeypointResponseGreater
 };
 
 // takes keypoints and culls them by the response
-void KeyPointsFilter::retainBest(std::vector<KeyPoint>& keypoints, int n_points)
+void KeyPointsFilter::retainBest(KeyPointCollection& keypoints, int n_points)
 {
     //this is only necessary if the keypoints size is greater than the number of desired points.
     if( n_points >= 0 && keypoints.size() > (size_t)n_points )
@@ -102,7 +102,7 @@ struct RoiPredicate
     Rect r;
 };
 
-void KeyPointsFilter::runByImageBorder( std::vector<KeyPoint>& keypoints, Size imageSize, int borderSize )
+void KeyPointsFilter::runByImageBorder( KeyPointCollection& keypoints, Size imageSize, int borderSize )
 {
     if( borderSize > 0)
     {
@@ -130,7 +130,7 @@ struct SizePredicate
     float minSize, maxSize;
 };
 
-void KeyPointsFilter::runByKeypointSize( std::vector<KeyPoint>& keypoints, float minSize, float maxSize )
+void KeyPointsFilter::runByKeypointSize( KeyPointCollection& keypoints, float minSize, float maxSize )
 {
     CV_Assert( minSize >= 0 );
     CV_Assert( maxSize >= 0);
@@ -154,7 +154,7 @@ private:
     MaskPredicate& operator=(const MaskPredicate&);
 };
 
-void KeyPointsFilter::runByPixelsMask( std::vector<KeyPoint>& keypoints, const Mat& mask )
+void KeyPointsFilter::runByPixelsMask( KeyPointCollection& keypoints, const Mat& mask )
 {
     CV_INSTRUMENT_REGION();
 
@@ -166,7 +166,7 @@ void KeyPointsFilter::runByPixelsMask( std::vector<KeyPoint>& keypoints, const M
 
 struct KeyPoint_LessThan
 {
-    KeyPoint_LessThan(const std::vector<KeyPoint>& _kp) : kp(&_kp) {}
+    KeyPoint_LessThan(const KeyPointCollection& _kp) : kp(&_kp) {}
     bool operator()(int i, int j) const
     {
         const KeyPoint& kp1 = (*kp)[i];
@@ -188,10 +188,10 @@ struct KeyPoint_LessThan
 
         return i < j;
     }
-    const std::vector<KeyPoint>* kp;
+    const KeyPointCollection* kp;
 };
 
-void KeyPointsFilter::removeDuplicated( std::vector<KeyPoint>& keypoints )
+void KeyPointsFilter::removeDuplicated( KeyPointCollection& keypoints )
 {
     int i, j, n = (int)keypoints.size();
     std::vector<int> kpidx(n);
@@ -243,7 +243,7 @@ struct KeyPoint12_LessThan
     }
 };
 
-void KeyPointsFilter::removeDuplicatedSorted( std::vector<KeyPoint>& keypoints )
+void KeyPointsFilter::removeDuplicatedSorted( KeyPointCollection& keypoints )
 {
     int i, j, n = (int)keypoints.size();
 

--- a/modules/features2d/src/keypoint.cpp
+++ b/modules/features2d/src/keypoint.cpp
@@ -185,6 +185,8 @@ struct KeyPoint_LessThan
             return kp1.octave > kp2.octave;
         if( kp1.class_id != kp2.class_id )
             return kp1.class_id > kp2.class_id;
+        if( kp1.level != kp2.level)
+            return kp1.level > kp2.level;
 
         return i < j;
     }
@@ -239,7 +241,9 @@ struct KeyPoint12_LessThan
             return kp1.response > kp2.response;
         if( kp1.octave != kp2.octave )
             return kp1.octave > kp2.octave;
-        return kp1.class_id > kp2.class_id;
+        if( kp1.class_id > kp2.class_id )
+            return kp1.class_id > kp2.class_id;
+        return kp1.level > kp2.level;
     }
 };
 

--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -365,7 +365,7 @@ public:
     void detectRegions( InputArray image,
                         std::vector<std::vector<Point> >& msers,
                         std::vector<Rect>& bboxes ) CV_OVERRIDE;
-    void detect( InputArray _src, vector<KeyPoint>& keypoints, InputArray _mask ) CV_OVERRIDE;
+    void detect( InputArray _src, KeyPointCollection& keypoints, InputArray _mask ) CV_OVERRIDE;
 
     void preprocess1( const Mat& img, int* level_size )
     {
@@ -1072,7 +1072,7 @@ void MSER_Impl::detectRegions( InputArray _src, vector<vector<Point> >& msers, v
     }
 }
 
-void MSER_Impl::detect( InputArray _image, vector<KeyPoint>& keypoints, InputArray _mask )
+void MSER_Impl::detect( InputArray _image, KeyPointCollection& keypoints, InputArray _mask )
 {
     CV_INSTRUMENT_REGION();
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -129,7 +129,7 @@ ocl_computeOrbDescriptors(const UMat& imgbuf, const UMat& layerInfo,
  */
 static void
 HarrisResponses(const Mat& img, const std::vector<Rect>& layerinfo,
-                std::vector<KeyPoint>& pts, int blockSize, float harris_k)
+                KeyPointCollection& pts, int blockSize, float harris_k)
 {
     CV_Assert( img.type() == CV_8UC1 && blockSize*blockSize <= 2048 );
 
@@ -174,7 +174,7 @@ HarrisResponses(const Mat& img, const std::vector<Rect>& layerinfo,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static void ICAngles(const Mat& img, const std::vector<Rect>& layerinfo,
-                     std::vector<KeyPoint>& pts, const std::vector<int> & u_max, int half_k)
+                     KeyPointCollection& pts, const std::vector<int> & u_max, int half_k)
 {
     int step = (int)img.step1();
     size_t ptidx, ptsize = pts.size();
@@ -213,7 +213,7 @@ static void ICAngles(const Mat& img, const std::vector<Rect>& layerinfo,
 
 static void
 computeOrbDescriptors( const Mat& imagePyramid, const std::vector<Rect>& layerInfo,
-                       const std::vector<float>& layerScale, std::vector<KeyPoint>& keypoints,
+                       const std::vector<float>& layerScale, KeyPointCollection& keypoints,
                        Mat& descriptors, const std::vector<Point>& _pattern, int dsize, int wta_k )
 {
     int step = (int)imagePyramid.step;
@@ -696,7 +696,7 @@ public:
     int defaultNorm() const CV_OVERRIDE;
 
     // Compute the ORB_Impl features and descriptors on an image
-    void detectAndCompute( InputArray image, InputArray mask, std::vector<KeyPoint>& keypoints,
+    void detectAndCompute( InputArray image, InputArray mask, KeyPointCollection& keypoints,
                      OutputArray descriptors, bool useProvidedKeypoints=false ) CV_OVERRIDE;
 
 protected:
@@ -737,7 +737,7 @@ int ORB_Impl::defaultNorm() const
 }
 
 #ifdef HAVE_OPENCL
-static void uploadORBKeypoints(const std::vector<KeyPoint>& src, std::vector<Vec3i>& buf, OutputArray dst)
+static void uploadORBKeypoints(const KeyPointCollection& src, std::vector<Vec3i>& buf, OutputArray dst)
 {
     size_t i, n = src.size();
     buf.resize(std::max(buf.size(), n));
@@ -753,7 +753,7 @@ typedef union if32_t
 }
 if32_t;
 
-static void uploadORBKeypoints(const std::vector<KeyPoint>& src,
+static void uploadORBKeypoints(const KeyPointCollection& src,
                                const std::vector<float>& layerScale,
                                std::vector<Vec4i>& buf, OutputArray dst)
 {
@@ -782,7 +782,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
                              const std::vector<Rect>& layerInfo,
                              const UMat& ulayerInfo,
                              const std::vector<float>& layerScale,
-                             std::vector<KeyPoint>& allKeypoints,
+                             KeyPointCollection& allKeypoints,
                              int nfeatures, double scaleFactor,
                              int edgeThreshold, int patchSize, int scoreType,
                              bool useOCL, int fastThreshold  )
@@ -829,7 +829,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
     }
 
     allKeypoints.clear();
-    std::vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     std::vector<int> counters(nlevels);
     keypoints.reserve(nfeaturesPerLevel[0]*2);
 
@@ -896,7 +896,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
 #endif
             HarrisResponses(imagePyramid, layerInfo, allKeypoints, 7, HARRIS_K);
 
-        std::vector<KeyPoint> newAllKeypoints;
+        KeyPointCollection newAllKeypoints;
         newAllKeypoints.reserve(nfeaturesPerLevel[0]*nlevels);
 
         int offset = 0;
@@ -963,7 +963,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
  * @param do_descriptors if true, also computes the descriptors
  */
 void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
-                                 std::vector<KeyPoint>& keypoints,
+                                 KeyPointCollection& keypoints,
                                  OutputArray _descriptors, bool useProvidedKeypoints )
 {
     CV_INSTRUMENT_REGION();
@@ -1126,7 +1126,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
 
         if( !sortedByLevel )
         {
-            std::vector<std::vector<KeyPoint> > allKeypoints(nLevels);
+            std::vector<KeyPointCollection > allKeypoints(nLevels);
             nkeypoints = (int)keypoints.size();
             for( i = 0; i < nkeypoints; i++ )
             {

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -860,8 +860,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
             keypoints[i].octave = level;
             keypoints[i].size = patchSize*sf;
         }
-
-        std::copy(keypoints.begin(), keypoints.end(), std::back_inserter(allKeypoints));
+        allKeypoints.insert(keypoints.begin(), keypoints.end(), allKeypoints.end());
     }
 
     std::vector<Vec3i> ukeypoints_buf;
@@ -912,8 +911,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
 
             //cull to the final desired level, using the new Harris scores.
             KeyPointsFilter::retainBest(keypoints, featuresNum);
-
-            std::copy(keypoints.begin(), keypoints.end(), std::back_inserter(newAllKeypoints));
+            newAllKeypoints.insert(keypoints.begin(), keypoints.end(), allKeypoints.end());
         }
         std::swap(allKeypoints, newAllKeypoints);
     }
@@ -1136,7 +1134,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
             }
             keypoints.clear();
             for( level = 0; level < nLevels; level++ )
-                std::copy(allKeypoints[level].begin(), allKeypoints[level].end(), std::back_inserter(keypoints));
+                keypoints.insert(allKeypoints[level].begin(), allKeypoints[level].end(),  keypoints.end());
         }
     }
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -991,7 +991,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
     if( image.type() != CV_8UC1 )
         cvtColor(_image, image, COLOR_BGR2GRAY);
 
-    int i, level, nLevels = this->nlevels, nkeypoints = (int)keypoints.size();
+    int level, nLevels = this->nlevels, nkeypoints = (int)keypoints.size();
     bool sortedByLevel = true;
     keypoints.setScaleFactorCallable([&](const KeyPoint& kp){
         return getScale(kp.octave, firstLevel, scaleFactor);

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -860,7 +860,8 @@ static void computeKeyPoints(const Mat& imagePyramid,
             keypoints[i].octave = level;
             keypoints[i].size = patchSize*sf;
         }
-        allKeypoints.insert(keypoints.begin(), keypoints.end(), allKeypoints.end());
+
+        std::copy(keypoints.begin(), keypoints.end(), std::back_inserter(allKeypoints));
     }
 
     std::vector<Vec3i> ukeypoints_buf;
@@ -911,7 +912,8 @@ static void computeKeyPoints(const Mat& imagePyramid,
 
             //cull to the final desired level, using the new Harris scores.
             KeyPointsFilter::retainBest(keypoints, featuresNum);
-            newAllKeypoints.insert(keypoints.begin(), keypoints.end(), allKeypoints.end());
+
+            std::copy(keypoints.begin(), keypoints.end(), std::back_inserter(newAllKeypoints));
         }
         std::swap(allKeypoints, newAllKeypoints);
     }
@@ -1134,7 +1136,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
             }
             keypoints.clear();
             for( level = 0; level < nLevels; level++ )
-                keypoints.insert(allKeypoints[level].begin(), allKeypoints[level].end(),  keypoints.end());
+                std::copy(allKeypoints[level].begin(), allKeypoints[level].end(), std::back_inserter(keypoints));
         }
     }
 

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -527,7 +527,6 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
             {
                 KeyPoint& kpt = keypoints[i];
                 float scale = 1.f/(float)(1 << -firstOctave);
-                kpt.octave = (kpt.octave & ~255) | ((kpt.octave + firstOctave) & 255);
                 kpt.pt *= scale;
                 kpt.size *= scale;
             }

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -146,8 +146,8 @@ String SIFT::getDefaultName() const
 static inline void
 unpackOctave(const KeyPoint& kpt, int& octave, int& layer, float& scale)
 {
-    octave = kpt.octave & 255;
-    layer = (kpt.octave >> 8) & 255;
+    octave = kpt.octave;
+    layer = kpt.layer;
     octave = octave < 128 ? octave : (-128 | octave);
     scale = octave >= 0 ? 1.f/(1 << octave) : (float)(1 << -octave);
 }
@@ -527,7 +527,6 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
             {
                 KeyPoint& kpt = keypoints[i];
                 float scale = 1.f/(float)(1 << -firstOctave);
-                kpt.octave = (kpt.octave & ~255) | ((kpt.octave + firstOctave) & 255);
                 kpt.pt *= scale;
                 kpt.size *= scale;
             }

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -527,6 +527,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
             {
                 KeyPoint& kpt = keypoints[i];
                 float scale = 1.f/(float)(1 << -firstOctave);
+                kpt.octave = (kpt.octave & ~255) | ((kpt.octave + firstOctave) & 255);
                 kpt.pt *= scale;
                 kpt.size *= scale;
             }

--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -388,7 +388,8 @@ bool adjustLocalExtrema(
 
     kpt.pt.x = (c + xc) * (1 << octv);
     kpt.pt.y = (r + xr) * (1 << octv);
-    kpt.octave = octv + (layer << 8) + (cvRound((xi + 0.5)*255) << 16);
+    kpt.layer = layer;
+    kpt.octave = octv;
     kpt.size = sigma*powf(2.f, (layer + xi) / nOctaveLayers)*(1 << octv)*2;
     kpt.response = std::abs(contr);
 

--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -145,7 +145,7 @@ void findScaleSpaceExtrema(
     double sigma,
     const std::vector<Mat>& gauss_pyr,
     const std::vector<Mat>& dog_pyr,
-    std::vector<KeyPoint>& kpts,
+    KeyPointCollection& kpts,
     const cv::Range& range);
 
 void calcSIFTDescriptor(
@@ -413,7 +413,7 @@ public:
         double _sigma,
         const std::vector<Mat>& _gauss_pyr,
         const std::vector<Mat>& _dog_pyr,
-        std::vector<KeyPoint>& kpts)
+        KeyPointCollection& kpts)
 
         : o(_o),
           i(_i),
@@ -521,7 +521,7 @@ private:
     double sigma;
     const std::vector<Mat>& gauss_pyr;
     const std::vector<Mat>& dog_pyr;
-    std::vector<KeyPoint>& kpts_;
+    KeyPointCollection& kpts_;
 };
 
 }  // namespace
@@ -540,7 +540,7 @@ void findScaleSpaceExtrema(
     double sigma,
     const std::vector<Mat>& gauss_pyr,
     const std::vector<Mat>& dog_pyr,
-    std::vector<KeyPoint>& kpts,
+    KeyPointCollection& kpts,
     const cv::Range& range)
 {
     CV_TRACE_FUNCTION();

--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -389,7 +389,7 @@ bool adjustLocalExtrema(
     kpt.pt.x = (c + xc) * (1 << octv);
     kpt.pt.y = (r + xr) * (1 << octv);
     kpt.layer = layer;
-    kpt.octave = octv;
+    kpt.octave = octv + (cvRound((xi + 0.5)));
     kpt.size = sigma*powf(2.f, (layer + xi) / nOctaveLayers)*(1 << octv)*2;
     kpt.response = std::abs(contr);
 

--- a/modules/features2d/test/ocl/test_feature2d.cpp
+++ b/modules/features2d/test/ocl/test_feature2d.cpp
@@ -20,9 +20,9 @@ PARAM_TEST_CASE(Feature2DFixture, Ptr<Feature2D>, std::string)
 {
     std::string filename;
     Mat image, descriptors;
-    vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     UMat uimage, udescriptors;
-    vector<KeyPoint> ukeypoints;
+    KeyPointCollection ukeypoints;
     Ptr<Feature2D> feature;
 
     virtual void SetUp()

--- a/modules/features2d/test/test_affine_feature.cpp
+++ b/modules/features2d/test/test_affine_feature.cpp
@@ -85,7 +85,7 @@ TEST(Features2d_AFFINE_FEATURE, regression)
     const float maxBadDescriptorRatio = 0.15f;
 
     // read keypoints
-    vector<KeyPoint> validKeypoints;
+    KeyPointCollection validKeypoints;
     Mat validDescriptors;
     FileStorage fs(xml, FileStorage::READ);
     ASSERT_TRUE(fs.isOpened()) << xml;
@@ -120,7 +120,7 @@ TEST(Features2d_AFFINE_FEATURE, regression)
     fs.release();
 
     // calc and compare keypoints
-    vector<KeyPoint> calcKeypoints;
+    KeyPointCollection calcKeypoints;
     ext->detectAndCompute(gray, Mat(), calcKeypoints, noArray(), false);
 
     float countRatio = (float)validKeypoints.size() / (float)calcKeypoints.size();

--- a/modules/features2d/test/test_agast.cpp
+++ b/modules/features2d/test/test_agast.cpp
@@ -73,8 +73,8 @@ void CV_AgastTest::run( int )
     cvtColor(image1, gray1, COLOR_BGR2GRAY);
     cvtColor(image2, gray2, COLOR_BGR2GRAY);
 
-    vector<KeyPoint> keypoints1;
-    vector<KeyPoint> keypoints2;
+    KeyPointCollection keypoints1;
+    KeyPointCollection keypoints2;
     AGAST(gray1, keypoints1, 30, true, type);
     AGAST(gray2, keypoints2, (type > 0 ? 30 : 20), true, type);
 

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -44,5 +44,19 @@ TEST(Features2d_AKAZE, uninitialized_and_nans)
     Ptr<Feature2D> akaze = AKAZE::create();
     akaze->detectAndCompute(b1, noArray(), keypoints, desc);
 }
+TEST(Features2d_AKAZE, describe_with_different_detector)
+{
+    Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
+    ASSERT_FALSE(image.empty());
+    Ptr<DescriptorExtractor> fd = SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+    Ptr<FeatureDetector> de =
+            AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 0, 3, 0.001f, 3, 1, KAZE::DIFF_PM_G2);
+    KeyPointCollection keypoints;
+    Mat desc;
+    fd->detect(image, keypoints);
+    Mat descriptors;
+    de->compute(image, keypoints, descriptors);
+}
+
 
 }} // namespace

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -13,11 +13,11 @@ TEST(Features2d_AKAZE, detect_and_compute_split)
     rng.fill(testImg, RNG::UNIFORM, Scalar(0), Scalar(255), true);
 
     Ptr<Feature2D> ext = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 0, 3, 0.001f, 1, 1, KAZE::DIFF_PM_G2);
-    vector<KeyPoint> detAndCompKps;
+    KeyPointCollection detAndCompKps;
     Mat desc;
     ext->detectAndCompute(testImg, noArray(), detAndCompKps, desc);
 
-    vector<KeyPoint> detKps;
+    KeyPointCollection detKps;
     ext->detect(testImg, detKps);
 
     ASSERT_EQ(detKps.size(), detAndCompKps.size());
@@ -39,7 +39,7 @@ TEST(Features2d_AKAZE, uninitialized_and_nans)
     Mat b1 = imread(cvtest::TS::ptr()->get_data_path() + "../stitching/b1.png");
     ASSERT_FALSE(b1.empty());
 
-    vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     Mat desc;
     Ptr<Feature2D> akaze = AKAZE::create();
     akaze->detectAndCompute(b1, noArray(), keypoints, desc);

--- a/modules/features2d/test/test_blobdetector.cpp
+++ b/modules/features2d/test/test_blobdetector.cpp
@@ -12,7 +12,7 @@ TEST(Features2d_BlobDetector, bug_6667)
     SimpleBlobDetector::Params params;
     params.minThreshold = 250;
     params.maxThreshold = 260;
-    std::vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
 
     Ptr<SimpleBlobDetector> detector = SimpleBlobDetector::create(params);
     detector->detect(image, keypoints);

--- a/modules/features2d/test/test_brisk.cpp
+++ b/modules/features2d/test/test_brisk.cpp
@@ -73,8 +73,8 @@ void CV_BRISKTest::run( int )
 
   Ptr<FeatureDetector> detector = BRISK::create();
 
-  vector<KeyPoint> keypoints1;
-  vector<KeyPoint> keypoints2;
+  KeyPointCollection keypoints1;
+  KeyPointCollection keypoints2;
   detector->detect(image1, keypoints1);
   detector->detect(image2, keypoints2);
 

--- a/modules/features2d/test/test_descriptors_invariance.cpp
+++ b/modules/features2d/test/test_descriptors_invariance.cpp
@@ -16,7 +16,7 @@ const static std::string IMAGE_BIKES = "detectors_descriptors_evaluation/images_
 #define Value(...) Values(String_FeatureDetector_DescriptorExtractor_Float_t(__VA_ARGS__))
 
 static
-void SetSuitableSIFTOctave(vector<KeyPoint>& keypoints,
+void SetSuitableSIFTOctave(KeyPointCollection& keypoints,
                              int firstOctave = -1, int nOctaveLayers = 3, double sigma = 1.6)
 {
     for (size_t i = 0; i < keypoints.size(); i++ )
@@ -36,7 +36,7 @@ void SetSuitableSIFTOctave(vector<KeyPoint>& keypoints,
 }
 
 static
-void rotateKeyPoints(const vector<KeyPoint>& src, const Mat& H, float angle, vector<KeyPoint>& dst)
+void rotateKeyPoints(const KeyPointCollection& src, const Mat& H, float angle, KeyPointCollection& dst)
 {
     // suppose that H is rotation given from rotateImage() and angle has value passed to rotateImage()
     vector<Point2f> srcCenters, dstCenters;
@@ -85,7 +85,7 @@ TEST_P(DescriptorRotationInvariance, rotation)
     Mat mask0(image0.size(), CV_8UC1, Scalar(0));
     mask0(Rect(borderSize, borderSize, mask0.cols - 2*borderSize, mask0.rows - 2*borderSize)).setTo(Scalar(255));
 
-    vector<KeyPoint> keypoints0;
+    KeyPointCollection keypoints0;
     Mat descriptors0;
     featureDetector->detect(image0, keypoints0, mask0);
     std::cout << "Keypoints: " << keypoints0.size() << std::endl;
@@ -100,7 +100,7 @@ TEST_P(DescriptorRotationInvariance, rotation)
     {
         Mat H = rotateImage(image0, mask0, static_cast<float>(angle), image1, mask1);
 
-        vector<KeyPoint> keypoints1;
+        KeyPointCollection keypoints1;
         rotateKeyPoints(keypoints0, H, static_cast<float>(angle), keypoints1);
         Mat descriptors1;
         descriptorExtractor->compute(image1, keypoints1, descriptors1);
@@ -135,7 +135,7 @@ TEST_P(DescriptorRotationInvariance, rotation)
 
 TEST_P(DescriptorScaleInvariance, scale)
 {
-    vector<KeyPoint> keypoints0;
+    KeyPointCollection keypoints0;
     featureDetector->detect(image0, keypoints0);
     std::cout << "Keypoints: " << keypoints0.size() << std::endl;
     EXPECT_GE(keypoints0.size(), 15u);
@@ -150,7 +150,7 @@ TEST_P(DescriptorScaleInvariance, scale)
         Mat image1;
         resize(image0, image1, Size(), 1./scale, 1./scale, INTER_LINEAR_EXACT);
 
-        vector<KeyPoint> keypoints1;
+        KeyPointCollection keypoints1;
         scaleKeyPoints(keypoints0, keypoints1, 1.0f/scale);
         if (featureDetector->getDefaultName() == "Feature2D.SIFT")
         {

--- a/modules/features2d/test/test_descriptors_regression.cpp
+++ b/modules/features2d/test/test_descriptors_regression.cpp
@@ -163,7 +163,7 @@ protected:
 
         // One image.
         Mat image;
-        vector<KeyPoint> keypoints;
+        KeyPointCollection keypoints;
         Mat descriptors;
 
         try
@@ -190,7 +190,7 @@ protected:
 
         // Several images.
         vector<Mat> images;
-        vector<vector<KeyPoint> > keypointsCollection;
+        vector<KeyPointCollection > keypointsCollection;
         vector<Mat> descriptorsCollection;
         try
         {
@@ -222,7 +222,7 @@ protected:
                         : (DESCRIPTOR_DIR + "/" + name + "_keypoints.xml.gz"));
         FileStorage fs(keypoints_filename, FileStorage::READ);
 
-        vector<KeyPoint> keypoints;
+        KeyPointCollection keypoints;
         EXPECT_TRUE(fs.isOpened()) << "Keypoint testdata is missing. Re-computing and re-writing keypoints testdata...";
         if (!fs.isOpened())
         {
@@ -248,7 +248,7 @@ protected:
 
         if(!detector.empty())
         {
-            vector<KeyPoint> calcKeypoints;
+            KeyPointCollection calcKeypoints;
             detector->detect(img, calcKeypoints);
             // TODO validate received keypoints
             int diff = abs((int)calcKeypoints.size() - (int)keypoints.size());
@@ -399,7 +399,7 @@ TEST( Features2d_DescriptorExtractor, batch_ORB )
 {
     string path = string(cvtest::TS::ptr()->get_data_path() + "detectors_descriptors_evaluation/images_datasets/graf");
     vector<Mat> imgs, descriptors;
-    vector<vector<KeyPoint> > keypoints;
+    vector<KeyPointCollection> keypoints;
     int i, n = 6;
     Ptr<ORB> orb = ORB::create();
 
@@ -427,7 +427,7 @@ TEST( Features2d_DescriptorExtractor, batch_SIFT )
 {
     string path = string(cvtest::TS::ptr()->get_data_path() + "detectors_descriptors_evaluation/images_datasets/graf");
     vector<Mat> imgs, descriptors;
-    vector<vector<KeyPoint> > keypoints;
+    vector<KeyPointCollection > keypoints;
     int i, n = 6;
     Ptr<SIFT> sift = SIFT::create();
 
@@ -478,7 +478,7 @@ TEST_P(DescriptorImage, no_crash)
     Ptr<KAZE> kaze = KAZE::create();
     Ptr<BRISK> brisk = BRISK::create();
     size_t n = fnames.size();
-    vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     Mat descriptors;
     orb->setMaxFeatures(5000);
 

--- a/modules/features2d/test/test_detectors_invariance.cpp
+++ b/modules/features2d/test/test_detectors_invariance.cpp
@@ -16,8 +16,8 @@ const static std::string IMAGE_BIKES = "detectors_descriptors_evaluation/images_
 #define Value(...) Values(String_FeatureDetector_Float_Float_t(__VA_ARGS__))
 
 static
-void matchKeyPoints(const vector<KeyPoint>& keypoints0, const Mat& H,
-                    const vector<KeyPoint>& keypoints1,
+void matchKeyPoints(const KeyPointCollection& keypoints0, const Mat& H,
+                    const KeyPointCollection& keypoints1,
                     vector<DMatch>& matches)
 {
     vector<Point2f> points0;
@@ -81,7 +81,7 @@ TEST_P(DetectorRotationInvariance, rotation)
     Mat mask0(image0.size(), CV_8UC1, Scalar(0));
     mask0(Rect(borderSize, borderSize, mask0.cols - 2*borderSize, mask0.rows - 2*borderSize)).setTo(Scalar(255));
 
-    vector<KeyPoint> keypoints0;
+    KeyPointCollection keypoints0;
     featureDetector->detect(image0, keypoints0, mask0);
     EXPECT_GE(keypoints0.size(), 15u);
 
@@ -90,7 +90,7 @@ TEST_P(DetectorRotationInvariance, rotation)
     {
         Mat H = rotateImage(image0, mask0, static_cast<float>(angle), image1, mask1);
 
-        vector<KeyPoint> keypoints1;
+        KeyPointCollection keypoints1;
         featureDetector->detect(image1, keypoints1, mask1);
 
         vector<DMatch> matches;
@@ -150,7 +150,7 @@ TEST_P(DetectorRotationInvariance, rotation)
 
 TEST_P(DetectorScaleInvariance, scale)
 {
-    vector<KeyPoint> keypoints0;
+    KeyPointCollection keypoints0;
     featureDetector->detect(image0, keypoints0);
     EXPECT_GE(keypoints0.size(),  15u);
 
@@ -160,7 +160,7 @@ TEST_P(DetectorScaleInvariance, scale)
         Mat image1;
         resize(image0, image1, Size(), 1./scale, 1./scale, INTER_LINEAR_EXACT);
 
-        vector<KeyPoint> keypoints1, osiKeypoints1; // osi - original size image
+        KeyPointCollection keypoints1, osiKeypoints1; // osi - original size image
         featureDetector->detect(image1, keypoints1);
         EXPECT_GE(keypoints1.size(), 15u);
         EXPECT_LE(keypoints1.size(), keypoints0.size()) << "Strange behavior of the detector. "

--- a/modules/features2d/test/test_detectors_regression.cpp
+++ b/modules/features2d/test/test_detectors_regression.cpp
@@ -59,7 +59,7 @@ public:
 
 protected:
     bool isSimilarKeypoints( const KeyPoint& p1, const KeyPoint& p2 );
-    void compareKeypointSets( const vector<KeyPoint>& validKeypoints, const vector<KeyPoint>& calcKeypoints );
+    void compareKeypointSets( const KeyPointCollection& validKeypoints, const KeyPointCollection& calcKeypoints );
 
     void emptyDataTest();
     void regressionTest(); // TODO test of detect() with mask
@@ -74,7 +74,7 @@ void CV_FeatureDetectorTest::emptyDataTest()
 {
     // One image.
     Mat image;
-    vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     try
     {
         fdetector->detect( image, keypoints );
@@ -94,7 +94,7 @@ void CV_FeatureDetectorTest::emptyDataTest()
 
     // Several images.
     vector<Mat> images;
-    vector<vector<KeyPoint> > keypointCollection;
+    vector<KeyPointCollection> keypointCollection;
     try
     {
         fdetector->detect( images, keypointCollection );
@@ -122,7 +122,7 @@ bool CV_FeatureDetectorTest::isSimilarKeypoints( const KeyPoint& p1, const KeyPo
             p1.class_id == p2.class_id );
 }
 
-void CV_FeatureDetectorTest::compareKeypointSets( const vector<KeyPoint>& validKeypoints, const vector<KeyPoint>& calcKeypoints )
+void CV_FeatureDetectorTest::compareKeypointSets( const KeyPointCollection& validKeypoints, const KeyPointCollection& calcKeypoints )
 {
     const float maxCountRatioDif = 0.01f;
 
@@ -187,7 +187,7 @@ void CV_FeatureDetectorTest::regressionTest()
     FileStorage fs( resFilename, FileStorage::READ );
 
     // Compute keypoints.
-    vector<KeyPoint> calcKeypoints;
+    KeyPointCollection calcKeypoints;
     fdetector->detect( image, calcKeypoints );
 
     if( fs.isOpened() ) // Compare computed and valid keypoints.
@@ -195,7 +195,7 @@ void CV_FeatureDetectorTest::regressionTest()
         // TODO compare saved feature detector params with current ones
 
         // Read validation keypoints set.
-        vector<KeyPoint> validKeypoints;
+        KeyPointCollection validKeypoints;
         read( fs["keypoints"], validKeypoints );
         if( validKeypoints.empty() )
         {

--- a/modules/features2d/test/test_drawing.cpp
+++ b/modules/features2d/test/test_drawing.cpp
@@ -34,7 +34,7 @@ TEST_P(Features2D_drawKeypoints, Accuracy)
     const int cn = CV_MAT_CN(GetParam());
     Mat inpImg(11, 11, GetParam(), Scalar(1, 1, 1, 255)), outImg;
 
-    std::vector<KeyPoint> keypoints(1, KeyPoint(5, 5, 1));
+    KeyPointCollection keypoints(1, KeyPoint(5, 5, 1));
     drawKeypoints(inpImg, keypoints, outImg, Scalar::all(255));
     ASSERT_EQ(outImg.channels(), (cn == 4) ? 4 : 3);
 
@@ -49,7 +49,7 @@ TEST_P(Features2D_drawMatches, Accuracy)
     Mat inpImg1(11, 11, get<0>(GetParam()), Scalar(1, 1, 1, 255));
     Mat inpImg2(11, 11, get<1>(GetParam()), Scalar(2, 2, 2, 255)), outImg2, outImg;
 
-    std::vector<KeyPoint> keypoints(1, KeyPoint(5, 5, 1));
+    KeyPointCollection keypoints(1, KeyPoint(5, 5, 1));
 
     // Get outImg2 using drawKeypoints assuming that it works correctly (see the test above).
     drawKeypoints(inpImg2, keypoints, outImg2, Scalar::all(255));

--- a/modules/features2d/test/test_fast.cpp
+++ b/modules/features2d/test/test_fast.cpp
@@ -73,8 +73,8 @@ void CV_FastTest::run( int )
     cvtColor(image1, gray1, COLOR_BGR2GRAY);
     cvtColor(image2, gray2, COLOR_BGR2GRAY);
 
-    vector<KeyPoint> keypoints1;
-    vector<KeyPoint> keypoints2;
+    KeyPointCollection keypoints1;
+    KeyPointCollection keypoints2;
     FAST(gray1, keypoints1, 30, true, type);
     FAST(gray2, keypoints2, (type > 0 ? 30 : 20), true, type);
 

--- a/modules/features2d/test/test_invariance_utils.hpp
+++ b/modules/features2d/test/test_invariance_utils.hpp
@@ -70,7 +70,7 @@ float calcIntersectRatio(const Point2f& p0, float r0, const Point2f& p1, float r
     return intersectArea / unionArea;
 }
 
-void scaleKeyPoints(const vector<KeyPoint>& src, vector<KeyPoint>& dst, float scale)
+void scaleKeyPoints(const KeyPointCollection& src, KeyPointCollection& dst, float scale)
 {
     dst.resize(src.size());
     for (size_t i = 0; i < src.size(); i++) {

--- a/modules/features2d/test/test_keypoints.cpp
+++ b/modules/features2d/test/test_keypoints.cpp
@@ -72,7 +72,7 @@ protected:
             return;
         }
 
-        vector<KeyPoint> keypoints;
+        KeyPointCollection keypoints;
         detector->detect(image, keypoints);
 
         if(keypoints.empty())

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -64,7 +64,7 @@ TEST(Features2D_ORB, _1996)
     //image.setTo(Scalar(255,255,255), roi);
 
     int roiViolations = 0;
-    for(KeyPointCollection::const_iterator kp = keypoints.begin(); kp != keypoints.end(); ++kp)
+    for(std::vector<KeyPoint>::const_iterator kp = keypoints.begin(); kp != keypoints.end(); ++kp)
     {
         int x = cvRound(kp->pt.x);
         int y = cvRound(kp->pt.y);
@@ -106,7 +106,7 @@ TEST(Features2D_ORB, crash_5031)
 
     Ptr<ORB> orb = cv::ORB::create(nfeatures, orbScaleFactor, nlevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize, fastThreshold);
 
-    std::vector<cv::KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     cv::Mat descriptors;
 
     cv::KeyPoint kp;
@@ -145,7 +145,7 @@ TEST(Features2D_ORB, enhancement_10555)
 {
     Ptr<SIFT> sift = SIFT::create();
     vector<KeyPointCollection> keypoints;
-    KeyPointCollection descriptors;
+    Mat descriptors;
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
     sift->detect(image, keypoints);
     Ptr<ORB> orb = ORB::create();

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -143,13 +143,21 @@ TEST(Features2D_ORB, regression_16197)
 
 TEST(Features2D_ORB, enhancement_10555)
 {
-    Ptr<SIFT> sift = SIFT::create();
-    vector<KeyPointCollection> keypoints;
-    Mat descriptors;
+    Ptr<FeatureDetector> fd = ORB::create(10000, 1.2f, 8, 31, 0, 2, ORB::HARRIS_SCORE, 31, 20);
+    Ptr<DescriptorExtractor> de = SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
-    sift->detect(image, keypoints);
-    Ptr<ORB> orb = ORB::create();
-    orb -> compute(image, keypoints, descriptors);
+    ASSERT_FALSE(image.empty());
+
+    Mat roi(image.size(), CV_8UC1, Scalar(0));
+
+    Point poly[] = {Point(100, 20), Point(300, 50), Point(400, 200), Point(10, 500)};
+    fillConvexPoly(roi, poly, int(sizeof(poly) / sizeof(poly[0])), Scalar(255));
+
+    KeyPointCollection keypoints;
+    fd->detect(image, keypoints, roi);
+    Mat descriptors;
+    de->compute(image, keypoints, descriptors);
 }
 
 

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -143,8 +143,8 @@ TEST(Features2D_ORB, regression_16197)
 
 TEST(Features2D_ORB, enhancement_10555)
 {
-    Ptr<FeatureDetector> fd = ORB::create(10000, 1.2f, 8, 31, 0, 2, ORB::HARRIS_SCORE, 31, 20);
-    Ptr<DescriptorExtractor> de = SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+    Ptr<DescriptorExtractor> fd = SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+    Ptr<FeatureDetector> de = ORB::create(10000, 1.2f, 8, 31, 0, 2, ORB::HARRIS_SCORE, 31, 20);
 
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
     ASSERT_FALSE(image.empty());

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -144,8 +144,8 @@ TEST(Features2D_ORB, regression_16197)
 TEST(Features2D_ORB, enhancement_10555)
 {
     Ptr<SIFT> sift = SIFT::create();
-    vector<vector<KeyPoint> > keypoints;
-    std::vector<Mat> descriptors;
+    vector<KeyPointCollection> keypoints;
+    KeyPointCollection descriptors;
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
     sift->detect(image, keypoints);
     Ptr<ORB> orb = ORB::create();

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -56,7 +56,7 @@ TEST(Features2D_ORB, _1996)
     Point poly[] = {Point(100, 20), Point(300, 50), Point(400, 200), Point(10, 500)};
     fillConvexPoly(roi, poly, int(sizeof(poly) / sizeof(poly[0])), Scalar(255));
 
-    std::vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     fd->detect(image, keypoints, roi);
     Mat descriptors;
     de->compute(image, keypoints, descriptors);
@@ -64,7 +64,7 @@ TEST(Features2D_ORB, _1996)
     //image.setTo(Scalar(255,255,255), roi);
 
     int roiViolations = 0;
-    for(std::vector<KeyPoint>::const_iterator kp = keypoints.begin(); kp != keypoints.end(); ++kp)
+    for(KeyPointCollection::const_iterator kp = keypoints.begin(); kp != keypoints.end(); ++kp)
     {
         int x = cvRound(kp->pt.x);
         int y = cvRound(kp->pt.y);
@@ -134,11 +134,22 @@ TEST(Features2D_ORB, regression_16197)
     orbPtr->setPatchSize(8);
     orbPtr->setEdgeThreshold(8);
 
-    std::vector<KeyPoint> kps;
+    KeyPointCollection kps;
     Mat fv;
 
     // exception in debug mode, crash in release
     ASSERT_NO_THROW(orbPtr->detectAndCompute(img, noArray(), kps, fv));
+}
+
+TEST(Features2D_ORB, enhancement_10555)
+{
+    Ptr<SIFT> sift = SIFT::create();
+    vector<vector<KeyPoint> > keypoints;
+    std::vector<Mat> descriptors;
+    Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
+    sift->detect(image, keypoints);
+    Ptr<ORB> orb = ORB::create();
+    orb -> compute(image, keypoints, descriptors);
 }
 
 

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -149,13 +149,8 @@ TEST(Features2D_ORB, enhancement_10555)
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
     ASSERT_FALSE(image.empty());
 
-    Mat roi(image.size(), CV_8UC1, Scalar(0));
-
-    Point poly[] = {Point(100, 20), Point(300, 50), Point(400, 200), Point(10, 500)};
-    fillConvexPoly(roi, poly, int(sizeof(poly) / sizeof(poly[0])), Scalar(255));
-
     KeyPointCollection keypoints;
-    fd->detect(image, keypoints, roi);
+    fd->detect(image, keypoints);
     Mat descriptors;
     de->compute(image, keypoints, descriptors);
 }

--- a/modules/features2d/test/test_sift.cpp
+++ b/modules/features2d/test/test_sift.cpp
@@ -14,7 +14,7 @@ TEST(Features2d_SIFT, descriptor_type)
     Mat gray;
     cvtColor(image, gray, COLOR_BGR2GRAY);
 
-    vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     Mat descriptorsFloat, descriptorsUchar;
     Ptr<SIFT> siftFloat = cv::SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
     siftFloat->detectAndCompute(gray, Mat(), keypoints, descriptorsFloat, false);

--- a/modules/features2d/test/test_utils.cpp
+++ b/modules/features2d/test/test_utils.cpp
@@ -19,8 +19,8 @@ TEST(Features2D_KeypointUtils, retainBest_issue_12594)
     const size_t NBEST  = 3u;
     const size_t ANSWER = 6u;
 
-    std::vector<cv::KeyPoint> sorted_cv(N);
-    std::vector<cv::KeyPoint> unsorted_cv(N);
+    KeyPointCollection sorted_cv(N);
+    KeyPointCollection unsorted_cv(N);
 
     for (size_t i = 0; i < N; ++i)
     {

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -511,7 +511,7 @@ typedef std::vector<Vec4i> vector_Vec4i;
 typedef std::vector<Rect> vector_Rect;
 typedef std::vector<Rect2d> vector_Rect2d;
 typedef std::vector<RotatedRect> vector_RotatedRect;
-typedef std::vector<KeyPoint> vector_KeyPoint;
+typedef KeyPointCollection vector_KeyPoint;
 typedef std::vector<Mat> vector_Mat;
 typedef std::vector<std::vector<Mat> > vector_vector_Mat;
 typedef std::vector<UMat> vector_UMat;
@@ -524,7 +524,7 @@ typedef std::vector<std::vector<Point> > vector_vector_Point;
 typedef std::vector<std::vector<Point2f> > vector_vector_Point2f;
 typedef std::vector<std::vector<Point3f> > vector_vector_Point3f;
 typedef std::vector<std::vector<DMatch> > vector_vector_DMatch;
-typedef std::vector<std::vector<KeyPoint> > vector_vector_KeyPoint;
+typedef std::vector<KeyPointCollection > vector_vector_KeyPoint;
 
 class NumpyAllocator : public MatAllocator
 {
@@ -1676,12 +1676,12 @@ template<> struct pyopencvVecConverter<UMat>
 
 template<> struct pyopencvVecConverter<KeyPoint>
 {
-    static bool to(PyObject* obj, std::vector<KeyPoint>& value, const ArgInfo& info)
+    static bool to(PyObject* obj, KeyPointCollection& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
 
-    static PyObject* from(const std::vector<KeyPoint>& value)
+    static PyObject* from(const KeyPointCollection& value)
     {
         return pyopencv_from_generic_vec(value);
     }

--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -63,7 +63,7 @@ struct CV_EXPORTS ImageFeatures
 {
     int img_idx;
     Size img_size;
-    std::vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     UMat descriptors;
 };
 

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -536,7 +536,7 @@ void OrbFeaturesFinder::find(InputArray image, ImageFeatures &features)
         features.keypoints.clear();
         features.descriptors.release();
 
-        std::vector<KeyPoint> points;
+        KeyPointCollection points;
         Mat _descriptors;
         UMat descriptors;
 
@@ -563,7 +563,7 @@ void OrbFeaturesFinder::find(InputArray image, ImageFeatures &features)
                 orb->detectAndCompute(gray_image_part, UMat(), points, descriptors);
 
                 features.keypoints.reserve(features.keypoints.size() + points.size());
-                for (std::vector<KeyPoint>::iterator kp = points.begin(); kp != points.end(); ++kp)
+                for (KeyPointCollection::iterator kp = points.begin(); kp != points.end(); ++kp)
                 {
                     kp->pt.x += xl;
                     kp->pt.y += yl;

--- a/modules/videostab/include/opencv2/videostab/global_motion.hpp
+++ b/modules/videostab/include/opencv2/videostab/global_motion.hpp
@@ -245,7 +245,7 @@ private:
     Ptr<IOutlierRejector> outlierRejector_;
 
     std::vector<uchar> status_;
-    std::vector<KeyPoint> keypointsPrev_;
+    KeyPointCollection keypointsPrev_;
     std::vector<Point2f> pointsPrev_, points_;
     std::vector<Point2f> pointsPrevGood_, pointsGood_;
 };

--- a/samples/cpp/flann_search_dataset.cpp
+++ b/samples/cpp/flann_search_dataset.cpp
@@ -81,7 +81,7 @@ int main( int argc, char* argv[] )
     return -1;
 #endif
 
-    std::vector<KeyPoint> db_keypoints;
+    KeyPointCollection db_keypoints;
     Mat db_descriptors;
     std::vector<unsigned int> db_images_indice_range; //store the range of indices per image
     std::vector<int> db_indice_2_image_lut;           //match descriptor indice to its image
@@ -94,7 +94,7 @@ int main( int argc, char* argv[] )
         Mat tmp_img = imread( *itr, IMREAD_GRAYSCALE );
         if (!tmp_img.empty())
         {
-            std::vector<KeyPoint> kpts;
+            KeyPointCollection kpts;
             Mat descriptors;
             detector->detectAndCompute( tmp_img, noArray(), kpts, descriptors );
 
@@ -148,7 +148,7 @@ int main( int argc, char* argv[] )
         return 0;
 
     //-- Detect the keypoints and compute the descriptors for the query image
-    std::vector<KeyPoint> img_keypoints;
+    KeyPointCollection img_keypoints;
     Mat img_descriptors;
     detector->detectAndCompute( img, noArray(), img_keypoints, img_descriptors );
 

--- a/samples/cpp/tutorial_code/features2D/feature_description/SURF_matching_Demo.cpp
+++ b/samples/cpp/tutorial_code/features2D/feature_description/SURF_matching_Demo.cpp
@@ -30,7 +30,7 @@ int main( int argc, char* argv[] )
     //-- Step 1: Detect the keypoints using SURF Detector, compute the descriptors
     int minHessian = 400;
     Ptr<SURF> detector = SURF::create( minHessian );
-    std::vector<KeyPoint> keypoints1, keypoints2;
+    KeyPointCollection keypoints1, keypoints2;
     Mat descriptors1, descriptors2;
     detector->detectAndCompute( img1, noArray(), keypoints1, descriptors1 );
     detector->detectAndCompute( img2, noArray(), keypoints2, descriptors2 );

--- a/samples/cpp/tutorial_code/features2D/feature_detection/SURF_detection_Demo.cpp
+++ b/samples/cpp/tutorial_code/features2D/feature_detection/SURF_detection_Demo.cpp
@@ -24,7 +24,7 @@ int main( int argc, char* argv[] )
     //-- Step 1: Detect the keypoints using SURF Detector
     int minHessian = 400;
     Ptr<SURF> detector = SURF::create( minHessian );
-    std::vector<KeyPoint> keypoints;
+    KeyPointCollection keypoints;
     detector->detect( src, keypoints );
 
     //-- Draw keypoints

--- a/samples/cpp/tutorial_code/features2D/feature_flann_matcher/SURF_FLANN_matching_Demo.cpp
+++ b/samples/cpp/tutorial_code/features2D/feature_flann_matcher/SURF_FLANN_matching_Demo.cpp
@@ -30,7 +30,7 @@ int main( int argc, char* argv[] )
     //-- Step 1: Detect the keypoints using SURF Detector, compute the descriptors
     int minHessian = 400;
     Ptr<SURF> detector = SURF::create( minHessian );
-    std::vector<KeyPoint> keypoints1, keypoints2;
+    KeyPointCollection keypoints1, keypoints2;
     Mat descriptors1, descriptors2;
     detector->detectAndCompute( img1, noArray(), keypoints1, descriptors1 );
     detector->detectAndCompute( img2, noArray(), keypoints2, descriptors2 );

--- a/samples/cpp/tutorial_code/features2D/feature_homography/SURF_FLANN_matching_homography_Demo.cpp
+++ b/samples/cpp/tutorial_code/features2D/feature_homography/SURF_FLANN_matching_homography_Demo.cpp
@@ -32,7 +32,7 @@ int main( int argc, char* argv[] )
     //-- Step 1: Detect the keypoints using SURF Detector, compute the descriptors
     int minHessian = 400;
     Ptr<SURF> detector = SURF::create( minHessian );
-    std::vector<KeyPoint> keypoints_object, keypoints_scene;
+    KeyPointCollection keypoints_object, keypoints_scene;
     Mat descriptors_object, descriptors_scene;
     detector->detectAndCompute( img_object, noArray(), keypoints_object, descriptors_object );
     detector->detectAndCompute( img_scene, noArray(), keypoints_scene, descriptors_scene );


### PR DESCRIPTION
Main objectives:
- abstract the `KeyPoint` container (`std::vector<KeyPoint>`) to add context and enable compatibility between detector/descriptors. This is done using the `KeyPointCollection` class, which is an iterable class that wraps a vector and provides other fields.
- add relevant fields to `KeyPoint` to remove the need to encode values or provide them in descriptor code. Specifically, add the `layer` field to ensure that SIFT doesn't need to encode `octave` and `layer` together anymore.
- Remove logic in descriptors which are detector specific i.e; `AKAZE` and `KAZE` enforce that the descriptor can only work with keypoints provided by their detection method, `ORB` contains a snippet to handle scaling for different detectors.

Relevant Issues:
- https://github.com/opencv/opencv/issues/10562
- https://github.com/opencv/opencv/issues/10555
- https://github.com/opencv/opencv/issues/4554
- https://github.com/opencv/opencv_contrib/issues/171
- https://github.com/kyamagu/mexopencv/issues/351
- https://stackoverflow.com/questions/16186361/strange-octave-value-in-sift-algorithm
- https://stackoverflow.com/questions/48385672/opencv-python-unpack-sift-octave
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
