### PR TITLE
dnn : modified onnx importer to concat const input blobs

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1792,6 +1792,23 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto_)
                 addConstant(layerParams.name, concatenated[0]);
                 return;
             }
+            else
+            {
+                for (int i = 0; i < node_proto.input_size(); ++i)
+                {
+                    if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+                    {
+                        LayerParams constParams;
+                        constParams.name = node_proto.input(i);
+                        constParams.type = "Const";
+                        constParams.blobs.push_back(getBlob(node_proto, i));
+
+                        opencv_onnx::NodeProto proto;
+                        proto.add_output(constParams.name);
+                        addLayer(constParams, proto);
+                    }
+                }
+            }
         }
         else if (layer_type == "Resize")
         {

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -327,6 +327,7 @@ TEST_P(Test_ONNX_layers, Concatenation)
         if (target == DNN_TARGET_MYRIAD)      applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
     }
     testONNXModels("concatenation");
+    testONNXModels("concat_const_blobs");
 }
 
 TEST_P(Test_ONNX_layers, Eltwise3D)


### PR DESCRIPTION
**Merge with extra**: opencv/opencv_extra#879

resolves : #20273 #20332
Similar to patch for tensorflow importer #13359


<cut/>
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=Custom
build_image:Custom=ubuntu-openvino-2021.4.0:20.04
build_image:Custom Win=openvino-2021.4.0
build_image:Custom Mac=openvino-2021.4.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
YOLO*:*VINO*:*Infer*:*Layer*:*layer*

build_contrib:Custom Win=OFF
build_examples:Custom Win=OFF
```