### PR TITLE
fix: convert arguments names that are keywords reserved by Python

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -117,6 +117,12 @@ String dumpRange(const Range& argument)
 }
 
 CV_WRAP static inline
+String testReservedKeywordConversion(int positional_argument, int lambda = 2, int from = 3)
+{
+    return format("arg=%d, lambda=%d, from=%d", positional_argument, lambda, from);
+}
+
+CV_WRAP static inline
 void testRaiseGeneralException()
 {
     throw std::runtime_error("exception text");

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -212,6 +212,16 @@ simple_argtype_mapping = {
     "c_string": ArgTypeInfo("char*", FormatStrings.string, '(char*)""')
 }
 
+# Set of reserved keywords for Python. Can be acquired via the following call
+# $ python -c "help('keywords')"
+# Keywords that are reserved in C/C++ are excluded because they can not be
+# used as variables identifiers
+python_reserved_keywords = {
+    "True", "None", "False", "as", "assert", "def", "del", "elif", "except", "exec",
+    "finally", "from", "global",  "import", "in", "is", "lambda", "nonlocal",
+    "pass", "print", "raise", "with", "yield"
+}
+
 
 def normalize_class_name(name):
     return re.sub(r"^cv\.", "", name).replace(".", "_")
@@ -369,6 +379,8 @@ class ArgInfo(object):
     def __init__(self, arg_tuple):
         self.tp = handle_ptr(arg_tuple[0])
         self.name = arg_tuple[1]
+        if self.name in python_reserved_keywords:
+            self.name += "_"
         self.defval = arg_tuple[2]
         self.isarray = False
         self.arraylen = 0

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -463,6 +463,23 @@ class Arguments(NewOpenCVTests):
             with self.assertRaises((TypeError), msg=get_no_exception_msg(not_convertible)):
                 _ = cv.utils.dumpRange(not_convertible)
 
+    def test_reserved_keywords_are_transformed(self):
+        default_lambda_value = 2
+        default_from_value = 3
+        format_str = "arg={}, lambda={}, from={}"
+        self.assertEqual(
+            cv.utils.testReservedKeywordConversion(20), format_str.format(20, default_lambda_value, default_from_value)
+        )
+        self.assertEqual(
+            cv.utils.testReservedKeywordConversion(10, lambda_=10), format_str.format(10, 10, default_from_value)
+        )
+        self.assertEqual(
+            cv.utils.testReservedKeywordConversion(10, from_=10), format_str.format(10, default_lambda_value, 10)
+        )
+        self.assertEqual(
+            cv.utils.testReservedKeywordConversion(20, lambda_=-4, from_=12), format_str.format(20, -4, 12)
+        )
+
 
 class SamplesFindFile(NewOpenCVTests):
 


### PR DESCRIPTION
This PR allows to call functions with slightly modified keyword arguments if original argument name is reserved by Python.
Moreover it fixes stub file syntax for both positional and keyword arguments.

Resolves #16142
Resolves https://github.com/opencv/opencv_contrib/issues/2370

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
