### PR TITLE
Fix data overflow problem in GaussianBlur

### DIFF
--- a/modules/imgproc/src/smooth.simd.hpp
+++ b/modules/imgproc/src/smooth.simd.hpp
@@ -1236,8 +1236,12 @@ void hlineSmoothONa_yzy_a<uint16_t, ufixedpoint32>(const uint16_t* src, int cn, 
         v_mul_expand(vx_load(src + pre_shift * cn), vx_setall_u16((uint16_t) *((uint32_t*)(m + pre_shift))), v_res0, v_res1);
         for (int j = 0; j < pre_shift; j ++)
         {
+            v_uint16 v_weight = vx_setall_u16((uint16_t) *((uint32_t*)(m + j)));
             v_uint32 v_add0, v_add1;
-            v_mul_expand(vx_load(src + j * cn) + vx_load(src + (n - 1 - j)*cn), vx_setall_u16((uint16_t) *((uint32_t*)(m + j))), v_add0, v_add1);
+            v_mul_expand(vx_load(src + j * cn), v_weight, v_add0, v_add1);
+            v_res0 += v_add0;
+            v_res1 += v_add1;
+            v_mul_expand(vx_load(src + (n - 1 - j)*cn), v_weight, v_add0, v_add1);
             v_res0 += v_add0;
             v_res1 += v_add1;
         }

--- a/modules/imgproc/test/test_smooth_bitexact.cpp
+++ b/modules/imgproc/test/test_smooth_bitexact.cpp
@@ -220,6 +220,15 @@ TEST(GaussianBlur_Bitexact, regression_15015)
     ASSERT_EQ(0.0, cvtest::norm(dst, src, NORM_INF));
 }
 
+TEST(GaussianBlur_Bitexact, overflow_20121)
+{
+    Mat src(100, 100, CV_16UC1, Scalar(65535));
+    Mat dst;
+    GaussianBlur(src, dst, cv::Size(9, 9), 0.0);
+    double min_val;
+    minMaxLoc(dst, &min_val);
+    ASSERT_EQ(cvRound(min_val), 65535);
+}
 
 static void checkGaussianBlur_8Uvs32F(const Mat& src8u, const Mat& src32f, int N, double sigma)
 {


### PR DESCRIPTION
See issue #20121

The SIMD code in [smooth.simd.hpp](https://github.com/opencv/opencv/blob/5f4e55bc68db4a105fcafa465c19c047d35a2e0e/modules/imgproc/src/smooth.simd.hpp#L1240) adds two pixel values before multiplying by weights, which leads to data overflow:
```cpp
v_mul_expand(vx_load(src + j * cn) + vx_load(src + (n - 1 - j)*cn), vx_setall_u16((uint16_t) *((uint32_t*)(m + j))), v_add0, v_add1);
```
Both 3.4 and master branches are affected.

Test case is also added in this PR.

relates #18983

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
