### PR TITLE
G-API: Init cv structures in pyopencv_gapi

### DIFF
--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -366,11 +366,11 @@ static PyObject* pyopencv_cv_GOut(PyObject* , PyObject* py_args, PyObject* kw)
 
 static cv::detail::OpaqueRef extract_opaque_ref(PyObject* from, cv::detail::OpaqueKind kind)
 {
-#define HANDLE_CASE(T, O) case cv::detail::OpaqueKind::CV_##T:  \
-{                                                               \
-    O obj{};                                                    \
-    pyopencv_to_with_check(from, obj, "Failed to obtain " # O); \
-    return cv::detail::OpaqueRef{std::move(obj)};               \
+#define HANDLE_CASE(T, O, ...) case cv::detail::OpaqueKind::CV_##T:  \
+{                                                                    \
+    O obj{__VA_ARGS__};                                              \
+    pyopencv_to_with_check(from, obj, "Failed to obtain " # O);      \
+    return cv::detail::OpaqueRef{std::move(obj)};                    \
 }
 #define UNSUPPORTED(T) case cv::detail::OpaqueKind::CV_##T: break
     switch (kind)
@@ -380,10 +380,10 @@ static cv::detail::OpaqueRef extract_opaque_ref(PyObject* from, cv::detail::Opaq
         HANDLE_CASE(DOUBLE,  double);
         HANDLE_CASE(FLOAT,   float);
         HANDLE_CASE(STRING,  std::string);
-        HANDLE_CASE(POINT,   cv::Point);
-        HANDLE_CASE(POINT2F, cv::Point2f);
-        HANDLE_CASE(SIZE,    cv::Size);
-        HANDLE_CASE(RECT,    cv::Rect);
+        HANDLE_CASE(POINT,   cv::Point  , -1, -1);
+        HANDLE_CASE(POINT2F, cv::Point2f, -1.f, -1.f);
+        HANDLE_CASE(SIZE,    cv::Size   , -1, -1);
+        HANDLE_CASE(RECT,    cv::Rect   , -1, -1, -1, -1);
         HANDLE_CASE(UNKNOWN, cv::GArg);
         UNSUPPORTED(UINT64);
         UNSUPPORTED(SCALAR);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
