### PR TITLE
[G-API] Prohibit setPrecision & preprocessing for importedNetworks

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -274,9 +274,9 @@ struct IEUnit {
         }
         if (params.num_out == 1u && params.output_names.empty()) {
             if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
-                params.input_names = { outputs.begin()->first };
+                params.output_names = { outputs.begin()->first };
             } else {
-                params.input_names = { this_network.GetOutputsInfo().begin()->first };
+                params.output_names = { this_network.GetOutputsInfo().begin()->first };
             }
         }
         if (!params.reshape_table.empty()) {

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -243,10 +243,6 @@ struct IEUnit {
             this_plugin = cv::gimpl::ie::wrap::getPlugin(params);
             this_plugin.SetConfig(params.config);
             this_network = cv::gimpl::ie::wrap::importNetwork(this_plugin, params, rctx);
-            // FIXME: ICNNetwork returns InputsDataMap/OutputsDataMap,
-            // but ExecutableNetwork returns ConstInputsDataMap/ConstOutputsDataMap
-            inputs  = cv::gimpl::ie::wrap::toInputsDataMap(this_network.GetInputsInfo());
-            outputs = cv::gimpl::ie::wrap::toOutputsDataMap(this_network.GetOutputsInfo());
             if (!params.reshape_table.empty() || !params.layer_names_to_reshape.empty()) {
                 GAPI_LOG_WARNING(NULL, "Reshape isn't supported for imported network");
             }
@@ -270,10 +266,18 @@ struct IEUnit {
                                                    + params.model_path));
         }
         if (params.num_in == 1u && params.input_names.empty()) {
-            params.input_names = { inputs.begin()->first };
+            if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                params.input_names = { inputs.begin()->first };
+            } else {
+                params.input_names = { this_network.GetInputsInfo().begin()->first };
+            }
         }
         if (params.num_out == 1u && params.output_names.empty()) {
-            params.output_names = { outputs.begin()->first };
+            if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                params.input_names = { outputs.begin()->first };
+            } else {
+                params.input_names = { this_network.GetOutputsInfo().begin()->first };
+            }
         }
         if (!params.reshape_table.empty()) {
             GAPI_Assert((params.reshape_table.size() + params.layer_names_to_reshape.size()) <=
@@ -891,25 +895,30 @@ struct Infer: public cv::detail::KernelTag {
         // meta order.
         GAPI_Assert(uu.params.input_names.size() == in_metas.size()
                     && "Known input layers count doesn't match input meta count");
-        for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
-                                        ade::util::toRange(in_metas))) {
-            const auto &input_name = std::get<0>(it);
-            auto       &&ii = uu.inputs.at(input_name);
-            const auto & mm = std::get<1>(it);
 
-            configureInputInfo(ii, mm);
-            if (uu.params.layer_names_to_reshape.find(input_name) !=
-                uu.params.layer_names_to_reshape.end()) {
-                configureInputReshapeByImage(ii, mm, input_reshape_table);
+        // NB: Configuring input precision and network reshape must be done
+        // only for loadNetwork way.
+        if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+            for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
+                                            ade::util::toRange(in_metas))) {
+                    const auto &input_name = std::get<0>(it);
+                    auto       &&ii = uu.inputs.at(input_name);
+                    const auto & mm = std::get<1>(it);
+
+                    configureInputInfo(ii, mm);
+                    if (uu.params.layer_names_to_reshape.find(input_name) !=
+                            uu.params.layer_names_to_reshape.end()) {
+                        configureInputReshapeByImage(ii, mm, input_reshape_table);
+                    }
+                    ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
             }
-            ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
-        }
 
-        // FIXME: This isn't the best place to call reshape function.
-        // Сorrect solution would be to do this in compile() method of network,
-        // but now input meta isn't passed to compile() method.
-        if (!input_reshape_table.empty()) {
-            const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            // FIXME: This isn't the best place to call reshape function.
+            // Сorrect solution would be to do this in compile() method of network,
+            // but now input meta isn't passed to compile() method.
+            if (!input_reshape_table.empty()) {
+                const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            }
         }
 
         // FIXME: It would be nice here to have an exact number of network's
@@ -941,7 +950,17 @@ struct Infer: public cv::detail::KernelTag {
                             // and redirect our data producers to this memory
                             // (A memory dialog comes to the picture again)
                             IE::Blob::Ptr this_blob = extractBlob(*ctx, i);
-                            req.SetBlob(ctx->uu.params.input_names[i], this_blob);
+                            // NB: In case importNetwork preprocessing must be
+                            // passed as SetBlob argument.
+                            if (ctx->uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                                req.SetBlob(ctx->uu.params.input_names[i], this_blob);
+                            } else {
+                                IE::PreProcessInfo info;
+                                info.setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                                req.SetBlob(ctx->uu.params.input_names[i],
+                                            this_blob,
+                                            info);
+                            }
                         }
                         // FIXME: Should it be done by kernel ?
                         // What about to do that in RequestPool ?
@@ -973,22 +992,26 @@ struct InferROI: public cv::detail::KernelTag {
         GAPI_Assert(1u == uu.params.input_names.size());
         GAPI_Assert(2u == in_metas.size());
 
-        // 0th is ROI, 1st is input image
-        const auto &input_name = uu.params.input_names.at(0);
-        auto &&ii = uu.inputs.at(input_name);
-        auto &&mm = in_metas.at(1u);
-        configureInputInfo(ii, mm);
-        if (uu.params.layer_names_to_reshape.find(input_name) !=
-            uu.params.layer_names_to_reshape.end()) {
-            configureInputReshapeByImage(ii, mm, input_reshape_table);
-        }
-        ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
+        // NB: Configuring input precision and network reshape must be done
+        // only for loadNetwork way.
+        if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+            // 0th is ROI, 1st is input image
+            const auto &input_name = uu.params.input_names.at(0);
+            auto &&ii = uu.inputs.at(input_name);
+            auto &&mm = in_metas.at(1u);
+            configureInputInfo(ii, mm);
+            if (uu.params.layer_names_to_reshape.find(input_name) !=
+                uu.params.layer_names_to_reshape.end()) {
+                configureInputReshapeByImage(ii, mm, input_reshape_table);
+            }
+            ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
 
-        // FIXME: This isn't the best place to call reshape function.
-        // Сorrect solution would be to do this in compile() method of network,
-        // but now input meta isn't passed to compile() method.
-        if (!input_reshape_table.empty()) {
-            const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            // FIXME: This isn't the best place to call reshape function.
+            // Сorrect solution would be to do this in compile() method of network,
+            // but now input meta isn't passed to compile() method.
+            if (!input_reshape_table.empty()) {
+                const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            }
         }
 
         // FIXME: It would be nice here to have an exact number of network's
@@ -1018,8 +1041,18 @@ struct InferROI: public cv::detail::KernelTag {
 
                         IE::Blob::Ptr this_blob = extractBlob(*ctx, 1);
 
-                        req.SetBlob(*(ctx->uu.params.input_names.begin()),
-                                IE::make_shared_blob(this_blob, toIE(this_roi)));
+                        // NB: In case importNetwork preprocessing must be
+                        // passed as SetBlob argument.
+                        if (ctx->uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                            req.SetBlob(*(ctx->uu.params.input_names.begin()),
+                                    IE::make_shared_blob(this_blob, toIE(this_roi)));
+                        } else {
+                            IE::PreProcessInfo info;
+                            info.setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                            req.SetBlob(*(ctx->uu.params.input_names.begin()),
+                                    IE::make_shared_blob(this_blob, toIE(this_roi)),
+                                    info);
+                        }
 
                         // FIXME: Should it be done by kernel ?
                         // What about to do that in RequestPool ?
@@ -1055,23 +1088,27 @@ struct InferList: public cv::detail::KernelTag {
         GAPI_Assert(uu.params.input_names.size() == (in_metas.size() - 1u)
                     && "Known input layers count doesn't match input meta count");
 
-        std::size_t idx = 1u;
-        for (auto &&input_name : uu.params.input_names) {
-            auto       &&ii = uu.inputs.at(input_name);
-            const auto & mm = in_metas[idx++];
-            configureInputInfo(ii, mm);
-            if (uu.params.layer_names_to_reshape.find(input_name) !=
-                uu.params.layer_names_to_reshape.end()) {
-                configureInputReshapeByImage(ii, mm, input_reshape_table);
+        // NB: Configuring input precision and network reshape must be done
+        // only for loadNetwork way.
+        if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+            std::size_t idx = 1u;
+            for (auto &&input_name : uu.params.input_names) {
+                auto       &&ii = uu.inputs.at(input_name);
+                const auto & mm = in_metas[idx++];
+                configureInputInfo(ii, mm);
+                if (uu.params.layer_names_to_reshape.find(input_name) !=
+                    uu.params.layer_names_to_reshape.end()) {
+                    configureInputReshapeByImage(ii, mm, input_reshape_table);
+                }
+                ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
             }
-            ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
-        }
 
-        // FIXME: This isn't the best place to call reshape function.
-        // Сorrect solution would be to do this in compile() method of network,
-        // but now input meta isn't passed to compile() method.
-        if (!input_reshape_table.empty()) {
-            const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            // FIXME: This isn't the best place to call reshape function.
+            // Сorrect solution would be to do this in compile() method of network,
+            // but now input meta isn't passed to compile() method.
+            if (!input_reshape_table.empty()) {
+                const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+            }
         }
 
         // roi-list version is much easier at the moment.
@@ -1117,7 +1154,15 @@ struct InferList: public cv::detail::KernelTag {
                 cv::gimpl::ie::RequestPool::Task {
                     [ctx, rc, this_blob](InferenceEngine::InferRequest &req) {
                         IE::Blob::Ptr roi_blob = IE::make_shared_blob(this_blob, toIE(rc));
-                        req.SetBlob(ctx->uu.params.input_names[0u], roi_blob);
+                        // NB: In case importNetwork preprocessing must be
+                        // passed as SetBlob argument.
+                        if (ctx->uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                            req.SetBlob(ctx->uu.params.input_names[0u], roi_blob);
+                        } else {
+                            IE::PreProcessInfo info;
+                            info.setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                            req.SetBlob(ctx->uu.params.input_names[0u], roi_blob, info);
+                        }
                         req.StartAsync();
                     },
                     std::bind(callback, std::placeholders::_1, pos)
@@ -1191,19 +1236,23 @@ struct InferList2: public cv::detail::KernelTag {
                         && "Non-array inputs are not supported");
 
             if (op.k.inKinds[idx] == cv::detail::OpaqueKind::CV_RECT) {
-                // This is a cv::Rect -- configure the IE preprocessing
-                configureInputInfo(ii, mm_0);
-                if (uu.params.layer_names_to_reshape.find(input_name) !=
-                    uu.params.layer_names_to_reshape.end()) {
-                    configureInputReshapeByImage(ii, mm_0, input_reshape_table);
-                }
-                ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                // NB: Configuring input precision and network reshape must be done
+                // only for loadNetwork way.
+                if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                    // This is a cv::Rect -- configure the IE preprocessing
+                    configureInputInfo(ii, mm_0);
+                    if (uu.params.layer_names_to_reshape.find(input_name) !=
+                        uu.params.layer_names_to_reshape.end()) {
+                        configureInputReshapeByImage(ii, mm_0, input_reshape_table);
+                    }
+                    ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
 
-                // FIXME: This isn't the best place to call reshape function.
-                // Сorrect solution would be to do this in compile() method of network,
-                // but now input meta isn't passed to compile() method.
-                if (!input_reshape_table.empty()) {
-                    const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+                    // FIXME: This isn't the best place to call reshape function.
+                    // Сorrect solution would be to do this in compile() method of network,
+                    // but now input meta isn't passed to compile() method.
+                    if (!input_reshape_table.empty()) {
+                        const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
+                    }
                 }
             } else {
                 // This is a cv::GMat (equals to: cv::Mat)
@@ -1269,7 +1318,17 @@ struct InferList2: public cv::detail::KernelTag {
                                         "Only Rect and Mat types are supported for infer list 2!");
                             }
 
-                            req.SetBlob(ctx->uu.params.input_names[in_idx], this_blob);
+                            // NB: In case importNetwork preprocessing must be
+                            // passed as SetBlob argument.
+                            if (ctx->uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                                req.SetBlob(ctx->uu.params.input_names[in_idx], this_blob);
+                            } else {
+                                IE::PreProcessInfo info;
+                                info.setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                                req.SetBlob(ctx->uu.params.input_names[in_idx],
+                                            this_blob,
+                                            info);
+                            }
                         }
                         req.StartAsync();
                     },

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -915,7 +915,7 @@ struct Infer: public cv::detail::KernelTag {
                     && "Known input layers count doesn't match input meta count");
 
         // NB: Configuring input precision and network reshape must be done
-        // only for loadNetwork way.
+        // only in the loadNetwork case.
         if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
                                             ade::util::toRange(in_metas))) {
@@ -1004,7 +1004,7 @@ struct InferROI: public cv::detail::KernelTag {
         GAPI_Assert(2u == in_metas.size());
 
         // NB: Configuring input precision and network reshape must be done
-        // only for loadNetwork way.
+        // only in the loadNetwork case.
         if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             // 0th is ROI, 1st is input image
             const auto &input_name = uu.params.input_names.at(0);
@@ -1091,7 +1091,7 @@ struct InferList: public cv::detail::KernelTag {
                     && "Known input layers count doesn't match input meta count");
 
         // NB: Configuring input precision and network reshape must be done
-        // only for loadNetwork way.
+        // only in the loadNetwork case.
         if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             std::size_t idx = 1u;
             for (auto &&input_name : uu.params.input_names) {
@@ -1234,7 +1234,7 @@ struct InferList2: public cv::detail::KernelTag {
 
             if (op.k.inKinds[idx] == cv::detail::OpaqueKind::CV_RECT) {
                 // NB: Configuring input precision and network reshape must be done
-                // only for loadNetwork way.
+                // only in the loadNetwork case.
                 if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
                     // This is a cv::Rect -- configure the IE preprocessing
                     configureInputInfo(ii, mm_0);

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -22,24 +22,6 @@ namespace IE = InferenceEngine;
 namespace giewrap = cv::gimpl::ie::wrap;
 using GIEParam = cv::gapi::ie::detail::ParamDesc;
 
-IE::InputsDataMap giewrap::toInputsDataMap (const IE::ConstInputsDataMap& inputs) {
-    IE::InputsDataMap transformed;
-    auto convert = [](const std::pair<std::string, IE::InputInfo::CPtr>& p) {
-        return std::make_pair(p.first, std::const_pointer_cast<IE::InputInfo>(p.second));
-    };
-    std::transform(inputs.begin(), inputs.end(), std::inserter(transformed, transformed.end()), convert);
-    return transformed;
-}
-
-IE::OutputsDataMap giewrap::toOutputsDataMap (const IE::ConstOutputsDataMap& outputs) {
-    IE::OutputsDataMap transformed;
-    auto convert = [](const std::pair<std::string, IE::CDataPtr>& p) {
-        return std::make_pair(p.first, std::const_pointer_cast<IE::Data>(p.second));
-    };
-    std::transform(outputs.begin(), outputs.end(), std::inserter(transformed, transformed.end()), convert);
-    return transformed;
-}
-
 #if INF_ENGINE_RELEASE < 2020000000  // < 2020.1
 // Load extensions (taken from DNN module)
 std::vector<std::string> giewrap::getExtensions(const GIEParam& params) {

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.hpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.hpp
@@ -29,9 +29,6 @@ namespace wrap {
 GAPI_EXPORTS std::vector<std::string> getExtensions(const GIEParam& params);
 GAPI_EXPORTS IE::CNNNetwork readNetwork(const GIEParam& params);
 
-IE::InputsDataMap  toInputsDataMap (const IE::ConstInputsDataMap& inputs);
-IE::OutputsDataMap toOutputsDataMap(const IE::ConstOutputsDataMap& outputs);
-
 #if INF_ENGINE_RELEASE < 2019020000  // < 2019.R2
 using Plugin = IE::InferencePlugin;
 GAPI_EXPORTS IE::InferencePlugin getPlugin(const GIEParam& params);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```