### PR TITLE
Updated To Modern Version of Aravis USB 3 Vision Protocol Library

### DIFF
--- a/modules/videoio/cmake/detect_aravis.cmake
+++ b/modules/videoio/cmake/detect_aravis.cmake
@@ -1,6 +1,6 @@
 # --- Aravis SDK ---
 if(NOT HAVE_ARAVIS_API AND PKG_CONFIG_FOUND)
-  ocv_check_modules(ARAVIS aravis-0.6 QUIET)
+  ocv_check_modules(ARAVIS aravis-0.8 QUIET)
   if(ARAVIS_FOUND)
     set(HAVE_ARAVIS_API TRUE)
   endif()
@@ -9,9 +9,9 @@ endif()
 if(NOT HAVE_ARAVIS_API)
   find_path(ARAVIS_INCLUDE "arv.h"
     PATHS "${ARAVIS_ROOT}" ENV ARAVIS_ROOT
-    PATH_SUFFIXES "include/aravis-0.6"
+    PATH_SUFFIXES "include/aravis-0.8"
     NO_DEFAULT_PATH)
-  find_library(ARAVIS_LIBRARY "aravis-0.6"
+  find_library(ARAVIS_LIBRARY "aravis-0.8"
     PATHS "${ARAVIS_ROOT}" ENV ARAVIS_ROOT
     PATH_SUFFIXES "lib"
     NO_DEFAULT_PATH)

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -221,7 +221,7 @@ bool CvCaptureCAM_Aravis::create( int index )
     if(!getDeviceNameById(index, deviceName))
         return false;
 
-    return NULL != (camera = arv_camera_new(deviceName.c_str()));
+    return NULL != (camera = arv_camera_new(deviceName.c_str(), NULL));
 }
 
 bool CvCaptureCAM_Aravis::init_buffers()
@@ -230,7 +230,7 @@ bool CvCaptureCAM_Aravis::init_buffers()
         g_object_unref(stream);
         stream = NULL;
     }
-    if( (stream = arv_camera_create_stream(camera, NULL, NULL)) ) {
+    if( (stream = arv_camera_create_stream(camera, NULL, NULL, NULL)) ) {
         if( arv_camera_is_gv_device(camera) ) {
             g_object_set(stream,
                 "socket-buffer", ARV_GV_STREAM_SOCKET_BUFFER_AUTO,
@@ -241,7 +241,7 @@ bool CvCaptureCAM_Aravis::init_buffers()
                 "packet-timeout", (unsigned) 40000,
                 "frame-retention", (unsigned) 200000, NULL);
         }
-        payload = arv_camera_get_payload (camera);
+        payload = arv_camera_get_payload (camera, NULL);
 
         for (int i = 0; i < num_buffers; i++)
             arv_stream_push_buffer(stream, arv_buffer_new(payload, NULL));

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -51,8 +51,8 @@
 #include <arv.h>
 
 //
-// This file provides wrapper for using Aravis SDK library to access GigE Vision cameras.
-// Aravis library (version 0.4 or 0.6) shall be installed else this code will not be included in build.
+// This file provides wrapper for using Aravis SDK library to access GigE and USB 3 Vision cameras.
+// Aravis library (version 0.8) shall be installed else this code will not be included in build.
 //
 // To include this module invoke cmake with -DWITH_ARAVIS=ON
 //
@@ -150,10 +150,6 @@ protected:
     double          targetGrey;             // Target grey value (mid grey))
     bool            softwareTriggered;      // Flag if the camera is software triggered
     bool            allowAutoTrigger;       // Flag that user allowed to trigger software triggered cameras automatically
-
-    gint64          *pixelFormats;
-    guint           pixelFormatsCnt;
-
 
     int             num_buffers;            // number of payload transmission buffers
 
@@ -260,25 +256,23 @@ bool CvCaptureCAM_Aravis::open( int index )
 {
     if(create(index)) {
         // fetch properties bounds
-        pixelFormats = arv_camera_get_available_pixel_formats(camera, &pixelFormatsCnt);
+        arv_camera_get_width_bounds(camera, &widthMin, &widthMax, NULL);
+        arv_camera_get_height_bounds(camera, &heightMin, &heightMax, NULL);
+        arv_camera_set_region(camera, 0, 0, widthMax, heightMax, NULL);
 
-        arv_camera_get_width_bounds(camera, &widthMin, &widthMax);
-        arv_camera_get_height_bounds(camera, &heightMin, &heightMax);
-        arv_camera_set_region(camera, 0, 0, widthMax, heightMax);
-
-        if( (fpsAvailable = arv_camera_is_frame_rate_available(camera)) )
-            arv_camera_get_frame_rate_bounds(camera, &fpsMin, &fpsMax);
-        if( (gainAvailable = arv_camera_is_gain_available(camera)) )
-            arv_camera_get_gain_bounds (camera, &gainMin, &gainMax);
-        if( (exposureAvailable = arv_camera_is_exposure_time_available(camera)) )
-            arv_camera_get_exposure_time_bounds (camera, &exposureMin, &exposureMax);
+        if( (fpsAvailable = arv_camera_is_frame_rate_available(camera, NULL)) )
+            arv_camera_get_frame_rate_bounds(camera, &fpsMin, &fpsMax, NULL);
+        if( (gainAvailable = arv_camera_is_gain_available(camera, NULL)) )
+            arv_camera_get_gain_bounds (camera, &gainMin, &gainMax, NULL);
+        if( (exposureAvailable = arv_camera_is_exposure_time_available(camera, NULL)) )
+            arv_camera_get_exposure_time_bounds (camera, &exposureMin, &exposureMax, NULL);
 
         // get initial values
-        pixelFormat = arv_camera_get_pixel_format(camera);
-        exposure = exposureAvailable ? arv_camera_get_exposure_time(camera) : 0;
-        gain = gainAvailable ? arv_camera_get_gain(camera) : 0;
-        fps = arv_camera_get_frame_rate(camera);
-        softwareTriggered = (strcmp(arv_camera_get_trigger_source(camera), "Software") == 0);
+        pixelFormat = arv_camera_get_pixel_format(camera, NULL);
+        exposure = exposureAvailable ? arv_camera_get_exposure_time(camera, NULL) : 0;
+        gain = gainAvailable ? arv_camera_get_gain(camera, NULL) : 0;
+        fps = arv_camera_get_frame_rate(camera, NULL);
+        softwareTriggered = (strcmp(arv_camera_get_trigger_source(camera, NULL), "Software") == 0);
 
         return startCapture();
     }
@@ -295,7 +289,7 @@ bool CvCaptureCAM_Aravis::grabFrame()
         int max_tries = 10;
         int tries = 0;
         if (softwareTriggered && allowAutoTrigger) {
-            arv_camera_software_trigger (camera);
+            arv_camera_software_trigger (camera, NULL);
         }
         for(; tries < max_tries; tries ++) {
             arv_buffer = arv_stream_timeout_pop_buffer (stream, 200000);
@@ -402,7 +396,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
 
             if( ng < gain ) {
                 // priority 1 - reduce gain
-                arv_camera_set_gain(camera, (gain = ng));
+                arv_camera_set_gain(camera, (gain = ng), NULL);
                 return;
             }
         }
@@ -411,7 +405,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
             // priority 2 - control of exposure time
             if(std::fabs(exposure - ne) > 2) {
                 // we have not yet reach the max-e level
-                arv_camera_set_exposure_time(camera, (exposure = ne) );
+                arv_camera_set_exposure_time(camera, (exposure = ne), NULL);
                 return;
             }
         }
@@ -420,12 +414,12 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
             if(exposureAvailable) {
                 // exposure at maximum - increase gain if possible
                 if(ng > gain && ng < gainMax && ne >= maxe) {
-                    arv_camera_set_gain(camera, (gain = ng));
+                    arv_camera_set_gain(camera, (gain = ng), NULL);
                     return;
                 }
             } else {
                 // priority 3 - increase gain
-                arv_camera_set_gain(camera, (gain = ng));
+                arv_camera_set_gain(camera, (gain = ng), NULL);
                 return;
             }
         }
@@ -435,7 +429,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
     if(gainAvailable && autoGain && exposureAvailable) {
         if(gain > gainMin && exposure < maxe) {
             exposure = CLIP( ne * 1.05, exposureMin, maxe);
-            arv_camera_set_exposure_time(camera, exposure );
+            arv_camera_set_exposure_time(camera, exposure, NULL);
         }
     }
 }
@@ -461,25 +455,25 @@ double CvCaptureCAM_Aravis::getProperty( int property_id ) const
         case CV_CAP_PROP_EXPOSURE:
             if(exposureAvailable) {
                 /* exposure time in seconds, like 1/100 s */
-                return arv_camera_get_exposure_time(camera) / 1e6;
+                return arv_camera_get_exposure_time(camera, NULL) / 1e6;
             }
             break;
 
         case CV_CAP_PROP_FPS:
             if(fpsAvailable) {
-                return arv_camera_get_frame_rate(camera);
+                return arv_camera_get_frame_rate(camera, NULL);
             }
             break;
 
         case CV_CAP_PROP_GAIN:
             if(gainAvailable) {
-                return arv_camera_get_gain(camera);
+                return arv_camera_get_gain(camera, NULL);
             }
             break;
 
         case CV_CAP_PROP_FOURCC:
             {
-                ArvPixelFormat currFormat = arv_camera_get_pixel_format(camera);
+                ArvPixelFormat currFormat = arv_camera_get_pixel_format(camera, NULL);
                 switch( currFormat ) {
                     case ARV_PIXEL_FORMAT_MONO_8:
                         return MODE_Y800;
@@ -517,8 +511,8 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
         case CV_CAP_PROP_AUTO_EXPOSURE:
             if(exposureAvailable || gainAvailable) {
                 if( (controlExposure = (bool)(int)value) ) {
-                    exposure = exposureAvailable ? arv_camera_get_exposure_time(camera) : 0;
-                    gain = gainAvailable ? arv_camera_get_gain(camera) : 0;
+                    exposure = exposureAvailable ? arv_camera_get_exposure_time(camera, NULL) : 0;
+                    gain = gainAvailable ? arv_camera_get_gain(camera, NULL) : 0;
                 }
             }
             break;
@@ -531,13 +525,13 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 /* exposure time in seconds, like 1/100 s */
                 value *= 1e6; // -> from s to us
 
-                arv_camera_set_exposure_time(camera, exposure = CLIP(value, exposureMin, exposureMax));
+                arv_camera_set_exposure_time(camera, exposure = CLIP(value, exposureMin, exposureMax), NULL);
                 break;
             } else return false;
 
         case CV_CAP_PROP_FPS:
             if(fpsAvailable) {
-                arv_camera_set_frame_rate(camera, fps = CLIP(value, fpsMin, fpsMax));
+                arv_camera_set_frame_rate(camera, fps = CLIP(value, fpsMin, fpsMax), NULL);
                 break;
             } else return false;
 
@@ -546,7 +540,7 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 if ( (autoGain = (-1 == value) ) )
                     break;
 
-                arv_camera_set_gain(camera, gain = CLIP(value, gainMin, gainMax));
+                arv_camera_set_gain(camera, gain = CLIP(value, gainMin, gainMax), NULL);
                 break;
             } else return false;
 
@@ -574,7 +568,7 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 }
                 if(newFormat != pixelFormat) {
                     stopCapture();
-                    arv_camera_set_pixel_format(camera, pixelFormat = newFormat);
+                    arv_camera_set_pixel_format(camera, pixelFormat = newFormat, NULL);
                     startCapture();
                 }
             }
@@ -606,7 +600,7 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
 
 void CvCaptureCAM_Aravis::stopCapture()
 {
-    arv_camera_stop_acquisition(camera);
+    arv_camera_stop_acquisition(camera, NULL);
 
     if(stream) {
         g_object_unref(stream);
@@ -617,8 +611,8 @@ void CvCaptureCAM_Aravis::stopCapture()
 bool CvCaptureCAM_Aravis::startCapture()
 {
     if(init_buffers() ) {
-        arv_camera_set_acquisition_mode(camera, ARV_ACQUISITION_MODE_CONTINUOUS);
-        arv_camera_start_acquisition(camera);
+        arv_camera_set_acquisition_mode(camera, ARV_ACQUISITION_MODE_CONTINUOUS, NULL);
+        arv_camera_start_acquisition(camera, NULL);
 
         return true;
     }


### PR DESCRIPTION
Confirmed working with Aravis-0.8 and my Pixelink USB 3 Vision protocol camera.

Aravis updated its API to make most function calls take in GObject data to write errors to (in addition to returning error codes); OpenCV doesn't use GObject, so we just don't pass a pointer to a GObject. Additionally, I removed a deprecated function call.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
