### PR TITLE
Handle minDiversity in Grayscale MSER

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -524,6 +524,9 @@ public:
     CV_WRAP virtual void setMaxArea(int maxArea) = 0;
     CV_WRAP virtual int getMaxArea() const = 0;
 
+    CV_WRAP virtual void setMinDiversity(double minDiversity) = 0;
+    CV_WRAP virtual double getMinDiversity() const = 0;
+
     CV_WRAP virtual void setPass2Only(bool f) = 0;
     CV_WRAP virtual bool getPass2Only() const = 0;
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;

--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -96,6 +96,9 @@ public:
     void setMaxArea(int maxArea) CV_OVERRIDE { params.maxArea = maxArea; }
     int getMaxArea() const CV_OVERRIDE { return params.maxArea; }
 
+    void setMinDiversity(double minDiversity) CV_OVERRIDE { params.minDiversity = minDiversity; }
+    double getMinDiversity() const CV_OVERRIDE { return params.minDiversity; }
+
     void setPass2Only(bool f) CV_OVERRIDE { params.pass2Only = f; }
     bool getPass2Only() const CV_OVERRIDE { return params.pass2Only; }
 
@@ -200,7 +203,7 @@ public:
             if( checked )
                 return;
             checked = true;
-            if( size < wp.p.minArea || size > wp.p.maxArea || var < 0.f || var > wp.p.maxVariation )
+            if( size < wp.p.minArea || size > wp.p.maxArea || var < wp.p.minDiversity || var > wp.p.maxVariation )
                 return;
             if( child_ )
             {

--- a/modules/features2d/test/test_mser.cpp
+++ b/modules/features2d/test/test_mser.cpp
@@ -119,6 +119,7 @@ TEST(Features2d_MSER, cases)
 
         mserExtractor->setMinArea(kMinArea);
         mserExtractor->setMaxArea(kMaxArea);
+        mserExtractor->setMinDiversity(0);
 
         if( invert )
             bitwise_not(src, src);
@@ -170,6 +171,7 @@ TEST(Features2d_MSER, history_update_regression)
         {
             Ptr<MSER> mser = MSER::create(1, minArea, (int)(tstImages[j].cols * tstImages[j].rows * 0.2));
             mser->setPass2Only(true);
+            mser->setMinDiversity(0);
             vector<vector<Point> > mserContours;
             vector<Rect> boxRects;
             mser->detectRegions(tstImages[j], mserContours, boxRects);
@@ -177,6 +179,30 @@ TEST(Features2d_MSER, history_update_regression)
             previous_size = mserContours.size();
         }
     }
+}
+
+
+TEST(Features2d_MSER, bug_5630)
+{
+    String dataPath = cvtest::TS::ptr()->get_data_path() + "mser/";
+    Mat img = imread(dataPath + "mser_test.png", IMREAD_GRAYSCALE);
+    Ptr<MSER> mser = MSER::create(1, 1);
+    vector<vector<Point> > mserContours;
+    vector<Rect> boxRects;
+
+    // set min diversity and run detection
+    mser->setMinDiversity(0.1);
+    mser->detectRegions(img, mserContours, boxRects);
+    size_t originalNumberOfContours = mserContours.size();
+
+    // increase min diversity and run detection again
+    mser->setMinDiversity(0.2);
+    mser->detectRegions(img, mserContours, boxRects);
+    size_t newNumberOfContours = mserContours.size();
+
+    // there should be fewer regions detected with a higher min diversity
+    ASSERT_LT(newNumberOfContours, originalNumberOfContours);
+
 }
 
 }} // namespace

--- a/modules/python/test/test_mser.py
+++ b/modules/python/test/test_mser.py
@@ -35,6 +35,7 @@ class mser_test(NewOpenCVTests):
         kDelta = 5
         mserExtractor = cv.MSER_create()
         mserExtractor.setDelta(kDelta)
+        mserExtractor.setMinDiversity(0)
         np.random.seed(10)
 
         for _i in range(100):


### PR DESCRIPTION
Note: copy of https://github.com/opencv/opencv/pull/20022, but applied to `next` instead of `3.4`, as this results in an API change.


Addresses issue described here https://github.com/opencv/opencv/issues/5630. In MSER, `min_diversity` was used for color images but not for grayscale. There was a check to verify variance was positive, which I replaced with checking to verify the variance is greater than `minDiversity`. I also expose setter/getter for `minDiversity`.
 
Note:
- Had to explicitly set `minDiversity` to 0 (to replicate the original logic) in `history_update_regression`, `cases`, and `test_mser.py` unit tests, as `min_diversity` defaults to 0.2.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
