### PR TITLE
docs(core/ocl): clarify ownership of arguments passed into OpenCL related functions

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -235,7 +235,11 @@ public:
 
     /**
      * @param d OpenCL handle (cl_device_id). clRetainDevice() is called on success.
-     */
+     *
+     * @note Ownership of the passed device is passed to OpenCV on success.
+     * The caller should additionally call `clRetainDevice` on it if it intends
+     * to continue using the device.
+      */
     static Device fromHandle(void* d);
 
     struct Impl;

--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -826,11 +826,13 @@ public:
     OpenCLExecutionContext cloneWithNewQueue() const;
 
     /** @brief Creates OpenCL execution context
-     * OpenCV will check if available OpenCL platform has platformName name, then assign context to
-     * OpenCV and call `clRetainContext` function. The deviceID device will be used as target device and
-     * new command queue will be created.
+     * OpenCV will check if available OpenCL platform has platformName name,
+     * then assign context to OpenCV.
+     * The deviceID device will be used as target device and a new command queue will be created.
      *
-     * @note Lifetime of passed handles is transferred to OpenCV wrappers on success
+     * @note On success, ownership of one reference of the context and device is taken.
+     * The caller should additionally call `clRetainContext` and/or `clRetainDevice`
+     * to increase the reference count if it wishes to continue using them.
      *
      * @param platformName name of OpenCL platform to attach, this string is used to check if platform is available to OpenCV at runtime
      * @param platformID ID of platform attached context was created for (cl_platform_id)


### PR DESCRIPTION
resolves #20518

I've documented the behavior of the following functions, which take ownership of one reference of the raw OpenCL arguments passed in:
 - `ocl::OpenCLExecutionContext::create`
 - `ocl::Device::fromHandle`

I did not change the documentation for the following functions, which do not take ownership of their arguments:
 - `ocl::Context::fromHandle`
 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
