### PR TITLE
Initial oneVPL support

### DIFF
--- a/modules/videoio/cmake/detect_msdk.cmake
+++ b/modules/videoio/cmake/detect_msdk.cmake
@@ -1,3 +1,16 @@
+set(MFX_DEFS "")
+
+if(NOT HAVE_MFX)
+  find_package(VPL)
+  if(VPL_FOUND)
+    set(MFX_INCLUDE_DIRS "")
+    set(MFX_LIBRARIES "${VPL_IMPORTED_TARGETS}")
+    set(HAVE_MFX TRUE)
+    list(APPEND MFX_DEFS "HAVE_ONEVPL")
+  endif()
+endif()
+
+
 if(NOT HAVE_MFX)
   set(paths "${MFX_HOME}" ENV "MFX_HOME" ENV "INTELMEDIASDKROOT")
   if(MSVC)
@@ -24,6 +37,7 @@ if(NOT HAVE_MFX)
     set(HAVE_MFX TRUE)
     set(MFX_INCLUDE_DIRS "${MFX_INCLUDE}")
     set(MFX_LIBRARIES "${MFX_LIBRARY}")
+    list(APPEND MFX_DEFS "HAVE_MFX_PLUGIN")
   endif()
 endif()
 
@@ -49,7 +63,8 @@ if(HAVE_MFX AND UNIX)
 endif()
 
 if(HAVE_MFX)
-  ocv_add_external_target(mediasdk "${MFX_INCLUDE_DIRS}" "${MFX_LIBRARIES}" "HAVE_MFX")
+  list(APPEND MFX_DEFS "HAVE_MFX")
+  ocv_add_external_target(mediasdk "${MFX_INCLUDE_DIRS}" "${MFX_LIBRARIES}" "${MFX_DEFS}")
 endif()
 
 set(HAVE_MFX ${HAVE_MFX} PARENT_SCOPE)


### PR DESCRIPTION
* https://github.com/oneapi-src/oneVPL
* https://oneapi-src.github.io/oneAPI-spec/elements/oneVPL/source/VPL_intel_media_sdk.html
* uses legacy MediaSDK interface

Things to do on the next step:
* don't use `mfxvideo++.h`
* init using `MFXLoad()`

Tested with open-source version on Windows and oneAPI 2021.2 on Windows and Linux.

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```