### PR TITLE
Update PatchNaN to support CV_64F

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -1574,7 +1574,7 @@ static bool ocl_patchNaNs( InputOutputArray _a, float value )
     int rowsPerWI = ocl::Device::getDefault().isIntel() ? 4 : 1;
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc,
                      format("-D UNARY_OP -D OP_PATCH_NANS -D dstT=float -D DEPTH_dst=%d -D rowsPerWI=%d",
-                            CV_32F, rowsPerWI));
+                            _a.depth(), rowsPerWI));
     if (k.empty())
         return false;
 
@@ -1594,7 +1594,7 @@ void patchNaNs( InputOutputArray _a, double _val )
 {
     CV_INSTRUMENT_REGION();
 
-    CV_Assert( _a.depth() == CV_32F );
+    CV_Assert( _a.depth() == CV_32F || _a.depth() == CV_64F);
 
     CV_OCL_RUN(_a.isUMat() && _a.dims() <= 2,
                ocl_patchNaNs(_a, (float)_val))

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -4005,5 +4005,11 @@ TEST(Core_FastMath, InlineIsInf)
     EXPECT_EQ( cvIsInf(0.0), 0);
 }
 
+TEST(Core_FastMath, patchnan_feat_19587)
+{
+    Mat test = Mat::ones(2,2, CV_64F);
+    ASSERT_NO_THROW(patchNaNs(test));
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
Addresses https://github.com/opencv/opencv/issues/19587. Removes validation for input to `patchNaNs` to be `CV_32F`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
