### PR TITLE
G-API: Documentation for Params (IE and ONNX).

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -53,7 +53,7 @@ namespace detail {
 */
 struct ParamDesc {
     /*@{*/
-    std::string model_path; //!< Path to topology IR (.xml file)
+    std::string model_path; //!< Path to model.
     std::string weights_path; //!< Path to weights (.bin file).
     std::string device_id; //!< Device specifier.
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -29,7 +29,7 @@ namespace ie {
 GAPI_EXPORTS cv::gapi::GBackend backend();
 
 /**
- * Specify how G-API and IE should trait input data
+ * Specifies how G-API and IE should trait input data
  *
  * In OpenCV, the same cv::Mat is used to represent both
  * image and tensor data. Sometimes those are hardly distinguishable,
@@ -85,18 +85,19 @@ struct PortCfg {
 };
 
 /**
- * @brief This structure provides functions that fill inference parameters.
+ * @brief This structure provides functions
+ * that fill inference parameters for "OpenVINO Toolkit" model.
  */
 template<typename Net> class Params {
 public:
     /** @brief Class constructor.
 
-    Constructs Params based on model information and sets default values for other
-    inference description parameters. Model is loaded and compiled with OpenVINO.
+    Constructs Params based on model information and specifies default values for other
+    inference description parameters. Model is loaded and compiled using "OpenVINO Toolkit".
 
     @param model Path to topology IR (.xml file).
     @param weights Path to weights (.bin file).
-    @param device Name of device.
+    @param device target device to use.
     */
     Params(const std::string &model,
            const std::string &weights,
@@ -113,11 +114,11 @@ public:
     };
 
     /** @overload
-    This constructor for pre-compiled networks. Model is imported from pre-compiled
-    blob.
+    Use this constructor to work with pre-compiled network.
+    Model is imported from a pre-compiled blob.
 
     @param model Path to model.
-    @param device Name of device.
+    @param device target device to use.
     */
     Params(const std::string &model,
            const std::string &device)
@@ -134,15 +135,13 @@ public:
 
     /** @brief Specifies sequence of network input layers names for inference.
 
-    The function is used to associate data of graph inputs with input layers of
-    network topology. Number of names has to match the number of network inputs. If a network
-    has only one input layer, there is no need to call it as the layer is
-    associated with input automatically but this doesn't prevent you from
-    doing it yourself. Count of names has to match to number of network inputs.
+    The function is used to associate cv::gapi::infer<> inputs with the model inputs.
+    Number of names has to match the number of network inputs as defined in G_API_NET().
+    In case a network has only single input layer, there is no need to specify name manually.
 
     @param layer_names std::array<std::string, N> where N is the number of inputs
     as defined in the @ref G_API_NET. Contains names of input layers.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &layer_names) {
         desc.input_names.clear();
@@ -152,17 +151,15 @@ public:
         return *this;
     }
 
-    /** @brief Sets sequence of network output layers names for inference.
+    /** @brief Specifies sequence of network output layers names for inference.
 
-    The function is used to associate data of graph outputs with output layers of
-    network topology. If a network has only one output layer, there is no need to call it
-    as the layer is associated with ouput automatically but this doesn't prevent
-    you from doing it yourself. Count of names has to match to number of network
-    outputs.
+    The function is used to associate cv::gapi::infer<> outputs with the model outputs.
+    Number of names has to match the number of network outputs as defined in G_API_NET().
+    In case a network has only single output layer, there is no need to specify name manually.
 
     @param layer_names std::array<std::string, N> where N is the number of outputs
     as defined in the @ref G_API_NET. Contains names of output layers.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &layer_names) {
         desc.output_names.clear();
@@ -175,14 +172,13 @@ public:
     /** @brief Specifies a constant input.
 
     The function is used to set a constant input. This input has to be
-    a preprocessed tensor if its type is TENSOR. You should provide name of network layer
-    which will receive provided data. For example, this can be useful for
-    specifying size of image tensor defined in Faster-Rnetwork.
+    a preprocessed tensor if its type is TENSOR. Need to provide name of the
+    network layer which will receive provided data.
 
     @param layer_name Name of network layer.
     @param data cv::Mat that contains data which will be associated with network layer.
-    @param hint Type of input (IMAGE or TENSOR).
-    @return the reference on modified object.
+    @param hint Input type @sa cv::gapi::ie::TraitAs.
+    @return reference to this parameter structure.
     */
     Params<Net>& constInput(const std::string &layer_name,
                             const cv::Mat &data,
@@ -191,14 +187,14 @@ public:
         return *this;
     }
 
-    /** @brief Sets OpenVINO plugin configuration.
+    /** @brief Specifies OpenVINO plugin configuration.
 
     The function is used to set configuration for OpenVINO plugin. Some parameters
     can be different for each plugin. Please follow https://docs.openvinotoolkit.org/latest/index.html
     to check information about specific plugin.
 
     @param cfg Map of pairs: (config parameter name, config parameter value).
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
        Params& pluginConfig(const IEConfig& cfg) {
         desc.config = cfg;
@@ -209,7 +205,7 @@ public:
     Function with a rvalue parameter.
 
     @param cfg rvalue map of pairs: (config parameter name, config parameter value).
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params& pluginConfig(IEConfig&& cfg) {
         desc.config = std::move(cfg);
@@ -219,7 +215,7 @@ public:
     /** @brief Specifies number of asynchronous inference requests.
 
     @param nireq Number of inference asynchronous requests.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params& cfgNumRequests(size_t nireq) {
         GAPI_Assert(nireq > 0 && "Number of infer requests must be greater than zero!");
@@ -229,14 +225,12 @@ public:
 
     /** @brief Specifies new input shapes for the network inputs.
 
-    The function is used to set new input shapes for network. You can specify
-    new dimensions for one or some or all of Network input layers. network will be
-    reshaped based on this information and your inputs will be preprocessed for
-    new input sizes. Follow https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1networkNetwork.html
+    The function is used to specify new input shapes for the network inputs.
+    Follow https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1networkNetwork.html
     for additional information.
 
     @param reshape_table Map of pairs: name of corresponding data and its dimension.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgInputReshape(const std::map<std::string, std::vector<std::size_t>>& reshape_table) {
         desc.reshape_table = reshape_table;
@@ -253,7 +247,7 @@ public:
 
     @param layer_name Name of layer.
     @param layer_dims New dimensions for this layer.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgInputReshape(const std::string& layer_name, const std::vector<size_t>& layer_dims) {
         desc.reshape_table.emplace(layer_name, layer_dims);
@@ -268,12 +262,8 @@ public:
 
     /** @overload
 
-    The function is used to set names of layers that will be used for network reshape.
-    Dimensions will be constructed automatically by current network input and height and
-    width of image.
-
     @param layer_names set of names of network layers that will be used for network reshape.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgInputReshape(const std::unordered_set<std::string>& layer_names) {
         desc.layer_names_to_reshape = layer_names;
@@ -284,7 +274,7 @@ public:
 
     @param layer_names rvalue set of the selected layers will be reshaped automatically
     its input image size.
-    @return the reference on modified object.
+    @return reference to this parameter structure.
     */
     Params<Net>& cfgInputReshape(std::unordered_set<std::string>&& layer_names) {
         desc.layer_names_to_reshape = std::move(layer_names);

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 
 #ifndef OPENCV_GAPI_INFER_IE_HPP
 #define OPENCV_GAPI_INFER_IE_HPP
@@ -47,34 +47,38 @@ enum class TraitAs: int
 using IEConfig = std::map<std::string, std::string>;
 
 namespace detail {
-    struct ParamDesc {
-        std::string model_path;
-        std::string weights_path;
-        std::string device_id;
+/**
+* @brief This structure contains description of inference parameters
+* which is specific to OpenVINO models.
+*/
+struct ParamDesc {
+    /*@{*/
+    std::string model_path; //!< Path to topology IR (.xml file)
+    std::string weights_path; //!< Path to weights (.bin file).
+    std::string device_id; //!< Device specifier.
 
-        // NB: Here order follows the `Net` API
-        std::vector<std::string> input_names;
-        std::vector<std::string> output_names;
+    // NB: Here order follows the `Net` API
+    std::vector<std::string> input_names; //!< Names of input CNN layers.
+    std::vector<std::string> output_names; //!< Names of output CNN layers.
 
-        using ConstInput = std::pair<cv::Mat, TraitAs>;
-        std::unordered_map<std::string, ConstInput> const_inputs;
+    using ConstInput = std::pair<cv::Mat, TraitAs>;
+    std::unordered_map<std::string, ConstInput> const_inputs; //!< Map with pair of name of CNN layer and ConstInput which will be associated with this.
 
-        // NB: nun_* may differ from topology's real input/output port numbers
-        // (e.g. topology's partial execution)
-        std::size_t num_in;  // How many inputs are defined in the operation
-        std::size_t num_out; // How many outputs are defined in the operation
+    // NB: nun_* may differ from topology's real input/output port numbers
+    // (e.g. topology's partial execution)
+    std::size_t num_in;  //!< How many inputs are defined in the operation
+    std::size_t num_out; //!< How many outputs are defined in the operation
 
-        enum class Kind { Load, Import };
-        Kind kind;
-        bool is_generic;
-        IEConfig config;
+    enum class Kind { Load, Import };
+    Kind kind; //!< What kind of model will be used: standard or pre-compiled.
+    bool is_generic; //!< Enable generic version of inference.
+    IEConfig config; //!< OpenVINO plugin configuration.
 
-        std::map<std::string, std::vector<std::size_t>> reshape_table;
-        std::unordered_set<std::string> layer_names_to_reshape;
+    std::map<std::string, std::vector<std::size_t>> reshape_table; //!< Map of pairs: name of corresponding data and its dimension.
+    std::unordered_set<std::string> layer_names_to_reshape; //!< Set of names of CNN layers that will be used for CNN reshape.
 
-        // NB: Number of asyncrhonious infer requests
-        size_t nireq;
-    };
+    size_t nireq; //!< Number of asyncrhonious infer requests.
+};
 } // namespace detail
 
 // FIXME: this is probably a shared (reusable) thing
@@ -88,8 +92,20 @@ struct PortCfg {
         , std::tuple_size<typename Net::OutArgs>::value >;
 };
 
+/**
+ * @brief This structure provides functions that fill inference parameters.
+ */
 template<typename Net> class Params {
 public:
+    /** @brief Class constructor.
+
+    Constructs Params based on model information and sets default values for other
+    inference description parameters. Model is loaded and compiled with OpenVINO.
+
+    @param model path to topology IR (.xml file).
+    @param weights path to weights (.bin file).
+    @param device device specifier.
+    */
     Params(const std::string &model,
            const std::string &weights,
            const std::string &device)
@@ -104,6 +120,13 @@ public:
               , 1u} {
     };
 
+    /** @overload
+    This constructor for pre-compiled networks. Model is imported from pre-compiled
+    blob.
+
+    @param model path to model.
+    @param device device specifier.
+    */
     Params(const std::string &model,
            const std::string &device)
         : desc{ model, {}, device, {}, {}, {}
@@ -117,22 +140,58 @@ public:
               , 1u} {
     };
 
-    Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &ll) {
+    /** @brief Specifies sequence of CNN input layers names for inference.
+
+    The function is used to associate data of graph inputs with input layers of
+    CNN topology. Number of names has to match the number of CNN inputs. If a CNN
+    has only one input layer, there is no need to call it as the layer is
+    associated with input automatically but this doesn't prevent you from
+    doing it yourself. Count of names has to match to number of CNN inputs.
+
+    @param layer_names std::array<std::string, N> where N is the number of inputs
+    as defined in the @ref G_API_NET. Contains names of input layers.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &layer_names) {
         desc.input_names.clear();
-        desc.input_names.reserve(ll.size());
-        std::copy(ll.begin(), ll.end(),
+        desc.input_names.reserve(layer_names.size());
+        std::copy(layer_names.begin(), layer_names.end(),
                   std::back_inserter(desc.input_names));
         return *this;
     }
 
-    Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &ll) {
+    /** @brief Sets sequence of CNN output layers names for inference.
+
+    The function is used to associate data of graph outputs with output layers of
+    CNN topology. If a CNN has only one output layer, there is no need to call it
+    as the layer is associated with ouput automatically but this doesn't prevent 
+    you from doing it yourself. Count of names has to match to number of CNN
+    outputs.
+
+    @param layer_names std::array<std::string, N> where N is the number of outputs
+    as defined in the @ref G_API_NET. Contains names of output layers.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &layer_names) {
         desc.output_names.clear();
-        desc.output_names.reserve(ll.size());
-        std::copy(ll.begin(), ll.end(),
+        desc.output_names.reserve(layer_names.size());
+        std::copy(layer_names.begin(), layer_names.end(),
                   std::back_inserter(desc.output_names));
         return *this;
     }
 
+    /** @brief Specifies a constant input.
+
+    The function is used to set a constant input. This input has to be
+    a preprocessed tensor if its type is TENSOR. You should provide name of CNN layer
+    which will receive provided data. For example, this can be useful for
+    specifying size of image tensor defined in Faster-RCNN.
+
+    @param layer_name name of CNN layer.
+    @param data cv::Mat that contains data which will be associated with CNN layer.
+    @param hint type of input (IMAGE or TENSOR).
+    @return reference to object of class Params.
+    */
     Params<Net>& constInput(const std::string &layer_name,
                             const cv::Mat &data,
                             TraitAs hint = TraitAs::TENSOR) {
@@ -140,49 +199,118 @@ public:
         return *this;
     }
 
+    /** @brief Sets OpenVINO plugin configuration.
+
+    The function is used to set configuration for OpenVINO plugin. Some parameters
+    can be different for each plugin. Please follow https://docs.openvinotoolkit.org/latest/index.html
+    for check information about your plugin.
+
+    @param cfg map of pairs: (config parameter name, config parameter value).
+    @return reference to object of class Params.
+    */
+       Params& pluginConfig(const IEConfig& cfg) {
+        desc.config = cfg;
+        return *this;
+    }
+
+    /** @overload
+    Function with an rvalue parameter.
+
+    @param cfg rvalue map of pairs: (config parameter name, config parameter value).
+    @return reference to object of class Params.
+    */
     Params& pluginConfig(IEConfig&& cfg) {
         desc.config = std::move(cfg);
         return *this;
     }
 
-    Params& pluginConfig(const IEConfig& cfg) {
-        desc.config = cfg;
-        return *this;
-    }
+    /** @brief Specifies count of asynchronous inference requests.
 
+    @param nireq count of inference asynchronous requests.
+    @return reference to object of class Params.
+    */
     Params& cfgNumRequests(size_t nireq) {
         GAPI_Assert(nireq > 0 && "Number of infer requests must be greater than zero!");
         desc.nireq = nireq;
         return *this;
     }
 
-    Params<Net>& cfgInputReshape(std::map<std::string, std::vector<std::size_t>>&& reshape_table) {
-        desc.reshape_table = std::move(reshape_table);
-        return *this;
-    }
+    /** @brief Specifies new input shapes for the CNN inputs.
 
+    The function is used to set new input shapes for network. You can specify
+    new dimensions for one or some or all of CNN input layers. CNN will be
+    reshaped based on this information and your inputs will be preprocessed for
+    new input sizes. Follow https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1CNNNetwork.html
+    for additional information.
+
+    @param reshape_table map of pairs: name of corresponding data and its dimension.
+    @return reference to object of class Params.
+    */
     Params<Net>& cfgInputReshape(const std::map<std::string, std::vector<std::size_t>>& reshape_table) {
         desc.reshape_table = reshape_table;
         return *this;
     }
 
-    Params<Net>& cfgInputReshape(std::string&& layer_name, std::vector<size_t>&& layer_dims) {
-        desc.reshape_table.emplace(layer_name, layer_dims);
+    /** @overload
+    Function with an rvalue parameters.
+
+    @param reshape_table rvalue map of pairs: name of corresponding data and its
+    dimension.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgInputReshape(std::map<std::string, std::vector<std::size_t>>&& reshape_table) {
+        desc.reshape_table = std::move(reshape_table);
         return *this;
     }
 
+    /** @overload
+    Function for one input layer.
+
+    @param layer_name name of layer.
+    @param layer_dims new dimensions for this layer.
+    @return reference to object of class Params.
+    */
     Params<Net>& cfgInputReshape(const std::string& layer_name, const std::vector<size_t>& layer_dims) {
         desc.reshape_table.emplace(layer_name, layer_dims);
         return *this;
     }
 
-    Params<Net>& cfgInputReshape(std::unordered_set<std::string>&& layer_names) {
-        desc.layer_names_to_reshape = std::move(layer_names);
+    /** @overload
+    Function with an rvalue parameters for one input layer.
+
+    @param layer_name rvalue name of layer.
+    @param layer_dims rvalue new dimensions for this layer.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgInputReshape(std::string&& layer_name, std::vector<size_t>&& layer_dims) {
+        desc.reshape_table.emplace(layer_name, layer_dims);
         return *this;
     }
 
+    /** @overload
+    Function for reshape by image size.
+
+    The function is used to set names of layers that will be used for CNN reshape.
+    Dimensions will be constructed automatically by current CNN input and height and
+    width of image.
+
+    @param layer_names set of names of CNN layers that will be used for CNN reshape.
+    @return reference to object of class Params.
+    */
     Params<Net>& cfgInputReshape(const std::unordered_set<std::string>& layer_names) {
         desc.layer_names_to_reshape = layer_names;
+        return *this;
+    }
+
+    /** @overload
+    Function with an rvalue parameters for reshape by image size.
+
+    @param layer_names rvalue set of the selected layers will be reshaped automatically
+    its input image size.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgInputReshape(std::unordered_set<std::string>&& layer_names) {
+        desc.layer_names_to_reshape = std::move(layer_names);
         return *this;
     }
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -47,37 +47,29 @@ enum class TraitAs: int
 using IEConfig = std::map<std::string, std::string>;
 
 namespace detail {
-/**
-* @brief This structure contains description of inference parameters
-* which is specific to OpenVINO models.
-*/
 struct ParamDesc {
-    /*@{*/
-    std::string model_path; //!< Path to model.
-    std::string weights_path; //!< Path to weights (.bin file).
-    std::string device_id; //!< Device specifier.
+    std::string model_path;
+    std::string weights_path;
+    std::string device_id;
 
-    // NB: Here order follows the `Net` API
-    std::vector<std::string> input_names; //!< Names of input network layers.
-    std::vector<std::string> output_names; //!< Names of output network layers.
+    std::vector<std::string> input_names;
+    std::vector<std::string> output_names;
 
     using ConstInput = std::pair<cv::Mat, TraitAs>;
-    std::unordered_map<std::string, ConstInput> const_inputs; //!< Map with pair of name of network layer and ConstInput which will be associated with this.
+    std::unordered_map<std::string, ConstInput> const_inputs;
 
-    // NB: nun_* may differ from topology's real input/output port numbers
-    // (e.g. topology's partial execution)
-    std::size_t num_in;  //!< The number of network inputs.
-    std::size_t num_out; //!< The number of network outputs.
+    std::size_t num_in;
+    std::size_t num_out;
 
-    enum class Kind { Load, Import };
-    Kind kind; //!< What kind of model will be used: standard or pre-compiled.
-    bool is_generic; //!< Enable generic version of inference.
-    IEConfig config; //!< OpenVINO plugin configuration.
+    enum class Kind {Load, Import};
+    Kind kind;
+    bool is_generic;
+    IEConfig config;
 
-    std::map<std::string, std::vector<std::size_t>> reshape_table; //!< Map of pairs: name of corresponding data and its dimension.
-    std::unordered_set<std::string> layer_names_to_reshape; //!< Set of names of network layers that will be used for network reshape.
+    std::map<std::string, std::vector<std::size_t>> reshape_table;
+    std::unordered_set<std::string> layer_names_to_reshape;
 
-    size_t nireq; //!< Number of asynchronous infer requests.
+    size_t nireq;
 };
 } // namespace detail
 
@@ -238,7 +230,7 @@ public:
     /** @brief Specifies new input shapes for the network inputs.
 
     The function is used to set new input shapes for network. You can specify
-    new dimensions for one or some or all of network input layers. network will be
+    new dimensions for one or some or all of Network input layers. network will be
     reshaped based on this information and your inputs will be preprocessed for
     new input sizes. Follow https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1networkNetwork.html
     for additional information.
@@ -251,20 +243,13 @@ public:
         return *this;
     }
 
-    /** @overload
-    Function with a rvalue parameters.
-
-    @param reshape_table rvalue map of pairs: name of corresponding data and its
-    dimension.
-    @return the reference on modified object.
-    */
+    /** @overload */
     Params<Net>& cfgInputReshape(std::map<std::string, std::vector<std::size_t>>&& reshape_table) {
         desc.reshape_table = std::move(reshape_table);
         return *this;
     }
 
     /** @overload
-    Function for one input layer.
 
     @param layer_name Name of layer.
     @param layer_dims New dimensions for this layer.
@@ -275,20 +260,13 @@ public:
         return *this;
     }
 
-    /** @overload
-    Function with a rvalue parameters for one input layer.
-
-    @param layer_name rvalue name of layer.
-    @param layer_dims rvalue new dimensions for this layer.
-    @return the reference on modified object.
-    */
+    /** @overload */
     Params<Net>& cfgInputReshape(std::string&& layer_name, std::vector<size_t>&& layer_dims) {
         desc.reshape_table.emplace(layer_name, layer_dims);
         return *this;
     }
 
     /** @overload
-    Function for reshape by image size.
 
     The function is used to set names of layers that will be used for network reshape.
     Dimensions will be constructed automatically by current network input and height and
@@ -303,7 +281,6 @@ public:
     }
 
     /** @overload
-    Function with a rvalue parameters for reshape by image size.
 
     @param layer_names rvalue set of the selected layers will be reshaped automatically
     its input image size.

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -164,7 +164,7 @@ public:
 
     The function is used to associate data of graph outputs with output layers of
     CNN topology. If a CNN has only one output layer, there is no need to call it
-    as the layer is associated with ouput automatically but this doesn't prevent 
+    as the layer is associated with ouput automatically but this doesn't prevent
     you from doing it yourself. Count of names has to match to number of CNN
     outputs.
 

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -122,7 +122,7 @@ public:
 
      The function is used to associate data of graph outputs with output layers of
     CNN topology. If a CNN has only one output layer, there is no need to call it
-    as the layer is associated with ouput automatically but this doesn't prevent 
+    as the layer is associated with ouput automatically but this doesn't prevent
     you from doing it yourself. Count of names has to match to number of CNN
     outputs or you can set your own output but for this case you have to
     additionally use @ref cfgPostProc function.

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -40,7 +40,7 @@ namespace detail {
 * which is specific to ONNX models.
 */
 struct ParamDesc {
-    std::string model_path;
+    std::string model_path; //!< Path to model.
 
     // NB: nun_* may differ from topology's real input/output port numbers
     // (e.g. topology's partial execution)

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -48,11 +48,11 @@ struct ParamDesc {
     std::size_t num_out; //!< How many outputs are defined in the operation
 
     // NB: Here order follows the `Net` API
-    std::vector<std::string> input_names; //!< Names of input CNN layers.
-    std::vector<std::string> output_names; //!< Names of output CNN layers.
+    std::vector<std::string> input_names; //!< Names of input network layers.
+    std::vector<std::string> output_names; //!< Names of output network layers.
 
     using ConstInput = std::pair<cv::Mat, TraitAs>;
-    std::unordered_map<std::string, ConstInput> const_inputs; //!< Map with pair of name of CNN layer and ConstInput which will be associated with this.
+    std::unordered_map<std::string, ConstInput> const_inputs; //!< Map with pair of name of network layer and ConstInput which will be associated with this.
 
     std::vector<cv::Scalar> mean; //!< Mean values for preprocessing.
     std::vector<cv::Scalar> stdev; //!< Standard deviation values for preprocessing.
@@ -93,7 +93,7 @@ public:
     Constructs Params based on model information and sets default values for other
     inference description parameters.
 
-    @param model path to model (.onnx file).
+    @param model Path to model (.onnx file).
     */
     Params(const std::string &model) {
         desc.model_path = model;
@@ -101,17 +101,17 @@ public:
         desc.num_out = std::tuple_size<typename Net::OutArgs>::value;
     };
 
-    /** @brief Specifies sequence of CNN input layers names for inference.
+    /** @brief Specifies sequence of network input layers names for inference.
 
     The function is used to associate data of graph inputs with input layers of
-    CNN topology. Number of names has to match the number of CNN inputs. If a CNN
+    network topology. Number of names has to match the number of network inputs. If a network
     has only one input layer, there is no need to call it as the layer is
     associated with input automatically but this doesn't prevent you from
-    doing it yourself. Count of names has to match to number of CNN inputs.
+    doing it yourself. Count of names has to match to number of network inputs.
 
     @param layer_names std::array<std::string, N> where N is the number of inputs
     as defined in the @ref G_API_NET. Contains names of input layers.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &layer_names) {
         desc.input_names.assign(layer_names.begin(), layer_names.end());
@@ -121,15 +121,15 @@ public:
     /** @brief Specifies sequence of output layers names for inference.
 
      The function is used to associate data of graph outputs with output layers of
-    CNN topology. If a CNN has only one output layer, there is no need to call it
+    network topology. If a network has only one output layer, there is no need to call it
     as the layer is associated with ouput automatically but this doesn't prevent
-    you from doing it yourself. Count of names has to match to number of CNN
+    you from doing it yourself. Count of names has to match to number of network
     outputs or you can set your own output but for this case you have to
     additionally use @ref cfgPostProc function.
 
     @param layer_names std::array<std::string, N> where N is the number of outputs
     as defined in the @ref G_API_NET. Contains names of output layers.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &layer_names) {
         desc.output_names.assign(layer_names.begin(), layer_names.end());
@@ -140,12 +140,12 @@ public:
 
     The function is used to set constant input. This input has to be
     a prepared tensor since preprocessing is disabled for this case. You should
-    provide name of CNN layer which will receive provided data.
+    provide name of network layer which will receive provided data.
 
-    @param layer_name name of CNN layer.
-    @param data cv::Mat that contains data which will be associated with CNN layer.
-    @param hint type of input (TENSOR).
-    @return reference to object of class Params.
+    @param layer_name Name of network layer.
+    @param data cv::Mat that contains data which will be associated with network layer.
+    @param hint Type of input (TENSOR).
+    @return the reference on modified object.
     */
     Params<Net>& constInput(const std::string &layer_name,
                             const cv::Mat &data,
@@ -163,7 +163,7 @@ public:
     as defined in the @ref G_API_NET. Contains mean values.
     @param s std::array<cv::Scalar, N> where N is the number of inputs
     as defined in the @ref G_API_NET. Contains standard deviation values.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgMeanStd(const typename PortCfg<Net>::NormCoefs &m,
                             const typename PortCfg<Net>::NormCoefs &s) {
@@ -180,11 +180,11 @@ public:
     So you have to provide @ref PostProc function that gets information from inference
     result and fill output which is constructed by dimensions from out_metas.
 
-    @param out_metas out meta information about your output (type, dimension).
-    @param remap_function post processing function, which has two parameters. First is onnx
+    @param out_metas Out meta information about your output (type, dimension).
+    @param remap_function Post processing function, which has two parameters. First is onnx
     result, second is graph output. Both parameters is std::map that contain pair of
     layer's name and cv::Mat.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
                              const PostProc &remap_function) {
@@ -194,13 +194,13 @@ public:
     }
 
     /** @overload
-    Function with an rvalue parameters.
+    Function with a rvalue parameters.
 
     @param out_metas rvalue out meta information about your output (type, dimension).
     @param remap_function rvalue post processing function, which has two parameters. First is onnx
     result, second is graph output. Both parameters is std::map that contain pair of
     layer's name and cv::Mat.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
                              PostProc &&remap_function) {
@@ -214,12 +214,12 @@ public:
     information about output layers which will be used for inference and post
     processing function.
 
-    @param out_metas out meta information.
-    @param remap_function post processing function.
-    @param names_to_remap names of output layers. CNN's inference will
+    @param out_metas Out meta information.
+    @param remap_function Post processing function.
+    @param names_to_remap Names of output layers. network's inference will
     be done on these layers. Inference's result will be processed in post processing
     function using these names.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
                              const PostProc &remap_function,
@@ -231,14 +231,14 @@ public:
     }
 
     /** @overload
-    Function with an rvalue parameters and additional parameter names_to_remap.
+    Function with a rvalue parameters and additional parameter names_to_remap.
 
     @param out_metas rvalue out meta information.
     @param remap_function rvalue post processing function.
-    @param names_to_remap rvalue names of output layers. CNN's inference will
+    @param names_to_remap rvalue names of output layers. network's inference will
     be done on these layers. Inference's result will be processed in post processing
     function using these names.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
                              PostProc &&remap_function,
@@ -256,7 +256,7 @@ public:
     @param normalizations std::array<cv::Scalar, N> where N is the number of inputs
     as defined in the @ref G_API_NET. Сontains bool values that enabled or disabled
     normalize of input data.
-    @return reference to object of class Params.
+    @return the reference on modified object.
     */
     Params<Net>& cfgNormalize(const typename PortCfg<Net>::Normalize &normalizations) {
         desc.normalize.assign(normalizations.begin(), normalizations.end());

--- a/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/onnx.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 
 #ifndef OPENCV_GAPI_INFER_ONNX_HPP
 #define OPENCV_GAPI_INFER_ONNX_HPP
@@ -34,32 +34,35 @@ enum class TraitAs: int {
 using PostProc = std::function<void(const std::unordered_map<std::string, cv::Mat> &,
                                           std::unordered_map<std::string, cv::Mat> &)>;
 
-
 namespace detail {
+/**
+* @brief This structure contains description of inference parameters
+* which is specific to ONNX models.
+*/
 struct ParamDesc {
     std::string model_path;
 
     // NB: nun_* may differ from topology's real input/output port numbers
     // (e.g. topology's partial execution)
-    std::size_t num_in;  // How many inputs are defined in the operation
-    std::size_t num_out; // How many outputs are defined in the operation
+    std::size_t num_in;  //!< How many inputs are defined in the operation
+    std::size_t num_out; //!< How many outputs are defined in the operation
 
     // NB: Here order follows the `Net` API
-    std::vector<std::string> input_names;
-    std::vector<std::string> output_names;
+    std::vector<std::string> input_names; //!< Names of input CNN layers.
+    std::vector<std::string> output_names; //!< Names of output CNN layers.
 
     using ConstInput = std::pair<cv::Mat, TraitAs>;
-    std::unordered_map<std::string, ConstInput> const_inputs;
+    std::unordered_map<std::string, ConstInput> const_inputs; //!< Map with pair of name of CNN layer and ConstInput which will be associated with this.
 
-    std::vector<cv::Scalar> mean;
-    std::vector<cv::Scalar> stdev;
+    std::vector<cv::Scalar> mean; //!< Mean values for preprocessing.
+    std::vector<cv::Scalar> stdev; //!< Standard deviation values for preprocessing.
 
-    std::vector<cv::GMatDesc> out_metas;
-    PostProc custom_post_proc;
+    std::vector<cv::GMatDesc> out_metas; //!< Out meta information about your output (type, dimension).
+    PostProc custom_post_proc; //!< Post processing function.
 
-    std::vector<bool> normalize;
+    std::vector<bool> normalize; //!< Vector of bool values that enabled or disabled normalize of input data.
 
-    std::vector<std::string> names_to_remap;
+    std::vector<std::string> names_to_remap; //!< Names of output layers that will be processed in PostProc function.
 };
 } // namespace detail
 
@@ -79,30 +82,71 @@ struct PortCfg {
         , std::tuple_size<typename Net::InArgs>::value >;
 };
 
+/**
+ * Contains description of inference parameters and kit of functions that
+ * fill this parameters.
+ */
 template<typename Net> class Params {
 public:
+    /** @brief Class constructor.
+
+    Constructs Params based on model information and sets default values for other
+    inference description parameters.
+
+    @param model path to model (.onnx file).
+    */
     Params(const std::string &model) {
         desc.model_path = model;
         desc.num_in  = std::tuple_size<typename Net::InArgs>::value;
         desc.num_out = std::tuple_size<typename Net::OutArgs>::value;
     };
 
-    // BEGIN(G-API's network parametrization API)
-    GBackend      backend() const { return cv::gapi::onnx::backend(); }
-    std::string   tag()     const { return Net::tag(); }
-    cv::util::any params()  const { return { desc }; }
-    // END(G-API's network parametrization API)
+    /** @brief Specifies sequence of CNN input layers names for inference.
 
-    Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &ll) {
-        desc.input_names.assign(ll.begin(), ll.end());
+    The function is used to associate data of graph inputs with input layers of
+    CNN topology. Number of names has to match the number of CNN inputs. If a CNN
+    has only one input layer, there is no need to call it as the layer is
+    associated with input automatically but this doesn't prevent you from
+    doing it yourself. Count of names has to match to number of CNN inputs.
+
+    @param layer_names std::array<std::string, N> where N is the number of inputs
+    as defined in the @ref G_API_NET. Contains names of input layers.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &layer_names) {
+        desc.input_names.assign(layer_names.begin(), layer_names.end());
         return *this;
     }
 
-    Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &ll) {
-        desc.output_names.assign(ll.begin(), ll.end());
+    /** @brief Specifies sequence of output layers names for inference.
+
+     The function is used to associate data of graph outputs with output layers of
+    CNN topology. If a CNN has only one output layer, there is no need to call it
+    as the layer is associated with ouput automatically but this doesn't prevent 
+    you from doing it yourself. Count of names has to match to number of CNN
+    outputs or you can set your own output but for this case you have to
+    additionally use @ref cfgPostProc function.
+
+    @param layer_names std::array<std::string, N> where N is the number of outputs
+    as defined in the @ref G_API_NET. Contains names of output layers.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgOutputLayers(const typename PortCfg<Net>::Out &layer_names) {
+        desc.output_names.assign(layer_names.begin(), layer_names.end());
         return *this;
     }
 
+    /** @brief Sets a constant input.
+
+    The function is used to set constant input. This input has to be
+    a prepared tensor since preprocessing is disabled for this case. You should
+    provide name of CNN layer which will receive provided data.
+
+    @param layer_name name of CNN layer.
+    @param data cv::Mat that contains data which will be associated with CNN layer.
+    @param hint type of input (TENSOR).
+    @return reference to object of class Params.
+    */
     Params<Net>& constInput(const std::string &layer_name,
                             const cv::Mat &data,
                             TraitAs hint = TraitAs::TENSOR) {
@@ -110,6 +154,17 @@ public:
         return *this;
     }
 
+    /** @brief Specifies mean value and standard deviation for preprocessing.
+
+    The function is used to set mean value and standard deviation for preprocessing
+    of input data.
+
+    @param m std::array<cv::Scalar, N> where N is the number of inputs
+    as defined in the @ref G_API_NET. Contains mean values.
+    @param s std::array<cv::Scalar, N> where N is the number of inputs
+    as defined in the @ref G_API_NET. Contains standard deviation values.
+    @return reference to object of class Params.
+    */
     Params<Net>& cfgMeanStd(const typename PortCfg<Net>::NormCoefs &m,
                             const typename PortCfg<Net>::NormCoefs &s) {
         desc.mean.assign(m.begin(), m.end());
@@ -117,74 +172,102 @@ public:
         return *this;
     }
 
-    /** @brief Configures graph output and sets the post processing function from user.
+    /** @brief Configures graph output and provides the post processing function from user.
 
-    The function is used for the case of infer of networks with dynamic outputs.
-    Since these networks haven't known output parameters needs provide them for
-    construction of output of graph.
-    The function provides meta information of outputs and post processing function.
-    Post processing function is used for copy information from ONNX infer's result
-    to output of graph which is allocated by out meta information.
+    The function is used when you work with networks with dynamic outputs.
+    Since we can't know dimensions of inference result needs provide them for
+    construction of graph output. This dimensions can differ from inference result.
+    So you have to provide @ref PostProc function that gets information from inference
+    result and fill output which is constructed by dimensions from out_metas.
 
-    @param out_metas out meta information.
-    @param pp post processing function, which has two parameters. First is onnx
+    @param out_metas out meta information about your output (type, dimension).
+    @param remap_function post processing function, which has two parameters. First is onnx
     result, second is graph output. Both parameters is std::map that contain pair of
     layer's name and cv::Mat.
     @return reference to object of class Params.
     */
     Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
-                             const PostProc &pp) {
+                             const PostProc &remap_function) {
         desc.out_metas        = out_metas;
-        desc.custom_post_proc = pp;
+        desc.custom_post_proc = remap_function;
         return *this;
     }
 
     /** @overload
-    The function has rvalue parameters.
+    Function with an rvalue parameters.
+
+    @param out_metas rvalue out meta information about your output (type, dimension).
+    @param remap_function rvalue post processing function, which has two parameters. First is onnx
+    result, second is graph output. Both parameters is std::map that contain pair of
+    layer's name and cv::Mat.
+    @return reference to object of class Params.
     */
     Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
-                             PostProc &&pp) {
+                             PostProc &&remap_function) {
         desc.out_metas        = std::move(out_metas);
-        desc.custom_post_proc = std::move(pp);
+        desc.custom_post_proc = std::move(remap_function);
         return *this;
     }
 
     /** @overload
     The function has additional parameter names_to_remap. This parameter provides
-    information about output layers which will be used for infer and in post
+    information about output layers which will be used for inference and post
     processing function.
 
     @param out_metas out meta information.
-    @param pp post processing function.
-    @param names_to_remap contains names of output layers. CNN's infer will be done on these layers.
-    Infer's result will be processed in post processing function using these names.
+    @param remap_function post processing function.
+    @param names_to_remap names of output layers. CNN's inference will
+    be done on these layers. Inference's result will be processed in post processing
+    function using these names.
     @return reference to object of class Params.
     */
     Params<Net>& cfgPostProc(const std::vector<cv::GMatDesc> &out_metas,
-                             const PostProc &pp,
+                             const PostProc &remap_function,
                              const std::vector<std::string> &names_to_remap) {
         desc.out_metas        = out_metas;
-        desc.custom_post_proc = pp;
+        desc.custom_post_proc = remap_function;
         desc.names_to_remap   = names_to_remap;
         return *this;
     }
 
     /** @overload
-    The function has rvalue parameters.
+    Function with an rvalue parameters and additional parameter names_to_remap.
+
+    @param out_metas rvalue out meta information.
+    @param remap_function rvalue post processing function.
+    @param names_to_remap rvalue names of output layers. CNN's inference will
+    be done on these layers. Inference's result will be processed in post processing
+    function using these names.
+    @return reference to object of class Params.
     */
     Params<Net>& cfgPostProc(std::vector<cv::GMatDesc> &&out_metas,
-                             PostProc &&pp,
+                             PostProc &&remap_function,
                              std::vector<std::string> &&names_to_remap) {
         desc.out_metas        = std::move(out_metas);
-        desc.custom_post_proc = std::move(pp);
+        desc.custom_post_proc = std::move(remap_function);
         desc.names_to_remap   = std::move(names_to_remap);
         return *this;
     }
 
-    Params<Net>& cfgNormalize(const typename PortCfg<Net>::Normalize &n) {
-        desc.normalize.assign(n.begin(), n.end());
+    /** @brief Specifies normalize parameter for preprocessing.
+
+    The function is used to set normalize parameter for preprocessing of input data.
+
+    @param normalizations std::array<cv::Scalar, N> where N is the number of inputs
+    as defined in the @ref G_API_NET. Сontains bool values that enabled or disabled
+    normalize of input data.
+    @return reference to object of class Params.
+    */
+    Params<Net>& cfgNormalize(const typename PortCfg<Net>::Normalize &normalizations) {
+        desc.normalize.assign(normalizations.begin(), normalizations.end());
         return *this;
     }
+
+    // BEGIN(G-API's network parametrization API)
+    GBackend      backend() const { return cv::gapi::onnx::backend(); }
+    std::string   tag()     const { return Net::tag(); }
+    cv::util::any params()  const { return { desc }; }
+    // END(G-API's network parametrization API)
 
 protected:
     detail::ParamDesc desc;


### PR DESCRIPTION
Documentation for cfg_functions of Params.

Docs:  http://pullrequest.opencv.org/buildbot/export/pr/20112/docs/
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Magic commands:
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

