### PR TITLE
Add operator != and == for MatStep.

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -596,6 +596,8 @@ struct CV_EXPORTS MatStep
     size_t& operator[](int i) CV_NOEXCEPT;
     operator size_t() const;
     MatStep& operator = (size_t s);
+    bool operator != (const MatStep &a)const;
+    bool operator == (const MatStep &a)const;
 
     size_t* p;
     size_t buf[2];

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1272,6 +1272,15 @@ inline MatStep& MatStep::operator = (size_t s)
     return *this;
 }
 
+inline bool MatStep::operator != (const MatStep &a) const
+{
+    return p[0] != a.p[0];
+}
+
+inline bool MatStep::operator == (const MatStep &a) const
+{
+    return p[0] == a.p[0];
+}
 
 
 ////////////////////////////// Mat_<_Tp> ////////////////////////////


### PR DESCRIPTION
I'm not sure if this is a bug or if it is necessary to fix it, because it is ok for now but might cause ambiguity. And it is also a very basic module of OpenCV and it seems to have been here for 8 years. If this is not necessary to fix it, please feel free to close this PR.

When I try to add another class contain a data member (with type size_t) and has overload operator != or == to compare the class by that data member, an error occurred about ambiguous overload for the operator in [copy.cpp#L971](https://github.com/opencv/opencv/blob/4.5.3/modules/core/src/copy.cpp#L971).

```
error: ambiguous overload for 'operator!=' (operand types are 'cv::MatStep' and 'cv::MatStep')
  971 |         if(src.u != dst.u || src.step != dst.step)
      |                              ~~~~~~~~ ^~ ~~~~~~~~
      |                                  |           |
      |                                  cv::MatStep cv::MatStep
```
one of the candidates is my new class, and the other one is 
```
'operator!=(size_t {aka long unsigned int}, size_t {aka long unsigned int})' (built-in)
```
also the overloaded operator used before. It seems like `MatStep` (a class) was implicitly converted to `size_t` (a basic type). It causes ambiguity. 

So I add two overload operators(== and !=) to solve it.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
