### PR TITLE
fix Split partial sum

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -851,7 +851,7 @@ void ONNXImporter::parseSplit(LayerParams& layerParams, const opencv_onnx::NodeP
         std::vector<int> slicePoints(numSplits - 1, splits.get<int>(0));
         for (int i = 1; i < splits.size() - 1; ++i)
         {
-            slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i - 1);
+            slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i);
         }
         layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
     }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -617,6 +617,7 @@ TEST_P(Test_ONNX_layers, Split)
     testONNXModels("split_2");
     testONNXModels("split_3");
     testONNXModels("split_4");
+    testONNXModels("split_sizes");
 }
 
 TEST_P(Test_ONNX_layers, Slice)


### PR DESCRIPTION
Test data is at https://github.com/opencv/opencv_extra/pull/895

`opencv_extra=onnx_split_sum_fix`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
