### PR TITLE
EXR reading: support Z channel if no Y channel

### DIFF
--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -156,6 +156,10 @@ bool  ExrDecoder::readHeader()
     else
     {
         m_green = channels.findChannel( "Y" );
+        if( !m_green )
+        {
+            m_green = channels.findChannel( "Z" ); // Distance of the front of a sample from the viewer
+        }
         if( m_green )
         {
             m_ischroma = true;


### PR DESCRIPTION
Hi, some applications can produce float32 depth maps in OpenEXR format and they can use Z channel instead of Y channel (but only Y is supported in OpenCV). And this is quite natural because Z channel is a "Distance of the front of a sample from the viewer" - see [OpenEXR documentation](https://www.openexr.com/documentation/TechnicalIntroduction.pdf).

Currently if you will try to read such float32 .exr image with single Z channel via ```imread(path, cv::IMREAD_UNCHANGED)``` - empty image will be returned.

The proposed fix will try to find Z channel only if no Y channel is found (i.e. this fix is backwards compatible).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
