### PR TITLE
WIP - Convert scalars-to-vector constructors in SIMD backend to lookup table constructors

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -198,14 +198,12 @@ struct v_uint16x16
     __m256i val;
 
     explicit v_uint16x16(__m256i v) : val(v) {}
-    v_uint16x16(ushort v0,  ushort v1,  ushort v2,  ushort v3,
-                ushort v4,  ushort v5,  ushort v6,  ushort v7,
-                ushort v8,  ushort v9,  ushort v10, ushort v11,
-                ushort v12, ushort v13, ushort v14, ushort v15)
+    v_uint16x16(ushort *data, int *idx)
     {
-        val = _mm256_setr_epi16((short)v0, (short)v1, (short)v2, (short)v3,
-            (short)v4,  (short)v5,  (short)v6,  (short)v7,  (short)v8,  (short)v9,
-            (short)v10, (short)v11, (short)v12, (short)v13, (short)v14, (short)v15);
+        val = _mm256_setr_epi16((short)data[idx[0]], (short)data[idx[1]], (short)data[idx[2]], (short)data[idx[3]],
+                                (short)data[idx[4]], (short)data[idx[5]], (short)data[idx[6]], (short)data[idx[7]],
+                                (short)data[idx[8]], (short)data[idx[9]], (short)data[idx[10]], (short)data[idx[11]],
+                                (short)data[idx[12]], (short)data[idx[13]], (short)data[idx[14]], (short)data[idx[15]]);
     }
     /* coverity[uninit_ctor]: suppress warning */
     v_uint16x16() {}
@@ -220,13 +218,12 @@ struct v_int16x16
     __m256i val;
 
     explicit v_int16x16(__m256i v) : val(v) {}
-    v_int16x16(short v0,  short v1,  short v2,  short v3,
-               short v4,  short v5,  short v6,  short v7,
-               short v8,  short v9,  short v10, short v11,
-               short v12, short v13, short v14, short v15)
+    v_int16x16(short *data, int *idx)
     {
-        val = _mm256_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7,
-            v8, v9, v10, v11, v12, v13, v14, v15);
+        val = _mm256_setr_epi16(data[idx[0]], data[idx[1]], data[idx[2]], data[idx[3]],
+                                data[idx[4]], data[idx[5]], data[idx[6]], data[idx[7]],
+                                data[idx[8]], data[idx[9]], data[idx[10]], data[idx[11]],
+                                data[idx[12]], data[idx[13]], data[idx[14]], data[idx[15]]);
     }
     /* coverity[uninit_ctor]: suppress warning */
     v_int16x16() {}

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -244,13 +244,12 @@ struct v_uint32x16
     __m512i val;
 
     explicit v_uint32x16(__m512i v) : val(v) {}
-    v_uint32x16(unsigned v0,  unsigned v1,  unsigned v2,  unsigned v3,
-                unsigned v4,  unsigned v5,  unsigned v6,  unsigned v7,
-                unsigned v8,  unsigned v9,  unsigned v10, unsigned v11,
-                unsigned v12, unsigned v13, unsigned v14, unsigned v15)
+    v_uint32x16(unsigned *data, int *idx)
     {
-        val = _mm512_setr_epi32((int)v0,  (int)v1,  (int)v2,  (int)v3, (int)v4,  (int)v5,  (int)v6,  (int)v7,
-                                (int)v8,  (int)v9,  (int)v10, (int)v11, (int)v12, (int)v13, (int)v14, (int)v15);
+        val = _mm512_setr_epi32((int)data[idx[0]], (int)data[idx[1]], (int)data[idx[2]], (int)data[idx[3]],
+                                (int)data[idx[4]], (int)data[idx[5]], (int)data[idx[6]], (int)data[idx[7]],
+                                (int)data[idx[8]], (int)data[idx[9]], (int)data[idx[10]], (int)data[idx[11]],
+                                (int)data[idx[12]], (int)data[idx[13]], (int)data[idx[14]], (int)data[idx[15]]);         
     }
     v_uint32x16() {}
 
@@ -266,10 +265,12 @@ struct v_int32x16
     __m512i val;
 
     explicit v_int32x16(__m512i v) : val(v) {}
-    v_int32x16(int v0, int v1, int v2,  int v3,  int v4,  int v5,  int v6,  int v7,
-               int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15)
+    v_int32x16(int *data, int *idx)
     {
-        val = _mm512_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        val = _mm512_setr_epi32(data[idx[0]], data[idx[1]], data[idx[2]], data[idx[3]],
+                                data[idx[4]], data[idx[5]], data[idx[6]], data[idx[7]],
+                                data[idx[8]], data[idx[9]], data[idx[10]], data[idx[11]],
+                                data[idx[12]], data[idx[13]], data[idx[14]], data[idx[15]]);         
     }
     v_int32x16() {}
 
@@ -285,10 +286,12 @@ struct v_float32x16
     __m512 val;
 
     explicit v_float32x16(__m512 v) : val(v) {}
-    v_float32x16(float v0, float v1, float v2,  float v3,  float v4,  float v5,  float v6,  float v7,
-                 float v8, float v9, float v10, float v11, float v12, float v13, float v14, float v15)
+    v_float32x16(float *data, int *idx)
     {
-        val = _mm512_setr_ps(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        val = _mm512_setr_ps(data[idx[0]], data[idx[1]], data[idx[2]], data[idx[3]],
+                             data[idx[4]], data[idx[5]], data[idx[6]], data[idx[7]],
+                             data[idx[8]], data[idx[9]], data[idx[10]], data[idx[11]],
+                             data[idx[12]], data[idx[13]], data[idx[14]], data[idx[15]]);
     }
     v_float32x16() {}
 

--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -412,6 +412,14 @@ template<typename _Tp, int n> struct v_reg
         s[12] = s12; s[13] = s13; s[14] = s14; s[15] = s15;
     }
 
+    v_reg(_Tp* data, int* idx)
+    {
+        for (int i = 0; i < n; ++i)
+        {
+            s[i] = data[idx[i]];
+        }
+    }
+
     /** @brief Default constructor
 
     Does not initialize anything*/

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -142,11 +142,13 @@ struct v_uint8x16
 
     v_uint8x16() {}
     explicit v_uint8x16(uint8x16_t v) : val(v) {}
-    v_uint8x16(uchar v0, uchar v1, uchar v2, uchar v3, uchar v4, uchar v5, uchar v6, uchar v7,
-               uchar v8, uchar v9, uchar v10, uchar v11, uchar v12, uchar v13, uchar v14, uchar v15)
+    v_uint8x16(uchar *data, int *idx)
     {
-        uchar v[] = {v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15};
-        val = vld1q_u8(v);
+        uchar arr[] = { data[idx[0]], data[idx[1]], data[idx[2]], data[idx[3]],
+                        data[idx[4]], data[idx[5]], data[idx[6]], data[idx[7]],
+                        data[idx[8]], data[idx[9]], data[idx[10]], data[idx[11]],
+                        data[idx[12]], data[idx[13]], data[idx[14]], data[idx[15]] };
+        val = vld1q_u8(arr);
     }
     uchar get0() const
     {
@@ -163,11 +165,13 @@ struct v_int8x16
 
     v_int8x16() {}
     explicit v_int8x16(int8x16_t v) : val(v) {}
-    v_int8x16(schar v0, schar v1, schar v2, schar v3, schar v4, schar v5, schar v6, schar v7,
-               schar v8, schar v9, schar v10, schar v11, schar v12, schar v13, schar v14, schar v15)
+    v_int8x16(schar *data, int *idx)
     {
-        schar v[] = {v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15};
-        val = vld1q_s8(v);
+        schar arr[] = { data[idx[0]], data[idx[1]], data[idx[2]], data[idx[3]],
+                        data[idx[4]], data[idx[5]], data[idx[6]], data[idx[7]],
+                        data[idx[8]], data[idx[9]], data[idx[10]], data[idx[11]],
+                        data[idx[12]], data[idx[13]], data[idx[14]], data[idx[15]] };
+        val = vld1q_s8(arr);
     }
     schar get0() const
     {

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -78,13 +78,12 @@ struct v_uint8x16
     /* coverity[uninit_ctor]: suppress warning */
     v_uint8x16() {}
     explicit v_uint8x16(__m128i v) : val(v) {}
-    v_uint8x16(uchar v0, uchar v1, uchar v2, uchar v3, uchar v4, uchar v5, uchar v6, uchar v7,
-               uchar v8, uchar v9, uchar v10, uchar v11, uchar v12, uchar v13, uchar v14, uchar v15)
+    v_uint8x16(uchar *data, int *idx)
     {
-        val = _mm_setr_epi8((char)v0, (char)v1, (char)v2, (char)v3,
-                            (char)v4, (char)v5, (char)v6, (char)v7,
-                            (char)v8, (char)v9, (char)v10, (char)v11,
-                            (char)v12, (char)v13, (char)v14, (char)v15);
+        val = _mm_setr_epi8((char)data[idx[0]], (char)data[idx[1]], (char)data[idx[2]], (char)data[idx[3]],
+                            (char)data[idx[4]], (char)data[idx[5]], (char)data[idx[6]], (char)data[idx[7]],
+                            (char)data[idx[8]], (char)data[idx[9]], (char)data[idx[10]], (char)data[idx[11]],
+                            (char)data[idx[12]], (char)data[idx[13]], (char)data[idx[14]], (char)data[idx[15]]);
     }
 
     uchar get0() const
@@ -104,13 +103,12 @@ struct v_int8x16
     /* coverity[uninit_ctor]: suppress warning */
     v_int8x16() {}
     explicit v_int8x16(__m128i v) : val(v) {}
-    v_int8x16(schar v0, schar v1, schar v2, schar v3, schar v4, schar v5, schar v6, schar v7,
-              schar v8, schar v9, schar v10, schar v11, schar v12, schar v13, schar v14, schar v15)
+    v_int8x16(schar *data, int *idx)
     {
-        val = _mm_setr_epi8((char)v0, (char)v1, (char)v2, (char)v3,
-                            (char)v4, (char)v5, (char)v6, (char)v7,
-                            (char)v8, (char)v9, (char)v10, (char)v11,
-                            (char)v12, (char)v13, (char)v14, (char)v15);
+        val = _mm_setr_epi8((char)data[idx[0]], (char)data[idx[1]], (char)data[idx[2]], (char)data[idx[3]],
+                            (char)data[idx[4]], (char)data[idx[5]], (char)data[idx[6]], (char)data[idx[7]],
+                            (char)data[idx[8]], (char)data[idx[9]], (char)data[idx[10]], (char)data[idx[11]],
+                            (char)data[idx[12]], (char)data[idx[13]], (char)data[idx[14]], (char)data[idx[15]]);
     }
 
     schar get0() const
@@ -1959,7 +1957,8 @@ inline v_uint8x16 v_reverse(const v_uint8x16 &a)
 #else
     uchar CV_DECL_ALIGNED(32) d[16];
     v_store_aligned(d, a);
-    return v_uint8x16(d[15], d[14], d[13], d[12], d[11], d[10], d[9], d[8], d[7], d[6], d[5], d[4], d[3], d[2], d[1], d[0]);
+    int reverse_idx[] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    return v_uint8x16(d, reverse_idx);
 #endif
 }
 

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -218,7 +218,9 @@ static void minMaxIdx_8u(const uchar* src, const uchar* mask, int* minval, int* 
         {
             v_uint8x16 inc = v_setall_u8(v_uint8x16::nlanes);
             v_uint8x16 none = v_reinterpret_as_u8(v_setall_s8(-1));
-            v_uint8x16 idxStart(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+            uchar arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            int tmp_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            v_uint8x16 idxStart(arr, tmp_idx);
 
             do
             {
@@ -295,7 +297,9 @@ static void minMaxIdx_8s(const schar* src, const uchar* mask, int* minval, int* 
         {
             v_uint8x16 inc = v_setall_u8(v_int8x16::nlanes);
             v_uint8x16 none = v_reinterpret_as_u8(v_setall_s8(-1));
-            v_uint8x16 idxStart(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+            uchar arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            int tmp_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            v_uint8x16 idxStart(arr, tmp_idx);
 
             do
             {

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -49,9 +49,13 @@ template <> struct initializer<16>
 {
     template <typename R> static R init(const Data<R> & d)
     {
-        return R(d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]);
+        typename R::lane_type data[] = {d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]};
+        int idx[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 , 13, 14, 15 };
+        return R(data, idx);
     }
 };
+
+
 
 template <> struct initializer<8>
 {

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -90,10 +90,12 @@ public:
 #if CV_SIMD128
                     for( ; i <= len - 16; i += 16 )
                     {
-                        v_int8x16 out(table[srcptr[i] + 128], table[srcptr[i+1] + 128], table[srcptr[i+2] + 128], table[srcptr[i+3] + 128],
-                                      table[srcptr[i+4] + 128], table[srcptr[i+5] + 128], table[srcptr[i+6] + 128], table[srcptr[i+7] + 128],
-                                      table[srcptr[i+8] + 128], table[srcptr[i+9] + 128], table[srcptr[i+10] + 128], table[srcptr[i+11] + 128],
-                                      table[srcptr[i+12] + 128], table[srcptr[i+13] + 128], table[srcptr[i+14] + 128], table[srcptr[i+15] + 128]);
+                        int8_t data[] = {table[srcptr[i] + 128], table[srcptr[i+1] + 128], table[srcptr[i+2] + 128], table[srcptr[i+3] + 128],
+                                         table[srcptr[i+4] + 128], table[srcptr[i+5] + 128], table[srcptr[i+6] + 128], table[srcptr[i+7] + 128],
+                                         table[srcptr[i+8] + 128], table[srcptr[i+9] + 128], table[srcptr[i+10] + 128], table[srcptr[i+11] + 128],
+                                         table[srcptr[i+12] + 128], table[srcptr[i+13] + 128], table[srcptr[i+14] + 128], table[srcptr[i+15] + 128]};
+                        int idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8 , 9, 10, 11, 12, 13, 14, 15};
+                        v_int8x16 out(data, idx);
                         v_store(dstptr + i, out);
                     }
 #endif
@@ -141,10 +143,12 @@ public:
 #if CV_SIMD128
             for( ; i <= len - 16; i += 16 )
             {
-                v_int8x16 out(lut[src[i] + 128], lut[src[i+1] + 128], lut[src[i+2] + 128], lut[src[i+3] + 128],
-                              lut[src[i+4] + 128], lut[src[i+5] + 128], lut[src[i+6] + 128], lut[src[i+7] + 128],
-                              lut[src[i+8] + 128], lut[src[i+9] + 128], lut[src[i+10] + 128], lut[src[i+11] + 128],
-                              lut[src[i+12] + 128], lut[src[i+13] + 128], lut[src[i+14] + 128], lut[src[i+15] + 128]);
+                int8_t data[] = {lut[src[i] + 128], lut[src[i+1] + 128], lut[src[i+2] + 128], lut[src[i+3] + 128],
+                                 lut[src[i+4] + 128], lut[src[i+5] + 128], lut[src[i+6] + 128], lut[src[i+7] + 128],
+                                 lut[src[i+8] + 128], lut[src[i+9] + 128], lut[src[i+10] + 128], lut[src[i+11] + 128],
+                                 lut[src[i+12] + 128], lut[src[i+13] + 128], lut[src[i+14] + 128], lut[src[i+15] + 128]};
+                int idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+               v_int8x16 out(data, idx);
                 v_store(dst + i, out);
             }
 #endif

--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -330,14 +330,16 @@ public:
                                     for (int k = 0; k < kernel_w*kernel_h; k++)
                                     {
                                         int index = ofsptr[k];
-                                        v_int8x16 v0(srcData1[index], srcData1[index + stride_w],
-                                                     srcData1[index + stride_w*2], srcData1[index + stride_w*3],
-                                                     srcData1[index + stride_w*4], srcData1[index + stride_w*5],
-                                                     srcData1[index + stride_w*6], srcData1[index + stride_w*7],
-                                                     srcData1[index + stride_w*8], srcData1[index + stride_w*9],
-                                                     srcData1[index + stride_w*10], srcData1[index + stride_w*11],
-                                                     srcData1[index + stride_w*12], srcData1[index + stride_w*13],
-                                                     srcData1[index + stride_w*14], srcData1[index + stride_w*15]);
+                                        int8_t data[] = {srcData1[index], srcData1[index + stride_w],
+                                                         srcData1[index + stride_w*2], srcData1[index + stride_w*3],
+                                                         srcData1[index + stride_w*4], srcData1[index + stride_w*5],
+                                                         srcData1[index + stride_w*6], srcData1[index + stride_w*7],
+                                                         srcData1[index + stride_w*8], srcData1[index + stride_w*9],
+                                                         srcData1[index + stride_w*10], srcData1[index + stride_w*11],
+                                                         srcData1[index + stride_w*12], srcData1[index + stride_w*13],
+                                                         srcData1[index + stride_w*14], srcData1[index + stride_w*15]};
+                                        int data_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+                                        v_int8x16 v0(data, data_idx);
                                         max_val0 = v_max(max_val0, v0);
                                     }
                             }
@@ -348,14 +350,16 @@ public:
                                     for (int x = xstart; x < xend; ++x)
                                     {
                                         const int index = y * inp_width + x;
-                                        v_int8x16 v0(srcData[index], srcData[index + stride_w],
-                                                     srcData[index + stride_w*2], srcData[index + stride_w*3],
-                                                     srcData[index + stride_w*4], srcData[index + stride_w*5],
-                                                     srcData[index + stride_w*6], srcData[index + stride_w*7],
-                                                     srcData[index + stride_w*8], srcData[index + stride_w*9],
-                                                     srcData[index + stride_w*10], srcData[index + stride_w*11],
-                                                     srcData[index + stride_w*12], srcData[index + stride_w*13],
-                                                     srcData[index + stride_w*14], srcData[index + stride_w*15]);
+                                        int8_t data[] = {srcData[index], srcData[index + stride_w],
+                                                         srcData[index + stride_w*2], srcData[index + stride_w*3],
+                                                         srcData[index + stride_w*4], srcData[index + stride_w*5],
+                                                         srcData[index + stride_w*6], srcData[index + stride_w*7],
+                                                         srcData[index + stride_w*8], srcData[index + stride_w*9],
+                                                         srcData[index + stride_w*10], srcData[index + stride_w*11],
+                                                         srcData[index + stride_w*12], srcData[index + stride_w*13],
+                                                         srcData[index + stride_w*14], srcData[index + stride_w*15]};
+                                        int data_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+                                        v_int8x16 v0(data, data_idx);
                                         max_val0 = v_max(max_val0, v0);
                                     }
                                 }

--- a/modules/gapi/src/backends/fluid/gfluidimgproc_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc_func.simd.hpp
@@ -303,10 +303,15 @@ void run_rgb2hsv_impl(uchar out[], const uchar in[], const int sdiv_table[],
         const int vectorStep = 16;
 
         uint8_t ff = 0xff;
-        v_uint8x16 mask1(ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0);
-        v_uint8x16 mask2(0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0);
-        v_uint8x16 mask3(0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0);
-        v_uint8x16 mask4(0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff);
+        uint8_t mask1_arr[] = {ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0};
+        uint8_t mask2_arr[] = {0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0};
+        uint8_t mask3_arr[] = {0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0};
+        uint8_t mask4_arr[] = {0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff, 0, 0, 0, ff};
+        int mask_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        v_uint8x16 mask1(mask1_arr, mask_idx);
+        v_uint8x16 mask2(mask2_arr, mask_idx);
+        v_uint8x16 mask3(mask3_arr, mask_idx);
+        v_uint8x16 mask4(mask4_arr, mask_idx);
 
         for (int w = 0; w <= 3 * (width - vectorStep); w += 3 * vectorStep)
         {
@@ -952,7 +957,9 @@ void run_rgb2yuv422_impl(uchar out[], const uchar in[], int width)
                          (v2 + v_setall_s16(257 << 2)) >> 3);
 
             uint8_t ff = 0xff;
-            v_uint8x16 mask(ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0);
+            uint8_t mask_arr[] = {ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0, ff, 0};
+            int mask_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            v_uint8x16 mask(mask_arr, mask_idx);
             v_uint8x16 uu = u & mask;
             v_uint8x16 vv = v & mask;
             // extract even u and v


### PR DESCRIPTION
This is a work in progress patch which showcases the changes suggested by @fpetrogalli  in #20562. The current SIMD types make use of scalars-to-vector constructors to build a SIMD vector. To prepare for Scalable Vector Extension(SVE), they are now replaced with lookup table constructors. This facilitates vector length agnostic code while making sure that current compilers can still build them. Currently only SIMD types with 16 lanes have been changed as the nature of this patch is exploratory and not intended for merging.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
