### PR TITLE
release: OpenCV 3.4.15

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 15
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.15

relates #20236


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3415.dll (vc14)](https://www.virustotal.com/gui/file/7f92e88814465cffda4c7b3ae79a3deeabd3a594c5da48226649ea0228071a05/detection)
[opencv_world3415d.dll (vc14)](https://www.virustotal.com/gui/file/fb74c7209dd0797e670cf52ed2868ec0cc8abada9c818963b8d7327095c54c7e/detection)
[opencv_world3415.dll (vc15)](https://www.virustotal.com/gui/file/3efb02b69038309da6adc09ed9b4688c966cf88871d433a49687c3840aba9343/detection)
[opencv_world3415d.dll (vc15)](https://www.virustotal.com/gui/file/7820efdf7a466ef3ab077302ffe5f5dc79520cf432d505d3b692ff79ac59a3fb/detection)

[opencv_ffmpeg3415_64.dll](https://www.virustotal.com/gui/file/3f61eaff916f22b95a444ccde7d30c75423b1b8bfbbdb6b6f3e987fafed9d77e/detection)

</details>
