### PR TITLE
core(ocl): handle NULL in dumpValue() debug call

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2981,6 +2981,8 @@ bool Kernel::empty() const
 
 static cv::String dumpValue(size_t sz, const void* p)
 {
+    if (!p)
+        return "NULL";
     if (sz == 4)
         return cv::format("%d / %uu / 0x%08x / %g", *(int*)p, *(int*)p, *(int*)p, *(float*)p);
     if (sz == 8)


### PR DESCRIPTION
- NULL is used for allocation of workgroup local variables
