### PR TITLE
dnn(OpenCL): fix conv BASIC workgroup

### DIFF
--- a/modules/dnn/src/opencl/conv_layer_spatial.cl
+++ b/modules/dnn/src/opencl/conv_layer_spatial.cl
@@ -158,10 +158,14 @@ __kernel void ConvolveBasic(
 )
 {
     __global Dtype* convolved_image = convolved_image_base + convolved_image_base_offset;
-    const int outputX = get_global_id(0);
-    const int outputY = get_global_id(1);
-    const int kernelNum = get_global_id(2) * ZPAR;
-    if (outputX < output_width && outputY < output_height)
+    const int out_idx = get_global_id(0);  // 1D task layout: [output_width * output_height * OUTPUT_Z]
+    const int plane_size = output_width * output_height;
+    const int out_plane_idx = out_idx % plane_size;
+    const int outputZ = out_idx / plane_size;
+    const int outputY = out_plane_idx / output_width;
+    const int outputX = out_plane_idx % output_width;
+    const int kernelNum = outputZ * ZPAR;
+    if (kernelNum < OUTPUT_Z)
     {
         Dtype sum[ZPAR];
         for (int kern = 0; kern < ZPAR; kern++)


### PR DESCRIPTION
Avoid inefficient automatic scheduling of 3D task layout with LWS=1x1x256
Also there is no efficient selection of 3D LWS (GWS must be divisible to LVS).

Finally, task is reworked to process as 1D array.

relates #20655

<cut/>

```
force_builders=Custom,Linux AVX2,Linux OpenCL,Custom Win
build_image:Custom=ubuntu:18.04
buildworker:Custom=linux-5
test_opencl:Custom=ON

build_image:Linux AVX2=ubuntu:18.04
buildworker:Linux AVX2=linux-3
test_opencl:Linux AVX2=ON

buildworker:Custom Win=windows-3
build_image:Custom Win=msvs2019
test_opencl:Custom Win=ON
```