### PR TITLE
[G-API] Generic type documentation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -531,7 +531,11 @@ typename Net::Result infer(Args&&... args) {
 }
 
 /**
- * @brief Special network type
+ * @brief Special network type.
+ *
+ * Unlike network type, which is defined by G_API_NET macro, this one
+ * doesn't fix number of network inputs and outputs on the compilation stage
+ * thus providing to user an opportunity to program them in runtime.
  */
 struct Generic { };
 

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -531,11 +531,11 @@ typename Net::Result infer(Args&&... args) {
 }
 
 /**
- * @brief Special network type.
+ * @brief Generic network type: input and output layers are configured dynamically at runtime
  *
- * Unlike network type, which is defined by G_API_NET macro, this one
- * doesn't fix number of network inputs and outputs on the compilation stage
- * thus providing to user an opportunity to program them in runtime.
+ * Unlike the network types defined with G_API_NET macro, this one
+ * doesn't fix number of network inputs and outputs at the compilation stage
+ * thus providing user with an opportunity to program them in runtime.
  */
 struct Generic { };
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -207,12 +207,12 @@ public:
     /** @brief Class constructor.
 
     Constructs Params based on model information and sets default values for other
-    inference description parameters. Model is loaded and compiled with OpenVINO.
+    inference description parameters. Model is loaded and compiled using OpenVINO Toolkit.
 
     @param tag string tag of the network for which these parameters are intended.
     @param model path to topology IR (.xml file).
     @param weights path to weights (.bin file).
-    @param device device specifier.
+    @param device target device to use.
     */
     Params(const std::string &tag,
            const std::string &model,
@@ -228,7 +228,7 @@ public:
 
     @param tag string tag of the network for which these parameters are intended.
     @param model path to model.
-    @param device device specifier.
+    @param device target device to use.
     */
     Params(const std::string &tag,
            const std::string &model,
@@ -236,7 +236,7 @@ public:
         : desc{ model, {}, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u}, m_tag(tag) {
     };
 
-    /** @see Params::pluginConfig. */
+    /** @see ie::Params::pluginConfig. */
     Params& pluginConfig(const IEConfig& cfg) {
         desc.config = cfg;
         return *this;
@@ -248,7 +248,7 @@ public:
         return *this;
     }
 
-    /** @see Params::constInput. */
+    /** @see ie::Params::constInput. */
     Params& constInput(const std::string &layer_name,
                        const cv::Mat &data,
                        TraitAs hint = TraitAs::TENSOR) {
@@ -256,14 +256,14 @@ public:
         return *this;
     }
 
-    /** @see Params::cfgNumRequests. */
+    /** @see ie::Params::cfgNumRequests. */
     Params& cfgNumRequests(size_t nireq) {
         GAPI_Assert(nireq > 0 && "Number of infer requests must be greater than zero!");
         desc.nireq = nireq;
         return *this;
     }
 
-    /** @see Params::cfgInputReshape */
+    /** @see ie::Params::cfgInputReshape */
     Params& cfgInputReshape(const std::map<std::string, std::vector<std::size_t>>&reshape_table) {
         desc.reshape_table = reshape_table;
         return *this;

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -196,9 +196,24 @@ protected:
     detail::ParamDesc desc;
 };
 
+/*
+* @brief This structure provides functions for generic network type that
+* fill inference parameters.
+* @see struct Generic
+*/
 template<>
 class Params<cv::gapi::Generic> {
 public:
+    /** @brief Class constructor.
+
+    Constructs Params based on model information and sets default values for other
+    inference description parameters. Model is loaded and compiled with OpenVINO.
+
+    @param tag string tag of the network for which these parameters are intended.
+    @param model path to topology IR (.xml file).
+    @param weights path to weights (.bin file).
+    @param device device specifier.
+    */
     Params(const std::string &tag,
            const std::string &model,
            const std::string &weights,
@@ -206,22 +221,34 @@ public:
         : desc{ model, weights, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Load, true, {}, {}, {}, 1u}, m_tag(tag) {
     };
 
+    /** @overload
+
+    This constructor for pre-compiled networks. Model is imported from pre-compiled
+    blob.
+
+    @param tag string tag of the network for which these parameters are intended.
+    @param model path to model.
+    @param device device specifier.
+    */
     Params(const std::string &tag,
            const std::string &model,
            const std::string &device)
         : desc{ model, {}, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u}, m_tag(tag) {
     };
 
-    Params& pluginConfig(IEConfig&& cfg) {
-        desc.config = std::move(cfg);
-        return *this;
-    }
-
+    /** @see Params::pluginConfig. */
     Params& pluginConfig(const IEConfig& cfg) {
         desc.config = cfg;
         return *this;
     }
 
+    /** @overload */
+    Params& pluginConfig(IEConfig&& cfg) {
+        desc.config = std::move(cfg);
+        return *this;
+    }
+
+    /** @see Params::constInput. */
     Params& constInput(const std::string &layer_name,
                        const cv::Mat &data,
                        TraitAs hint = TraitAs::TENSOR) {
@@ -229,37 +256,44 @@ public:
         return *this;
     }
 
+    /** @see Params::cfgNumRequests. */
     Params& cfgNumRequests(size_t nireq) {
         GAPI_Assert(nireq > 0 && "Number of infer requests must be greater than zero!");
         desc.nireq = nireq;
         return *this;
     }
 
-    Params& cfgInputReshape(std::map<std::string, std::vector<std::size_t>> && reshape_table) {
-        desc.reshape_table = std::move(reshape_table);
-        return *this;
-    }
-
+    /** @see Params::cfgInputReshape */
     Params& cfgInputReshape(const std::map<std::string, std::vector<std::size_t>>&reshape_table) {
         desc.reshape_table = reshape_table;
         return *this;
     }
 
+    /** @overload */
+    Params& cfgInputReshape(std::map<std::string, std::vector<std::size_t>> && reshape_table) {
+        desc.reshape_table = std::move(reshape_table);
+        return *this;
+    }
+
+    /** @overload */
     Params& cfgInputReshape(std::string && layer_name, std::vector<size_t> && layer_dims) {
         desc.reshape_table.emplace(layer_name, layer_dims);
         return *this;
     }
 
+    /** @overload */
     Params& cfgInputReshape(const std::string & layer_name, const std::vector<size_t>&layer_dims) {
         desc.reshape_table.emplace(layer_name, layer_dims);
         return *this;
     }
 
+    /** @overload */
     Params& cfgInputReshape(std::unordered_set<std::string> && layer_names) {
         desc.layer_names_to_reshape = std::move(layer_names);
         return *this;
     }
 
+    /** @overload */
     Params& cfgInputReshape(const std::unordered_set<std::string>&layer_names) {
         desc.layer_names_to_reshape = layer_names;
         return *this;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Preview
https://pullrequest.opencv.org/buildbot/export/pr/20169/docs/

### Build configuration

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```