### PR TITLE
imgproc: suppress GaussianBlur to generate empty images

### DIFF
--- a/modules/cudafilters/test/test_filters.cpp
+++ b/modules/cudafilters/test/test_filters.cpp
@@ -445,8 +445,8 @@ PARAM_TEST_CASE(GaussianBlur, cv::cuda::DeviceInfo, cv::Size, MatDepth, Channels
 CUDA_TEST_P(GaussianBlur, Accuracy)
 {
     cv::Mat src = randomMat(size, type);
-    double sigma1 = randomDouble(0.1, 1.0);
-    double sigma2 = randomDouble(0.1, 1.0);
+    double sigma1 = randomDouble(0.0, 1.0);
+    double sigma2 = randomDouble(0.0, 1.0);
 
     cv::Ptr<cv::cuda::Filter> gauss = cv::cuda::createGaussianFilter(src.type(), -1, ksize, sigma1, sigma2, borderType);
 

--- a/modules/imgproc/src/smooth.simd.hpp
+++ b/modules/imgproc/src/smooth.simd.hpp
@@ -1958,7 +1958,10 @@ public:
         }
         else if (kxlen % 2 == 1)
         {
-            hlineSmoothFunc = hlineSmoothONa_yzy_a;
+            if (kx[(kxlen - 1)/ 2] == FT::one())
+                hlineSmoothFunc = hlineSmooth1N1;
+            else
+                hlineSmoothFunc = hlineSmoothONa_yzy_a;
             for (int i = 0; i < kxlen / 2; i++)
                 if (!(kx[i] == kx[kxlen - 1 - i]))
                 {

--- a/modules/imgproc/test/test_smooth_bitexact.cpp
+++ b/modules/imgproc/test/test_smooth_bitexact.cpp
@@ -249,4 +249,15 @@ TEST(GaussianBlur_Bitexact, regression_9863)
     checkGaussianBlur_8Uvs32F(src8u, src32f, 151, 30);
 }
 
+TEST(GaussianBlur_Bitexact, overflow_20792)
+{
+    Mat src(128, 128, CV_16UC1, Scalar(255));
+    Mat dst;
+    double sigma = theRNG().uniform(0.0, 0.2);        // a peaky kernel
+    GaussianBlur(src, dst, Size(7, 7), sigma, 0.9);
+    int count = (int)countNonZero(dst);
+    int nintyPercent = (int)(src.rows*src.cols * 0.9);
+    EXPECT_GT(count, nintyPercent);
+}
+
 }} // namespace


### PR DESCRIPTION
resolve #20792
resolve #20666

  * sharp Gaussian kernel causes over flow and ends up in blank image

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
