### PR TITLE
Adding functions rbegin() and rend() functions to matrix class.

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2013,7 +2013,7 @@ public:
 
     /** @brief Same as begin() but for inverse traversal
      */
-    template<typename _Tp>   std::reverse_iterator<MatIterator_<_Tp>> rbegin();
+    template<typename _Tp> std::reverse_iterator<MatIterator_<_Tp>> rbegin();
     template<typename _Tp> std::reverse_iterator<MatConstIterator_<_Tp>> rbegin() const;
 
     /** @brief Returns the matrix iterator and sets it to the after-last matrix element.

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2011,6 +2011,11 @@ public:
     template<typename _Tp> MatIterator_<_Tp> begin();
     template<typename _Tp> MatConstIterator_<_Tp> begin() const;
 
+    /** @brief Same as begin() but for inverse traversal
+     */
+    template<typename _Tp>   std::reverse_iterator<MatIterator_<_Tp>> rbegin();
+    template<typename _Tp> std::reverse_iterator<MatConstIterator_<_Tp>> rbegin() const;
+
     /** @brief Returns the matrix iterator and sets it to the after-last matrix element.
 
     The methods return the matrix read-only or read-write iterators, set to the point following the last
@@ -2018,6 +2023,12 @@ public:
      */
     template<typename _Tp> MatIterator_<_Tp> end();
     template<typename _Tp> MatConstIterator_<_Tp> end() const;
+
+    /** @brief Same as end() but for inverse traversal
+     */
+    template<typename _Tp> std::reverse_iterator< MatIterator_<_Tp>> rend();
+    template<typename _Tp> std::reverse_iterator< MatConstIterator_<_Tp>> rend() const;
+
 
     /** @brief Runs the given functor over all matrix elements in parallel.
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2261,6 +2261,12 @@ public:
     const_iterator begin() const;
     const_iterator end() const;
 
+    //reverse iterators
+    std::reverse_iterator<iterator> rbegin();
+    std::reverse_iterator<iterator> rend();
+    std::reverse_iterator<const_iterator> rbegin() const;
+    std::reverse_iterator<const_iterator> rend() const;
+
     //! template methods for for operation over all matrix elements.
     // the operations take care of skipping gaps in the end of rows (if any)
     template<typename Functor> void forEach(const Functor& operation);

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1754,9 +1754,21 @@ MatConstIterator_<_Tp> Mat_<_Tp>::begin() const
 }
 
 template<typename _Tp> inline
+std::reverse_iterator<MatConstIterator_<_Tp>> Mat_<_Tp>::rbegin() const
+{
+    return Mat::rbegin<_Tp>();
+}
+
+template<typename _Tp> inline
 MatConstIterator_<_Tp> Mat_<_Tp>::end() const
 {
     return Mat::end<_Tp>();
+}
+
+template<typename _Tp> inline
+std::reverse_iterator<MatConstIterator_<_Tp>> Mat_<_Tp>::rend() const
+{
+    return Mat::rend<_Tp>();
 }
 
 template<typename _Tp> inline
@@ -1766,9 +1778,21 @@ MatIterator_<_Tp> Mat_<_Tp>::begin()
 }
 
 template<typename _Tp> inline
+std::reverse_iterator<MatIterator_<_Tp>> Mat_<_Tp>::rbegin()
+{
+    return Mat::rbegin<_Tp>();
+}
+
+template<typename _Tp> inline
 MatIterator_<_Tp> Mat_<_Tp>::end()
 {
     return Mat::end<_Tp>();
+}
+
+template<typename _Tp> inline
+std::reverse_iterator<MatIterator_<_Tp>> Mat_<_Tp>::rend()
+{
+    return Mat::rend<_Tp>();
 }
 
 template<typename _Tp> template<typename Functor> inline

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1016,6 +1016,17 @@ MatConstIterator_<_Tp> Mat::begin() const
 }
 
 template<typename _Tp> inline
+std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rbegin() const
+{
+    if (empty())
+        return MatConstIterator_<_Tp>();
+    CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    MatConstIterator_<_Tp> it((const Mat_<_Tp>*)this);
+    it += total();
+    return std::reverse_iterator<MatConstIterator_<_Tp>> (it);
+}
+
+template<typename _Tp> inline
 MatConstIterator_<_Tp> Mat::end() const
 {
     if (empty())
@@ -1024,6 +1035,15 @@ MatConstIterator_<_Tp> Mat::end() const
     MatConstIterator_<_Tp> it((const Mat_<_Tp>*)this);
     it += total();
     return it;
+}
+
+template<typename _Tp> inline
+std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rend() const
+{
+    if (empty())
+        return MatConstIterator_<_Tp>();
+    CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    return std::reverse_iterator<MatConstIterator_<_Tp>>((const Mat_<_Tp>*)this);
 }
 
 template<typename _Tp> inline
@@ -1036,6 +1056,18 @@ MatIterator_<_Tp> Mat::begin()
 }
 
 template<typename _Tp> inline
+std::reverse_iterator<MatIterator_<_Tp>> Mat::rbegin()
+{
+    if (empty())
+        return MatIterator_<_Tp>();
+    CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    MatIterator_<_Tp> it((Mat_<_Tp>*)this);
+    it += total();
+    return  std::reverse_iterator<MatIterator_<_Tp>>(it);
+
+}
+
+template<typename _Tp> inline
 MatIterator_<_Tp> Mat::end()
 {
     if (empty())
@@ -1044,6 +1076,15 @@ MatIterator_<_Tp> Mat::end()
     MatIterator_<_Tp> it((Mat_<_Tp>*)this);
     it += total();
     return it;
+}
+
+template<typename _Tp> inline
+std::reverse_iterator<MatIterator_<_Tp>> Mat::rend()
+{
+    if (empty())
+        return MatIterator_<_Tp>();
+    CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    return std::reverse_iterator<MatIterator_<_Tp>>(MatIterator_<_Tp>((Mat_<_Tp>*)this));
 }
 
 template<typename _Tp, typename Functor> inline

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1063,8 +1063,7 @@ std::reverse_iterator<MatIterator_<_Tp>> Mat::rbegin()
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     MatIterator_<_Tp> it((Mat_<_Tp>*)this);
     it += total();
-    return  std::reverse_iterator<MatIterator_<_Tp>>(it);
-
+    return std::reverse_iterator<MatIterator_<_Tp>>(it);
 }
 
 template<typename _Tp> inline

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1019,7 +1019,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rbegin() const
 {
     if (empty())
-        return MatConstIterator_<_Tp>();
+        return std::reverse_iterator<MatConstIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     MatConstIterator_<_Tp> it((const Mat_<_Tp>*)this);
     it += total();
@@ -1041,7 +1041,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatConstIterator_<_Tp>> Mat::rend() const
 {
     if (empty())
-        return MatConstIterator_<_Tp>();
+        return std::reverse_iterator<MatConstIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     return std::reverse_iterator<MatConstIterator_<_Tp>>((const Mat_<_Tp>*)this);
 }
@@ -1059,7 +1059,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatIterator_<_Tp>> Mat::rbegin()
 {
     if (empty())
-        return MatIterator_<_Tp>();
+        return std::reverse_iterator<MatIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     MatIterator_<_Tp> it((Mat_<_Tp>*)this);
     it += total();
@@ -1082,7 +1082,7 @@ template<typename _Tp> inline
 std::reverse_iterator<MatIterator_<_Tp>> Mat::rend()
 {
     if (empty())
-        return MatIterator_<_Tp>();
+        return std::reverse_iterator<MatIterator_<_Tp>>();
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
     return std::reverse_iterator<MatIterator_<_Tp>>(MatIterator_<_Tp>((Mat_<_Tp>*)this));
 }

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2390,7 +2390,7 @@ TEST(Mat, reverse_iterator_19967)
     EXPECT_EQ(mismatch_it_pair_1d.second, m_1d.rend<uchar>());
 
     //Templated derived class
-    cv::Mat_<uchar> m_1d_t(sizes_1d.size(), sizes_1d.data(), data.data());
+    cv::Mat_<uchar> m_1d_t(static_cast<int>(sizes_1d.size()), sizes_1d.data(), data.data());
     auto mismatch_it_pair_1d_t = std::mismatch(data.rbegin(), data.rend(), m_1d_t.rbegin());
     EXPECT_EQ(mismatch_it_pair_1d_t.first, data.rend());  // expect no mismatch
     EXPECT_EQ(mismatch_it_pair_1d_t.second, m_1d_t.rend());
@@ -2406,7 +2406,7 @@ TEST(Mat, reverse_iterator_19967)
     EXPECT_EQ(mismatch_it_pair_2d.second, m_2d.rend<uchar>());
 
     //Templated derived class
-    cv::Mat_<uchar> m_2d_t(sizes_2d.size(),sizes_2d.data(), data.data());
+    cv::Mat_<uchar> m_2d_t(static_cast<int>(sizes_2d.size()),sizes_2d.data(), data.data());
     auto mismatch_it_pair_2d_t = std::mismatch(data.rbegin(), data.rend(), m_2d_t.rbegin());
     EXPECT_EQ(mismatch_it_pair_2d_t.first, data.rend());
     EXPECT_EQ(mismatch_it_pair_2d_t.second, m_2d_t.rend());
@@ -2422,7 +2422,7 @@ TEST(Mat, reverse_iterator_19967)
     EXPECT_EQ(mismatch_it_pair_3d.second, m_3d.rend<uchar>());
 
     //Templated derived class
-    cv::Mat_<uchar> m_3d_t(sizes_3d.size(),sizes_3d.data(), data_3d.data());
+    cv::Mat_<uchar> m_3d_t(static_cast<int>(sizes_3d.size()),sizes_3d.data(), data_3d.data());
     auto mismatch_it_pair_3d_t = std::mismatch(data_3d.rbegin(), data_3d.rend(), m_3d_t.rbegin());
     EXPECT_EQ(mismatch_it_pair_3d_t.first, data_3d.rend());
     EXPECT_EQ(mismatch_it_pair_3d_t.second, m_3d_t.rend());
@@ -2438,7 +2438,7 @@ TEST(Mat, reverse_iterator_19967)
     EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rbegin<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
 
     // const test templated dervied class
-    const cv::Mat_<uchar> m_1d_const_t(sizes_1d.size(), sizes_1d.data(), data.data());
+    const cv::Mat_<uchar> m_1d_const_t(static_cast<int>(sizes_1d.size()), sizes_1d.data(), data.data());
 
     auto mismatch_it_pair_1d_const_t = std::mismatch(data.rbegin(), data.rend(), m_1d_const_t.rbegin());
     EXPECT_EQ(mismatch_it_pair_1d_const_t.first, data.rend());  // expect no mismatch

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2371,4 +2371,49 @@ TEST(Mat, ptrVecni_20044)
     EXPECT_EQ(int(6), *(ci));
 }
 
+TEST(Mat, reverse_iterator_19967)
+{
+    // empty iterator (#16855)
+    cv::Mat m_empty;
+    EXPECT_NO_THROW(m_empty.rbegin<uchar>());
+    EXPECT_NO_THROW(m_empty.rend<uchar>());
+    EXPECT_TRUE(m_empty.rbegin<uchar>() == m_empty.rend<uchar>());
+
+    // 1D test
+    std::vector<uchar> data{0, 1, 2, 3};
+    const std::vector<int> sizes_1d{4};
+    cv::Mat m_1d(sizes_1d, CV_8U, data.data());
+
+    auto mismatch_it_pair_1d = std::mismatch(data.rbegin(), data.rend(), m_1d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_1d.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d.second, m_1d.rend<uchar>());
+
+    // 2D test
+    const std::vector<int> sizes_2d{2, 2};
+    cv::Mat m_2d(sizes_2d, CV_8U, data.data());
+
+    auto mismatch_it_pair_2d = std::mismatch(data.rbegin(), data.rend(), m_2d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_2d.first, data.rend());
+    EXPECT_EQ(mismatch_it_pair_2d.second, m_2d.rend<uchar>());
+
+    // 3D test
+    std::vector<uchar> data_3d{0, 1, 2, 3, 4, 5, 6, 7};
+    const std::vector<int> sizes_3d{2, 2, 2};
+    cv::Mat m_3d(sizes_3d, CV_8U, data_3d.data());
+
+    auto mismatch_it_pair_3d = std::mismatch(data_3d.rbegin(), data_3d.rend(), m_3d.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_3d.first, data_3d.rend());
+    EXPECT_EQ(mismatch_it_pair_3d.second, m_3d.rend<uchar>());
+
+    // const test
+    const cv::Mat m_1d_const(sizes_1d, CV_8U, data.data());
+
+    auto mismatch_it_pair_1d_const = std::mismatch(data.rbegin(), data.rend(), m_1d_const.rbegin<uchar>());
+    EXPECT_EQ(mismatch_it_pair_1d_const.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d_const.second, m_1d_const.rend<uchar>());
+
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rend<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rbegin<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
+}
+
 }} // namespace

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2382,30 +2382,52 @@ TEST(Mat, reverse_iterator_19967)
     // 1D test
     std::vector<uchar> data{0, 1, 2, 3};
     const std::vector<int> sizes_1d{4};
-    cv::Mat m_1d(sizes_1d, CV_8U, data.data());
 
+    //Base class
+    cv::Mat m_1d(sizes_1d, CV_8U, data.data());
     auto mismatch_it_pair_1d = std::mismatch(data.rbegin(), data.rend(), m_1d.rbegin<uchar>());
     EXPECT_EQ(mismatch_it_pair_1d.first, data.rend());  // expect no mismatch
     EXPECT_EQ(mismatch_it_pair_1d.second, m_1d.rend<uchar>());
 
+    //Templated derived class
+    cv::Mat_<uchar> m_1d_t(sizes_1d.size(), sizes_1d.data(), data.data());
+    auto mismatch_it_pair_1d_t = std::mismatch(data.rbegin(), data.rend(), m_1d_t.rbegin());
+    EXPECT_EQ(mismatch_it_pair_1d_t.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d_t.second, m_1d_t.rend());
+
+
     // 2D test
     const std::vector<int> sizes_2d{2, 2};
-    cv::Mat m_2d(sizes_2d, CV_8U, data.data());
 
+    //Base class
+    cv::Mat m_2d(sizes_2d, CV_8U, data.data());
     auto mismatch_it_pair_2d = std::mismatch(data.rbegin(), data.rend(), m_2d.rbegin<uchar>());
     EXPECT_EQ(mismatch_it_pair_2d.first, data.rend());
     EXPECT_EQ(mismatch_it_pair_2d.second, m_2d.rend<uchar>());
 
+    //Templated derived class
+    cv::Mat_<uchar> m_2d_t(sizes_2d.size(),sizes_2d.data(), data.data());
+    auto mismatch_it_pair_2d_t = std::mismatch(data.rbegin(), data.rend(), m_2d_t.rbegin());
+    EXPECT_EQ(mismatch_it_pair_2d_t.first, data.rend());
+    EXPECT_EQ(mismatch_it_pair_2d_t.second, m_2d_t.rend());
+
     // 3D test
     std::vector<uchar> data_3d{0, 1, 2, 3, 4, 5, 6, 7};
     const std::vector<int> sizes_3d{2, 2, 2};
-    cv::Mat m_3d(sizes_3d, CV_8U, data_3d.data());
 
+    //Base class
+    cv::Mat m_3d(sizes_3d, CV_8U, data_3d.data());
     auto mismatch_it_pair_3d = std::mismatch(data_3d.rbegin(), data_3d.rend(), m_3d.rbegin<uchar>());
     EXPECT_EQ(mismatch_it_pair_3d.first, data_3d.rend());
     EXPECT_EQ(mismatch_it_pair_3d.second, m_3d.rend<uchar>());
 
-    // const test
+    //Templated derived class
+    cv::Mat_<uchar> m_3d_t(sizes_3d.size(),sizes_3d.data(), data_3d.data());
+    auto mismatch_it_pair_3d_t = std::mismatch(data_3d.rbegin(), data_3d.rend(), m_3d_t.rbegin());
+    EXPECT_EQ(mismatch_it_pair_3d_t.first, data_3d.rend());
+    EXPECT_EQ(mismatch_it_pair_3d_t.second, m_3d_t.rend());
+
+    // const test base class
     const cv::Mat m_1d_const(sizes_1d, CV_8U, data.data());
 
     auto mismatch_it_pair_1d_const = std::mismatch(data.rbegin(), data.rend(), m_1d_const.rbegin<uchar>());
@@ -2414,6 +2436,17 @@ TEST(Mat, reverse_iterator_19967)
 
     EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rend<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
     EXPECT_FALSE((std::is_assignable<decltype(m_1d_const.rbegin<uchar>()), uchar>::value)) << "Constness of const iterator violated.";
+
+    // const test templated dervied class
+    const cv::Mat_<uchar> m_1d_const_t(sizes_1d.size(), sizes_1d.data(), data.data());
+
+    auto mismatch_it_pair_1d_const_t = std::mismatch(data.rbegin(), data.rend(), m_1d_const_t.rbegin());
+    EXPECT_EQ(mismatch_it_pair_1d_const_t.first, data.rend());  // expect no mismatch
+    EXPECT_EQ(mismatch_it_pair_1d_const_t.second, m_1d_const_t.rend());
+
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const_t.rend()), uchar>::value)) << "Constness of const iterator violated.";
+    EXPECT_FALSE((std::is_assignable<decltype(m_1d_const_t.rbegin()), uchar>::value)) << "Constness of const iterator violated.";
+
 }
 
 }} // namespace


### PR DESCRIPTION
This is important to be more standard compliant with C++ and an ever increasing number of people using standard algorithms for better code readability- and maintainability.

The functions are copy pasted from their counterparts (even though they should probably call the counterparts but this gave me some trouble).
They return iterators using std::reverse_iterators

Follow up of an open feature request:
https://github.com/opencv/opencv/issues/4641

Edit: Additionally there should be a test implemented for it. This still has to be done.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs,Custom,Win64

build_image:Custom=centos:7
buildworker:Custom=linux-1,linux-4,linux-6
```