### PR TITLE
Added QRCodeDetector to excludes

### DIFF
--- a/modules/java/test/pure_test/build.xml
+++ b/modules/java/test/pure_test/build.xml
@@ -53,7 +53,7 @@
       <formatter type="xml"/>
 
       <batchtest fork="yes" todir="${test.dir}">
-        <zipfileset src="build/jar/opencv-test.jar" includes="**/${opencv.test.package}/${opencv.test.class}.class" excludes="**/OpenCVTest*">
+        <zipfileset src="build/jar/opencv-test.jar" includes="**/${opencv.test.package}/${opencv.test.class}.class" excludes="**/OpenCVTest*, **/QRCodeDetector*">
           <exclude name="**/*$*.class"/>
         </zipfileset>
       </batchtest>


### PR DESCRIPTION
This PR fixes the issue with java tests on ARM. 

As an example of this failure I provide a log in Jenkins: https://build.opencv.org.cn/job/precommit/job/ubuntu-20.04-arm64/1784/console

Related issues: https://github.com/opencv/opencv/issues/19172, https://github.com/opencv/opencv/issues/19173

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
