### PR TITLE
G-API: Wrap GStreamerSource

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -54,6 +54,7 @@ file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/streaming/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/streaming/gstreamer/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/streaming/onevpl/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/plaidml/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/util/*.hpp"
     )
 

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
@@ -28,6 +28,10 @@ public:
     IStreamSource::Ptr getStreamingSource(const std::string& appsinkName,
                                           const GStreamerSource::OutputType outputType =
                                               GStreamerSource::OutputType::MAT);
+    // NB: Function for using from python
+    GAPI_WRAP cv::Ptr<cv::gapi::wip::IStreamSource> get_streaming_source(
+        const std::string& appsinkName,
+        const GStreamerSource::OutputType outputType = GStreamerSource::OutputType::MAT);
     virtual ~GStreamerPipeline();
 
 protected:
@@ -40,15 +44,6 @@ protected:
 
 using GStreamerPipeline = gst::GStreamerPipeline;
 
-// NB: Function for using from python
-GAPI_EXPORTS_W cv::Ptr<IStreamSource>
-inline get_streaming_source(cv::Ptr<GStreamerPipeline>& pipeline,
-                            const std::string& appsinkName,
-                            const GStreamerSource::OutputType outputType =
-                                GStreamerSource::OutputType::MAT)
-{
-    return pipeline->getStreamingSource(appsinkName, outputType);
-}
 } // namespace wip
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
@@ -24,7 +24,7 @@ class GAPI_EXPORTS_W GStreamerPipeline
 public:
     class Priv;
 
-    CV_WRAP explicit GStreamerPipeline(const std::string& pipeline);
+    GAPI_WRAP explicit GStreamerPipeline(const std::string& pipeline);
     IStreamSource::Ptr getStreamingSource(const std::string& appsinkName,
                                           const GStreamerSource::OutputType outputType =
                                               GStreamerSource::OutputType::MAT);
@@ -43,9 +43,9 @@ using GStreamerPipeline = gst::GStreamerPipeline;
 // NB: Function for using from python
 GAPI_EXPORTS_W cv::Ptr<IStreamSource>
 inline get_streaming_source(cv::Ptr<GStreamerPipeline>& pipeline,
-                    const std::string& appsinkName,
-                    const GStreamerSource::OutputType outputType =
-                    GStreamerSource::OutputType::MAT)
+                            const std::string& appsinkName,
+                            const GStreamerSource::OutputType outputType =
+                                GStreamerSource::OutputType::MAT)
 {
     return pipeline->getStreamingSource(appsinkName, outputType);
 }

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
@@ -19,12 +19,12 @@ namespace gapi {
 namespace wip {
 namespace gst {
 
-class GAPI_EXPORTS GStreamerPipeline
+class GAPI_EXPORTS_W GStreamerPipeline
 {
 public:
     class Priv;
 
-    explicit GStreamerPipeline(const std::string& pipeline);
+    CV_WRAP explicit GStreamerPipeline(const std::string& pipeline);
     IStreamSource::Ptr getStreamingSource(const std::string& appsinkName,
                                           const GStreamerSource::OutputType outputType =
                                               GStreamerSource::OutputType::MAT);
@@ -40,6 +40,15 @@ protected:
 
 using GStreamerPipeline = gst::GStreamerPipeline;
 
+// NB: Function for using from python
+GAPI_EXPORTS_W cv::Ptr<IStreamSource>
+inline get_streaming_source(cv::Ptr<GStreamerPipeline>& pipeline,
+                    const std::string& appsinkName,
+                    const GStreamerSource::OutputType outputType =
+                    GStreamerSource::OutputType::MAT)
+{
+    return pipeline->getStreamingSource(appsinkName, outputType);
+}
 } // namespace wip
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
@@ -28,7 +28,6 @@ public:
     IStreamSource::Ptr getStreamingSource(const std::string& appsinkName,
                                           const GStreamerSource::OutputType outputType =
                                               GStreamerSource::OutputType::MAT);
-    // NB: Function for using from python
     GAPI_WRAP cv::Ptr<cv::gapi::wip::IStreamSource> get_streaming_source(
         const std::string& appsinkName,
         const GStreamerSource::OutputType outputType = GStreamerSource::OutputType::MAT);

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamerpipeline.hpp
@@ -28,9 +28,6 @@ public:
     IStreamSource::Ptr getStreamingSource(const std::string& appsinkName,
                                           const GStreamerSource::OutputType outputType =
                                               GStreamerSource::OutputType::MAT);
-    GAPI_WRAP cv::Ptr<cv::gapi::wip::IStreamSource> get_streaming_source(
-        const std::string& appsinkName,
-        const GStreamerSource::OutputType outputType = GStreamerSource::OutputType::MAT);
     virtual ~GStreamerPipeline();
 
 protected:
@@ -42,6 +39,18 @@ protected:
 } // namespace gst
 
 using GStreamerPipeline = gst::GStreamerPipeline;
+
+// NB: Function for using from python
+// FIXME: a separate function is created due to absence of wrappers for `shared_ptr<> `
+// Ideally would be to wrap the `GStreamerPipeline::getStreamingSource()` method as is
+GAPI_EXPORTS_W cv::Ptr<IStreamSource>
+inline get_streaming_source(cv::Ptr<GStreamerPipeline>& pipeline,
+                            const std::string& appsinkName,
+                            const GStreamerSource::OutputType outputType
+                                = GStreamerSource::OutputType::MAT)
+{
+    return pipeline->getStreamingSource(appsinkName, outputType);
+}
 
 } // namespace wip
 } // namespace gapi

--- a/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamersource.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/gstreamer/gstreamersource.hpp
@@ -82,6 +82,14 @@ protected:
 
 using GStreamerSource = gst::GStreamerSource;
 
+// NB: Overload for using from python
+GAPI_EXPORTS_W cv::Ptr<IStreamSource>
+inline make_gst_src(const std::string& pipeline,
+                    const GStreamerSource::OutputType outputType =
+                    GStreamerSource::OutputType::MAT)
+{
+    return make_src<GStreamerSource>(pipeline, outputType);
+}
 } // namespace wip
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -298,4 +298,4 @@ cv.gapi.wip.draw.Poly = cv.gapi_wip_draw_Poly
 
 cv.gapi.streaming.queue_capacity = cv.gapi_streaming_queue_capacity
 
-cv.gapi.wip.gst.GStreamerPipeline = cv.gapi.wip.GStreamerPipeline = cv.gapi_wip_gst_GStreamerPipeline
+cv.gapi.wip.GStreamerPipeline = cv.gapi_wip_gst_GStreamerPipeline

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -297,3 +297,5 @@ cv.gapi.wip.draw.Image = cv.gapi_wip_draw_Image
 cv.gapi.wip.draw.Poly = cv.gapi_wip_draw_Poly
 
 cv.gapi.streaming.queue_capacity = cv.gapi_streaming_queue_capacity
+
+cv.gapi.wip.gst.GStreamerPipeline = cv.gapi.wip.GStreamerPipeline = cv.gapi_wip_gst_GStreamerPipeline

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -231,7 +231,7 @@ PyObject* pyopencv_from(const cv::GArg& value)
     {
         HANDLE_CASE(BOOL,      bool);
         HANDLE_CASE(INT,       int);
-        HANDLE_CASE(INT64,   int64_t);
+        HANDLE_CASE(INT64,     int64_t);
         HANDLE_CASE(DOUBLE,    double);
         HANDLE_CASE(FLOAT,     float);
         HANDLE_CASE(STRING,    std::string);
@@ -1074,7 +1074,6 @@ bool pyopencv_to(PyObject* obj, cv::GProtoOutputArgs& value, const ArgInfo& info
 #define PYOPENCV_EXTRA_METHODS_GAPI \
   {"kernels", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_kernels), "kernels(...) -> GKernelPackage"}, \
   {"__op", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_op), "__op(...) -> retval\n"},
-
 
 #endif  // HAVE_OPENCV_GAPI
 #endif  // OPENCV_GAPI_PYOPENCV_GAPI_HPP

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -1075,5 +1075,6 @@ bool pyopencv_to(PyObject* obj, cv::GProtoOutputArgs& value, const ArgInfo& info
   {"kernels", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_kernels), "kernels(...) -> GKernelPackage"}, \
   {"__op", CV_PY_FN_WITH_KW(pyopencv_cv_gapi_op), "__op(...) -> retval\n"},
 
+
 #endif  // HAVE_OPENCV_GAPI
 #endif  // OPENCV_GAPI_PYOPENCV_GAPI_HPP

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -19,6 +19,7 @@ using detail_ExtractArgsCallback    = cv::detail::ExtractArgsCallback;
 using detail_ExtractMetaCallback    = cv::detail::ExtractMetaCallback;
 using vector_GNetParam              = std::vector<cv::gapi::GNetParam>;
 using gapi_streaming_queue_capacity = cv::gapi::streaming::queue_capacity;
+using GStreamerSource_OutputType    = cv::gapi::wip::GStreamerSource::OutputType;
 
 // NB: Python wrapper generate T_U for T<U>
 // This behavior is only observed for inputs

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -350,6 +350,35 @@ try:
                     cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
+        # FIXME: Add more tests
+        def test_gstreaming_source(self):
+            pipeline = """videotestsrc is-live=true pattern=colors num-buffers=10 !
+                          videorate ! videoscale ! video/x-raw,width=1920,height=1080,
+                          framerate=3/1 ! appsink"""
+
+            g_in = cv.GMat()
+            g_out = cv.gapi.copy(g_in)
+            c = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+
+            ccomp = c.compileStreaming()
+
+
+            # NB: Skip test in case gstreamer isn't available.
+            try:
+                source = cv.gapi.wip.make_gst_src(pipeline)
+            except:
+                raise TestSkip()
+
+            ccomp.setSource(cv.gin(source))
+            ccomp.start()
+
+            while True:
+                has_frame, output = ccomp.pull()
+                if not has_frame:
+                    break
+                self.assertTrue(output.size != 0)
+
+
 
 except unittest.SkipTest as e:
 

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -397,6 +397,8 @@ try:
                 pp = cv.gapi.wip.GStreamerPipeline(pipeline)
             except cv.error as e:
                 raise unittest.SkipTest(str(e))
+            except SystemError as e:
+                raise unittest.SkipTest(str(e.__cause__))
 
             src1 = cv.gapi.wip.get_streaming_source(pp, "sink1")
             src2 = cv.gapi.wip.get_streaming_source(pp, "sink2")

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -349,7 +349,7 @@ try:
                     cv.gapi.compile_args(cv.gapi.streaming.queue_capacity(1)))
 
 
-        def test_gstreamer_source(self):
+        def test_gst_source(self):
             pipeline = """videotestsrc is-live=true pattern=colors num-buffers=10 !
                           videorate ! videoscale ! video/x-raw,width=1920,height=1080,
                           framerate=3/1 ! appsink"""
@@ -375,7 +375,7 @@ try:
                 has_frame, output = ccomp.pull()
 
 
-        def test_gstreamer_pipeline(self):
+        def test_gst_multiple_sources(self):
             pipeline = """videotestsrc is-live=true pattern=colors num-buffers=10 !
                           videorate ! videoscale !
                           video/x-raw,width=1920,height=1080,framerate=3/1 !
@@ -400,8 +400,8 @@ try:
             except SystemError as e:
                 raise unittest.SkipTest(str(e.__cause__))
 
-            src1 = cv.gapi.wip.get_streaming_source(pp, "sink1")
-            src2 = cv.gapi.wip.get_streaming_source(pp, "sink2")
+            src1 = pp.get_streaming_source("sink1")
+            src2 = pp.get_streaming_source("sink2")
 
             ccomp.setSource(cv.gin(src1, src2))
             ccomp.start()

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -369,6 +369,7 @@ try:
                 else:
                     raise unittest.SkipTest(str(e))
 
+
         def test_gst_source(self):
             if not cv.videoio_registry.hasBackend(cv.CAP_GSTREAMER):
                 raise unittest.SkipTest("Backend is not available/disabled: GSTREAMER")
@@ -403,6 +404,7 @@ try:
             if not cap.isOpened():
                 raise unittest.SkipTest("Backend GSTREAMER can't open the video")
             return cap
+
 
         def test_gst_source_accuracy(self):
             if not cv.videoio_registry.hasBackend(cv.CAP_GSTREAMER):
@@ -454,6 +456,7 @@ try:
             except SystemError as e:
                 raise unittest.SkipTest(str(e) + ", casued by " + str(e.__cause__))
 
+
         def test_gst_multiple_sources(self):
             if not cv.videoio_registry.hasBackend(cv.CAP_GSTREAMER):
                 raise unittest.SkipTest("Backend is not available/disabled: GSTREAMER")
@@ -487,7 +490,7 @@ try:
                 has_frame, out = ccomp.pull()
 
 
-        def test_gst_multisource_accuracy(self):
+        def test_gst_multiple_sources_accuracy(self):
             if not cv.videoio_registry.hasBackend(cv.CAP_GSTREAMER):
                 raise unittest.SkipTest("Backend is not available/disabled: GSTREAMER")
 

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -351,7 +351,7 @@ try:
 
 
         # FIXME: Add more tests
-        def test_gstreaming_source(self):
+        def test_gstreamer_source(self):
             pipeline = """videotestsrc is-live=true pattern=colors num-buffers=10 !
                           videorate ! videoscale ! video/x-raw,width=1920,height=1080,
                           framerate=3/1 ! appsink"""
@@ -362,12 +362,11 @@ try:
 
             ccomp = c.compileStreaming()
 
-
             # NB: Skip test in case gstreamer isn't available.
             try:
                 source = cv.gapi.wip.make_gst_src(pipeline)
-            except:
-                raise TestSkip()
+            except cv.error as e:
+                raise unittest.SkipTest(str(e))
 
             ccomp.setSource(cv.gin(source))
             ccomp.start()

--- a/modules/gapi/misc/python/test/test_gapi_streaming.py
+++ b/modules/gapi/misc/python/test/test_gapi_streaming.py
@@ -478,8 +478,8 @@ try:
             ccomp = c.compileStreaming()
 
             pp = self.get_gst_pipeline(gstpipeline)
-            src1 = pp.get_streaming_source("sink1")
-            src2 = pp.get_streaming_source("sink2")
+            src1 = cv.gapi.wip.get_streaming_source(pp, "sink1")
+            src2 = cv.gapi.wip.get_streaming_source(pp, "sink2")
 
             ccomp.setSource(cv.gin(src1, src2))
             ccomp.start()
@@ -515,8 +515,8 @@ try:
             # G-API Gst-source
             pp = self.get_gst_pipeline(gstpipeline_gapi)
 
-            src1 = pp.get_streaming_source("sink1")
-            src2 = pp.get_streaming_source("sink2")
+            src1 = cv.gapi.wip.get_streaming_source(pp, "sink1")
+            src2 = cv.gapi.wip.get_streaming_source(pp, "sink2")
             ccomp.setSource(cv.gin(src1, src2))
             ccomp.start()
 

--- a/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
@@ -99,6 +99,12 @@ IStreamSource::Ptr GStreamerPipeline::getStreamingSource(
     return m_priv->getStreamingSource(appsinkName, outputType);
 }
 
+cv::Ptr<IStreamSource> GStreamerPipeline::get_streaming_source(
+    const std::string& appsinkName, const GStreamerSource::OutputType outputType)
+{
+    return this->m_priv->getStreamingSource(appsinkName, outputType);
+}
+
 GStreamerPipeline::~GStreamerPipeline()
 { }
 

--- a/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
@@ -99,12 +99,6 @@ IStreamSource::Ptr GStreamerPipeline::getStreamingSource(
     return m_priv->getStreamingSource(appsinkName, outputType);
 }
 
-cv::Ptr<IStreamSource> GStreamerPipeline::get_streaming_source(
-    const std::string& appsinkName, const GStreamerSource::OutputType outputType)
-{
-    return this->m_priv->getStreamingSource(appsinkName, outputType);
-}
-
 GStreamerPipeline::~GStreamerPipeline()
 { }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Build configuration
```
build_image:Linux AVX2=ubuntu:20.04

force_builders=Custom,Custom Win,Custom Mac,Linux AVX2
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
