### PR TITLE
cmake(IE): extract INF_ENGINE_RELEASE from InferenceEngine package

### DIFF
--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -140,12 +140,21 @@ endif()
 # Add more features to the target
 
 if(INF_ENGINE_TARGET)
-  if(NOT INF_ENGINE_RELEASE)
-    message(WARNING "InferenceEngine version has not been set, 2021.4 will be used by default. Set INF_ENGINE_RELEASE variable if you experience build errors.")
+  if(DEFINED InferenceEngine_VERSION)
+    message(STATUS "InferenceEngine: ${InferenceEngine_VERSION}")
+    if(NOT INF_ENGINE_RELEASE AND NOT (InferenceEngine_VERSION VERSION_LESS "2021.4"))
+      math(EXPR INF_ENGINE_RELEASE_INIT "${InferenceEngine_VERSION_MAJOR} * 1000000 + ${InferenceEngine_VERSION_MINOR} * 10000 + ${InferenceEngine_VERSION_PATCH} * 100")
+    endif()
   endif()
-  set(INF_ENGINE_RELEASE "2021040000" CACHE STRING "Force IE version, should be in form YYYYAABBCC (e.g. 2020.1.0.2 -> 2020010002)")
+  if(NOT INF_ENGINE_RELEASE AND NOT INF_ENGINE_RELEASE_INIT)
+    message(WARNING "InferenceEngine version has not been set, 2021.4 will be used by default. Set INF_ENGINE_RELEASE variable if you experience build errors.")
+    set(INF_ENGINE_RELEASE_INIT "2021040000")
+  elseif(DEFINED INF_ENGINE_RELEASE)
+    set(INF_ENGINE_RELEASE_INIT "${INF_ENGINE_RELEASE}")
+  endif()
+  set(INF_ENGINE_RELEASE "${INF_ENGINE_RELEASE_INIT}" CACHE STRING "Force IE version, should be in form YYYYAABBCC (e.g. 2020.1.0.2 -> 2020010002)")
   set_target_properties(${INF_ENGINE_TARGET} PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "HAVE_INF_ENGINE=1;INF_ENGINE_RELEASE=${INF_ENGINE_RELEASE}"
+      INTERFACE_COMPILE_DEFINITIONS "HAVE_INF_ENGINE=1;INF_ENGINE_RELEASE=${INF_ENGINE_RELEASE}"
   )
 endif()
 


### PR DESCRIPTION
backport #20026 + CMake fixes


```
force_builders_only=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.4.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2021.4.0-autovers
build_image:Custom Mac=openvino-2021.4.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

build_contrib:Custom Win=OFF
build_examples:Custom Win=OFF
```