### PR TITLE
Fix PReLU negative slope access pattern

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1542,7 +1542,7 @@ Ptr<Layer> ChannelsPReLULayer::create(const LayerParams& params)
     if (params.blobs[0].total() == 1)
     {
         LayerParams reluParams = params;
-        reluParams.set("negative_slope", *params.blobs[0].begin<float>());
+        reluParams.set("negative_slope", *params.blobs[0].ptr<float>());
         return ReLULayer::create(reluParams);
     }
     Ptr<ChannelsPReLULayer> l(new ElementWiseLayer<ChannelsPReLUFunctor>(ChannelsPReLUFunctor(params.blobs[0])));

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1542,7 +1542,7 @@ Ptr<Layer> ChannelsPReLULayer::create(const LayerParams& params)
     if (params.blobs[0].total() == 1)
     {
         LayerParams reluParams = params;
-        reluParams.set("negative_slope", params.blobs[0].at<float>(0));
+        reluParams.set("negative_slope", *params.blobs[0].begin<float>());
         return ReLULayer::create(reluParams);
     }
     Ptr<ChannelsPReLULayer> l(new ElementWiseLayer<ChannelsPReLUFunctor>(ChannelsPReLUFunctor(params.blobs[0])));

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -250,6 +250,11 @@ TEST_P(Test_ONNX_layers, ReLU)
     testONNXModels("ReLU");
 }
 
+TEST_P(Test_ONNX_layers, PReLU)
+{
+    testONNXModels("PReLU_slope");
+}
+
 TEST_P(Test_ONNX_layers, Clip)
 {
     testONNXModels("clip", npy);


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/907

Fixes https://github.com/opencv/opencv/issues/20643.

```opencv_extra=prelu_slope```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
