### PR TITLE
Fix hasDynamicShapes for batch_size and axis selection in Scale layer

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -284,6 +284,7 @@ TEST_P(Test_ONNX_layers, Scale)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
     testONNXModels("scale");
+    testONNXModels("scale_broadcast", npy, 0, 0, false, true, 3);
 }
 
 TEST_P(Test_ONNX_layers, ReduceMean3D)
@@ -825,6 +826,7 @@ TEST_P(Test_ONNX_layers, DynamicAxes)
     testONNXModels("resize_opset11_torch1.6_dynamic_axes");
     testONNXModels("average_pooling_dynamic_axes");
     testONNXModels("maxpooling_sigmoid_dynamic_axes");
+    testONNXModels("dynamic_batch");
 }
 
 TEST_P(Test_ONNX_layers, MaxPool1d)


### PR DESCRIPTION
Fixes ONNX model from https://github.com/opencv/opencv/issues/20540 and https://github.com/opencv/opencv/issues/19499. Tests: https://github.com/opencv/opencv_extra/pull/897.

`opencv_extra=onnx_scale_fix`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
