### PR TITLE
Use correct BibTeX syntax for month field

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -835,12 +835,12 @@
   journal = {IEEE Transactions on Robotics and Automation},
   title = {Robot sensor calibration: solving AX=XB on the Euclidean group},
   year = {1994},
+  month = oct,
   volume = {10},
   number = {5},
   pages = {717-721},
   doi = {10.1109/70.326576},
-  ISSN = {1042-296X},
-  month = {Oct}
+  issn = {1042-296X}
 }
 @inproceedings{PM03,
   author = {P{\'e}rez, Patrick and Gangnet, Michel and Blake, Andrew},
@@ -1028,12 +1028,12 @@
   journal = {IEEE Transactions on Robotics and Automation},
   title = {A new technique for fully autonomous and efficient 3D robotics hand/eye calibration},
   year = {1989},
+  month = jun,
   volume = {5},
   number = {3},
   pages = {345-358},
   doi = {10.1109/70.34770},
-  ISSN = {1042-296X},
-  month = {June}
+  issn = {1042-296X}
 }
 @inproceedings{UES01,
   author = {Uyttendaele, Matthew and Eden, Ashley and Skeliski, R},


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

---

**Warning: issue is still present with this PR. Maybe someone will found the solution**

---

See:
- [How to use the month field in BibTeX?](https://www.bibtex.com/f/month-field/)
- [Bibtex day and Month Problem](https://tex.stackexchange.com/questions/345321/bibtex-day-and-month-problem)

Unfortunately, there are still some issues (year is still not rendered for the two entries).

- In current master, [e.g. 1](https://docs.opencv.org/master/d0/de3/citelist.html#CITEREF_Tsai89), [e.g. 2](https://docs.opencv.org/master/d0/de3/citelist.html#CITEREF_Park94):

![image](https://user-images.githubusercontent.com/8229425/118814194-29cd3000-b8b0-11eb-8e94-0a5a198b3d7e.png)

- **With this PR, issue is still present on my computer**
- Removing the `month` or the `doi` solve the rendering:

(Without `month`)

![image](https://user-images.githubusercontent.com/8229425/118815757-cfcd6a00-b8b1-11eb-89dd-d657ff3a7ef2.png)

(Without `doi`)

![image](https://user-images.githubusercontent.com/8229425/118815809-e1167680-b8b1-11eb-8d0c-2d53a041f386.png)
