### PR TITLE
[G-API] Draft: Wrap GComputation::compile into python

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -63,7 +63,7 @@ namespace cv {
  *
  * @sa GStreamingCompiled
  */
-class GAPI_EXPORTS GCompiled
+class GAPI_EXPORTS_W_SIMPLE GCompiled
 {
 public:
     /// @private
@@ -72,7 +72,7 @@ public:
     /**
      * @brief Constructs an empty object
      */
-    GCompiled();
+    GAPI_WRAP GCompiled();
 
     /**
      * @brief Run the compiled computation, a generic version.
@@ -173,7 +173,7 @@ public:
      * metadata vector passed to reshape() (if that call was
      * successful).
      */
-    const GMetaArgs& metas() const; // Meta passed to compile()
+    GAPI_WRAP const GMetaArgs& metas() const; // Meta passed to compile()
 
     /**
      * @brief Vector of metadata descriptions of graph outputs
@@ -186,14 +186,14 @@ public:
      * cv::GComputiation graph with different input metas may return
      * different values in this vector.
      */
-    const GMetaArgs& outMetas() const;
+    GAPI_WRAP const GMetaArgs& outMetas() const;
 
     /**
      * @brief Check if the underlying backends support reshape or not.
      *
      * @return true if supported, false otherwise.
      */
-    bool canReshape() const;
+    GAPI_WRAP bool canReshape() const;
 
     /**
      * @brief Reshape a compiled graph to support new image
@@ -206,7 +206,7 @@ public:
      * @param args compilation arguments to use.
      */
     // FIXME: Why it requires compile args?
-    void reshape(const GMetaArgs& inMetas, const GCompileArgs& args);
+    GAPI_WRAP void reshape(const GMetaArgs& inMetas, const GCompileArgs& args);
 
     /**
      * @brief Prepare inner kernels states for a new video-stream.
@@ -220,6 +220,10 @@ public:
      * their internal states to a new video stream.
      */
     void prepareForNewStream();
+
+    /// @private -- Exclude this function from OpenCV documentation
+    GAPI_WRAP GRunArgs run(const cv::detail::ExtractArgsCallback  &callback,
+                                 GCompileArgs                    &&args = {});
 
 protected:
     /// @private

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -437,11 +437,7 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
-
-    /// @private -- Exclude this function from OpenCV documentation
-    GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                              GCompileArgs                   &&args = {});
+    GAPI_WRAP GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     /**
      * @brief Compile the computation for streaming mode.
@@ -462,7 +458,11 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+
+    /// @private -- Exclude this function from OpenCV documentation
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                                  GCompileArgs                   &&args = {});
 
     // 2. Direct metadata version
     /**

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -440,8 +440,8 @@ public:
     GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     /// @private -- Exclude this function from OpenCV documentation
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                                        GCompileArgs                   &&args = {});
+    GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                              GCompileArgs                   &&args = {});
 
     /**
      * @brief Compile the computation for streaming mode.

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -462,7 +462,7 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
+    GStreamingCompiled compileStreaming(GCompileArgs &&args = {});
 
     // 2. Direct metadata version
     /**

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -356,7 +356,7 @@ public:
      *
      * @sa @ref gapi_compile_args
      */
-    GCompiled compile(GMetaArgs &&in_metas, GCompileArgs &&args = {});
+    GAPI_WRAP GCompiled compile(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     // 2. Syntax sugar - variadic list of metas, no extra compile args
     // FIXME: SFINAE looks ugly in the generated documentation

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -265,7 +265,7 @@ namespace gapi { namespace own {
 GAPI_EXPORTS GMatDesc descr_of(const RMat &mat);
 
 #if !defined(GAPI_STANDALONE)
-GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
+GAPI_EXPORTS_W GMatDesc descr_of(const cv::Mat &mat);
 #else
 using gapi::own::descr_of;
 #endif

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -396,10 +396,10 @@ namespace streaming {
  * In the streaming mode the pipeline steps are connected with queues
  * and this compile argument controls every queue's size.
  */
-struct GAPI_EXPORTS queue_capacity
+struct GAPI_EXPORTS_W_SIMPLE queue_capacity
 {
-    explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
-    size_t capacity;
+    GAPI_WRAP explicit queue_capacity(size_t cap = 1) : capacity(cap) { };
+    GAPI_PROP size_t capacity;
 };
 /** @} */
 } // namespace streaming

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -295,3 +295,5 @@ cv.gapi.wip.draw.Line = cv.gapi_wip_draw_Line
 cv.gapi.wip.draw.Mosaic = cv.gapi_wip_draw_Mosaic
 cv.gapi.wip.draw.Image = cv.gapi_wip_draw_Image
 cv.gapi.wip.draw.Poly = cv.gapi_wip_draw_Poly
+
+cv.gapi.streaming.queue_capacity = cv.gapi_streaming_queue_capacity

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -36,11 +36,6 @@ def gin(*args):
     return [*args]
 
 
-@register('cv2.gapi')
-def descr_of(*args):
-    return [*args]
-
-
 @register('cv2')
 class GOpaque():
     # NB: Inheritance from c++ class cause segfault.

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -211,10 +211,35 @@ bool pyopencv_to(PyObject* obj, cv::GMetaArg& value, const ArgInfo&)
     return true;
 }
 
+// #FIXME: Is it possible to implement pyopencv_from/pyopencv_to for generic
+// cv::variant<Types...> ?
+template <>
+PyObject* pyopencv_from(const cv::GMetaArg& value)
+{
+    switch (value.index()) {
+        case cv::GMetaArg::index_of<cv::GMatDesc>():
+            return pyopencv_from(cv::util::get<cv::GMatDesc>(value));
+        case cv::GMetaArg::index_of<cv::GScalarDesc>():
+            return pyopencv_from(cv::util::get<cv::GScalarDesc>(value));
+        case cv::GMetaArg::index_of<cv::GArrayDesc>():
+            return pyopencv_from(cv::util::get<cv::GArrayDesc>(value));
+        case cv::GMetaArg::index_of<cv::GOpaqueDesc>():
+            return pyopencv_from(cv::util::get<cv::GOpaqueDesc>(value));
+    }
+    PyErr_SetString(PyExc_TypeError, "Unsupported GMetaArg type");
+    return NULL;
+}
+
 template <>
 bool pyopencv_to(PyObject* obj, cv::GMetaArgs& value, const ArgInfo& info)
 {
     return pyopencv_to_generic_vec(obj, value, info);
+}
+
+template <>
+PyObject* pyopencv_from(const cv::GMetaArgs& value)
+{
+    return pyopencv_from_generic_vec(value);
 }
 
 template <>

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -5,8 +5,9 @@ namespace cv
 {
 struct GAPI_EXPORTS_W_SIMPLE GCompileArg
 {
-    GAPI_WRAP GCompileArg(gapi::GKernelPackage pkg);
-    GAPI_WRAP GCompileArg(gapi::GNetPackage pkg);
+    GAPI_WRAP GCompileArg(gapi::GKernelPackage arg);
+    GAPI_WRAP GCompileArg(gapi::GNetPackage arg);
+    GAPI_WRAP GCompileArg(gapi::streaming::queue_capacity arg);
 };
 
 class GAPI_EXPORTS_W_SIMPLE GInferInputs
@@ -37,16 +38,6 @@ class GAPI_EXPORTS_W_SIMPLE GInferListOutputs
 public:
     GAPI_WRAP GInferListOutputs();
     GAPI_WRAP cv::GArray<cv::GMat> at(const std::string& name);
-};
-
-class GComputation
-{
-public:
-    GAPI_WRAP GStreamingCompiled compileStreaming();
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
-                                                        GCompileArgs                   &&args);
 };
 
 namespace gapi

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -42,9 +42,11 @@ public:
 class GComputation
 {
 public:
-    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
-    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
     GAPI_WRAP GStreamingCompiled compileStreaming();
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback,
+                                                        GCompileArgs                   &&args);
 };
 
 namespace gapi

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -39,6 +39,14 @@ public:
     GAPI_WRAP cv::GArray<cv::GMat> at(const std::string& name);
 };
 
+class GComputation
+{
+public:
+    GAPI_WRAP GStreamingCompiled compileStreaming(const cv::detail::ExtractMetaCallback &callback);
+    GAPI_WRAP GStreamingCompiled compileStreaming(GCompileArgs &&args);
+    GAPI_WRAP GStreamingCompiled compileStreaming();
+};
+
 namespace gapi
 {
 namespace wip

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -209,458 +209,494 @@ try:
 
     class gapi_sample_pipelines(NewOpenCVTests):
 
-        def test_custom_op_add(self):
-            sz = (3, 3)
-            in_mat1 = np.full(sz, 45, dtype=np.uint8)
-            in_mat2 = np.full(sz, 50, dtype=np.uint8)
+        # def test_custom_op_add(self):
+            # sz = (3, 3)
+            # in_mat1 = np.full(sz, 45, dtype=np.uint8)
+            # in_mat2 = np.full(sz, 50, dtype=np.uint8)
 
-            # OpenCV
-            expected = cv.add(in_mat1, in_mat2)
+            # # OpenCV
+            # expected = cv.add(in_mat1, in_mat2)
 
-            # G-API
-            g_in1  = cv.GMat()
-            g_in2  = cv.GMat()
-            g_out = GAdd.on(g_in1, g_in2, cv.CV_8UC1)
+            # # G-API
+            # g_in1  = cv.GMat()
+            # g_in2  = cv.GMat()
+            # g_out = GAdd.on(g_in1, g_in2, cv.CV_8UC1)
 
-            comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
+            # comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
 
-            pkg = cv.gapi.kernels(GAddImpl)
-            actual = comp.apply(cv.gin(in_mat1, in_mat2), args=cv.gapi.compile_args(pkg))
+            # pkg = cv.gapi.kernels(GAddImpl)
+            # actual = comp.apply(cv.gin(in_mat1, in_mat2), args=cv.gapi.compile_args(pkg))
 
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-
-        def test_custom_op_split3(self):
-            sz = (4, 4)
-            in_ch1 = np.full(sz, 1, dtype=np.uint8)
-            in_ch2 = np.full(sz, 2, dtype=np.uint8)
-            in_ch3 = np.full(sz, 3, dtype=np.uint8)
-            # H x W x C
-            in_mat = np.stack((in_ch1, in_ch2, in_ch3), axis=2)
-
-            # G-API
-            g_in  = cv.GMat()
-            g_ch1, g_ch2, g_ch3 = GSplit3.on(g_in)
-
-            comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ch1, g_ch2, g_ch3))
-
-            pkg = cv.gapi.kernels(GSplit3Impl)
-            ch1, ch2, ch3 = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
-
-            self.assertEqual(0.0, cv.norm(in_ch1, ch1, cv.NORM_INF))
-            self.assertEqual(0.0, cv.norm(in_ch2, ch2, cv.NORM_INF))
-            self.assertEqual(0.0, cv.norm(in_ch3, ch3, cv.NORM_INF))
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
 
-        def test_custom_op_mean(self):
-            img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
-            in_mat = cv.imread(img_path)
+        # def test_custom_op_split3(self):
+            # sz = (4, 4)
+            # in_ch1 = np.full(sz, 1, dtype=np.uint8)
+            # in_ch2 = np.full(sz, 2, dtype=np.uint8)
+            # in_ch3 = np.full(sz, 3, dtype=np.uint8)
+            # # H x W x C
+            # in_mat = np.stack((in_ch1, in_ch2, in_ch3), axis=2)
 
-            # OpenCV
-            expected = cv.mean(in_mat)
+            # # G-API
+            # g_in  = cv.GMat()
+            # g_ch1, g_ch2, g_ch3 = GSplit3.on(g_in)
 
-            # G-API
-            g_in  = cv.GMat()
-            g_out = GMean.on(g_in)
+            # comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ch1, g_ch2, g_ch3))
 
-            comp = cv.GComputation(g_in, g_out)
+            # pkg = cv.gapi.kernels(GSplit3Impl)
+            # ch1, ch2, ch3 = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
 
-            pkg    = cv.gapi.kernels(GMeanImpl)
-            actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
-
-            # Comparison
-            self.assertEqual(expected, actual)
-
-
-        def test_custom_op_addC(self):
-            sz = (3, 3, 3)
-            in_mat = np.full(sz, 45, dtype=np.uint8)
-            sc = (50, 10, 20)
-
-            # Numpy reference, make array from sc to keep uint8 dtype.
-            expected = in_mat + np.array(sc, dtype=np.uint8)
-
-            # G-API
-            g_in  = cv.GMat()
-            g_sc  = cv.GScalar()
-            g_out = GAddC.on(g_in, g_sc, cv.CV_8UC1)
-            comp  = cv.GComputation(cv.GIn(g_in, g_sc), cv.GOut(g_out))
-
-            pkg = cv.gapi.kernels(GAddCImpl)
-            actual = comp.apply(cv.gin(in_mat, sc), args=cv.gapi.compile_args(pkg))
-
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            # self.assertEqual(0.0, cv.norm(in_ch1, ch1, cv.NORM_INF))
+            # self.assertEqual(0.0, cv.norm(in_ch2, ch2, cv.NORM_INF))
+            # self.assertEqual(0.0, cv.norm(in_ch3, ch3, cv.NORM_INF))
 
 
-        def test_custom_op_size(self):
-            sz = (100, 150, 3)
-            in_mat = np.full(sz, 45, dtype=np.uint8)
+        # def test_custom_op_mean(self):
+            # img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+            # in_mat = cv.imread(img_path)
 
-            # Open_cV
-            expected = (100, 150)
+            # # OpenCV
+            # expected = cv.mean(in_mat)
 
-            # G-API
+            # # G-API
+            # g_in  = cv.GMat()
+            # g_out = GMean.on(g_in)
+
+            # comp = cv.GComputation(g_in, g_out)
+
+            # pkg    = cv.gapi.kernels(GMeanImpl)
+            # actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
+
+            # # Comparison
+            # self.assertEqual(expected, actual)
+
+
+        # def test_custom_op_addC(self):
+            # sz = (3, 3, 3)
+            # in_mat = np.full(sz, 45, dtype=np.uint8)
+            # sc = (50, 10, 20)
+
+            # # Numpy reference, make array from sc to keep uint8 dtype.
+            # expected = in_mat + np.array(sc, dtype=np.uint8)
+
+            # # G-API
+            # g_in  = cv.GMat()
+            # g_sc  = cv.GScalar()
+            # g_out = GAddC.on(g_in, g_sc, cv.CV_8UC1)
+            # comp  = cv.GComputation(cv.GIn(g_in, g_sc), cv.GOut(g_out))
+
+            # pkg = cv.gapi.kernels(GAddCImpl)
+            # actual = comp.apply(cv.gin(in_mat, sc), args=cv.gapi.compile_args(pkg))
+
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_custom_op_size(self):
+            # sz = (100, 150, 3)
+            # in_mat = np.full(sz, 45, dtype=np.uint8)
+
+            # # Open_cV
+            # expected = (100, 150)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_sz = GSize.on(g_in)
+            # comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_sz))
+
+            # pkg = cv.gapi.kernels(GSizeImpl)
+            # actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
+
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_custom_op_sizeR(self):
+            # # x, y, h, w
+            # roi = (10, 15, 100, 150)
+
+            # expected = (100, 150)
+
+            # # G-API
+            # g_r  = cv.GOpaque.Rect()
+            # g_sz = GSizeR.on(g_r)
+            # comp = cv.GComputation(cv.GIn(g_r), cv.GOut(g_sz))
+
+            # pkg = cv.gapi.kernels(GSizeRImpl)
+            # actual = comp.apply(cv.gin(roi), args=cv.gapi.compile_args(pkg))
+
+            # # cv.norm works with tuples ?
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_custom_op_boundingRect(self):
+            # points = [(0,0), (0,1), (1,0), (1,1)]
+
+            # # OpenCV
+            # expected = cv.boundingRect(np.array(points))
+
+            # # G-API
+            # g_pts = cv.GArray.Point()
+            # g_br  = GBoundingRect.on(g_pts)
+            # comp  = cv.GComputation(cv.GIn(g_pts), cv.GOut(g_br))
+
+            # pkg = cv.gapi.kernels(GBoundingRectImpl)
+            # actual = comp.apply(cv.gin(points), args=cv.gapi.compile_args(pkg))
+
+            # # cv.norm works with tuples ?
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_custom_op_goodFeaturesToTrack(self):
+            # # G-API
+            # img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+            # in_mat = cv.cvtColor(cv.imread(img_path), cv.COLOR_RGB2GRAY)
+
+            # # NB: goodFeaturesToTrack configuration
+            # max_corners         = 50
+            # quality_lvl         = 0.01
+            # min_distance        = 10.0
+            # block_sz            = 3
+            # use_harris_detector = True
+            # k                   = 0.04
+
+            # # OpenCV
+            # expected = cv.goodFeaturesToTrack(in_mat, max_corners, quality_lvl,
+                                              # min_distance, mask=None,
+                                              # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = GGoodFeatures.on(g_in, max_corners, quality_lvl,
+                                     # min_distance, block_sz, use_harris_detector, k)
+
+            # comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+            # pkg = cv.gapi.kernels(GGoodFeaturesImpl)
+            # actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
+
+            # # NB: OpenCV & G-API have different output types.
+            # # OpenCV - numpy array with shape (num_points, 1, 2)
+            # # G-API  - list of tuples with size - num_points
+            # # Comparison
+            # self.assertEqual(0.0, cv.norm(expected.flatten(),
+                                          # np.array(actual, dtype=np.float32).flatten(), cv.NORM_INF))
+
+
+        # def test_invalid_op(self):
+            # # NB: Empty input types list
+            # with self.assertRaises(Exception): create_op(in_types=[], out_types=[cv.GMat])
+            # # NB: Empty output types list
+            # with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[])
+
+            # # Invalid output types
+            # with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[int])
+            # with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[cv.GMat, int])
+            # with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[str, cv.GScalar])
+
+
+        # def test_invalid_op_input(self):
+            # # NB: Check GMat/GScalar
+            # with self.assertRaises(Exception): create_op([cv.GMat]   , [cv.GScalar]).on(cv.GScalar())
+            # with self.assertRaises(Exception): create_op([cv.GScalar], [cv.GScalar]).on(cv.GMat())
+
+            # # NB: Check GOpaque
+            # op = create_op([cv.GOpaque.Rect], [cv.GMat])
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Bool())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Int())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Double())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Float())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.String())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Point())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Point2f())
+            # with self.assertRaises(Exception): op.on(cv.GOpaque.Size())
+
+            # # NB: Check GArray
+            # op = create_op([cv.GArray.Rect], [cv.GMat])
+            # with self.assertRaises(Exception): op.on(cv.GArray.Bool())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Int())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Double())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Float())
+            # with self.assertRaises(Exception): op.on(cv.GArray.String())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Point())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Point2f())
+            # with self.assertRaises(Exception): op.on(cv.GArray.Size())
+
+            # # Check other possible invalid options
+            # with self.assertRaises(Exception): op.on(cv.GMat())
+            # with self.assertRaises(Exception): op.on(cv.GScalar())
+
+            # with self.assertRaises(Exception): op.on(1)
+            # with self.assertRaises(Exception): op.on('foo')
+            # with self.assertRaises(Exception): op.on(False)
+
+            # with self.assertRaises(Exception): create_op([cv.GMat, int], [cv.GMat]).on(cv.GMat(), 'foo')
+            # with self.assertRaises(Exception): create_op([cv.GMat, int], [cv.GMat]).on(cv.GMat())
+
+
+        # def test_stateful_kernel(self):
+            # @cv.gapi.op('custom.sum', in_types=[cv.GArray.Int], out_types=[cv.GOpaque.Int])
+            # class GSum:
+                # @staticmethod
+                # def outMeta(arr_desc):
+                    # return cv.empty_gopaque_desc()
+
+
+            # @cv.gapi.kernel(GSum)
+            # class GSumImpl:
+                # last_result = 0
+
+                # @staticmethod
+                # def run(arr):
+                    # GSumImpl.last_result = sum(arr)
+                    # return GSumImpl.last_result
+
+
+            # g_in  = cv.GArray.Int()
+            # comp  = cv.GComputation(cv.GIn(g_in), cv.GOut(GSum.on(g_in)))
+
+            # s = comp.apply(cv.gin([1, 2, 3, 4]), args=cv.gapi.compile_args(cv.gapi.kernels(GSumImpl)))
+            # self.assertEqual(10, s)
+
+            # s = comp.apply(cv.gin([1, 2, 8, 7]), args=cv.gapi.compile_args(cv.gapi.kernels(GSumImpl)))
+            # self.assertEqual(18, s)
+
+            # self.assertEqual(18, GSumImpl.last_result)
+
+
+        # def test_opaq_with_custom_type(self):
+            # @cv.gapi.op('custom.op', in_types=[cv.GOpaque.Any, cv.GOpaque.String], out_types=[cv.GOpaque.Any])
+            # class GLookUp:
+                # @staticmethod
+                # def outMeta(opaq_desc0, opaq_desc1):
+                    # return cv.empty_gopaque_desc()
+
+            # @cv.gapi.kernel(GLookUp)
+            # class GLookUpImpl:
+                # @staticmethod
+                # def run(table, key):
+                    # return table[key]
+
+
+            # g_table = cv.GOpaque.Any()
+            # g_key   = cv.GOpaque.String()
+            # g_out   = GLookUp.on(g_table, g_key)
+
+            # comp = cv.GComputation(cv.GIn(g_table, g_key), cv.GOut(g_out))
+
+            # table = {
+                        # 'int':   42,
+                        # 'str':   'hello, world!',
+                        # 'tuple': (42, 42)
+                    # }
+
+            # out = comp.apply(cv.gin(table, 'int'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
+            # self.assertEqual(42, out)
+
+            # out = comp.apply(cv.gin(table, 'str'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
+            # self.assertEqual('hello, world!', out)
+
+            # out = comp.apply(cv.gin(table, 'tuple'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
+            # self.assertEqual((42, 42), out)
+
+
+        # def test_array_with_custom_type(self):
+            # @cv.gapi.op('custom.op', in_types=[cv.GArray.Any, cv.GArray.Any], out_types=[cv.GArray.Any])
+            # class GConcat:
+                # @staticmethod
+                # def outMeta(arr_desc0, arr_desc1):
+                    # return cv.empty_array_desc()
+
+            # @cv.gapi.kernel(GConcat)
+            # class GConcatImpl:
+                # @staticmethod
+                # def run(arr0, arr1):
+                    # return arr0 + arr1
+
+            # g_arr0 = cv.GArray.Any()
+            # g_arr1 = cv.GArray.Any()
+            # g_out  = GConcat.on(g_arr0, g_arr1)
+
+            # comp = cv.GComputation(cv.GIn(g_arr0, g_arr1), cv.GOut(g_out))
+
+            # arr0 = [(2, 2), 2.0]
+            # arr1 = [3,    'str']
+
+            # out = comp.apply(cv.gin(arr0, arr1),
+                             # args=cv.gapi.compile_args(cv.gapi.kernels(GConcatImpl)))
+
+            # self.assertEqual(arr0 + arr1, out)
+
+
+        # def test_raise_in_kernel(self):
+            # @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
+            # class GAdd:
+                # @staticmethod
+                # def outMeta(desc0, desc1):
+                    # return desc0
+
+            # @cv.gapi.kernel(GAdd)
+            # class GAddImpl:
+                # @staticmethod
+                # def run(img0, img1):
+                    # raise Exception('Error')
+                    # return img0 + img1
+
+            # g_in0 = cv.GMat()
+            # g_in1 = cv.GMat()
+            # g_out = GAdd.on(g_in0, g_in1)
+
+            # comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
+
+            # img0 = np.array([1, 2, 3])
+            # img1 = np.array([1, 2, 3])
+
+            # with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
+                                                          # args=cv.gapi.compile_args(
+                                                              # cv.gapi.kernels(GAddImpl)))
+
+
+        # def test_raise_in_outMeta(self):
+            # @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
+            # class GAdd:
+                # @staticmethod
+                # def outMeta(desc0, desc1):
+                    # raise NotImplementedError("outMeta isn't implemented")
+
+            # @cv.gapi.kernel(GAdd)
+            # class GAddImpl:
+                # @staticmethod
+                # def run(img0, img1):
+                    # return img0 + img1
+
+            # g_in0 = cv.GMat()
+            # g_in1 = cv.GMat()
+            # g_out = GAdd.on(g_in0, g_in1)
+
+            # comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
+
+            # img0 = np.array([1, 2, 3])
+            # img1 = np.array([1, 2, 3])
+
+            # with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
+                                                          # args=cv.gapi.compile_args(
+                                                              # cv.gapi.kernels(GAddImpl)))
+
+
+        # def test_invalid_outMeta(self):
+            # @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
+            # class GAdd:
+                # @staticmethod
+                # def outMeta(desc0, desc1):
+                    # # Invalid outMeta
+                    # return cv.empty_gopaque_desc()
+
+            # @cv.gapi.kernel(GAdd)
+            # class GAddImpl:
+                # @staticmethod
+                # def run(img0, img1):
+                    # return img0 + img1
+
+            # g_in0 = cv.GMat()
+            # g_in1 = cv.GMat()
+            # g_out = GAdd.on(g_in0, g_in1)
+
+            # comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
+
+            # img0 = np.array([1, 2, 3])
+            # img1 = np.array([1, 2, 3])
+
+            # # FIXME: Cause Bad variant access.
+            # # Need to provide more descriptive error messsage.
+            # with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
+                                                          # args=cv.gapi.compile_args(
+                                                              # cv.gapi.kernels(GAddImpl)))
+
+        # def test_pipeline_with_custom_kernels(self):
+            # @cv.gapi.op('custom.resize', in_types=[cv.GMat, tuple], out_types=[cv.GMat])
+            # class GResize:
+                # @staticmethod
+                # def outMeta(desc, size):
+                    # return desc.withSize(size)
+
+            # @cv.gapi.kernel(GResize)
+            # class GResizeImpl:
+                # @staticmethod
+                # def run(img, size):
+                    # return cv.resize(img, size)
+
+            # @cv.gapi.op('custom.transpose', in_types=[cv.GMat, tuple], out_types=[cv.GMat])
+            # class GTranspose:
+                # @staticmethod
+                # def outMeta(desc, order):
+                    # return desc
+
+            # @cv.gapi.kernel(GTranspose)
+            # class GTransposeImpl:
+                # @staticmethod
+                # def run(img, order):
+                    # return np.transpose(img, order)
+
+            # img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
+            # img      = cv.imread(img_path)
+            # size     = (32, 32)
+            # order    = (1, 0, 2)
+
+            # # Dummy pipeline just to validate this case:
+            # # gapi -> custom -> custom -> gapi
+
+            # # OpenCV
+            # expected = cv.cvtColor(img, cv.COLOR_BGR2RGB)
+            # expected = cv.resize(expected, size)
+            # expected = np.transpose(expected, order)
+            # expected = cv.mean(expected)
+
+            # # G-API
+            # g_bgr        = cv.GMat()
+            # g_rgb        = cv.gapi.BGR2RGB(g_bgr)
+            # g_resized    = GResize.on(g_rgb, size)
+            # g_transposed = GTranspose.on(g_resized, order)
+            # g_mean       = cv.gapi.mean(g_transposed)
+
+            # comp = cv.GComputation(cv.GIn(g_bgr), cv.GOut(g_mean))
+            # actual = comp.apply(cv.gin(img), args=cv.gapi.compile_args(
+                # cv.gapi.kernels(GResizeImpl, GTransposeImpl)))
+
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_compiled_api(self):
+            # g_in = cv.GMat()
+
+            # comp = cv.GComputation(cv.GIn(g_in), cv.GOut(cv.gapi.mean(g_in)))
+            # cc = comp.compile([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
+
+            # metas = cc.metas()
+            # self.assertEqual(list, type(metas))
+            # self.assertEqual(1, len(metas))
+            # self.assertEqual(cv.CV_8U, metas[0].depth)
+            # self.assertEqual((300, 300), metas[0].size)
+
+            # out_metas = cc.outMetas()
+            # self.assertEqual(list, type(out_metas))
+            # self.assertEqual(1, len(out_metas))
+            # self.assertEqual(type(cv.empty_scalar_desc()), type(out_metas[0]))
+
+            # # NB: CPU backend isn't reshapeable
+            # self.assertEqual(False, cc.canReshape())
+
+
+        def test_compiled_run(self):
             g_in = cv.GMat()
-            g_sz = GSize.on(g_in)
-            comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_sz))
 
-            pkg = cv.gapi.kernels(GSizeImpl)
-            actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
+            img_path = self.find_file('cv/face/david2.jpg',
+                                      [os.environ.get('OPENCV_TEST_DATA_PATH')])
+            img = cv.imread(img_path)
 
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            comp = cv.GComputation(cv.GIn(g_in), cv.GOut(cv.gapi.mean(g_in)))
+            cc = comp.compile([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
 
+            out = cc.run(cv.gin(img))
+            print(out)
 
-        def test_custom_op_sizeR(self):
-            # x, y, h, w
-            roi = (10, 15, 100, 150)
-
-            expected = (100, 150)
-
-            # G-API
-            g_r  = cv.GOpaque.Rect()
-            g_sz = GSizeR.on(g_r)
-            comp = cv.GComputation(cv.GIn(g_r), cv.GOut(g_sz))
-
-            pkg = cv.gapi.kernels(GSizeRImpl)
-            actual = comp.apply(cv.gin(roi), args=cv.gapi.compile_args(pkg))
-
-            # cv.norm works with tuples ?
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-
-        def test_custom_op_boundingRect(self):
-            points = [(0,0), (0,1), (1,0), (1,1)]
-
-            # OpenCV
-            expected = cv.boundingRect(np.array(points))
-
-            # G-API
-            g_pts = cv.GArray.Point()
-            g_br  = GBoundingRect.on(g_pts)
-            comp  = cv.GComputation(cv.GIn(g_pts), cv.GOut(g_br))
-
-            pkg = cv.gapi.kernels(GBoundingRectImpl)
-            actual = comp.apply(cv.gin(points), args=cv.gapi.compile_args(pkg))
-
-            # cv.norm works with tuples ?
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-
-        def test_custom_op_goodFeaturesToTrack(self):
-            # G-API
-            img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
-            in_mat = cv.cvtColor(cv.imread(img_path), cv.COLOR_RGB2GRAY)
-
-            # NB: goodFeaturesToTrack configuration
-            max_corners         = 50
-            quality_lvl         = 0.01
-            min_distance        = 10.0
-            block_sz            = 3
-            use_harris_detector = True
-            k                   = 0.04
-
-            # OpenCV
-            expected = cv.goodFeaturesToTrack(in_mat, max_corners, quality_lvl,
-                                              min_distance, mask=None,
-                                              blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-
-            # G-API
-            g_in = cv.GMat()
-            g_out = GGoodFeatures.on(g_in, max_corners, quality_lvl,
-                                     min_distance, block_sz, use_harris_detector, k)
-
-            comp = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-            pkg = cv.gapi.kernels(GGoodFeaturesImpl)
-            actual = comp.apply(cv.gin(in_mat), args=cv.gapi.compile_args(pkg))
-
-            # NB: OpenCV & G-API have different output types.
-            # OpenCV - numpy array with shape (num_points, 1, 2)
-            # G-API  - list of tuples with size - num_points
-            # Comparison
-            self.assertEqual(0.0, cv.norm(expected.flatten(),
-                                          np.array(actual, dtype=np.float32).flatten(), cv.NORM_INF))
-
-
-        def test_invalid_op(self):
-            # NB: Empty input types list
-            with self.assertRaises(Exception): create_op(in_types=[], out_types=[cv.GMat])
-            # NB: Empty output types list
-            with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[])
-
-            # Invalid output types
-            with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[int])
-            with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[cv.GMat, int])
-            with self.assertRaises(Exception): create_op(in_types=[cv.GMat], out_types=[str, cv.GScalar])
-
-
-        def test_invalid_op_input(self):
-            # NB: Check GMat/GScalar
-            with self.assertRaises(Exception): create_op([cv.GMat]   , [cv.GScalar]).on(cv.GScalar())
-            with self.assertRaises(Exception): create_op([cv.GScalar], [cv.GScalar]).on(cv.GMat())
-
-            # NB: Check GOpaque
-            op = create_op([cv.GOpaque.Rect], [cv.GMat])
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Bool())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Int())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Double())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Float())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.String())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Point())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Point2f())
-            with self.assertRaises(Exception): op.on(cv.GOpaque.Size())
-
-            # NB: Check GArray
-            op = create_op([cv.GArray.Rect], [cv.GMat])
-            with self.assertRaises(Exception): op.on(cv.GArray.Bool())
-            with self.assertRaises(Exception): op.on(cv.GArray.Int())
-            with self.assertRaises(Exception): op.on(cv.GArray.Double())
-            with self.assertRaises(Exception): op.on(cv.GArray.Float())
-            with self.assertRaises(Exception): op.on(cv.GArray.String())
-            with self.assertRaises(Exception): op.on(cv.GArray.Point())
-            with self.assertRaises(Exception): op.on(cv.GArray.Point2f())
-            with self.assertRaises(Exception): op.on(cv.GArray.Size())
-
-            # Check other possible invalid options
-            with self.assertRaises(Exception): op.on(cv.GMat())
-            with self.assertRaises(Exception): op.on(cv.GScalar())
-
-            with self.assertRaises(Exception): op.on(1)
-            with self.assertRaises(Exception): op.on('foo')
-            with self.assertRaises(Exception): op.on(False)
-
-            with self.assertRaises(Exception): create_op([cv.GMat, int], [cv.GMat]).on(cv.GMat(), 'foo')
-            with self.assertRaises(Exception): create_op([cv.GMat, int], [cv.GMat]).on(cv.GMat())
-
-
-        def test_stateful_kernel(self):
-            @cv.gapi.op('custom.sum', in_types=[cv.GArray.Int], out_types=[cv.GOpaque.Int])
-            class GSum:
-                @staticmethod
-                def outMeta(arr_desc):
-                    return cv.empty_gopaque_desc()
-
-
-            @cv.gapi.kernel(GSum)
-            class GSumImpl:
-                last_result = 0
-
-                @staticmethod
-                def run(arr):
-                    GSumImpl.last_result = sum(arr)
-                    return GSumImpl.last_result
-
-
-            g_in  = cv.GArray.Int()
-            comp  = cv.GComputation(cv.GIn(g_in), cv.GOut(GSum.on(g_in)))
-
-            s = comp.apply(cv.gin([1, 2, 3, 4]), args=cv.gapi.compile_args(cv.gapi.kernels(GSumImpl)))
-            self.assertEqual(10, s)
-
-            s = comp.apply(cv.gin([1, 2, 8, 7]), args=cv.gapi.compile_args(cv.gapi.kernels(GSumImpl)))
-            self.assertEqual(18, s)
-
-            self.assertEqual(18, GSumImpl.last_result)
-
-
-        def test_opaq_with_custom_type(self):
-            @cv.gapi.op('custom.op', in_types=[cv.GOpaque.Any, cv.GOpaque.String], out_types=[cv.GOpaque.Any])
-            class GLookUp:
-                @staticmethod
-                def outMeta(opaq_desc0, opaq_desc1):
-                    return cv.empty_gopaque_desc()
-
-            @cv.gapi.kernel(GLookUp)
-            class GLookUpImpl:
-                @staticmethod
-                def run(table, key):
-                    return table[key]
-
-
-            g_table = cv.GOpaque.Any()
-            g_key   = cv.GOpaque.String()
-            g_out   = GLookUp.on(g_table, g_key)
-
-            comp = cv.GComputation(cv.GIn(g_table, g_key), cv.GOut(g_out))
-
-            table = {
-                        'int':   42,
-                        'str':   'hello, world!',
-                        'tuple': (42, 42)
-                    }
-
-            out = comp.apply(cv.gin(table, 'int'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
-            self.assertEqual(42, out)
-
-            out = comp.apply(cv.gin(table, 'str'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
-            self.assertEqual('hello, world!', out)
-
-            out = comp.apply(cv.gin(table, 'tuple'), args=cv.gapi.compile_args(cv.gapi.kernels(GLookUpImpl)))
-            self.assertEqual((42, 42), out)
-
-
-        def test_array_with_custom_type(self):
-            @cv.gapi.op('custom.op', in_types=[cv.GArray.Any, cv.GArray.Any], out_types=[cv.GArray.Any])
-            class GConcat:
-                @staticmethod
-                def outMeta(arr_desc0, arr_desc1):
-                    return cv.empty_array_desc()
-
-            @cv.gapi.kernel(GConcat)
-            class GConcatImpl:
-                @staticmethod
-                def run(arr0, arr1):
-                    return arr0 + arr1
-
-            g_arr0 = cv.GArray.Any()
-            g_arr1 = cv.GArray.Any()
-            g_out  = GConcat.on(g_arr0, g_arr1)
-
-            comp = cv.GComputation(cv.GIn(g_arr0, g_arr1), cv.GOut(g_out))
-
-            arr0 = [(2, 2), 2.0]
-            arr1 = [3,    'str']
-
-            out = comp.apply(cv.gin(arr0, arr1),
-                             args=cv.gapi.compile_args(cv.gapi.kernels(GConcatImpl)))
-
-            self.assertEqual(arr0 + arr1, out)
-
-
-        def test_raise_in_kernel(self):
-            @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
-            class GAdd:
-                @staticmethod
-                def outMeta(desc0, desc1):
-                    return desc0
-
-            @cv.gapi.kernel(GAdd)
-            class GAddImpl:
-                @staticmethod
-                def run(img0, img1):
-                    raise Exception('Error')
-                    return img0 + img1
-
-            g_in0 = cv.GMat()
-            g_in1 = cv.GMat()
-            g_out = GAdd.on(g_in0, g_in1)
-
-            comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
-
-            img0 = np.array([1, 2, 3])
-            img1 = np.array([1, 2, 3])
-
-            with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
-                                                          args=cv.gapi.compile_args(
-                                                              cv.gapi.kernels(GAddImpl)))
-
-
-        def test_raise_in_outMeta(self):
-            @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
-            class GAdd:
-                @staticmethod
-                def outMeta(desc0, desc1):
-                    raise NotImplementedError("outMeta isn't implemented")
-
-            @cv.gapi.kernel(GAdd)
-            class GAddImpl:
-                @staticmethod
-                def run(img0, img1):
-                    return img0 + img1
-
-            g_in0 = cv.GMat()
-            g_in1 = cv.GMat()
-            g_out = GAdd.on(g_in0, g_in1)
-
-            comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
-
-            img0 = np.array([1, 2, 3])
-            img1 = np.array([1, 2, 3])
-
-            with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
-                                                          args=cv.gapi.compile_args(
-                                                              cv.gapi.kernels(GAddImpl)))
-
-
-        def test_invalid_outMeta(self):
-            @cv.gapi.op('custom.op', in_types=[cv.GMat, cv.GMat], out_types=[cv.GMat])
-            class GAdd:
-                @staticmethod
-                def outMeta(desc0, desc1):
-                    # Invalid outMeta
-                    return cv.empty_gopaque_desc()
-
-            @cv.gapi.kernel(GAdd)
-            class GAddImpl:
-                @staticmethod
-                def run(img0, img1):
-                    return img0 + img1
-
-            g_in0 = cv.GMat()
-            g_in1 = cv.GMat()
-            g_out = GAdd.on(g_in0, g_in1)
-
-            comp = cv.GComputation(cv.GIn(g_in0, g_in1), cv.GOut(g_out))
-
-            img0 = np.array([1, 2, 3])
-            img1 = np.array([1, 2, 3])
-
-            # FIXME: Cause Bad variant access.
-            # Need to provide more descriptive error messsage.
-            with self.assertRaises(Exception): comp.apply(cv.gin(img0, img1),
-                                                          args=cv.gapi.compile_args(
-                                                              cv.gapi.kernels(GAddImpl)))
-
-        def test_pipeline_with_custom_kernels(self):
-            @cv.gapi.op('custom.resize', in_types=[cv.GMat, tuple], out_types=[cv.GMat])
-            class GResize:
-                @staticmethod
-                def outMeta(desc, size):
-                    return desc.withSize(size)
-
-            @cv.gapi.kernel(GResize)
-            class GResizeImpl:
-                @staticmethod
-                def run(img, size):
-                    return cv.resize(img, size)
-
-            @cv.gapi.op('custom.transpose', in_types=[cv.GMat, tuple], out_types=[cv.GMat])
-            class GTranspose:
-                @staticmethod
-                def outMeta(desc, order):
-                    return desc
-
-            @cv.gapi.kernel(GTranspose)
-            class GTransposeImpl:
-                @staticmethod
-                def run(img, order):
-                    return np.transpose(img, order)
-
-            img_path = self.find_file('cv/face/david2.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
-            img      = cv.imread(img_path)
-            size     = (32, 32)
-            order    = (1, 0, 2)
-
-            # Dummy pipeline just to validate this case:
-            # gapi -> custom -> custom -> gapi
-
-            # OpenCV
-            expected = cv.cvtColor(img, cv.COLOR_BGR2RGB)
-            expected = cv.resize(expected, size)
-            expected = np.transpose(expected, order)
-            expected = cv.mean(expected)
-
-            # G-API
-            g_bgr        = cv.GMat()
-            g_rgb        = cv.gapi.BGR2RGB(g_bgr)
-            g_resized    = GResize.on(g_rgb, size)
-            g_transposed = GTranspose.on(g_resized, order)
-            g_mean       = cv.gapi.mean(g_transposed)
-
-            comp = cv.GComputation(cv.GIn(g_bgr), cv.GOut(g_mean))
-            actual = comp.apply(cv.gin(img), args=cv.gapi.compile_args(
-                cv.gapi.kernels(GResizeImpl, GTransposeImpl)))
-
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
 
 except unittest.SkipTest as e:

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -47,7 +47,8 @@ try:
             g_in = cv.GMat()
             g_out = cv.gapi.medianBlur(g_in, 3)
             c = cv.GComputation(g_in, g_out)
-            ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
+            print([cv.descr_of(in_mat)])
+            ccomp = c.compileStreaming([cv.descr_of(in_mat)])
             ccomp.setSource(cv.gin(in_mat))
             ccomp.start()
 
@@ -57,297 +58,297 @@ try:
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
 
-        def test_video_input(self):
-            ksize = 3
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+        # def test_video_input(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
-            # OpenCV
-            cap = cv.VideoCapture(path)
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
 
-            # G-API
-            g_in = cv.GMat()
-            g_out = cv.gapi.medianBlur(g_in, ksize)
-            c = cv.GComputation(g_in, g_out)
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = cv.gapi.medianBlur(g_in, ksize)
+            # c = cv.GComputation(g_in, g_out)
 
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
 
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, expected = cap.read()
-                has_actual,   actual   = ccomp.pull()
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, expected = cap.read()
+                # has_actual,   actual   = ccomp.pull()
 
-                self.assertEqual(has_expected, has_actual)
+                # self.assertEqual(has_expected, has_actual)
 
-                if not has_actual:
-                    break
+                # if not has_actual:
+                    # break
 
-                self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+                # self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
 
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
 
 
-        def test_video_split3(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+        # def test_video_split3(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
-            # OpenCV
-            cap = cv.VideoCapture(path)
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
 
-            # G-API
-            g_in = cv.GMat()
-            b, g, r = cv.gapi.split3(g_in)
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
+            # # G-API
+            # g_in = cv.GMat()
+            # b, g, r = cv.gapi.split3(g_in)
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
 
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
 
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame = cap.read()
-                has_actual,   actual   = ccomp.pull()
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame = cap.read()
+                # has_actual,   actual   = ccomp.pull()
 
-                self.assertEqual(has_expected, has_actual)
+                # self.assertEqual(has_expected, has_actual)
 
-                if not has_actual:
-                    break
-
-                expected = cv.split(frame)
-                for e, a in zip(expected, actual):
-                    self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
+                # if not has_actual:
+                    # break
+
+                # expected = cv.split(frame)
+                # for e, a in zip(expected, actual):
+                    # self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
 
 
-        def test_video_add(self):
-            sz = (576, 768, 3)
-            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        # def test_video_add(self):
+            # sz = (576, 768, 3)
+            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
 
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in1 = cv.GMat()
-            g_in2 = cv.GMat()
-            out = cv.gapi.add(g_in1, g_in2)
-            c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source, in_mat))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                expected = cv.add(frame, in_mat)
-                self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_good_features_to_track(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # NB: goodFeaturesToTrack configuration
-            max_corners         = 50
-            quality_lvl         = 0.01
-            min_distance        = 10
-            block_sz            = 3
-            use_harris_detector = True
-            k                   = 0.04
-            mask                = None
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in = cv.GMat()
-            g_gray = cv.gapi.RGB2Gray(g_in)
-            g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
-                                                min_distance, mask, block_sz, use_harris_detector, k)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                # OpenCV
-                frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
-                expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
-                                                  min_distance, mask=mask,
-                                                  blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-                for e, a in zip(expected, actual):
-                    # NB: OpenCV & G-API have different output shapes:
-                    # OpenCV - (num_points, 1, 2)
-                    # G-API  - (num_points, 2)
-                    self.assertEqual(0.0, cv.norm(e.flatten(),
-                                                  np.array(a, np.float32).flatten(),
-                                                  cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_gapi_streaming_meta(self):
-            ksize = 3
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_ts = cv.gapi.streaming.timestamp(g_in)
-            g_seqno = cv.gapi.streaming.seqNo(g_in)
-            g_seqid = cv.gapi.streaming.seq_id(g_in)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            curr_frame_number = 0
-            while True:
-                has_frame, (ts, seqno, seqid) = ccomp.pull()
-
-                if not has_frame:
-                    break
-
-                self.assertEqual(curr_frame_number, seqno)
-                self.assertEqual(curr_frame_number, seqid)
-
-                curr_frame_number += 1
-                if curr_frame_number == max_num_frames:
-                    break
-
-
-        def test_desync(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_out1 = cv.gapi.copy(g_in)
-            des = cv.gapi.streaming.desync(g_in)
-            g_out2 = GDelay.on(des)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
-
-            kernels = cv.gapi.kernels(GDelayImpl)
-            ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-
-            out_counter = 0
-            desync_out_counter = 0
-            none_counter = 0
-            while True:
-                has_frame, (out1, out2) = ccomp.pull()
-                if not has_frame:
-                    break
-
-                if not out1 is None:
-                    out_counter += 1
-                if not out2 is None:
-                    desync_out_counter += 1
-                else:
-                    none_counter += 1
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    ccomp.stop()
-                    break
-
-            self.assertLess(0, proc_num_frames)
-            self.assertLess(desync_out_counter, out_counter)
-            self.assertLess(0, none_counter)
-
-
-        def test_compile_streaming_empty(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            comp.compileStreaming()
-
-
-        def test_compile_streaming_args(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
-
-
-        def test_compile_streaming_descr_of(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gapi.descr_of(img))
-
-
-        def test_compile_streaming_descr_of_and_args(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gapi.descr_of(img),
-                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
-
-
-        def test_compile_streaming_meta(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
-
-
-        def test_compile_streaming_meta_and_args(self):
-            g_in = cv.GMat()
-            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
-            img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))],
-                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in1 = cv.GMat()
+            # g_in2 = cv.GMat()
+            # out = cv.gapi.add(g_in1, g_in2)
+            # c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source, in_mat))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # expected = cv.add(frame, in_mat)
+                # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_good_features_to_track(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # NB: goodFeaturesToTrack configuration
+            # max_corners         = 50
+            # quality_lvl         = 0.01
+            # min_distance        = 10
+            # block_sz            = 3
+            # use_harris_detector = True
+            # k                   = 0.04
+            # mask                = None
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_gray = cv.gapi.RGB2Gray(g_in)
+            # g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
+                                                # min_distance, mask, block_sz, use_harris_detector, k)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # # OpenCV
+                # frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                # expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
+                                                  # min_distance, mask=mask,
+                                                  # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+                # for e, a in zip(expected, actual):
+                    # # NB: OpenCV & G-API have different output shapes:
+                    # # OpenCV - (num_points, 1, 2)
+                    # # G-API  - (num_points, 2)
+                    # self.assertEqual(0.0, cv.norm(e.flatten(),
+                                                  # np.array(a, np.float32).flatten(),
+                                                  # cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_gapi_streaming_meta(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_ts = cv.gapi.streaming.timestamp(g_in)
+            # g_seqno = cv.gapi.streaming.seqNo(g_in)
+            # g_seqid = cv.gapi.streaming.seq_id(g_in)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # curr_frame_number = 0
+            # while True:
+                # has_frame, (ts, seqno, seqid) = ccomp.pull()
+
+                # if not has_frame:
+                    # break
+
+                # self.assertEqual(curr_frame_number, seqno)
+                # self.assertEqual(curr_frame_number, seqid)
+
+                # curr_frame_number += 1
+                # if curr_frame_number == max_num_frames:
+                    # break
+
+
+        # def test_desync(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out1 = cv.gapi.copy(g_in)
+            # des = cv.gapi.streaming.desync(g_in)
+            # g_out2 = GDelay.on(des)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
+
+            # kernels = cv.gapi.kernels(GDelayImpl)
+            # ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+
+            # out_counter = 0
+            # desync_out_counter = 0
+            # none_counter = 0
+            # while True:
+                # has_frame, (out1, out2) = ccomp.pull()
+                # if not has_frame:
+                    # break
+
+                # if not out1 is None:
+                    # out_counter += 1
+                # if not out2 is None:
+                    # desync_out_counter += 1
+                # else:
+                    # none_counter += 1
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # ccomp.stop()
+                    # break
+
+            # self.assertLess(0, proc_num_frames)
+            # self.assertLess(desync_out_counter, out_counter)
+            # self.assertLess(0, none_counter)
+
+
+        # def test_compile_streaming_empty(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # comp.compileStreaming()
+
+
+        # def test_compile_streaming_args(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        # def test_compile_streaming_descr_of(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # img = np.zeros((3,300,300), dtype=np.float32)
+            # comp.compileStreaming([cv.descr_of(img)])
+
+
+        # def test_compile_streaming_descr_of_and_args(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # img = np.zeros((3,300,300), dtype=np.float32)
+            # comp.compileStreaming([cv.descr_of(img)],
+                    # cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        # def test_compile_streaming_meta(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # img = np.zeros((3,300,300), dtype=np.float32)
+            # comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
+
+
+        # def test_compile_streaming_meta_and_args(self):
+            # g_in = cv.GMat()
+            # comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            # img = np.zeros((3,300,300), dtype=np.float32)
+            # comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))],
+                    # cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
 

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -36,297 +36,29 @@ try:
 
     class test_gapi_streaming(NewOpenCVTests):
 
-        # def test_image_input(self):
-            # sz = (1280, 720)
-            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            # # OpenCV
-            # expected = cv.medianBlur(in_mat, 3)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out = cv.gapi.medianBlur(g_in, 3)
-            # c = cv.GComputation(g_in, g_out)
-            # ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
-            # ccomp.setSource(cv.gin(in_mat))
-            # ccomp.start()
-
-            # _, actual = ccomp.pull()
-
-            # # Assert
-            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-
-        # def test_video_input(self):
-            # ksize = 3
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out = cv.gapi.medianBlur(g_in, ksize)
-            # c = cv.GComputation(g_in, g_out)
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, expected = cap.read()
-                # has_actual,   actual   = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_split3(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # b, g, r = cv.gapi.split3(g_in)
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame = cap.read()
-                # has_actual,   actual   = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # expected = cv.split(frame)
-                # for e, a in zip(expected, actual):
-                    # self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_add(self):
-            # sz = (576, 768, 3)
-            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in1 = cv.GMat()
-            # g_in2 = cv.GMat()
-            # out = cv.gapi.add(g_in1, g_in2)
-            # c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source, in_mat))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame  = cap.read()
-                # has_actual,   actual = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # expected = cv.add(frame, in_mat)
-                # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_video_good_features_to_track(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # NB: goodFeaturesToTrack configuration
-            # max_corners         = 50
-            # quality_lvl         = 0.01
-            # min_distance        = 10
-            # block_sz            = 3
-            # use_harris_detector = True
-            # k                   = 0.04
-            # mask                = None
-
-            # # OpenCV
-            # cap = cv.VideoCapture(path)
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_gray = cv.gapi.RGB2Gray(g_in)
-            # g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
-                                                # min_distance, mask, block_sz, use_harris_detector, k)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-            # while cap.isOpened():
-                # has_expected, frame  = cap.read()
-                # has_actual,   actual = ccomp.pull()
-
-                # self.assertEqual(has_expected, has_actual)
-
-                # if not has_actual:
-                    # break
-
-                # # OpenCV
-                # frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
-                # expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
-                                                  # min_distance, mask=mask,
-                                                  # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-                # for e, a in zip(expected, actual):
-                    # # NB: OpenCV & G-API have different output shapes:
-                    # # OpenCV - (num_points, 1, 2)
-                    # # G-API  - (num_points, 2)
-                    # self.assertEqual(0.0, cv.norm(e.flatten(),
-                                                  # np.array(a, np.float32).flatten(),
-                                                  # cv.NORM_INF))
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # break
-
-
-        # def test_gapi_streaming_meta(self):
-            # ksize = 3
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_ts = cv.gapi.streaming.timestamp(g_in)
-            # g_seqno = cv.gapi.streaming.seqNo(g_in)
-            # g_seqid = cv.gapi.streaming.seq_id(g_in)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
-
-            # ccomp = c.compileStreaming()
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # curr_frame_number = 0
-            # while True:
-                # has_frame, (ts, seqno, seqid) = ccomp.pull()
-
-                # if not has_frame:
-                    # break
-
-                # self.assertEqual(curr_frame_number, seqno)
-                # self.assertEqual(curr_frame_number, seqid)
-
-                # curr_frame_number += 1
-                # if curr_frame_number == max_num_frames:
-                    # break
-
-
-        # def test_desync(self):
-            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # # G-API
-            # g_in = cv.GMat()
-            # g_out1 = cv.gapi.copy(g_in)
-            # des = cv.gapi.streaming.desync(g_in)
-            # g_out2 = GDelay.on(des)
-
-            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
-
-            # kernels = cv.gapi.kernels(GDelayImpl)
-            # ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
-            # source = cv.gapi.wip.make_capture_src(path)
-            # ccomp.setSource(cv.gin(source))
-            # ccomp.start()
-
-            # # Assert
-            # max_num_frames  = 10
-            # proc_num_frames = 0
-
-            # out_counter = 0
-            # desync_out_counter = 0
-            # none_counter = 0
-            # while True:
-                # has_frame, (out1, out2) = ccomp.pull()
-                # if not has_frame:
-                    # break
-
-                # if not out1 is None:
-                    # out_counter += 1
-                # if not out2 is None:
-                    # desync_out_counter += 1
-                # else:
-                    # none_counter += 1
-
-                # proc_num_frames += 1
-                # if proc_num_frames == max_num_frames:
-                    # ccomp.stop()
-                    # break
-
-            # self.assertLess(0, proc_num_frames)
-            # self.assertLess(desync_out_counter, out_counter)
-            # self.assertLess(0, none_counter)
+        def test_image_input(self):
+            sz = (1280, 720)
+            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            # OpenCV
+            expected = cv.medianBlur(in_mat, 3)
+
+            # G-API
+            g_in = cv.GMat()
+            g_out = cv.gapi.medianBlur(g_in, 3)
+            c = cv.GComputation(g_in, g_out)
+            ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
+            ccomp.setSource(cv.gin(in_mat))
+            ccomp.start()
+
+            _, actual = ccomp.pull()
+
+            # Assert
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
 
         def test_video_input(self):
-            @cv.gapi.op('custom.mean', in_types=[cv.GMat, tuple], out_types=[cv.GScalar])
-            class GBlur:
-                """Blur input image"""
-
-                @staticmethod
-                def outMeta(desc, ksize):
-                    return desc
-
-
-            @cv.gapi.kernel(GBlur)
-            class GBlurImpl:
-                """Implementation for GBlur operation."""
-
-                @staticmethod
-                def run(img, ksize):
-                    return cv.blur(img, ksize)
-
-            ksize = (10, 10)
+            ksize = 3
             path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
             # OpenCV
@@ -334,20 +66,288 @@ try:
 
             # G-API
             g_in = cv.GMat()
-            g_out = GBlur.on(g_in, ksize)
+            g_out = cv.gapi.medianBlur(g_in, ksize)
             c = cv.GComputation(g_in, g_out)
 
-            kernels = cv.gapi.kernels(GBlurImpl)
-            # ccomp = c.compileStreaming(cv.GMatDesc())
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
 
-            # ccomp = c.compileStreaming(cv.gapi.compile_args(...), cv.GMatDesc())
-            # ccomp = c.compileStreaming()
-            ccomp = c.compileStreaming(cv.gapi.compile_args(kernels))
-            # ccomp = c.compileStreaming(cv.gapi.compile_args(...))
-            # ccomp = c.compileStreaming(cv.GMatDesc())
-            # ccomp = c.compileStreaming(cv.descr_of(img))
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, expected = cap.read()
+                has_actual,   actual   = ccomp.pull()
 
-            # print('HHHHHHHHHHHHHHHHHHHHH')
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_split3(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in = cv.GMat()
+            b, g, r = cv.gapi.split3(g_in)
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame = cap.read()
+                has_actual,   actual   = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                expected = cv.split(frame)
+                for e, a in zip(expected, actual):
+                    self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_add(self):
+            sz = (576, 768, 3)
+            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in1 = cv.GMat()
+            g_in2 = cv.GMat()
+            out = cv.gapi.add(g_in1, g_in2)
+            c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source, in_mat))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame  = cap.read()
+                has_actual,   actual = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                expected = cv.add(frame, in_mat)
+                self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_video_good_features_to_track(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # NB: goodFeaturesToTrack configuration
+            max_corners         = 50
+            quality_lvl         = 0.01
+            min_distance        = 10
+            block_sz            = 3
+            use_harris_detector = True
+            k                   = 0.04
+            mask                = None
+
+            # OpenCV
+            cap = cv.VideoCapture(path)
+
+            # G-API
+            g_in = cv.GMat()
+            g_gray = cv.gapi.RGB2Gray(g_in)
+            g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
+                                                min_distance, mask, block_sz, use_harris_detector, k)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+            while cap.isOpened():
+                has_expected, frame  = cap.read()
+                has_actual,   actual = ccomp.pull()
+
+                self.assertEqual(has_expected, has_actual)
+
+                if not has_actual:
+                    break
+
+                # OpenCV
+                frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
+                                                  min_distance, mask=mask,
+                                                  blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+                for e, a in zip(expected, actual):
+                    # NB: OpenCV & G-API have different output shapes:
+                    # OpenCV - (num_points, 1, 2)
+                    # G-API  - (num_points, 2)
+                    self.assertEqual(0.0, cv.norm(e.flatten(),
+                                                  np.array(a, np.float32).flatten(),
+                                                  cv.NORM_INF))
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    break
+
+
+        def test_gapi_streaming_meta(self):
+            ksize = 3
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # G-API
+            g_in = cv.GMat()
+            g_ts = cv.gapi.streaming.timestamp(g_in)
+            g_seqno = cv.gapi.streaming.seqNo(g_in)
+            g_seqid = cv.gapi.streaming.seq_id(g_in)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
+
+            ccomp = c.compileStreaming()
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            curr_frame_number = 0
+            while True:
+                has_frame, (ts, seqno, seqid) = ccomp.pull()
+
+                if not has_frame:
+                    break
+
+                self.assertEqual(curr_frame_number, seqno)
+                self.assertEqual(curr_frame_number, seqid)
+
+                curr_frame_number += 1
+                if curr_frame_number == max_num_frames:
+                    break
+
+
+        def test_desync(self):
+            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # G-API
+            g_in = cv.GMat()
+            g_out1 = cv.gapi.copy(g_in)
+            des = cv.gapi.streaming.desync(g_in)
+            g_out2 = GDelay.on(des)
+
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
+
+            kernels = cv.gapi.kernels(GDelayImpl)
+            ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
+            source = cv.gapi.wip.make_capture_src(path)
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            # Assert
+            max_num_frames  = 10
+            proc_num_frames = 0
+
+            out_counter = 0
+            desync_out_counter = 0
+            none_counter = 0
+            while True:
+                has_frame, (out1, out2) = ccomp.pull()
+                if not has_frame:
+                    break
+
+                if not out1 is None:
+                    out_counter += 1
+                if not out2 is None:
+                    desync_out_counter += 1
+                else:
+                    none_counter += 1
+
+                proc_num_frames += 1
+                if proc_num_frames == max_num_frames:
+                    ccomp.stop()
+                    break
+
+            self.assertLess(0, proc_num_frames)
+            self.assertLess(desync_out_counter, out_counter)
+            self.assertLess(0, none_counter)
+
+
+        def test_compile_streaming_empty(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            comp.compileStreaming()
+
+
+        def test_compile_streaming_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        def test_compile_streaming_gin(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming(cv.gin(img))
+
+
+        def test_compile_streaming_gin_and_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming(cv.gin(img),
+                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
+
+
+        def test_compile_streaming_meta(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))])
+
+
+        def test_compile_streaming_meta_and_args(self):
+            g_in = cv.GMat()
+            comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
+            img = np.zeros((3,300,300), dtype=np.float32)
+            comp.compileStreaming([cv.GMatDesc(cv.CV_8U, 3, (300, 300))],
+                    cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
 

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -36,29 +36,297 @@ try:
 
     class test_gapi_streaming(NewOpenCVTests):
 
-        def test_image_input(self):
-            sz = (1280, 720)
-            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        # def test_image_input(self):
+            # sz = (1280, 720)
+            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
 
-            # OpenCV
-            expected = cv.medianBlur(in_mat, 3)
+            # # OpenCV
+            # expected = cv.medianBlur(in_mat, 3)
 
-            # G-API
-            g_in = cv.GMat()
-            g_out = cv.gapi.medianBlur(g_in, 3)
-            c = cv.GComputation(g_in, g_out)
-            ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
-            ccomp.setSource(cv.gin(in_mat))
-            ccomp.start()
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = cv.gapi.medianBlur(g_in, 3)
+            # c = cv.GComputation(g_in, g_out)
+            # ccomp = c.compileStreaming(cv.gapi.descr_of(in_mat))
+            # ccomp.setSource(cv.gin(in_mat))
+            # ccomp.start()
 
-            _, actual = ccomp.pull()
+            # _, actual = ccomp.pull()
 
-            # Assert
-            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            # # Assert
+            # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+        # def test_video_input(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out = cv.gapi.medianBlur(g_in, ksize)
+            # c = cv.GComputation(g_in, g_out)
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, expected = cap.read()
+                # has_actual,   actual   = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_split3(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # b, g, r = cv.gapi.split3(g_in)
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame = cap.read()
+                # has_actual,   actual   = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # expected = cv.split(frame)
+                # for e, a in zip(expected, actual):
+                    # self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_add(self):
+            # sz = (576, 768, 3)
+            # in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in1 = cv.GMat()
+            # g_in2 = cv.GMat()
+            # out = cv.gapi.add(g_in1, g_in2)
+            # c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source, in_mat))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # expected = cv.add(frame, in_mat)
+                # self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_video_good_features_to_track(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # NB: goodFeaturesToTrack configuration
+            # max_corners         = 50
+            # quality_lvl         = 0.01
+            # min_distance        = 10
+            # block_sz            = 3
+            # use_harris_detector = True
+            # k                   = 0.04
+            # mask                = None
+
+            # # OpenCV
+            # cap = cv.VideoCapture(path)
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_gray = cv.gapi.RGB2Gray(g_in)
+            # g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
+                                                # min_distance, mask, block_sz, use_harris_detector, k)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+            # while cap.isOpened():
+                # has_expected, frame  = cap.read()
+                # has_actual,   actual = ccomp.pull()
+
+                # self.assertEqual(has_expected, has_actual)
+
+                # if not has_actual:
+                    # break
+
+                # # OpenCV
+                # frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                # expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
+                                                  # min_distance, mask=mask,
+                                                  # blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
+                # for e, a in zip(expected, actual):
+                    # # NB: OpenCV & G-API have different output shapes:
+                    # # OpenCV - (num_points, 1, 2)
+                    # # G-API  - (num_points, 2)
+                    # self.assertEqual(0.0, cv.norm(e.flatten(),
+                                                  # np.array(a, np.float32).flatten(),
+                                                  # cv.NORM_INF))
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # break
+
+
+        # def test_gapi_streaming_meta(self):
+            # ksize = 3
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_ts = cv.gapi.streaming.timestamp(g_in)
+            # g_seqno = cv.gapi.streaming.seqNo(g_in)
+            # g_seqid = cv.gapi.streaming.seq_id(g_in)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
+
+            # ccomp = c.compileStreaming()
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # curr_frame_number = 0
+            # while True:
+                # has_frame, (ts, seqno, seqid) = ccomp.pull()
+
+                # if not has_frame:
+                    # break
+
+                # self.assertEqual(curr_frame_number, seqno)
+                # self.assertEqual(curr_frame_number, seqid)
+
+                # curr_frame_number += 1
+                # if curr_frame_number == max_num_frames:
+                    # break
+
+
+        # def test_desync(self):
+            # path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
+
+            # # G-API
+            # g_in = cv.GMat()
+            # g_out1 = cv.gapi.copy(g_in)
+            # des = cv.gapi.streaming.desync(g_in)
+            # g_out2 = GDelay.on(des)
+
+            # c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
+
+            # kernels = cv.gapi.kernels(GDelayImpl)
+            # ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
+            # source = cv.gapi.wip.make_capture_src(path)
+            # ccomp.setSource(cv.gin(source))
+            # ccomp.start()
+
+            # # Assert
+            # max_num_frames  = 10
+            # proc_num_frames = 0
+
+            # out_counter = 0
+            # desync_out_counter = 0
+            # none_counter = 0
+            # while True:
+                # has_frame, (out1, out2) = ccomp.pull()
+                # if not has_frame:
+                    # break
+
+                # if not out1 is None:
+                    # out_counter += 1
+                # if not out2 is None:
+                    # desync_out_counter += 1
+                # else:
+                    # none_counter += 1
+
+                # proc_num_frames += 1
+                # if proc_num_frames == max_num_frames:
+                    # ccomp.stop()
+                    # break
+
+            # self.assertLess(0, proc_num_frames)
+            # self.assertLess(desync_out_counter, out_counter)
+            # self.assertLess(0, none_counter)
 
 
         def test_video_input(self):
-            ksize = 3
+            @cv.gapi.op('custom.mean', in_types=[cv.GMat, tuple], out_types=[cv.GScalar])
+            class GBlur:
+                """Blur input image"""
+
+                @staticmethod
+                def outMeta(desc, ksize):
+                    return desc
+
+
+            @cv.gapi.kernel(GBlur)
+            class GBlurImpl:
+                """Implementation for GBlur operation."""
+
+                @staticmethod
+                def run(img, ksize):
+                    return cv.blur(img, ksize)
+
+            ksize = (10, 10)
             path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
 
             # OpenCV
@@ -66,245 +334,21 @@ try:
 
             # G-API
             g_in = cv.GMat()
-            g_out = cv.gapi.medianBlur(g_in, ksize)
+            g_out = GBlur.on(g_in, ksize)
             c = cv.GComputation(g_in, g_out)
 
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
+            kernels = cv.gapi.kernels(GBlurImpl)
+            # ccomp = c.compileStreaming(cv.GMatDesc())
 
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, expected = cap.read()
-                has_actual,   actual   = ccomp.pull()
+            # ccomp = c.compileStreaming(cv.gapi.compile_args(...), cv.GMatDesc())
+            # ccomp = c.compileStreaming()
+            ccomp = c.compileStreaming(cv.gapi.compile_args(kernels))
+            # ccomp = c.compileStreaming(cv.gapi.compile_args(...))
+            # ccomp = c.compileStreaming(cv.GMatDesc())
+            # ccomp = c.compileStreaming(cv.descr_of(img))
 
-                self.assertEqual(has_expected, has_actual)
+            # print('HHHHHHHHHHHHHHHHHHHHH')
 
-                if not has_actual:
-                    break
-
-                self.assertEqual(0.0, cv.norm(cv.medianBlur(expected, ksize), actual, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_split3(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in = cv.GMat()
-            b, g, r = cv.gapi.split3(g_in)
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(b, g, r))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame = cap.read()
-                has_actual,   actual   = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                expected = cv.split(frame)
-                for e, a in zip(expected, actual):
-                    self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_add(self):
-            sz = (576, 768, 3)
-            in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
-
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in1 = cv.GMat()
-            g_in2 = cv.GMat()
-            out = cv.gapi.add(g_in1, g_in2)
-            c = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source, in_mat))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                expected = cv.add(frame, in_mat)
-                self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_video_good_features_to_track(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # NB: goodFeaturesToTrack configuration
-            max_corners         = 50
-            quality_lvl         = 0.01
-            min_distance        = 10
-            block_sz            = 3
-            use_harris_detector = True
-            k                   = 0.04
-            mask                = None
-
-            # OpenCV
-            cap = cv.VideoCapture(path)
-
-            # G-API
-            g_in = cv.GMat()
-            g_gray = cv.gapi.RGB2Gray(g_in)
-            g_out = cv.gapi.goodFeaturesToTrack(g_gray, max_corners, quality_lvl,
-                                                min_distance, mask, block_sz, use_harris_detector, k)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-            while cap.isOpened():
-                has_expected, frame  = cap.read()
-                has_actual,   actual = ccomp.pull()
-
-                self.assertEqual(has_expected, has_actual)
-
-                if not has_actual:
-                    break
-
-                # OpenCV
-                frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
-                expected = cv.goodFeaturesToTrack(frame, max_corners, quality_lvl,
-                                                  min_distance, mask=mask,
-                                                  blockSize=block_sz, useHarrisDetector=use_harris_detector, k=k)
-                for e, a in zip(expected, actual):
-                    # NB: OpenCV & G-API have different output shapes:
-                    # OpenCV - (num_points, 1, 2)
-                    # G-API  - (num_points, 2)
-                    self.assertEqual(0.0, cv.norm(e.flatten(),
-                                                  np.array(a, np.float32).flatten(),
-                                                  cv.NORM_INF))
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    break
-
-
-        def test_gapi_streaming_meta(self):
-            ksize = 3
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_ts = cv.gapi.streaming.timestamp(g_in)
-            g_seqno = cv.gapi.streaming.seqNo(g_in)
-            g_seqid = cv.gapi.streaming.seq_id(g_in)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_ts, g_seqno, g_seqid))
-
-            ccomp = c.compileStreaming()
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            curr_frame_number = 0
-            while True:
-                has_frame, (ts, seqno, seqid) = ccomp.pull()
-
-                if not has_frame:
-                    break
-
-                self.assertEqual(curr_frame_number, seqno)
-                self.assertEqual(curr_frame_number, seqid)
-
-                curr_frame_number += 1
-                if curr_frame_number == max_num_frames:
-                    break
-
-        def test_desync(self):
-            path = self.find_file('cv/video/768x576.avi', [os.environ['OPENCV_TEST_DATA_PATH']])
-
-            # G-API
-            g_in = cv.GMat()
-            g_out1 = cv.gapi.copy(g_in)
-            des = cv.gapi.streaming.desync(g_in)
-            g_out2 = GDelay.on(des)
-
-            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out1, g_out2))
-
-            kernels = cv.gapi.kernels(GDelayImpl)
-            ccomp = c.compileStreaming(args=cv.gapi.compile_args(kernels))
-            source = cv.gapi.wip.make_capture_src(path)
-            ccomp.setSource(cv.gin(source))
-            ccomp.start()
-
-            # Assert
-            max_num_frames  = 10
-            proc_num_frames = 0
-
-            out_counter = 0
-            desync_out_counter = 0
-            none_counter = 0
-            while True:
-                has_frame, (out1, out2) = ccomp.pull()
-                if not has_frame:
-                    break
-
-                if not out1 is None:
-                    out_counter += 1
-                if not out2 is None:
-                    desync_out_counter += 1
-                else:
-                    none_counter += 1
-
-                proc_num_frames += 1
-                if proc_num_frames == max_num_frames:
-                    ccomp.stop()
-                    break
-
-            self.assertLess(0, proc_num_frames)
-            self.assertLess(desync_out_counter, out_counter)
-            self.assertLess(0, none_counter)
 
 
 except unittest.SkipTest as e:

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -320,18 +320,18 @@ try:
             comp.compileStreaming(cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
-        def test_compile_streaming_gin(self):
+        def test_compile_streaming_descr_of(self):
             g_in = cv.GMat()
             comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
             img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gin(img))
+            comp.compileStreaming(cv.gapi.descr_of(img))
 
 
-        def test_compile_streaming_gin_and_args(self):
+        def test_compile_streaming_descr_of_and_args(self):
             g_in = cv.GMat()
             comp = cv.GComputation(g_in, cv.gapi.medianBlur(g_in, 3))
             img = np.zeros((3,300,300), dtype=np.float32)
-            comp.compileStreaming(cv.gin(img),
+            comp.compileStreaming(cv.gapi.descr_of(img),
                     cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -131,16 +131,16 @@ cv::GStreamingCompiled cv::GComputation::compileStreaming(GMetaArgs &&metas, GCo
 cv::GStreamingCompiled cv::GComputation::compileStreaming(GCompileArgs &&args)
 {
     // NB: Used by python bridge
-    if (!m_priv->m_info)
-    {
-        m_priv->m_info = collectGraphInfo(*m_priv);
-    }
+    //if (!m_priv->m_info)
+    //{
+        //m_priv->m_info = collectGraphInfo(*m_priv);
+    //}
 
     cv::gimpl::GCompiler comp(*this, {}, std::move(args));
     auto compiled = comp.compileStreaming();
 
-    compiled.priv().setInInfo(m_priv->m_info->inputs);
-    compiled.priv().setOutInfo(m_priv->m_info->outputs);
+    //compiled.priv().setInInfo(m_priv->m_info->inputs);
+    //compiled.priv().setOutInfo(m_priv->m_info->outputs);
 
     return compiled;
 }

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -172,3 +172,10 @@ void cv::GCompiled::prepareForNewStream()
 {
     m_priv->prepareForNewStream();
 }
+
+cv::GRunArgs cv::GCompiled::run(const cv::detail::ExtractArgsCallback  &callback,
+                                GCompileArgs                         &&args)
+{
+    std::cout << "HHHHHHHHHHHHH" << std::endl;
+    return {};
+}

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -39,9 +39,9 @@ class GAPI_EXPORTS GCompiler
 public:
     // Metas may be empty in case when graph compiling for streaming
     // In this case graph get metas from first frame
-    explicit GCompiler(const GComputation &c,
-                             GMetaArgs    &&metas,
-                             GCompileArgs &&args);
+    GCompiler(const GComputation &c,
+                    GMetaArgs    &&metas,
+                    GCompileArgs &&args);
 
     // The method which does everything...
     GCompiled compile();

--- a/modules/gapi/src/executor/gexecutor.hpp
+++ b/modules/gapi/src/executor/gexecutor.hpp
@@ -83,6 +83,8 @@ protected:
 
     void initResource(const ade::NodeHandle &nh, const ade::NodeHandle &orig_nh); // FIXME: shouldn't it be RcDesc?
 
+    cv::GTypesInfo out_info;
+
 public:
     explicit GExecutor(std::unique_ptr<ade::Graph> &&g_model);
     void run(cv::gimpl::GRuntimeArgs &&args);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

