### PR TITLE
Explicit usage of int64_t in CropAndResizeLayer (IE backend)

### DIFF
--- a/modules/dnn/src/layers/crop_and_resize_layer.cpp
+++ b/modules/dnn/src/layers/crop_and_resize_layer.cpp
@@ -125,14 +125,15 @@ public:
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         auto rois = nodes[1].dynamicCast<InfEngineNgraphNode>()->node;
 
-        std::vector<size_t> dims = rois->get_shape(), offsets(4, 0);
+        auto rois_shape = rois->get_shape();
+        std::vector<int64_t> dims(rois_shape.begin(), rois_shape.end()), offsets(4, 0);
         offsets[3] = 2;
         dims[3] = 7;
 
         auto lower_bounds = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
-                                             ngraph::Shape{offsets.size()}, std::vector<int64_t>(offsets.begin(), offsets.end()));
+                                             ngraph::Shape{offsets.size()}, offsets.data());
         auto upper_bounds = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
-                                             ngraph::Shape{dims.size()}, std::vector<int64_t>(dims.begin(), dims.end()));
+                                             ngraph::Shape{dims.size()}, dims.data());
         auto strides = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
                                         ngraph::Shape{dims.size()}, std::vector<int64_t>((int64_t)dims.size(), 1));
         auto slice = std::make_shared<ngraph::op::v1::StridedSlice>(rois,

--- a/modules/dnn/src/layers/crop_and_resize_layer.cpp
+++ b/modules/dnn/src/layers/crop_and_resize_layer.cpp
@@ -140,7 +140,7 @@ public:
                                       lower_bounds, upper_bounds, strides, std::vector<int64_t>{}, std::vector<int64_t>{});
 
         // Reshape rois from 4D to 2D
-        std::vector<int64_t> shapeData = {(int64_t)dims[2], 5};
+        std::vector<int64_t> shapeData = {dims[2], 5};
         auto shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{2}, shapeData.data());
         auto reshape = std::make_shared<ngraph::op::v1::Reshape>(slice, shape, true);
 

--- a/modules/dnn/src/layers/crop_and_resize_layer.cpp
+++ b/modules/dnn/src/layers/crop_and_resize_layer.cpp
@@ -139,7 +139,7 @@ public:
                                       lower_bounds, upper_bounds, strides, std::vector<int64_t>{}, std::vector<int64_t>{});
 
         // Reshape rois from 4D to 2D
-        std::vector<int64_t> shapeData = {dims[2], 5};
+        std::vector<int64_t> shapeData = {(int64_t)dims[2], 5};
         auto shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{2}, shapeData.data());
         auto reshape = std::make_shared<ngraph::op::v1::Reshape>(slice, shape, true);
 

--- a/modules/dnn/src/layers/crop_and_resize_layer.cpp
+++ b/modules/dnn/src/layers/crop_and_resize_layer.cpp
@@ -130,16 +130,16 @@ public:
         dims[3] = 7;
 
         auto lower_bounds = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
-                                             ngraph::Shape{offsets.size()}, offsets.data());
+                                             ngraph::Shape{offsets.size()}, std::vector<int64_t>(offsets.begin(), offsets.end()));
         auto upper_bounds = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
-                                             ngraph::Shape{dims.size()}, dims.data());
+                                             ngraph::Shape{dims.size()}, std::vector<int64_t>(dims.begin(), dims.end()));
         auto strides = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
                                         ngraph::Shape{dims.size()}, std::vector<int64_t>((int64_t)dims.size(), 1));
         auto slice = std::make_shared<ngraph::op::v1::StridedSlice>(rois,
                                       lower_bounds, upper_bounds, strides, std::vector<int64_t>{}, std::vector<int64_t>{});
 
         // Reshape rois from 4D to 2D
-        std::vector<size_t> shapeData = {dims[2], 5};
+        std::vector<int64_t> shapeData = {dims[2], 5};
         auto shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{2}, shapeData.data());
         auto reshape = std::make_shared<ngraph::op::v1::Reshape>(slice, shape, true);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

The fix complements [#17998](https://github.com/opencv/opencv/pull/17998)

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```