### PR TITLE
Apply modifier mask to the state of modifier keys

### DIFF
--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -1881,6 +1881,7 @@ static gboolean icvOnMouse( GtkWidget *widget, GdkEvent *event, gpointer user_da
                (unsigned)pt.y < (unsigned)(image_widget->original_image->height)
             ))
         {
+            state &= gtk_accelerator_get_default_mod_mask();
             flags |= BIT_MAP(state, GDK_SHIFT_MASK,   CV_EVENT_FLAG_SHIFTKEY) |
                 BIT_MAP(state, GDK_CONTROL_MASK, CV_EVENT_FLAG_CTRLKEY)  |
                 BIT_MAP(state, GDK_MOD1_MASK,    CV_EVENT_FLAG_ALTKEY)   |


### PR DESCRIPTION
Fixing https://github.com/opencv/opencv/issues/20073.
According to https://developer.gnome.org/gtk3/stable/checklist-modifiers.html: "With `gtk_accelerator_get_default_mod_mask()` you can test for modifier keys reliably; this way your key event handlers will work correctly even if `NumLock` or `CapsLock` are activated. "

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
