### PR TITLE
dnn: LSTM optimisation

### DIFF
--- a/modules/dnn/perf/perf_recurrent.cpp
+++ b/modules/dnn/perf/perf_recurrent.cpp
@@ -52,9 +52,9 @@ PERF_TEST_P_(Layer_LSTM, lstm) {
     lp.set("produce_cell_output", false);
     lp.set("use_timestamp_dim", true);
 
-    Mat weightH(params.hiddenSize*4, params.hiddenSize, CV_32FC1, cv::Scalar(0));
-    Mat weightX(params.hiddenSize*4, params.inputSize, CV_32FC1, cv::Scalar(0));
-    Mat bias(params.hiddenSize*4, 1, CV_32FC1, cv::Scalar(0));
+    Mat weightH(params.hiddenSize * 4, params.hiddenSize, CV_32FC1, cv::Scalar(0));
+    Mat weightX(params.hiddenSize * 4, params.inputSize, CV_32FC1, cv::Scalar(0));
+    Mat bias(params.hiddenSize * 4, 1, CV_32FC1, cv::Scalar(0));
     Mat hInternal(params.nrSteps, params.hiddenSize, CV_32FC1, cv::Scalar(0));
     Mat cInternal(params.nrSteps, params.hiddenSize, CV_32FC1, cv::Scalar(0));
     lp.blobs.push_back(weightH);
@@ -63,7 +63,10 @@ PERF_TEST_P_(Layer_LSTM, lstm) {
     lp.blobs.push_back(hInternal);
     lp.blobs.push_back(cInternal);
 
-    std::vector<int> inputDims{ params.nrSamples, params.nrSteps, params.inputSize };
+    std::vector<int> inputDims;
+    inputDims.push_back(params.nrSamples);
+    inputDims.push_back(params.nrSteps);
+    inputDims.push_back(params.inputSize);
     Mat input(inputDims.size(), inputDims.data(), CV_32FC1);
     input = cv::Scalar(0);
 

--- a/modules/dnn/perf/perf_recurrent.cpp
+++ b/modules/dnn/perf/perf_recurrent.cpp
@@ -1,0 +1,87 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test {
+
+struct LstmParams {
+    // Batch size
+    int nrSamples;
+
+    // Size of the input vector
+    int inputSize;
+
+    // Size of the internal state vector
+    int hiddenSize;
+
+    // Number of timesteps for the LSTM
+    int nrSteps;
+};
+
+static inline void PrintTo(const LstmParams& params, ::std::ostream* os) {
+    (*os) << "BATCH=" << params.nrSamples
+        << ", IN=" << params.inputSize
+        << ", HIDDEN=" << params.hiddenSize
+        << ", TS=" << params.nrSteps;
+}
+
+static const LstmParams testLstmConfigs[] = {
+    {1, 192, 192, 100},
+    {1, 1024, 192, 100},
+    {1, 64, 192, 100},
+    {1, 192, 512, 100},
+    {64, 192, 192, 2},
+    {64, 1024, 192, 2},
+    {64, 64, 192, 2},
+    {64, 192, 512, 2},
+    {128, 192, 192, 2},
+    {128, 1024, 192, 2},
+    {128, 64, 192, 2},
+    {128, 192, 512, 2}
+};
+
+class Layer_LSTM : public TestBaseWithParam<LstmParams> {};
+
+PERF_TEST_P_(Layer_LSTM, lstm) {
+    const LstmParams& params = GetParam();
+    LayerParams lp;
+    lp.type = "LSTM";
+    lp.name = "testLstm";
+    lp.set("produce_cell_output", false);
+    lp.set("use_timestamp_dim", true);
+
+    Mat weightH(params.hiddenSize*4, params.hiddenSize, CV_32FC1, cv::Scalar(0));
+    Mat weightX(params.hiddenSize*4, params.inputSize, CV_32FC1, cv::Scalar(0));
+    Mat bias(params.hiddenSize*4, 1, CV_32FC1, cv::Scalar(0));
+    Mat hInternal(params.nrSteps, params.hiddenSize, CV_32FC1, cv::Scalar(0));
+    Mat cInternal(params.nrSteps, params.hiddenSize, CV_32FC1, cv::Scalar(0));
+    lp.blobs.push_back(weightH);
+    lp.blobs.push_back(weightX);
+    lp.blobs.push_back(bias);
+    lp.blobs.push_back(hInternal);
+    lp.blobs.push_back(cInternal);
+
+    std::vector<int> inputDims{ params.nrSamples, params.nrSteps, params.inputSize };
+    Mat input(inputDims.size(), inputDims.data(), CV_32FC1);
+    input = cv::Scalar(0);
+
+    Net net;
+    net.addLayerToPrev(lp.name, lp.type, lp);
+    net.setInput(input);
+
+    // Warm up
+    std::vector<Mat> outputs(2);
+    net.forward(outputs, "testLstm");
+
+    TEST_CYCLE()
+    {
+        net.forward(outputs, "testLstm");
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Layer_LSTM, testing::ValuesIn(testLstmConfigs));
+
+} // namespace

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -222,17 +222,17 @@ public:
 
             #if CV_TRY_AVX512_SKX
                 if( useAVX512 )
-                    opt_AVX512_SKX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize);
+                    opt_AVX512_SKX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize_aligned);
                 else
             #endif
             #if CV_TRY_AVX2
                 if( useAVX2 )
-                    opt_AVX2::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize);
+                    opt_AVX2::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize_aligned);
                 else
             #endif
             #if CV_TRY_AVX
                 if( useAVX )
-                    opt_AVX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize);
+                    opt_AVX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize_aligned);
                 else
             #endif
                 {

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -551,6 +551,7 @@ void fastDepthwiseConv( const float* wptr,
 }
 
 // dst = vec * weights^t + bias
+// Requires that vecsize is at least 8 or equal to 0 to avoid memory access problems.  Does not require alignment.
 void fastGEMM1T( const float* vec, const float* weights,
                  size_t wstep, const float* bias,
                  float* dst, int nvecs, int vecsize )

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -651,6 +651,7 @@ void fastGEMM1T( const float* vec, const float* weights,
     _mm256_zeroupper();
 }
 
+
 void fastGEMM( const float* aptr, size_t astep, const float* bptr,
                size_t bstep, float* cptr, size_t cstep,
                int ma, int na, int nb )

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -126,8 +126,8 @@ public:
 
     LSTMLayerImpl(const LayerParams& params)
         : numTimeStamps(0), numSamples(0),
-          useAVX2(checkHardwareSupport(CPU_AVX2)),
-          useAVX(checkHardwareSupport(CPU_AVX))
+          useAVX(checkHardwareSupport(CPU_AVX)),
+          useAVX2(checkHardwareSupport(CPU_AVX2))
     {
         setParamsFrom(params);
 

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -125,9 +125,13 @@ class LSTMLayerImpl CV_FINAL : public LSTMLayer
 public:
 
     LSTMLayerImpl(const LayerParams& params)
-        : numTimeStamps(0), numSamples(0),
-          useAVX(checkHardwareSupport(CPU_AVX)),
-          useAVX2(checkHardwareSupport(CPU_AVX2))
+        : numTimeStamps(0), numSamples(0)
+#if CV_TRY_AVX
+          , useAVX(checkHardwareSupport(CPU_AVX))
+#endif
+#if CV_TRY_AVX2
+          , useAVX2(checkHardwareSupport(CPU_AVX2))
+#endif
     {
         setParamsFrom(params);
 
@@ -430,7 +434,9 @@ public:
                     }
                 else
 #endif
-                gemm(hInternal, Wh, 1, gates, 1, gates, GEMM_2_T);  //+Wh * h_{t-1}
+                {
+                    gemm(hInternal, Wh, 1, gates, 1, gates, GEMM_2_T);  //+Wh * h_{t-1}
+                }
 
                 Mat gateI = gates.colRange(0*numOut, 1*numOut);
                 Mat gateF = gates.colRange(1*numOut, 2*numOut);

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -365,7 +365,7 @@ public:
                 Range curRowRange(ts*numSamples, (ts + 1)*numSamples);
                 Mat xCurr = xTs.rowRange(curRowRange);
 
-#ifdef CV_TRY_AVX2
+#if CV_TRY_AVX2
                 if (useAVX2 && xCurr.isContinuous() && gates.isContinuous() && bias.isContinuous() && Wx.depth() == CV_32F && xCurr.depth() == CV_32F && gates.depth() == CV_32F && bias.depth() == CV_32F && Wx.cols >= 8)
                     for (int n = 0; n < xCurr.rows; n++) {
                         opt_AVX2::fastGEMM1T(
@@ -380,7 +380,7 @@ public:
                     }
                 else
 #endif
-#ifdef CV_TRY_AVX
+#if CV_TRY_AVX
                 if (useAVX && xCurr.isContinuous() && gates.isContinuous() && bias.isContinuous() && Wx.depth() == CV_32F && xCurr.depth() == CV_32F && gates.depth() == CV_32F && bias.depth() == CV_32F && Wx.cols >= 8)
                     for (int n = 0; n < xCurr.rows; n++) {
                         opt_AVX::fastGEMM1T(
@@ -400,7 +400,7 @@ public:
                     gemm(dummyOnes, bias, 1, gates, 1, gates);          //+b
                 }
 
-#ifdef CV_TRY_AVX2
+#if CV_TRY_AVX2
                 if (useAVX2 && hInternal.isContinuous() && gates.isContinuous() && bias.isContinuous() && Wh.depth() == CV_32F && hInternal.depth() == CV_32F && gates.depth() == CV_32F && Wh.cols >= 8)
                     for (int n = 0; n < hInternal.rows; n++) {
                         opt_AVX2::fastGEMM1T(
@@ -415,7 +415,7 @@ public:
                     }
                 else
 #endif
-#ifdef CV_TRY_AVX
+#if CV_TRY_AVX
                 if (useAVX && hInternal.isContinuous() && gates.isContinuous() && bias.isContinuous() && Wh.depth() == CV_32F && hInternal.depth() == CV_32F && gates.depth() == CV_32F && Wh.cols >= 8)
                     for (int n = 0; n < hInternal.rows; n++) {
                         opt_AVX::fastGEMM1T(


### PR DESCRIPTION
This uses the AVX-optimised fastGEMM1T for matrix multiplications where available, instead of the standard cv::gemm.

fastGEMM1T is already used by the fully-connected layer.  This PR involves two minor modifications to allow use with the LSTM layer:
 - Use unaligned access.  I don't believe this involves any performance hit in on modern CPUs (Nehalem and Bulldozer onwards) in the case where the address is actually aligned.
 - Allow for weight matrices where the number of columns is not a multiple of 8.

I have not enabled AVX-512 or RVV as I don't have access to such CPUs to test on.  If there are no problems with this PR I'll send a separate PR which deals with ARM NEON.

<cut/>

Performance comparison (vs built-in gemm, i.e. build without a BLAS):

```
Median (ms)

                     Name of Test                      original4  AVX    AVX2     AVX        AVX2
                                                                                   vs         vs
                                                                               original4  original4
                                                                               (x-factor) (x-factor)
lstm::Layer_LSTM::BATCH=1, IN=64, HIDDEN=192, TS=100    22.851   3.819  3.093     5.98       7.39
lstm::Layer_LSTM::BATCH=1, IN=192, HIDDEN=192, TS=100   31.183   4.601  3.252     6.78       9.59
lstm::Layer_LSTM::BATCH=1, IN=192, HIDDEN=512, TS=100   144.946  19.302 15.570    7.51       9.31
lstm::Layer_LSTM::BATCH=1, IN=1024, HIDDEN=192, TS=100  93.162   10.639 8.068     8.76      11.55
lstm::Layer_LSTM::BATCH=64, IN=64, HIDDEN=192, TS=2     27.403   5.502  4.301     4.98       6.37
lstm::Layer_LSTM::BATCH=64, IN=192, HIDDEN=192, TS=2    40.038   6.830  5.548     5.86       7.22
lstm::Layer_LSTM::BATCH=64, IN=192, HIDDEN=512, TS=2    200.630  29.869 22.061    6.72       9.09
lstm::Layer_LSTM::BATCH=64, IN=1024, HIDDEN=192, TS=2   119.687  14.251 11.480    8.40      10.43
lstm::Layer_LSTM::BATCH=128, IN=64, HIDDEN=192, TS=2    57.895   10.394 9.101     5.57       6.36
lstm::Layer_LSTM::BATCH=128, IN=192, HIDDEN=192, TS=2   82.741   13.166 10.971    6.28       7.54
lstm::Layer_LSTM::BATCH=128, IN=192, HIDDEN=512, TS=2   394.310  60.755 45.158    6.49       8.73
lstm::Layer_LSTM::BATCH=128, IN=1024, HIDDEN=192, TS=2  245.459  28.773 23.413    8.53      10.48
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work (N/A)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name. (N/A)
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Linux AVX2
```