### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2021.06

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,9 +1,9 @@
-# Binaries branch name: ffmpeg/master_20210303
-# Binaries were created for OpenCV: 7ac6abe02a33bef445a5b77214ad31964e2c5cc1
-ocv_update(FFMPEG_BINARIES_COMMIT "629590c3ba09fb0c8eaa9ab858ff13d3a84ca1aa")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "638065d5a0dab8a828879942375dcac4")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "7f10ae2e6a080ba3714f7a38ee03ae15")
-ocv_update(FFMPEG_FILE_HASH_CMAKE "f8e65dbe4a3b4eedc0d2997e07c3f3fd")
+# Binaries branch name: ffmpeg/master_20210608
+# Binaries were created for OpenCV: eaa9228a4fdfb9c2465aea65a50ce2d16b55dce0
+ocv_update(FFMPEG_BINARIES_COMMIT "213fcd5d4897319a83207406036c4a5957fba010")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "bab661341c30862fa88627130219c0a5")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "ac99f9767a83103c31709628af685924")
+ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
 
 function(download_win_ffmpeg script_var)
   set(${script_var} "" PARENT_SCOPE)

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -748,6 +748,9 @@ TEST_P(videocapture_acceleration, read)
             {
                 if (filename == "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4")
                     throw SkipTestException("Unable to read the first frame with VP9 codec (media stack misconfiguration / bug)");
+                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't suppport hardware accelerated AV1 decoding.
+                if (filename == "sample_322x242_15frames.yuv420p.libaom-av1.mp4")
+                    throw SkipTestException("Unable to read the first frame with AV1 codec (missing support)");
             }
             EXPECT_TRUE(read_umat_result);
             ASSERT_FALSE(umat.empty());
@@ -760,6 +763,9 @@ TEST_P(videocapture_acceleration, read)
             {
                 if (filename == "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4")
                     throw SkipTestException("Unable to read the first frame with VP9 codec (media stack misconfiguration / bug)");
+                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't suppport hardware accelerated AV1 decoding.
+                if (filename == "sample_322x242_15frames.yuv420p.libaom-av1.mp4")
+                    throw SkipTestException("Unable to read the first frame with AV1 codec (missing support)");
             }
             EXPECT_TRUE(read_result);
         }


### PR DESCRIPTION
**Merge with 3rdparty**: https://github.com/opencv/opencv_3rdparty/pull/65

- FFmpeg 4.4
- libvpx 1.10.0

previous update: #19666


```
allow_multiple_commits=1
```