### PR TITLE
[G-API] IE backend convert fp32 to fp16

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -118,6 +118,7 @@ inline int toCV(IE::Precision prec) {
     case IE::Precision::FP32: return CV_32F;
     case IE::Precision::I32:  return CV_32S;
     case IE::Precision::I64:  return CV_32S;
+    case IE::Precision::FP16: return CV_16F;
     default:     GAPI_Assert(false && "IE. Unsupported data type");
     }
     return -1;
@@ -196,6 +197,7 @@ inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
         HANDLE(U8, uint8_t);
         HANDLE(FP32, float);
         HANDLE(I32, int);
+        HANDLE(FP16, cv::float16_t);
 #undef HANDLE
         case IE::Precision::I64: {
             GAPI_LOG_WARNING(NULL, "INT64 isn't supported for cv::Mat. Conversion to INT32 is used.");

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -241,6 +241,12 @@ struct IEUnit {
             cv::util::throw_error(std::logic_error("Unsupported ParamDesc::Kind"));
         }
 
+        for (const auto& output : outputs) {
+            if (output.second->getPrecision() == IE::Precision::FP16) {
+                output.second->setPrecision(IE::Precision::FP32);
+            }
+        }
+
         // The practice shows that not all inputs and not all outputs
         // are mandatory to specify in IE model.
         // So what we're concerned here about is:

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -241,12 +241,6 @@ struct IEUnit {
             cv::util::throw_error(std::logic_error("Unsupported ParamDesc::Kind"));
         }
 
-        for (const auto& output : outputs) {
-            if (output.second->getPrecision() == IE::Precision::FP16) {
-                output.second->setPrecision(IE::Precision::FP32);
-            }
-        }
-
         // The practice shows that not all inputs and not all outputs
         // are mandatory to specify in IE model.
         // So what we're concerned here about is:


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
