### PR TITLE
fix cast in text detection sample

### DIFF
--- a/samples/dnn/text_detection.py
+++ b/samples/dnn/text_detection.py
@@ -214,8 +214,8 @@ def main():
                            0.5, (255, 0, 0))
 
             for j in range(4):
-                p1 = (vertices[j][0], vertices[j][1])
-                p2 = (vertices[(j + 1) % 4][0], vertices[(j + 1) % 4][1])
+                p1 = (int(vertices[j][0]), int(vertices[j][1]))
+                p2 = (int(vertices[(j + 1) % 4][0]), int(vertices[(j + 1) % 4][1]))
                 cv.line(frame, p1, p2, (0, 255, 0), 1)
 
         # Put efficiency information


### PR DESCRIPTION
This pull request will fix text detection sample.
cv.line() accepts only input int type point. Therefor, it is need cast to int type.

This is an error to be fixed by this pull request.
```
Traceback (most recent call last):
  File "text_detection.py", line 239, in <module>
    main()
  File "text_detection.py", line 227, in main
    cv.line(frame, p1, p2, (0, 255, 0), 1)
cv2.error: OpenCV(4.5.3) :-1: error: (-5:Bad argument) in function 'line'
> Overload resolution failed:
>  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type
>  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
