### PR TITLE
deleted dublicated "private" createConvexHull and convertTo

### DIFF
--- a/modules/imgproc/src/min_enclosing_triangle.cpp
+++ b/modules/imgproc/src/min_enclosing_triangle.cpp
@@ -318,7 +318,7 @@ namespace minEnclosingTriangle {
 static void findMinEnclosingTriangle(cv::InputArray points,
                                      CV_OUT cv::OutputArray triangle, CV_OUT double &area) {
     std::vector<cv::Point2f> resultingTriangle, polygon;
-    CV_Assert(points.getMat().checkVector(2) > 0);
+    CV_Assert(!points.empty());
     convexHull(points, polygon, true, true);
     findMinEnclosingTriangle(polygon, resultingTriangle, area);
     cv::Mat(resultingTriangle).copyTo(triangle);

--- a/modules/imgproc/src/min_enclosing_triangle.cpp
+++ b/modules/imgproc/src/min_enclosing_triangle.cpp
@@ -129,7 +129,6 @@ static bool areOnTheSameSideOfLine(const cv::Point2f &p1, const cv::Point2f &p2,
 
 static double areaOfTriangle(const cv::Point2f &a, const cv::Point2f &b, const cv::Point2f &c);
 
-static void createConvexHull(cv::InputArray points, std::vector<cv::Point2f> &polygon);
 
 static double distanceBtwPoints(const cv::Point2f &a, const cv::Point2f &b);
 
@@ -319,27 +318,10 @@ namespace minEnclosingTriangle {
 static void findMinEnclosingTriangle(cv::InputArray points,
                                      CV_OUT cv::OutputArray triangle, CV_OUT double &area) {
     std::vector<cv::Point2f> resultingTriangle, polygon;
-
-    createConvexHull(points, polygon);
+    CV_Assert(points.getMat().checkVector(2) > 0);
+    convexHull(points, polygon, true, true);
     findMinEnclosingTriangle(polygon, resultingTriangle, area);
     cv::Mat(resultingTriangle).copyTo(triangle);
-}
-
-//! Create the convex hull of the given set of points
-/*!
-* @param points     The provided set of points
-* @param polygon    The polygon representing the convex hull of the points
-*/
-static void createConvexHull(cv::InputArray points, std::vector<cv::Point2f> &polygon) {
-    cv::Mat pointsMat = points.getMat();
-    std::vector<cv::Point2f> pointsVector;
-
-    CV_Assert((pointsMat.checkVector(2) > 0) &&
-              ((pointsMat.depth() == CV_32F) || (pointsMat.depth() == CV_32S)));
-
-    pointsMat.convertTo(pointsVector, CV_32F);
-
-    convexHull(pointsVector, polygon, true, true);
 }
 
 //! Find the minimum enclosing triangle and its area


### PR DESCRIPTION
Fixes #17585
Function `createConvexHull` just cast `cv::Mat` to `vector<cv::Point2f>` by `convertTo()` and call `ConvexHull`.
There is problem: `convertTo()` can't cast `cv::Mat(n, 2, CV_32FC1)` to `vector<cv::Point2f>`. But `ConvexHull` can take `cv::Mat(n, 2, CV_32FC1)`.
To fix problem can delete `createConvexHull` (this is "private" function and calls once).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
