### PR TITLE
[G-API] Support postprocessing for not argmaxed outputs

### DIFF
--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -59,11 +59,11 @@ void classesToColors(const cv::Mat &out_blob,
 
     for (int rowId = 0; rowId < H; ++rowId) {
         for (int colId = 0; colId < W; ++colId) {
-            uint8_t classId = static_cast<uint8_t>(classes[rowId * W + colId]);
+            uint8_t classId = classes[rowId * W + colId];
             maskImg.at<cv::Vec3b>(rowId, colId) =
                 classId < colors.size()
                 ? colors[classId]
-                : cv::Vec3b{0, 0, 0}; // sample detects 20 classes
+                : cv::Vec3b{0, 0, 0}; // NB: sample supports 20 classes
         }
     }
 }

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -74,6 +74,7 @@ void probsToClasses(const cv::Mat& probs, cv::Mat& classes) {
      int W = probs.size[3];
 
      classes.create(H, W, CV_8UC1);
+     GAPI_Assert(probs.depth() == CV_32F);
      float* out_p       = reinterpret_cast<float*>(probs.data);
      uint8_t* classes_p = reinterpret_cast<uint8_t*>(classes.data);
 

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -105,7 +105,7 @@ G_API_OP(PostProcessing, <cv::GMat(cv::GMat, cv::GMat)>, "sample.custom.post_pro
 GAPI_OCV_KERNEL(OCVPostProcessing, PostProcessing) {
     static void run(const cv::Mat &in, const cv::Mat &out_blob, cv::Mat &out) {
         cv::Mat classes;
-        // NB: If output has more than single plane, it contains probabilites
+        // NB: If output has more than single plane, it contains probabilities
         // otherwise class id.
         if (out_blob.size[1] > 1) {
             probsToClasses(out_blob, classes);

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -47,6 +47,52 @@ std::string get_weights_path(const std::string &model_path) {
     CV_Assert(ext == ".xml");
     return model_path.substr(0u, sz - EXT_LEN) + ".bin";
 }
+
+void classesToColors(const cv::Mat &out_blob,
+                           cv::Mat &maskImg) {
+    const int H = out_blob.size[0];
+    const int W = out_blob.size[1];
+
+    maskImg.create(H, W, CV_8UC3);
+    GAPI_Assert(out_blob.type() == CV_8UC1);
+    const uint8_t* const classes = out_blob.ptr<uint8_t>();
+
+    for (int rowId = 0; rowId < H; ++rowId) {
+        for (int colId = 0; colId < W; ++colId) {
+            uint8_t classId = static_cast<uint8_t>(classes[rowId * W + colId]);
+            maskImg.at<cv::Vec3b>(rowId, colId) =
+                classId < colors.size()
+                ? colors[classId]
+                : cv::Vec3b{0, 0, 0}; // sample detects 20 classes
+        }
+    }
+}
+
+void probsToClasses(const cv::Mat& probs, cv::Mat& classes) {
+     int C = probs.size[1];
+     int H = probs.size[2];
+     int W = probs.size[3];
+
+     classes.create(H, W, CV_8UC1);
+     float* out_p       = reinterpret_cast<float*>(probs.data);
+     uint8_t* classes_p = reinterpret_cast<uint8_t*>(classes.data);
+
+     for (int h = 0; h < H; ++h) {
+         for (int w = 0; w < W; ++w) {
+             double max = 0;
+             int class_id = 0;
+             for (int c = 0; c < C; ++c) {
+                int idx = c * H * W + h * W + w;
+                    if (out_p[idx] > max) {
+                        max = out_p[idx];
+                        class_id = c;
+                    }
+             }
+             classes_p[h * W + w] = class_id;
+         }
+     }
+}
+
 } // anonymous namespace
 
 namespace custom {
@@ -57,24 +103,20 @@ G_API_OP(PostProcessing, <cv::GMat(cv::GMat, cv::GMat)>, "sample.custom.post_pro
 };
 
 GAPI_OCV_KERNEL(OCVPostProcessing, PostProcessing) {
-    static void run(const cv::Mat &in, const cv::Mat &detected_classes, cv::Mat &out) {
-        // This kernel constructs output image by class table and colors vector
-
-        // The semantic-segmentation-adas-0001 output a blob with the shape
-        // [B, C=1, H=1024, W=2048]
-        const int outHeight = 1024;
-        const int outWidth = 2048;
-        cv::Mat maskImg(outHeight, outWidth, CV_8UC3);
-        const int* const classes = detected_classes.ptr<int>();
-        for (int rowId = 0; rowId < outHeight; ++rowId) {
-            for (int colId = 0; colId < outWidth; ++colId) {
-                size_t classId = static_cast<size_t>(classes[rowId * outWidth + colId]);
-                maskImg.at<cv::Vec3b>(rowId, colId) =
-                    classId < colors.size()
-                        ? colors[classId]
-                        : cv::Vec3b{0, 0, 0}; // sample detects 20 classes
-            }
+    static void run(const cv::Mat &in, const cv::Mat &out_blob, cv::Mat &out) {
+        cv::Mat classes;
+        // NB: If output has more than single plane, it contains probabilites
+        // otherwise class id.
+        if (out_blob.size[1] > 1) {
+            probsToClasses(out_blob, classes);
+        } else {
+            out_blob.convertTo(classes, CV_8UC1);
+            classes = classes.reshape(1, out_blob.size[2]);
         }
+
+        cv::Mat maskImg;
+        classesToColors(classes, maskImg);
+
         cv::resize(maskImg, out, in.size());
         const float blending = 0.3f;
         out = in * blending + out * (1 - blending);
@@ -104,8 +146,8 @@ int main(int argc, char *argv[]) {
 
     // Now build the graph
     cv::GMat in;
-    cv::GMat detected_classes = cv::gapi::infer<SemSegmNet>(in);
-    cv::GMat out = custom::PostProcessing::on(in, detected_classes);
+    cv::GMat out_blob = cv::gapi::infer<SemSegmNet>(in);
+    cv::GMat out = custom::PostProcessing::on(in, out_blob);
 
     cv::GStreamingCompiled pipeline = cv::GComputation(cv::GIn(in), cv::GOut(out))
         .compileStreaming(cv::compile_args(kernels, networks));

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -69,9 +69,9 @@ void classesToColors(const cv::Mat &out_blob,
 }
 
 void probsToClasses(const cv::Mat& probs, cv::Mat& classes) {
-     int C = probs.size[1];
-     int H = probs.size[2];
-     int W = probs.size[3];
+     const int C = probs.size[1];
+     const int H = probs.size[2];
+     const int W = probs.size[3];
 
      classes.create(H, W, CV_8UC1);
      GAPI_Assert(probs.depth() == CV_32F);

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -49,20 +49,20 @@ std::string get_weights_path(const std::string &model_path) {
 }
 
 void classesToColors(const cv::Mat &out_blob,
-                           cv::Mat &maskImg) {
+                           cv::Mat &mask_img) {
     const int H = out_blob.size[0];
     const int W = out_blob.size[1];
 
-    maskImg.create(H, W, CV_8UC3);
+    mask_img.create(H, W, CV_8UC3);
     GAPI_Assert(out_blob.type() == CV_8UC1);
     const uint8_t* const classes = out_blob.ptr<uint8_t>();
 
     for (int rowId = 0; rowId < H; ++rowId) {
         for (int colId = 0; colId < W; ++colId) {
-            uint8_t classId = classes[rowId * W + colId];
-            maskImg.at<cv::Vec3b>(rowId, colId) =
-                classId < colors.size()
-                ? colors[classId]
+            uint8_t class_id = classes[rowId * W + colId];
+            mask_img.at<cv::Vec3b>(rowId, colId) =
+                class_id < colors.size()
+                ? colors[class_id]
                 : cv::Vec3b{0, 0, 0}; // NB: sample supports 20 classes
         }
     }
@@ -115,10 +115,10 @@ GAPI_OCV_KERNEL(OCVPostProcessing, PostProcessing) {
             classes = classes.reshape(1, out_blob.size[2]);
         }
 
-        cv::Mat maskImg;
-        classesToColors(classes, maskImg);
+        cv::Mat mask_img;
+        classesToColors(classes, mask_img);
 
-        cv::resize(maskImg, out, in.size());
+        cv::resize(mask_img, out, in.size());
         const float blending = 0.3f;
         out = in * blending + out * (1 - blending);
     }

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -89,7 +89,7 @@ void probsToClasses(const cv::Mat& probs, cv::Mat& classes) {
                         class_id = c;
                     }
              }
-             classes_p[h * W + w] = class_id;
+             classes_p[h * W + w] = static_cast<uint8_t>(class_id);
          }
      }
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Overview
Some semantic segmentation networks such as unet-camvid-0001 from OMZ produce multi-plane output (1 x num_classesx H x W). In that case need to perform argmax operation for every pixel through channel plane in order to convert output to 1 x 1 x H x W representation where every pixel is class id.

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
// disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
