### PR TITLE
Fix unsigned int bug in computeECC

### DIFF
--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -333,15 +333,15 @@ double cv::computeECC(InputArray templateImage, InputArray inputImage, InputArra
      * For unsigned ints, when the mean is computed and subtracted, any values less than the mean
      * will be set to 0 (since there are no negatives values). This impacts the norm and dot product, which
      * ultimately results in an incorrect ECC. To circumvent this problem, if unsigned ints are provided,
-     * we convert them to a signed ints for the subtraction step.
+     * we convert them to a signed ints with larger resolution for the subtraction step.
      */
     if(type == CV_8U) {
-        templateMat.convertTo(templateMat, CV_8S);
-        inputMat.convertTo(inputMat, CV_8S);
-    }
-    else if(type == CV_16U) {
         templateMat.convertTo(templateMat, CV_16S);
         inputMat.convertTo(inputMat, CV_16S);
+    }
+    else if(type == CV_16U) {
+        templateMat.convertTo(templateMat, CV_32S);
+        inputMat.convertTo(inputMat, CV_32S);
     }
     subtract(templateMat, meanTemplate, templateImage_zeromean, inputMask);
     double templateImagenorm = std::sqrt(active_pixels*sdTemplate.val[0]*sdTemplate.val[0]);

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -335,18 +335,12 @@ double cv::computeECC(InputArray templateImage, InputArray inputImage, InputArra
      * ultimately results in an incorrect ECC. To circumvent this problem, if unsigned ints are provided,
      * we convert them to a signed ints with larger resolution for the subtraction step.
      */
-    if(type == CV_8U) {
+    if(type == CV_8U || type == CV_16U) {
+        int newType = type == CV_8U ? CV_16S : CV_32S;
         Mat templateMatConverted, inputMatConverted;
-        templateMat.convertTo(templateMatConverted, CV_16S);
+        templateMat.convertTo(templateMatConverted, newType);
         cv::swap(templateMat, templateMatConverted);
-        inputMat.convertTo(inputMatConverted, CV_16S);
-        cv::swap(inputMat, inputMatConverted);
-    }
-    else if(type == CV_16U) {
-        Mat templateMatConverted, inputMatConverted;
-        templateMat.convertTo(templateMatConverted, CV_32S);
-        cv::swap(templateMat, templateMatConverted);
-        inputMat.convertTo(inputMatConverted, CV_32S);
+        inputMat.convertTo(inputMatConverted, newType);
         cv::swap(inputMat, inputMatConverted);
     }
     subtract(templateMat, meanTemplate, templateImage_zeromean, inputMask);

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -336,12 +336,18 @@ double cv::computeECC(InputArray templateImage, InputArray inputImage, InputArra
      * we convert them to a signed ints with larger resolution for the subtraction step.
      */
     if(type == CV_8U) {
-        templateMat.convertTo(templateMat, CV_16S);
-        inputMat.convertTo(inputMat, CV_16S);
+        Mat templateMatConverted, inputMatConverted;
+        templateMat.convertTo(templateMatConverted, CV_16S);
+        cv::swap(templateMat, templateMatConverted);
+        inputMat.convertTo(inputMatConverted, CV_16S);
+        cv::swap(inputMat, inputMatConverted);
     }
     else if(type == CV_16U) {
-        templateMat.convertTo(templateMat, CV_32S);
-        inputMat.convertTo(inputMat, CV_32S);
+        Mat templateMatConverted, inputMatConverted;
+        templateMat.convertTo(templateMatConverted, CV_32S);
+        cv::swap(templateMat, templateMatConverted);
+        inputMat.convertTo(inputMatConverted, CV_32S);
+        cv::swap(inputMat, inputMatConverted);
     }
     subtract(templateMat, meanTemplate, templateImage_zeromean, inputMask);
     double templateImagenorm = std::sqrt(active_pixels*sdTemplate.val[0]*sdTemplate.val[0]);

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -501,6 +501,18 @@ TEST(Video_ECC_Test_Compute, accuracy)
     EXPECT_NEAR(ecc, -0.5f, 1e-5f);
 }
 
+TEST(Video_ECC_Test_Compute, bug_14657)
+{
+    /*
+     * Simple test case - a 2 x 2 matrix with 10, 10, 10, 6. When the mean (36 / 4 = 9) is subtracted,
+     * it results in 1, 1, 1, 0 for the unsigned int case - compare to  1, 1, 1, -3 in the signed case.
+     * For this reason, when the same matrix was provided as the input and the template, we didn't get 1 as expected.
+     */
+    Mat img = (Mat_<uint8_t>(2, 2) << 10, 10, 10, 6);
+    EXPECT_NEAR(computeECC(img, img), 1.0f, 1e-5f);
+}
+
+
 TEST(Video_ECC_Translation, accuracy) { CV_ECC_Test_Translation test; test.safe_run();}
 TEST(Video_ECC_Euclidean, accuracy) { CV_ECC_Test_Euclidean test; test.safe_run(); }
 TEST(Video_ECC_Affine, accuracy) { CV_ECC_Test_Affine test; test.safe_run(); }


### PR DESCRIPTION
Addresses https://github.com/opencv/opencv/issues/14657. The problem in the original issue was they were using unsigned int values. This causes problems in the ECC computation, as subtracting the mean will result in certain being 0 instead of negative, and this impacts the dot product / norm.

I know this isn't pretty - the alternative solution is just raise an exception if a matrix of type `CV_8U` or `CV_16U` is supplied.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
