### PR TITLE
fix wrong path for rubberwhale images

### DIFF
--- a/modules/imgproc/perf/opencl/perf_gftt.cpp
+++ b/modules/imgproc/perf/opencl/perf_gftt.cpp
@@ -57,7 +57,7 @@ typedef tuple<String, double, bool> GoodFeaturesToTrackParams;
 typedef TestBaseWithParam<GoodFeaturesToTrackParams> GoodFeaturesToTrackFixture;
 
 OCL_PERF_TEST_P(GoodFeaturesToTrackFixture, GoodFeaturesToTrack,
-                ::testing::Combine(OCL_PERF_ENUM(String("gpu/opticalflow/rubberwhale1.png")),
+                ::testing::Combine(OCL_PERF_ENUM(String("samples/data/rubberwhale1.png")),
                                    OCL_PERF_ENUM(0.0, 3.0), Bool()))
 {
     GoodFeaturesToTrackParams params = GetParam();
@@ -83,7 +83,7 @@ OCL_PERF_TEST_P(GoodFeaturesToTrackFixture, GoodFeaturesToTrack,
 }
 
 OCL_PERF_TEST_P(GoodFeaturesToTrackFixture, GoodFeaturesToTrackWithQuality,
-                ::testing::Combine(OCL_PERF_ENUM(String("gpu/opticalflow/rubberwhale1.png")),
+                ::testing::Combine(OCL_PERF_ENUM(String("samples/data/rubberwhale1.png")),
                                    OCL_PERF_ENUM(3.0), Bool()))
 {
     GoodFeaturesToTrackParams params = GetParam();

--- a/modules/imgproc/test/ocl/test_gftt.cpp
+++ b/modules/imgproc/test/ocl/test_gftt.cpp
@@ -72,8 +72,8 @@ PARAM_TEST_CASE(GoodFeaturesToTrack, double, bool)
 
     void generateTestData()
     {
-        Mat frame = readImage("../gpu/opticalflow/rubberwhale1.png", IMREAD_GRAYSCALE);
-        ASSERT_FALSE(frame.empty()) << "could not load gpu/opticalflow/rubberwhale1.png";
+        Mat frame = readImage("../samples/data/rubberwhale1.png", IMREAD_GRAYSCALE);
+        ASSERT_FALSE(frame.empty()) << "could not load samples/data/rubberwhale1.png";
 
         Size roiSize = frame.size();
         Border srcBorder = randomBorder(0, useRoi ? 2 : 0);

--- a/modules/video/perf/opencl/perf_optflow_farneback.cpp
+++ b/modules/video/perf/opencl/perf_optflow_farneback.cpp
@@ -69,10 +69,10 @@ OCL_PERF_TEST_P(FarnebackOpticalFlowFixture, FarnebackOpticalFlow,
                     )
                 )
 {
-    Mat frame0 = imread(getDataPath("gpu/opticalflow/rubberwhale1.png"), cv::IMREAD_GRAYSCALE);
+    Mat frame0 = imread(getDataPath("samples/data/rubberwhale1.png"), cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame0.empty()) << "can't load rubberwhale1.png";
 
-    Mat frame1 = imread(getDataPath("gpu/opticalflow/rubberwhale2.png"), cv::IMREAD_GRAYSCALE);
+    Mat frame1 = imread(getDataPath("samples/data/rubberwhale2.png"), cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame1.empty()) << "can't load rubberwhale2.png";
 
     const Size srcSize = frame0.size();

--- a/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
+++ b/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
@@ -59,10 +59,10 @@ OCL_PERF_TEST_P(PyrLKOpticalFlowFixture, PyrLKOpticalFlow,
                 ::testing::Values(1000, 2000, 4000)
                 )
 {
-    Mat frame0 = imread(getDataPath("gpu/opticalflow/rubberwhale1.png"), cv::IMREAD_GRAYSCALE);
+    Mat frame0 = imread(getDataPath("samples/data/rubberwhale1.png"), cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame0.empty()) << "can't load rubberwhale1.png";
 
-    Mat frame1 = imread(getDataPath("gpu/opticalflow/rubberwhale2.png"), cv::IMREAD_GRAYSCALE);
+    Mat frame1 = imread(getDataPath("samples/data/rubberwhale2.png"), cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame1.empty()) << "can't load rubberwhale2.png";
 
     UMat uFrame0; frame0.copyTo(uFrame0);


### PR DESCRIPTION
I saw that a test in imgproc segfaulted due to not finding the image and it seems that these images have been moved. I could not find an issue on this and therefore simply made a pull request.