### PR TITLE
Do not use = 0 for a cv::Mat.

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -3924,7 +3924,7 @@ bool findChessboardCornersSB(cv::InputArray image_, cv::Size pattern_size,
     {
         meta_.create(int(board.rowCount()),int(board.colCount()),CV_8UC1);
         cv::Mat meta = meta_.getMat();
-        meta = 0;
+        meta.setTo(cv::Scalar::all(0));
         for(int row =0;row < meta.rows-1;++row)
         {
             for(int col=0;col< meta.cols-1;++col)


### PR DESCRIPTION
There are several operator= overloads and some compilers can be confused.

This is not present in 3.4. I cannot get my compiler options but here is the error I get:

error: use of overloaded operator '=' is ambiguous (with operand types 'cv::Mat' and 'int')
    meta = 0;
          ~ ^ ~
./include/opencv2/core/mat.hpp:1070:10: note: candidate function
    Mat& operator = (const Mat& m);
         ^
./include/opencv2/core/mat.hpp:1257:10: note: candidate function
    Mat& operator = (const Scalar& s);
         ^
./include/opencv2/core/mat.hpp:2099:10: note: candidate function
    Mat& operator = (Mat&& m);

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
