### PR TITLE
dnn(pytest/test_input_3d): reload model between switching targets

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -323,20 +323,22 @@ class dnn_test(NewOpenCVTests):
             raise unittest.SkipTest("Missing DNN test files (dnn/onnx/data/{input/output}_hidden_lstm.npy). "
                                     "Verify OPENCV_DNN_TEST_DATA_PATH configuration parameter.")
 
-        net = cv.dnn.readNet(model)
         input = np.load(input_file)
         # we have to expand the shape of input tensor because Python bindings cut 3D tensors to 2D
         # it should be fixed in future. see : https://github.com/opencv/opencv/issues/19091
         # please remove `expand_dims` after that
         input = np.expand_dims(input, axis=3)
         gold_output = np.load(output_file)
-        net.setInput(input)
 
         for backend, target in self.dnnBackendsAndTargets:
             printParams(backend, target)
 
+            net = cv.dnn.readNet(model)
+
             net.setPreferableBackend(backend)
             net.setPreferableTarget(target)
+
+            net.setInput(input)
             real_output = net.forward()
 
             normAssert(self, real_output, gold_output, "", getDefaultThreshold(target))


### PR DESCRIPTION
resolves #20534
relates #20480

Reusing `dnn:Net` after target switching is buggy (TBD).

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

buildworker:Custom Win=windows-3
test_opencl:Custom Win=ON
```