### PR TITLE
fix TypeError when specifying compose_megapix in stitching_detailed python sample

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -450,7 +450,8 @@ def main():
                 cameras[i].focal *= compose_work_aspect
                 cameras[i].ppx *= compose_work_aspect
                 cameras[i].ppy *= compose_work_aspect
-                sz = (full_img_sizes[i][0] * compose_scale, full_img_sizes[i][1] * compose_scale)
+                sz = (int(round(full_img_sizes[i][0] * compose_scale)),
+                      int(round(full_img_sizes[i][1] * compose_scale)))
                 K = cameras[i].K().astype(np.float32)
                 roi = warper.warpRoi(sz, K, cameras[i].R)
                 corners.append(roi[0:2])


### PR DESCRIPTION
In some cases the user wants to specify the `compose_megapix ` parameter if the resulting image size should be limited.

This causes `"compose_scale"` to be different than 1

without rounding the composed image sizes (variable "sz") which are calculated by `full_img_sizes[i][0] * compose_scale` they will be odly fractions of a pixel (e.g. (**5300.965, 3772.897**)) and therefore cause a "TypeError: integer argument expected, got float" in line

456        roi = warper.warpRoi(sz, K, cameras[i].R)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
