### PR TITLE
fix opencv/opencv#20542 cv::countNonZero() for UMats that are non-OpenCL allocated

### DIFF
--- a/modules/core/src/count_non_zero.dispatch.cpp
+++ b/modules/core/src/count_non_zero.dispatch.cpp
@@ -132,7 +132,9 @@ int countNonZero(InputArray _src)
 #endif
 
 #ifdef HAVE_OPENCL
-    CV_OCL_RUN_(OCL_PERFORMANCE_CHECK(_src.isUMat()) && _src.dims() <= 2,
+    CV_OCL_RUN_(_src.isUMat() &&
+                _src.dims() <= 2 &&
+                _src.getUMat().u->currAllocator == ocl::getOpenCLAllocator(),
                 ocl_countNonZero(_src, res),
                 res)
 #endif


### PR DESCRIPTION
- fixes cv::countNonZero() for UMats that are non-OpenCL allocated https://github.com/opencv/opencv/issues/20542
- can be applied to both Opencv 3.4 and 4.x.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] The feature is well documented and sample code can be built with the project CMake
