### PR TITLE
[G-API] Expand PyParams to support constInput

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
@@ -22,16 +22,20 @@ namespace ie {
 // This class can be marked as SIMPLE, because it's implemented as pimpl
 class GAPI_EXPORTS_W_SIMPLE PyParams {
 public:
-    PyParams() = default;
+    GAPI_WRAP PyParams() = default;
 
-    PyParams(const std::string &tag,
+    GAPI_WRAP PyParams(const std::string &tag,
              const std::string &model,
              const std::string &weights,
              const std::string &device);
 
-    PyParams(const std::string &tag,
+    GAPI_WRAP PyParams(const std::string &tag,
              const std::string &model,
              const std::string &device);
+
+    GAPI_WRAP PyParams& constInput(const std::string &layer_name,
+                                   const cv::Mat &data,
+                                   TraitAs hint = TraitAs::TENSOR);
 
     GBackend      backend() const;
     std::string   tag()     const;

--- a/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
@@ -37,6 +37,8 @@ public:
                                    const cv::Mat &data,
                                    TraitAs hint = TraitAs::TENSOR);
 
+    GAPI_WRAP PyParams& cfgNumRequests(size_t nireq);
+
     GBackend      backend() const;
     std::string   tag()     const;
     cv::util::any params()  const;

--- a/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
@@ -22,22 +22,27 @@ namespace ie {
 // This class can be marked as SIMPLE, because it's implemented as pimpl
 class GAPI_EXPORTS_W_SIMPLE PyParams {
 public:
-    GAPI_WRAP PyParams() = default;
+    GAPI_WRAP
+    PyParams() = default;
 
-    GAPI_WRAP PyParams(const std::string &tag,
+    GAPI_WRAP
+    PyParams(const std::string &tag,
              const std::string &model,
              const std::string &weights,
              const std::string &device);
 
-    GAPI_WRAP PyParams(const std::string &tag,
-                       const std::string &model,
-                       const std::string &device);
+    GAPI_WRAP
+    PyParams(const std::string &tag,
+             const std::string &model,
+             const std::string &device);
 
-    GAPI_WRAP PyParams& constInput(const std::string &layer_name,
-                                   const cv::Mat &data,
-                                   TraitAs hint = TraitAs::TENSOR);
+    GAPI_WRAP
+    PyParams& constInput(const std::string &layer_name,
+                         const cv::Mat &data,
+                         TraitAs hint = TraitAs::TENSOR);
 
-    GAPI_WRAP PyParams& cfgNumRequests(size_t nireq);
+    GAPI_WRAP
+    PyParams& cfgNumRequests(size_t nireq);
 
     GBackend      backend() const;
     std::string   tag()     const;

--- a/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/bindings_ie.hpp
@@ -30,8 +30,8 @@ public:
              const std::string &device);
 
     GAPI_WRAP PyParams(const std::string &tag,
-             const std::string &model,
-             const std::string &device);
+                       const std::string &model,
+                       const std::string &device);
 
     GAPI_WRAP PyParams& constInput(const std::string &layer_name,
                                    const cv::Mat &data,

--- a/modules/gapi/src/backends/ie/bindings_ie.cpp
+++ b/modules/gapi/src/backends/ie/bindings_ie.cpp
@@ -44,3 +44,8 @@ cv::gapi::ie::PyParams& cv::gapi::ie::PyParams::constInput(const std::string &la
     m_priv->constInput(layer_name, data, hint);
     return *this;
 }
+
+cv::gapi::ie::PyParams& cv::gapi::ie::PyParams::cfgNumRequests(size_t nireq) {
+    m_priv->cfgNumRequests(nireq);
+    return *this;
+}

--- a/modules/gapi/src/backends/ie/bindings_ie.cpp
+++ b/modules/gapi/src/backends/ie/bindings_ie.cpp
@@ -37,3 +37,10 @@ cv::gapi::ie::PyParams cv::gapi::ie::params(const std::string &tag,
                                             const std::string &device) {
     return {tag, model, device};
 }
+
+cv::gapi::ie::PyParams& cv::gapi::ie::PyParams::constInput(const std::string &layer_name,
+                                                           const cv::Mat &data,
+                                                           TraitAs hint) {
+    m_priv->constInput(layer_name, data, hint);
+    return *this;
+}


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2021.3.0
build_image:Custom Mac=openvino-2021.3.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
// disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```