### PR TITLE
UMat usageFlags fixes opencv/opencv#19807

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2572,27 +2572,38 @@ public:
          - number of channels
      */
     int flags;
+
     //! the matrix dimensionality, >= 2
     int dims;
-    //! the number of rows and columns or (-1, -1) when the matrix has more than 2 dimensions
-    int rows, cols;
+
+    //! number of rows in the matrix; -1 when the matrix has more than 2 dimensions
+    int rows;
+
+    //! number of columns in the matrix; -1 when the matrix has more than 2 dimensions
+    int cols;
 
     //! custom allocator
     MatAllocator* allocator;
-    UMatUsageFlags usageFlags; // usage flags for allocator
+
+    //! usage flags for allocator; recommend do not set directly, instead set during construct/create/getUMat
+    UMatUsageFlags usageFlags;
+
     //! and the standard allocator
     static MatAllocator* getStdAllocator();
 
     //! internal use method: updates the continuity flag
     void updateContinuityFlag();
 
-    // black-box container of UMat data
+    //! black-box container of UMat data
     UMatData* u;
 
-    // offset of the submatrix (or 0)
+    //! offset of the submatrix (or 0)
     size_t offset;
 
+    //! dimensional size of the matrix; accessible in various formats
     MatSize size;
+
+    //! number of bytes each matrix element/row/plane/dimension occupies
     MatStep step;
 
 protected:

--- a/modules/core/perf/opencl/perf_usage_flags.cpp
+++ b/modules/core/perf/opencl/perf_usage_flags.cpp
@@ -12,25 +12,33 @@
 namespace opencv_test {
 namespace ocl {
 
-typedef TestBaseWithParam<tuple<cv::Size, bool> > UsageFlagsBoolFixture;
+typedef TestBaseWithParam<tuple<cv::Size, UMatUsageFlags, UMatUsageFlags, UMatUsageFlags>> SizeUsageFlagsFixture;
 
-OCL_PERF_TEST_P(UsageFlagsBoolFixture, UsageFlags_AllocHostMem, ::testing::Combine(OCL_TEST_SIZES, Bool()))
+OCL_PERF_TEST_P(SizeUsageFlagsFixture, UsageFlags_AllocMem,
+    ::testing::Combine(
+        OCL_TEST_SIZES,
+        testing::Values(USAGE_DEFAULT, USAGE_ALLOCATE_HOST_MEMORY, USAGE_ALLOCATE_DEVICE_MEMORY), // USAGE_ALLOCATE_SHARED_MEMORY
+        testing::Values(USAGE_DEFAULT, USAGE_ALLOCATE_HOST_MEMORY, USAGE_ALLOCATE_DEVICE_MEMORY), // USAGE_ALLOCATE_SHARED_MEMORY
+        testing::Values(USAGE_DEFAULT, USAGE_ALLOCATE_HOST_MEMORY, USAGE_ALLOCATE_DEVICE_MEMORY) // USAGE_ALLOCATE_SHARED_MEMORY
+    ))
 {
     Size sz = get<0>(GetParam());
-    bool allocHostMem = get<1>(GetParam());
+    UMatUsageFlags srcAllocMem = get<1>(GetParam());
+    UMatUsageFlags dstAllocMem = get<2>(GetParam());
+    UMatUsageFlags finalAllocMem = get<3>(GetParam());
 
-    UMat src(sz, CV_8UC1, Scalar::all(128));
+    UMat src(sz, CV_8UC1, Scalar::all(128), srcAllocMem);
 
     OCL_TEST_CYCLE()
     {
-        UMat dst(allocHostMem ? USAGE_ALLOCATE_HOST_MEMORY : USAGE_DEFAULT);
+        UMat dst(dstAllocMem);
 
         cv::add(src, Scalar::all(1), dst);
         {
             Mat canvas = dst.getMat(ACCESS_RW);
             cv::putText(canvas, "Test", Point(20, 20), FONT_HERSHEY_PLAIN, 1, Scalar::all(255));
         }
-        UMat final;
+        UMat final(finalAllocMem);
         cv::subtract(dst, Scalar::all(1), final);
     }
 

--- a/modules/core/test/test_opencl.cpp
+++ b/modules/core/test/test_opencl.cpp
@@ -207,9 +207,32 @@ TEST_P(OCL_OpenCLExecutionContext_P, ScopeTest)
     executeUMatCall();
 }
 
-
-
 INSTANTIATE_TEST_CASE_P(/*nothing*/, OCL_OpenCLExecutionContext_P, getOpenCLTestConfigurations());
+
+
+typedef testing::TestWithParam<UMatUsageFlags> UsageFlagsFixture;
+OCL_TEST_P(UsageFlagsFixture, UsageFlagsRetained)
+{
+    if (!cv::ocl::useOpenCL())
+    {
+        throw SkipTestException("OpenCL is not available / disabled");
+    }
+
+    const UMatUsageFlags usage = GetParam();
+    cv::UMat flip_in(10, 10, CV_32F, usage);
+    cv::UMat flip_out(usage);
+    cv::flip(flip_in, flip_out, 1);
+    cv::ocl::finish();
+
+    ASSERT_EQ(usage, flip_in.usageFlags);
+    ASSERT_EQ(usage, flip_out.usageFlags);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    /*nothing*/,
+    UsageFlagsFixture,
+    testing::Values(USAGE_DEFAULT, USAGE_ALLOCATE_HOST_MEMORY, USAGE_ALLOCATE_DEVICE_MEMORY)
+);
 
 
 } } // namespace opencv_test::ocl


### PR DESCRIPTION
fixes opencv/opencv#19807

* Request code review of these changes before merge.
* I do not recommend merging this until after code review, then I try this on the 3.x branch, and then I make any needed changes. ***I have not done any coding or testing of this on the 3.x legacy branch.*** I request code review of this approach before I do anything in 3.x
* Clarified doxygen comments on some fields of `cv::UMat`
* Please consider my notes and caveats at https://github.com/opencv/opencv/issues/19807#issuecomment-810645975

I have been using this in my own code for one month with opencl on/off and with two GPUs (intel and nvidia).
Passes all core unit tests when applied to the 4.5.2 branch.
No known issues.

```
[----------] Global test environment tear-down
[ SKIPSTAT ] 36 tests skipped
[ SKIPSTAT ] TAG='mem_6gb' skip 1 tests
[ SKIPSTAT ] TAG='skip_bigdata' skip 1 tests
[ SKIPSTAT ] TAG='skip_other' skip 34 tests
[==========] 11621 tests from 250 test cases ran. (764388 ms total)
[  PASSED  ] 11621 tests.
  YOU HAVE 19 DISABLED TESTS
```

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] The feature is well documented and sample code can be built with the project CMake
