### PR TITLE
Add ExpandDims layer of tf_importer.cpp

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1146,7 +1146,7 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
         axis = inpShape.size() + axis + 1;
     }
 
-    CV_Assert( 0 <= axis && axis <= inpShape.size());
+    CV_Assert(0 <= axis && axis <= inpShape.size());
 
     // After ExpendDims, 3-dim data will become 4-dim data, and OpenCV retains 4-dim data as NCHW data layout.
     // Convert OpenCV's NHC to NCH first.
@@ -1156,7 +1156,7 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
         if(axis != outShapeSize)
         {
             int order[] = {0, 2, 1};  // From OpenCV's NHC to NCH.
-            addPermuteLayer(order, name + "/nhc", inpId, 3);
+            addPermuteLayer(order, name + "/nch", inpId, 3);
 
             std::swap(outShape[1], outShape[2]);
         }
@@ -1204,7 +1204,7 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
     outShapeSize += 1;
 
     // From OpenCV's NCDHW to NDHWC.
-    if((inpLayout != DATA_LAYOUT_NHWC && inpLayout != DATA_LAYOUT_NCHW) && outShapeSize == 5 )
+    if((inpLayout != DATA_LAYOUT_NHWC && inpLayout != DATA_LAYOUT_NCHW) && outShapeSize == 5)
     {
         for(int i = 1; i < outShapeSize - 1; i++)
         {
@@ -1221,10 +1221,13 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
     if(outShapeSize == 5)
     {
         data_layouts[name] = DATA_LAYOUT_NDHWC;
-    }else if(outShapeSize == 4)
+    }
+    else if(outShapeSize == 4)
     {
         data_layouts[name] = DATA_LAYOUT_NCHW;
-    }else{
+    }
+    else
+    {
         data_layouts[name] = inpLayout;
     }
 }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1509,6 +1509,15 @@ void TFImporter::parsePlaceholder(tensorflow::GraphDef& net, const tensorflow::N
             if (dims[0] == -1)  // It's OK to have undetermined batch size
                 dims[0] = 1;
         }
+
+        if (dims.size() == 5 && predictedLayout == DATA_LAYOUT_NDHWC)
+        {
+            std::swap(dims[3], dims[4]);  // NDHWC->NDHCW
+            std::swap(dims[2], dims[3]);  // NDHCW->NDCHW
+            std::swap(dims[1], dims[2]);  // NDCHW->NCDHW
+            if (dims[0] == -1)  // It's OK to have undetermined batch size
+                dims[0] = 1;
+        }
         bool hasNeg = false;
         for (int i = 0; i < dims.size() && !hasNeg; ++i)
         {

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1156,11 +1156,11 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
         if(axis != outShapeSize)
         {
             int order[] = {0, 2, 1};  // From OpenCV's NHC to NCH.
-            addPermuteLayer(order, name + "/ndhwc", inpId, 3);
+            addPermuteLayer(order, name + "/nhc", inpId, 3);
 
             std::swap(outShape[1], outShape[2]);
         }
-        axis = (axis != 0)?(axis % outShapeSize + 1):0;
+        axis = (axis != 0)?(axis % outShapeSize + 1):2;
     }
 
     if(inpShape.size() == 4)

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1117,7 +1117,7 @@ void TFImporter::parseReshape(tensorflow::GraphDef& net, const tensorflow::NodeD
 
 void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams)
 {
-      const std::string& name = layer.name();
+    const std::string& name = layer.name();
     const int num_inputs = layer.input_size();
 
     CV_Assert(!netInputShapes.empty());

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -603,6 +603,7 @@ TEST_P(Test_TensorFlow_layers, ExpandDims)
 #endif
 
     runTensorFlowNet("expand_dims_1");
+    runTensorFlowNet("expand_dims_2");
 }
 
 // TODO: fix it and add to l2_normalize

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -593,6 +593,18 @@ TEST_P(Test_TensorFlow_layers, BiasAdd)
     runTensorFlowNet("bias_add_1");
 }
 
+TEST_P(Test_TensorFlow_layers, ExpandDims)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2019010000)
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && target == DNN_TARGET_MYRIAD
+            && getInferenceEngineVPUType() == CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X
+    )
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD_X, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+#endif
+
+    runTensorFlowNet("expand_dims_1");
+}
+
 // TODO: fix it and add to l2_normalize
 TEST_P(Test_TensorFlow_layers, l2_normalize_3d)
 {


### PR DESCRIPTION
The `ExpandDims` layer was implemented by "Reshape layer."
The following code will generate the `ExpandDims` layer:
```py
expand_dim = tf.expand_dims(input, -1)
# or
expand_dim = tf.expand_dims(input, 2)

```
Related test data could be found at [PR in opencv_extra](https://github.com/opencv/opencv_extra/pull/911).

There are still some unresolved issues here:
- 1. ~~**Currently, this code can only handle when the dimension input layer dimension is 4.**, since the different Datalayout between OpenCV and Tensorflow.~~(Solved.)
- 2. Since the implementation uses the `dstNet.getLayerShapes()` function. This implementation can not handle [this model](https://drive.google.com/drive/folders/1-y9zh3fiwARdAXjL41X-2vNwtr9Phjqi?usp=sharing). 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
opencv_extra=tf_expand_dim_layer
```