### PR TITLE
core(TLS): force TlsAbstraction initialization before main()

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1834,6 +1834,12 @@ static void WINAPI opencv_fls_destructor(void* pData)
 #endif // CV_USE_FLS
 #endif // _WIN32
 
+static TlsAbstraction* const g_force_initialization_of_TlsAbstraction
+#if defined __GNUC__
+    __attribute__((unused))
+#endif
+    = getTlsAbstraction();
+
 } // namespace details
 using namespace details;
 


### PR DESCRIPTION
relates #20606
