### PR TITLE
Fix Robertson Calibration NaN Bug

### DIFF
--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -342,9 +342,9 @@ public:
             LUT(images[i], response, im);
 
             result += times.at<float>((int)i) * w.mul(im);
-            wsum += times.at<float>((int)i) * times.at<float>((int)i) * (w + DBL_EPSILON);
+            wsum += times.at<float>((int)i) * times.at<float>((int)i) * w;
         }
-        result = result.mul(1 / wsum);
+        result = result.mul(1 / (wsum + DBL_EPSILON));
     }
 
     void process(InputArrayOfArrays src, OutputArray dst, InputArray times) CV_OVERRIDE

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -342,7 +342,7 @@ public:
             LUT(images[i], response, im);
 
             result += times.at<float>((int)i) * w.mul(im);
-            wsum += times.at<float>((int)i) * times.at<float>((int)i) * w;
+            wsum += times.at<float>((int)i) * times.at<float>((int)i) * (w + DBL_EPSILON);
         }
         result = result.mul(1 / wsum);
     }

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -342,9 +342,9 @@ public:
             LUT(images[i], response, im);
 
             result += times.at<float>((int)i) * w.mul(im);
-            wsum += times.at<float>((int)i) * times.at<float>((int)i) * w;
+            wsum += times.at<float>((int)i) * times.at<float>((int)i) * (w + DBL_EPSILON);
         }
-        result = result.mul(1 / (wsum + DBL_EPSILON));
+        result = result.mul(1 / wsum);
     }
 
     void process(InputArrayOfArrays src, OutputArray dst, InputArray times) CV_OVERRIDE

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -342,9 +342,9 @@ public:
             LUT(images[i], response, im);
 
             result += times.at<float>((int)i) * w.mul(im);
-            wsum += times.at<float>((int)i) * times.at<float>((int)i) * (w + DBL_EPSILON);
+            wsum += times.at<float>((int)i) * times.at<float>((int)i) * w;
         }
-        result = result.mul(1 / wsum);
+        result = result.mul(1 / (wsum + Scalar::all(DBL_EPSILON)));
     }
 
     void process(InputArrayOfArrays src, OutputArray dst, InputArray times) CV_OVERRIDE

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -262,6 +262,7 @@ TEST(Photo_CalibrateRobertson, bug_18180)
     calibrate->process(images, response, times);
     Mat response_no_nans = response.clone();
     patchNaNs(response_no_nans);
+    // since there should be no NaNs, original response vs. response with NaNs patched should be identical
     bool isEqual = (sum(response != response_no_nans) == Scalar(0,0,0));
     ASSERT_TRUE(isEqual);
 }

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -262,7 +262,6 @@ TEST(Photo_CalibrateRobertson, bug_18180)
     calibrate->process(images, response, times);
     Mat response_no_nans = response.clone();
     patchNaNs(response_no_nans);
-    std::cout << response << std::endl;
     // since there should be no NaNs, original response vs. response with NaNs patched should be identical
     EXPECT_EQ(0.0, cv::norm(response, response_no_nans, NORM_L2));
 }

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -253,18 +253,18 @@ TEST(Photo_CalibrateRobertson, bug_18180)
 {
     vector<Mat> images;
     vector<cv::String> fn;
-    glob(string(cvtest::TS::ptr()->get_data_path()) + "hdr/exposures/bug_18180/*.jpg", fn, false);
-    for (auto & i : fn)
-        images.push_back(imread(i));
-    vector<float> times {15, 2.5, 0.25, 0.333333};
+    string test_path = cvtest::TS::ptr()->get_data_path() + "hdr/exposures/bug_18180/";
+    for(int i = 1; i <= 4; ++i)
+        images.push_back(imread(test_path + std::to_string(i) + ".jpg"));
+    vector<float> times {15.0f, 2.5f, 0.25f, 0.33f};
     Mat response, expected;
-    Ptr<CalibrateRobertson> calibrate = createCalibrateRobertson(2, 0.01);
+    Ptr<CalibrateRobertson> calibrate = createCalibrateRobertson(2, 0.01f);
     calibrate->process(images, response, times);
     Mat response_no_nans = response.clone();
     patchNaNs(response_no_nans);
+    std::cout << response << std::endl;
     // since there should be no NaNs, original response vs. response with NaNs patched should be identical
-    bool isEqual = (sum(response != response_no_nans) == Scalar(0,0,0));
-    ASSERT_TRUE(isEqual);
+    EXPECT_EQ(0.0, cv::norm(response, response_no_nans, NORM_L2));
 }
 
 }} // namespace

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -249,4 +249,21 @@ TEST(Photo_CalibrateRobertson, regression)
     checkEqual(expected, response, 1e-1f, "CalibrateRobertson");
 }
 
+TEST(Photo_CalibrateRobertson, bug_18180)
+{
+    vector<Mat> images;
+    vector<cv::String> fn;
+    glob(string(cvtest::TS::ptr()->get_data_path()) + "hdr/exposures/bug_18180/*.jpg", fn, false);
+    for (size_t i=0; i<fn.size(); i++)
+        images.push_back(imread(fn[i]));
+    vector<float> times {15, 2.5, 0.25, 0.333333};
+    Mat response, expected;
+    Ptr<CalibrateRobertson> calibrate = createCalibrateRobertson(2, 0.01);
+    calibrate->process(images, response, times);
+    Mat response_no_nans = response.clone();
+    patchNaNs(response_no_nans);
+    bool isEqual = (sum(response != response_no_nans) == Scalar(0,0,0));
+    ASSERT_TRUE(isEqual);
+}
+
 }} // namespace

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -254,8 +254,8 @@ TEST(Photo_CalibrateRobertson, bug_18180)
     vector<Mat> images;
     vector<cv::String> fn;
     glob(string(cvtest::TS::ptr()->get_data_path()) + "hdr/exposures/bug_18180/*.jpg", fn, false);
-    for (size_t i=0; i<fn.size(); i++)
-        images.push_back(imread(fn[i]));
+    for (auto & i : fn)
+        images.push_back(imread(i));
     vector<float> times {15, 2.5, 0.25, 0.333333};
     Mat response, expected;
     Ptr<CalibrateRobertson> calibrate = createCalibrateRobertson(2, 0.01);


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/873

Addresses https://github.com/opencv/opencv/issues/18180. The issue seemed to be with numerical stability when `w_sum` matrix contained zeroes. Should be merged in conjunction with https://github.com/opencv/opencv_extra/pull/873, which contains test data taken from original issue.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
