### PR TITLE
Fix squares sample failure when a single file passed

### DIFF
--- a/samples/cpp/squares.cpp
+++ b/samples/cpp/squares.cpp
@@ -123,14 +123,14 @@ static void findSquares( const Mat& image, vector<vector<Point> >& squares )
 
 int main(int argc, char** argv)
 {
-    static const char* names[] = { "pic1.png", "pic2.png", "pic3.png",
+    const char* names[] = { "pic1.png", "pic2.png", "pic3.png",
         "pic4.png", "pic5.png", "pic6.png", 0 };
     help(argv[0]);
 
     if( argc > 1)
     {
      names[0] =  argv[1];
-     names[1] =  "0";
+     names[1] =  0;
     }
 
     for( int i = 0; names[i] != 0; i++ )


### PR DESCRIPTION
Fix samples/cpp/squares.cpp:

```
$ ../build/opencv_squares pic1.png 

A program using pyramid scaling, Canny, contours and contour simplification
to find squares in a list of images (pic1-6.png)
Returns sequence of squares detected on the image.
Call:
./../build/opencv_squares [file_name (optional)]
Using OpenCV version 4.5.2-dev

[ WARN:0] global /home/alexander/git/opencv/modules/core/src/utils/samples.cpp (59) findFile cv::samples::findFile('0') => ''
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.5.2-dev) /home/alexander/git/opencv/modules/core/src/utils/samples.cpp:62: error: (-2:Unspecified error) OpenCV samples: Can't find required data file: 0 in function 'findFile'

Aborted (core dumped)

```

It tries to find file "0" and fails.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
