### PR TITLE
Expose Outlier Ratio in LMeDSPointSetRegistrator

### DIFF
--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -1938,6 +1938,7 @@ between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow dow
 significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
 @param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
 Passing 0 will disable refining, so the output matrix will be output of robust method.
+@param outlierRatio outlier ratio used to compute iterations. Applies only to LMeDS.
 
 @return Output 2D affine transformation matrix \f$2 \times 3\f$ or empty matrix if transformation
 could not be estimated. The returned matrix has the following form:
@@ -1964,7 +1965,7 @@ correctly only when there are more than 50% of inliers.
 CV_EXPORTS_W cv::Mat estimateAffine2D(InputArray from, InputArray to, OutputArray inliers = noArray(),
                                   int method = RANSAC, double ransacReprojThreshold = 3,
                                   size_t maxIters = 2000, double confidence = 0.99,
-                                  size_t refineIters = 10);
+                                  size_t refineIters = 10, double outlierRatio=0.45);
 
 
 CV_EXPORTS_W cv::Mat estimateAffine2D(InputArray pts1, InputArray pts2, OutputArray inliers,
@@ -1988,6 +1989,7 @@ between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow dow
 significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
 @param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
 Passing 0 will disable refining, so the output matrix will be output of robust method.
+@param outlierRatio outlier ratio used to compute iterations. Applies only to LMeDS.
 
 @return Output 2D affine transformation (4 degrees of freedom) matrix \f$2 \times 3\f$ or
 empty matrix if transformation could not be estimated.
@@ -2016,7 +2018,7 @@ correctly only when there are more than 50% of inliers.
 CV_EXPORTS_W cv::Mat estimateAffinePartial2D(InputArray from, InputArray to, OutputArray inliers = noArray(),
                                   int method = RANSAC, double ransacReprojThreshold = 3,
                                   size_t maxIters = 2000, double confidence = 0.99,
-                                  size_t refineIters = 10);
+                                  size_t refineIters = 10, double outlierRatio=0.45);
 
 /** @example samples/cpp/tutorial_code/features2D/Homography/decompose_homography.cpp
 An example program with homography decomposition.

--- a/modules/3d/src/precomp.hpp
+++ b/modules/3d/src/precomp.hpp
@@ -95,7 +95,7 @@ CV_EXPORTS Ptr<PointSetRegistrator> createRANSACPointSetRegistrator(const Ptr<Po
                                                                     double confidence=0.99, int maxIters=1000 );
 
 CV_EXPORTS Ptr<PointSetRegistrator> createLMeDSPointSetRegistrator(const Ptr<PointSetRegistrator::Callback>& cb,
-                                                                   int modelPoints, double confidence=0.99, int maxIters=1000 );
+                                                                   int modelPoints, double confidence=0.99, int maxIters=1000, double outlierRatio=0.45 );
 
 template<typename T> inline int compressElems( T* ptr, const uchar* mask, int mstep, int count )
 {

--- a/modules/3d/src/ptsetreg.cpp
+++ b/modules/3d/src/ptsetreg.cpp
@@ -265,8 +265,8 @@ class LMeDSPointSetRegistrator : public RANSACPointSetRegistrator
 {
 public:
     LMeDSPointSetRegistrator(const Ptr<PointSetRegistrator::Callback>& _cb=Ptr<PointSetRegistrator::Callback>(),
-                              int _modelPoints=0, double _confidence=0.99, int _maxIters=1000)
-    : RANSACPointSetRegistrator(_cb, _modelPoints, 0, _confidence, _maxIters) {}
+                              int _modelPoints=0, double _confidence=0.99, int _maxIters=1000, double _outlierRatio=0.45)
+    : RANSACPointSetRegistrator(_cb, _modelPoints, 0, _confidence, _maxIters) { outlierRatio = _outlierRatio; }
 
     bool run(InputArray _m1, InputArray _m2, OutputArray _model, OutputArray _mask) const CV_OVERRIDE
     {
@@ -371,6 +371,8 @@ public:
         return result;
     }
 
+private:
+    double outlierRatio;
 };
 
 Ptr<PointSetRegistrator> createRANSACPointSetRegistrator(const Ptr<PointSetRegistrator::Callback>& _cb,

--- a/modules/3d/src/ptsetreg.cpp
+++ b/modules/3d/src/ptsetreg.cpp
@@ -270,7 +270,6 @@ public:
 
     bool run(InputArray _m1, InputArray _m2, OutputArray _model, OutputArray _mask) const CV_OVERRIDE
     {
-        const double outlierRatio = 0.45;
         bool result = false;
         Mat m1 = _m1.getMat(), m2 = _m2.getMat();
         Mat ms1, ms2, err, errf, model, bestModel, mask, mask0;
@@ -385,10 +384,10 @@ Ptr<PointSetRegistrator> createRANSACPointSetRegistrator(const Ptr<PointSetRegis
 
 
 Ptr<PointSetRegistrator> createLMeDSPointSetRegistrator(const Ptr<PointSetRegistrator::Callback>& _cb,
-                             int _modelPoints, double _confidence, int _maxIters)
+                             int _modelPoints, double _confidence, int _maxIters, double outlierRatio)
 {
     return Ptr<PointSetRegistrator>(
-        new LMeDSPointSetRegistrator(_cb, _modelPoints, _confidence, _maxIters));
+        new LMeDSPointSetRegistrator(_cb, _modelPoints, _confidence, _maxIters, outlierRatio));
 }
 
 
@@ -928,7 +927,7 @@ int estimateTranslation3D(InputArray _from, InputArray _to,
 Mat estimateAffine2D(InputArray _from, InputArray _to, OutputArray _inliers,
                      const int method, const double ransacReprojThreshold,
                      const size_t maxIters, const double confidence,
-                     const size_t refineIters)
+                     const size_t refineIters, const double outlierRatio)
 {
 
     if (method >= USAC_DEFAULT && method <= USAC_MAGSAC)
@@ -973,7 +972,7 @@ Mat estimateAffine2D(InputArray _from, InputArray _to, OutputArray _inliers,
     if( method == RANSAC )
         result = createRANSACPointSetRegistrator(cb, 3, ransacReprojThreshold, confidence, static_cast<int>(maxIters))->run(from, to, H, inliers);
     else if( method == LMEDS )
-        result = createLMeDSPointSetRegistrator(cb, 3, confidence, static_cast<int>(maxIters))->run(from, to, H, inliers);
+        result = createLMeDSPointSetRegistrator(cb, 3, confidence, static_cast<int>(maxIters), outlierRatio)->run(from, to, H, inliers);
     else
         CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
 
@@ -1019,7 +1018,7 @@ Mat estimateAffine2D(InputArray _from, InputArray _to, OutputArray inliers,
 Mat estimateAffinePartial2D(InputArray _from, InputArray _to, OutputArray _inliers,
                             const int method, const double ransacReprojThreshold,
                             const size_t maxIters, const double confidence,
-                            const size_t refineIters)
+                            const size_t refineIters, const double outlierRatio)
 {
     Mat from = _from.getMat(), to = _to.getMat();
     const int count = from.checkVector(2);
@@ -1059,7 +1058,7 @@ Mat estimateAffinePartial2D(InputArray _from, InputArray _to, OutputArray _inlie
     if( method == RANSAC )
         result = createRANSACPointSetRegistrator(cb, 2, ransacReprojThreshold, confidence, static_cast<int>(maxIters))->run(from, to, H, inliers);
     else if( method == LMEDS )
-        result = createLMeDSPointSetRegistrator(cb, 2, confidence, static_cast<int>(maxIters))->run(from, to, H, inliers);
+        result = createLMeDSPointSetRegistrator(cb, 2, confidence, static_cast<int>(maxIters), outlierRatio)->run(from, to, H, inliers);
     else
         CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
 


### PR DESCRIPTION
Note: copy of https://github.com/opencv/opencv/pull/20028 but applied to `next`.

Expose `outlierRatio` param in `LMeDSPointSetRegistrator` rather than have it hardcoded to 0.45.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

- [ ] The feature is well documented and sample code can be built with the project CMake
