### PR TITLE
Improvements/fixes for unsigned type handling in Swift/Kotlin

### DIFF
--- a/modules/core/misc/java/src/java/core+MatAt.kt
+++ b/modules/core/misc/java/src/java/core+MatAt.kt
@@ -3,6 +3,16 @@ package org.opencv.core
 import org.opencv.core.Mat.*
 import java.lang.RuntimeException
 
+fun Mat.get(row: Int, col: Int, data: UByteArray)  = this.get(row, col, data.asByteArray())
+fun Mat.get(indices: IntArray, data: UByteArray)  = this.get(indices, data.asByteArray())
+fun Mat.put(row: Int, col: Int, data: UByteArray)  = this.put(row, col, data.asByteArray())
+fun Mat.put(indices: IntArray, data: UByteArray)  = this.put(indices, data.asByteArray())
+
+fun Mat.get(row: Int, col: Int, data: UShortArray)  = this.get(row, col, data.asShortArray())
+fun Mat.get(indices: IntArray, data: UShortArray)  = this.get(indices, data.asShortArray())
+fun Mat.put(row: Int, col: Int, data: UShortArray)  = this.put(row, col, data.asShortArray())
+fun Mat.put(indices: IntArray, data: UShortArray)  = this.put(indices, data.asShortArray())
+
 /***
  *  Example use:
  *
@@ -19,6 +29,7 @@ inline fun <reified T> Mat.at(row: Int, col: Int) : Atable<T> =
             col
         )
         UByte::class -> AtableUByte(this, row, col) as Atable<T>
+        UShort::class -> AtableUShort(this, row, col) as Atable<T>
         else -> throw RuntimeException("Unsupported class type")
     }
 
@@ -30,6 +41,7 @@ inline fun <reified T> Mat.at(idx: IntArray) : Atable<T> =
             idx
         )
         UByte::class -> AtableUByte(this, idx) as Atable<T>
+        UShort::class -> AtableUShort(this, idx) as Atable<T>
         else -> throw RuntimeException("Unsupported class type")
     }
 
@@ -38,46 +50,95 @@ class AtableUByte(val mat: Mat, val indices: IntArray): Atable<UByte> {
     constructor(mat: Mat, row: Int, col: Int) : this(mat, intArrayOf(row, col))
 
     override fun getV(): UByte {
-        val data = ByteArray(1)
-        mat[indices, data]
-        return data[0].toUByte()
+        val data = UByteArray(1)
+        mat.get(indices, data)
+        return data[0]
     }
 
     override fun setV(v: UByte) {
-        val data = byteArrayOf(v.toByte())
+        val data = ubyteArrayOf(v)
         mat.put(indices, data)
     }
 
     override fun getV2c(): Tuple2<UByte> {
-        val data = ByteArray(2)
-        mat[indices, data]
-        return Tuple2(data[0].toUByte(), data[1].toUByte())
+        val data = UByteArray(2)
+        mat.get(indices, data)
+        return Tuple2(data[0], data[1])
     }
 
     override fun setV2c(v: Tuple2<UByte>) {
-        val data = byteArrayOf(v._0.toByte(), v._1.toByte())
+        val data = ubyteArrayOf(v._0, v._1)
         mat.put(indices, data)
     }
 
     override fun getV3c(): Tuple3<UByte> {
-        val data = ByteArray(3)
-        mat[indices, data]
-        return Tuple3(data[0].toUByte(), data[1].toUByte(), data[2].toUByte())
+        val data = UByteArray(3)
+        mat.get(indices, data)
+        return Tuple3(data[0], data[1], data[2])
     }
 
     override fun setV3c(v: Tuple3<UByte>) {
-        val data = byteArrayOf(v._0.toByte(), v._1.toByte(), v._2.toByte())
+        val data = ubyteArrayOf(v._0, v._1, v._2)
         mat.put(indices, data)
     }
 
     override fun getV4c(): Tuple4<UByte> {
-        val data = ByteArray(4)
-        mat[indices, data]
-        return Tuple4(data[0].toUByte(), data[1].toUByte(), data[2].toUByte(), data[3].toUByte())
+        val data = UByteArray(4)
+        mat.get(indices, data)
+        return Tuple4(data[0], data[1], data[2], data[3])
     }
 
     override fun setV4c(v: Tuple4<UByte>) {
-        val data = byteArrayOf(v._0.toByte(), v._1.toByte(), v._2.toByte(), v._3.toByte())
+        val data = ubyteArrayOf(v._0, v._1, v._2, v._3)
+        mat.put(indices, data)
+    }
+}
+
+class AtableUShort(val mat: Mat, val indices: IntArray): Atable<UShort> {
+
+    constructor(mat: Mat, row: Int, col: Int) : this(mat, intArrayOf(row, col))
+
+    override fun getV(): UShort {
+        val data = UShortArray(1)
+        mat.get(indices, data)
+        return data[0]
+    }
+
+    override fun setV(v: UShort) {
+        val data = ushortArrayOf(v)
+        mat.put(indices, data)
+    }
+
+    override fun getV2c(): Tuple2<UShort> {
+        val data = UShortArray(2)
+        mat.get(indices, data)
+        return Tuple2(data[0], data[1])
+    }
+
+    override fun setV2c(v: Tuple2<UShort>) {
+        val data = ushortArrayOf(v._0, v._1)
+        mat.put(indices, data)
+    }
+
+    override fun getV3c(): Tuple3<UShort> {
+        val data = UShortArray(3)
+        mat.get(indices, data)
+        return Tuple3(data[0], data[1], data[2])
+    }
+
+    override fun setV3c(v: Tuple3<UShort>) {
+        val data = ushortArrayOf(v._0, v._1, v._2)
+        mat.put(indices, data)
+    }
+
+    override fun getV4c(): Tuple4<UShort> {
+        val data = UShortArray(4)
+        mat.get(indices, data)
+        return Tuple4(data[0], data[1], data[2], data[3])
+    }
+
+    override fun setV4c(v: Tuple4<UShort>) {
+        val data = ushortArrayOf(v._0, v._1, v._2, v._3)
         mat.put(indices, data)
     }
 }

--- a/modules/core/misc/objc/common/Mat.mm
+++ b/modules/core/misc/objc/common/Mat.mm
@@ -548,7 +548,7 @@ template<typename T> void putData(uchar* dataDest, int count, T (^readData)(int)
     if (depth == CV_8U) {
         putData(dest, count, ^uchar (int index) { return cv::saturate_cast<uchar>(data[offset + index].doubleValue);} );
     } else if (depth == CV_8S) {
-        putData(dest, count, ^char (int index) { return cv::saturate_cast<char>(data[offset + index].doubleValue);} );
+        putData(dest, count, ^schar (int index) { return cv::saturate_cast<schar>(data[offset + index].doubleValue);} );
     } else if (depth == CV_16U) {
         putData(dest, count, ^ushort (int index) { return cv::saturate_cast<ushort>(data[offset + index].doubleValue);} );
     } else if (depth == CV_16S) {

--- a/modules/core/misc/objc/common/MatExt.swift
+++ b/modules/core/misc/objc/common/MatExt.swift
@@ -62,6 +62,21 @@ public extension Mat {
         }
     }
 
+    @discardableResult func get(indices:[Int32], data:inout [UInt8]) throws -> Int32 {
+        let channels = CvType.channels(Int32(type()))
+        if Int32(data.count) % channels != 0 {
+            try throwIncompatibleBufferSize(count: data.count, channels: channels)
+        } else if depth() != CvType.CV_8U {
+            try throwIncompatibleDataType(typeName: CvType.type(toString: type()))
+        }
+        let count = Int32(data.count)
+        return data.withUnsafeMutableBufferPointer { body in
+            body.withMemoryRebound(to: Int8.self) { reboundBody in
+                return __get(indices as [NSNumber], count: count, byteBuffer: reboundBody.baseAddress!)
+            }
+        }
+    }
+
     @discardableResult func get(indices:[Int32], data:inout [Double]) throws -> Int32 {
         let channels = CvType.channels(Int32(type()))
         if Int32(data.count) % channels != 0 {
@@ -114,7 +129,26 @@ public extension Mat {
         }
     }
 
+    @discardableResult func get(indices:[Int32], data:inout [UInt16]) throws -> Int32 {
+        let channels = CvType.channels(Int32(type()))
+        if Int32(data.count) % channels != 0 {
+            try throwIncompatibleBufferSize(count: data.count, channels: channels)
+        } else if depth() != CvType.CV_16U {
+            try throwIncompatibleDataType(typeName: CvType.type(toString: type()))
+        }
+        let count = Int32(data.count)
+        return data.withUnsafeMutableBufferPointer { body in
+            body.withMemoryRebound(to: Int16.self) { reboundBody in
+                return __get(indices as [NSNumber], count: count, shortBuffer: reboundBody.baseAddress!)
+            }
+        }
+    }
+
     @discardableResult func get(row: Int32, col: Int32, data:inout [Int8]) throws -> Int32 {
+        return try get(indices: [row, col], data: &data)
+    }
+
+    @discardableResult func get(row: Int32, col: Int32, data:inout [UInt8]) throws -> Int32 {
         return try get(indices: [row, col], data: &data)
     }
 
@@ -134,6 +168,10 @@ public extension Mat {
         return try get(indices: [row, col], data: &data)
     }
 
+    @discardableResult func get(row: Int32, col: Int32, data:inout [UInt16]) throws -> Int32 {
+        return try get(indices: [row, col], data: &data)
+    }
+
     @discardableResult func put(indices:[Int32], data:[Int8]) throws -> Int32 {
         let channels = CvType.channels(Int32(type()))
         if Int32(data.count) % channels != 0 {
@@ -144,6 +182,21 @@ public extension Mat {
         let count = Int32(data.count)
         return data.withUnsafeBufferPointer { body in
             return __put(indices as [NSNumber], count: count, byteBuffer: body.baseAddress!)
+        }
+    }
+
+    @discardableResult func put(indices:[Int32], data:[UInt8]) throws -> Int32 {
+        let channels = CvType.channels(Int32(type()))
+        if Int32(data.count) % channels != 0 {
+            try throwIncompatibleBufferSize(count: data.count, channels: channels)
+        } else if depth() != CvType.CV_8U {
+            try throwIncompatibleDataType(typeName: CvType.type(toString: type()))
+        }
+        let count = Int32(data.count)
+        return data.withUnsafeBufferPointer { body in
+            body.withMemoryRebound(to: Int8.self) { reboundBody in
+                return __put(indices as [NSNumber], count: count, byteBuffer: reboundBody.baseAddress!)
+            }
         }
     }
 
@@ -214,7 +267,26 @@ public extension Mat {
         }
     }
 
+    @discardableResult func put(indices:[Int32], data:[UInt16]) throws -> Int32 {
+        let channels = CvType.channels(Int32(type()))
+        if Int32(data.count) % channels != 0 {
+            try throwIncompatibleBufferSize(count: data.count, channels: channels)
+        } else if depth() != CvType.CV_16U {
+            try throwIncompatibleDataType(typeName: CvType.type(toString: type()))
+        }
+        let count = Int32(data.count)
+        return data.withUnsafeBufferPointer { body in
+            body.withMemoryRebound(to: Int16.self) { reboundBody in
+                return __put(indices as [NSNumber], count: count, shortBuffer: reboundBody.baseAddress!)
+            }
+        }
+    }
+
     @discardableResult func put(row: Int32, col: Int32, data:[Int8]) throws -> Int32 {
+        return try put(indices: [row, col], data: data)
+    }
+
+    @discardableResult func put(row: Int32, col: Int32, data:[UInt8]) throws -> Int32 {
         return try put(indices: [row, col], data: data)
     }
 
@@ -235,6 +307,10 @@ public extension Mat {
     }
 
     @discardableResult func put(row: Int32, col: Int32, data: [Int16]) throws -> Int32 {
+        return try put(indices: [row, col], data: data)
+    }
+
+    @discardableResult func put(row: Int32, col: Int32, data: [UInt16]) throws -> Int32 {
         return try put(indices: [row, col], data: data)
     }
 
@@ -303,46 +379,46 @@ public class MatAt<N: Atable> {
 
 extension UInt8: Atable {
     public static func getAt(m: Mat, indices:[Int32]) -> UInt8 {
-        var tmp = [Int8](repeating: 0, count: 1)
+        var tmp = [UInt8](repeating: 0, count: 1)
         try! m.get(indices: indices, data: &tmp)
-        return UInt8(bitPattern: tmp[0])
+        return tmp[0]
     }
 
     public static func putAt(m: Mat, indices: [Int32], v: UInt8) {
-        let tmp = [Int8(bitPattern: v)]
+        let tmp = [v]
         try! m.put(indices: indices, data: tmp)
     }
 
     public static func getAt2c(m: Mat, indices:[Int32]) -> (UInt8, UInt8) {
-        var tmp = [Int8](repeating: 0, count: 2)
+        var tmp = [UInt8](repeating: 0, count: 2)
         try! m.get(indices: indices, data: &tmp)
-        return (UInt8(bitPattern: tmp[0]), UInt8(bitPattern: tmp[1]))
+        return (tmp[0], tmp[1])
     }
 
     public static func putAt2c(m: Mat, indices: [Int32], v: (UInt8, UInt8)) {
-        let tmp = [Int8(bitPattern: v.0), Int8(bitPattern: v.1)]
+        let tmp = [v.0, v.1]
         try! m.put(indices: indices, data: tmp)
     }
 
     public static func getAt3c(m: Mat, indices:[Int32]) -> (UInt8, UInt8, UInt8) {
-        var tmp = [Int8](repeating: 0, count: 3)
+        var tmp = [UInt8](repeating: 0, count: 3)
         try! m.get(indices: indices, data: &tmp)
-        return (UInt8(bitPattern: tmp[0]), UInt8(bitPattern: tmp[1]), UInt8(bitPattern: tmp[2]))
+        return (tmp[0], tmp[1], tmp[2])
     }
 
     public static func putAt3c(m: Mat, indices: [Int32], v: (UInt8, UInt8, UInt8)) {
-        let tmp = [Int8(bitPattern: v.0), Int8(bitPattern: v.1), Int8(bitPattern: v.2)]
+        let tmp = [v.0, v.1, v.2]
         try! m.put(indices: indices, data: tmp)
     }
 
     public static func getAt4c(m: Mat, indices:[Int32]) -> (UInt8, UInt8, UInt8, UInt8) {
-        var tmp = [Int8](repeating: 0, count: 4)
+        var tmp = [UInt8](repeating: 0, count: 4)
         try! m.get(indices: indices, data: &tmp)
-        return (UInt8(bitPattern: tmp[0]), UInt8(bitPattern: tmp[1]), UInt8(bitPattern: tmp[2]), UInt8(bitPattern: tmp[3]))
+        return (tmp[0], tmp[1], tmp[2], tmp[3])
     }
 
     public static func putAt4c(m: Mat, indices: [Int32], v: (UInt8, UInt8, UInt8, UInt8)) {
-        let tmp = [Int8(bitPattern: v.0), Int8(bitPattern: v.1), Int8(bitPattern: v.2), Int8(bitPattern: v.3)]
+        let tmp = [v.0, v.1, v.2, v.3]
         try! m.put(indices: indices, data: tmp)
     }
 }
@@ -526,6 +602,52 @@ extension Int32: Atable {
     }
 
     public static func putAt4c(m: Mat, indices: [Int32], v: (Int32, Int32, Int32, Int32)) {
+        let tmp = [v.0, v.1, v.2, v.3]
+        try! m.put(indices: indices, data: tmp)
+    }
+}
+
+extension UInt16: Atable {
+    public static func getAt(m: Mat, indices:[Int32]) -> UInt16 {
+        var tmp = [UInt16](repeating: 0, count: 1)
+        try! m.get(indices: indices, data: &tmp)
+        return tmp[0]
+    }
+
+    public static func putAt(m: Mat, indices: [Int32], v: UInt16) {
+        let tmp = [v]
+        try! m.put(indices: indices, data: tmp)
+    }
+
+    public static func getAt2c(m: Mat, indices:[Int32]) -> (UInt16, UInt16) {
+        var tmp = [UInt16](repeating: 0, count: 2)
+        try! m.get(indices: indices, data: &tmp)
+        return (tmp[0], tmp[1])
+    }
+
+    public static func putAt2c(m: Mat, indices: [Int32], v: (UInt16, UInt16)) {
+        let tmp = [v.0, v.1]
+        try! m.put(indices: indices, data: tmp)
+    }
+
+    public static func getAt3c(m: Mat, indices:[Int32]) -> (UInt16, UInt16, UInt16) {
+        var tmp = [UInt16](repeating: 0, count: 3)
+        try! m.get(indices: indices, data: &tmp)
+        return (tmp[0], tmp[1], tmp[2])
+    }
+
+    public static func putAt3c(m: Mat, indices: [Int32], v: (UInt16, UInt16, UInt16)) {
+        let tmp = [v.0, v.1, v.2]
+        try! m.put(indices: indices, data: tmp)
+    }
+
+    public static func getAt4c(m: Mat, indices:[Int32]) -> (UInt16, UInt16, UInt16, UInt16) {
+        var tmp = [UInt16](repeating: 0, count: 4)
+        try! m.get(indices: indices, data: &tmp)
+        return (tmp[0], tmp[1], tmp[2], tmp[3])
+    }
+
+    public static func putAt4c(m: Mat, indices: [Int32], v: (UInt16, UInt16, UInt16, UInt16)) {
         let tmp = [v.0, v.1, v.2, v.3]
         try! m.put(indices: indices, data: tmp)
     }

--- a/modules/core/misc/objc/test/MatTest.swift
+++ b/modules/core/misc/objc/test/MatTest.swift
@@ -308,15 +308,15 @@ class MatTests: OpenCVTestCase {
         XCTAssert([340] == sm.get(row: 1, col: 1))
     }
 
-    func testGetIntIntByteArray() throws {
-        let m = try getTestMat(size: 5, type: CvType.CV_8UC3)
+    func testGetIntIntInt8Array() throws {
+        let m = try getTestMat(size: 5, type: CvType.CV_8SC3)
         var goodData = [Int8](repeating: 0, count: 9)
 
         // whole Mat
         var bytesNum = try m.get(row: 1, col: 1, data: &goodData)
 
         XCTAssertEqual(9, bytesNum)
-        XCTAssert([110, 111, 112, 120, 121, 122, -126, -125, -124] == goodData)
+        XCTAssert([110, 111, 112, 120, 121, 122, 127, 127, 127] == goodData)
 
         var badData = [Int8](repeating: 0, count: 7)
         XCTAssertThrowsError(bytesNum = try m.get(row: 0, col: 0, data: &badData))
@@ -326,11 +326,36 @@ class MatTests: OpenCVTestCase {
         var buff00 = [Int8](repeating: 0, count: 3)
         bytesNum = try sm.get(row: 0, col: 0, data: &buff00)
         XCTAssertEqual(3, bytesNum)
-        XCTAssert(buff00 == [-26, -25, -24])
+        XCTAssert(buff00 == [127, 127, 127])
         var buff11 = [Int8](repeating: 0, count: 3)
         bytesNum = try sm.get(row: 1, col: 1, data: &buff11)
         XCTAssertEqual(3, bytesNum)
-        XCTAssert(buff11 == [-1, -1, -1])
+        XCTAssert(buff11 == [127, 127, 127])
+    }
+
+    func testGetIntIntUInt8Array() throws {
+        let m = try getTestMat(size: 5, type: CvType.CV_8UC3)
+        var goodData = [UInt8](repeating: 0, count: 9)
+
+        // whole Mat
+        var bytesNum = try m.get(row: 1, col: 1, data: &goodData)
+
+        XCTAssertEqual(9, bytesNum)
+        XCTAssert([110, 111, 112, 120, 121, 122, 130, 131, 132] == goodData)
+
+        var badData = [UInt8](repeating: 0, count: 7)
+        XCTAssertThrowsError(bytesNum = try m.get(row: 0, col: 0, data: &badData))
+
+        // sub-Mat
+        let sm = m.submat(rowStart: 2, rowEnd: 4, colStart: 3, colEnd: 5)
+        var buff00 = [UInt8](repeating: 0, count: 3)
+        bytesNum = try sm.get(row: 0, col: 0, data: &buff00)
+        XCTAssertEqual(3, bytesNum)
+        XCTAssert(buff00 == [230, 231, 232])
+        var buff11 = [UInt8](repeating: 0, count: 3)
+        bytesNum = try sm.get(row: 1, col: 1, data: &buff11)
+        XCTAssertEqual(3, bytesNum)
+        XCTAssert(buff11 == [255, 255, 255])
     }
 
     func testGetIntIntDoubleArray() throws {
@@ -399,7 +424,7 @@ class MatTests: OpenCVTestCase {
         XCTAssert(buff11 == [340, 341, 0, 0])
     }
 
-    func testGetIntIntShortArray() throws {
+    func testGetIntIntInt16Array() throws {
         let m = try getTestMat(size: 5, type: CvType.CV_16SC2)
         var buff = [Int16](repeating: 0, count: 6)
 
@@ -416,6 +441,28 @@ class MatTests: OpenCVTestCase {
         XCTAssertEqual(8, bytesNum)
         XCTAssert(buff00 == [230, 231, 240, 241])
         var buff11 = [Int16](repeating: 0, count: 4)
+        bytesNum = try sm.get(row: 1, col: 1, data: &buff11)
+        XCTAssertEqual(4, bytesNum);
+        XCTAssert(buff11 == [340, 341, 0, 0])
+    }
+
+    func testGetIntIntUInt16Array() throws {
+        let m = try getTestMat(size: 5, type: CvType.CV_16UC2)
+        var buff = [UInt16](repeating: 0, count: 6)
+
+        // whole Mat
+        var bytesNum = try m.get(row: 1, col: 1, data: &buff)
+
+        XCTAssertEqual(12, bytesNum);
+        XCTAssert(buff == [110, 111, 120, 121, 130, 131])
+
+        // sub-Mat
+        let sm = m.submat(rowStart: 2, rowEnd: 4, colStart: 3, colEnd: 5)
+        var buff00 = [UInt16](repeating: 0, count: 4)
+        bytesNum = try sm.get(row: 0, col: 0, data: &buff00)
+        XCTAssertEqual(8, bytesNum)
+        XCTAssert(buff00 == [230, 231, 240, 241])
+        var buff11 = [UInt16](repeating: 0, count: 4)
         bytesNum = try sm.get(row: 1, col: 1, data: &buff11)
         XCTAssertEqual(4, bytesNum);
         XCTAssert(buff11 == [340, 341, 0, 0])
@@ -653,7 +700,7 @@ class MatTests: OpenCVTestCase {
         try assertMatEqual(truth!, m1, OpenCVTestCase.EPS)
     }
 
-    func testPutIntIntByteArray() throws {
+    func testPutIntIntInt8Array() throws {
         let m = Mat(rows: 5, cols: 5, type: CvType.CV_8SC3, scalar: Scalar(1, 2, 3))
         let sm = m.submat(rowStart: 2, rowEnd: 4, colStart: 3, colEnd: 5)
         var buff = [Int8](repeating: 0, count: 6)
@@ -683,7 +730,37 @@ class MatTests: OpenCVTestCase {
         XCTAssert(buff == buff0)
     }
 
-    func testPutIntArrayByteArray() throws {
+    func testPutIntIntUInt8Array() throws {
+        let m = Mat(rows: 5, cols: 5, type: CvType.CV_8UC3, scalar: Scalar(1, 2, 3))
+        let sm = m.submat(rowStart: 2, rowEnd: 4, colStart: 3, colEnd: 5)
+        var buff = [UInt8](repeating: 0, count: 6)
+        let buff0:[UInt8] = [10, 20, 30, 40, 50, 60]
+        let buff1:[UInt8] = [255, 254, 253, 252, 251, 250]
+
+        var bytesNum = try m.put(row:1, col:2, data:buff0)
+
+        XCTAssertEqual(6, bytesNum)
+        bytesNum = try m.get(row: 1, col: 2, data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff0)
+
+        bytesNum = try sm.put(row:0, col:0, data:buff1)
+
+        XCTAssertEqual(6, bytesNum)
+        bytesNum = try sm.get(row: 0, col: 0, data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff1)
+        bytesNum = try m.get(row: 2, col: 3, data: &buff)
+        XCTAssertEqual(6, bytesNum);
+        XCTAssert(buff == buff1)
+
+        let m1 = m.row(1)
+        bytesNum = try m1.get(row: 0, col: 2, data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff0)
+    }
+
+    func testPutIntArrayInt8Array() throws {
         let m = Mat(sizes: [5, 5, 5], type: CvType.CV_8SC3, scalar: Scalar(1, 2, 3))
         let sm = m.submat(ranges: [Range(start: 0, end: 2), Range(start: 1, end: 3), Range(start: 2, end: 4)])
         var buff = [Int8](repeating: 0, count: 6)
@@ -714,10 +791,41 @@ class MatTests: OpenCVTestCase {
         XCTAssert(buff == buff0)
     }
 
+    func testPutIntArrayUInt8Array() throws {
+        let m = Mat(sizes: [5, 5, 5], type: CvType.CV_8UC3, scalar: Scalar(1, 2, 3))
+        let sm = m.submat(ranges: [Range(start: 0, end: 2), Range(start: 1, end: 3), Range(start: 2, end: 4)])
+        var buff = [UInt8](repeating: 0, count: 6)
+        let buff0:[UInt8] = [10, 20, 30, 40, 50, 60]
+        let buff1:[UInt8] = [255, 254, 253, 252, 251, 250]
+
+        var bytesNum = try m.put(indices:[1, 2, 0], data:buff0)
+
+        XCTAssertEqual(6, bytesNum)
+        bytesNum = try m.get(indices: [1, 2, 0], data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff0)
+
+        bytesNum = try sm.put(indices: [0, 0, 0], data: buff1)
+
+        XCTAssertEqual(6, bytesNum)
+        bytesNum = try sm.get(indices: [0, 0, 0], data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff1)
+
+        bytesNum = try m.get(indices: [0, 1, 2], data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff1)
+
+        let m1 = m.submat(ranges: [Range(start: 1,end: 2), Range.all(), Range.all()])
+        bytesNum = try m1.get(indices: [0, 2, 0], data: &buff)
+        XCTAssertEqual(6, bytesNum)
+        XCTAssert(buff == buff0)
+    }
+
     func testPutIntIntDoubleArray() throws {
-        let m = Mat(rows: 5, cols: 5, type: CvType.CV_8SC3, scalar: Scalar(1, 2, 3))
+        let m = Mat(rows: 5, cols: 5, type: CvType.CV_8UC3, scalar: Scalar(1, 2, 3))
         let sm = m.submat(rowStart: 2, rowEnd: 4, colStart: 3, colEnd: 5)
-        var buff = [Int8](repeating: 0, count: 6)
+        var buff = [UInt8](repeating: 0, count: 6)
 
         var bytesNum = try m.put(row: 1, col: 2, data: [10, 20, 30, 40, 50, 60] as [Double])
 
@@ -731,16 +839,16 @@ class MatTests: OpenCVTestCase {
         XCTAssertEqual(6, bytesNum)
         bytesNum = try sm.get(row: 0, col: 0, data: &buff)
         XCTAssertEqual(6, bytesNum);
-        XCTAssert(buff == [-1, -2, -3, -4, -5, -6])
+        XCTAssert(buff == [255, 254, 253, 252, 251, 250])
         bytesNum = try m.get(row: 2, col: 3, data: &buff)
         XCTAssertEqual(6, bytesNum);
-        XCTAssert(buff == [-1, -2, -3, -4, -5, -6])
+        XCTAssert(buff == [255, 254, 253, 252, 251, 250])
     }
 
     func testPutIntArrayDoubleArray() throws {
-        let m = Mat(sizes: [5, 5, 5], type: CvType.CV_8SC3, scalar: Scalar(1, 2, 3))
+        let m = Mat(sizes: [5, 5, 5], type: CvType.CV_8UC3, scalar: Scalar(1, 2, 3))
         let sm = m.submat(ranges: [Range(start: 0, end: 2), Range(start: 1, end: 3), Range(start: 2, end: 4)])
-        var buff = [Int8](repeating: 0, count: 6)
+        var buff = [UInt8](repeating: 0, count: 6)
 
         var bytesNum = try m.put(indices: [1, 2, 0], data: [10, 20, 30, 40, 50, 60] as [Double])
 
@@ -754,10 +862,10 @@ class MatTests: OpenCVTestCase {
         XCTAssertEqual(6, bytesNum);
         bytesNum = try sm.get(indices: [0, 0, 0], data: &buff)
         XCTAssertEqual(6, bytesNum);
-        XCTAssert(buff == [-1, -2, -3, -4, -5, -6])
+        XCTAssert(buff == [255, 254, 253, 252, 251, 250])
         bytesNum = try m.get(indices: [0, 1, 2], data: &buff)
         XCTAssertEqual(6, bytesNum)
-        XCTAssert(buff == [-1, -2, -3, -4, -5, -6])
+        XCTAssert(buff == [255, 254, 253, 252, 251, 250])
     }
 
     func testPutIntIntFloatArray() throws {
@@ -820,7 +928,7 @@ class MatTests: OpenCVTestCase {
         XCTAssert([40, 50, 60] == m.get(indices: [0, 1, 0]))
     }
 
-    func testPutIntIntShortArray() throws {
+    func testPutIntIntInt16Array() throws {
         let m = Mat(rows: 5, cols: 5, type: CvType.CV_16SC3, scalar: Scalar(-1, -2, -3))
         let elements: [Int16] = [ 10, 20, 30, 40, 50, 60]
 
@@ -834,7 +942,21 @@ class MatTests: OpenCVTestCase {
         XCTAssert([40, 50, 60] == m.get(row: 2, col: 4))
     }
 
-    func testPutIntArrayShortArray() throws {
+    func testPutIntIntUInt16Array() throws {
+        let m = Mat(rows: 5, cols: 5, type: CvType.CV_16UC3, scalar: Scalar(-1, -2, -3))
+        let elements: [UInt16] = [ 10, 20, 30, 40, 50, 60]
+
+        var bytesNum = try m.put(row: 2, col: 3, data: elements)
+
+        XCTAssertEqual(Int32(elements.count * 2), bytesNum)
+        let m1 = m.col(3)
+        var buff = [UInt16](repeating: 0, count: 3)
+        bytesNum = try m1.get(row: 2, col: 0, data: &buff)
+        XCTAssert(buff == [10, 20, 30])
+        XCTAssert([40, 50, 60] == m.get(row: 2, col: 4))
+    }
+
+    func testPutIntArrayInt16Array() throws {
         let m = Mat(sizes: [5, 5, 5], type: CvType.CV_16SC3, scalar: Scalar(-1, -2, -3))
         let elements: [Int16] = [ 10, 20, 30, 40, 50, 60]
 
@@ -843,6 +965,20 @@ class MatTests: OpenCVTestCase {
         XCTAssertEqual(Int32(elements.count * 2), bytesNum)
         let m1 = m.submat(ranges: [Range.all(), Range.all(), Range(start: 3, end: 4)])
         var buff = [Int16](repeating: 0, count: 3)
+        bytesNum = try m1.get(indices: [0, 2, 0], data: &buff)
+        XCTAssert(buff == [10, 20, 30])
+        XCTAssert([40, 50, 60] == m.get(indices: [0, 2, 4]))
+    }
+
+    func testPutIntArrayUInt16Array() throws {
+        let m = Mat(sizes: [5, 5, 5], type: CvType.CV_16UC3, scalar: Scalar(-1, -2, -3))
+        let elements: [UInt16] = [ 10, 20, 30, 40, 50, 60]
+
+        var bytesNum = try m.put(indices: [0, 2, 3], data: elements)
+
+        XCTAssertEqual(Int32(elements.count * 2), bytesNum)
+        let m1 = m.submat(ranges: [Range.all(), Range.all(), Range(start: 3, end: 4)])
+        var buff = [UInt16](repeating: 0, count: 3)
         bytesNum = try m1.get(indices: [0, 2, 0], data: &buff)
         XCTAssert(buff == [10, 20, 30])
         XCTAssert([40, 50, 60] == m.get(indices: [0, 2, 4]))


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] The feature is well documented and sample code can be built with the project CMake

On Java there are no signed type so the Java binding just handles CV_8U as CV_8S and CV_16U as CV_16S
The Objective-C/Swift binding mostly just followed the Java binding as much as possible so the original implementation also does not have good handling for CV_8U and CV_16U.
This PR:
 - adds Mat.put/Mat.get functions for Swift/Kotlin using the relevant unsigned types (UInt8/Uint16/UByte/UShort)
 - updates other functions to use the new Mat.put/Mat.get functions
 - fixes a bug in the Objective-C [Mat put:(int)row col:(int)col data:(NSArray<NSNumber*>*)data] implementation
 - adds tests for the new unsigned put/get functions on Swift

```
force_builders=docs,ios,Custom Mac
buildworker:Mac=macosx-1
buildworker:iOS=macosx-2
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-1
allow_multiple_commits=1
```