### PR TITLE
Throw an exception if VideoWriter write fails

### DIFF
--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -645,8 +645,8 @@ public:
         if (CV_ERROR_OK != plugin_api_->v0.Writer_write(writer_, img.data, (int)img.step[0], img.cols, img.rows, img.channels()))
         {
             CV_LOG_DEBUG(NULL, "Video I/O: Can't write frame by plugin '" << plugin_api_->api_header.api_description << "'");
+            throw;
         }
-        // TODO return bool result?
     }
     int getCaptureDomain() const CV_OVERRIDE
     {


### PR DESCRIPTION
Writing a matrix to the VideoWriter with an internal GStreamer pipeline does not report any errors. The pipeline might be broken due to a lost network connection (RTSP client stream). Without the exception it is impossible to trigger a reconnect.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
