### PR TITLE
pass 3d arrays from py to cpp

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -54,9 +54,11 @@ class ArgInfo
 public:
     const char* name;
     bool outputarg;
+    bool isimage = true;
     // more fields may be added if necessary
 
     ArgInfo(const char* name_, bool outputarg_) : name(name_), outputarg(outputarg_) {}
+    ArgInfo(const char* name_, bool outputarg_,bool isimage_) : name(name_), outputarg(outputarg_), isimage(isimage_) {}
 
 private:
     ArgInfo(const ArgInfo&) = delete;
@@ -766,7 +768,7 @@ static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
         ndims++;
     }
 
-    if( ismultichannel )
+    if( ismultichannel && info.isimage)
     {
         ndims--;
         type |= CV_MAKETYPE(0, size[2]);

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -379,6 +379,7 @@ class ArgInfo(object):
         self.outputarg = False
         self.returnarg = False
         self.isrvalueref = False
+        self.isImage = True
         for m in arg_tuple[3]:
             if m == "/O":
                 self.inputarg = False
@@ -403,7 +404,7 @@ class ArgInfo(object):
         return self.tp in ["Mat", "vector_Mat", "cuda::GpuMat", "GpuMat", "vector_GpuMat", "UMat", "vector_UMat"] # or self.tp.startswith("vector")
 
     def crepr(self):
-        return "ArgInfo(\"%s\", %d)" % (self.name, self.outputarg)
+        return "ArgInfo(\"%s\", %d, %d)" % (self.name, self.outputarg, self.isImage)
 
 
 class FuncVariant(object):
@@ -422,6 +423,10 @@ class FuncVariant(object):
         self.array_counters = {}
         for a in decl[3]:
             ainfo = ArgInfo(a)
+            # Do not treat blob as an image while passing
+            # from python to cpp if passed from setInput()
+            if name=='setInput' and a[1]=='blob':
+                ainfo.isImage=False
             if ainfo.isarray and not ainfo.arraycvt:
                 c = ainfo.arraylen
                 c_arrlist = self.array_counters.get(c, [])


### PR DESCRIPTION
addressing #19091
> Currently OpenCV Python bindings "automatically" converts 3D NumPy arrays into 2D cv::Mat with wrapping last dimension onto number of channels (to simulate Image with colors)

We don't need to treat array passed from `dnn::net::setInput()` as an image. `isImage` in `ArgInfo` class does that in this solution.

> relates #17272
> relates #19001
> probably relates #18413 #17456

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
