### PR TITLE
Closing brackets missing

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.markdown
@@ -91,7 +91,7 @@ convexity defects, which are the local maximum deviations of hull from contours.
 
 There is a little bit things to discuss about it its syntax:
 @code{.py}
-hull = cv.convexHull(points[, hull[, clockwise[, returnPoints]]
+hull = cv.convexHull(points[, hull[, clockwise[, returnPoints]]])
 @endcode
 Arguments details:
 


### PR DESCRIPTION
In line 94,  closing brackets are added which were missing .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
