### PR TITLE
G-API: Add more parameters to render fixture

### DIFF
--- a/modules/gapi/test/common/gapi_tests_helpers.hpp
+++ b/modules/gapi/test/common/gapi_tests_helpers.hpp
@@ -50,6 +50,18 @@ namespace opencv_test
     __TUPLE_PARAM_TYPE(index) param_name = getSpecificParam<index>(); \
     __WRAP_VAARGS(__DEFINE_PARAMS_IMPL7(index+1, __VA_ARGS__))
 
+#define __DEFINE_PARAMS_IMPL9(index, param_name, ...) \
+    __TUPLE_PARAM_TYPE(index) param_name = getSpecificParam<index>(); \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL8(index+1, __VA_ARGS__))
+
+#define __DEFINE_PARAMS_IMPL10(index, param_name, ...) \
+    __TUPLE_PARAM_TYPE(index) param_name = getSpecificParam<index>(); \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL9(index+1, __VA_ARGS__))
+
+#define __DEFINE_PARAMS_IMPL11(index, param_name, ...) \
+    __TUPLE_PARAM_TYPE(index) param_name = getSpecificParam<index>(); \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL10(index+1, __VA_ARGS__))
+
 // user interface to define member variables of specified names
 #define DEFINE_SPECIFIC_PARAMS_0()
 
@@ -76,6 +88,15 @@ namespace opencv_test
 
 #define DEFINE_SPECIFIC_PARAMS_8(...) \
     __WRAP_VAARGS(__DEFINE_PARAMS_IMPL8(0, __VA_ARGS__))
+
+#define DEFINE_SPECIFIC_PARAMS_9(...) \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL9(0, __VA_ARGS__))
+
+#define DEFINE_SPECIFIC_PARAMS_10(...) \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL10(0, __VA_ARGS__))
+
+#define DEFINE_SPECIFIC_PARAMS_11(...) \
+    __WRAP_VAARGS(__DEFINE_PARAMS_IMPL11(0, __VA_ARGS__))
 } // namespace opencv_test
 
 #endif //OPENCV_GAPI_TESTS_HELPERS_HPP


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```