### PR TITLE
Support queue capacity as graph compilation argument

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -195,6 +195,14 @@ private:
 
 using GCompileArgs = std::vector<GCompileArg>;
 
+inline cv::GCompileArgs& operator += (      cv::GCompileArgs &lhs,
+                                      const cv::GCompileArgs &rhs)
+{
+    lhs.reserve(lhs.size() + rhs.size());
+    lhs.insert(lhs.end(), rhs.begin(), rhs.end());
+    return lhs;
+}
+
 /**
  * @brief Wraps a list of arguments (a parameter pack) into a vector of
  *        compilation arguments (cv::GCompileArg).

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -380,8 +380,9 @@ namespace streaming {
  * fetch next frame while current is being processed. This compilation argument
  * specifies the capacity of this queue.
  */
-struct queue_capacity
+struct GAPI_EXPORTS queue_capacity
 {
+    queue_capacity(size_t cap = 1) : capacity(cap) { };
     size_t capacity;
 };
 /** @} */
@@ -390,10 +391,10 @@ struct queue_capacity
 
 namespace detail
 {
-    template<> struct CompileArgTag<cv::gapi::streaming::queue_capacity>
-    {
-        static const char* tag() { return "gapi.queue_capacity"; }
-    };
+template<> struct CompileArgTag<cv::gapi::streaming::queue_capacity>
+{
+    static const char* tag() { return "gapi.queue_capacity"; }
+};
 }
 
 }

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -372,6 +372,7 @@ protected:
 /** @} */
 
 namespace gapi {
+namespace streaming {
 /**
  * @brief Ask G-API to set specific queue capacity for streaming execution.
  *
@@ -384,11 +385,12 @@ struct queue_capacity
     size_t capacity;
 };
 /** @} */
+} // namespace streaming
 } // namespace gapi
 
 namespace detail
 {
-    template<> struct CompileArgTag<cv::gapi::queue_capacity>
+    template<> struct CompileArgTag<cv::gapi::streaming::queue_capacity>
     {
         static const char* tag() { return "gapi.queue_capacity"; }
     };

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -371,6 +371,29 @@ protected:
 };
 /** @} */
 
+namespace gapi {
+/**
+ * @brief Ask G-API to set specific queue capacity for streaming execution.
+ *
+ * For streaming execution G-API has a special concurrent bounded queue to
+ * fetch next frame while current is being processed. This compilation argument
+ * specifies the capacity of this queue.
+ */
+struct queue_capacity
+{
+    size_t capacity;
+};
+/** @} */
+} // namespace gapi
+
+namespace detail
+{
+    template<> struct CompileArgTag<cv::gapi::queue_capacity>
+    {
+        static const char* tag() { return "gapi.queue_capacity"; }
+    };
+}
+
 }
 
 #endif // OPENCV_GAPI_GSTREAMING_COMPILED_HPP

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -374,15 +374,14 @@ protected:
 namespace gapi {
 namespace streaming {
 /**
- * @brief Ask G-API to set specific queue capacity for streaming execution.
+ * @brief Specify queue capacity for streaming execution.
  *
- * For streaming execution G-API has a special concurrent bounded queue to
- * fetch next frame while current is being processed. This compilation argument
- * specifies the capacity of this queue.
+ * In the streaming mode the pipeline steps are connected with queues
+ * and this compile argument controls every queue's size.
  */
 struct GAPI_EXPORTS queue_capacity
 {
-    queue_capacity(size_t cap = 1) : capacity(cap) { };
+    explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
     size_t capacity;
 };
 /** @} */

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1128,7 +1128,7 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
 
     // Very rough estimation to limit internal queue sizes if not specified by the user.
     // Pipeline depth is equal to number of its (pipeline) steps.
-    auto has_queue_capacity = cv::gapi::getCompileArg<cv::gapi::queue_capacity>(m_comp_args);
+    auto has_queue_capacity = cv::gapi::getCompileArg<cv::gapi::streaming::queue_capacity>(m_comp_args);
     const auto queue_capacity = has_queue_capacity ? has_queue_capacity->capacity :
             3*std::count_if
             (m_gim.nodes().begin(),

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1136,6 +1136,7 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
             [&](ade::NodeHandle nh) {
                 return m_gim.metadata(nh).get<NodeKind>().k == NodeKind::ISLAND;
             });
+    GAPI_Assert(queue_capacity != 0u);
 
     auto sync_policy = cv::gimpl::getCompileArg<cv::gapi::streaming::sync_policy>(m_comp_args)
                        .value_or(cv::gapi::streaming::sync_policy::dont_sync);

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1126,14 +1126,16 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
     m_sink_queues   .resize(proto.out_nhs.size(), nullptr);
     m_sink_sync     .resize(proto.out_nhs.size(), -1);
 
-    // Very rough estimation to limit internal queue sizes.
+    // Very rough estimation to limit internal queue sizes if not specified by the user.
     // Pipeline depth is equal to number of its (pipeline) steps.
-    const auto queue_capacity = 3*std::count_if
-        (m_gim.nodes().begin(),
-         m_gim.nodes().end(),
-         [&](ade::NodeHandle nh) {
-            return m_gim.metadata(nh).get<NodeKind>().k == NodeKind::ISLAND;
-         });
+    auto has_queue_capacity = cv::gapi::getCompileArg<cv::gapi::queue_capacity>(m_comp_args);
+    const auto queue_capacity = has_queue_capacity ? has_queue_capacity->capacity :
+            3*std::count_if
+            (m_gim.nodes().begin(),
+            m_gim.nodes().end(),
+            [&](ade::NodeHandle nh) {
+                return m_gim.metadata(nh).get<NodeKind>().k == NodeKind::ISLAND;
+            });
 
     auto sync_policy = cv::gimpl::getCompileArg<cv::gapi::streaming::sync_policy>(m_comp_args)
                        .value_or(cv::gapi::streaming::sync_policy::dont_sync);

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -447,7 +447,8 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoConstSource_NoHang)
     auto testc = cv::GComputation(cv::GIn(in, in2), cv::GOut(out))
         .compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{256,256}},
                           cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
-                          cv::compile_args(cv::gapi::use_only{getKernelPackage()}));
+                          cv::compile_args(cv::gapi::use_only{getKernelPackage()},
+                                           cv::gapi::queue_capacity{1}));
 
     cv::Mat in_const = cv::Mat::eye(cv::Size(256,256), CV_8UC3);
     testc.setSource(cv::gin(in_const,


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```