### PR TITLE
Automatically write RTSP streams to file during VideoCapture Decode with FFmpeg

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -853,6 +853,22 @@ public:
      */
     CV_WRAP virtual bool read(OutputArray image);
 
+    /** @brief Signals VideoCapture to start writing the raw bitstream to the given file from the next key frame.
+
+    @param filename Full path to the output file.
+    @return `true` if VideoCapture is open.  This does not mean the file has or can be created as this is
+    performed inside read()/grab().
+
+    The function is intended to be used when streaming from an rtsp source where it is either
+    a) desirable to store the original streamed data, or
+    b) the overhead of re-encoding the decoded frame is undesirable.
+
+    @note This should only be used when streaming from rtsp and is not guaranteed to work when reading from a
+    file, especially from container formats avi, mp4 etc.  If the filename provided is invalid, cannot be opened
+    or written to, the first call to read()/grab() after calling this function will return false.
+     */
+    CV_WRAP virtual bool writeToFile(const char* filename);
+
     /** @brief Sets a property in the VideoCapture.
 
     @param propId Property identifier from cv::VideoCaptureProperties (eg. cv::CAP_PROP_POS_MSEC, cv::CAP_PROP_POS_FRAMES, ...)

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -867,7 +867,7 @@ public:
     file, especially from container formats avi, mp4 etc.  If the filename provided is invalid, cannot be opened
     or written to, the first call to read()/grab() after calling this function will return false.
      */
-    CV_WRAP virtual bool writeToFile(const char* filename);
+    CV_WRAP virtual bool writeToFile(const char* filename, const bool autoDetectExt = false);
 
     /** @brief Sets a property in the VideoCapture.
 

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -515,10 +515,10 @@ public:
                 return true;
         return false;
     }
-    bool writeToFile(const char* filename) CV_OVERRIDE
+    bool writeToFile(const char* filename, const bool autoDetectExt = false) CV_OVERRIDE
     {
         if (plugin_api_->v0.Capture_writeToFile)
-            if (CV_ERROR_OK == plugin_api_->v0.Capture_writeToFile(capture_, filename))
+            if (CV_ERROR_OK == plugin_api_->v0.Capture_writeToFile(capture_, filename, autoDetectExt))
                 return true;
         return false;
     }

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -515,6 +515,13 @@ public:
                 return true;
         return false;
     }
+    bool writeToFile(const char* filename) CV_OVERRIDE
+    {
+        if (plugin_api_->v0.Capture_writeToFile)
+            if (CV_ERROR_OK == plugin_api_->v0.Capture_writeToFile(capture_, filename))
+                return true;
+        return false;
+    }
     bool grabFrame() CV_OVERRIDE
     {
         if (plugin_api_->v0.Capture_grab)

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -408,6 +408,16 @@ VideoCapture& VideoCapture::operator >> (UMat& image)
     return *this;
 }
 
+bool VideoCapture::writeToFile(const char* filename)
+{
+    bool ret = false;
+    if (!icap.empty()) {
+        icap->writeToFile(filename);
+        ret = true;
+    }
+    return ret;
+}
+
 bool VideoCapture::set(int propId, double value)
 {
     CV_CheckNE(propId, (int)CAP_PROP_BACKEND, "Can't set read-only property");

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -410,12 +410,7 @@ VideoCapture& VideoCapture::operator >> (UMat& image)
 
 bool VideoCapture::writeToFile(const char* filename)
 {
-    bool ret = false;
-    if (!icap.empty()) {
-        icap->writeToFile(filename);
-        ret = true;
-    }
-    return ret;
+    return !icap.empty() ? icap->writeToFile(filename) : false;
 }
 
 bool VideoCapture::set(int propId, double value)

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -408,9 +408,9 @@ VideoCapture& VideoCapture::operator >> (UMat& image)
     return *this;
 }
 
-bool VideoCapture::writeToFile(const char* filename)
+bool VideoCapture::writeToFile(const char* filename, const bool autoDetectExt)
 {
-    return !icap.empty() ? icap->writeToFile(filename) : false;
+    return !icap.empty() ? icap->writeToFile(filename, autoDetectExt) : false;
 }
 
 bool VideoCapture::set(int propId, double value)

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -402,7 +402,8 @@ CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char
     try
     {
         CvCapture_FFMPEG_proxy* instance = (CvCapture_FFMPEG_proxy*)handle;
-        return instance->writeToFile(filename) ? CV_ERROR_OK : CV_ERROR_FAIL;
+        instance->writeToFile(filename);
+        return CV_ERROR_OK;
     }
     catch (const std::exception& e)
     {

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -84,11 +84,11 @@ public:
     {
         return ffmpegCapture ? icvSetCaptureProperty_FFMPEG_p(ffmpegCapture, propId, value)!=0 : false;
     }
-    virtual bool writeToFile(const char* filename) CV_OVERRIDE
+    virtual bool writeToFile(const char* filename, const bool autoDetectExt = false) CV_OVERRIDE
     {
         if (!ffmpegCapture)
             return false;
-        icvWriteToFile_FFMPEG_p(ffmpegCapture, filename);
+        icvWriteToFile_FFMPEG_p(ffmpegCapture, filename, autoDetectExt);
         return true;
     }
     virtual bool grabFrame() CV_OVERRIDE
@@ -395,14 +395,14 @@ CvResult CV_API_CALL cv_capture_set_prop(CvPluginCapture handle, int prop, doubl
 }
 
 static
-CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char* filename)
+CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char* filename, const bool autoDetectExt = false)
 {
     if (!handle)
         return CV_ERROR_FAIL;
     try
     {
         CvCapture_FFMPEG_proxy* instance = (CvCapture_FFMPEG_proxy*)handle;
-        instance->writeToFile(filename);
+        instance->writeToFile(filename, autoDetectExt);
         return CV_ERROR_OK;
     }
     catch (const std::exception& e)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -529,7 +529,6 @@ struct CvCapture_FFMPEG
 
     bool setRaw();
     bool processRawPacket();
-    bool fixSideData();
     bool rawMode;
     bool rawModeInitialized;
     bool sendSideInfo;
@@ -1456,7 +1455,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int, unsigned char** data, int* step, int* 
     {
         AVPacket& p = bsfc ? packet_filtered : packet;
         if (sendSideInfo) {
-            sendSideInfo = false;            
+            sendSideInfo = false;
             *step = ic->streams[video_stream]->codec->extradata_size + p.size;
             sideInfo = new uint8_t[*step];
             memcpy(sideInfo, ic->streams[video_stream]->codec->extradata, ic->streams[video_stream]->codec->extradata_size);

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1201,7 +1201,7 @@ bool CvCapture_FFMPEG::processRawPacket()
     if (!rawModeInitialized)
     {
         rawModeInitialized = true;
-        if (ic->streams[video_stream]->codec->extradata_size)
+        if (ic->streams[video_stream]->codec->extradata_size && strcmp(ic->iformat->name,"rtsp") == 0)
             writeSideInfo = true;
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(58, 20, 100)
         CV_CODEC_ID eVideoCodec = ic->streams[video_stream]->codecpar->codec_id;
@@ -1392,7 +1392,7 @@ bool CvCapture_FFMPEG::grabFrame()
                 if (!oFile)
                     return false;
                 restartRtspFileWrite = false;
-                if (ic->streams[video_stream]->codec->extradata_size)
+                if (ic->streams[video_stream]->codec->extradata_size && strcmp(ic->iformat->name, "rtsp") == 0)
                     writeSideInfo = true;
             }
         }

--- a/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
+++ b/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
@@ -28,7 +28,7 @@ typedef struct CvVideoWriter_FFMPEG CvVideoWriter_FFMPEG;
 OPENCV_FFMPEG_API int cvSetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap,
                                                   int prop, double value);
 OPENCV_FFMPEG_API double cvGetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap, int prop);
-OPENCV_FFMPEG_API void cvWriteToFile_FFMPEG(struct CvCapture_FFMPEG* cap, const char* filename);
+OPENCV_FFMPEG_API void cvWriteToFile_FFMPEG(struct CvCapture_FFMPEG* cap, const char* filename, const bool autoDetectExt = false);
 OPENCV_FFMPEG_API int cvGrabFrame_FFMPEG(struct CvCapture_FFMPEG* cap);
 OPENCV_FFMPEG_API int cvRetrieveFrame_FFMPEG(struct CvCapture_FFMPEG* capture, unsigned char** data,
                                              int* step, int* width, int* height, int* cn);

--- a/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
+++ b/modules/videoio/src/cap_ffmpeg_legacy_api.hpp
@@ -28,6 +28,7 @@ typedef struct CvVideoWriter_FFMPEG CvVideoWriter_FFMPEG;
 OPENCV_FFMPEG_API int cvSetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap,
                                                   int prop, double value);
 OPENCV_FFMPEG_API double cvGetCaptureProperty_FFMPEG(struct CvCapture_FFMPEG* cap, int prop);
+OPENCV_FFMPEG_API void cvWriteToFile_FFMPEG(struct CvCapture_FFMPEG* cap, const char* filename);
 OPENCV_FFMPEG_API int cvGrabFrame_FFMPEG(struct CvCapture_FFMPEG* cap);
 OPENCV_FFMPEG_API int cvRetrieveFrame_FFMPEG(struct CvCapture_FFMPEG* capture, unsigned char** data,
                                              int* step, int* width, int* height, int* cn);

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -219,6 +219,7 @@ public:
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;
     virtual int getCaptureDomain() { return CAP_ANY; } // Return the type of the capture object: CAP_DSHOW, etc...
+    virtual bool writeToFile(const char* filename) { return false; }
 };
 
 class IVideoWriter

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -219,7 +219,7 @@ public:
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;
     virtual int getCaptureDomain() { return CAP_ANY; } // Return the type of the capture object: CAP_DSHOW, etc...
-    virtual bool writeToFile(const char* filename) { return false; }
+    virtual bool writeToFile(const char*) { return false; }
 };
 
 class IVideoWriter

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -219,7 +219,7 @@ public:
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;
     virtual int getCaptureDomain() { return CAP_ANY; } // Return the type of the capture object: CAP_DSHOW, etc...
-    virtual bool writeToFile(const char*) { return false; }
+    virtual bool writeToFile(const char*, const bool) { return false; }
 };
 
 class IVideoWriter

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1985,6 +1985,12 @@ CvResult CV_API_CALL cv_capture_set_prop(CvPluginCapture handle, int prop, doubl
 }
 
 static
+CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char* filename)
+{
+    return CV_ERROR_FAIL;
+}
+
+static
 CvResult CV_API_CALL cv_capture_grab(CvPluginCapture handle)
 {
     if (!handle)
@@ -2184,11 +2190,12 @@ static const OpenCV_VideoIO_Capture_Plugin_API capture_plugin_api =
         /*  3*/cv::cv_capture_release,
         /*  4*/cv::cv_capture_get_prop,
         /*  5*/cv::cv_capture_set_prop,
-        /*  6*/cv::cv_capture_grab,
-        /*  7*/cv::cv_capture_retrieve,
+        /*  6*/cv_capture_write_to_file,
+        /*  7*/cv::cv_capture_grab,
+        /*  8*/cv::cv_capture_retrieve,
     },
     {
-        /*  8*/cv::cv_capture_open_with_params,
+        /*  9*/cv::cv_capture_open_with_params,
     }
 };
 

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1985,7 +1985,7 @@ CvResult CV_API_CALL cv_capture_set_prop(CvPluginCapture handle, int prop, doubl
 }
 
 static
-CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char* filename)
+CvResult CV_API_CALL cv_capture_write_to_file(CvPluginCapture handle, const char* filename, const bool autoDetectExt = false)
 {
     return CV_ERROR_FAIL;
 }

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -95,7 +95,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
 
     @note API-CALL 6, API-Version == 0
      */
-    CvResult (CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
+    CvResult (CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename, const bool autoDetectExt);
 
     /** @brief Grab frame
 

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -88,11 +88,20 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
      */
     CvResult (CV_API_CALL *Capture_setProperty)(CvPluginCapture handle, int prop, double val);
 
+    /** @brief WriteToFile property value
+
+    @param handle Capture handle
+    @param filename Full path to output file
+
+    @note API-CALL 6, API-Version == 0
+     */
+    CvResult(CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
+
     /** @brief Grab frame
 
     @param handle Capture handle
 
-    @note API-CALL 6, API-Version == 0
+    @note API-CALL 7, API-Version == 0
      */
     CvResult (CV_API_CALL *Capture_grab)(CvPluginCapture handle);
 
@@ -103,7 +112,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
     @param callback retrieve callback (synchronous)
     @param userdata callback context data
 
-    @note API-CALL 7, API-Version == 0
+    @note API-CALL 8, API-Version == 0
      */
     CvResult (CV_API_CALL *Capture_retreive)(CvPluginCapture handle, int stream_idx, cv_videoio_retrieve_cb_t callback, void* userdata);
 
@@ -118,7 +127,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
     @param isColor true if video stream should save color frames
     @param[out] handle pointer on Writer handle
 
-    @note API-CALL 8, API-Version == 0
+    @note API-CALL 9, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_open)(const char* filename, int fourcc, double fps, int width, int height, int isColor,
                                          CV_OUT CvPluginWriter* handle);
@@ -127,7 +136,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
 
     @param handle Writer handle
 
-    @note API-CALL 9, API-Version == 0
+    @note API-CALL 10, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_release)(CvPluginWriter handle);
 
@@ -137,7 +146,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
     @param prop Property index
     @param[out] val property value
 
-    @note API-CALL 10, API-Version == 0
+    @note API-CALL 11, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_getProperty)(CvPluginWriter handle, int prop, CV_OUT double* val);
 
@@ -147,7 +156,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
     @param prop Property index
     @param val property value
 
-    @note API-CALL 11, API-Version == 0
+    @note API-CALL 12, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_setProperty)(CvPluginWriter handle, int prop, double val);
 
@@ -160,7 +169,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
     @param height frame height
     @param cn number of channels per pixel
 
-    @note API-CALL 12, API-Version == 0
+    @note API-CALL 13, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_write)(CvPluginWriter handle, const unsigned char *data, int step, int width, int height, int cn);
 }; // OpenCV_VideoIO_Plugin_API_v0_0_api_entries

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -95,7 +95,7 @@ struct OpenCV_VideoIO_Plugin_API_v0_0_api_entries
 
     @note API-CALL 6, API-Version == 0
      */
-    CvResult(CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
+    CvResult (CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
 
     /** @brief Grab frame
 

--- a/modules/videoio/src/plugin_capture_api.hpp
+++ b/modules/videoio/src/plugin_capture_api.hpp
@@ -83,11 +83,20 @@ struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries
      */
     CvResult (CV_API_CALL *Capture_setProperty)(CvPluginCapture handle, int prop, double val);
 
+    /** @brief WriteToFile property value
+
+    @param handle Capture handle
+    @param filename Full path to output file
+
+    @note API-CALL 6, API-Version == 0
+     */
+    CvResult(CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
+
     /** @brief Grab frame
 
     @param handle Capture handle
 
-    @note API-CALL 6, API-Version == 0
+    @note API-CALL 7, API-Version == 0
      */
     CvResult (CV_API_CALL *Capture_grab)(CvPluginCapture handle);
 
@@ -98,7 +107,7 @@ struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries
     @param callback retrieve callback (synchronous)
     @param userdata callback context data
 
-    @note API-CALL 7, API-Version == 0
+    @note API-CALL 8, API-Version == 0
      */
     CvResult (CV_API_CALL *Capture_retreive)(CvPluginCapture handle, int stream_idx, cv_videoio_capture_retrieve_cb_t callback, void* userdata);
 }; // OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries

--- a/modules/videoio/src/plugin_capture_api.hpp
+++ b/modules/videoio/src/plugin_capture_api.hpp
@@ -90,7 +90,7 @@ struct OpenCV_VideoIO_Capture_Plugin_API_v1_0_api_entries
 
     @note API-CALL 6, API-Version == 0
      */
-    CvResult(CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename);
+    CvResult(CV_API_CALL* Capture_writeToFile)(CvPluginCapture handle, const char* filename, const bool autoDetectExt);
 
     /** @brief Grab frame
 


### PR DESCRIPTION
It is really common these days to live stream directly from IP camera's and perform image processing on the decoded frames.  Because the data is live it is also desirable to save the original data somewhere for archival and/or later processing.  Currently the only way to do this is to re-encode the decoded frames, which has a significant overhead and will not be produce an exact duplicate of the source, due to encoding differences.

The pull request adds the functionality to write the raw bitstream to a given file during the calls to read()/grab().  It seemed appropriate to place this functionality there because it can also be utilized when reading raw data only, currently used by cudacodec.

Additionally I added the capacity for raw reads to append the side info which is commonly provided when streaming from and RTSP source to the beginning of the stream.  This will mostly be a duplicate but some IP cameras, from memory axis is one, don't send the SPS and PPS in band.

In loop restart of recording cannot be tested because there are no media test file with more than one key frame.  If this pull request is suitable for inclusion it may be worth including an extra media file and test.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
