### PR TITLE
Analog of gtest_filter for java tests

### DIFF
--- a/modules/java/test/pure_test/build.xml
+++ b/modules/java/test/pure_test/build.xml
@@ -6,6 +6,7 @@
 
   <property name="opencv.test.package" value="*"/>
   <property name="opencv.test.class" value="*"/>
+  <property name="opencv.test.exclude" value=""/>
 
   <path id="master-classpath">
     <fileset dir="lib">
@@ -53,7 +54,7 @@
       <formatter type="xml"/>
 
       <batchtest fork="yes" todir="${test.dir}">
-        <zipfileset src="build/jar/opencv-test.jar" includes="**/${opencv.test.package}/${opencv.test.class}.class" excludes="**/OpenCVTest*">
+        <zipfileset src="build/jar/opencv-test.jar" includes="**/${opencv.test.package}/${opencv.test.class}.class" excludes="**/OpenCVTest*, ${opencv.test.exclude}">
           <exclude name="**/*$*.class"/>
         </zipfileset>
       </batchtest>

--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
     parser.add_argument("--android_propagate_opencv_env", action="store_true", default=False, help="Android: propagate OPENCV* environment variables")
     parser.add_argument("--serial", metavar="serial number", default="", help="Android: directs command to the USB device or emulator with the given serial number")
     parser.add_argument("--package", metavar="package", default="", help="Java: run JUnit tests for specified module or Android package")
+    parser.add_argument("--java_test_exclude", metavar="java_test_exclude", default="", help="Java: Filter out specific JUnit tests")
 
     parser.add_argument("--trace", action="store_true", default=False, help="Trace: enable OpenCV tracing")
     parser.add_argument("--trace_dump", metavar="trace_dump", default=-1, help="Trace: dump highlight calls (specify max entries count, 0 - dump all)")

--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -115,6 +115,8 @@ class TestSuite(object):
             cmd = [self.cache.ant_executable, "-Dopencv.build.type=%s" % self.cache.build_type]
             if self.options.package:
                 cmd += ["-Dopencv.test.package=%s" % self.options.package]
+            if self.options.java_test_exclude:
+                cmd += ["-Dopencv.test.exclude=%s" % self.options.java_test_exclude]
             cmd += ["buildAndTest"]
             ret = execute(cmd, cwd=self.cache.java_test_dir)
             return None, ret


### PR DESCRIPTION
Replacement: https://github.com/opencv/opencv/pull/20037

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
