### PR TITLE
Improves FLANN's heap allocations by a memory pool

### DIFF
--- a/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
+++ b/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
@@ -532,7 +532,7 @@ public:
         const bool explore_all_trees = get_param(searchParams,"explore_all_trees",false);
 
         // Priority queue storing intermediate branches in the best-bin-first search
-        Heap<BranchSt>* heap = new Heap<BranchSt>((int)size_);
+        const cv::Ptr<Heap<BranchSt>>& heap = Heap<BranchSt>::getPooledInstance(cv::utils::getThreadID(), (int)size_);
 
         std::vector<bool> checked(size_,false);
         int checks = 0;
@@ -547,8 +547,6 @@ public:
             NodePtr node = branch.node;
             findNN(node, result, vec, checks, maxChecks, heap, checked, false);
         }
-
-        delete heap;
 
         CV_Assert(result.full());
     }
@@ -742,7 +740,7 @@ private:
 
 
     void findNN(NodePtr node, ResultSet<DistanceType>& result, const ElementType* vec, int& checks, int maxChecks,
-                Heap<BranchSt>* heap, std::vector<bool>& checked, bool explore_all_trees = false)
+                const cv::Ptr<Heap<BranchSt>>& heap, std::vector<bool>& checked, bool explore_all_trees = false)
     {
         if (node->childs==NULL) {
             if (!explore_all_trees && (checks>=maxChecks) && result.full()) {

--- a/modules/flann/include/opencv2/flann/kdtree_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_index.h
@@ -445,10 +445,11 @@ private:
     {
         int i;
         BranchSt branch;
-
         int checkCount = 0;
-        Heap<BranchSt>* heap = new Heap<BranchSt>((int)size_);
         DynamicBitset checked(size_);
+
+        // Priority queue storing intermediate branches in the best-bin-first search
+        const cv::Ptr<Heap<BranchSt>>& heap = Heap<BranchSt>::getPooledInstance(cv::utils::getThreadID(), (int)size_);
 
         /* Search once through each tree down to root. */
         for (i = 0; i < trees_; ++i) {
@@ -464,8 +465,6 @@ private:
                         epsError, heap, checked, false);
         }
 
-        delete heap;
-
         CV_Assert(result.full());
     }
 
@@ -476,7 +475,7 @@ private:
      *  at least "mindistsq".
      */
     void searchLevel(ResultSet<DistanceType>& result_set, const ElementType* vec, NodePtr node, DistanceType mindist, int& checkCount, int maxCheck,
-                     float epsError, Heap<BranchSt>* heap, DynamicBitset& checked, bool explore_all_trees = false)
+                     float epsError, const cv::Ptr<Heap<BranchSt>>& heap, DynamicBitset& checked, bool explore_all_trees = false)
     {
         if (result_set.worstDist()<mindist) {
             //			printf("Ignoring branch, too far\n");

--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -528,7 +528,7 @@ public:
         }
         else {
             // Priority queue storing intermediate branches in the best-bin-first search
-            Heap<BranchSt>* heap = new Heap<BranchSt>((int)size_);
+            const cv::Ptr<Heap<BranchSt>>& heap = Heap<BranchSt>::getPooledInstance(cv::utils::getThreadID(), (int)size_);
 
             int checks = 0;
             for (int i=0; i<trees_; ++i) {
@@ -542,8 +542,6 @@ public:
                 KMeansNodePtr node = branch.node;
                 findNN(node, result, vec, checks, maxChecks, heap);
             }
-            delete heap;
-
             CV_Assert(result.full());
         }
     }
@@ -1529,7 +1527,7 @@ private:
 
 
     void findNN(KMeansNodePtr node, ResultSet<DistanceType>& result, const ElementType* vec, int& checks, int maxChecks,
-                Heap<BranchSt>* heap)
+                const cv::Ptr<Heap<BranchSt>>& heap)
     {
         // Ignore those clusters that are too far away
         {
@@ -1577,7 +1575,7 @@ private:
      *     distances = array with the distances to each child node.
      * Returns:
      */
-    int exploreNodeBranches(KMeansNodePtr node, const ElementType* q, DistanceType* domain_distances, Heap<BranchSt>* heap)
+    int exploreNodeBranches(KMeansNodePtr node, const ElementType* q, DistanceType* domain_distances, const cv::Ptr<Heap<BranchSt>>& heap)
     {
 
         int best_index = 0;


### PR DESCRIPTION
FLANN allocates huge amounts of memory with every call to `findNeighbors` due to its private heap allocations. This affects memory throughput and overall speed of user applications, especially the ones that frequently query for neighbors. After all, although `malloc` does cache on its own, it also does a lot of smart things besides that, which costs some time penalty. To solve the problem, this PR introduces a static, thread-safe, and bounded memory pool for heap allocations. It have been tested thoroughly for very long hours, under extensive parallelization, and with strict leakage profiling. **The tests showed more than 70x memory throughput gain**. For roughly the same amount of calls, the memory footprint of `findNeighbors` using master branch was around 18.2 GB/sec, which got reduced by this PR to just 250.5 MB/sec (see the allocations throughput table below). Additionally, this PR cleans up some unnecessary variables in the `cvflann::Heap` class.

| Master | This PR |
|----------|---------|
| ![master](https://user-images.githubusercontent.com/42140441/126982801-304ac0b6-e8a9-48a6-a8c6-369f0fdc5a45.png) | ![PR](https://user-images.githubusercontent.com/42140441/126982824-b4ff41f2-9e18-4925-a7ef-95901efe785d.png) |

### Pull Request Readiness Checklist

<!-- See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request -->

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- N/A: There is reference to original bug report and related work

#### Already existing:
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=linux32
```