### PR TITLE
partial support for quantized models in ONNX importer

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -706,7 +706,7 @@ CV__DNN_INLINE_NS_BEGIN
     public:
         float a_scale, b_scale, c_scale;
         int a_zeropoint, b_zeropoint, c_zeropoint;
-        
+
         static Ptr<QLinearAddLayer> create(const LayerParams& params);
     };
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -701,6 +701,15 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<DequantizeLinearLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS QLinearAddLayer : public Layer
+    {
+    public:
+        float a_scale, b_scale, c_scale;
+        int a_zeropoint, b_zeropoint, c_zeropoint;
+        
+        static Ptr<QLinearAddLayer> create(const LayerParams& params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -689,6 +689,18 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<Layer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS QuantizeLinearLayer : public Layer
+    {
+    public:
+        static Ptr<QuantizeLinearLayer> create(const LayerParams& params);
+    };
+
+    class CV_EXPORTS DequantizeLinearLayer : public Layer
+    {
+    public:
+        static Ptr<DequantizeLinearLayer> create(const LayerParams& params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -139,6 +139,8 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(FlowWarp,       FlowWarpLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(LSTM,           LSTMLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(QuantizeLinear, QuantizeLinearLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(DequantizeLinear, DequantizeLinearLayer);
 }
 
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -141,6 +141,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(LSTM,           LSTMLayer);
     CV_DNN_REGISTER_LAYER_CLASS(QuantizeLinear, QuantizeLinearLayer);
     CV_DNN_REGISTER_LAYER_CLASS(DequantizeLinear, DequantizeLinearLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(QLinearAdd, QLinearAddLayer);
 }
 
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -117,7 +117,7 @@ public:
         outputs_arr.getMatVector(outputs);
 
         CV_Assert((inputs.size() > outputs.size() && blobs.empty()) ||
-                  (!inputs.empty() && (blobs.size() == 1 || blobs.size() == 2)));
+                  (!inputs.empty() && blobs.size() >= 1));
         MatSize weightShape = blobs.empty() ? inputs[1].size : blobs[0].size;
 
         CV_Assert(inputs[0].dims == outputs[0].dims);
@@ -246,6 +246,7 @@ class ConvolutionLayerImpl CV_FINAL : public BaseConvolutionLayerImpl
 public:
     enum { VEC_ALIGN = 8, DFT_TYPE = CV_32F };
     Mat weightsMat;
+    int xzeroPoint;
     std::vector<float> biasvec;
     std::vector<float> reluslope;
     Ptr<ActivationLayer> activ;
@@ -271,6 +272,8 @@ public:
 
     ConvolutionLayerImpl(const LayerParams &params) : BaseConvolutionLayerImpl(params)
     {
+        xzeroPoint = params.get<int>("x_zeropoint", 0);
+        CV_Assert(xzeroPoint == 0);
 #ifdef HAVE_OPENCL
         newActiv = false;
         activType = OCL4DNN_CONV_FUSED_ACTIV_NONE;

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -82,12 +82,12 @@ public:
         axis = params.get<int>("axis", 1);
         if (!blobs.empty())
         {
-            CV_Assert(1 <= blobs.size() && blobs.size() <= 2);
+            CV_Assert(1 <= blobs.size());
             int numOutput = params.get<int>("num_output");
             int innerSize = (int)blobs[0].total() / numOutput;
 
             CV_Assert(blobs[0].dims >= 2 && (size_t)(innerSize * numOutput) == blobs[0].total());
-            CV_Assert(!bias || (blobs.size() == 2 && (size_t)numOutput == blobs[1].total()));
+            CV_Assert(!bias || (blobs.size() >= 2 && (size_t)numOutput == blobs[1].total()));
 
             weightsMat = blobs[0] = blobs[0].reshape(1, numOutput);
             int vecsize = weightsMat.cols;

--- a/modules/dnn/src/layers/qlinearadd_layer.cpp
+++ b/modules/dnn/src/layers/qlinearadd_layer.cpp
@@ -1,0 +1,185 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2016, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+/*
+Implementation of Quantization & Dequantization Layers.
+*/
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+////////////////////////////// Quantize Layer /////////////////////////////
+
+class QLinearAddLayerImpl CV_FINAL : public QLinearAddLayer
+{
+public:
+    QLinearAddLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        
+        a_scale = params.get<float>("a_scale", 1.f);
+        b_scale = params.get<float>("b_scale", 1.f);
+        c_scale = params.get<float>("c_scale", 1.f);
+        
+        a_zeropoint = params.get<int>("a_zeropoint", 0);
+        b_zeropoint = params.get<int>("b_zeropoint", 0);
+        c_zeropoint = params.get<int>("c_zeropoint", 0);
+        
+        params.blobs[0].convertTo(bias, CV_32F, b_scale, -b_zeropoint*b_scale);
+        outDepth = CV_32F; // should be changed to CV_8S (or CV_8U) eventually
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        outputs.assign(1, inputs[0]);
+        return true;
+    }
+
+    virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays) CV_OVERRIDE
+    {
+        std::vector<Mat> inputs;
+        inputs_arr.getMatVector(inputs);
+        CV_Assert(inputs.size() == 1);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        CV_Assert(outputs.size() == 1);
+
+        Mat &inpBlob = inputs[0];
+        Mat &outBlob = outputs[0];
+        int bdepth = bias.depth();
+        int idepth = inpBlob.depth();
+        int odepth = outBlob.depth();
+        
+        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous() && bias.isContinuous();
+        
+        CV_Assert(idepth == CV_32F || idepth == CV_8U || idepth == CV_8S);
+        CV_Assert(odepth == CV_32F);
+        CV_Assert(bdepth == CV_32F);
+        
+        int ndims = inpBlob.dims;
+        
+        CV_Assert(ndims >= 2 && ndims <= 4 && ndims == bias.dims || ndims == bias.dims+1);
+        int W = inpBlob.size.p[ndims-1];
+        int H = inpBlob.size.p[ndims-2];
+        int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
+        int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
+        
+        float a_sc = a_scale, ic_scale = 1.f/c_scale;
+        float a_zp = (float)a_zeropoint, c_zp = (float)c_zeropoint;
+        
+        if (isContinuous) {
+            W *= H;
+            H = 1;
+        }
+        
+        for(int n = 0; n < N; n++)
+        {
+            for(int c = 0; c < C; c++)
+            {
+                // [TODO] change the output to int8_t/uint8_t
+                float* outptr =
+                    ndims == 2 ? outBlob.ptr<float>() :
+                    ndims == 3 ? outBlob.ptr<float>(c) :
+                    outBlob.ptr<float>(n, c);
+                const float* biasptr = bias.ptr<float>();
+                size_t ostep = outBlob.step.p[0]/sizeof(outptr[0]);
+                size_t bstep = bias.step.p[1]/sizeof(biasptr[0]);
+                
+                if(idepth == CV_8U) {
+                    const uint8_t* inptr =
+                        ndims == 2 ? inpBlob.ptr<uint8_t>() :
+                        ndims == 3 ? inpBlob.ptr<uint8_t>(c) :
+                        inpBlob.ptr<uint8_t>(n, c);
+                    size_t istep = inpBlob.step.p[ndims-2]/sizeof(inptr[0]);
+
+                    for(int y = 0; y < H; y++, inptr += istep, outptr += ostep, biasptr += bstep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = ((inptr[x] - a_zp)*a_sc + biasptr[x])*ic_scale + c_zp;
+                    }
+                } else if(idepth == CV_8S) {
+                    const int8_t* inptr =
+                        ndims == 2 ? inpBlob.ptr<int8_t>() :
+                        ndims == 3 ? inpBlob.ptr<int8_t>(c) :
+                        inpBlob.ptr<int8_t>(n, c);
+                    size_t istep = inpBlob.step.p[ndims-2]/sizeof(inptr[0]);
+
+                    for(int y = 0; y < H; y++, inptr += istep, outptr += ostep, biasptr += bstep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = ((inptr[x] - a_zp)*a_sc + biasptr[x])*ic_scale + c_zp;
+                    }
+                } else {
+                    CV_Assert(idepth == CV_32F);
+                    const float* inptr =
+                        ndims == 2 ? inpBlob.ptr<float>() :
+                        ndims == 3 ? inpBlob.ptr<float>(c) :
+                        inpBlob.ptr<float>(n, c);
+                    size_t istep = inpBlob.step.p[ndims-2]/sizeof(inptr[0]);
+
+                    for(int y = 0; y < H; y++,
+                        inptr += istep, outptr += ostep, biasptr += bstep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = ((inptr[x] - a_zp)*a_sc + biasptr[x])*ic_scale + c_zp;
+                    }
+                }
+            }
+        }
+    }
+
+    virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
+                           const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_UNUSED(outputs); // suppress unused variable warning
+        long flops = 0;
+        for(int i = 0; i < inputs.size(); i++)
+        {
+            flops += 2*total(inputs[i]);
+        }
+        return flops;
+    }
+
+private:
+    int outDepth;
+    Mat bias;
+};
+
+
+Ptr<QLinearAddLayer> QLinearAddLayer::create(const LayerParams& params)
+{
+    return Ptr<QLinearAddLayer>(new QLinearAddLayerImpl(params));
+}
+
+}  // namespace dnn
+}  // namespace cv

--- a/modules/dnn/src/layers/qlinearadd_layer.cpp
+++ b/modules/dnn/src/layers/qlinearadd_layer.cpp
@@ -28,15 +28,15 @@ public:
     QLinearAddLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        
+
         a_scale = params.get<float>("a_scale", 1.f);
         b_scale = params.get<float>("b_scale", 1.f);
         c_scale = params.get<float>("c_scale", 1.f);
-        
+
         a_zeropoint = params.get<int>("a_zeropoint", 0);
         b_zeropoint = params.get<int>("b_zeropoint", 0);
         c_zeropoint = params.get<int>("c_zeropoint", 0);
-        
+
         params.blobs[0].convertTo(bias, CV_32F, b_scale, -b_zeropoint*b_scale);
         outDepth = CV_32F; // should be changed to CV_8S (or CV_8U) eventually
     }
@@ -79,29 +79,29 @@ public:
         int bdepth = bias.depth();
         int idepth = inpBlob.depth();
         int odepth = outBlob.depth();
-        
+
         bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous() && bias.isContinuous();
-        
+
         CV_Assert(idepth == CV_32F || idepth == CV_8U || idepth == CV_8S);
         CV_Assert(odepth == CV_32F);
         CV_Assert(bdepth == CV_32F);
-        
+
         int ndims = inpBlob.dims;
-        
-        CV_Assert(ndims >= 2 && ndims <= 4 && ndims == bias.dims || ndims == bias.dims+1);
+
+        CV_Assert(ndims >= 2 && ndims <= 4 && (ndims == bias.dims || ndims == bias.dims+1));
         int W = inpBlob.size.p[ndims-1];
         int H = inpBlob.size.p[ndims-2];
         int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
         int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
-        
+
         float a_sc = a_scale, ic_scale = 1.f/c_scale;
         float a_zp = (float)a_zeropoint, c_zp = (float)c_zeropoint;
-        
+
         if (isContinuous) {
             W *= H;
             H = 1;
         }
-        
+
         for(int n = 0; n < N; n++)
         {
             for(int c = 0; c < C; c++)
@@ -114,7 +114,7 @@ public:
                 const float* biasptr = bias.ptr<float>();
                 size_t ostep = outBlob.step.p[0]/sizeof(outptr[0]);
                 size_t bstep = bias.step.p[1]/sizeof(biasptr[0]);
-                
+
                 if(idepth == CV_8U) {
                     const uint8_t* inptr =
                         ndims == 2 ? inpBlob.ptr<uint8_t>() :

--- a/modules/dnn/src/layers/quantize_dequantize_layer.cpp
+++ b/modules/dnn/src/layers/quantize_dequantize_layer.cpp
@@ -28,7 +28,7 @@ public:
     QuantizeLinearLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        
+
         axis = params.get<int>("axis", -1);
         scale = !params.blobs.empty() ? params.blobs[0] : Mat();
         zeroPoint = params.blobs.size() > 1 ? params.blobs[1] : Mat::zeros(1, 1, CV_8U);
@@ -70,37 +70,37 @@ public:
         Mat &inpBlob = inputs[0];
         Mat &outBlob = outputs[0];
         bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
-        
+
         int odepth = outBlob.depth();
         CV_Assert(inpBlob.depth() == CV_32F && (odepth == CV_32F));
         int ndims = inpBlob.dims;
-        
+
         CV_Assert(ndims >= 2 && ndims <= 4);
         int W = inpBlob.size.p[ndims-1];
         int H = inpBlob.size.p[ndims-2];
         int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
         int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
-        
+
         CV_Assert(axis == ndims - 3 || axis == -1);
-        
+
         int stotal = (int)scale.total();
         CV_Assert(!scale.empty() && scale.isContinuous() &&
                   scale.type() == CV_32FC1 &&
-                  stotal == 1 || stotal == C);
+                  (stotal == 1 || stotal == C));
         int ztype = zeroPoint.type();
         int ztotal = (int)zeroPoint.total();
         CV_Assert(zeroPoint.empty() ||
                   ((ztype == CV_8U || ztype == CV_8S) &&
-                   ztotal == 1 || ztotal == C));
-         
+                   (ztotal == 1 || ztotal == C)));
+
         const float* sptr = scale.ptr<float>();
         const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
-        
+
         if(isContinuous) {
             W *= H;
             H = 1;
         }
-        
+
         for(int n = 0; n < N; n++)
         {
             for(int c = 0; c < C; c++)
@@ -164,7 +164,7 @@ public:
     DequantizeLinearLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        
+
         axis = params.get<int>("axis", -1);
         scale = !params.blobs.empty() ? params.blobs[0] : Mat();
         zeroPoint = params.blobs.size() > 1 ? params.blobs[1] : Mat::zeros(1, 1, CV_8U);
@@ -206,38 +206,38 @@ public:
         Mat &outBlob = outputs[0];
         int idepth = inpBlob.depth();
         int odepth = outBlob.depth();
-        
+
         bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
-        
+
         CV_Assert((idepth == CV_8U || idepth == CV_8S || idepth == CV_32F) &&
                   (odepth == CV_32F));
         int ndims = inpBlob.dims;
-        
+
         CV_Assert(ndims >= 2 && ndims <= 4);
         int W = inpBlob.size.p[ndims-1];
         int H = inpBlob.size.p[ndims-2];
         int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
         int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
-        
+
         CV_Assert(axis == ndims - 3 || axis == -1);
         int stotal = (int)scale.total();
         CV_Assert(!scale.empty() && scale.isContinuous() &&
                   scale.type() == CV_32FC1 &&
-                  stotal == 1 || stotal == C);
+                  (stotal == 1 || stotal == C));
         int ztype = zeroPoint.type();
         int ztotal = (int)zeroPoint.total();
         CV_Assert(zeroPoint.empty() ||
                   ((ztype == CV_8U || ztype == CV_8S) &&
-                   ztotal == 1 || ztotal == C));
-        
+                   (ztotal == 1 || ztotal == C)));
+
         const float* sptr = scale.ptr<float>();
         const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
-        
+
         if(isContinuous) {
             W *= H;
             H = 1;
         }
-        
+
         for(int n = 0; n < N; n++)
         {
             for(int c = 0; c < C; c++)
@@ -253,7 +253,7 @@ public:
                         (float)((const int8_t*)zptr)[zidx];
                 size_t istep = inpBlob.step.p[ndims-2];
                 size_t ostep = outBlob.step.p[ndims-2]/sizeof(outptr[0]);
-                
+
                 if (idepth == CV_8U)
                 {
                     const uint8_t* inptr =

--- a/modules/dnn/src/layers/quantize_dequantize_layer.cpp
+++ b/modules/dnn/src/layers/quantize_dequantize_layer.cpp
@@ -1,0 +1,282 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2016, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+/*
+Implementation of Quantization & Dequantization Layers.
+*/
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+////////////////////////////// Quantize Layer /////////////////////////////
+
+class QuantizeLinearLayerImpl CV_FINAL : public QuantizeLinearLayer
+{
+public:
+    QuantizeLinearLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        
+        axis = params.get<int>("axis", 1);
+        scale = !params.blobs.empty() ? params.blobs[0] : Mat();
+        zeroPoint = params.blobs.size() > 1 ? params.blobs[0] : Mat::zeros(1, 1, CV_8U);
+        outDepth = CV_32F; // should be changed to CV_8S eventually
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        outputs.assign(1, inputs[0]);
+        return true;
+    }
+
+    virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays) CV_OVERRIDE
+    {
+        std::vector<Mat> inputs;
+        inputs_arr.getMatVector(inputs);
+        CV_Assert(inputs.size() == 1);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        CV_Assert(outputs.size() == 1);
+
+        Mat &inpBlob = inputs[0];
+        Mat &outBlob = outputs[0];
+        int odepth = outBlob.depth();
+        
+        CV_Assert(inpBlob.depth() == CV_32F && (odepth == CV_32F));
+        CV_Assert(axis == 1);
+        int nchannels = inpBlob.size.p[1];
+        int stotal = (int)scale.total();
+        CV_Assert(!scale.empty() && scale.isContinuous() && scale.type() == CV_32FC1 &&
+                  stotal == 1 || stotal == nchannels);
+        int ztype = zeroPoint.type();
+        int ztotal = (int)zeroPoint.total();
+        CV_Assert(zeroPoint.empty() ||
+                  ((ztype == CV_8U || ztype == CV_8S) &&
+                   ztotal == 1 || ztotal == nchannels));
+        
+        const float* sptr = scale.ptr<float>();
+        const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
+        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
+        
+        for(int n = 0; n < inpBlob.size.p[0]; n++)
+        {
+            for(int c = 0; c < inpBlob.size.p[1]; c++)
+            {
+                const float* inptr = inpBlob.ptr<float>(n, c);
+                // [TODO] change the output to int8_t
+                float* outptr = outBlob.ptr<float>(n, c);
+                float a = 1.f/sptr[stotal == nchannels ? c : 0];
+                int zidx = ztotal == nchannels ? c : 0;
+                float b = !zptr ? 0.f :
+                        ztype == CV_8U ? (float)zptr[zidx] :
+                        (float)((const int8_t*)zptr)[zidx];
+                size_t istep = inpBlob.step.p[2]/sizeof(inptr[0]);
+                size_t ostep = outBlob.step.p[2]/sizeof(outptr[0]);
+                int H = inpBlob.size.p[2], W = inpBlob.size.p[3];
+                
+                if (isContinuous)
+                {
+                    W *= H;
+                    H = 1;
+                }
+
+                for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
+                {
+                    for(int x = 0; x < W; x++)
+                        outptr[x] = inptr[x]*a + b;
+                }
+            }
+        }
+    }
+
+    virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
+                           const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_UNUSED(outputs); // suppress unused variable warning
+        long flops = 0;
+        for(int i = 0; i < inputs.size(); i++)
+        {
+            flops += 2*total(inputs[i]);
+        }
+        return flops;
+    }
+
+private:
+    Mat scale;
+    Mat zeroPoint;
+    int axis, outDepth;
+};
+
+
+Ptr<QuantizeLinearLayer> QuantizeLinearLayer::create(const LayerParams& params)
+{
+    return Ptr<QuantizeLinearLayer>(new QuantizeLinearLayerImpl(params));
+}
+
+////////////////////////////// Dequantize Layer /////////////////////////////
+
+class DequantizeLinearLayerImpl CV_FINAL : public DequantizeLinearLayer
+{
+public:
+    DequantizeLinearLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        
+        axis = params.get<int>("axis", 1);
+        scale = !params.blobs.empty() ? params.blobs[0] : Mat();
+        zeroPoint = params.blobs.size() > 1 ? params.blobs[0] : Mat::zeros(1, 1, CV_8U);
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        outputs.assign(1, inputs[0]);
+        return true;
+    }
+
+    virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays) CV_OVERRIDE
+    {
+        std::vector<Mat> inputs;
+        inputs_arr.getMatVector(inputs);
+        CV_Assert(inputs.size() == 1);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        CV_Assert(outputs.size() == 1);
+
+        Mat &inpBlob = inputs[0];
+        Mat &outBlob = outputs[0];
+        int idepth = inpBlob.depth();
+        int odepth = outBlob.depth();
+        
+        CV_Assert((idepth == CV_8S || idepth == CV_32F) && (odepth == CV_32F));
+        CV_Assert(axis == 1);
+        int nchannels = inpBlob.size.p[1];
+        int stotal = (int)scale.total();
+        CV_Assert(!scale.empty() && scale.isContinuous() && scale.type() == CV_32FC1 &&
+                  stotal == 1 || stotal == nchannels);
+        int ztype = zeroPoint.type();
+        int ztotal = (int)zeroPoint.total();
+        CV_Assert(zeroPoint.empty() ||
+                  ((ztype == CV_8U || ztype == CV_8S) &&
+                   ztotal == 1 || ztotal == nchannels));
+        
+        const float* sptr = scale.ptr<float>();
+        const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
+        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
+        
+        for(int n = 0; n < inpBlob.size.p[0]; n++)
+        {
+            for(int c = 0; c < inpBlob.size.p[1]; c++)
+            {
+                float* outptr = outBlob.ptr<float>(n, c);
+                float a = sptr[stotal == nchannels ? c : 0];
+                int zidx = ztotal == nchannels ? c : 0;
+                float b = !zptr ? 0.f :
+                        ztype == CV_8U ? (float)zptr[zidx] :
+                        (float)((const int8_t*)zptr)[zidx];
+                size_t istep = inpBlob.step.p[2];
+                size_t ostep = outBlob.step.p[2]/sizeof(outptr[0]);
+                int H = inpBlob.size.p[2], W = inpBlob.size.p[3];
+                
+                if (isContinuous)
+                {
+                    W *= H;
+                    H = 1;
+                }
+                
+                if (idepth == CV_8S)
+                {
+                    const int8_t* inptr = inpBlob.ptr<int8_t>(n, c);
+                    istep /= sizeof(inptr[0]);
+                    for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = (inptr[x] - b)*a;
+                    }
+                }
+                else
+                {
+                    CV_Assert(idepth == CV_32F);
+                    const float* inptr = inpBlob.ptr<float>(n, c);
+                    istep /= sizeof(inptr[0]);
+                    for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = (inptr[x] - b)*a;
+                    }
+                }
+            }
+        }
+    }
+
+    virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
+                           const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_UNUSED(outputs); // suppress unused variable warning
+        long flops = 0;
+        for(int i = 0; i < inputs.size(); i++)
+        {
+            flops += 2*total(inputs[i]);
+        }
+        return flops;
+    }
+
+private:
+    Mat scale;
+    Mat zeroPoint;
+    int axis;
+};
+
+
+Ptr<DequantizeLinearLayer> DequantizeLinearLayer::create(const LayerParams& params)
+{
+    return Ptr<DequantizeLinearLayer>(new DequantizeLinearLayerImpl(params));
+}
+
+}  // namespace dnn
+}  // namespace cv

--- a/modules/dnn/src/layers/quantize_dequantize_layer.cpp
+++ b/modules/dnn/src/layers/quantize_dequantize_layer.cpp
@@ -29,9 +29,9 @@ public:
     {
         setParamsFrom(params);
         
-        axis = params.get<int>("axis", 1);
+        axis = params.get<int>("axis", -1);
         scale = !params.blobs.empty() ? params.blobs[0] : Mat();
-        zeroPoint = params.blobs.size() > 1 ? params.blobs[0] : Mat::zeros(1, 1, CV_8U);
+        zeroPoint = params.blobs.size() > 1 ? params.blobs[1] : Mat::zeros(1, 1, CV_8U);
         outDepth = CV_32F; // should be changed to CV_8S eventually
     }
 
@@ -69,45 +69,59 @@ public:
 
         Mat &inpBlob = inputs[0];
         Mat &outBlob = outputs[0];
-        int odepth = outBlob.depth();
+        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
         
+        int odepth = outBlob.depth();
         CV_Assert(inpBlob.depth() == CV_32F && (odepth == CV_32F));
-        CV_Assert(axis == 1);
-        int nchannels = inpBlob.size.p[1];
+        int ndims = inpBlob.dims;
+        
+        CV_Assert(ndims >= 2 && ndims <= 4);
+        int W = inpBlob.size.p[ndims-1];
+        int H = inpBlob.size.p[ndims-2];
+        int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
+        int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
+        
+        CV_Assert(axis == ndims - 3 || axis == -1);
+        
         int stotal = (int)scale.total();
-        CV_Assert(!scale.empty() && scale.isContinuous() && scale.type() == CV_32FC1 &&
-                  stotal == 1 || stotal == nchannels);
+        CV_Assert(!scale.empty() && scale.isContinuous() &&
+                  scale.type() == CV_32FC1 &&
+                  stotal == 1 || stotal == C);
         int ztype = zeroPoint.type();
         int ztotal = (int)zeroPoint.total();
         CV_Assert(zeroPoint.empty() ||
                   ((ztype == CV_8U || ztype == CV_8S) &&
-                   ztotal == 1 || ztotal == nchannels));
-        
+                   ztotal == 1 || ztotal == C));
+         
         const float* sptr = scale.ptr<float>();
         const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
-        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
         
-        for(int n = 0; n < inpBlob.size.p[0]; n++)
+        if(isContinuous) {
+            W *= H;
+            H = 1;
+        }
+        
+        for(int n = 0; n < N; n++)
         {
-            for(int c = 0; c < inpBlob.size.p[1]; c++)
+            for(int c = 0; c < C; c++)
             {
-                const float* inptr = inpBlob.ptr<float>(n, c);
+                const float* inptr =
+                    ndims == 2 ? inpBlob.ptr<float>() :
+                    ndims == 3 ? inpBlob.ptr<float>(c) :
+                    inpBlob.ptr<float>(n, c);
                 // [TODO] change the output to int8_t
-                float* outptr = outBlob.ptr<float>(n, c);
-                float a = 1.f/sptr[stotal == nchannels ? c : 0];
-                int zidx = ztotal == nchannels ? c : 0;
+                float* outptr =
+                    ndims == 2 ? outBlob.ptr<float>() :
+                    ndims == 3 ? outBlob.ptr<float>(c) :
+                    outBlob.ptr<float>(n, c);
+                //float a = 1.f/sptr[stotal == C ? c : 0];
+                float a = sptr[stotal == C ? c : 0];
+                int zidx = ztotal == C ? c : 0;
                 float b = !zptr ? 0.f :
                         ztype == CV_8U ? (float)zptr[zidx] :
                         (float)((const int8_t*)zptr)[zidx];
-                size_t istep = inpBlob.step.p[2]/sizeof(inptr[0]);
-                size_t ostep = outBlob.step.p[2]/sizeof(outptr[0]);
-                int H = inpBlob.size.p[2], W = inpBlob.size.p[3];
-                
-                if (isContinuous)
-                {
-                    W *= H;
-                    H = 1;
-                }
+                size_t istep = inpBlob.step.p[ndims-2]/sizeof(inptr[0]);
+                size_t ostep = outBlob.step.p[ndims-2]/sizeof(outptr[0]);
 
                 for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
                 {
@@ -151,9 +165,9 @@ public:
     {
         setParamsFrom(params);
         
-        axis = params.get<int>("axis", 1);
+        axis = params.get<int>("axis", -1);
         scale = !params.blobs.empty() ? params.blobs[0] : Mat();
-        zeroPoint = params.blobs.size() > 1 ? params.blobs[0] : Mat::zeros(1, 1, CV_8U);
+        zeroPoint = params.blobs.size() > 1 ? params.blobs[1] : Mat::zeros(1, 1, CV_8U);
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,
@@ -193,45 +207,72 @@ public:
         int idepth = inpBlob.depth();
         int odepth = outBlob.depth();
         
-        CV_Assert((idepth == CV_8S || idepth == CV_32F) && (odepth == CV_32F));
-        CV_Assert(axis == 1);
-        int nchannels = inpBlob.size.p[1];
+        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
+        
+        CV_Assert((idepth == CV_8U || idepth == CV_8S || idepth == CV_32F) &&
+                  (odepth == CV_32F));
+        int ndims = inpBlob.dims;
+        
+        CV_Assert(ndims >= 2 && ndims <= 4);
+        int W = inpBlob.size.p[ndims-1];
+        int H = inpBlob.size.p[ndims-2];
+        int C = ndims > 2 ? inpBlob.size.p[ndims-3] : 1;
+        int N = ndims > 3 ? inpBlob.size.p[ndims-4] : 1;
+        
+        CV_Assert(axis == ndims - 3 || axis == -1);
         int stotal = (int)scale.total();
-        CV_Assert(!scale.empty() && scale.isContinuous() && scale.type() == CV_32FC1 &&
-                  stotal == 1 || stotal == nchannels);
+        CV_Assert(!scale.empty() && scale.isContinuous() &&
+                  scale.type() == CV_32FC1 &&
+                  stotal == 1 || stotal == C);
         int ztype = zeroPoint.type();
         int ztotal = (int)zeroPoint.total();
         CV_Assert(zeroPoint.empty() ||
                   ((ztype == CV_8U || ztype == CV_8S) &&
-                   ztotal == 1 || ztotal == nchannels));
+                   ztotal == 1 || ztotal == C));
         
         const float* sptr = scale.ptr<float>();
         const uint8_t* zptr = zeroPoint.ptr<uint8_t>();
-        bool isContinuous = inpBlob.isContinuous() && outBlob.isContinuous();
         
-        for(int n = 0; n < inpBlob.size.p[0]; n++)
+        if(isContinuous) {
+            W *= H;
+            H = 1;
+        }
+        
+        for(int n = 0; n < N; n++)
         {
-            for(int c = 0; c < inpBlob.size.p[1]; c++)
+            for(int c = 0; c < C; c++)
             {
-                float* outptr = outBlob.ptr<float>(n, c);
-                float a = sptr[stotal == nchannels ? c : 0];
-                int zidx = ztotal == nchannels ? c : 0;
+                float* outptr =
+                    ndims == 2 ? outBlob.ptr<float>() :
+                    ndims == 3 ? outBlob.ptr<float>(c) :
+                    outBlob.ptr<float>(n, c);
+                float a = sptr[stotal == C ? c : 0];
+                int zidx = ztotal == C ? c : 0;
                 float b = !zptr ? 0.f :
                         ztype == CV_8U ? (float)zptr[zidx] :
                         (float)((const int8_t*)zptr)[zidx];
-                size_t istep = inpBlob.step.p[2];
-                size_t ostep = outBlob.step.p[2]/sizeof(outptr[0]);
-                int H = inpBlob.size.p[2], W = inpBlob.size.p[3];
+                size_t istep = inpBlob.step.p[ndims-2];
+                size_t ostep = outBlob.step.p[ndims-2]/sizeof(outptr[0]);
                 
-                if (isContinuous)
+                if (idepth == CV_8U)
                 {
-                    W *= H;
-                    H = 1;
+                    const uint8_t* inptr =
+                        ndims == 2 ? inpBlob.ptr<uint8_t>() :
+                        ndims == 3 ? inpBlob.ptr<uint8_t>(c) :
+                        inpBlob.ptr<uint8_t>(n, c);
+                    istep /= sizeof(inptr[0]);
+                    for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
+                    {
+                        for(int x = 0; x < W; x++)
+                            outptr[x] = (inptr[x] - b)*a;
+                    }
                 }
-                
-                if (idepth == CV_8S)
+                else if (idepth == CV_8S)
                 {
-                    const int8_t* inptr = inpBlob.ptr<int8_t>(n, c);
+                    const int8_t* inptr =
+                        ndims == 2 ? inpBlob.ptr<int8_t>() :
+                        ndims == 3 ? inpBlob.ptr<int8_t>(c) :
+                        inpBlob.ptr<int8_t>(n, c);
                     istep /= sizeof(inptr[0]);
                     for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
                     {
@@ -242,7 +283,10 @@ public:
                 else
                 {
                     CV_Assert(idepth == CV_32F);
-                    const float* inptr = inpBlob.ptr<float>(n, c);
+                    const float* inptr =
+                        ndims == 2 ? inpBlob.ptr<float>() :
+                        ndims == 3 ? inpBlob.ptr<float>(c) :
+                        inpBlob.ptr<float>(n, c);
                     istep /= sizeof(inptr[0]);
                     for(int y = 0; y < H; y++, inptr += istep, outptr += ostep)
                     {

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -641,6 +641,22 @@ Mat getMatFromTensor(opencv_onnx::TensorProto& tensor_proto)
             convertInt64ToInt32(src, dst, blob.total());
         }
     }
+    else if (datatype == opencv_onnx::TensorProto_DataType_INT8 ||
+             datatype == opencv_onnx::TensorProto_DataType_UINT8)
+    {
+        int depth = datatype == opencv_onnx::TensorProto_DataType_INT8 ? CV_8S : CV_8U;
+        if (!tensor_proto.int32_data().empty())
+        {
+            const ::google::protobuf::RepeatedField<int32_t> field = tensor_proto.int32_data();
+            Mat(sizes, CV_32SC1, (void*)field.data()).convertTo(blob, depth);
+        }
+        else
+        {
+            // [TODO] shall we use a conversion here as well?
+            char* val = const_cast<char*>(tensor_proto.raw_data().c_str());
+            Mat(sizes, depth, val).copyTo(blob);
+        }
+    }
     else
     {
         std::string errorMsg = "Unsupported data type: " +

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1343,8 +1343,8 @@ TEST_P(Test_ONNX_nets, QuantStatic)
 {
     if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
         throw SkipTestException("Only the default backend; CPU target is supported");
-    
-    String onnxmodel = findDataFile("dnn/model_quant_static.onnx", true);
+
+    String onnxmodel = findDataFile("dnn/onnx/models/model_quant_static.onnx", true);
     Net net = readNetFromONNX(onnxmodel);
     ASSERT_FALSE(net.empty());
     net.setPreferableBackend(backend);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1339,6 +1339,27 @@ TEST_P(Test_ONNX_nets, Resnet34_kinetics)
     expectNoFallbacksFromIE(net);
 }
 
+TEST_P(Test_ONNX_nets, QuantStatic)
+{
+    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
+        throw SkipTestException("Only the default backend; CPU target is supported");
+    
+    String onnxmodel = findDataFile("dnn/model_quant_static.onnx", true);
+    Net net = readNetFromONNX(onnxmodel);
+    ASSERT_FALSE(net.empty());
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+    std::cout << net.dump() << "\n";
+    int shape[] = {1, 3, 16, 16};
+    Mat input(4, shape, CV_32F);
+    RNG& rng = theRNG();
+    rng.fill(input, RNG::UNIFORM, 0, 255);
+    net.setInput(input);
+    Mat output = net.forward();
+    //std::cout << output << std::endl;
+    ASSERT_EQ(output.size(), Size(128, 1));
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
See https://github.com/opencv/opencv/issues/20188. Merge together with https://github.com/opencv/opencv_extra/pull/878.

* Note that the code is not fully tested. There is just a smoke test that checks that one simple quantized model is loaded successfully, and then we can run inference on it and get 'some' result of the proper type and size. We need some real quantized deep nets to test the functionality properly.
* QLinearConv is converted to a normal Convolution layer; QLinearMatMul is converted to MatMul. The original 8-bit weights and the quantization/de-quantization factors are preserved though, so Convlution and MatMul layers can, in principle, be extended to support 8-bit weights.
* QuantizeLinear outputs FP32 data; it needs to be extended to output 8-bit tensors.
* DequantizeLinear and QLinearAdd take FP32, as well as INT8/UINT8 inputs, but the output is always FP32 for now. 

The PR is submitted to master branch, rather than 3.4, because the whole support for 8-bit compute paths will be added to master (see #20228)

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```