### PR TITLE
cmake: use relative path for mode vars

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -1978,4 +1978,4 @@ endif()
 #
 # Include configuration override settings
 #
-include(cmake/vars/EnableModeVars.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/vars/EnableModeVars.cmake")


### PR DESCRIPTION
relates #19985