### PR TITLE
[G-API] Extend compileStreaming to support different overloads

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -437,11 +437,7 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
-
-    /// @private -- Exclude this function from OpenCV documentation
-    GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                              GCompileArgs                   &&args = {});
+    GAPI_WRAP GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     /**
      * @brief Compile the computation for streaming mode.
@@ -462,7 +458,11 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+
+    /// @private -- Exclude this function from OpenCV documentation
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                                  GCompileArgs                   &&args = {});
 
     // 2. Direct metadata version
     /**

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -440,8 +440,8 @@ public:
     GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     /// @private -- Exclude this function from OpenCV documentation
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                                        GCompileArgs                   &&args = {});
+    GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                              GCompileArgs                   &&args = {});
 
     /**
      * @brief Compile the computation for streaming mode.

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -462,7 +462,7 @@ public:
 
     /// @private -- Exclude this function from OpenCV documentation
     GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                                  GCompileArgs                   &&args = {});
+                                                        GCompileArgs                   &&args = {});
 
     // 2. Direct metadata version
     /**

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -462,7 +462,7 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+    GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
 
     // 2. Direct metadata version
     /**

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -396,10 +396,10 @@ namespace streaming {
  * In the streaming mode the pipeline steps are connected with queues
  * and this compile argument controls every queue's size.
  */
-struct GAPI_EXPORTS queue_capacity
+struct GAPI_EXPORTS_W_SIMPLE queue_capacity
 {
-    explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
-    size_t capacity;
+    GAPI_WRAP explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
+    GAPI_PROP size_t capacity;
 };
 /** @} */
 } // namespace streaming

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -398,8 +398,10 @@ namespace streaming {
  */
 struct GAPI_EXPORTS_W_SIMPLE queue_capacity
 {
-    GAPI_WRAP explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
-    GAPI_PROP size_t capacity;
+    GAPI_WRAP
+    explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
+    GAPI_PROP_RW
+    size_t capacity;
 };
 /** @} */
 } // namespace streaming

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -295,3 +295,5 @@ cv.gapi.wip.draw.Line = cv.gapi_wip_draw_Line
 cv.gapi.wip.draw.Mosaic = cv.gapi_wip_draw_Mosaic
 cv.gapi.wip.draw.Image = cv.gapi_wip_draw_Image
 cv.gapi.wip.draw.Poly = cv.gapi_wip_draw_Poly
+
+cv.gapi.streaming.queue_capacity = cv.gapi_streaming_queue_capacity

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -206,6 +206,7 @@ bool pyopencv_to(PyObject* obj, cv::GMetaArg& value, const ArgInfo&)
     }
     else
     {
+        failmsg("Unsupported cv::GMetaArg type");
         return false;
     }
     return true;

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -176,40 +176,37 @@ bool pyopencv_to(PyObject* obj, cv::gapi::wip::draw::Prim& value, const ArgInfo&
     TRY_EXTRACT(Mosaic)
     TRY_EXTRACT(Image)
     TRY_EXTRACT(Poly)
+#undef TRY_EXTRACT
 
     failmsg("Unsupported primitive type");
     return false;
 }
 
 template <>
+bool pyopencv_to(PyObject* obj, cv::gapi::wip::draw::Prims& value, const ArgInfo& info)
+{
+    return pyopencv_to_generic_vec(obj, value, info);
+}
+
+template <>
 bool pyopencv_to(PyObject* obj, cv::GMetaArg& value, const ArgInfo&)
 {
-    if (PyObject_TypeCheck(obj,
-                reinterpret_cast<PyTypeObject*>(pyopencv_GMatDesc_TypePtr)))
-    {
-        value = reinterpret_cast<pyopencv_GMatDesc_t*>(obj)->v;
-    }
-    else if (PyObject_TypeCheck(obj,
-                reinterpret_cast<PyTypeObject*>(pyopencv_GScalarDesc_TypePtr)))
-    {
-        value = reinterpret_cast<pyopencv_GScalarDesc_t*>(obj)->v;
-    }
-    else if (PyObject_TypeCheck(obj,
-                reinterpret_cast<PyTypeObject*>(pyopencv_GArrayDesc_TypePtr)))
-    {
-        value = reinterpret_cast<pyopencv_GArrayDesc_t*>(obj)->v;
-    }
-    else if (PyObject_TypeCheck(obj,
-                reinterpret_cast<PyTypeObject*>(pyopencv_GOpaqueDesc_TypePtr)))
-    {
-        value = reinterpret_cast<pyopencv_GOpaqueDesc_t*>(obj)->v;
-    }
-    else
-    {
-        failmsg("Unsupported cv::GMetaArg type");
-        return false;
-    }
-    return true;
+#define TRY_EXTRACT(Meta)                                                    \
+    if (PyObject_TypeCheck(obj,                                              \
+                reinterpret_cast<PyTypeObject*>(pyopencv_##Meta##_TypePtr))) \
+    {                                                                        \
+        value = reinterpret_cast<pyopencv_##Meta##_t*>(obj)->v;              \
+        return true;                                                         \
+    }                                                                        \
+
+    TRY_EXTRACT(GMatDesc)
+    TRY_EXTRACT(GScalarDesc)
+    TRY_EXTRACT(GArrayDesc)
+    TRY_EXTRACT(GOpaqueDesc)
+#undef TRY_EXTRACT
+
+    failmsg("Unsupported cv::GMetaArg type");
+    return false;
 }
 
 template <>
@@ -218,11 +215,6 @@ bool pyopencv_to(PyObject* obj, cv::GMetaArgs& value, const ArgInfo& info)
     return pyopencv_to_generic_vec(obj, value, info);
 }
 
-template <>
-bool pyopencv_to(PyObject* obj, cv::gapi::wip::draw::Prims& value, const ArgInfo& info)
-{
-    return pyopencv_to_generic_vec(obj, value, info);
-}
 
 template<>
 PyObject* pyopencv_from(const cv::GArg& value)

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -5,8 +5,9 @@ namespace cv
 {
 struct GAPI_EXPORTS_W_SIMPLE GCompileArg
 {
-    GAPI_WRAP GCompileArg(gapi::GKernelPackage pkg);
-    GAPI_WRAP GCompileArg(gapi::GNetPackage pkg);
+    GAPI_WRAP GCompileArg(gapi::GKernelPackage arg);
+    GAPI_WRAP GCompileArg(gapi::GNetPackage arg);
+    GAPI_WRAP GCompileArg(gapi::streaming::queue_capacity arg);
 };
 
 class GAPI_EXPORTS_W_SIMPLE GInferInputs
@@ -37,16 +38,6 @@ class GAPI_EXPORTS_W_SIMPLE GInferListOutputs
 public:
     GAPI_WRAP GInferListOutputs();
     GAPI_WRAP cv::GArray<cv::GMat> at(const std::string& name);
-};
-
-class GComputation
-{
-public:
-    GAPI_WRAP GStreamingCompiled compileStreaming();
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                                        GCompileArgs                   &&args);
 };
 
 namespace gapi

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -42,9 +42,11 @@ public:
 class GComputation
 {
 public:
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
     GAPI_WRAP GStreamingCompiled compileStreaming();
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                                        GCompileArgs                   &&args);
 };
 
 namespace gapi

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -39,6 +39,14 @@ public:
     GAPI_WRAP cv::GArray<cv::GMat> at(const std::string& name);
 };
 
+class GComputation
+{
+public:
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
+    GAPI_WRAP GStreamingCompiled compileStreaming();
+};
+
 namespace gapi
 {
 namespace wip

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -36,297 +36,29 @@ try:
 
     class test_gapi_streaming(NewOpenCVTests):
 
-        # def test_image_input(self):
-            # sz = (1280, 720)
-            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            # # OpenCV
-            # expected = cv.medianBlur(in_mat, 3)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out = cv.gapi.medianBlur(g_in, 3)
-            # c = cv.GComputation(g_in, g_out)
-            # ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
-            # ccomp.setSource(cv.gin(in_mat))
-            # ccomp.start()
-
-            # _, actual = ccomp.pull()
-
-            # # Assert
-            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-
-        # def test_video_input(self):
-            # ksize = 3
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out = cv.gapi.medianBlur(g_in, ksize)
-            # c = cv.GComputation(g_in, g_out)
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, expected = cap.read()
-                # has_actual,   actual   = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_split3(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # b, g, r = cv.gapi.split3(g_in)
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame = cap.read()
-                # has_actual,   actual   = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # expected = cv.split(frame)
-                # for e, a in zip(expected, actual):
-                    # self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_add(self):
-            # sz = (576, 768, 3)
-            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in1 = cv.GMat()
-            # g_in2 = cv.GMat()
-            # out = cv.gapi.add(g_in1, g_in2)
-            # c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source, in_mat))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame  = cap.read()
-                # has_actual,   actual = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # expected = cv.add(frame, in_mat)
-                # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_good_features_to_track(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # NB: goodFeaturesToTrack configuration
-            # max_corners         = 50
-            # quality_lvl         = 0.01
-            # min_distance        = 10
-            # block_sz            = 3
-            # use_harris_detector = True
-            # k                   = 0.04
-            # mask                = None
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_gray = cv.gapi.RGB2Gray(g_in)
-            # g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
-                                                # min_distance, mask, block_sz, use_harris_detector, k)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame  = cap.read()
-                # has_actual,   actual = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # # OpenCV
-                # frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
-                # expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
-                                                  # min_distance, mask=mask,
-                                                  # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-                # for e, a in zip(expected, actual):
-                    # # NB: OpenCV & G-API have different output shapes:
-                    # # OpenCV - (num_points, 1, 2)
-                    # # G-API  - (num_points, 2)
-                    # self.assertEqual(0.0, cv.norm(e.flatten(),
-                                                  # np.array(a, np.float32).flatten(),
-                                                  # cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_gapi_streaming_meta(self):
-            # ksize = 3
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_ts = cv.gapi.streaming.timestamp(g_in)
-            # g_seqno = cv.gapi.streaming.seqNo(g_in)
-            # g_seqid = cv.gapi.streaming.seq_id(g_in)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # curr_frame_number = 0
-            # while True:
-                # has_frame, (ts, seqno, seqid) = ccomp.pull()
-
-                # if not has_frame:
-                    # break
-
-                # self.assertEqual(curr_frame_number, seqno)
-                # self.assertEqual(curr_frame_number, seqid)
-
-                # curr_frame_number += 1
-                # if curr_frame_number == max_num_frames:
-                    # break
-
-
-        # def test_desync(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out1 = cv.gapi.copy(g_in)
-            # des = cv.gapi.streaming.desync(g_in)
-            # g_out2 = GDelay.on(des)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
-
-            # kernels = cv.gapi.kernels(GDelayImpl)
-            # ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-
-            # out_counter = 0
-            # desync_out_counter = 0
-            # none_counter = 0
-            # while True:
-                # has_frame, (out1, out2) = ccomp.pull()
-                # if not has_frame:
-                    # break
-
-                # if not out1 is None:
-                    # out_counter += 1
-                # if not out2 is None:
-                    # desync_out_counter += 1
-                # else:
-                    # none_counter += 1
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # ccomp.stop()
-                    # break
-
-            # self.assertLess(0, proc_num_frames)
-            # self.assertLess(desync_out_counter, out_counter)
-            # self.assertLess(0, none_counter)
+        def test_image_input(self):
+            sz = (1280, 720)
+            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            # OpenCV
+            expected = cv.medianBlur(in_mat, 3)
+
+            # G-API
+            g_in = cv.GMat()
+            g_out = cv.gapi.medianBlur(g_in, 3)
+            c = cv.GComputation(g_in, g_out)
+            ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
+            ccomp.setSource(cv.gin(in_mat))
+            ccomp.start()
+
+            _, actual = ccomp.pull()
+
+            # Assert
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
 
         def test_video_input(self):
-            @cv.gapi.op('custom.mean', in_types=[cv.GMat, tuple], out_types=[cv.GScalar])
-            class GBlur:
-                """Blur input image"""
-
-                @staticmethod
-                def outMeta(desc, ksize):
-                    return desc
-
-
-            @cv.gapi.kernel(GBlur)
-            class GBlurImpl:
-                """Implementation for GBlur operation."""
-
-                @staticmethod
-                def run(img, ksize):
-                    return cv.blur(img, ksize)
-
-            ksize = (10, 10)
+            ksize = 3
             path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
             # OpenCV
@@ -334,20 +66,288 @@ try:
 
             # G-API
             g_in = cv.GMat()
-            g_out = GBlur.on(g_in, ksize)
+            g_out = cv.gapi.medianBlur(g_in, ksize)
             c = cv.GComputation(g_in, g_out)
 
-            kernels = cv.gapi.kernels(GBlurImpl)
-            # ccomp = c.compileStreaming(cv.GMatDesc())
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
 
-            # ccomp = c.compileStreaming(cv.gapi.compile_args(...), cv.GMatDesc())
-            # ccomp = c.compileStreaming()
-            ccomp = c.compileStreaming(cv.gapi.compile_args(kernels))
-            # ccomp = c.compileStreaming(cv.gapi.compile_args(...))
-            # ccomp = c.compileStreaming(cv.GMatDesc())
-            # ccomp = c.compileStreaming(cv.descr_of(img))
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, expected = cap.read()
+                has_actual,   actual   = ccomp.pull()
 
-            # print('HHHHHHHHHHHHHHHHHHHHH')
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_split3(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in = cv.GMat()
+            b, g, r = cv.gapi.split3(g_in)
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame = cap.read()
+                has_actual,   actual   = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                expected = cv.split(frame)
+                for e, a in zip(expected, actual):
+                    self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_add(self):
+            sz = (576, 768, 3)
+            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in1 = cv.GMat()
+            g_in2 = cv.GMat()
+            out = cv.gapi.add(g_in1, g_in2)
+            c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source, in_mat))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame  = cap.read()
+                has_actual,   actual = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                expected = cv.add(frame, in_mat)
+                self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_good_features_to_track(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # NB: goodFeaturesToTrack configuration
+            max_corners         = 50
+            quality_lvl         = 0.01
+            min_distance        = 10
+            block_sz            = 3
+            use_harris_detector = True
+            k                   = 0.04
+            mask                = None
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in = cv.GMat()
+            g_gray = cv.gapi.RGB2Gray(g_in)
+            g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
+                                                min_distance, mask, block_sz, use_harris_detector, k)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame  = cap.read()
+                has_actual,   actual = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                # OpenCV
+                frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
+                                                  min_distance, mask=mask,
+                                                  blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+                for e, a in zip(expected, actual):
+                    # NB: OpenCV & G-API have different output shapes:
+                    # OpenCV - (num_points, 1, 2)
+                    # G-API  - (num_points, 2)
+                    self.assertEqual(0.0, cv.norm(e.flatten(),
+                                                  np.array(a, np.float32).flatten(),
+                                                  cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_gapi_streaming_meta(self):
+            ksize = 3
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # G-API
+            g_in = cv.GMat()
+            g_ts = cv.gapi.streaming.timestamp(g_in)
+            g_seqno = cv.gapi.streaming.seqNo(g_in)
+            g_seqid = cv.gapi.streaming.seq_id(g_in)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            curr_frame_number = 0
+            while True:
+                has_frame, (ts, seqno, seqid) = ccomp.pull()
+
+                if not has_frame:
+                    break
+
+                self.assertEqual(curr_frame_number, seqno)
+                self.assertEqual(curr_frame_number, seqid)
+
+                curr_frame_number += 1
+                if curr_frame_number == max_num_frames:
+                    break
+
+
+        def test_desync(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # G-API
+            g_in = cv.GMat()
+            g_out1 = cv.gapi.copy(g_in)
+            des = cv.gapi.streaming.desync(g_in)
+            g_out2 = GDelay.on(des)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
+
+            kernels = cv.gapi.kernels(GDelayImpl)
+            ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+
+            out_counter = 0
+            desync_out_counter = 0
+            none_counter = 0
+            while True:
+                has_frame, (out1, out2) = ccomp.pull()
+                if not has_frame:
+                    break
+
+                if not out1 is None:
+                    out_counter += 1
+                if not out2 is None:
+                    desync_out_counter += 1
+                else:
+                    none_counter += 1
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    ccomp.stop()
+                    break
+
+            self.assertLess(0, proc_num_frames)
+            self.assertLess(desync_out_counter, out_counter)
+            self.assertLess(0, none_counter)
+
+
+        def test_compile_streaming_empty(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            comp.compileStreaming()
+
+
+        def test_compile_streaming_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        def test_compile_streaming_gin(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming(cv.gin(img))
+
+
+        def test_compile_streaming_gin_and_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming(cv.gin(img),
+                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        def test_compile_streaming_meta(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
+
+
+        def test_compile_streaming_meta_and_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))],
+                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
 

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -36,29 +36,297 @@ try:
 
     class test_gapi_streaming(NewOpenCVTests):
 
-        def test_image_input(self):
-            sz = (1280, 720)
-            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        # def test_image_input(self):
+            # sz = (1280, 720)
+            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
 
-            # OpenCV
-            expected = cv.medianBlur(in_mat, 3)
+            # # OpenCV
+            # expected = cv.medianBlur(in_mat, 3)
 
-            # G-API
-            g_in = cv.GMat()
-            g_out = cv.gapi.medianBlur(g_in, 3)
-            c = cv.GComputation(g_in, g_out)
-            ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
-            ccomp.setSource(cv.gin(in_mat))
-            ccomp.start()
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = cv.gapi.medianBlur(g_in, 3)
+            # c = cv.GComputation(g_in, g_out)
+            # ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
+            # ccomp.setSource(cv.gin(in_mat))
+            # ccomp.start()
 
-            _, actual = ccomp.pull()
+            # _, actual = ccomp.pull()
 
-            # Assert
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            # # Assert
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_video_input(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = cv.gapi.medianBlur(g_in, ksize)
+            # c = cv.GComputation(g_in, g_out)
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, expected = cap.read()
+                # has_actual,   actual   = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_split3(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # b, g, r = cv.gapi.split3(g_in)
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame = cap.read()
+                # has_actual,   actual   = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # expected = cv.split(frame)
+                # for e, a in zip(expected, actual):
+                    # self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_add(self):
+            # sz = (576, 768, 3)
+            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in1 = cv.GMat()
+            # g_in2 = cv.GMat()
+            # out = cv.gapi.add(g_in1, g_in2)
+            # c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source, in_mat))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # expected = cv.add(frame, in_mat)
+                # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_good_features_to_track(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # NB: goodFeaturesToTrack configuration
+            # max_corners         = 50
+            # quality_lvl         = 0.01
+            # min_distance        = 10
+            # block_sz            = 3
+            # use_harris_detector = True
+            # k                   = 0.04
+            # mask                = None
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_gray = cv.gapi.RGB2Gray(g_in)
+            # g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
+                                                # min_distance, mask, block_sz, use_harris_detector, k)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # # OpenCV
+                # frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                # expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
+                                                  # min_distance, mask=mask,
+                                                  # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+                # for e, a in zip(expected, actual):
+                    # # NB: OpenCV & G-API have different output shapes:
+                    # # OpenCV - (num_points, 1, 2)
+                    # # G-API  - (num_points, 2)
+                    # self.assertEqual(0.0, cv.norm(e.flatten(),
+                                                  # np.array(a, np.float32).flatten(),
+                                                  # cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_gapi_streaming_meta(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_ts = cv.gapi.streaming.timestamp(g_in)
+            # g_seqno = cv.gapi.streaming.seqNo(g_in)
+            # g_seqid = cv.gapi.streaming.seq_id(g_in)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # curr_frame_number = 0
+            # while True:
+                # has_frame, (ts, seqno, seqid) = ccomp.pull()
+
+                # if not has_frame:
+                    # break
+
+                # self.assertEqual(curr_frame_number, seqno)
+                # self.assertEqual(curr_frame_number, seqid)
+
+                # curr_frame_number += 1
+                # if curr_frame_number == max_num_frames:
+                    # break
+
+
+        # def test_desync(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out1 = cv.gapi.copy(g_in)
+            # des = cv.gapi.streaming.desync(g_in)
+            # g_out2 = GDelay.on(des)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
+
+            # kernels = cv.gapi.kernels(GDelayImpl)
+            # ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+
+            # out_counter = 0
+            # desync_out_counter = 0
+            # none_counter = 0
+            # while True:
+                # has_frame, (out1, out2) = ccomp.pull()
+                # if not has_frame:
+                    # break
+
+                # if not out1 is None:
+                    # out_counter += 1
+                # if not out2 is None:
+                    # desync_out_counter += 1
+                # else:
+                    # none_counter += 1
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # ccomp.stop()
+                    # break
+
+            # self.assertLess(0, proc_num_frames)
+            # self.assertLess(desync_out_counter, out_counter)
+            # self.assertLess(0, none_counter)
 
 
         def test_video_input(self):
-            ksize = 3
+            @cv.gapi.op('custom.mean', in_types=[cv.GMat, tuple], out_types=[cv.GScalar])
+            class GBlur:
+                """Blur input image"""
+
+                @staticmethod
+                def outMeta(desc, ksize):
+                    return desc
+
+
+            @cv.gapi.kernel(GBlur)
+            class GBlurImpl:
+                """Implementation for GBlur operation."""
+
+                @staticmethod
+                def run(img, ksize):
+                    return cv.blur(img, ksize)
+
+            ksize = (10, 10)
             path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
             # OpenCV
@@ -66,245 +334,21 @@ try:
 
             # G-API
             g_in = cv.GMat()
-            g_out = cv.gapi.medianBlur(g_in, ksize)
+            g_out = GBlur.on(g_in, ksize)
             c = cv.GComputation(g_in, g_out)
 
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
+            kernels = cv.gapi.kernels(GBlurImpl)
+            # ccomp = c.compileStreaming(cv.GMatDesc())
 
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, expected = cap.read()
-                has_actual,   actual   = ccomp.pull()
+            # ccomp = c.compileStreaming(cv.gapi.compile_args(...), cv.GMatDesc())
+            # ccomp = c.compileStreaming()
+            ccomp = c.compileStreaming(cv.gapi.compile_args(kernels))
+            # ccomp = c.compileStreaming(cv.gapi.compile_args(...))
+            # ccomp = c.compileStreaming(cv.GMatDesc())
+            # ccomp = c.compileStreaming(cv.descr_of(img))
 
-                self.assertEqual(has_expected, has_actual)
+            # print('HHHHHHHHHHHHHHHHHHHHH')
 
-                if not has_actual:
-                    break
-
-                self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_split3(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in = cv.GMat()
-            b, g, r = cv.gapi.split3(g_in)
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame = cap.read()
-                has_actual,   actual   = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                expected = cv.split(frame)
-                for e, a in zip(expected, actual):
-                    self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_add(self):
-            sz = (576, 768, 3)
-            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in1 = cv.GMat()
-            g_in2 = cv.GMat()
-            out = cv.gapi.add(g_in1, g_in2)
-            c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source, in_mat))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                expected = cv.add(frame, in_mat)
-                self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_good_features_to_track(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # NB: goodFeaturesToTrack configuration
-            max_corners         = 50
-            quality_lvl         = 0.01
-            min_distance        = 10
-            block_sz            = 3
-            use_harris_detector = True
-            k                   = 0.04
-            mask                = None
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in = cv.GMat()
-            g_gray = cv.gapi.RGB2Gray(g_in)
-            g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
-                                                min_distance, mask, block_sz, use_harris_detector, k)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                # OpenCV
-                frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
-                expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
-                                                  min_distance, mask=mask,
-                                                  blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-                for e, a in zip(expected, actual):
-                    # NB: OpenCV & G-API have different output shapes:
-                    # OpenCV - (num_points, 1, 2)
-                    # G-API  - (num_points, 2)
-                    self.assertEqual(0.0, cv.norm(e.flatten(),
-                                                  np.array(a, np.float32).flatten(),
-                                                  cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_gapi_streaming_meta(self):
-            ksize = 3
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_ts = cv.gapi.streaming.timestamp(g_in)
-            g_seqno = cv.gapi.streaming.seqNo(g_in)
-            g_seqid = cv.gapi.streaming.seq_id(g_in)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            curr_frame_number = 0
-            while True:
-                has_frame, (ts, seqno, seqid) = ccomp.pull()
-
-                if not has_frame:
-                    break
-
-                self.assertEqual(curr_frame_number, seqno)
-                self.assertEqual(curr_frame_number, seqid)
-
-                curr_frame_number += 1
-                if curr_frame_number == max_num_frames:
-                    break
-
-        def test_desync(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_out1 = cv.gapi.copy(g_in)
-            des = cv.gapi.streaming.desync(g_in)
-            g_out2 = GDelay.on(des)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
-
-            kernels = cv.gapi.kernels(GDelayImpl)
-            ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-
-            out_counter = 0
-            desync_out_counter = 0
-            none_counter = 0
-            while True:
-                has_frame, (out1, out2) = ccomp.pull()
-                if not has_frame:
-                    break
-
-                if not out1 is None:
-                    out_counter += 1
-                if not out2 is None:
-                    desync_out_counter += 1
-                else:
-                    none_counter += 1
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    ccomp.stop()
-                    break
-
-            self.assertLess(0, proc_num_frames)
-            self.assertLess(desync_out_counter, out_counter)
-            self.assertLess(0, none_counter)
 
 
 except unittest.SkipTest as e:

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -320,18 +320,18 @@ try:
             comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
-        def test_compile_streaming_gin(self):
+        def test_compile_streaming_descr_of(self):
             g_in = cv.GMat()
             comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
             img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gin(img))
+            comp.compileStreaming(cv.gapi.descr_of(img))
 
 
-        def test_compile_streaming_gin_and_args(self):
+        def test_compile_streaming_descr_of_and_args(self):
             g_in = cv.GMat()
             comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
             img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gin(img),
+            comp.compileStreaming(cv.gapi.descr_of(img),
                     cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Overview
The goal of this PR is to support all different overloads for `compileStreaming` method in python, such as:
* compileStreaming(cv::GMetaArgs, cv::GCompileArgs = { })
* compileStreaming(cv::ExtractMetaCallback, cv::GCompileArgs = { })
* compileStreaming(cv::GCompileArgs = { })

To wrap these methods need to add `GAPI_WRAP` macros before every signature. The generated code will try every overloads in order from top to bottom as declared in c++ file and if overload isn't suitable (`pyopencv_to` for params return false) try the next one. So the problem was that `pyopencv_to(cv::ExtractMetaCallback)` always return `true` which means  that the `compileStreaming(cv::ExtractMetaCallback, cv::GCompileArgs = { })` is always suitable.
So the possible solution for that problem is put this overload in the end in that case it will be chosen only if others aren't suitable.


* Added `queue_capacity` compile arg in order to test overloads.
* Implemented `pyopencv_to(cv::GMetaArg)` in order to wrap `compileStreaming(cv::GMetaArgs, cv::GCompileArgs)`

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```