### PR TITLE
Fix hough circles alt dimensions

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -2301,14 +2301,16 @@ static void HoughCircles( InputArray _image, OutputArray _circles,
                 std::vector<Vec4f> cw(ncircles);
                 for( i = 0; i < ncircles; i++ )
                     cw[i] = GetCircle4f(circles[i]);
-                Mat(cw).copyTo(_circles);
+                if (ncircles > 0)
+                    Mat(1, ncircles, cv::traits::Type<Vec4f>::value, &cw[0]).copyTo(_circles);
             }
             else if( type == CV_32FC3 )
             {
                 std::vector<Vec3f> cwow(ncircles);
                 for( i = 0; i < ncircles; i++ )
                     cwow[i] = GetCircle(circles[i]);
-                Mat(cwow).copyTo(_circles);
+                if (ncircles > 0)
+                    Mat(1, ncircles, cv::traits::Type<Vec3f>::value, &cwow[0]).copyTo(_circles);
             }
             else
                 CV_Error(Error::StsError, "Internal error");

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -2302,7 +2302,7 @@ static void HoughCircles( InputArray _image, OutputArray _circles,
                 for( i = 0; i < ncircles; i++ )
                     cw[i] = GetCircle4f(circles[i]);
                 if (ncircles > 0)
-                    Mat(1, ncircles, cv::traits::Type<Vec4f>::value, &cw[0]).copyTo(_circles);
+                    Mat(1, (int)ncircles, cv::traits::Type<Vec4f>::value, &cw[0]).copyTo(_circles);
             }
             else if( type == CV_32FC3 )
             {
@@ -2310,7 +2310,7 @@ static void HoughCircles( InputArray _image, OutputArray _circles,
                 for( i = 0; i < ncircles; i++ )
                     cwow[i] = GetCircle(circles[i]);
                 if (ncircles > 0)
-                    Mat(1, ncircles, cv::traits::Type<Vec3f>::value, &cwow[0]).copyTo(_circles);
+                    Mat(1, (int)ncircles, cv::traits::Type<Vec3f>::value, &cwow[0]).copyTo(_circles);
             }
             else
                 CV_Error(Error::StsError, "Internal error");

--- a/modules/python/test/test_houghcircles.py
+++ b/modules/python/test/test_houghcircles.py
@@ -90,9 +90,7 @@ class houghcircles_test(NewOpenCVTests):
 
         circles = cv.HoughCircles(img, cv.HOUGH_GRADIENT_ALT, 1, 10, np.array([]), 300, 0.9, 1, 30)
 
-        self.assertEqual(circles.shape[0], 1)
-        self.assertEqual(circles.shape[1], 18)
-        self.assertEqual(circles.shape[2], 3)
+        self.assertEqual(circles.shape, (1, 18, 3))
 
         circles = circles[0]
 

--- a/modules/python/test/test_houghcircles.py
+++ b/modules/python/test/test_houghcircles.py
@@ -88,7 +88,13 @@ class houghcircles_test(NewOpenCVTests):
         img = cv.cvtColor(src, cv.COLOR_BGR2GRAY)
         img = cv.medianBlur(img, 5)
 
-        circles = cv.HoughCircles(img, cv.HOUGH_GRADIENT_ALT, 1, 10, np.array([]), 300, 0.9, 1, 30)[0]
+        circles = cv.HoughCircles(img, cv.HOUGH_GRADIENT_ALT, 1, 10, np.array([]), 300, 0.9, 1, 30)
+
+        self.assertEqual(circles.shape[0], 1)
+        self.assertEqual(circles.shape[1], 18)
+        self.assertEqual(circles.shape[2], 3)
+
+        circles = circles[0]
 
         testCircles = [[38, 181, 17.6],
         [99.7, 166, 13.12],

--- a/modules/python/test/test_houghcircles.py
+++ b/modules/python/test/test_houghcircles.py
@@ -80,5 +80,48 @@ class houghcircles_test(NewOpenCVTests):
         self.assertLess(float(len(circles) - matches_counter) / len(circles), .75)
 
 
+    def test_houghcircles_alt(self):
+
+        fn = "samples/data/board.jpg"
+
+        src = self.get_sample(fn, 1)
+        img = cv.cvtColor(src, cv.COLOR_BGR2GRAY)
+        img = cv.medianBlur(img, 5)
+
+        circles = cv.HoughCircles(img, cv.HOUGH_GRADIENT_ALT, 1, 10, np.array([]), 300, 0.9, 1, 30)[0]
+
+        testCircles = [[38, 181, 17.6],
+        [99.7, 166, 13.12],
+        [142.7, 160, 13.52],
+        [223.6, 110, 8.62],
+        [79.1, 206.7, 8.62],
+        [47.5, 351.6, 11.64],
+        [189.5, 354.4, 11.64],
+        [189.8, 298.9, 10.64],
+        [189.5, 252.4, 14.62],
+        [252.5, 393.4, 15.62],
+        [602.9, 467.5, 11.42],
+        [222, 210.4, 9.12],
+        [263.1, 216.7, 9.12],
+        [359.8, 222.6, 9.12],
+        [518.9, 120.9, 9.12],
+        [413.8, 113.4, 9.12],
+        [489, 127.2, 9.12],
+        [448.4, 121.3, 9.12],
+        [384.6, 128.9, 8.62]]
+
+        matches_counter = 0
+
+        for i in range(len(testCircles)):
+            for j in range(len(circles)):
+
+                tstCircle = circleApproximation(testCircles[i])
+                circle = circleApproximation(circles[j])
+                if convContoursIntersectiponRate(tstCircle, circle) > 0.6:
+                    matches_counter += 1
+
+        self.assertGreater(float(matches_counter) / len(testCircles), .5)
+        self.assertLess(float(len(circles) - matches_counter) / len(circles), .75)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Fixes #19238
Relates #16561

cvMat with different dimensions were copied to OutputArray _circles.

HOUGH_GRADIENT :
```
Mat(1, numCircles, cv::traits::Type<CircleType>::value, &circles[0]).copyTo(_circles);
```

vs

HOUGH_GRADIENT_ALT :
```
std::vector<Vec3f> cwow(ncircles);
Mat(cwow).copyTo(_circles);
```

This has been fixed and a test has been added.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
