### PR TITLE
Remove Octave-Layer Encoding in SIFT

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -720,8 +720,9 @@ public:
     @param _response keypoint detector response on the keypoint (that is, strength of the keypoint)
     @param _octave pyramid octave in which the keypoint has been detected
     @param _class_id object id
+    @param _layer the layer of the octave
      */
-    KeyPoint(Point2f _pt, float _size, float _angle=-1, float _response=0, int _octave=0, int _class_id=-1);
+    KeyPoint(Point2f _pt, float _size, float _angle=-1, float _response=0, int _octave=0, int _class_id=-1, int _layer=-1);
     /**
     @param x x-coordinate of the keypoint
     @param y y-coordinate of the keypoint
@@ -730,8 +731,9 @@ public:
     @param _response keypoint detector response on the keypoint (that is, strength of the keypoint)
     @param _octave pyramid octave in which the keypoint has been detected
     @param _class_id object id
+    @param _layer the layer of the octave
      */
-    CV_WRAP KeyPoint(float x, float y, float _size, float _angle=-1, float _response=0, int _octave=0, int _class_id=-1);
+    CV_WRAP KeyPoint(float x, float y, float _size, float _angle=-1, float _response=0, int _octave=0, int _class_id=-1, int _layer=-1);
 
     size_t hash() const;
 
@@ -776,6 +778,7 @@ public:
     CV_PROP_RW float response; //!< the response by which the most strong keypoints have been selected. Can be used for the further sorting or subsampling
     CV_PROP_RW int octave; //!< octave (pyramid layer) from which the keypoint has been extracted
     CV_PROP_RW int class_id; //!< object class (if the keypoints need to be clustered by an object they belong to)
+    CV_PROP_RW int layer; //!< layer of the octave (-1 if not applicable)
 };
 
 #ifdef OPENCV_TRAITS_ENABLE_DEPRECATED
@@ -2425,15 +2428,15 @@ Scalar operator * (const Matx<double, 4, 4>& a, const Scalar& b)
 
 inline
 KeyPoint::KeyPoint()
-    : pt(0,0), size(0), angle(-1), response(0), octave(0), class_id(-1) {}
+    : pt(0,0), size(0), angle(-1), response(0), octave(0), class_id(-1), layer(-1) {}
 
 inline
-KeyPoint::KeyPoint(Point2f _pt, float _size, float _angle, float _response, int _octave, int _class_id)
-    : pt(_pt), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+KeyPoint::KeyPoint(Point2f _pt, float _size, float _angle, float _response, int _octave, int _class_id, int _layer)
+    : pt(_pt), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id), layer(_layer) {}
 
 inline
-KeyPoint::KeyPoint(float x, float y, float _size, float _angle, float _response, int _octave, int _class_id)
-    : pt(x, y), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+KeyPoint::KeyPoint(float x, float y, float _size, float _angle, float _response, int _octave, int _class_id, int _layer)
+    : pt(x, y), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id), layer(_layer) {}
 
 
 

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -146,7 +146,7 @@ String SIFT::getDefaultName() const
 static inline void
 unpackOctave(const KeyPoint& kpt, int& octave, int& layer, float& scale)
 {
-    octave = kpt.octave & 255;
+    octave = kpt.octave;
     layer = kpt.layer;
     octave = octave < 128 ? octave : (-128 | octave);
     scale = octave >= 0 ? 1.f/(1 << octave) : (float)(1 << -octave);

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -147,7 +147,7 @@ static inline void
 unpackOctave(const KeyPoint& kpt, int& octave, int& layer, float& scale)
 {
     octave = kpt.octave & 255;
-    layer = (kpt.octave >> 8) & 255;
+    layer = kpt.layer;
     octave = octave < 128 ? octave : (-128 | octave);
     scale = octave >= 0 ? 1.f/(1 << octave) : (float)(1 << -octave);
 }
@@ -527,7 +527,6 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
             {
                 KeyPoint& kpt = keypoints[i];
                 float scale = 1.f/(float)(1 << -firstOctave);
-                kpt.octave = (kpt.octave & ~255) | ((kpt.octave + firstOctave) & 255);
                 kpt.pt *= scale;
                 kpt.size *= scale;
             }

--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -388,7 +388,7 @@ bool adjustLocalExtrema(
 
     kpt.pt.x = (c + xc) * (1 << octv);
     kpt.pt.y = (r + xr) * (1 << octv);
-    kpt.octave = octv + (layer << 8) + (cvRound((xi + 0.5)*255) << 16);
+    kpt.octave = octv + (cvRound((xi + 0.5)));
     kpt.size = sigma*powf(2.f, (layer + xi) / nOctaveLayers)*(1 << octv)*2;
     kpt.response = std::abs(contr);
 

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -141,5 +141,18 @@ TEST(Features2D_ORB, regression_16197)
     ASSERT_NO_THROW(orbPtr->detectAndCompute(img, noArray(), kps, fv));
 }
 
+TEST(Features2D_ORB, enhancement_10555)
+{
+    Ptr<DescriptorExtractor> fd = SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+    Ptr<FeatureDetector> de = ORB::create(10000, 1.2f, 8, 31, 0, 2, ORB::HARRIS_SCORE, 31, 20);
+
+    Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
+    ASSERT_FALSE(image.empty());
+
+    std::vector<KeyPoint> keypoints;
+    fd->detect(image, keypoints);
+    Mat descriptors;
+    ASSERT_NO_THROW(de->compute(image, keypoints, descriptors));
+}
 
 }} // namespace


### PR DESCRIPTION
 Remove the octave-layer encoding piece in SIFT. The logic around this encoding, as well as workarounds, has been discussed in various threads over the years:
- https://stackoverflow.com/questions/17015995/opencv-sift-descriptor-keypoint-radius
- https://stackoverflow.com/questions/61479729/how-to-get-the-proper-octave-for-sift-keypoints-opencv
- https://stackoverflow.com/questions/48385672/opencv-python-unpack-sift-octave
- https://stackoverflow.com/questions/16186361/strange-octave-value-in-sift-algorithm
- https://groups.google.com/g/javacv/c/E9xngMMwVW4
- https://github.com/opencv/opencv/pull/10556
- https://github.com/opencv/opencv/issues/4554


And it prevents compatibility with other descriptors:
- https://github.com/opencv/opencv/issues/10555

The change is just adding a `layer` field to `Keypoint`, which is -1 if not applicable (similar to how we treat `class_id`). This addresses https://github.com/opencv/opencv/issues/10555 and will also hopefully make things easier for developers moving forward. I recognize that this is a breaking API change, which is why I am requesting to merge with `next`.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=linux,docs
```