### PR TITLE
Fix resize+concat optimization

### DIFF
--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -111,7 +111,13 @@ public:
         internals_arr.getMatVector(internals);
 
         if (outHeight == inputs[0].size[2] && outWidth == inputs[0].size[3])
+        {
+           if (inputs[0].data != outputs[0].data)
+           {
+               inputs[0].copyTo(outputs[0]);
+           }
             return;
+        }
 
         Mat& inp = inputs[0];
         Mat& out = outputs[0];

--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -112,10 +112,11 @@ public:
 
         if (outHeight == inputs[0].size[2] && outWidth == inputs[0].size[3])
         {
-           if (inputs[0].data != outputs[0].data)
-           {
-               inputs[0].copyTo(outputs[0]);
-           }
+            // outputs[0] = inputs[0] doesn't work due to BlobManager optimizations
+            if (inputs[0].data != outputs[0].data)
+            {
+                inputs[0].copyTo(outputs[0]);
+            }
             return;
         }
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -1125,6 +1125,11 @@ TEST_P(Test_TensorFlow_layers, resize_bilinear_down)
     runTensorFlowNet("resize_bilinear_down");
 }
 
+TEST_P(Test_TensorFlow_layers, resize_concat_optimization)
+{
+    runTensorFlowNet("resize_concat_optimization");
+}
+
 TEST_P(Test_TensorFlow_layers, tf2_dense)
 {
     runTensorFlowNet("tf2_dense");


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/905

Fixes https://github.com/opencv/opencv/issues/17726
relates #11050 (code branch has [zero coverage](http://pullrequest.opencv.org/buildbot/export/opencv_releases/3_4_coverage-lin64-debug/20210902-021141_1204/coverage_html/opencv/modules/dnn/src/layers/resize_layer.cpp.gcov.html))

The results of nets start diverging after(including) 'decoder/concat' `Concat` layer. I tracked it down to dnn.cpp:2962, where the optimization of this layer is applied: it disables 'decoder/concat' layer and changes the output mats of input layers of type `ResizeBilinear` to point to different parts of the one big matrix. The problem is in 'decoder/ResizeBilinear_1': it effectively does nothing since its input is already has 64x64 WxH, and so it just returns, doing nothing. But if the optimization was applied, input and output matrices differ and a copy should be performed.

`opencv_extra=resize_concat_optimization`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
