### PR TITLE
docs:fix python retvals

### DIFF
--- a/doc/tools/html_functions.py
+++ b/doc/tools/html_functions.py
@@ -107,17 +107,10 @@ def add_signature_to_table(soup, table, signature, language, type):
     """ Add a signature to an html table"""
     row = soup.new_tag('tr')
     row.append(soup.new_tag('td', style='width: 20px;'))
-
-    if 'ret' in signature:
-        row.append(append(soup.new_tag('td'), signature['ret']))
-        row.append(append(soup.new_tag('td'), '='))
-    else:
-        row.append(soup.new_tag('td')) # return values
-        row.append(soup.new_tag('td')) # '='
-
     row.append(append(soup.new_tag('td'), signature['name'] + '('))
     row.append(append(soup.new_tag('td', **{'class': 'paramname'}), signature['arg']))
-    row.append(append(soup.new_tag('td'), ')'))
+    row.append(append(soup.new_tag('td'), ') -> '))
+    row.append(append(soup.new_tag('td'), signature['ret']))
     table.append(row)
 
 


### PR DESCRIPTION
resolves #19896

<strike>omit generating a return value for `None` in the docs</strike>
[edit] generate a more pythonic `func() -> ret` signature

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
