### PR TITLE
Fix ORB integer overflow

### DIFF
--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -131,13 +131,15 @@ static void
 HarrisResponses(const Mat& img, const std::vector<Rect>& layerinfo,
                 std::vector<KeyPoint>& pts, int blockSize, float harris_k)
 {
-    CV_Assert( img.type() == CV_8UC1 && blockSize*blockSize <= 2048 );
+    CV_CheckTypeEQ(img.type(), CV_8UC1, "");
+    CV_CheckGT(blockSize, 0, "");
+    CV_CheckLE(blockSize*blockSize, 2048, "");
 
     size_t ptidx, ptsize = pts.size();
 
     const uchar* ptr00 = img.ptr<uchar>();
-    size_t size_t_step = img.step/img.elemSize1();
-    CV_Check(size_t_step, size_t_step + 1 <= INT_MAX, "step in img > INT_MAX");
+    size_t size_t_step = img.step;
+    CV_CheckLE(size_t_step * blockSize + blockSize + 1, (size_t)INT_MAX, "");  // ofs computation, step+1
     int step = static_cast<int>(size_t_step);
 
     int r = blockSize/2;
@@ -157,8 +159,7 @@ HarrisResponses(const Mat& img, const std::vector<Rect>& layerinfo,
         int y0 = cvRound(pts[ptidx].pt.y);
         int z = pts[ptidx].octave;
 
-        size_t offset = (y0 - r + layerinfo[z].y)*size_t_step + (x0 - r + layerinfo[z].x);
-        const uchar* ptr0 = ptr00 + offset;
+        const uchar* ptr0 = ptr00 + (y0 - r + layerinfo[z].y)*size_t_step + (x0 - r + layerinfo[z].x);
         int a = 0, b = 0, c = 0;
 
         for( int k = 0; k < blockSize*blockSize; k++ )

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -141,9 +141,15 @@ TEST(Features2D_ORB, regression_16197)
     ASSERT_NO_THROW(orbPtr->detectAndCompute(img, noArray(), kps, fv));
 }
 
-BIGDATA_TEST(Features2D_ORB, issue_537) // memory usage: ~2.3 Gb
+// https://github.com/opencv/opencv-python/issues/537
+BIGDATA_TEST(Features2D_ORB, regression_opencv_python_537)  // memory usage: ~3 Gb
 {
-    applyTestTag(CV_TEST_TAG_LONG, CV_TEST_TAG_DEBUG_VERYLONG, CV_TEST_TAG_MEMORY_6GB);
+    applyTestTag(
+        CV_TEST_TAG_LONG,
+        CV_TEST_TAG_DEBUG_VERYLONG,
+        CV_TEST_TAG_MEMORY_6GB
+    );
+
     const int width = 25000;
     const int height = 25000;
     Mat img(Size(width, height), CV_8UC1, Scalar::all(0));


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv-python/issues/537 "segmentation fault using ORB"


- Problem in HarrisResponses(const Mat& img, const std::vector<Rect>& layerinfo, std::vector<KeyPoint>& pts, int blockSize, float harris_k) from orb.cpp
- An integer overflow has occurred in this line:
`const uchar* ptr0 = ptr00 + (y0 - r + layerinfo[z].y)*step + x0 - r + layerinfo[z].x;`
- To fix this problem, integer variable `step` was declared as `size_t`.
- Also I ran performance tests: `PERF_TEST_P(feature2d, detectAndExtract, testing::Combine(testing::Values(DETECTORS_EXTRACTORS), TEST_IMAGES))`
And the performance remained almost unchanged:
[test_new_version.txt](https://github.com/opencv/opencv/files/7296384/test_new_version.txt)
[test_old_version.txt](https://github.com/opencv/opencv/files/7296385/test_old_version.txt)
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
