### PR TITLE
Fix header sorting for modules without headers

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -877,7 +877,9 @@ macro(_ocv_create_module)
 
   ocv_compiler_optimization_process_sources(OPENCV_MODULE_${the_module}_SOURCES OPENCV_MODULE_${the_module}_DEPS_EXT ${the_module})
   set(__module_headers ${OPENCV_MODULE_${the_module}_HEADERS})
-  list(SORT __module_headers)  # fix headers order, useful for bindings
+  if(__module_headers)
+    list(SORT __module_headers)  # fix headers order, useful for bindings
+  endif()
   set(OPENCV_MODULE_${the_module}_HEADERS ${__module_headers} CACHE INTERNAL "List of header files for ${the_module}")
   set(OPENCV_MODULE_${the_module}_SOURCES ${OPENCV_MODULE_${the_module}_SOURCES} CACHE INTERNAL "List of source files for ${the_module}")
 


### PR DESCRIPTION
related #19819
There can exist modules without headers causing configuration issue:
```
CMake Error at /opencv/cmake/OpenCVModule.cmake:883 (list):
  list sub-command SORT requires list to be present.
```
