### PR TITLE
Fixes for Swift troubles

### DIFF
--- a/modules/core/misc/objc/common/Point2i.h
+++ b/modules/core/misc/objc/common/Point2i.h
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a two dimensional point the coordinate values of which are of type `int`
 */
-NS_SWIFT_NAME(Point)
 CV_EXPORTS @interface Point2i : NSObject
 
 # pragma mark - Properties

--- a/modules/core/misc/objc/common/Rect2i.h
+++ b/modules/core/misc/objc/common/Rect2i.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a rectange the coordinate and dimension values of which are of type `int`
 */
-NS_SWIFT_NAME(Rect)
 CV_EXPORTS @interface Rect2i : NSObject
 
 #pragma mark - Properties

--- a/modules/core/misc/objc/common/Size2i.h
+++ b/modules/core/misc/objc/common/Size2i.h
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents the dimensions of a rectangle the values of which are of type `int`
 */
-NS_SWIFT_NAME(Size)
 CV_EXPORTS @interface Size2i : NSObject
 
 #pragma mark - Properties

--- a/modules/core/misc/objc/common/Typealiases.swift
+++ b/modules/core/misc/objc/common/Typealiases.swift
@@ -1,0 +1,11 @@
+//
+//  Typealiases.swift
+//
+//  Created by Chris Ballinger on 2020/11/18.
+//
+
+import Foundation
+
+public typealias Rect = Rect2i
+public typealias Point = Point2i
+public typealias Size = Size2i

--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -113,13 +113,13 @@
             "objc_type": "Point2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Point2i fromNative:%(n)s]",
-            "swift_type": "Point"
+            "swift_type": "Point2i"
         },
         "Point2i": {
             "objc_type": "Point2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Point2i fromNative:%(n)s]",
-            "swift_type": "Point"
+            "swift_type": "Point2i"
         },
         "Point2f": {
             "objc_type": "Point2f*",
@@ -153,13 +153,13 @@
             "objc_type": "Rect2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Rect2i fromNative:%(n)s]",
-            "swift_type": "Rect"
+            "swift_type": "Rect2i"
         },
         "Rect2i": {
             "objc_type": "Rect2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Rect2i fromNative:%(n)s]",
-            "swift_type": "Rect"
+            "swift_type": "Rect2i"
         },
         "Rect2f": {
             "objc_type": "Rect2f*",
@@ -185,13 +185,13 @@
             "objc_type": "Size2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Size2i fromNative:%(n)s]",
-            "swift_type": "Size"
+            "swift_type": "Size2i"
         },
         "Size2i": {
             "objc_type": "Size2i*",
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[Size2i fromNative:%(n)s]",
-            "swift_type": "Size"
+            "swift_type": "Size2i"
         },
         "Size2f": {
             "objc_type": "Size2f*",
@@ -273,7 +273,7 @@
         "vector_Point": {
             "objc_type": "Point2i*",
             "v_type": "Point2i",
-            "swift_type": "[Point]"
+            "swift_type": "[Point2i]"
         },
         "vector_Point2f": {
             "objc_type": "Point2f*",
@@ -298,7 +298,7 @@
         "vector_Rect": {
             "objc_type": "Rect2i*",
             "v_type": "Rect2i",
-            "swift_type": "[Rect]"
+            "swift_type": "[Rect2i]"
         },
         "vector_Rect2d": {
             "objc_type": "Rect2d*",
@@ -386,7 +386,7 @@
         "vector_vector_Point": {
             "objc_type": "Point2i*",
             "v_v_type": "Point2i",
-            "swift_type": "[[Point]]"
+            "swift_type": "[[Point2i]]"
         },
         "vector_vector_Point2f": {
             "objc_type": "Point2f*",

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -42,7 +42,7 @@ from cv_build_utils import execute, print_error, get_xcode_major, get_xcode_sett
 IPHONEOS_DEPLOYMENT_TARGET='9.0'  # default, can be changed via command line options or environment variable
 
 class Builder:
-    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, disable, enablenonfree, targets, debug, debug_info, framework_name, run_tests, build_docs):
+    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, disable, enablenonfree, targets, debug, debug_info, framework_name, run_tests, build_docs, swiftdisabled):
         self.opencv = os.path.abspath(opencv)
         self.contrib = None
         if contrib:
@@ -63,6 +63,7 @@ class Builder:
         self.framework_name = framework_name
         self.run_tests = run_tests
         self.build_docs = build_docs
+        self.swiftdisabled = swiftdisabled
 
     def checkCMakeVersion(self):
         if get_xcode_version() >= (12, 2):
@@ -153,6 +154,14 @@ class Builder:
                 print("To build docs call:")
                 print(sys.argv[0].replace("build_framework", "build_docs") + " " + dirs[0] + "/modules/objc/framework_build")
             self.copy_samples(outdir)
+            if self.swiftdisabled:
+                swift_sources_dir = os.path.join(outdir, "SwiftSources")
+                if not os.path.exists(swift_sources_dir):
+                    os.makedirs(swift_sources_dir)
+                for root, dirs, files in os.walk(dirs[0]):
+                    for file in files:
+                        if file.endswith(".swift") and file.find("Test") == -1:
+                            shutil.copy(os.path.join(root, file), os.path.join(swift_sources_dir, file))
 
     def build(self, outdir):
         try:
@@ -297,8 +306,8 @@ class Builder:
         execute(["cmake", "-DBUILD_TYPE=%s" % self.getConfiguration(), "-P", "cmake_install.cmake"], cwd = builddir)
         if self.build_objc_wrapper:
             cmakecmd = self.makeCMakeCmd(arch, target, builddir + "/modules/objc_bindings_generator/{}/gen".format(self.getObjcTarget(target)), cmakeargs)
-            # cmakecmd.append("-DCMAKE_Swift_FLAGS=" + "-target x86_64-apple-ios13.0-macabi")
-            # cmakecmd.append("-DCMAKE_EXE_LINKER_FLAGS=" + "-target x86_64-apple-ios13.0-macabi")
+            if self.swiftdisabled:
+                cmakecmd.append("-DSWIFT_DISABLED=1")
             cmakecmd.append("-DBUILD_ROOT=%s" % builddir)
             cmakecmd.append("-DCMAKE_INSTALL_NAME_TOOL=install_name_tool")
             cmakecmd.append("--no-warn-unused-cli")
@@ -509,6 +518,7 @@ if __name__ == "__main__":
     parser.add_argument('--legacy_build', default=False, dest='legacy_build', action='store_true', help='Build legacy opencv2 framework (default: False, equivalent to "--framework_name=opencv2 --without=objc")')
     parser.add_argument('--run_tests', default=False, dest='run_tests', action='store_true', help='Run tests')
     parser.add_argument('--build_docs', default=False, dest='build_docs', action='store_true', help='Build docs')
+    parser.add_argument('--disable-swift', default=False, dest='swiftdisabled', action='store_true', help='Disable building of Swift extensions')
 
     args, unknown_args = parser.parse_known_args()
     if unknown_args:
@@ -562,6 +572,6 @@ if __name__ == "__main__":
         if iphonesimulator_archs:
             targets.append((iphonesimulator_archs, "iPhoneSimulator"))
 
-    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.bitcodedisabled, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs)
+    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.bitcodedisabled, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
 
     b.build(args.out)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
     parser.add_argument('--legacy_build', default=False, dest='legacy_build', action='store_true', help='Build legacy framework (default: False, equivalent to "--framework_name=opencv2 --without=objc")')
     parser.add_argument('--run_tests', default=False, dest='run_tests', action='store_true', help='Run tests')
     parser.add_argument('--build_docs', default=False, dest='build_docs', action='store_true', help='Build docs')
+    parser.add_argument('--disable-swift', default=False, dest='swiftdisabled', action='store_true', help='Disable building of Swift extensions')
 
     args, unknown_args = parser.parse_known_args()
     if unknown_args:
@@ -127,5 +128,5 @@ if __name__ == "__main__":
     if catalyst_archs:
         targets.append((catalyst_archs, "Catalyst")),
 
-    b = OSXBuilder(args.opencv, args.contrib, args.dynamic, True, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs)
+    b = OSXBuilder(args.opencv, args.contrib, args.dynamic, True, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
     b.build(args.out)


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

This PR hopefully addresses a few issues that have been giving trouble when building the Swift wrapper for iOS/macOS

- add a build flag `disable-swift` flag to suppress building Swift extensions
- when the `disable-swift` is set - still generate Swift extensions and put them in SwiftSources output folder such they can be added manually to a project if needed
- change to use `typealias` instead of `NS_SWIFT_NAME` to handle Point2i → Point, Rect2i → Rect, Size2i → Size type mappings (thanks to @chrisballinger for this)

Issue that may be fixed or partially fixed by this PR: #19645 #19992 #19254

```
force_builders=docs,ios,Custom Mac
buildworker:Mac=macosx-1
buildworker:iOS=macosx-2
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-1
```