### PR TITLE
G-API: Python. Wrapper for networks.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -693,6 +693,14 @@ template<typename... Args>
 cv::gapi::GNetPackage networks(Args&&... args) {
     return cv::gapi::GNetPackage({ cv::detail::strip(args)... });
 }
+
+inline cv::gapi::GNetPackage& operator += (      cv::gapi::GNetPackage& lhs,
+                                           const cv::gapi::GNetPackage& rhs) {
+    lhs.networks.reserve(lhs.networks.size() + rhs.networks.size());
+    lhs.networks.insert(lhs.networks.end(), rhs.networks.begin(), rhs.networks.end());
+    return lhs;
+}
+
 } // namespace gapi
 } // namespace cv
 

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -756,6 +756,28 @@ static PyObject* pyopencv_cv_gapi_kernels(PyObject* , PyObject* py_args, PyObjec
     return pyopencv_from(pkg);
 }
 
+static PyObject* pyopencv_cv_gapi_networks(PyObject*, PyObject* py_args, PyObject*)
+{
+    using namespace cv;
+    gapi::GNetPackage pkg;
+    Py_ssize_t size = PyTuple_Size(py_args);
+    for (int i = 0; i < size; ++i)
+    {
+        PyObject* item = PyTuple_GetItem(py_args, i);
+        if (PyObject_TypeCheck(item,
+            reinterpret_cast<PyTypeObject*>(pyopencv_gapi_ie_PyParams_TypePtr)))
+        {
+            pkg += gapi::networks(reinterpret_cast<pyopencv_gapi_ie_PyParams_t*>(item)->v);
+        }
+        else
+        {
+            PyErr_SetString(PyExc_TypeError,
+                "Python net package should contain PyParams, please use cv.gapi.ie.params to define params");
+        }
+    }
+    return pyopencv_from(pkg);
+}
+
 static PyObject* pyopencv_cv_gapi_op(PyObject* , PyObject* py_args, PyObject*)
 {
     using namespace cv;
@@ -916,6 +938,7 @@ struct PyOpenCV_Converter<cv::GOpaque<T>>
 // extend cv.gapi methods
 #define PYOPENCV_EXTRA_METHODS_GAPI \
   {"kernels", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_kernels), "kernels(...) -> GKernelPackage"}, \
+  {"networks", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_networks), "networks(...) -> GNetPackage"}, \
   {"__op", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_op), "__op(...) -> retval\n"},
 
 

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -764,15 +764,10 @@ static PyObject* pyopencv_cv_gapi_networks(PyObject*, PyObject* py_args, PyObjec
     for (int i = 0; i < size; ++i)
     {
         PyObject* item = PyTuple_GetItem(py_args, i);
-        if (PyObject_TypeCheck(item,
-            reinterpret_cast<PyTypeObject*>(pyopencv_gapi_ie_PyParams_TypePtr)))
+        auto params = reinterpret_cast<pyopencv_gapi_ie_PyParams_t*>(item)->v;
+        if (pyopencv_to(item, params, ArgInfo("PyParams", false)))
         {
-            pkg += gapi::networks(reinterpret_cast<pyopencv_gapi_ie_PyParams_t*>(item)->v);
-        }
-        else
-        {
-            PyErr_SetString(PyExc_TypeError,
-                "Python net package should contain PyParams, please use cv.gapi.ie.params to define params");
+            pkg += gapi::networks(params);
         }
     }
     return pyopencv_from(pkg);

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -763,8 +763,8 @@ static PyObject* pyopencv_cv_gapi_networks(PyObject*, PyObject* py_args, PyObjec
     Py_ssize_t size = PyTuple_Size(py_args);
     for (int i = 0; i < size; ++i)
     {
+        gapi_ie_PyParams params;
         PyObject* item = PyTuple_GetItem(py_args, i);
-        auto params = reinterpret_cast<pyopencv_gapi_ie_PyParams_t*>(item)->v;
         if (pyopencv_to(item, params, ArgInfo("PyParams", false)))
         {
             pkg += gapi::networks(params);

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -58,7 +58,6 @@ namespace cv
 
    namespace gapi
    {
-       GAPI_EXPORTS_W gapi::GNetPackage networks(const cv::gapi::ie::PyParams& params);
        namespace wip
        {
            class GAPI_EXPORTS_W IStreamSource { };

--- a/modules/gapi/samples/face_detection_mtcnn.cpp
+++ b/modules/gapi/samples/face_detection_mtcnn.cpp
@@ -496,13 +496,6 @@ static inline std::tuple<cv::GMat, cv::GMat> run_mtcnn_p(cv::GMat &in, const std
     return std::make_tuple(regressions, scores);
 }
 
-//Operator fot PNet network package creation in the loop
-inline cv::gapi::GNetPackage& operator += (cv::gapi::GNetPackage& lhs, const cv::gapi::GNetPackage& rhs) {
-    lhs.networks.reserve(lhs.networks.size() + rhs.networks.size());
-    lhs.networks.insert(lhs.networks.end(), rhs.networks.begin(), rhs.networks.end());
-    return lhs;
-}
-
 static inline std::string get_pnet_level_name(const cv::Size &in_size) {
     return "MTCNNProposal_" + std::to_string(in_size.width) + "x" + std::to_string(in_size.height);
 }


### PR DESCRIPTION
Removed `networks` from shadow_gapi. Added wrapper for networks and `operator +=` for GNetPackage.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Magic commands:
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```