### PR TITLE
fix: NumPy array allocation error message in vector conversion

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1778,7 +1778,7 @@ private:
 
         const NPY_TYPES target_type = asNumpyType<UnderlyingArrayType>();
         const int cols = DType::channels;
-        PyObject* array;
+        PyObject* array = NULL;
         if (cols == 1)
         {
             npy_intp dims = static_cast<npy_intp>(value.size());
@@ -1796,14 +1796,16 @@ private:
             String shape;
             if (cols > 1)
             {
-                shape = cv::format("(%d x %d)", static_cast<int>(value.size()), cols);
+                shape = format("(%d x %d)", static_cast<int>(value.size()), cols);
             }
             else
             {
-                shape = cv::format("(%d)", static_cast<int>(value.size()));
+                shape = format("(%d)", static_cast<int>(value.size()));
             }
-            CV_Error_(Error::StsError, ("Can't allocate NumPy array for vector with dtype=%d shape=%s",
-                    static_cast<int>(target_type), static_cast<int>(value.size()), shape.c_str()));
+            const String error_message = format("Can't allocate NumPy array for vector with dtype=%d and shape=%s",
+                                                static_cast<int>(target_type), shape.c_str());
+            emit_failmsg(PyExc_MemoryError, error_message.c_str());
+            return array;
         }
         // Fill the array
         PyArrayObject* array_obj = reinterpret_cast<PyArrayObject*>(array);


### PR DESCRIPTION
If allocation fails it should raise the following error in Python
```
MemoryError: Can't allocate NumPy array for vector with dtype=5 and shape=(10)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
