### PR TITLE
ts: migrate from cgi.escape to html.escape in .py file

### DIFF
--- a/modules/ts/misc/table_formatter.py
+++ b/modules/ts/misc/table_formatter.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import sys, re, os.path, cgi, stat, math
+import sys, re, os.path, stat, math
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape  # Python 2.7
 from optparse import OptionParser
 from color import getColorizer, dummyColorizer
 
@@ -23,7 +27,7 @@ class tblRow(object):
         self.props = props
 
 def htmlEncode(str):
-    return '<br/>'.join([cgi.escape(s) for s in str])
+    return '<br/>'.join([escape(s) for s in str])
 
 class table(object):
     def_align = "left"


### PR DESCRIPTION
resolves #20032

- [x] Validated with Python 3.9.5 (original problem is reproduced and fixed by this patch)
- [x] Validated with Python 2.7.18
