### PR TITLE
fix videoio/src/container_avi.cpp VideoInputStream alignment crashes on 32bit arm (android)

### DIFF
--- a/modules/videoio/src/container_avi.cpp
+++ b/modules/videoio/src/container_avi.cpp
@@ -124,6 +124,7 @@ struct RiffList
     uint32_t m_size;
     uint32_t m_list_type_cc;
 };
+#pragma pack(pop)
 
 class VideoInputStream
 {
@@ -149,7 +150,6 @@ private:
     String  m_fname;
 };
 
-#pragma pack(pop)
 
 inline VideoInputStream& operator >> (VideoInputStream& is, AviMainHeader& avih)
 {


### PR DESCRIPTION
In https://github.com/opencv/opencv/pull/10145 refactoring VideoInputStream was misplaced inside #pragma pack block resulting in broken std::string alignment = crashes on 32bit arm.

To reproduce we must hit cap_mjpeg_decoder.cpp:
```
cv::VideoCapture icap;
icap.open("anyfile.mp4");
```
crash in VideoInputStream::m_fname std::string ctor.

Existing videoio tests should catch this crash, but none of the arm32 builders run videoio tests.
I don't have an opencv test setup for arm32, is there any way to enable and run videoio tests on the CI?


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
