### PR TITLE
Fix Matcher Confidence Handling

### DIFF
--- a/modules/flann/src/kdtree_index.cpp
+++ b/modules/flann/src/kdtree_index.cpp
@@ -1,0 +1,9 @@
+//
+// Created by daniel on 4/18/21.
+//
+
+#include "general.h"
+#include "kdtree_index.h"
+
+cvflann::KDTreeIndex<cvflann::L2<float> >::heap_ = nullptr;
+cvflann::KDTreeIndex<cvflann::L1<float> >::heap_ = nullptr;

--- a/modules/flann/src/kdtree_index.cpp
+++ b/modules/flann/src/kdtree_index.cpp
@@ -1,9 +1,0 @@
-//
-// Created by daniel on 4/18/21.
-//
-
-#include "general.h"
-#include "kdtree_index.h"
-
-cvflann::KDTreeIndex<cvflann::L2<float> >::heap_ = nullptr;
-cvflann::KDTreeIndex<cvflann::L1<float> >::heap_ = nullptr;

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -766,8 +766,7 @@ void BestOf2NearestMatcher::match(const ImageFeatures &features1, const ImageFea
     // using Invariant Features"
     matches_info.confidence = matches_info.num_inliers / (8 + 0.3 * matches_info.matches.size());
 
-    // Set zero confidence to remove matches between too close images, as they don't provide
-    // additional information anyway. The threshold was set experimentally.
+    /* should we remove matches between too close images? */
     // matches_info.confidence = matches_info.confidence > 3. ? 0. : matches_info.confidence;
 
     // Check if we should try to refine motion

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -768,7 +768,7 @@ void BestOf2NearestMatcher::match(const ImageFeatures &features1, const ImageFea
 
     // Set zero confidence to remove matches between too close images, as they don't provide
     // additional information anyway. The threshold was set experimentally.
-    matches_info.confidence = matches_info.confidence > 3. ? 0. : matches_info.confidence;
+    // matches_info.confidence = matches_info.confidence > 3. ? 0. : matches_info.confidence;
 
     // Check if we should try to refine motion
     if (matches_info.num_inliers < num_matches_thresh2_)


### PR DESCRIPTION
Per the issue https://github.com/opencv/opencv/issues/11084, we don't throw high confidence matches in `AffineBestOf2NearestMatcher`, but we do in `BestOf2NearestMatcher`. In this PR, I am commenting out the line for consistency across the two feature matchers (it's currently commented out in the affine as well). An alternative idea is making this threshold configurable.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
