### PR TITLE
dnn: update links for the colorization samples

### DIFF
--- a/samples/dnn/colorization.cpp
+++ b/samples/dnn/colorization.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         "  https://github.com/richzhang/colorization\n"
         "Download caffemodel and prototxt files:\n"
         "  http://eecs.berkeley.edu/~rich.zhang/projects/2016_colorization/files/demo_v2/colorization_release_v2.caffemodel\n"
-        "  https://raw.githubusercontent.com/richzhang/colorization/master/colorization/models/colorization_deploy_v2.prototxt\n";
+        "  https://raw.githubusercontent.com/richzhang/colorization/caffe/models/colorization_deploy_v2.prototxt\n";
     const string keys =
         "{ h help |                                    | print this help message }"
         "{ proto  | colorization_deploy_v2.prototxt    | model configuration }"

--- a/samples/dnn/colorization.py
+++ b/samples/dnn/colorization.py
@@ -1,6 +1,6 @@
 # Script is based on https://github.com/richzhang/colorization/blob/master/colorization/colorize.py
-# To download the caffemodel and the prototxt, see: https://github.com/richzhang/colorization/tree/master/colorization/models
-# To download pts_in_hull.npy, see: https://github.com/richzhang/colorization/blob/master/colorization/resources/pts_in_hull.npy
+# To download the caffemodel and the prototxt, see: https://github.com/richzhang/colorization/tree/caffe/colorization/models
+# To download pts_in_hull.npy, see: https://github.com/richzhang/colorization/tree/caffe/colorization/resources/pts_in_hull.npy
 import numpy as np
 import argparse
 import cv2 as cv


### PR DESCRIPTION
[development here](https://github.com/richzhang/colorization) has moved from caffe to pytorch,
the old implementation/data was moved to a `caffe` branch, invalidating our previous download links

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
