### PR TITLE
Fix gst_initializer

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -216,10 +216,10 @@ private:
         call_deinit = utils::getConfigurationParameterBool("OPENCV_VIDEOIO_GSTREAMER_CALL_DEINIT", false);
 
         GSafePtr<GError> err;
-        gst_init_check(NULL, NULL, err.getRef());
-        if (err)
+        gboolean gst_init_res = gst_init_check(NULL, NULL, err.getRef());
+        if (!gst_init_res)
         {
-            CV_WARN("Can't initialize GStreamer: " << err->message);
+            CV_WARN("Can't initialize GStreamer: " << (err ? err->message : "<unknown reason>"));
             isFailed = true;
             return;
         }


### PR DESCRIPTION
I noticed this while reading the code, and it seems wrong to me. From the [documentation](https://gstreamer.freedesktop.org/documentation/gstreamer/gst.html?gi-language=c#gst_init_check), `gst_init_check` "will return FALSE if GStreamer could not be initialized for some reason".

I do not understand why the current code ever works, because in my test project (with gstreamer 1.16.2), `err` is never `NULL` after a call to `gst_init_check(NULL, NULL, &err);`. But I could imagine that it is different with other versions of gstreamer.

I haven't tested my patch at all, but it seemed important enough to open a discussion, and a PR seemed like a good way. Feel free to close if I am missing something :innocent:.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=gstreamer:14.04
buildworker:Custom=linux-4
```