### PR TITLE
fix OPENCV_DISABLE_THREAD_SUPPORT

### DIFF
--- a/cmake/OpenCVFindFrameworks.cmake
+++ b/cmake/OpenCVFindFrameworks.cmake
@@ -17,7 +17,7 @@ else()
 endif()
 
 # --- Concurrency ---
-if(MSVC AND NOT HAVE_TBB)
+if(MSVC AND NOT HAVE_TBB AND NOT OPENCV_DISABLE_THREAD_SUPPORT)
   set(_fname "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/concurrencytest.cpp")
   file(WRITE "${_fname}" "#if _MSC_VER < 1600\n#error\n#endif\nint main() { return 0; }\n")
   try_compile(HAVE_CONCURRENCY "${CMAKE_BINARY_DIR}" "${_fname}")


### PR DESCRIPTION
Fix `OPENCV_DISABLE_THREAD_SUPPORT` with MSVC.

To reproduce,

```
> cmake -GNinja -DOPENCV_DISABLE_THREAD_SUPPORT=1 ..

CMake Error at CMakeLists.txt:1477 (message):
  Not all parallel frameworks have been disabled (using Concurrency).
```

<cut/>

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```