### PR TITLE
Adding option to use of single gpu in tests.

### DIFF
--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -95,6 +95,11 @@ namespace cvtest
     };
 
     #define ALL_DEVICES testing::ValuesIn(cvtest::DeviceManager::instance().values())
+    #define FIRST_DEVICE testing::ValuesIn( \
+        std::vector<cv::cuda::DeviceInfo>( \
+            cvtest::DeviceManager::instance().values().begin(), \
+            std::min(cvtest::DeviceManager::instance().values().begin() + 1, \
+                     cvtest::DeviceManager::instance().values().end())))
 
     //////////////////////////////////////////////////////////////////////
     // Additional assertion


### PR DESCRIPTION
There are cases in `cudaoptflow` that do not work if there are multiple gpu used (possibly gpu there is fixed to gpu0).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- N/A There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable

