### PR TITLE
CMake: fix cross-compilation problems

### DIFF
--- a/modules/highgui/cmake/init.cmake
+++ b/modules/highgui/cmake/init.cmake
@@ -25,7 +25,9 @@ endif()
 # Detect available dependencies
 #
 
-include(FindPkgConfig)
+if(NOT PROJECT_NAME STREQUAL "OpenCV")
+  include(FindPkgConfig)
+endif()
 
 macro(add_backend backend_id cond_var)
   if(${cond_var})

--- a/modules/videoio/cmake/init.cmake
+++ b/modules/videoio/cmake/init.cmake
@@ -1,4 +1,6 @@
-include(FindPkgConfig)
+if(NOT PROJECT_NAME STREQUAL "OpenCV")
+  include(FindPkgConfig)
+endif()
 
 macro(add_backend backend_id cond_var)
   if(${cond_var})

--- a/platforms/linux/gnu.toolchain.cmake
+++ b/platforms/linux/gnu.toolchain.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 # load settings in case of "try compile"
 set(TOOLCHAIN_CONFIG_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/toolchain.config.cmake")

--- a/platforms/linux/riscv.toolchain.cmake
+++ b/platforms/linux/riscv.toolchain.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if(COMMAND toolchain_save_config)
   return() # prevent recursive call


### PR DESCRIPTION
- unexpected pkg-config module (we should not use host binary)
- bump cmake_minimum_required to 3.5 in toolchain files