### PR TITLE
Fix RVV toolchain conflicts.

### DIFF
--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -142,7 +142,7 @@
 #  define CV_NEON 1
 #endif
 
-#if defined(__riscv) && defined(__riscv_vector)
+#if defined(__riscv) && defined(__riscv_vector) && defined(__riscv_vector_071)
 # include<riscv-vector.h>
 # define CV_RVV071 1
 #endif

--- a/platforms/linux/riscv64-071-gcc.toolchain.cmake
+++ b/platforms/linux/riscv64-071-gcc.toolchain.cmake
@@ -5,5 +5,5 @@ set(CMAKE_CXX_COMPILER riscv64-unknown-linux-gnu-g++)
 set(CMAKE_CXX_FLAGS ""    CACHE STRING "")
 set(CMAKE_C_FLAGS ""    CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread")
-set(CMAKE_C_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread")
+set(CMAKE_CXX_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread -D__riscv_vector_071")
+set(CMAKE_C_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread -D__riscv_vector_071")


### PR DESCRIPTION
Thanks to @damonyu1989 for bringing us a parallel implementations based on RVV 0.7.1 with pr #19778. However, there is a minor bug that causes conflicts with the existing toolchain.

In [cv_cpu_dispatch.h](https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/cv_cpu_dispatch.h#L145), 
```
#if defined(__riscv) && defined(__riscv_vector)
# include<riscv-vector.h>
# define CV_RVV071 1
#endif
```
`CV_RVV071` will be defined when `__riscv`, `__riscv_vector` are defined, which are compiler preset macros. This will cause conflicts because any compiler that supports RVV will generate these two macros, not specific to RVV 0.7.1. This means that when you try to compile OpenCV using the toolchain base on the latest RVV draft of the standard, you will incorrectly define the macro `CV_RVV071` and try to reference a header file(`riscv-vector.h`) that does not exist (renamed `riscv_vector.h`), which will cause the compilation to fail.

Therefore, I added a preset macro in cmake to solve the problem.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
