### PR TITLE
fix memory leak when exception is thrown

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1835,7 +1835,15 @@ void* TLSDataContainer::getData() const
     {
         // Create new data instance and save it to TLS storage
         pData = createDataInstance();
-        getTlsStorage().setData(key_, pData);
+        try
+        {
+            getTlsStorage().setData(key_, pData);
+        }
+        catch (...)
+        {
+            deleteDataInstance(pData);
+            throw;
+        }
     }
     return pData;
 }


### PR DESCRIPTION
The call to `setData` may throw an exception without `CV_THREAD_SANITIZER`.

This fix is to avoid the memory leak on `pData` when exception is thrown.
