### PR TITLE
Fix gst error handling

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -761,7 +761,7 @@ bool GStreamerCapture::open(const String &filename_)
             }
             else
             {
-                CV_WARN("Error opening file: " << filename << " (" << err->message << ")");
+                CV_WARN("Error opening file: " << filename << " (" << (err ? err->message : "<unknown reason>") << ")");
                 return false;
             }
         }
@@ -769,9 +769,9 @@ bool GStreamerCapture::open(const String &filename_)
         {
             GSafePtr<GError> err;
             uridecodebin.attach(gst_parse_launch(filename, err.getRef()));
-            if (err)
+            if (!uridecodebin)
             {
-                CV_WARN("Error opening bin: " << err->message);
+                CV_WARN("Error opening bin: " << (err ? err->message : "<unknown reason>"));
                 return false;
             }
             manualpipeline = true;
@@ -1523,17 +1523,6 @@ bool CvVideoWriter_GStreamer::open( const char * filename, int fourcc,
 
     if (manualpipeline)
     {
-        if (err)
-        {
-            CV_WARN("error opening writer pipeline: " << err->message);
-            if (encodebin)
-            {
-                gst_element_set_state(encodebin, GST_STATE_NULL);
-            }
-            handleMessage(encodebin);
-            encodebin.release();
-            return false;
-        }
 #if GST_VERSION_MAJOR == 0
         it = gst_bin_iterate_sources(GST_BIN(encodebin.get()));
         if (gst_iterator_next(it, (gpointer *)source.getRef()) != GST_ITERATOR_OK) {
@@ -1979,7 +1968,7 @@ void handleMessage(GstElement * pipeline)
                 gst_message_parse_error(msg, err.getRef(), debug.getRef());
                 GSafePtr<gchar> name; name.attach(gst_element_get_name(GST_MESSAGE_SRC (msg)));
                 CV_WARN("Embedded video playback halted; module " << name.get() <<
-                        " reported: " << err->message);
+                        " reported: " << (err ? err->message : "<unknown reason>"));
                 CV_LOG_DEBUG(NULL, "GStreamer debug: " << debug.get());
 
                 gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_NULL);


### PR DESCRIPTION
@alalek: similar to https://github.com/opencv/opencv/pull/20796. I think I have found a case where somebody had an issue with one of those bugs: https://stackoverflow.com/questions/61394756/how-to-use-opencv-videowriter-with-gstreamer :slightly_smiling_face: 

* Use the return value instead of the error, which gives no guarantee of being NULL in case of error
* Test err pointer before accessing it
* Remove unreachable code

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
