### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1288,10 +1288,8 @@ status("    ZLib:"   ZLIB_FOUND THEN "${ZLIB_LIBRARIES} (ver ${ZLIB_VERSION_STRI
 if(WITH_JPEG OR HAVE_JPEG)
   if(NOT HAVE_JPEG)
     status("    JPEG:" NO)
-  elseif(BUILD_JPEG)
-    status("    JPEG:" "build-${JPEG_LIBRARY} (ver ${JPEG_LIB_VERSION})")
   else()
-    status("    JPEG:" "${JPEG_LIBRARY} (ver ${JPEG_LIB_VERSION})")
+    status("    JPEG:" JPEG_FOUND THEN "${JPEG_LIBRARY} (ver ${JPEG_LIB_VERSION})" ELSE "build (ver ${JPEG_LIBRARY})")
   endif()
 endif()
 


### PR DESCRIPTION
to address the inconsistency between MEDIA IO output information and the actual situation.

If I don't have the JPEG, and if I do not have the flag BUILD_JEPG, it will go the the 3rd branch:
status(" JPEG:" "${JPEG_LIBRARY} (ver ${JPEG_LIB_VERSION})")

but actually cmake will still build the libjpeg from the source. Therefore, I think it should be
status(" JPEG:" "build-${JPEG_LIBRARY} (ver ${JPEG_LIB_VERSION})")

See #20118 


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [YES] I agree to contribute to the project under Apache 2 License.
- [YES] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [YES] The PR is proposed to proper branch
- [YES] There is reference to original bug report and related work
- [YES] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [YES] The feature is well documented and sample code can be built with the project CMake
