### PR TITLE
Fix OpenCV build with OpenEXR before 2.2.0

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -120,8 +120,8 @@ enum ImwriteEXRCompressionFlags {
        IMWRITE_EXR_COMPRESSION_PXR24 = 5, //!< lossy 24-bit float compression
        IMWRITE_EXR_COMPRESSION_B44   = 6, //!< lossy 4-by-4 pixel block compression, fixed compression rate
        IMWRITE_EXR_COMPRESSION_B44A  = 7, //!< lossy 4-by-4 pixel block compression, flat fields are compressed more
-       IMWRITE_EXR_COMPRESSION_DWAA  = 8, //!< lossy DCT based compression, in blocks of 32 scanlines. More efficient for partial buffer access.
-       IMWRITE_EXR_COMPRESSION_DWAB  = 9, //!< lossy DCT based compression, in blocks of 256 scanlines. More efficient space wise and faster to decode full frames than DWAA_COMPRESSION.
+       IMWRITE_EXR_COMPRESSION_DWAA  = 8, //!< lossy DCT based compression, in blocks of 32 scanlines. More efficient for partial buffer access. Supported since OpenEXR 2.2.0.
+       IMWRITE_EXR_COMPRESSION_DWAB  = 9, //!< lossy DCT based compression, in blocks of 256 scanlines. More efficient space wise and faster to decode full frames than DWAA_COMPRESSION. Supported since OpenEXR 2.2.0.
      };
 
 //! Imwrite PNG specific flags used to tune the compression algorithm.

--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -64,6 +64,7 @@
 #include <ImfStandardAttributes.h>
 #include <half.h>
 #include "grfmt_exr.hpp"
+#include "OpenEXRConfig.h"
 
 #if defined _WIN32
 
@@ -649,12 +650,14 @@ bool  ExrEncoder::write( const Mat& img, const std::vector<int>& params )
             case IMWRITE_EXR_COMPRESSION_B44A:
                 header.compression() = B44A_COMPRESSION;
                 break;
+#if ((OPENEXR_VERSION_MAJOR * 1000 + OPENEXR_VERSION_MINOR) >= (2 * 1000 + 2)) // available since version 2.2.0
             case IMWRITE_EXR_COMPRESSION_DWAA:
                 header.compression() = DWAA_COMPRESSION;
                 break;
             case IMWRITE_EXR_COMPRESSION_DWAB:
                 header.compression() = DWAB_COMPRESSION;
                 break;
+#endif
             default:
                 CV_Error(Error::StsBadArg, "IMWRITE_EXR_COMPRESSION is invalid or not supported");
             }


### PR DESCRIPTION
Issue https://github.com/opencv/opencv/issues/19925

OpenEXR 1.7.1 provided with CentOS 7 does not support `DWAA_COMPRESSION` and `DWAB_COMPRESSION` compression options.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
