### PR TITLE
Handle Octave Dependence in SIFT Descriptor Calculation

### DIFF
--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -481,7 +481,6 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( useProvidedKeypoints )
     {
-        firstOctave = -1;
         int maxOctave = INT_MIN;
         for( size_t i = 0; i < keypoints.size(); i++ )
         {

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -481,7 +481,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( useProvidedKeypoints )
     {
-        firstOctave = 0;
+        firstOctave = keypoints.size() > 1 ? 0 : -1; // handle edge case if only a single keypoint is supplied
         int maxOctave = INT_MIN;
         for( size_t i = 0; i < keypoints.size(); i++ )
         {

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -481,29 +481,24 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( useProvidedKeypoints )
     {
-        firstOctave = 0;
         int maxOctave = INT_MIN;
         for( size_t i = 0; i < keypoints.size(); i++ )
         {
             int octave, layer;
             float scale;
             unpackOctave(keypoints[i], octave, layer, scale);
-            firstOctave = std::min(firstOctave, octave);
             maxOctave = std::max(maxOctave, octave);
             actualNLayers = std::max(actualNLayers, layer-2);
         }
-
-        firstOctave = std::min(firstOctave, 0);
         CV_Assert( firstOctave >= -1 && actualNLayers <= nOctaveLayers );
         actualNOctaves = maxOctave - firstOctave + 1;
     }
-    Mat base = createInitialImage(image, firstOctave < 0, (float)sigma);
+    Mat base = createInitialImage(image, true, (float)sigma);
     std::vector<Mat> gpyr;
     int nOctaves = actualNOctaves > 0 ? actualNOctaves : cvRound(std::log( (double)std::min( base.cols, base.rows ) ) / std::log(2.) - 2) - firstOctave;
     //double t, tf = getTickFrequency();
     //t = (double)getTickCount();
     buildGaussianPyramid(base, gpyr, nOctaves);
-
     //t = (double)getTickCount() - t;
     //printf("pyramid construction time: %g\n", t*1000./tf);
 

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -481,6 +481,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( useProvidedKeypoints )
     {
+        firstOctave = 0;
         int maxOctave = INT_MIN;
         for( size_t i = 0; i < keypoints.size(); i++ )
         {
@@ -496,11 +497,9 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
         CV_Assert( firstOctave >= -1 && actualNLayers <= nOctaveLayers );
         actualNOctaves = maxOctave - firstOctave + 1;
     }
-
     Mat base = createInitialImage(image, firstOctave < 0, (float)sigma);
     std::vector<Mat> gpyr;
     int nOctaves = actualNOctaves > 0 ? actualNOctaves : cvRound(std::log( (double)std::min( base.cols, base.rows ) ) / std::log(2.) - 2) - firstOctave;
-
     //double t, tf = getTickFrequency();
     //t = (double)getTickCount();
     buildGaussianPyramid(base, gpyr, nOctaves);

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -481,7 +481,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
 
     if( useProvidedKeypoints )
     {
-        firstOctave = keypoints.size() > 1 ? 0 : -1; // handle edge case if only a single keypoint is supplied
+        firstOctave = -1;
         int maxOctave = INT_MIN;
         for( size_t i = 0; i < keypoints.size(); i++ )
         {

--- a/modules/features2d/test/test_sift.cpp
+++ b/modules/features2d/test/test_sift.cpp
@@ -30,5 +30,22 @@ TEST(Features2d_SIFT, descriptor_type)
     ASSERT_EQ(countNonZero(diff), 0) << "descriptors are not identical";
 }
 
+TEST(Features2d_SIFT, 177_octave_independence)
+{
+    Ptr<SIFT> sift = cv::SIFT::create(10, 5, 0.01, 10, 1.1, CV_32F);
+
+    Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");
+    ASSERT_FALSE(image.empty());
+
+    vector<KeyPoint> keypoints;
+    sift->detect(image, keypoints);
+    Mat descriptorsAll, descriptorsOne;
+    vector<KeyPoint> oneKeypoint(keypoints.begin(), keypoints.begin()+1);
+    sift->compute(image, keypoints, descriptorsAll);
+    sift->compute(image, oneKeypoint, descriptorsOne);
+    // I should be able to provide all keypoints or one keypoint and get the same descriptor value
+    ASSERT_EQ(descriptorsAll.at<float>(0, 1), descriptorsOne.at<float>(0, 1));
+}
+
 
 }} // namespace


### PR DESCRIPTION
Handle the case where a collection of keypoints is provided and none of them have an octave of -1 - there is some logic which depends on `firstOctave` being negative, such as doubling the image size and building the gaussian pyramid, and that can have an effect on the computed descriptors. The test verifies this approach by running `compute` on all keypoints, then again on only keypoints with a positive octave, and without the PR change, the descriptors are indeed different.

Notice in the original logic, we were just checking to see if we could find a Keypoint with an octave of -1, and otherwise setting `firstOctave` to 0. Rather than go through that, we just keep `firstOctave` set to -1, and remove any reassignment logic.  This addresses https://github.com/opencv/opencv_contrib/issues/171. 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
