### PR TITLE
Use explicit version of ngraph NormalizeL2

### DIFF
--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -328,7 +328,7 @@ public:
             std::iota(axes_data.begin(), axes_data.end(), 1);
         }
         auto axes = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{axes_data.size()}, axes_data);
-        auto norm = std::make_shared<ngraph::op::NormalizeL2>(ieInpNode, axes, epsilon, ngraph::op::EpsMode::ADD);
+        auto norm = std::make_shared<ngraph::op::v0::NormalizeL2>(ieInpNode, axes, epsilon, ngraph::op::EpsMode::ADD);
 
         CV_Assert(blobs.empty() || numChannels == blobs[0].total());
         std::vector<size_t> shape(ieInpNode->get_shape().size(), 1);


### PR DESCRIPTION
### Description:
[`using v0::NormalizeL2`](https://github.com/openvinotoolkit/openvino/blob/5cee8bbf29797f4544b343e803de957e9f041f92/ngraph/core/include/ngraph/op/normalize_l2.hpp#L60) is going to be removed from the ngraph op namespace so the external usages need to be updated.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch

```
force_builders_only=Custom
build_image:Custom=ubuntu-openvino-2021.4.0:20.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
YOLO*:*VINO*:*Infer*:*Layer*:*layer*

build_contrib:Custom Win=OFF
build_examples:Custom Win=OFF

allow_multiple_commits=1
```
