### PR TITLE
G-API: oneVPL (simplification) added surface & frame adapter

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -169,17 +169,12 @@ set(gapi_srcs
     src/streaming/onevpl/file_data_provider.cpp
     src/streaming/onevpl/cfg_params.cpp
     src/streaming/onevpl/data_provider_interface_exception.cpp
+    src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+    src/streaming/onevpl/accelerators/surface/surface.cpp
 
     # Utils (ITT tracing)
     src/utils/itt.cpp
     )
-
-if(HAVE_GAPI_ONEVPL)
-    list(APPEND gapi_srcs
-        src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
-        src/streaming/onevpl/accelerators/surface/surface.cpp
-    )
-endif()
 
 ocv_add_dispatched_file(backends/fluid/gfluidimgproc_func SSE4_1 AVX2)
 

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -174,6 +174,13 @@ set(gapi_srcs
     src/utils/itt.cpp
     )
 
+if(HAVE_GAPI_ONEVPL)
+    list(APPEND gapi_srcs
+        src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+        src/streaming/onevpl/accelerators/surface/surface.cpp
+    )
+endif()
+
 ocv_add_dispatched_file(backends/fluid/gfluidimgproc_func SSE4_1 AVX2)
 
 ocv_list_add_prefix(gapi_srcs "${CMAKE_CURRENT_LIST_DIR}/")

--- a/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_interface.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_interface.hpp
@@ -1,0 +1,59 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef GAPI_STREAMING_ONEVPL_ACCELERATORS_ACCEL_POLICY_INTERFACE_HPP
+#define GAPI_STREAMING_ONEVPL_ACCELERATORS_ACCEL_POLICY_INTERFACE_HPP
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include <opencv2/gapi/media.hpp>
+
+#ifdef HAVE_ONEVPL
+#include <vpl/mfxvideo.h>
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+class Surface;
+struct VPLAccelerationPolicy
+{
+    virtual ~VPLAccelerationPolicy() {}
+
+    using pool_key_t = void*;
+
+    using session_t = mfxSession;
+    using surface_t = Surface;
+    using surface_ptr_t = std::shared_ptr<surface_t>;
+    using surface_weak_ptr_t = std::weak_ptr<surface_t>;
+    using surface_ptr_ctr_t = std::function<surface_ptr_t(std::shared_ptr<void> out_buf_ptr,
+                                                          size_t out_buf_ptr_offset,
+                                                          size_t out_buf_ptr_size)>;
+
+    virtual void init(session_t session) = 0;
+    virtual void deinit(session_t session) = 0;
+
+    // Limitation: cannot give guarantee in succesful memory realloccation
+    // for existing workspace in existing pool (see realloc)
+    // thus it is not implemented,
+    // PLEASE provide initial memory area large enough
+    virtual pool_key_t create_surface_pool(size_t pool_size, size_t surface_size_bytes, surface_ptr_ctr_t creator) = 0;
+
+    virtual surface_weak_ptr_t get_free_surface(pool_key_t key) = 0;
+    virtual size_t get_free_surface_count(pool_key_t key) const = 0;
+    virtual size_t get_surface_count(pool_key_t key) const = 0;
+
+    virtual cv::MediaFrame::AdapterPtr create_frame_adapter(pool_key_t key,
+                                                            mfxFrameSurface1* surface) = 0;
+};
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // HAVE_ONEVPL
+#endif // GAPI_STREAMING_ONEVPL_ACCELERATORS_ACCEL_POLICY_INTERFACE_HPP

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -63,7 +63,6 @@ MediaFrame::View VPLMediaFrameCPUAdapter::access(MediaFrame::Access) {
     const Surface::data_t& data = parent_surface_ptr->get_data();
     const Surface::info_t& info = parent_surface_ptr->get_info();
     using stride_t = typename cv::MediaFrame::View::Strides::value_type;
-    GAPI_Assert(data.Pitch >= 0 && "Pitch is less than 0");
 
     stride_t pitch = static_cast<stride_t>(data.Pitch);
     switch(info.FourCC) {

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -101,19 +101,16 @@ MediaFrame::View VPLMediaFrameCPUAdapter::access(MediaFrame::Access) {
 }
 
 cv::util::any VPLMediaFrameCPUAdapter::blobParams() const {
-    GAPI_Assert(false && CV_Func
-                         "is not implemented");
+    GAPI_Assert("VPLMediaFrameCPUAdapter::blobParams() is not implemented");
     return {};
 }
 
 void VPLMediaFrameCPUAdapter::serialize(cv::gapi::s11n::IOStream&) {
-    GAPI_Assert(false && CV_Func
-                         "is not implemented");
+    GAPI_Assert("VPLMediaFrameCPUAdapter::serialize() is not implemented");
 }
 
 void VPLMediaFrameCPUAdapter::deserialize(cv::gapi::s11n::IIStream&) {
-    GAPI_Assert(false && CV_Func
-                         "is not implemented");
+    GAPI_Assert("VPLMediaFrameCPUAdapter::deserialize() is not implemented");
 }
 } // namespace wip
 } // namespace gapi

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -118,4 +118,4 @@ void VPLMediaFrameCPUAdapter::deserialize(cv::gapi::s11n::IIStream&) {
 } // namespace wip
 } // namespace gapi
 } // namespace cv
-#endif HAVE_ONEVPL
+#endif // HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -26,13 +26,10 @@ VPLMediaFrameCPUAdapter::VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> surfac
     GAPI_Assert(parent_surface_ptr && "Surface is nullptr");
     parent_surface_ptr->obtain_lock();
 
-
-    const Surface::info_t& info = parent_surface_ptr->get_info();
-    const Surface::data_t& data = parent_surface_ptr->get_data();
-
     GAPI_LOG_DEBUG(nullptr, "surface: " << parent_surface_ptr->get_handle() <<
-                            ", w: " << info.Width << ", h: " << info.Height <<
-                            ", p: " << data.Pitch);
+                            ", w: " << parent_surface_ptr->get_info().Width <<
+                            ", h: " << parent_surface_ptr->get_info().Height <<
+                            ", p: " << parent_surface_ptr->get_data().Pitch);
 }
 
 VPLMediaFrameCPUAdapter::~VPLMediaFrameCPUAdapter() {
@@ -104,16 +101,19 @@ MediaFrame::View VPLMediaFrameCPUAdapter::access(MediaFrame::Access) {
 }
 
 cv::util::any VPLMediaFrameCPUAdapter::blobParams() const {
-    GAPI_Assert("VPLMediaFrameCPUAdapter::blobParams() is not implemented");
+    GAPI_Assert(false && CV_Func
+                         "is not implemented");
     return {};
 }
 
 void VPLMediaFrameCPUAdapter::serialize(cv::gapi::s11n::IOStream&) {
-    GAPI_Assert("VPLMediaFrameCPUAdapter::serialize() is not implemented");
+    GAPI_Assert(false && CV_Func
+                         "is not implemented");
 }
 
 void VPLMediaFrameCPUAdapter::deserialize(cv::gapi::s11n::IIStream&) {
-    GAPI_Assert("VPLMediaFrameCPUAdapter::deserialize() is not implemented");
+    GAPI_Assert(false && CV_Func
+                         "is not implemented");
 }
 } // namespace wip
 } // namespace gapi

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -1,0 +1,121 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#include "streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp"
+#include "streaming/onevpl/accelerators/surface/surface.hpp"
+#include "logger.hpp"
+
+#ifdef HAVE_ONEVPL
+
+#if (MFX_VERSION >= 2000)
+#include <vpl/mfxdispatcher.h>
+#endif
+
+#include <vpl/mfx.h>
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+VPLMediaFrameCPUAdapter::VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> surface):
+    parent_surface_ptr(surface) {
+
+    GAPI_Assert(parent_surface_ptr && "Surface is nullptr");
+    parent_surface_ptr->obtain_lock();
+
+
+    const Surface::info_t& info = parent_surface_ptr->get_info();
+    const Surface::data_t& data = parent_surface_ptr->get_data();
+
+    GAPI_LOG_DEBUG(nullptr, "surface: " << parent_surface_ptr->get_handle() <<
+                            ", w: " << info.Width << ", h: " << info.Height <<
+                            ", p: " << data.Pitch);
+}
+
+VPLMediaFrameCPUAdapter::~VPLMediaFrameCPUAdapter() {
+
+    // Each VPLMediaFrameCPUAdapter releases mfx surface counter
+    // The last VPLMediaFrameCPUAdapter releases shared Surface pointer
+    // The last surface pointer releases workspace memory
+    parent_surface_ptr->release_lock();
+}
+
+cv::GFrameDesc VPLMediaFrameCPUAdapter::meta() const {
+    GFrameDesc desc;
+    const Surface::info_t info = parent_surface_ptr->get_info();
+    switch(info.FourCC)
+    {
+        case MFX_FOURCC_I420:
+            throw std::runtime_error("MediaFrame doesn't support I420 type");
+            break;
+        case MFX_FOURCC_NV12:
+            desc.fmt = MediaFormat::NV12;
+            break;
+        default:
+            throw std::runtime_error("MediaFrame unknown 'fmt' type: " + std::to_string(info.FourCC));
+    }
+
+    desc.size = cv::Size{info.Width, info.Height};
+    return desc;
+}
+
+MediaFrame::View VPLMediaFrameCPUAdapter::access(MediaFrame::Access) {
+    const Surface::data_t& data = parent_surface_ptr->get_data();
+    const Surface::info_t& info = parent_surface_ptr->get_info();
+    using stride_t = typename cv::MediaFrame::View::Strides::value_type;
+    GAPI_Assert(data.Pitch >= 0 && "Pitch is less than 0");
+
+    stride_t pitch = static_cast<stride_t>(data.Pitch);
+    switch(info.FourCC) {
+        case MFX_FOURCC_I420:
+        {
+            cv::MediaFrame::View::Ptrs pp = {
+                data.Y,
+                data.U,
+                data.V,
+                nullptr
+                };
+            cv::MediaFrame::View::Strides ss = {
+                    pitch,
+                    pitch / 2,
+                    pitch / 2, 0u
+                };
+            return cv::MediaFrame::View(std::move(pp), std::move(ss));
+        }
+        case MFX_FOURCC_NV12:
+        {
+            cv::MediaFrame::View::Ptrs pp = {
+                data.Y,
+                data.UV, nullptr, nullptr
+                };
+            cv::MediaFrame::View::Strides ss = {
+                    pitch,
+                    pitch, 0u, 0u
+                };
+            return cv::MediaFrame::View(std::move(pp), std::move(ss));
+        }
+            break;
+        default:
+            throw std::runtime_error("MediaFrame unknown 'fmt' type: " + std::to_string(info.FourCC));
+    }
+}
+
+cv::util::any VPLMediaFrameCPUAdapter::blobParams() const {
+    GAPI_Assert("VPLMediaFrameCPUAdapter::blobParams() is not implemented");
+    return {};
+}
+
+void VPLMediaFrameCPUAdapter::serialize(cv::gapi::s11n::IOStream&) {
+    GAPI_Assert("VPLMediaFrameCPUAdapter::serialize() is not implemented");
+}
+
+void VPLMediaFrameCPUAdapter::deserialize(cv::gapi::s11n::IIStream&) {
+    GAPI_Assert("VPLMediaFrameCPUAdapter::deserialize() is not implemented");
+}
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+#endif HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -45,7 +45,7 @@ VPLMediaFrameCPUAdapter::~VPLMediaFrameCPUAdapter() {
 
 cv::GFrameDesc VPLMediaFrameCPUAdapter::meta() const {
     GFrameDesc desc;
-    const Surface::info_t info = parent_surface_ptr->get_info();
+    const Surface::info_t& info = parent_surface_ptr->get_info();
     switch(info.FourCC)
     {
         case MFX_FOURCC_I420:

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
@@ -21,7 +21,7 @@ class Surface;
 class VPLMediaFrameCPUAdapter : public cv::MediaFrame::IAdapter {
 public:
     // GAPI_EXPORTS for tests
-    GAPI_EXPORTS VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> assoc_surface);
+    GAPI_EXPORTS explicit VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> assoc_surface);
     GAPI_EXPORTS ~VPLMediaFrameCPUAdapter();
     cv::GFrameDesc meta() const override;
     MediaFrame::View access(MediaFrame::Access) override;

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
@@ -1,0 +1,39 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_CPU_FRAME_ADAPTER_HPP
+#define GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_CPU_FRAME_ADAPTER_HPP
+#include <memory>
+
+#include <opencv2/gapi/media.hpp>
+
+#ifdef HAVE_ONEVPL
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+class Surface;
+class VPLMediaFrameCPUAdapter : public cv::MediaFrame::IAdapter {
+public:
+    VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> assoc_surface);
+    ~VPLMediaFrameCPUAdapter();
+    cv::GFrameDesc meta() const override;
+    MediaFrame::View access(MediaFrame::Access) override;
+
+    // The default implementation does nothing
+    cv::util::any blobParams() const override;
+    void serialize(cv::gapi::s11n::IOStream&) override;
+    void deserialize(cv::gapi::s11n::IIStream&) override;
+private:
+    std::shared_ptr<Surface> parent_surface_ptr;
+};
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // HAVE_ONEVPL
+#endif // GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_CPU_FRAME_ADAPTER_HPP

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include <opencv2/gapi/media.hpp>
+#include "opencv2/gapi/own/exports.hpp" // GAPI_EXPORTS
 
 #ifdef HAVE_ONEVPL
 
@@ -19,8 +20,9 @@ namespace wip {
 class Surface;
 class VPLMediaFrameCPUAdapter : public cv::MediaFrame::IAdapter {
 public:
-    VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> assoc_surface);
-    ~VPLMediaFrameCPUAdapter();
+    // GAPI_EXPORTS for tests
+    GAPI_EXPORTS VPLMediaFrameCPUAdapter(std::shared_ptr<Surface> assoc_surface);
+    GAPI_EXPORTS ~VPLMediaFrameCPUAdapter();
     cv::GFrameDesc meta() const override;
     MediaFrame::View access(MediaFrame::Access) override;
 

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.cpp
@@ -1,0 +1,76 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#include "streaming/onevpl/accelerators/surface/surface.hpp"
+#include "logger.hpp"
+
+#ifdef HAVE_ONEVPL
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+Surface::Surface(std::unique_ptr<handle_t>&& surf, std::shared_ptr<void> associated_memory) :
+    workspace_memory_ptr(associated_memory),
+    mfx_surface(std::move(surf)),
+    mirrored_locked_count() {
+
+    GAPI_Assert(mfx_surface && "Surface is nullptr");
+    mirrored_locked_count.store(mfx_surface->Data.Locked);
+    GAPI_LOG_DEBUG(nullptr, "create surface: " << mfx_surface <<
+                            ", locked count: " << mfx_surface->Data.Locked);
+}
+
+Surface::~Surface() {
+    GAPI_LOG_DEBUG(nullptr, "destroy surface: " << mfx_surface <<
+                            ", worspace memory counter: " << workspace_memory_ptr.use_count());
+}
+
+std::shared_ptr<Surface> Surface::create_surface(std::unique_ptr<handle_t>&& surf,
+                                                 std::shared_ptr<void> accociated_memory) {
+    surface_ptr_t ret {new Surface(std::move(surf), accociated_memory)};
+    return ret;
+}
+
+Surface::handle_t* Surface::get_handle() const {
+    return mfx_surface.get();
+}
+
+const Surface::info_t& Surface::get_info() const {
+    return mfx_surface->Info;
+}
+
+const Surface::data_t& Surface::get_data() const {
+    return mfx_surface->Data;
+}
+
+size_t Surface::get_locks_count() const {
+    return mirrored_locked_count.load();
+}
+
+size_t Surface::obtain_lock() {
+    size_t locked_count = mirrored_locked_count.fetch_add(1);
+    GAPI_Assert(locked_count < std::numeric_limits<mfxU16>::max() && "Too many references ");
+    mfx_surface->Data.Locked = static_cast<mfxU16>(locked_count + 1);
+    GAPI_LOG_DEBUG(nullptr, "surface: " << mfx_surface.get() <<
+                            ", locked times: " << locked_count + 1);
+    return locked_count; // return preceding value
+}
+
+size_t Surface::release_lock() {
+    size_t locked_count = mirrored_locked_count.fetch_sub(1);
+    GAPI_Assert(locked_count < std::numeric_limits<mfxU16>::max() && "Too many references ");
+    GAPI_Assert(locked_count && "Surface lock counter is invalid");
+    mfx_surface->Data.Locked = static_cast<mfxU16>(locked_count - 1);
+    GAPI_LOG_DEBUG(nullptr, "surface: " << mfx_surface.get() <<
+                            ", locked times: " << locked_count - 1);
+    return locked_count; // return preceding value
+}
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
@@ -24,6 +24,26 @@ namespace cv {
 namespace gapi {
 namespace wip {
 
+/**
+ * @brief Inner class for managing oneVPL surface through interface `mfxFrameSurface1`.
+ *
+ * Surface has no own memory and shares accelerator allocated memory using reference counter semantics.
+ * So it lives till a last memory consumer (surface/accelerator/media frame) lives.
+ * This approach allows to support different scenarious in releasing allocated memory
+ *
+ * VPL surface `mfxFrameSurface1` support Lock-Free semantics and application MUST NOT operate with a
+ * surface in locked state. But VPL inner counter is not threadsafe so it would be failed in any concurrent scenario.
+ * std::atomic counter introduced in a way to overcome this problem.
+ * But only few scenarious for concurrency are supported here because it is not assumed to implement entire Surface in
+ * for a fully multithread approach.
+ * Supported concurrency scenarios deal only with transaction pair: @ref Surface::get_locks_count() against
+ * @ref Surface::release_lock() - which may be called from different threads. On the other hand @ref Surface::get_locks_count() against
+ * @ref Surface::obtain_lock() happens in single thread only. Surface doesn't support shared ownership that
+ * because it doesn't require thread safe guarantee between transactions:
+ * - @ref Surface::obtain_lock() against @ref Surface::obtain_lock()
+ * - @ref Surface::obtain_lock() against @ref Surface::release_lock()
+ * - @ref Surface::release_lock() against @ref Surface::release_lock()
+ */
 class Surface {
     using handle_t = mfxFrameSurface1;
 
@@ -36,17 +56,38 @@ public:
 
     // GAPI_EXPORTS for tests
     GAPI_EXPORTS static std::shared_ptr<Surface> create_surface(std::unique_ptr<handle_t>&& surf,
-                                                   std::shared_ptr<void> accociated_memory);
+                                                                std::shared_ptr<void> accociated_memory);
     GAPI_EXPORTS ~Surface();
 
     GAPI_EXPORTS handle_t* get_handle() const;
     GAPI_EXPORTS const info_t& get_info() const;
     GAPI_EXPORTS const data_t& get_data() const;
 
+    /**
+     * Extract value thread-safe lock counter (see @ref Surface description).
+     * It's usual situation that counter may be instantly decreased in other thread after this method called.
+     * We need instantaneous value. This method syncronized in inter-threading way with @ref Surface::release_lock()
+     *
+     * @return fetched locks count.
+     */
     GAPI_EXPORTS size_t get_locks_count() const;
 
-    // it had better to implement RAII
+    /**
+     * Atomically increase value of thread-safe lock counter (see @ref Surface description).
+     * This method is single-threaded happens-after @ref Surface::get_locks_count() and
+     * multi-threaded happens-before @ref Surface::release_lock()
+     *
+     * @return locks count just before its increasing.
+     */
     GAPI_EXPORTS size_t obtain_lock();
+
+    /**
+     * Atomically decrease value of thread-safe lock counter (see @ref Surface description).
+     * This method is synchronized with @ref Surface::get_locks_count() and
+     * multi-threaded happens-after @ref Surface::obtain_lock()
+     *
+     * @return locks count just before its decreasing.
+     */
     GAPI_EXPORTS size_t release_lock();
 private:
     Surface(std::unique_ptr<handle_t>&& surf, std::shared_ptr<void> accociated_memory);

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
@@ -1,0 +1,58 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_HPP
+#define GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_HPP
+
+#include <atomic>
+#include <memory>
+
+#ifdef HAVE_ONEVPL
+#if (MFX_VERSION >= 2000)
+#include <vpl/mfxdispatcher.h>
+#endif
+
+#include <vpl/mfx.h>
+
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+class Surface {
+    using handle_t = mfxFrameSurface1;
+
+    std::shared_ptr<void> workspace_memory_ptr;
+    std::unique_ptr<handle_t> mfx_surface;
+    std::atomic<size_t> mirrored_locked_count;
+public:
+    using info_t = mfxFrameInfo;
+    using data_t = mfxFrameData;
+
+    static std::shared_ptr<Surface> create_surface(std::unique_ptr<handle_t>&& surf,
+                                                   std::shared_ptr<void> accociated_memory);
+    ~Surface();
+
+    handle_t* get_handle() const;
+    const info_t& get_info() const;
+    const data_t& get_data() const;
+
+    size_t get_locks_count() const;
+
+    // it had better to implement RAII
+    size_t obtain_lock();
+    size_t release_lock();
+private:
+    Surface(std::unique_ptr<handle_t>&& surf, std::shared_ptr<void> accociated_memory);
+};
+
+using surface_ptr_t = std::shared_ptr<Surface>;
+using surface_weak_ptr_t = std::weak_ptr<Surface>;
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+#endif // HAVE_ONEVPL
+#endif // GAPI_STREAMING_ONEVPL_ACCELERATORS_SURFACE_HPP

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/surface.hpp
@@ -10,6 +10,8 @@
 #include <atomic>
 #include <memory>
 
+#include "opencv2/gapi/own/exports.hpp" // GAPI_EXPORTS
+
 #ifdef HAVE_ONEVPL
 #if (MFX_VERSION >= 2000)
 #include <vpl/mfxdispatcher.h>
@@ -32,19 +34,20 @@ public:
     using info_t = mfxFrameInfo;
     using data_t = mfxFrameData;
 
-    static std::shared_ptr<Surface> create_surface(std::unique_ptr<handle_t>&& surf,
+    // GAPI_EXPORTS for tests
+    GAPI_EXPORTS static std::shared_ptr<Surface> create_surface(std::unique_ptr<handle_t>&& surf,
                                                    std::shared_ptr<void> accociated_memory);
-    ~Surface();
+    GAPI_EXPORTS ~Surface();
 
-    handle_t* get_handle() const;
-    const info_t& get_info() const;
-    const data_t& get_data() const;
+    GAPI_EXPORTS handle_t* get_handle() const;
+    GAPI_EXPORTS const info_t& get_info() const;
+    GAPI_EXPORTS const data_t& get_data() const;
 
-    size_t get_locks_count() const;
+    GAPI_EXPORTS size_t get_locks_count() const;
 
     // it had better to implement RAII
-    size_t obtain_lock();
-    size_t release_lock();
+    GAPI_EXPORTS size_t obtain_lock();
+    GAPI_EXPORTS size_t release_lock();
 private:
     Surface(std::unique_ptr<handle_t>&& surf, std::shared_ptr<void> accociated_memory);
 };

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -40,8 +40,7 @@ TEST(OneVPL_Source_Surface, InitSurface)
     using namespace cv::gapi::wip;
 
     // create raw MFX handle
-    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
-    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1{});
     mfxFrameSurface1 *mfx_core_handle = handle.get();
 
     // create preallocate surface memory: empty for test
@@ -63,8 +62,7 @@ TEST(OneVPL_Source_Surface, ConcurrentLock)
     using namespace cv::gapi::wip;
 
     // create raw MFX handle
-    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
-    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1{});
 
     // create preallocate surface memory: empty for test
     std::shared_ptr<void> associated_memory {};
@@ -116,8 +114,7 @@ TEST(OneVPL_Source_Surface, MemoryLifeTime)
     constexpr size_t surface_num = 10000;
     std::vector<std::shared_ptr<Surface>> surfaces(surface_num);
     std::generate(surfaces.begin(), surfaces.end(), [surface_num, associated_memory](){
-        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
-        memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1{});
         return Surface::create_surface(std::move(handle), associated_memory);
     });
 
@@ -138,8 +135,7 @@ TEST(OneVPL_Source_Surface, MemoryLifeTime)
     constexpr size_t surface_num_plus_one = 10001;
     surfaces.resize(surface_num_plus_one);
     std::generate(surfaces.begin(), surfaces.end(), [surface_num_plus_one, associated_memory](){
-        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
-        memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1{});
         return Surface::create_surface(std::move(handle), associated_memory);
     });
 
@@ -169,8 +165,7 @@ TEST(OneVPL_Source_CPUFrameAdapter, InitFrameAdapter)
     using namespace cv::gapi::wip;
 
     // create raw MFX handle
-    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
-    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1{});
 
     // create preallocate surface memory: empty for test
     std::shared_ptr<void> associated_memory {};

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019-2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 
 
 #include "../test_precomp.hpp"

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -25,7 +25,7 @@
 #include <opencv2/gapi/streaming/desync.hpp>
 #include <opencv2/gapi/streaming/format.hpp>
 
-#include <opencv2/gapi/streaming/onevpl/onevpl_source.hpp>
+#include <opencv2/gapi/streaming/onevpl/source.hpp>
 
 #ifdef HAVE_ONEVPL
 #include "streaming/onevpl/accelerators/surface/surface.hpp"

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -1,0 +1,155 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019-2020 Intel Corporation
+
+
+#include "../test_precomp.hpp"
+
+#include "../common/gapi_tests_common.hpp"
+
+#include <thread> // sleep_for (Delay)
+
+#include <opencv2/gapi/cpu/core.hpp>
+#include <opencv2/gapi/cpu/imgproc.hpp>
+
+#include <opencv2/gapi/fluid/core.hpp>
+#include <opencv2/gapi/fluid/imgproc.hpp>
+#include <opencv2/gapi/fluid/gfluidkernel.hpp>
+
+#include <opencv2/gapi/ocl/core.hpp>
+#include <opencv2/gapi/ocl/imgproc.hpp>
+
+#include <opencv2/gapi/streaming/cap.hpp>
+#include <opencv2/gapi/streaming/desync.hpp>
+#include <opencv2/gapi/streaming/format.hpp>
+
+#include <opencv2/gapi/streaming/onevpl/onevpl_source.hpp>
+
+#ifdef HAVE_ONEVPL
+//#include <../src/backends/common/gbackend.hpp> // asView
+#include "streaming/onevpl/accelerators/surface/surface.hpp"
+namespace opencv_test
+{
+namespace
+{
+TEST(OneVPL_Source_Surface, Init)
+{
+    // create raw MFX handle
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
+    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    mfxFrameSurface1 *mfx_core_handle = handle.get();
+
+    // create preallocate surface memory: empty for test
+    std::shared_ptr<void> associated_memory {};
+    auto surf = Surface::create_surface(std::move(handle), out_buf_ptr);
+
+    // check self consistency
+    EXPECT_EQ(surf->get_handle(), mfx_core_handle);
+    EXPECT_EQ(surf->get_locks_count(), 0);
+    EXPECT_EQ(surf->obtain_lock(), 0);
+    EXPECT_EQ(surf->get_locks_count(), 1);
+    EXPECT_EQ(surf->release_lock(), 1);
+    EXPECT_EQ(surf->get_locks_count(), 0);
+}
+
+TEST(OneVPL_Source_Surface, ConcurrentLock)
+{
+    // create raw MFX handle
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
+    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    mfxFrameSurface1 *mfx_core_handle = handle.get();
+
+    // create preallocate surface memory: empty for test
+    std::shared_ptr<void> associated_memory {};
+    auto surf = Surface::create_surface(std::move(handle), out_buf_ptr);
+
+    // check self consistency
+    EXPECT_EQ(surf->get_locks_count(), 0);
+
+    size_t lock_counter = 100000;
+    std::promise<void> barrier;
+    std::future<void> sync = barrier.get_future();
+    std::thread worker_thread([&barrier, surf, lock_counter] () {
+        barrier.set_value();
+
+        // concurrent lock
+        for (size_t i = 0; i < lock_counter; i ++) {
+            surf->obtain_lock();
+        }
+    });
+
+    sync.wait();
+    // concurrent lock
+    for (size_t i = 0; i < lock_counter; i ++) {
+            surf->obtain_lock();
+    }
+    worker_thread.join();
+    EXPECT_EQ(surf->get_locks_count(), lock_counter * 2);
+}
+
+TEST(OneVPL_Source_Surface, MemoryLifeTime)
+{
+    // create preallocate surface memory
+    std::unique_ptr<char> preallocated_memory_ptr(new char);
+    std::shared_ptr<void> associated_memory (preallocated_memory_ptr.get(),
+                                             [&preallocated_memory_ptr] (void* ptr) {
+                                                    EXPECT_TRUE(preallocated_memory_ptr);
+                                                    EXPECT_EQ(preallocated_memory_ptr.get(), ptr);
+                                                    preallocated_memory_ptr.reset();
+                                            });
+
+    // generate surfaces
+    constexpr size_t surface_num = 10000;
+    std::vector<std::shared_ptr<Surface>> surfaces(surface_num);
+    std::generate(surfaces.begin(), surfaces.end(), [surface_num, associated_memory](){
+        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
+        memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+        return Surface::create_surface(std::move(handle), associated_memory));
+    });
+
+    // destroy surfaces
+    {
+        std::thread deleter_thread([&surfaces]() {
+            surfaces.clear();
+        }).join();
+    }
+
+    // workspace memory must be alive
+    EXPECT_EQ(surfaces.size(), 0);
+    EXPECT_TRUE(associated_memory != nullptr);
+    EXPECT_TRUE(preallocated_memory_ptr.get() != nullptr);
+
+    // generate surfaces again + 1
+    constexpr size_t surface_num_plus_one = 10001;
+    surfaces.resize(surface_num_plus_one);
+    std::generate(surfaces.begin(), surfaces.end(), [surface_num_plus_one, associated_memory](){
+        std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
+        memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+        return Surface::create_surface(std::move(handle), associated_memory));
+    });
+
+    // remember one surface
+    std::shared_ptr<Surface> last_surface = surfaces.back();
+
+    // destroy another surfaces
+    surface.clear();
+
+    // destroy associated_memory
+    associated_memory.reset();
+
+    // workspace memory must be still alive
+    EXPECT_EQ(surfaces.size(), 0);
+    EXPECT_TRUE(associated_memory == nullptr);
+    EXPECT_TRUE(preallocated_memory_ptr.get() != nullptr);
+
+    // destroy last surface
+    last_surface.reset();
+
+    // workspace memory must be freed
+    EXPECT_TRUE(preallocated_memory_ptr.get() == nullptr);
+}
+}
+} // namespace opencv_test
+#endif // HAVE_ONEVPL

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -63,7 +63,7 @@ TEST(OneVPL_Source_Surface, ConcurrentLock)
 
     // create preallocate surface memory: empty for test
     std::shared_ptr<void> associated_memory {};
-    auto surf = Surface::create_surface(std::move(handle), out_buf_ptr);
+    auto surf = Surface::create_surface(std::move(handle), associated_memory);
 
     // check self consistency
     EXPECT_EQ(surf->get_locks_count(), 0);
@@ -149,6 +149,26 @@ TEST(OneVPL_Source_Surface, MemoryLifeTime)
 
     // workspace memory must be freed
     EXPECT_TRUE(preallocated_memory_ptr.get() == nullptr);
+}
+
+TEST(OneVPL_Source_CPUFrameAdapter, Init)
+{
+    // create raw MFX handle
+    std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
+    memset(handle.get(), 0, sizeof(mfxFrameSurface1));
+    mfxFrameSurface1 *mfx_core_handle = handle.get();
+
+    // create preallocate surface memory: empty for test
+    std::shared_ptr<void> associated_memory {};
+    auto surf = Surface::create_surface(std::move(handle), associated_memory);
+
+    // check consistency
+    EXPECT_EQ(surf->get_locks_count(), 0);
+    {
+        VPLMediaFrameCPUAdapter adapter(surf);
+        EXPECT_EQ(surf->get_locks_count(), 1);
+    }
+    EXPECT_EQ(surf->get_locks_count(), 0);
 }
 }
 } // namespace opencv_test


### PR DESCRIPTION
this PR is the single one in series of https://github.com/opencv/opencv/pull/20469

Introduce VPL Surface & CPU MediaFrame Adapter

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Build configuration

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```