### PR TITLE
Fix an arg for calcHist() in demos

### DIFF
--- a/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
@@ -89,7 +89,7 @@ void MatchingMethod( int, void* )
 
   //! [create_result_matrix]
   /// Create the result matrix
-  int result_cols =  img.cols - templ.cols + 1;
+  int result_cols = img.cols - templ.cols + 1;
   int result_rows = img.rows - templ.rows + 1;
 
   result.create( result_rows, result_cols, CV_32FC1 );

--- a/samples/cpp/tutorial_code/Histograms_Matching/calcBackProject_Demo1.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/calcBackProject_Demo1.cpp
@@ -72,18 +72,18 @@ void Hist_and_Backproj(int, void* )
     //! [initialize]
     int histSize = MAX( bins, 2 );
     float hue_range[] = { 0, 180 };
-    const float* ranges = { hue_range };
+    const float* ranges[] = { hue_range };
     //! [initialize]
 
     //! [Get the Histogram and normalize it]
     Mat hist;
-    calcHist( &hue, 1, 0, Mat(), hist, 1, &histSize, &ranges, true, false );
+    calcHist( &hue, 1, 0, Mat(), hist, 1, &histSize, ranges, true, false );
     normalize( hist, hist, 0, 255, NORM_MINMAX, -1, Mat() );
     //! [Get the Histogram and normalize it]
 
     //! [Get Backprojection]
     Mat backproj;
-    calcBackProject( &hue, 1, 0, hist, backproj, &ranges, 1, true );
+    calcBackProject( &hue, 1, 0, hist, backproj, ranges, 1, true );
     //! [Get Backprojection]
 
     //! [Draw the backproj]

--- a/samples/cpp/tutorial_code/Histograms_Matching/calcHist_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/calcHist_Demo.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
 
     //! [Set the ranges ( for B,G,R) )]
     float range[] = { 0, 256 }; //the upper boundary is exclusive
-    const float* histRange = { range };
+    const float* histRange[] = { range };
     //! [Set the ranges ( for B,G,R) )]
 
     //! [Set histogram param]
@@ -46,9 +46,9 @@ int main(int argc, char** argv)
 
     //! [Compute the histograms]
     Mat b_hist, g_hist, r_hist;
-    calcHist( &bgr_planes[0], 1, 0, Mat(), b_hist, 1, &histSize, &histRange, uniform, accumulate );
-    calcHist( &bgr_planes[1], 1, 0, Mat(), g_hist, 1, &histSize, &histRange, uniform, accumulate );
-    calcHist( &bgr_planes[2], 1, 0, Mat(), r_hist, 1, &histSize, &histRange, uniform, accumulate );
+    calcHist( &bgr_planes[0], 1, 0, Mat(), b_hist, 1, &histSize, histRange, uniform, accumulate );
+    calcHist( &bgr_planes[1], 1, 0, Mat(), g_hist, 1, &histSize, histRange, uniform, accumulate );
+    calcHist( &bgr_planes[2], 1, 0, Mat(), r_hist, 1, &histSize, histRange, uniform, accumulate );
     //! [Compute the histograms]
 
     //! [Draw the histograms for B, G and R]


### PR DESCRIPTION
`float* histRange = { range };` doesn't make much sense. `histRange` is
an array of array(s), so it should have a type of ptr to ptr. Strangely
some domos are correct as well as the example for the function
https://docs.opencv.org/master/d6/dc7/group__imgproc__hist.html#ga4b2b5fd75503ff9e6844cc4dcdaed35d

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
