### PR TITLE
Add matrix multiplication to Mat for iOS/Android

### DIFF
--- a/modules/core/misc/java/src/java/core+Mat.java
+++ b/modules/core/misc/java/src/java/core+Mat.java
@@ -466,14 +466,30 @@ public class Mat {
     // C++: Mat Mat::mul(Mat m, double scale = 1)
     //
 
-    // javadoc: Mat::mul(m, scale)
+    /**
+     * Element-wise multiplication with scale factor
+     * @param m operand with with which to perform element-wise multiplication
+     * @param scale scale factor
+     */
     public Mat mul(Mat m, double scale) {
         return new Mat(n_mul(nativeObj, m.nativeObj, scale));
     }
 
-    // javadoc: Mat::mul(m)
+    /**
+    * Element-wise multiplication
+    * @param m operand with with which to perform element-wise multiplication
+    */
     public Mat mul(Mat m) {
         return new Mat(n_mul(nativeObj, m.nativeObj));
+    }
+
+    /**
+    * Matrix multiplication
+    * @param m operand with with which to perform matrix multiplication
+    * @see Core#gemm(Mat, Mat, double, Mat, double, Mat, int)
+    */
+    public Mat matMul(Mat m) {
+        return new Mat(n_matMul(nativeObj, m.nativeObj));
     }
 
     //
@@ -1731,6 +1747,8 @@ public class Mat {
     private static native long n_mul(long nativeObj, long m_nativeObj, double scale);
 
     private static native long n_mul(long nativeObj, long m_nativeObj);
+
+    private static native long n_matMul(long nativeObj, long m_nativeObj);
 
     // C++: static Mat Mat::ones(int rows, int cols, int type)
     private static native long n_ones(int rows, int cols, int type);

--- a/modules/core/misc/java/src/java/core+MatMatMul.kt
+++ b/modules/core/misc/java/src/java/core+MatMatMul.kt
@@ -1,0 +1,3 @@
+package org.opencv.core
+
+operator fun Mat.times(other: Mat): Mat = this.matMul(other)

--- a/modules/core/misc/java/test/MatTest.java
+++ b/modules/core/misc/java/test/MatTest.java
@@ -686,6 +686,16 @@ public class MatTest extends OpenCVTestCase {
         assertMatEqual(truth, dst, EPS);
     }
 
+    public void testMatMulMat() {
+        Mat m1 = new Mat(2, 2, CvType.CV_32F, new Scalar(2));
+        Mat m2 = new Mat(2, 2, CvType.CV_32F, new Scalar(3));
+
+        dst = m1.matMul(m2);
+
+        truth = new Mat(2, 2, CvType.CV_32F, new Scalar(12));
+        assertMatEqual(truth, dst, EPS);
+    }
+
     public void testOnesIntIntInt() {
         dst = Mat.ones(matSize, matSize, CvType.CV_32F);
 

--- a/modules/core/misc/objc/common/Mat.h
+++ b/modules/core/misc/objc/common/Mat.h
@@ -114,7 +114,17 @@ CV_EXPORTS @interface Mat : NSObject
 - (BOOL)isSubmatrix;
 - (void)locateROI:(Size2i*)wholeSize ofs:(Point2i*)offset NS_SWIFT_NAME(locateROI(wholeSize:offset:));
 - (Mat*)mul:(Mat*)mat scale:(double)scale;
+/**
+ Performs element-wise multiplication
+ @param mat operand with with which to perform element-wise multiplication
+*/
 - (Mat*)mul:(Mat*)mat;
+/**
+ Performs matrix multiplication
+ @param mat operand with with which to perform matrix multiplication
+ @see `Core.gemm(...)`
+*/
+- (Mat*)matMul:(Mat*)mat;
 + (Mat*)ones:(int)rows cols:(int)cols type:(int)type NS_SWIFT_NAME(ones(rows:cols:type:));
 + (Mat*)ones:(Size2i*)size type:(int)type NS_SWIFT_NAME(ones(size:type:));
 + (Mat*)onesEx:(NSArray<NSNumber*>*)sizes type:(int)type NS_SWIFT_NAME(ones(sizes:type:));

--- a/modules/core/misc/objc/common/Mat.mm
+++ b/modules/core/misc/objc/common/Mat.mm
@@ -372,6 +372,11 @@ static bool updateIdx(cv::Mat* mat, std::vector<int>& indices, size_t inc) {
     return [[Mat alloc] initWithNativeMat:new cv::Mat(_nativePtr->mul(*(cv::Mat*)mat.nativePtr))];
 }
 
+- (Mat*)matMul:(Mat*)mat {
+    cv::Mat temp = self.nativeRef * mat.nativeRef;
+    return [Mat fromNative:temp];
+}
+
 + (Mat*)ones:(int)rows cols:(int)cols type:(int)type {
     return [[Mat alloc] initWithNativeMat:new cv::Mat(cv::Mat::ones(rows, cols, type))];
 }

--- a/modules/core/misc/objc/common/MatExt.swift
+++ b/modules/core/misc/objc/common/MatExt.swift
@@ -715,3 +715,9 @@ public extension Mat {
         return MatAt(mat: self, indices: indices)
     }
 }
+
+public extension Mat {
+    static func *(lhs:Mat, rhs: Mat) -> Mat {
+        return lhs.matMul(rhs)
+    }
+}

--- a/modules/core/misc/objc/test/MatTest.swift
+++ b/modules/core/misc/objc/test/MatTest.swift
@@ -683,6 +683,16 @@ class MatTests: OpenCVTestCase {
         try assertMatEqual(truth!, dst, OpenCVTestCase.EPS)
     }
 
+    func testMatMulMat() throws {
+        let m1 = Mat(rows: 2, cols: 2, type: CvType.CV_32F, scalar: Scalar(2))
+        let m2 = Mat(rows: 2, cols: 2, type: CvType.CV_32F, scalar: Scalar(3))
+
+        dst = m1.matMul(m2)
+
+        truth = Mat(rows: 2, cols: 2, type: CvType.CV_32F, scalar: Scalar(12))
+        try assertMatEqual(truth!, dst, OpenCVTestCase.EPS)
+    }
+
     func testOnesIntIntInt() throws {
         dst = Mat.ones(rows: OpenCVTestCase.matSize, cols: OpenCVTestCase.matSize, type: CvType.CV_32F)
 

--- a/modules/java/generator/src/cpp/Mat.cpp
+++ b/modules/java/generator/src/cpp/Mat.cpp
@@ -1372,6 +1372,32 @@ JNIEXPORT jlong JNICALL Java_org_opencv_core_Mat_n_1mul__JJ
 }
 
 
+//
+// Mat Mat Mat::matMul(Mat m)
+//
+
+JNIEXPORT jlong JNICALL Java_org_opencv_core_Mat_n_1matMul__JJ
+  (JNIEnv* env, jclass, jlong self, jlong m_nativeObj);
+
+JNIEXPORT jlong JNICALL Java_org_opencv_core_Mat_n_1matMul__JJ
+  (JNIEnv* env, jclass, jlong self, jlong m_nativeObj)
+{
+    static const char method_name[] = "Mat::n_1matMul__JJ()";
+    try {
+        LOGD("%s", method_name);
+        Mat* me = (Mat*) self; //TODO: check for NULL
+        Mat& m = *((Mat*)m_nativeObj);
+        Mat _retval_ = (*me) * m;
+        return (jlong) new Mat(_retval_);
+    } catch(const std::exception &e) {
+        throwJavaException(env, &e, method_name);
+    } catch (...) {
+        throwJavaException(env, 0, method_name);
+    }
+
+    return 0;
+}
+
 
 //
 // static Mat Mat::ones(int rows, int cols, int type)


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There are tests

Android and iOS wrapper both have element-wise multiplication operations (https://en.wikipedia.org/wiki/Hadamard_product_(matrices)) for `Mat`  but lack matrix multiplication operations (https://en.wikipedia.org/wiki/Matrix_multiplication).

This PR adds matrix multiplication for `Mat` in Android and iOS wrappers.
It also adds operator overloading for the `*` operator in Swift and Kotlin

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-2
```