### PR TITLE
Fix YUV indexes + YUV Planner detection condition

### DIFF
--- a/modules/videoio/src/cap_android_camera.cpp
+++ b/modules/videoio/src/cap_android_camera.cpp
@@ -304,8 +304,8 @@ public:
         AImage_getPlaneRowStride(image.get(), 0, &yStride);
         AImage_getPlaneRowStride(image.get(), 1, &uvStride);
         AImage_getPlaneData(image.get(), 0, &yPixel, &yLen);
-        AImage_getPlaneData(image.get(), 1, &vPixel, &vLen);
-        AImage_getPlaneData(image.get(), 2, &uPixel, &uLen);
+        AImage_getPlaneData(image.get(), 1, &uPixel, &uLen);
+        AImage_getPlaneData(image.get(), 2, &vPixel, &vLen);
         AImage_getPlanePixelStride(image.get(), 1, &uvPixelStride);
 
         if ( (uvPixelStride == 2) && (vPixel == uPixel + 1) && (yLen == frameWidth * frameHeight) && (uLen == ((yLen / 2) - 1)) && (vLen == uLen) ) {
@@ -313,7 +313,7 @@ public:
             if (fourCC == FOURCC_UNKNOWN) {
                 fourCC = FOURCC_NV21;
             }
-        } else if ( (uvPixelStride == 1) && (vPixel = uPixel + uLen) && (yLen == frameWidth * frameHeight) && (uLen == yLen / 4) && (vLen == uLen) ) {
+        } else if ( (uvPixelStride == 1) && (vPixel == uPixel + uLen) && (yLen == frameWidth * frameHeight) && (uLen == yLen / 4) && (vLen == uLen) ) {
             colorFormat = COLOR_FormatYUV420Planar;
             if (fourCC == FOURCC_UNKNOWN) {
                 fourCC = FOURCC_YV12;


### PR DESCRIPTION
continues #20509

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


The code was crashing on buffer.insert() line#330 on Android 11 Emulator with Camera2 NDK. This is tested with a C++ Test Application.

It looks like the U & V indexes are reversed and the YUVPlaner check condition is having an assignment operator than `==`.
This fix satisfies the YUV buffer memory layout expectation as in https://en.wikipedia.org/wiki/YUV#/media/File:Yuv420.svg