### PR TITLE
add links in python and js contours tutorial

### DIFF
--- a/doc/js_tutorials/js_imgproc/js_contours/js_contour_features/js_contour_features.markdown
+++ b/doc/js_tutorials/js_imgproc/js_contours/js_contour_features/js_contour_features.markdown
@@ -1,6 +1,9 @@
 Contour Features {#tutorial_js_contour_features}
 ================
 
+@prev_tutorial{tutorial_js_contours_begin}
+@next_tutorial{tutorial_js_contour_properties}
+
 Goal
 ----
 

--- a/doc/js_tutorials/js_imgproc/js_contours/js_contour_properties/js_contour_properties.markdown
+++ b/doc/js_tutorials/js_imgproc/js_contours/js_contour_properties/js_contour_properties.markdown
@@ -1,6 +1,9 @@
 Contour Properties {#tutorial_js_contour_properties}
 ==================
 
+@prev_tutorial{tutorial_js_contour_features}
+@next_tutorial{tutorial_js_contours_more_functions}
+
 Goal
 ----
 

--- a/doc/js_tutorials/js_imgproc/js_contours/js_contours_begin/js_contours_begin.markdown
+++ b/doc/js_tutorials/js_imgproc/js_contours/js_contours_begin/js_contours_begin.markdown
@@ -1,6 +1,8 @@
 Contours : Getting Started {#tutorial_js_contours_begin}
 ==========================
 
+@next_tutorial{tutorial_js_contour_features}
+
 Goal
 ----
 

--- a/doc/js_tutorials/js_imgproc/js_contours/js_contours_hierarchy/js_contours_hierarchy.markdown
+++ b/doc/js_tutorials/js_imgproc/js_contours/js_contours_hierarchy/js_contours_hierarchy.markdown
@@ -1,6 +1,8 @@
 Contours Hierarchy {#tutorial_js_contours_hierarchy}
 ==================
 
+@prev_tutorial{tutorial_js_contours_more_functions}
+
 Goal
 ----
 

--- a/doc/js_tutorials/js_imgproc/js_contours/js_contours_more_functions/js_contours_more_functions.markdown
+++ b/doc/js_tutorials/js_imgproc/js_contours/js_contours_more_functions/js_contours_more_functions.markdown
@@ -1,6 +1,9 @@
 Contours : More Functions {#tutorial_js_contours_more_functions}
 =========================
 
+@prev_tutorial{tutorial_js_contour_properties}
+@next_tutorial{tutorial_js_contours_hierarchy}
+
 Goal
 ----
 

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contour_features/py_contour_features.markdown
@@ -1,6 +1,9 @@
 Contour Features {#tutorial_py_contour_features}
 ================
 
+@prev_tutorial{tutorial_py_contours_begin}
+@next_tutorial{tutorial_py_contour_properties}
+
 Goal
 ----
 

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contour_properties/py_contour_properties.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contour_properties/py_contour_properties.markdown
@@ -1,6 +1,9 @@
 Contour Properties {#tutorial_py_contour_properties}
 ==================
 
+@prev_tutorial{tutorial_py_contour_features}
+@next_tutorial{tutorial_py_contours_more_functions}
+
 Here we will learn to extract some frequently used properties of objects like Solidity, Equivalent
 Diameter, Mask image, Mean Intensity etc. More features can be found at [Matlab regionprops
 documentation](http://www.mathworks.in/help/images/ref/regionprops.html).

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
@@ -1,6 +1,8 @@
 Contours : Getting Started {#tutorial_py_contours_begin}
 ==========================
 
+@next_tutorial{tutorial_py_contour_features}
+
 Goal
 ----
 

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_hierarchy/py_contours_hierarchy.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_hierarchy/py_contours_hierarchy.markdown
@@ -1,6 +1,8 @@
 Contours Hierarchy {#tutorial_py_contours_hierarchy}
 ==================
 
+@prev_tutorial{tutorial_py_contours_more_functions}
+
 Goal
 ----
 

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_more_functions/py_contours_more_functions.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_more_functions/py_contours_more_functions.markdown
@@ -1,6 +1,10 @@
 Contours : More Functions {#tutorial_py_contours_more_functions}
 =========================
 
+@prev_tutorial{tutorial_py_contour_properties}
+@next_tutorial{tutorial_py_contours_hierarchy}
+
+
 Goal
 ----
 


### PR DESCRIPTION
Add links in [python](https://docs.opencv.org/4.5.2/d3/d05/tutorial_py_table_of_contents_contours.html) and [js](https://docs.opencv.org/4.5.2/d0/d43/tutorial_js_table_of_contents_contours.html) contours tutorial.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake