### PR TITLE
cmake: exclude -pthread from Emscripten default build

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -177,7 +177,13 @@ if(CV_GCC OR CV_CLANG)
   endif()
 
   # We need pthread's
-  if(UNIX AND NOT ANDROID AND NOT (APPLE AND CV_CLANG)) # TODO
+  if((UNIX
+          AND NOT ANDROID
+          AND NOT (APPLE AND CV_CLANG)
+          AND NOT EMSCRIPTEN
+      )
+      OR (EMSCRIPTEN AND WITH_PTHREADS_PF)  # https://github.com/opencv/opencv/issues/20285
+  )
     add_extra_compiler_option(-pthread)
   endif()
 


### PR DESCRIPTION
resolves #20285

`platforms/js/build_js.py --threads` uses `-pthread`.

```
force_builders=Custom
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6
```