### PR TITLE
Add CAP_PROP_STREAM_OPEN_TIME

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -188,7 +188,7 @@ enum VideoCaptureProperties {
        CAP_PROP_HW_ACCELERATION_USE_OPENCL=52, //!< (**open-only**) If non-zero, create new OpenCL context and bind it to current thread. The OpenCL context created with Video Acceleration context attached it (if not attached yet) for optimized GPU data copy between HW accelerated decoder and cv::UMat.
        CAP_PROP_OPEN_TIMEOUT_MSEC=53, //!< (**open-only**) timeout in milliseconds for opening a video capture (applicable for FFmpeg back-end only)
        CAP_PROP_READ_TIMEOUT_MSEC=54, //!< (**open-only**) timeout in milliseconds for reading from a video capture (applicable for FFmpeg back-end only)
-       CAP_PROP_STREAM_OPEN_TIME_NSEC =55, //<! (read-only) time in nanoseconds since Jan 1 1970 when stream was opened. Applicable for FFmpeg backend only. Useful for RTSP and other live streams
+       CAP_PROP_STREAM_OPEN_TIME_USEC =55, //<! (read-only) time in microseconds since Jan 1 1970 when stream was opened. Applicable for FFmpeg backend only. Useful for RTSP and other live streams
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -188,7 +188,7 @@ enum VideoCaptureProperties {
        CAP_PROP_HW_ACCELERATION_USE_OPENCL=52, //!< (**open-only**) If non-zero, create new OpenCL context and bind it to current thread. The OpenCL context created with Video Acceleration context attached it (if not attached yet) for optimized GPU data copy between HW accelerated decoder and cv::UMat.
        CAP_PROP_OPEN_TIMEOUT_MSEC=53, //!< (**open-only**) timeout in milliseconds for opening a video capture (applicable for FFmpeg back-end only)
        CAP_PROP_READ_TIMEOUT_MSEC=54, //!< (**open-only**) timeout in milliseconds for reading from a video capture (applicable for FFmpeg back-end only)
-       CAP_PROP_STREAM_OPEN_TIME =55, //<! (read-only) time in seconds since Jan 1 1970 when stream was opened. Applicable for FFmpeg backend only. Useful for RTSP and other live streams
+       CAP_PROP_STREAM_OPEN_TIME_NSEC =55, //<! (read-only) time in nanoseconds since Jan 1 1970 when stream was opened. Applicable for FFmpeg backend only. Useful for RTSP and other live streams
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -188,6 +188,7 @@ enum VideoCaptureProperties {
        CAP_PROP_HW_ACCELERATION_USE_OPENCL=52, //!< (**open-only**) If non-zero, create new OpenCL context and bind it to current thread. The OpenCL context created with Video Acceleration context attached it (if not attached yet) for optimized GPU data copy between HW accelerated decoder and cv::UMat.
        CAP_PROP_OPEN_TIMEOUT_MSEC=53, //!< (**open-only**) timeout in milliseconds for opening a video capture (applicable for FFmpeg back-end only)
        CAP_PROP_READ_TIMEOUT_MSEC=54, //!< (**open-only**) timeout in milliseconds for reading from a video capture (applicable for FFmpeg back-end only)
+       CAP_PROP_STREAM_OPEN_TIME =55, //<! (read-only) time in seconds since Jan 1 1970 when stream was opened. Applicable for FFmpeg backend only. Useful for RTSP and other live streams
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1593,7 +1593,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
 #endif  // USE_AV_HW_CODECS
     case CAP_PROP_STREAM_OPEN_TIME_USEC:
         //ic->start_time_realtime is in microseconds
-        return ((double)ic->start_time_realtime); 
+        return ((double)ic->start_time_realtime);
     default:
         break;
     }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1591,9 +1591,9 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
     case CAP_PROP_HW_ACCELERATION_USE_OPENCL:
         return static_cast<double>(use_opencl);
 #endif  // USE_AV_HW_CODECS
-    case CAP_PROP_STREAM_OPEN_TIME_NSEC:
-        //ic->start_time_realtime is in microseconds - convert to nanoseconds
-        return ((double)ic->start_time_realtime * 1000.0); 
+    case CAP_PROP_STREAM_OPEN_TIME_USEC:
+        //ic->start_time_realtime is in microseconds
+        return ((double)ic->start_time_realtime); 
     default:
         break;
     }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1591,8 +1591,9 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
     case CAP_PROP_HW_ACCELERATION_USE_OPENCL:
         return static_cast<double>(use_opencl);
 #endif  // USE_AV_HW_CODECS
-    case CAP_PROP_STREAM_OPEN_TIME:
-        return ((double)ic->start_time_realtime / 1000000.0);
+    case CAP_PROP_STREAM_OPEN_TIME_NSEC:
+        //ic->start_time_realtime is in microseconds - convert to nanoseconds
+        return ((double)ic->start_time_realtime * 1000.0); 
     default:
         break;
     }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1591,6 +1591,8 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
     case CAP_PROP_HW_ACCELERATION_USE_OPENCL:
         return static_cast<double>(use_opencl);
 #endif  // USE_AV_HW_CODECS
+    case CAP_PROP_STREAM_OPEN_TIME:
+        return ((double)ic->start_time_realtime / 1000000.0);
     default:
         break;
     }


### PR DESCRIPTION
I added CAP_PROP_STREAM_OPEN_TIME to the capture properties enumeration and support for it in the `getProperty()` method of the FFmpeg VideoCapture object.

Motivation - RTSP (RTP) stream timestamps are relative to start of stream, which is undesirable when trying to correlate the stream to external data streams. 

Testing - I'm happy to add a test case, but as the return value of `cap.get(cv2::CAP_PROP_STREAM_OPEN_TIME)` is nondeterministic, I'm unsure if it needs one/how to do it. I tested locally (with an IP camera and an RTSP stream) and it works. Please advise if more extensive testing/sample code is needed.
