### PR TITLE
dnn(OpenCL): skip int8 tests due to memory access issues

### DIFF
--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -544,6 +544,12 @@ TEST_P(Test_Int8_nets, AlexNet)
     if (backend != DNN_BACKEND_OPENCV)
         throw SkipTestException("Only OpenCV backend is supported");
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
+
     Net net = readNetFromCaffe(findDataFile("dnn/bvlc_alexnet.prototxt"),
                                findDataFile("dnn/bvlc_alexnet.caffemodel", false));
 
@@ -557,6 +563,11 @@ TEST_P(Test_Int8_nets, AlexNet)
 
 TEST_P(Test_Int8_nets, GoogLeNet)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     Net net = readNetFromCaffe(findDataFile("dnn/bvlc_googlenet.prototxt"),
                                findDataFile("dnn/bvlc_googlenet.caffemodel", false));
 
@@ -576,6 +587,11 @@ TEST_P(Test_Int8_nets, ResNet50)
     if (backend != DNN_BACKEND_OPENCV)
         throw SkipTestException("Only OpenCV backend is supported");
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     Net net = readNetFromCaffe(findDataFile("dnn/ResNet-50-deploy.prototxt"),
                                findDataFile("dnn/ResNet-50-model.caffemodel", false));
 
@@ -590,6 +606,11 @@ TEST_P(Test_Int8_nets, ResNet50)
 TEST_P(Test_Int8_nets, DenseNet121)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_512MB);
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
     Net net = readNetFromCaffe(findDataFile("dnn/DenseNet_121.prototxt", false),
                                findDataFile("dnn/DenseNet_121.caffemodel", false));
@@ -606,6 +627,11 @@ TEST_P(Test_Int8_nets, SqueezeNet_v1_1)
 {
     if(target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
     Net net = readNetFromCaffe(findDataFile("dnn/squeezenet_v1.1.prototxt"),
                                findDataFile("dnn/squeezenet_v1.1.caffemodel", false));
@@ -626,6 +652,11 @@ TEST_P(Test_Int8_nets, CaffeNet)
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
 #endif
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2019030000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && target == DNN_TARGET_MYRIAD
         && getInferenceEngineVPUType() == CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)
@@ -643,6 +674,11 @@ TEST_P(Test_Int8_nets, RCNN_ILSVRC13)
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
 #endif
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2019030000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && target == DNN_TARGET_MYRIAD
         && getInferenceEngineVPUType() == CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)
@@ -654,16 +690,31 @@ TEST_P(Test_Int8_nets, RCNN_ILSVRC13)
 
 TEST_P(Test_Int8_nets, Inception_v2)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     testONNXNet("inception_v2",  default_l1,  default_lInf, true);
 }
 
 TEST_P(Test_Int8_nets, MobileNet_v2)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     testONNXNet("mobilenetv2", default_l1, default_lInf, true);
 }
 
 TEST_P(Test_Int8_nets, Shufflenet)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
     {
         if (target == DNN_TARGET_OPENCL_FP16) applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
@@ -675,6 +726,11 @@ TEST_P(Test_Int8_nets, Shufflenet)
 
 TEST_P(Test_Int8_nets, MobileNet_SSD)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     Net net = readNetFromCaffe(findDataFile("dnn/MobileNetSSD_deploy.prototxt", false),
                                findDataFile("dnn/MobileNetSSD_deploy.caffemodel", false));
 
@@ -688,6 +744,11 @@ TEST_P(Test_Int8_nets, MobileNet_SSD)
 
 TEST_P(Test_Int8_nets, MobileNet_v1_SSD)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     Net net = readNetFromTensorflow(findDataFile("dnn/ssd_mobilenet_v1_coco_2017_11_17.pb", false),
                                     findDataFile("dnn/ssd_mobilenet_v1_coco_2017_11_17.pbtxt"));
 
@@ -701,6 +762,11 @@ TEST_P(Test_Int8_nets, MobileNet_v1_SSD)
 
 TEST_P(Test_Int8_nets, MobileNet_v1_SSD_PPN)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2018050000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
         applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16,
@@ -720,6 +786,11 @@ TEST_P(Test_Int8_nets, MobileNet_v1_SSD_PPN)
 
 TEST_P(Test_Int8_nets, Inception_v2_SSD)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LE(2019010000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && target == DNN_TARGET_MYRIAD &&
@@ -744,6 +815,11 @@ TEST_P(Test_Int8_nets, Inception_v2_SSD)
 
 TEST_P(Test_Int8_nets, opencv_face_detector)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     Net net = readNetFromCaffe(findDataFile("dnn/opencv_face_detector.prototxt"),
                                findDataFile("dnn/opencv_face_detector.caffemodel", false));
 
@@ -762,6 +838,11 @@ TEST_P(Test_Int8_nets, opencv_face_detector)
 
 TEST_P(Test_Int8_nets, EfficientDet)
 {
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     if (target != DNN_TARGET_CPU)
     {
         if (target == DNN_TARGET_OPENCL_FP16) applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -788,6 +869,11 @@ TEST_P(Test_Int8_nets, FasterRCNN_resnet50)
         CV_TEST_TAG_LONG,
         CV_TEST_TAG_DEBUG_VERYLONG
     );
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #ifdef INF_ENGINE_RELEASE
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 &&
@@ -826,6 +912,11 @@ TEST_P(Test_Int8_nets, FasterRCNN_inceptionv2)
         CV_TEST_TAG_LONG,
         CV_TEST_TAG_DEBUG_VERYLONG
     );
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #ifdef INF_ENGINE_RELEASE
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 &&
@@ -869,6 +960,11 @@ TEST_P(Test_Int8_nets, FasterRCNN_vgg16)
         CV_TEST_TAG_DEBUG_VERYLONG
     );
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
 #if defined(INF_ENGINE_RELEASE)
     if ((backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
         applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16);
@@ -902,6 +998,11 @@ TEST_P(Test_Int8_nets, FasterRCNN_zf)
         CV_TEST_TAG_DEBUG_LONG
     );
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     if ((backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 ||
          backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16);
@@ -932,6 +1033,11 @@ TEST_P(Test_Int8_nets, RFCN)
         CV_TEST_TAG_DEBUG_VERYLONG
     );
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
     if ((backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 ||
          backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16);
@@ -960,6 +1066,11 @@ TEST_P(Test_Int8_nets, YoloVoc)
 #endif
         CV_TEST_TAG_LONG
     );
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2020040000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL)
@@ -1003,6 +1114,11 @@ TEST_P(Test_Int8_nets, TinyYoloVoc)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_512MB);
 
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2020040000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
@@ -1038,6 +1154,11 @@ TEST_P(Test_Int8_nets, TinyYoloVoc)
 TEST_P(Test_Int8_nets, YOLOv3)
 {
     applyTestTag(CV_TEST_TAG_LONG, (target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_1GB : CV_TEST_TAG_MEMORY_2GB));
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2020040000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL)
@@ -1096,6 +1217,11 @@ TEST_P(Test_Int8_nets, YOLOv3)
 TEST_P(Test_Int8_nets, YOLOv4)
 {
     applyTestTag(CV_TEST_TAG_LONG, (target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_1GB : CV_TEST_TAG_MEMORY_2GB));
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2020040000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL)
@@ -1158,6 +1284,11 @@ TEST_P(Test_Int8_nets, YOLOv4_tiny)
     applyTestTag(
         target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB
     );
+
+    if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2021010000)
     if (target == DNN_TARGET_MYRIAD)


### PR DESCRIPTION
Avoid linux-3,5 hosts crashes with dmesg messsages like:

<cut/>

```
[81605.579425] amdgpu 0000:65:00.0: GPU fault detected: 146 0x0108040c for process opencv_test_dnn pid 3018 thread opencv_test_dnn pid 3018
[81605.579474] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_ADDR   0x00103E21
[81605.579500] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_STATUS 0x0A00400C
[81605.579527] amdgpu 0000:65:00.0: VM fault (0x0c, vmid 5, pasid 32768) at page 1064481, read from 'TC3' (0x54433300) (4)
[81605.579566] amdgpu 0000:65:00.0: GPU fault detected: 146 0x0108080c for process opencv_test_dnn pid 3018 thread opencv_test_dnn pid 3018
[81605.579607] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_ADDR   0x00103E26
[81605.579632] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_STATUS 0x0A00800C
[81605.579659] amdgpu 0000:65:00.0: VM fault (0x0c, vmid 5, pasid 32768) at page 1064486, read from 'TC2' (0x54433200) (8)
[81609.588410] amdgpu 0000:65:00.0: GPU fault detected: 146 0x0d80440c for process opencv_test_dnn pid 3018 thread opencv_test_dnn pid 3018
[81609.588444] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_ADDR   0x00103DB0
[81609.588462] amdgpu 0000:65:00.0:   VM_CONTEXT1_PROTECTION_FAULT_STATUS 0x0404400C
```

---

```
force_builders=Custom,Linux AVX2,Linux OpenCL
build_image:Custom=ubuntu:18.04
buildworker:Custom=linux-5
test_opencl:Custom=ON

build_image:Linux AVX2=ubuntu:18.04
buildworker:Linux AVX2=linux-3
test_opencl:Linux AVX2=ON
```