### PR TITLE
Remove static initializers

### DIFF
--- a/modules/flann/include/opencv2/flann/any.h
+++ b/modules/flann/include/opencv2/flann/any.h
@@ -167,17 +167,15 @@ class SinglePolicy
 
 public:
     static base_any_policy* get_policy();
-
-private:
-    static typename choose_policy<T>::type policy;
 };
-
-template <typename T>
-typename choose_policy<T>::type SinglePolicy<T>::policy;
 
 /// This function will return a different policy for each type.
 template <typename T>
-inline base_any_policy* SinglePolicy<T>::get_policy() { return &policy; }
+inline base_any_policy* SinglePolicy<T>::get_policy()
+{
+    static typename choose_policy<T>::type policy;
+    return &policy;
+}
 
 } // namespace anyimpl
 


### PR DESCRIPTION
There are a handful of static initializers in our binary which originate from the opencv library. All of them are attributed to the `policy` private static member of the templated `SinglePolicy` class:
[opencv2/flann/any.h#L176](https://github.com/jstaahl/opencv/blob/3.4/modules/flann/include/opencv2/flann/any.h#L176).

These can be avoided by using the Meyer singleton pattern for the `get_policy()` function.

issue report: https://github.com/opencv/opencv/issues/20051

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
