### PR TITLE
Fix clipping bug in SQDIFF_NORMED template matching

### DIFF
--- a/modules/cudaimgproc/src/cuda/match_template.cu
+++ b/modules/cudaimgproc/src/cuda/match_template.cu
@@ -277,11 +277,7 @@ namespace cv { namespace cuda { namespace device
 
         __device__ float normAcc_SQDIFF(float num, float denum)
         {
-            if (::fabs(num) < denum)
-                return num / denum;
-            if (::fabs(num) < denum * 1.125f)
-                return num > 0 ? 1 : -1;
-            return 1;
+            return num / denum;
         }
 
 

--- a/modules/cudaimgproc/src/cuda/match_template.cu
+++ b/modules/cudaimgproc/src/cuda/match_template.cu
@@ -277,8 +277,6 @@ namespace cv { namespace cuda { namespace device
 
         __device__ float normAcc_SQDIFF(float num, float denum)
         {
-            if (::fabs(num) < denum * 1.125f)
-                return num > 0 ? 1 : -1;
             return num / denum;
         }
 

--- a/modules/cudaimgproc/src/cuda/match_template.cu
+++ b/modules/cudaimgproc/src/cuda/match_template.cu
@@ -277,6 +277,8 @@ namespace cv { namespace cuda { namespace device
 
         __device__ float normAcc_SQDIFF(float num, float denum)
         {
+            if (::fabs(num) < denum * 1.125f)
+                return num > 0 ? 1 : -1;
             return num / denum;
         }
 

--- a/modules/imgproc/src/opencl/match_template.cl
+++ b/modules/imgproc/src/opencl/match_template.cl
@@ -53,11 +53,7 @@ inline float normAcc(float num, float denum)
 
 inline float normAcc_SQDIFF(float num, float denum)
 {
-    if (fabs(num) < denum)
-        return num / denum;
-    if (fabs(num) < denum * 1.125f)
-        return num > 0 ? 1 : -1;
-    return 1;
+    return num / denum;
 }
 
 #define noconvert

--- a/modules/imgproc/src/opencl/match_template.cl
+++ b/modules/imgproc/src/opencl/match_template.cl
@@ -53,6 +53,8 @@ inline float normAcc(float num, float denum)
 
 inline float normAcc_SQDIFF(float num, float denum)
 {
+    if (fabs(num) < denum * 1.125f)
+        return num > 0 ? 1 : -1;
     return num / denum;
 }
 

--- a/modules/imgproc/src/opencl/match_template.cl
+++ b/modules/imgproc/src/opencl/match_template.cl
@@ -53,8 +53,6 @@ inline float normAcc(float num, float denum)
 
 inline float normAcc_SQDIFF(float num, float denum)
 {
-    if (fabs(num) < denum * 1.125f)
-        return num > 0 ? 1 : -1;
     return num / denum;
 }
 

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -950,12 +950,12 @@ static void common_matchTemplate( Mat& img, Mat& templ, Mat& result, int method,
                 else
                     t = std::sqrt(diff2)*templNorm;
 
-                if( fabs(num) < t )
+                if( fabs(num) < t || method == CV_TM_SQDIFF_NORMED)
                     num /= t;
                 else if( fabs(num) < t*1.125 )
                     num = num > 0 ? 1 : -1;
                 else
-                    num = method != CV_TM_SQDIFF_NORMED ? 0 : 1;
+                    num = 0;
             }
 
             rrow[j] = (float)num;

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -292,12 +292,12 @@ static void cvTsMatchTemplate( const CvMat* img, const CvMat* templ, CvMat* resu
                     denom += a_sum2.val[2] - (a_sum.val[2]*a_sum.val[2])/area;
                 }
                 denom = sqrt(MAX(denom,0))*b_denom;
-                if( fabs(value) < denom )
+                if( fabs(value) < denom || method == CV_TM_SQDIFF_NORMED)
                     value /= denom;
                 else if( fabs(value) < denom*1.125 )
                     value = value > 0 ? 1 : -1;
                 else
-                    value = method != CV_TM_SQDIFF_NORMED ? 0 : 1;
+                    value = 0;
             }
 
             ((float*)(result->data.ptr + result->step*i))[j] = (float)value;
@@ -436,15 +436,15 @@ TEST(Imgproc_MatchTemplate, bug_15215) {
 
         // manually compute sqdiff norm
         Scalar squaredDiff = delta.dot(delta);
-        float sqdiff = squaredDiff.val[0];
+        double sqdiff = squaredDiff.val[0];
         Scalar sumOfSquaredProduct = cv::sum(cvimg.mul(cvimg)) * cv::sum(cvtmpl.mul(cvtmpl));
         double norm_ = cv::sqrt(sumOfSquaredProduct.val[0]);
-        float expectedResult = sqdiff / (float) norm_;
+        double expectedResult = sqdiff / (float) norm_;
 
         // compute with matchTemplate
         cv::Mat output;
         cv::matchTemplate(cvimg, cvtmpl, output, CV_TM_SQDIFF_NORMED);
-        float actualResult = output.at<float>(0, 0);
+        double actualResult = output.at<float>(0, 0);
         ASSERT_FLOAT_EQ(actualResult, expectedResult);
 }
 } // namespace

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -436,15 +436,15 @@ TEST(Imgproc_MatchTemplate, bug_15215) {
 
         // manually compute sqdiff norm
         Scalar squaredDiff = delta.dot(delta);
-        double sqdiff = squaredDiff.val[0];
+        float sqdiff = squaredDiff.val[0];
         Scalar sumOfSquaredProduct = cv::sum(cvimg.mul(cvimg)) * cv::sum(cvtmpl.mul(cvtmpl));
-        double norm = cv::sqrt(sumOfSquaredProduct.val[0]);
-        double expectedResult = sqdiff / norm;
+        double norm_ = cv::sqrt(sumOfSquaredProduct.val[0]);
+        float expectedResult = sqdiff / (float) norm_;
 
         // compute with matchTemplate
         cv::Mat output;
         cv::matchTemplate(cvimg, cvtmpl, output, CV_TM_SQDIFF_NORMED);
-        double actualResult = output.at<float>(0, 0);
+        float actualResult = output.at<float>(0, 0);
         ASSERT_FLOAT_EQ(actualResult, expectedResult);
 }
 } // namespace

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -425,4 +425,15 @@ TEST(Imgproc_MatchTemplate, bug_9597) {
         cv::minMaxLoc(result, &minValue, NULL, NULL, NULL);
         ASSERT_GE(minValue, 0);
 }
+
+
+TEST(Imgproc_MatchTemplate, bug_15215) {
+        // simple example - a 2 x 2 template and 2 x 2 image, which just results in a matrix
+        // with one value, and this value should be > 1.
+        cv::Mat cvimg = (Mat_<float>(2, 2) << 5,1,2,8);
+        cv::Mat cvtmpl = (Mat_<float>(2, 2) << 1,5,7,1);
+        cv::Mat result;
+        cv::matchTemplate(cvimg, cvtmpl, result, CV_TM_SQDIFF_NORMED);
+        ASSERT_GT(result.at<float>(0, 0), 1);
+}
 } // namespace

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -429,11 +429,22 @@ TEST(Imgproc_MatchTemplate, bug_9597) {
 
 TEST(Imgproc_MatchTemplate, bug_15215) {
         // simple example - a 2 x 2 template and 2 x 2 image, which just results in a matrix
-        // with one value, and this value should be > 1.
+        // with one value
         cv::Mat cvimg = (Mat_<float>(2, 2) << 5,1,2,8);
         cv::Mat cvtmpl = (Mat_<float>(2, 2) << 1,5,7,1);
-        cv::Mat result;
-        cv::matchTemplate(cvimg, cvtmpl, result, CV_TM_SQDIFF_NORMED);
-        ASSERT_GT(result.at<float>(0, 0), 1);
+        Mat delta = cvimg - cvtmpl;
+
+        // manually compute sqdiff norm
+        Scalar squaredDiff = delta.dot(delta);
+        double sqdiff = squaredDiff.val[0];
+        Scalar sumOfSquaredProduct = cv::sum(cvimg.mul(cvimg)) * cv::sum(cvtmpl.mul(cvtmpl));
+        double norm = cv::sqrt(sumOfSquaredProduct.val[0]);
+        double expectedResult = sqdiff / norm;
+
+        // compute with matchTemplate
+        cv::Mat output;
+        cv::matchTemplate(cvimg, cvtmpl, output, CV_TM_SQDIFF_NORMED);
+        double actualResult = output.at<float>(0, 0);
+        ASSERT_FLOAT_EQ(actualResult, expectedResult);
 }
 } // namespace

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -439,12 +439,12 @@ TEST(Imgproc_MatchTemplate, bug_15215) {
         double sqdiff = squaredDiff.val[0];
         Scalar sumOfSquaredProduct = cv::sum(cvimg.mul(cvimg)) * cv::sum(cvtmpl.mul(cvtmpl));
         double norm_ = cv::sqrt(sumOfSquaredProduct.val[0]);
-        double expectedResult = sqdiff / (float) norm_;
+        double expectedResult = sqdiff / norm_;
 
         // compute with matchTemplate
         cv::Mat output;
         cv::matchTemplate(cvimg, cvtmpl, output, CV_TM_SQDIFF_NORMED);
-        double actualResult = output.at<float>(0, 0);
-        ASSERT_FLOAT_EQ(actualResult, expectedResult);
+        float actualResult = output.at<float>(0, 0);
+        ASSERT_FLOAT_EQ(actualResult, (float) expectedResult);
 }
 } // namespace


### PR DESCRIPTION
Addresses https://github.com/opencv/opencv/issues/15215 regarding `CV_TM_SQDIFF_NORMED`  clipping at 1.0, despite the range being > 1. The test case is the example presented in the ticket.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
