### PR TITLE
Add Thickness parameter in drawMatches function

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1314,6 +1314,13 @@ CV_EXPORTS_W void drawMatches( InputArray img1, const std::vector<KeyPoint>& key
                              const std::vector<char>& matchesMask=std::vector<char>(), int flags=DrawMatchesFlags::DEFAULT );
 
 /** @overload */
+CV_EXPORTS_W void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
+                             InputArray img2, const std::vector<KeyPoint>& keypoints2,
+                             const std::vector<DMatch>& matches1to2, InputOutputArray outImg,
+                             const int matchesThickness, const Scalar& matchColor=Scalar::all(-1),
+                             const Scalar& singlePointColor=Scalar::all(-1), const std::vector<char>& matchesMask=std::vector<char>(),
+                             int flags=DrawMatchesFlags::DEFAULT );
+
 CV_EXPORTS_AS(drawMatchesKnn) void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
                              InputArray img2, const std::vector<KeyPoint>& keypoints2,
                              const std::vector<std::vector<DMatch> >& matches1to2, InputOutputArray outImg,

--- a/modules/features2d/src/draw.cpp
+++ b/modules/features2d/src/draw.cpp
@@ -183,7 +183,8 @@ static void _prepareImgAndDrawKeypoints( InputArray img1, const std::vector<KeyP
 }
 
 static inline void _drawMatch( InputOutputArray outImg, InputOutputArray outImg1, InputOutputArray outImg2 ,
-                          const KeyPoint& kp1, const KeyPoint& kp2, const Scalar& matchColor, int flags )
+                          const KeyPoint& kp1, const KeyPoint& kp2, const Scalar& matchColor, int flags,
+                          const int matchesThickness )
 {
     RNG& rng = theRNG();
     bool isRandMatchColor = matchColor == Scalar::all(-1);
@@ -199,7 +200,7 @@ static inline void _drawMatch( InputOutputArray outImg, InputOutputArray outImg1
     line( outImg,
           Point(cvRound(pt1.x*draw_multiplier), cvRound(pt1.y*draw_multiplier)),
           Point(cvRound(dpt2.x*draw_multiplier), cvRound(dpt2.y*draw_multiplier)),
-          color, 1, LINE_AA, draw_shift_bits );
+          color, matchesThickness, LINE_AA, draw_shift_bits );
 }
 
 void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
@@ -207,6 +208,21 @@ void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
                   const std::vector<DMatch>& matches1to2, InputOutputArray outImg,
                   const Scalar& matchColor, const Scalar& singlePointColor,
                   const std::vector<char>& matchesMask, int flags )
+{
+    drawMatches( img1, keypoints1,
+                 img2, keypoints2,
+                 matches1to2, outImg,
+                 1, matchColor,
+                 singlePointColor, matchesMask,
+                 flags);
+}
+
+void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
+                  InputArray img2, const std::vector<KeyPoint>& keypoints2,
+                  const std::vector<DMatch>& matches1to2, InputOutputArray outImg,
+                  const int matchesThickness, const Scalar& matchColor,
+                  const Scalar& singlePointColor, const std::vector<char>& matchesMask,
+                  int flags )
 {
     if( !matchesMask.empty() && matchesMask.size() != matches1to2.size() )
         CV_Error( Error::StsBadSize, "matchesMask must have the same size as matches1to2" );
@@ -226,10 +242,11 @@ void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
             CV_Assert(i2 >= 0 && i2 < static_cast<int>(keypoints2.size()));
 
             const KeyPoint &kp1 = keypoints1[i1], &kp2 = keypoints2[i2];
-            _drawMatch( outImg, outImg1, outImg2, kp1, kp2, matchColor, flags );
+            _drawMatch( outImg, outImg1, outImg2, kp1, kp2, matchColor, flags, matchesThickness );
         }
     }
 }
+
 
 void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
                   InputArray img2, const std::vector<KeyPoint>& keypoints2,
@@ -254,7 +271,7 @@ void drawMatches( InputArray img1, const std::vector<KeyPoint>& keypoints1,
             if( matchesMask.empty() || matchesMask[i][j] )
             {
                 const KeyPoint &kp1 = keypoints1[i1], &kp2 = keypoints2[i2];
-                _drawMatch( outImg, outImg1, outImg2, kp1, kp2, matchColor, flags );
+                _drawMatch( outImg, outImg1, outImg2, kp1, kp2, matchColor, flags, 1 );
             }
         }
     }


### PR DESCRIPTION
This commit adds the feature of selecting the thickness
of the matches drawn by the drawMatches function.

In larger images, the default thickness of 1 pixel creates images
that are hard to visualize.

resolves https://github.com/opencv/opencv/issues/20095

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
