### PR TITLE
G-API: Extend MediaFrame to be able to extract additional info besides access

### DIFF
--- a/modules/gapi/include/opencv2/gapi/media.hpp
+++ b/modules/gapi/include/opencv2/gapi/media.hpp
@@ -13,6 +13,7 @@
 #include <utility>    // forward<>()
 
 #include <opencv2/gapi/gframe.hpp>
+#include <opencv2/gapi/util/any.hpp>
 
 namespace cv {
 
@@ -29,6 +30,8 @@ public:
 
     View access(Access) const;
     cv::GFrameDesc desc() const;
+
+    cv::util::any blobParams() const;
 
     // Cast underlying MediaFrame adapter to the particular adapter type,
     // return nullptr if underlying type is different
@@ -78,6 +81,7 @@ public:
     virtual ~IAdapter() = 0;
     virtual cv::GFrameDesc meta() const = 0;
     virtual MediaFrame::View access(MediaFrame::Access) = 0;
+    virtual cv::util::any blobParams() const = 0;
 };
 
 } //namespace cv

--- a/modules/gapi/src/api/media.cpp
+++ b/modules/gapi/src/api/media.cpp
@@ -26,6 +26,11 @@ cv::MediaFrame::View cv::MediaFrame::access(Access code) const {
     return m->adapter->access(code);
 }
 
+cv::util::any cv::MediaFrame::blobParams() const
+{
+    return m->adapter->blobParams();
+}
+
 cv::MediaFrame::IAdapter* cv::MediaFrame::getAdapter() const {
     return m->adapter.get();
 }

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1753,6 +1753,10 @@ namespace {
             cv::MediaFrame::View::Strides ss = { m_mat.step, 0u, 0u, 0u };
             return cv::MediaFrame::View(std::move(pp), std::move(ss));
         }
+        cv::util::any blobParams() const override {
+            GAPI_Assert(false && "Not implemented");
+            return {};
+        }
     };
 };
 

--- a/modules/gapi/test/gapi_frame_tests.cpp
+++ b/modules/gapi/test/gapi_frame_tests.cpp
@@ -49,6 +49,9 @@ public:
         cv::MediaFrame::View::Strides ss = { m_mat.step, 0u, 0u, 0u };
         return cv::MediaFrame::View(std::move(pp), std::move(ss), Cb{m_cb});
     }
+    cv::util::any blobParams() const override {
+        return std::make_pair<std::string, int>("hello", 42);
+    }
 };
 
 class TestMediaNV12 final: public cv::MediaFrame::IAdapter {
@@ -68,6 +71,10 @@ public:
             m_y.step, m_uv.step, 0u, 0u
         };
         return cv::MediaFrame::View(std::move(pp), std::move(ss));
+    }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
     }
 };
 } // anonymous namespace
@@ -172,6 +179,17 @@ TEST(MediaFrame, Callback) {
         EXPECT_EQ(1, counter);
     }
     EXPECT_EQ(3, counter);
+}
+
+TEST(MediaFrame, blobParams) {
+    cv::Mat bgr = cv::Mat::eye(240, 320, CV_8UC3);
+    cv::MediaFrame frame = cv::MediaFrame::Create<TestMediaBGR>(bgr);
+
+    cv::util::any any_params = frame.blobParams();
+    auto params = cv::util::any_cast<std::pair<std::string, int>>(any_params);
+
+    EXPECT_EQ("hello", params.first);
+    EXPECT_EQ(42, params.second);
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -35,6 +35,10 @@ public:
         cv::MediaFrame::View::Strides ss = { m_mat.step, 0u, 0u, 0u };
         return cv::MediaFrame::View(std::move(pp), std::move(ss), Cb{m_cb});
     }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
+    }
 };
 
 class TestMediaNV12 final: public cv::MediaFrame::IAdapter {
@@ -54,6 +58,10 @@ public:
             m_y.step, m_uv.step, 0u, 0u
         };
         return cv::MediaFrame::View(std::move(pp), std::move(ss));
+    }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
     }
 };
 struct ONNXInitPath {

--- a/modules/gapi/test/render/gapi_render_tests_ocv.cpp
+++ b/modules/gapi/test/render/gapi_render_tests_ocv.cpp
@@ -91,6 +91,10 @@ public:
         };
         return cv::MediaFrame::View(std::move(pp), std::move(ss));
     }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
+    }
 };
 
 TEST_P(RenderMFrameOCVTestTexts, AccuracyTest)

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -133,6 +133,10 @@ class TestMediaBGR final: public cv::MediaFrame::IAdapter {
         cv::MediaFrame::View::Strides ss = { m_mat.step, 0u, 0u, 0u };
         return cv::MediaFrame::View(std::move(pp), std::move(ss), Cb{m_cb});
     }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
+    }
 };
 
 class TestMediaNV12 final: public cv::MediaFrame::IAdapter {
@@ -152,6 +156,10 @@ public:
             m_y.step, m_uv.step, 0u, 0u
         };
         return cv::MediaFrame::View(std::move(pp), std::move(ss));
+    }
+    cv::util::any blobParams() const override {
+        GAPI_Assert(false && "Not implemented");
+        return {};
     }
 };
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```