### PR TITLE
Remove explicit PNet resizes from MTCNN graph

### DIFF
--- a/modules/gapi/samples/face_detection_mtcnn.cpp
+++ b/modules/gapi/samples/face_detection_mtcnn.cpp
@@ -598,9 +598,7 @@ int main(int argc, char* argv[]) {
     cv::GArray<custom::Face> total_faces[MAX_PYRAMID_LEVELS];
 
     //The very first PNet pyramid layer to init total_faces[0]
-    cv::Size currentSize = cv::Size(level_size[0].height, level_size[0].width);
-    in_resized[0] = cv::gapi::resize(in_transposedRGB, currentSize);
-    std::tie(regressions[0], scores[0]) = run_mtcnn_p(in_resized[0], get_pnet_level_name(level_size[0]));
+    std::tie(regressions[0], scores[0]) = run_mtcnn_p(in_transposedRGB, get_pnet_level_name(level_size[0]));
     cv::GArray<custom::Face> faces0 = custom::BuildFaces::on(scores[0], regressions[0], static_cast<float>(scales[0]), conf_thresh_p);
     cv::GArray<custom::Face> final_p_faces_for_bb2squares = custom::ApplyRegression::on(faces0, true);
     cv::GArray<custom::Face> final_faces_pnet0 = custom::BBoxesToSquares::on(final_p_faces_for_bb2squares);
@@ -608,9 +606,7 @@ int main(int argc, char* argv[]) {
     //The rest PNet pyramid layers to accumlate all layers result in total_faces[PYRAMID_LEVELS - 1]]
     for (int i = 1; i < pyramid_levels; ++i)
     {
-        currentSize = cv::Size(level_size[i].height, level_size[i].width);
-        in_resized[i] = cv::gapi::resize(in_transposedRGB, currentSize);
-        std::tie(regressions[i], scores[i]) = run_mtcnn_p(in_resized[i], get_pnet_level_name(level_size[i]));
+        std::tie(regressions[i], scores[i]) = run_mtcnn_p(in_transposedRGB, get_pnet_level_name(level_size[i]));
         cv::GArray<custom::Face> faces = custom::BuildFaces::on(scores[i], regressions[i], static_cast<float>(scales[i]), conf_thresh_p);
         cv::GArray<custom::Face> final_p_faces_for_bb2squares_i = custom::ApplyRegression::on(faces, true);
         cv::GArray<custom::Face> final_faces_pnet_i = custom::BBoxesToSquares::on(final_p_faces_for_bb2squares_i);

--- a/modules/gapi/samples/face_detection_mtcnn.cpp
+++ b/modules/gapi/samples/face_detection_mtcnn.cpp
@@ -591,7 +591,6 @@ int main(int argc, char* argv[]) {
     cv::GMat in_originalRGB = cv::gapi::BGR2RGB(in_original);
     cv::GMat in_transposedRGB = cv::gapi::transpose(in_originalRGB);
     cv::GOpaque<cv::Size> in_sz = cv::gapi::streaming::size(in_original);
-    cv::GMat in_resized[MAX_PYRAMID_LEVELS];
     cv::GMat regressions[MAX_PYRAMID_LEVELS];
     cv::GMat scores[MAX_PYRAMID_LEVELS];
     cv::GArray<custom::Face> nms_p_faces[MAX_PYRAMID_LEVELS];


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
// disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
