### PR TITLE
python: cv.Mat wrapper over numpy.ndarray

### DIFF
--- a/doc/py_tutorials/py_bindings/py_bindings_basics/py_bindings_basics.markdown
+++ b/doc/py_tutorials/py_bindings/py_bindings_basics/py_bindings_basics.markdown
@@ -60,6 +60,14 @@ of C++.
 
 So this is the basic version of how OpenCV-Python bindings are generated.
 
+@note There is no 1:1 mapping of numpy.ndarray on cv::Mat. For example, cv::Mat has channels field,
+which is emulated as last dimension of numpy.ndarray and implicitly converted.
+However, such implicit conversion has problem with passing of 3D numpy arrays into C++ code
+(the last dimension is implicitly reinterpreted as number of channels).
+Refer to the [issue](https://github.com/opencv/opencv/issues/19091) for workarounds if you need to process 3D arrays or ND-arrays with channels.
+OpenCV 4.5.4+ has `cv.Mat` wrapper derived from `numpy.ndarray` to explicitly handle the channels behavior.
+
+
 How to extend new modules to Python?
 ------------------------------------
 

--- a/modules/core/misc/python/package/mat_wrapper/__init__.py
+++ b/modules/core/misc/python/package/mat_wrapper/__init__.py
@@ -1,0 +1,33 @@
+__all__ = []
+
+import sys
+import numpy as np
+import cv2 as cv
+
+# NumPy documentation: https://numpy.org/doc/stable/user/basics.subclassing.html
+
+class Mat(np.ndarray):
+    '''
+    cv.Mat wrapper for numpy array.
+
+    Stores extra metadata information how to interpret and process of numpy array for underlying C++ code.
+    '''
+
+    def __new__(cls, arr, **kwargs):
+        obj = arr.view(Mat)
+        return obj
+
+    def __init__(self, arr, **kwargs):
+        self.wrap_channels = kwargs.pop('wrap_channels', getattr(arr, 'wrap_channels', False))
+        if len(kwargs) > 0:
+            raise TypeError('Unknown parameters: {}'.format(repr(kwargs)))
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.wrap_channels = getattr(obj, 'wrap_channels', None)
+
+
+Mat.__module__ = cv.__name__
+cv.Mat = Mat
+cv._registerMatType(Mat)

--- a/modules/python/test/test_mat.py
+++ b/modules/python/test/test_mat.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import numpy as np
+import cv2 as cv
+
+import os
+import sys
+import unittest
+
+from tests_common import NewOpenCVTests
+
+try:
+    if sys.version_info[:2] < (3, 0):
+        raise unittest.SkipTest('Python 2.x is not supported')
+
+
+    class MatTest(NewOpenCVTests):
+
+        def test_mat_construct(self):
+            data = np.random.random([10, 10, 3])
+
+            #print(np.ndarray.__dictoffset__)  # 0
+            #print(cv.Mat.__dictoffset__)  # 88 (> 0)
+            #print(cv.Mat)  # <class cv2.Mat>
+            #print(cv.Mat.__base__)  # <class 'numpy.ndarray'>
+
+            mat_data0 = cv.Mat(data)
+            assert isinstance(mat_data0, cv.Mat)
+            assert isinstance(mat_data0, np.ndarray)
+            self.assertEqual(mat_data0.wrap_channels, False)
+            res0 = cv.utils.dumpInputArray(mat_data0)
+            self.assertEqual(res0, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=300 dims(-1)=3 size(-1)=[10 10 3] type(-1)=CV_64FC1")
+
+            mat_data1 = cv.Mat(data, wrap_channels=True)
+            assert isinstance(mat_data1, cv.Mat)
+            assert isinstance(mat_data1, np.ndarray)
+            self.assertEqual(mat_data1.wrap_channels, True)
+            res1 = cv.utils.dumpInputArray(mat_data1)
+            self.assertEqual(res1, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=100 dims(-1)=2 size(-1)=10x10 type(-1)=CV_64FC3")
+
+            mat_data2 = cv.Mat(mat_data1)
+            assert isinstance(mat_data2, cv.Mat)
+            assert isinstance(mat_data2, np.ndarray)
+            self.assertEqual(mat_data2.wrap_channels, True)  # fail if __array_finalize__ doesn't work
+            res2 = cv.utils.dumpInputArray(mat_data2)
+            self.assertEqual(res2, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=100 dims(-1)=2 size(-1)=10x10 type(-1)=CV_64FC3")
+
+
+        def test_mat_construct_4d(self):
+            data = np.random.random([5, 10, 10, 3])
+
+            mat_data0 = cv.Mat(data)
+            assert isinstance(mat_data0, cv.Mat)
+            assert isinstance(mat_data0, np.ndarray)
+            self.assertEqual(mat_data0.wrap_channels, False)
+            res0 = cv.utils.dumpInputArray(mat_data0)
+            self.assertEqual(res0, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=1500 dims(-1)=4 size(-1)=[5 10 10 3] type(-1)=CV_64FC1")
+
+            mat_data1 = cv.Mat(data, wrap_channels=True)
+            assert isinstance(mat_data1, cv.Mat)
+            assert isinstance(mat_data1, np.ndarray)
+            self.assertEqual(mat_data1.wrap_channels, True)
+            res1 = cv.utils.dumpInputArray(mat_data1)
+            self.assertEqual(res1, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=500 dims(-1)=3 size(-1)=[5 10 10] type(-1)=CV_64FC3")
+
+            mat_data2 = cv.Mat(mat_data1)
+            assert isinstance(mat_data2, cv.Mat)
+            assert isinstance(mat_data2, np.ndarray)
+            self.assertEqual(mat_data2.wrap_channels, True)  # __array_finalize__ doesn't work
+            res2 = cv.utils.dumpInputArray(mat_data2)
+            self.assertEqual(res2, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=500 dims(-1)=3 size(-1)=[5 10 10] type(-1)=CV_64FC3")
+
+
+        def test_mat_wrap_channels_fail(self):
+            data = np.random.random([2, 3, 4, 520])
+
+            mat_data0 = cv.Mat(data)
+            assert isinstance(mat_data0, cv.Mat)
+            assert isinstance(mat_data0, np.ndarray)
+            self.assertEqual(mat_data0.wrap_channels, False)
+            res0 = cv.utils.dumpInputArray(mat_data0)
+            self.assertEqual(res0, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=12480 dims(-1)=4 size(-1)=[2 3 4 520] type(-1)=CV_64FC1")
+
+            with self.assertRaises(cv.error):
+                mat_data1 = cv.Mat(data, wrap_channels=True)  # argument unable to wrap channels, too high (520 > CV_CN_MAX=512)
+                res1 = cv.utils.dumpInputArray(mat_data1)
+                print(mat_data1.__dict__)
+                print(res1)
+
+
+        def test_ufuncs(self):
+            data = np.arange(10)
+            mat_data = cv.Mat(data)
+            mat_data2 = 2 * mat_data
+            self.assertEqual(type(mat_data2), cv.Mat)
+            np.testing.assert_equal(2 * data, 2 * mat_data)
+
+
+        def test_comparison(self):
+            # Undefined behavior, do NOT use that.
+            # Behavior may be changed in the future
+
+            data = np.ones((10, 10, 3))
+            mat_wrapped = cv.Mat(data, wrap_channels=True)
+            mat_simple = cv.Mat(data)
+            np.testing.assert_equal(mat_wrapped, mat_simple)  # ???: wrap_channels is not checked for now
+            np.testing.assert_equal(data, mat_simple)
+            np.testing.assert_equal(data, mat_wrapped)
+
+            #self.assertEqual(mat_wrapped, mat_simple)  # ???
+            #self.assertTrue(mat_wrapped == mat_simple)  # ???
+            #self.assertTrue((mat_wrapped == mat_simple).all())
+
+
+except unittest.SkipTest as e:
+
+    message = str(e)
+
+    class TestSkip(unittest.TestCase):
+        def setUp(self):
+            self.skipTest('Skip tests: ' + message)
+
+        def test_skip():
+            pass
+
+    pass
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -10,6 +10,7 @@ import random
 import argparse
 
 import numpy as np
+#sys.OpenCV_LOADER_DEBUG = True
 import cv2 as cv
 
 # Python 3 moved urlopen to urllib.requests


### PR DESCRIPTION
resolves #19091

~~**On hold, merge after**: #20611~~

Usage:
```
# data3D = np.zeros((3,3,2))
cv.call(cv.Mat(data3D))
cv.call(data3D)  # passes as 2D array with the last dimension wrapped into channels (current behavior for images)
```

C++-written cv.Mat is not reliable with Python limited API and numpy 1.20+ (not stable ABI guarantee).
Package loader is required (OPENCV_SKIP_PYTHON_LOADER must be OFF).
No plans to backport to "3.4" maintenance branch.
No plans to support Python 2.7.

<cut/>

TODO:
- [x] update [documentation](http://pullrequest.opencv.org/buildbot/export/pr/20558/docs/da/d49/tutorial_py_bindings_basics.html)
- [ ] extra tests
- [ ] (backlog) support metadata (#18792)
- [ ] (backlog) output metadata propagation