### PR TITLE
Fix bug in initializers Rect2f(Point2f,Point2f) and Rect2d(Point2d,Point2d)

### DIFF
--- a/modules/core/misc/objc/common/Rect2d.mm
+++ b/modules/core/misc/objc/common/Rect2d.mm
@@ -64,10 +64,10 @@
 }
 
 - (instancetype)initWithPoint:(Point2d*)point1 point:(Point2d*)point2 {
-    int x = (point1.x < point2.x ? point1.x : point2.x);
-    int y = (point1.y < point2.y ? point1.y : point2.y);
-    int width = (point1.x > point2.x ? point1.x : point2.x) - x;
-    int height = (point1.y > point2.y ? point1.y : point2.y) - y;
+    double x = (point1.x < point2.x ? point1.x : point2.x);
+    double y = (point1.y < point2.y ? point1.y : point2.y);
+    double width = (point1.x > point2.x ? point1.x : point2.x) - x;
+    double height = (point1.y > point2.y ? point1.y : point2.y) - y;
     return [self initWithX:x y:y width:width height:height];
 }
 

--- a/modules/core/misc/objc/common/Rect2f.mm
+++ b/modules/core/misc/objc/common/Rect2f.mm
@@ -64,10 +64,10 @@
 }
 
 - (instancetype)initWithPoint:(Point2f*)point1 point:(Point2f*)point2 {
-    int x = (point1.x < point2.x ? point1.x : point2.x);
-    int y = (point1.y < point2.y ? point1.y : point2.y);
-    int width = (point1.x > point2.x ? point1.x : point2.x) - x;
-    int height = (point1.y > point2.y ? point1.y : point2.y) - y;
+    float x = (point1.x < point2.x ? point1.x : point2.x);
+    float y = (point1.y < point2.y ? point1.y : point2.y);
+    float width = (point1.x > point2.x ? point1.x : point2.x) - x;
+    float height = (point1.y > point2.y ? point1.y : point2.y) - y;
     return [self initWithX:x y:y width:width height:height];
 }
 

--- a/modules/core/misc/objc/test/RectTest.swift
+++ b/modules/core/misc/objc/test/RectTest.swift
@@ -101,6 +101,30 @@ class RectTest: OpenCVTestCase {
         XCTAssertEqual(1, r.height);
     }
 
+    func testRect2fPointPoint() {
+        let p1 = Point2f(x:4.3, y:4.1)
+        let p2 = Point2f(x:2.7, y:3.9)
+
+        let r = Rect2f(point: p1, point: p2)
+        XCTAssertNotNil(r);
+        XCTAssertEqual(2.7, r.x);
+        XCTAssertEqual(3.9, r.y);
+        XCTAssertEqual(1.6, r.width, accuracy: OpenCVTestCase.FEPS);
+        XCTAssertEqual(0.2, r.height, accuracy: OpenCVTestCase.FEPS);
+    }
+
+    func testRect2dPointPoint() {
+        let p1 = Point2d(x:4.7879839, y:4.9922311)
+        let p2 = Point2d(x:2.1213123, y:3.1122129)
+
+        let r = Rect2d(point: p1, point: p2)
+        XCTAssertNotNil(r);
+        XCTAssertEqual(2.1213123, r.x);
+        XCTAssertEqual(3.1122129, r.y);
+        XCTAssertEqual(2.6666716, r.width, accuracy: OpenCVTestCase.EPS);
+        XCTAssertEqual(1.8800182, r.height, accuracy: OpenCVTestCase.EPS);
+    }
+
     func testRectPointSize() {
         let p1 = Point(x: 4, y: 4)
         let sz = Size(width: 3, height: 1)


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is a test

Fix a bug in iOS/macOS implementation of Rect2f(Point2f, Point2f) and Rect2d(Point2d, Point2d) initializers causing loss of precision due to erroneous casts to `int`
