### PR TITLE
G-API(IE): replace deprecated calls

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -124,7 +124,11 @@ IE::Core giewrap::getPlugin(const GIEParam& params) {
         {
             try
             {
+#if INF_ENGINE_RELEASE >= 2021040000
+                plugin.AddExtension(std::make_shared<IE::Extension>(extlib), params.device_id);
+#else
                 plugin.AddExtension(IE::make_so_pointer<IE::IExtension>(extlib), params.device_id);
+#endif
                 CV_LOG_INFO(NULL, "DNN-IE: Loaded extension plugin: " << extlib);
                 break;
             }


### PR DESCRIPTION
Deprecated in OpenVINO 2021.4

Resolves warnings from here: http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/6221

relates #20325

<cut/>

```
force_builders_only=Custom
build_image:Custom=ubuntu-openvino-2021.4.0:20.04
build_image:Custom Win=openvino-2021.4.0
build_image:Custom Mac=openvino-2021.4.0

test_modules:Custom=dnn,python2,python3,java,gapi
test_modules:Custom Win=dnn,python2,python3,java,gapi
test_modules:Custom Mac=dnn,python2,python3,java,gapi

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
YOLO*:*VINO*:*Infer*:*Layer*:*layer*

build_contrib:Custom Win=OFF
build_examples:Custom Win=OFF

allow_multiple_commits=1
```