### PR TITLE
Update SIFT Descriptor Calculation

### DIFF
--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -566,13 +566,13 @@ void calcSIFTDescriptor(
     float bins_per_rad = n / 360.f;
     float exp_scale = -1.f/(d * d * 0.5f);
     float hist_width = SIFT_DESCR_SCL_FCTR * scl;
-    int radius = cvRound(hist_width * 1.4142135623730951f * (d + 1) * 0.5f);
+    int radius = cvRound(hist_width * 1.4142135623730951f * (d + 1) * 0.5f + 0.5f);
     // Clip the radius to the diagonal of the image to avoid autobuffer too large exception
     radius = std::min(radius, (int)std::sqrt(((double) img.cols)*img.cols + ((double) img.rows)*img.rows));
     cos_t /= hist_width;
     sin_t /= hist_width;
 
-    int i, j, k, len = (radius*2+1)*(radius*2+1), histlen = (d+2)*(d+2)*(n+2);
+    int len = (radius*2+1)*(radius*2+1), histlen = (d+2)*(d+2)*(n+2);
     int rows = img.rows, cols = img.cols;
 
     cv::utils::BufferArea area;
@@ -588,6 +588,7 @@ void calcSIFTDescriptor(
     area.commit();
     Mag = Y;
 
+    int i, j, k;
     for( i = 0; i < d+2; i++ )
     {
         for( j = 0; j < d+2; j++ )


### PR DESCRIPTION
An issue brought up in https://github.com/opencv/opencv/issues/4620 (albeit not super clearly) is that the implementation of SIFT in OpenCV, while based on the OpenSift implementation (https://github.com/robwhess/opensift), has some discrepancies when compared to that version. The specific issue mentioned isn't a problem (as pointed out in my comment), but I did notice one discrepancy in how we're assigning `radius`. Specifically, it seems like we're missing a 0.5 (https://github.com/robwhess/opensift/blob/master/src/sift.c#L1082). In this PR, I add it, and I remove the unused initialization of our loop variables.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
