### PR TITLE
Fix potential NaN in cv::norm

### DIFF
--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -1171,7 +1171,7 @@ double norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask 
         // special case to handle "integer" overflow in accumulator
         const size_t esz = src1.elemSize();
         const int total = (int)it.size;
-        const int intSumBlockSize = normType == NORM_L1 && depth <= CV_8S ? (1 << 23) : (1 << 15);
+        const int intSumBlockSize = (normType == NORM_L1 && depth <= CV_8S ? (1 << 23) : (1 << 15))/cn;
         const int blockSize = std::min(total, intSumBlockSize);
         int isum = 0;
         int count = 0;


### PR DESCRIPTION
The behavior is actually proper in cv::norm( InputArray _src, int normType, InputArray _mask ), not in double cv::norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask ).
The fix and bug were both introduced in https://github.com/opencv/opencv/commit/34530da66e9e5d9fdba091b11ceef16ae267ae0c

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [ x To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
