### PR TITLE
Fix seam finder in stitching_detailed.py

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -49,8 +49,6 @@ except AttributeError:
     print("AKAZE not available")
 
 SEAM_FIND_CHOICES = OrderedDict()
-SEAM_FIND_CHOICES['gc_color'] = cv.detail_GraphCutSeamFinder('COST_COLOR')
-SEAM_FIND_CHOICES['gc_colorgrad'] = cv.detail_GraphCutSeamFinder('COST_COLOR_GRAD')
 SEAM_FIND_CHOICES['dp_color'] = cv.detail_DpSeamFinder('COLOR')
 SEAM_FIND_CHOICES['dp_colorgrad'] = cv.detail_DpSeamFinder('COLOR_GRAD')
 SEAM_FIND_CHOICES['voronoi'] = cv.detail.SeamFinder_createDefault(cv.detail.SeamFinder_VORONOI_SEAM)
@@ -433,7 +431,7 @@ def main():
     compensator.feed(corners=corners, images=images_warped, masks=masks_warped)
 
     seam_finder = SEAM_FIND_CHOICES[args.seam]
-    seam_finder.find(images_warped_f, corners, masks_warped)
+    masks_warped = seam_finder.find(images_warped_f, corners, masks_warped)
     compose_scale = 1
     corners = []
     sizes = []


### PR DESCRIPTION
Seam finder in stitching_detailed.py does not update the masks and output panorama looks blurry because of that. The blurryness problem was mentioned in issue #[14413](https://github.com/opencv/opencv/issues/14413) and seam finder update problem was mention in issue [#15520](https://github.com/opencv/opencv/issues/15520). 

To fix the updating problem, DP and Voronoi seam finder result needs to be assigned to a variable. In addition, graph cut seam finder should be removed from the script as it returns None.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
