### PR TITLE
Fix TFImporter diagnostic mode segfault

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -99,6 +99,15 @@ bool DNN_DIAGNOSTICS_RUN = false;
 void enableModelDiagnostics(bool isDiagnosticsMode)
 {
     DNN_DIAGNOSTICS_RUN = isDiagnosticsMode;
+
+    if (DNN_DIAGNOSTICS_RUN)
+    {
+        detail::NotImplemented::Register();
+    }
+    else
+    {
+        detail::NotImplemented::unRegister();
+    }
 }
 
 using std::vector;
@@ -4001,13 +4010,24 @@ int Net::addLayer(const String &name, const String &type, LayerParams &params)
 {
     CV_TRACE_FUNCTION();
 
-    if (impl->getLayerId(name) >= 0)
+    int id = impl->getLayerId(name);
+    if (id >= 0)
     {
-        CV_Error(Error::StsBadArg, "Layer \"" + name + "\" already into net");
-        return -1;
+        if (!DNN_DIAGNOSTICS_RUN || type != "NotImplemented")
+        {
+            CV_Error(Error::StsBadArg, "Layer \"" + name + "\" already into net");
+            return -1;
+        }
+        else
+        {
+            LayerData& ld = impl->layers.find(id)->second;
+            ld.type = type;
+            ld.params = params;
+            return -1;
+        }
     }
 
-    int id = ++impl->lastLayerId;
+    id = ++impl->lastLayerId;
     impl->layerNameToId.insert(std::make_pair(name, id));
     impl->layers.insert(std::make_pair(id, LayerData(id, name, type, params)));
     if (params.get<bool>("has_dynamic_shapes", false))

--- a/modules/dnn/src/dnn_common.hpp
+++ b/modules/dnn/src/dnn_common.hpp
@@ -15,6 +15,15 @@ void initializeLayerFactory();
 
 namespace detail {
 
+class NotImplemented : public Layer
+{
+public:
+    static Ptr<Layer> create(const LayerParams &params);
+
+    static void Register();
+    static void unRegister();
+};
+
 struct NetImplBase
 {
     const int networkId;  // network global identifier

--- a/modules/dnn/src/layers/not_implemented_layer.cpp
+++ b/modules/dnn/src/layers/not_implemented_layer.cpp
@@ -1,0 +1,194 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "../dnn_common.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+namespace detail {
+
+class NotImplementedImpl CV_FINAL : public NotImplemented
+{
+public:
+    NotImplementedImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        CV_Assert(params.has("type"));
+        std::stringstream ss;
+        ss << "Node for layer '" << params.name << "' of type '" << params.get("type") << "' wasn't initialized.";
+        msg = ss.str();
+    }
+
+    CV_DEPRECATED_EXTERNAL
+    virtual void finalize(const std::vector<Mat*> &input, std::vector<Mat> &output) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual void finalize(InputArrayOfArrays inputs, OutputArrayOfArrays outputs) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    CV_DEPRECATED_EXTERNAL
+    virtual void forward(std::vector<Mat*> &input, std::vector<Mat> &output, std::vector<Mat> &internals) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    void forward_fallback(InputArrayOfArrays inputs, OutputArrayOfArrays outputs, OutputArrayOfArrays internals)
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    CV_DEPRECATED_EXTERNAL
+    void finalize(const std::vector<Mat> &inputs, CV_OUT std::vector<Mat> &outputs)
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    CV_DEPRECATED std::vector<Mat> finalize(const std::vector<Mat> &inputs)
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    CV_DEPRECATED void run(const std::vector<Mat> &inputs,
+                           CV_OUT std::vector<Mat> &outputs,
+                           CV_IN_OUT std::vector<Mat> &internals)
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual int inputNameToIndex(String inputName) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual int outputNameToIndex(const String& outputName) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> initHalide(const std::vector<Ptr<BackendWrapper> > &inputs) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> initInfEngine(const std::vector<Ptr<BackendWrapper> > &inputs) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
+                                        const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> initVkCom(const std::vector<Ptr<BackendWrapper> > &inputs) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> initCUDA(
+            void *context,
+            const std::vector<Ptr<BackendWrapper>>& inputs,
+            const std::vector<Ptr<BackendWrapper>>& outputs
+    ) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual void applyHalideScheduler(Ptr<BackendNode>& node,
+                                      const std::vector<Mat*> &inputs,
+                                      const std::vector<Mat> &outputs,
+                                      int targetId) const CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual Ptr<BackendNode> tryAttach(const Ptr<BackendNode>& node) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual bool setActivation(const Ptr<ActivationLayer>& layer) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual bool tryFuse(Ptr<Layer>& top) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual void getScaleShift(Mat& scale, Mat& shift) const CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual void unsetAttached() CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                                 const int requiredOutputs,
+                                 std::vector<MatShape> &outputs,
+                                 std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
+                           const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+    virtual bool updateMemoryShapes(const std::vector<MatShape> &inputs) CV_OVERRIDE
+    {
+        CV_Error(Error::StsNotImplemented, msg);
+    }
+
+private:
+    std::string msg;
+};
+
+Ptr<Layer> NotImplemented::create(const LayerParams& params)
+{
+    return makePtr<NotImplementedImpl>(params);
+}
+
+Ptr<Layer> notImplementedRegisterer(LayerParams &params)
+{
+    return detail::NotImplemented::create(params);
+}
+
+void NotImplemented::Register()
+{
+    LayerFactory::registerLayer("NotImplemented", detail::notImplementedRegisterer);
+}
+
+void NotImplemented::unRegister()
+{
+    LayerFactory::unregisterLayer("NotImplemented");
+}
+
+} // namespace detail
+
+CV__DNN_INLINE_NS_END
+}}  // namespace cv::dnn

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -568,6 +568,39 @@ TEST_P(Test_TensorFlow_layers, l2_normalize_3d)
     runTensorFlowNet("l2_normalize_3d");
 }
 
+class Test_TensorFlow_diagnostics : public DNNTestLayer {
+public:
+    Test_TensorFlow_diagnostics()
+    {
+        enableModelDiagnostics(true);
+    }
+
+    ~Test_TensorFlow_diagnostics()
+    {
+        enableModelDiagnostics(false);
+    }
+
+    void runFailingTensorFlowNet(const std::string& prefix, bool hasText = false)
+    {
+        std::string netPath = path(prefix + "_net.pb");
+        std::string netConfig = (hasText ? path(prefix + "_net.pbtxt") : "");
+
+        Net net = readNetFromTensorflow(netPath, netConfig);
+    }
+};
+
+TEST_P(Test_TensorFlow_diagnostics, not_implemented_layer)
+{
+    runFailingTensorFlowNet("not_implemented_layer");
+}
+
+TEST_P(Test_TensorFlow_diagnostics, broken_parameters)
+{
+    runFailingTensorFlowNet("broken_layer");
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Test_TensorFlow_diagnostics, dnnBackendsAndTargets());
+
 class Test_TensorFlow_nets : public DNNTestLayer {};
 
 TEST_P(Test_TensorFlow_nets, MobileNet_SSD)


### PR DESCRIPTION
This PR adds `DummyLayer` and replaces all failed to initialize layers with it. This solves the issue of memory corruption in `getLayerShapes()` because `DummyLayer` just throws an exception in every function. 

Test data is at https://github.com/opencv/opencv_extra/pull/882

`opencv_extra=tf_diag_dummy`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
