### PR TITLE
Add Python's test for LSTM layer

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -62,6 +62,12 @@ def printParams(backend, target):
     }
     print('%s/%s' % (backendNames[backend], targetNames[target]))
 
+def getDefaultThreshold(target):
+    if target == cv.dnn.DNN_TARGET_OPENCL_FP16 or target == cv.dnn.DNN_TARGET_MYRIAD:
+        return 4e-3
+    else:
+        return 1e-5
+
 testdata_required = bool(os.environ.get('OPENCV_DNN_TEST_REQUIRE_TESTDATA', False))
 
 g_dnnBackendsAndTargets = None
@@ -330,7 +336,7 @@ class dnn_test(NewOpenCVTests):
             net.setPreferableTarget(target)
             real_output = net.forward()
 
-            normAssert(self, real_output, gold_output)
+            normAssert(self, real_output, gold_output, "", getDefaultThreshold(target))
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -311,7 +311,8 @@ class dnn_test(NewOpenCVTests):
 
         cv.dnn_unregisterLayer('CropCaffe')
 
-    def test_lstm(self):
+    # check that dnn module can work with 3D tensor as input for network
+    def test_input_3d(self):
         model = self.find_dnn_file('dnn/onnx/models/hidden_lstm.onnx')
         input_file = self.find_dnn_file('dnn/onnx/data/input_hidden_lstm.npy')
         output_file = self.find_dnn_file('dnn/onnx/data/output_hidden_lstm.npy')
@@ -325,6 +326,8 @@ class dnn_test(NewOpenCVTests):
         net = cv.dnn.readNet(model)
         input = np.load(input_file)
         # we have to expand the shape of input tensor because Python bindings cut 3D tensors to 2D
+        # it should be fixed in future. see : https://github.com/opencv/opencv/issues/19091
+        # please remove `expand_dims` after that
         input = np.expand_dims(input, axis=3)
         gold_output = np.load(output_file)
         net.setInput(input)


### PR DESCRIPTION
Add test for workaround mentioned at issue https://github.com/opencv/opencv/issues/18880

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
