### PR TITLE
GAPI: Implement ConstValue serialize/deserialize

### DIFF
--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -36,7 +36,7 @@ void putData(GSerialized& s, const cv::gimpl::GModel::ConstGraph& cg, const ade:
         if (cg.metadata(nh).contains<gimpl::ConstValue>()) {
             size_t datas_num = s.m_datas.size() - 1;
             GAPI_DbgAssert(datas_num <= static_cast<size_t>(std::numeric_limits<GSerialized::data_tag_t>::max()));
-            GSerialized::data_tag_t tag = static_cast<GSerialized::data_tag_t>(datas_num);            
+            GSerialized::data_tag_t tag = static_cast<GSerialized::data_tag_t>(datas_num);
             s.m_const_datas.emplace(tag,
                                     cg.metadata(nh).get<gimpl::ConstValue>());
         }

--- a/modules/gapi/src/backends/common/serialization.hpp
+++ b/modules/gapi/src/backends/common/serialization.hpp
@@ -32,7 +32,7 @@ struct GSerialized {
     cv::gimpl::DataObjectCounter m_counter;
     cv::gimpl::Protocol m_proto;
 
-    using data_tag_t = uint32_t;
+    using data_tag_t = uint64_t;
     std::map<data_tag_t, cv::gimpl::ConstValue> m_const_datas;
 };
 

--- a/modules/gapi/src/backends/common/serialization.hpp
+++ b/modules/gapi/src/backends/common/serialization.hpp
@@ -31,6 +31,7 @@ struct GSerialized {
     std::vector<cv::gimpl::Data> m_datas;
     cv::gimpl::DataObjectCounter m_counter;
     cv::gimpl::Protocol m_proto;
+    std::map<size_t, cv::gimpl::ConstValue> m_const_datas;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,6 +97,9 @@ GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::gimpl::Op &op);
 
 GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::gimpl::Data &op);
 GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::gimpl::Data &op);
+
+GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::gimpl::ConstValue &cd);
+GAPI_EXPORTS IIStream& operator>> (IIStream& os, cv::gimpl::ConstValue &cd);
 
 // Render types ////////////////////////////////////////////////////////////////
 

--- a/modules/gapi/src/backends/common/serialization.hpp
+++ b/modules/gapi/src/backends/common/serialization.hpp
@@ -31,7 +31,9 @@ struct GSerialized {
     std::vector<cv::gimpl::Data> m_datas;
     cv::gimpl::DataObjectCounter m_counter;
     cv::gimpl::Protocol m_proto;
-    std::map<size_t, cv::gimpl::ConstValue> m_const_datas;
+
+    using data_tag_t = uint32_t;
+    std::map<data_tag_t, cv::gimpl::ConstValue> m_const_datas;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/modules/gapi/test/s11n/gapi_sample_pipelines_s11n.cpp
+++ b/modules/gapi/test/s11n/gapi_sample_pipelines_s11n.cpp
@@ -806,4 +806,33 @@ TEST(S11N, Pipeline_Render_RGB)
 
     EXPECT_EQ(cv::norm(input,  ref_mat), 0);
 }
+
+TEST(S11N, Pipeline_Const_GScalar)
+{
+    static constexpr auto in_scalar= 10;
+
+    cv::GMat a;
+    cv::GScalar s;
+
+    cv::GComputation computation(GIn(a), GOut(cv::gapi::addC(a, in_scalar)));
+    auto p = cv::gapi::serialize(computation);
+    auto deserialized_computation = cv::gapi::deserialize<cv::GComputation>(p);
+
+    cv::Mat in_mat = cv::Mat::eye(32, 32, CV_8UC1);
+    cv::Mat ref_mat;
+    cv::add(in_mat, in_scalar, ref_mat);
+
+    cv::Mat out_mat;
+    computation.apply(cv::gin(in_mat/*, in_scalar*/), cv::gout(out_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
+
+    out_mat = cv::Mat();
+    deserialized_computation.apply(cv::gin(in_mat/*, in_scalar*/), cv::gout(out_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
+
+    out_mat = cv::Mat();
+    auto cc = deserialized_computation.compile(cv::descr_of(in_mat));
+    cc(cv::gin(in_mat/*, in_scalar*/), cv::gout(out_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
+}
 } // namespace opencv_test

--- a/modules/gapi/test/s11n/gapi_sample_pipelines_s11n.cpp
+++ b/modules/gapi/test/s11n/gapi_sample_pipelines_s11n.cpp
@@ -809,7 +809,7 @@ TEST(S11N, Pipeline_Render_RGB)
 
 TEST(S11N, Pipeline_Const_GScalar)
 {
-    static constexpr auto in_scalar= 10;
+    static constexpr auto in_scalar = 10;
 
     cv::GMat a;
     cv::GScalar s;


### PR DESCRIPTION
Currently GScalar may be value-initialized, in this case its value is bound within the graph as a ConstValue:

```
struct ConstValue
{
    static const char *name() { return "ConstValue"; }
    GRunArg arg;
};
```
Put this information into the serialized graph, and test that it deserialize properly (as part of a real graph).

 
The following use cases must be implemented

```
auto p = cv::gapi::serialize(cv::GComputation(GIn(a), GOut(cv::gapi::addC(a,10))));
...
auto p = cv::gapi::serialize(cv::GComputation(GIn(a), GOut(a+10)))
...
auto p = cv::gapi::serialize(cv::GComputation(a, a+10));
...

// then
auto c = cv::gapi::deserialize<cv::GComputation>(p);
// and then

c.apply(cv::gin(in_mat /*, 10 */), cv::gout(out_mat));   // without `10` in runargs, `in_mat` only
```
 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```