### PR TITLE
Fix for failing QRCodeDetectorTest.testDetectAndDecodeMulti test

### DIFF
--- a/modules/objdetect/misc/java/test/QRCodeDetectorTest.java
+++ b/modules/objdetect/misc/java/test/QRCodeDetectorTest.java
@@ -5,7 +5,10 @@ import org.opencv.core.Mat;
 import org.opencv.objdetect.QRCodeDetector;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.test.OpenCVTestCase;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 public class QRCodeDetectorTest extends OpenCVTestCase {
 
@@ -39,11 +42,7 @@ public class QRCodeDetectorTest extends OpenCVTestCase {
         boolean result = detector.detectAndDecodeMulti(img, output);
         assertTrue(result);
         assertEquals(output.size(), 6);
-        assertEquals(output.get(0), "SKIP");
-        assertEquals(output.get(1), "EXTRA");
-        assertEquals(output.get(2), "TWO STEPS FORWARD");
-        assertEquals(output.get(3), "STEP BACK");
-        assertEquals(output.get(4), "QUESTION");
-        assertEquals(output.get(5), "STEP FORWARD");
+        List < String > expectedResults = Arrays.asList("SKIP", "EXTRA", "TWO STEPS FORWARD", "STEP BACK", "QUESTION", "STEP FORWARD");
+        assertEquals(new HashSet<String>(output), new HashSet<String>(expectedResults));
     }
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch

Possible fix for failing test
https://build.opencv.org.cn/job/precommit/job/ubuntu-20.04-arm64/1868/

Assuming that `QRCodeDetector.detectAndDecodeMulti` does not guarantee the QR Codes are returned in any specific order then this I think this fix is reasonable