### PR TITLE
Optimization of DNN using native RISC-V vector intrinsics.

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 set(the_description "Deep neural network module. It allows to load models from different frameworks and to make forward pass")
 
-ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX)
+ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX RVV)
 
 ocv_add_module(dnn opencv_core opencv_imgproc WRAP python java objc js)
 

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1549,6 +1549,12 @@ public:
                                          outShape, bsz, vsz, vsz_a, relu, cn0 == 0);
                         else
                     #endif
+                    #if CV_TRY_RVV
+                        if(useRVV)
+                            opt_RVV::fastConv(wptr, wstep, biasptr, rowbuf0, data_out0 + ofs0,
+                                         outShape, bsz, vsz, vsz_a, relu, cn0 == 0);
+                        else
+                    #endif
                         for( int i = 0; i < outCn; i += 2 )
                         {
                             const float* wptr0 = wptr + i*wstep;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1179,6 +1179,13 @@ public:
                                     biasptr, relu, inptr_, height, width, outptr_, out_d, outH, outW);
                             else
                         #endif
+                        #if CV_TRY_RVV
+                            if(useRVV)
+                                opt_RVV::fastDepthwiseConv(wptr, kernel_h, kernel_w,
+                                    stride_h, stride_w, dilation_h, dilation_w, pad_t, pad_l,
+                                    biasptr, relu, inptr_, height, width, outptr_, out_d, outH, outW);
+                            else
+                        #endif
                             {
                                 const float w00_ = wptr[0], w01_ = wptr[1], w02_ = wptr[2],
                                             w10 = wptr[3], w11 = wptr[4], w12 = wptr[5],

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -744,9 +744,9 @@ void fastGEMM( const float* aptr, size_t astep, const float* bptr,
                int ma, int na, int nb )
 {
     int n = 0;
-    size_t vl = vsetvl_e32m2(128);
-    size_t mvl0 = vsetvl_e32m2(128);
-    size_t mvl1 = vsetvl_e32m2(128);
+    size_t vl = 8;
+    size_t mvl0 = 8;
+    size_t mvl1 = 8;
     for( ; n < nb; n += 16 )
     {
         if ( n + 16 > nb) {
@@ -805,8 +805,8 @@ void fastGEMM1T( const float* vec, const float* weights,
                  float* dst, int nvecs, int vecsize )
 {
     int i = 0;
-    size_t vl = vsetvl_e32m2(128);
-    size_t mvl = vsetvl_e32m2(128);
+    size_t vl = 8;
+    size_t mvl = 8;
     for( ; i < nvecs; i += 8 )
     {
         if (i + 8 >= nvecs)
@@ -864,7 +864,7 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
                int blockSize, int vecsize, int vecsize_aligned,
                const float* relu, bool initOutput )
 {
-    int vl = vsetvl_e32m1(128); // vl = 4
+    int vl = 4;
     int outCn = outShape[1];
     size_t outPlaneSize = outShape[2]*outShape[3];
     float r0 = 1.f, r1 = 1.f, r2 = 1.f;
@@ -930,7 +930,7 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
             }
             int k = 0;
             const float* rptr = rowbuf + j*vecsize_aligned;
-            int vlm2 = vsetvl_e32m2(128); // vl = 8
+            int vlm2 = 8;
             vfloat32m2_t vs00 = vfmv_v_f_f32m2(0, vlm2), vs01 = vfmv_v_f_f32m2(0, vlm2),
                    vs02 = vfmv_v_f_f32m2(0, vlm2), vs03 = vfmv_v_f_f32m2(0, vlm2),
                    vs10 = vfmv_v_f_f32m2(0, vlm2), vs11 = vfmv_v_f_f32m2(0, vlm2),
@@ -1046,7 +1046,7 @@ Example for load_deinterleave:
 */
 static inline void vfloat32m2_load_deinterleave(const float* ptr, vfloat32m2_t& a, vfloat32m2_t& b)
 {
-    int vl = vsetvl_e32m2(128);
+    int vl = 8;
     uint32_t masks[] = {1,1,1,1,0,0,0,0};
     vuint32m2_t vm = vle32_v_u32m2(masks,vl);
     vbool16_t mask01 = vmseq_vx_u32m2_b16 (vm, 0, vl);
@@ -1074,7 +1074,7 @@ void fastDepthwiseConv( const float* wptr,
                      float* outptr_,
                      int out_d, int outH, int outW )
 {
-    int vl = vsetvl_e32m2(128);
+    int vl = 8;
     const float w00_ = wptr[0], w01_ = wptr[1], w02_ = wptr[2],
                 w10 = wptr[3], w11 = wptr[4], w12 = wptr[5],
                 w20_ = wptr[6], w21_ = wptr[7], w22_ = wptr[8];

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -843,7 +843,7 @@ void fastGEMM1T( const float* vec, const float* weights,
         vfloat32m1_t temp5 = vfredsum_vs_f32m2_f32m1(temp5, vs5, zero, vl);
         vfloat32m1_t temp6 = vfredsum_vs_f32m2_f32m1(temp6, vs6, zero, vl);
         vfloat32m1_t temp7 = vfredsum_vs_f32m2_f32m1(temp7, vs7, zero, vl);
-        float32_t sum[8] = {0,0,0,0,0,0,0,0};
+        float32_t sum[8];
         sum[0] = vfmv_f_s_f32m1_f32(temp0);
         sum[1] = vfmv_f_s_f32m1_f32(temp1);
         sum[2] = vfmv_f_s_f32m1_f32(temp2);
@@ -995,7 +995,7 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
             vfloat32m1_t temp21 = vfredsum_vs_f32m2_f32m1(temp21, vs21, zero, 8);
             vfloat32m1_t temp22 = vfredsum_vs_f32m2_f32m1(temp22, vs22, zero, 8);
             vfloat32m1_t temp23 = vfredsum_vs_f32m2_f32m1(temp23, vs23, zero, 8);
-            float32_t sum0[4] = {0}, sum1[4] = {0}, sum2[4] = {0};
+            float32_t sum0[4], sum1[4], sum2[4];
             sum0[0] = vfmv_f_s_f32m1_f32(temp00);
             sum0[1] = vfmv_f_s_f32m1_f32(temp01);
             sum0[2] = vfmv_f_s_f32m1_f32(temp02);

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -820,15 +820,17 @@ void fastGEMM1T( const float* vec, const float* weights,
         for( int k = 0; k < vecsize; k += 8, wptr += 8 )
         {
             vfloat32m2_t v = vle32_v_f32m2(vec + k, vl);
-
-            vs0 = vfmacc_vv_f32m2(vs0, vle32_v_f32m2(wptr, vl), v, vl);
-            vs1 = vfmacc_vv_f32m2(vs1, vle32_v_f32m2(wptr + wstep, vl), v, vl);
-            vs2 = vfmacc_vv_f32m2(vs2, vle32_v_f32m2(wptr + wstep*2, vl), v, vl);
-            vs3 = vfmacc_vv_f32m2(vs3, vle32_v_f32m2(wptr + wstep*3, vl), v, vl);
-            vs4 = vfmacc_vv_f32m2(vs4, vle32_v_f32m2(wptr + wstep*4, vl), v, vl);
-            vs5 = vfmacc_vv_f32m2(vs5, vle32_v_f32m2(wptr + wstep*5, vl), v, vl);
-            vs6 = vfmacc_vv_f32m2(vs6, vle32_v_f32m2(wptr + wstep*6, vl), v, vl);
-            vs7 = vfmacc_vv_f32m2(vs7, vle32_v_f32m2(wptr + wstep*7, vl), v, vl);
+            switch (mvl) {
+                case 8: vs7 = vfmacc_vv_f32m2(vs7, vle32_v_f32m2(wptr + wstep*7, vl), v, vl); // fall through
+                case 7: vs6 = vfmacc_vv_f32m2(vs6, vle32_v_f32m2(wptr + wstep*6, vl), v, vl); // fall through
+                case 6: vs5 = vfmacc_vv_f32m2(vs5, vle32_v_f32m2(wptr + wstep*5, vl), v, vl); // fall through
+                case 5: vs4 = vfmacc_vv_f32m2(vs4, vle32_v_f32m2(wptr + wstep*4, vl), v, vl); // fall through
+                case 4: vs3 = vfmacc_vv_f32m2(vs3, vle32_v_f32m2(wptr + wstep*3, vl), v, vl); // fall through
+                case 3: vs2 = vfmacc_vv_f32m2(vs2, vle32_v_f32m2(wptr + wstep*2, vl), v, vl); // fall through
+                case 2: vs1 = vfmacc_vv_f32m2(vs1, vle32_v_f32m2(wptr + wstep, vl), v, vl); // fall through
+                case 1: vs0 = vfmacc_vv_f32m2(vs0, vle32_v_f32m2(wptr, vl), v, vl); break;
+                default: break;
+            }
         }
 
         // Calculate the sum of each vector


### PR DESCRIPTION
PR for GSoC'21 project on Optimize OpenCV DNN for RISC-V.

This PR is going to add the functions implemented by RVV intrinsics (0.10) in [layers_common.simd.hpp](https://github.com/opencv/opencv/blob/master/modules/dnn/src/layers/layers_common.simd.hpp), which has 4 functions as below. 

In this PR, we assume that vlen=128, which means if RVV Vector Registers are 256-bit or more longer, then the current implementation will use only a part of them. We will make the implementation adjustable to different vector sizes by other PR(s).

| Functions         | Implement && Build | Vectorize tails (No Scala)                             | Max used of vReg (v0-v31) | 
| ----------------- | ------------------ | ------------------------------------------------------ | ------------------------- |
| fastGEMM          | ✅                  | ✅                              | ≈ 14*2                |
| fastGEMM1T        | ✅                  | ✅                                   | ≈ 16*2                |
| fastConv          | ✅                  | ✅                                    | ≈ 4+14*2              |
| fastDepthwiseConv | ✅                  | ⏱ reviewing (still has a scalar part for stride) | ≈ 23*2                |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
