### PR TITLE
Stream default to Stream::Null() when no default in function prototype

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -211,6 +211,7 @@ simple_argtype_mapping = {
     "double": ArgTypeInfo("double", FormatStrings.double, "0", True),
     "c_string": ArgTypeInfo("char*", FormatStrings.string, '(char*)""'),
     "string": ArgTypeInfo("std::string", FormatStrings.object, None, True),
+    "Stream": ArgTypeInfo("Stream", FormatStrings.object, 'Stream::Null()', True),
 }
 
 

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -26,6 +26,15 @@ class cuda_test(NewOpenCVTests):
 
         self.assertTrue(np.allclose(cuMat.download(), npMat))
 
+    def test_cuda_upload_download_stream(self):
+        stream = cv.cuda_Stream()
+        npMat = (np.random.random((128, 128, 3)) * 255).astype(np.uint8)
+        cuMat = cv.cuda_GpuMat(128,128, cv.CV_8UC3)
+        cuMat.upload(npMat, stream)
+        npMat2 = cuMat.download(stream=stream)
+        stream.waitForCompletion()
+        self.assertTrue(np.allclose(npMat2, npMat))
+
     def test_cuda_interop(self):
         npMat = (np.random.random((128, 128, 3)) * 255).astype(np.uint8)
         cuMat = cv.cuda_GpuMat()


### PR DESCRIPTION
this corrects bug #16592 where a Stream is created at
each GpuMat::load(arr,stream) call

a correct solution would have been to add a default to GpuMat::load
but due to circular dependence between Stream and GpuMat, this is not possible

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<cut/>

<details>

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```

</details>
