### PR TITLE
Update _dst type in normalize function

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -803,6 +803,24 @@ normalization.
 */
 CV_EXPORTS void normalize( const SparseMat& src, SparseMat& dst, double alpha, int normType );
 
+
+/** @brief Normalizes the norm or value range of an array with an operational mask.
+
+@param src input array.
+@param dst output array of the same size as src .
+@param mask operation mask.
+@param alpha norm value to normalize to or the lower range boundary in case of the range
+normalization.
+@param beta upper range boundary in case of the range normalization; it is not used for the norm
+normalization.
+@param norm_type normalization type (see cv::NormTypes).
+@param dtype when negative, the output array has the same type as src; otherwise, it has the same
+number of channels as src and the depth =CV_MAT_DEPTH(dtype).
+@sa norm, Mat::convertTo, SparseMat::convertTo
+*/
+CV_EXPORTS_W void normalizeWithMask( InputArray src, InputOutputArray dst, InputArray _mask, double alpha = 1, double beta = 0,
+                                     int norm_type = NORM_L2, int dtype = -1);
+
 /** @brief Finds the global minimum and maximum in an array.
 
 The function cv::minMaxLoc finds the minimum and maximum element values and their positions. The

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -791,7 +791,7 @@ number of channels as src and the depth =CV_MAT_DEPTH(dtype).
 @param mask optional operation mask.
 @sa norm, Mat::convertTo, SparseMat::convertTo
 */
-CV_EXPORTS_W void normalize( InputArray src, InputOutputArray dst, double alpha = 1, double beta = 0,
+CV_EXPORTS_W void normalize( InputArray src, OutputArray dst, double alpha = 1, double beta = 0,
                              int norm_type = NORM_L2, int dtype = -1, InputArray mask = noArray());
 
 /** @overload

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -1284,7 +1284,7 @@ double PSNR(InputArray _src1, InputArray _src2, double R)
 
 
 #ifdef HAVE_OPENCL
-static bool ocl_normalize( InputArray _src, InputOutputArray _dst, InputArray _mask, int dtype,
+static bool ocl_normalize( InputArray _src, OutputArray _dst, InputArray _mask, int dtype,
                            double scale, double delta )
 {
     UMat src = _src.getUMat();
@@ -1370,7 +1370,7 @@ static bool ocl_normalize( InputArray _src, InputOutputArray _dst, InputArray _m
 }  // ocl_normalize
 #endif  // HAVE_OPENCL
 
-void normalize(InputArray _src, InputOutputArray _dst, double a, double b,
+void normalize(InputArray _src, OutputArray _dst, double a, double b,
                int norm_type, int rtype, InputArray _mask)
 {
     CV_INSTRUMENT_REGION();

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -1284,7 +1284,7 @@ double PSNR(InputArray _src1, InputArray _src2, double R)
 
 
 #ifdef HAVE_OPENCL
-static bool ocl_normalize( InputArray _src, OutputArray _dst, InputArray _mask, int dtype,
+static bool ocl_normalizeWithMask( InputArray _src, OutputArray _dst, InputArray _mask, int dtype,
                            double scale, double delta )
 {
     UMat src = _src.getUMat();
@@ -1371,7 +1371,13 @@ static bool ocl_normalize( InputArray _src, OutputArray _dst, InputArray _mask, 
 #endif  // HAVE_OPENCL
 
 void normalize(InputArray _src, OutputArray _dst, double a, double b,
-               int norm_type, int rtype, InputArray _mask)
+               int norm_type, int rtype)
+{
+    normalizeWithMask(_src, (InputOutputArray) _dst, noArray(), a, b, norm_type, rtype);
+}
+
+void normalizeWithMask(InputArray _src, InputOutputArray _dst, InputArray _mask, double a, double b,
+               int norm_type, int rtype)
 {
     CV_INSTRUMENT_REGION();
 
@@ -1405,7 +1411,7 @@ void normalize(InputArray _src, OutputArray _dst, double a, double b,
         CV_Error( CV_StsBadArg, "Unknown/unsupported norm type" );
 
     CV_OCL_RUN(_dst.isUMat(),
-               ocl_normalize(_src, _dst, _mask, rtype, scale, shift))
+               ocl_normalizeWithMask(_src, _dst, _mask, rtype, scale, shift))
 
     Mat src = _src.getMat();
     if( _mask.empty() )
@@ -1417,5 +1423,8 @@ void normalize(InputArray _src, OutputArray _dst, double a, double b,
         temp.copyTo( _dst, _mask );
     }
 }
+
+
+
 
 }  // namespace

--- a/modules/python/test/test_normalize.py
+++ b/modules/python/test/test_normalize.py
@@ -6,7 +6,6 @@ class normalize_test(NewOpenCVTests):
 
     def test_normalize(self):
         img = np.ones((2, 2))
-        img[0, 0] = 10
         # we should be able to call normalize with no additional args now
-        res = cv.normalize(img, 0, 1, cv.NORM_MINMAX)
-        self.assertEqual(res.tolist(), [[1.0, 0.0], [0.0, 0.0]])
+        res = cv.normalize(img)
+        self.assertEqual(res.tolist(), [[0.5, 0.5], [0.5, 0.5]])

--- a/modules/python/test/test_normalize.py
+++ b/modules/python/test/test_normalize.py
@@ -1,0 +1,12 @@
+import numpy as np
+from tests_common import NewOpenCVTests
+import cv2 as cv
+
+class normalize_test(NewOpenCVTests):
+
+    def test_normalize(self):
+        img = np.ones((2, 2))
+        img[0, 0] = 10
+        # we should be able to call normalize with no additional args now
+        res = cv.normalize(img, 0, 1, cv.NORM_MINMAX)
+        self.assertEqual(res.tolist(), [[1.0, 0.0], [0.0, 0.0]])


### PR DESCRIPTION
Addresses https://github.com/opencv/opencv/issues/19065. Change `_dst` to `OutputArray` instead of `InputOutputArray` in `normalize` function. This simplifies the Python API, as we now don't have supply a dummy argument.

Note: I know in https://github.com/opencv/opencv/issues/10728 it was mentioned that flags can change whether it's just an output or used as an input, but based on inspection, it doesn't appear it's used as an input.  

I've submitted this PR to `next`, as it will be a minor API change.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
