### PR TITLE
VideoCapture add open/read timeout params to FFMPEG backend

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -186,6 +186,8 @@ enum VideoCaptureProperties {
        CAP_PROP_HW_ACCELERATION=50, //!< (**open-only**) Hardware acceleration type (see #VideoAccelerationType). Setting supported only via `params` parameter in cv::VideoCapture constructor / .open() method. Default value is backend-specific.
        CAP_PROP_HW_DEVICE      =51, //!< (**open-only**) Hardware device index (select GPU if multiple available). Device enumeration is acceleration type specific.
        CAP_PROP_HW_ACCELERATION_USE_OPENCL=52, //!< (**open-only**) If non-zero, create new OpenCL context and bind it to current thread. The OpenCL context created with Video Acceleration context attached it (if not attached yet) for optimized GPU data copy between HW accelerated decoder and cv::UMat.
+       CAP_PROP_OPEN_TIMEOUT_MSEC=53, //!< (**open-only**) timeout in milliseconds for opening a video capture (applicable for FFmpeg back-end only)
+       CAP_PROP_READ_TIMEOUT_MSEC=54, //!< (**open-only**) timeout in milliseconds for reading from a video capture (applicable for FFmpeg back-end only)
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -940,7 +940,7 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
         {
             open_timeout = params.get<int>(CAP_PROP_OPEN_TIMEOUT_MSEC);
         }
-        if (params.has(CAP_PROP_READ_TIMEOUT))
+        if (params.has(CAP_PROP_READ_TIMEOUT_MSEC))
         {
             read_timeout = params.get<int>(CAP_PROP_READ_TIMEOUT_MSEC);
         }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -183,8 +183,8 @@ extern "C" {
 #endif
 
 #if USE_AV_INTERRUPT_CALLBACK
-#define LIBAVFORMAT_INTERRUPT_OPEN_TIMEOUT_MS 30000
-#define LIBAVFORMAT_INTERRUPT_READ_TIMEOUT_MS 30000
+#define LIBAVFORMAT_INTERRUPT_OPEN_DEFAULT_TIMEOUT_MS 30000
+#define LIBAVFORMAT_INTERRUPT_READ_DEFAULT_TIMEOUT_MS 30000
 
 #ifdef _WIN32
 // http://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows
@@ -523,6 +523,8 @@ struct CvCapture_FFMPEG
 
     AVDictionary *dict;
 #if USE_AV_INTERRUPT_CALLBACK
+    int open_timeout;
+    int read_timeout;
     AVInterruptCallbackMetadata interrupt_metadata;
 #endif
 
@@ -568,6 +570,11 @@ void CvCapture_FFMPEG::init()
     rotation_auto = false;
 #endif
     dict = NULL;
+
+#if USE_AV_INTERRUPT_CALLBACK
+    open_timeout = LIBAVFORMAT_INTERRUPT_OPEN_DEFAULT_TIMEOUT_MS;
+    read_timeout = LIBAVFORMAT_INTERRUPT_READ_DEFAULT_TIMEOUT_MS;
+#endif
 
     rawMode = false;
     rawModeInitialized = false;
@@ -928,6 +935,16 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
         if (params.has(CAP_PROP_HW_ACCELERATION_USE_OPENCL)) {
             use_opencl = params.get<int>(CAP_PROP_HW_ACCELERATION_USE_OPENCL);
         }
+#if USE_AV_INTERRUPT_CALLBACK
+        if (params.has(CAP_PROP_OPEN_TIMEOUT))
+        {
+            open_timeout = params.get<int>(CAP_PROP_OPEN_TIMEOUT);
+        }
+        if (params.has(CAP_PROP_READ_TIMEOUT))
+        {
+            read_timeout = params.get<int>(CAP_PROP_READ_TIMEOUT);
+        }
+#endif
         if (params.warnUnusedParameters())
         {
             CV_LOG_ERROR(NULL, "VIDEOIO/FFMPEG: unsupported parameters in .open(), see logger INFO channel for details. Bailout");
@@ -937,7 +954,7 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
 
 #if USE_AV_INTERRUPT_CALLBACK
     /* interrupt callback */
-    interrupt_metadata.timeout_after_ms = LIBAVFORMAT_INTERRUPT_OPEN_TIMEOUT_MS;
+    interrupt_metadata.timeout_after_ms = open_timeout;
     get_monotonic_time(&interrupt_metadata.value);
 
     ic = avformat_alloc_context();
@@ -1282,7 +1299,7 @@ bool CvCapture_FFMPEG::grabFrame()
 #if USE_AV_INTERRUPT_CALLBACK
     // activate interrupt callback
     get_monotonic_time(&interrupt_metadata.value);
-    interrupt_metadata.timeout_after_ms = LIBAVFORMAT_INTERRUPT_READ_TIMEOUT_MS;
+    interrupt_metadata.timeout_after_ms = read_timeout;
 #endif
 
 #if USE_AV_SEND_FRAME_API

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -936,13 +936,13 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
             use_opencl = params.get<int>(CAP_PROP_HW_ACCELERATION_USE_OPENCL);
         }
 #if USE_AV_INTERRUPT_CALLBACK
-        if (params.has(CAP_PROP_OPEN_TIMEOUT))
+        if (params.has(CAP_PROP_OPEN_TIMEOUT_MSEC))
         {
-            open_timeout = params.get<int>(CAP_PROP_OPEN_TIMEOUT);
+            open_timeout = params.get<int>(CAP_PROP_OPEN_TIMEOUT_MSEC);
         }
         if (params.has(CAP_PROP_READ_TIMEOUT))
         {
-            read_timeout = params.get<int>(CAP_PROP_READ_TIMEOUT);
+            read_timeout = params.get<int>(CAP_PROP_READ_TIMEOUT_MSEC);
         }
 #endif
         if (params.warnUnusedParameters())


### PR DESCRIPTION
A little feature that was merged recently to 3.4

port of #20541

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
