### PR TITLE
core: fix compilation of copy ctors/assignment operators with GCC 4.x

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -162,13 +162,23 @@ public:
     //! default constructor
     Point_();
     Point_(_Tp _x, _Tp _y);
+#if (defined(__GNUC__) && __GNUC__ < 5)  // GCC 4.x bug. Details: https://github.com/opencv/opencv/pull/20837
+    Point_(const Point_& pt);
+    Point_(Point_&& pt) CV_NOEXCEPT = default;
+#elif OPENCV_ABI_COMPATIBILITY < 500
     Point_(const Point_& pt) = default;
     Point_(Point_&& pt) CV_NOEXCEPT = default;
+#endif
     Point_(const Size_<_Tp>& sz);
     Point_(const Vec<_Tp, 2>& v);
 
+#if (defined(__GNUC__) && __GNUC__ < 5)  // GCC 4.x bug. Details: https://github.com/opencv/opencv/pull/20837
+    Point_& operator = (const Point_& pt);
+    Point_& operator = (Point_&& pt) CV_NOEXCEPT = default;
+#elif OPENCV_ABI_COMPATIBILITY < 500
     Point_& operator = (const Point_& pt) = default;
     Point_& operator = (Point_&& pt) CV_NOEXCEPT = default;
+#endif
     //! conversion to another data type
     template<typename _Tp2> operator Point_<_Tp2>() const;
 
@@ -244,13 +254,17 @@ public:
     //! default constructor
     Point3_();
     Point3_(_Tp _x, _Tp _y, _Tp _z);
+#if OPENCV_ABI_COMPATIBILITY < 500
     Point3_(const Point3_& pt) = default;
     Point3_(Point3_&& pt) CV_NOEXCEPT = default;
+#endif
     explicit Point3_(const Point_<_Tp>& pt);
     Point3_(const Vec<_Tp, 3>& v);
 
+#if OPENCV_ABI_COMPATIBILITY < 500
     Point3_& operator = (const Point3_& pt) = default;
     Point3_& operator = (Point3_&& pt) CV_NOEXCEPT = default;
+#endif
     //! conversion to another data type
     template<typename _Tp2> operator Point3_<_Tp2>() const;
     //! conversion to cv::Vec<>
@@ -320,12 +334,16 @@ public:
     //! default constructor
     Size_();
     Size_(_Tp _width, _Tp _height);
+#if OPENCV_ABI_COMPATIBILITY < 500
     Size_(const Size_& sz) = default;
     Size_(Size_&& sz) CV_NOEXCEPT = default;
+#endif
     Size_(const Point_<_Tp>& pt);
 
+#if OPENCV_ABI_COMPATIBILITY < 500
     Size_& operator = (const Size_& sz) = default;
     Size_& operator = (Size_&& sz) CV_NOEXCEPT = default;
+#endif
     //! the area (width*height)
     _Tp area() const;
     //! aspect ratio (width/height)
@@ -425,13 +443,17 @@ public:
     //! default constructor
     Rect_();
     Rect_(_Tp _x, _Tp _y, _Tp _width, _Tp _height);
+#if OPENCV_ABI_COMPATIBILITY < 500
     Rect_(const Rect_& r) = default;
     Rect_(Rect_&& r) CV_NOEXCEPT = default;
+#endif
     Rect_(const Point_<_Tp>& org, const Size_<_Tp>& sz);
     Rect_(const Point_<_Tp>& pt1, const Point_<_Tp>& pt2);
 
+#if OPENCV_ABI_COMPATIBILITY < 500
     Rect_& operator = (const Rect_& r) = default;
     Rect_& operator = (Rect_&& r) CV_NOEXCEPT = default;
+#endif
     //! the top-left corner
     Point_<_Tp> tl() const;
     //! the bottom-right corner
@@ -1164,6 +1186,12 @@ template<typename _Tp> inline
 Point_<_Tp>::Point_(_Tp _x, _Tp _y)
     : x(_x), y(_y) {}
 
+#if (defined(__GNUC__) && __GNUC__ < 5)  // GCC 4.x bug. Details: https://github.com/opencv/opencv/pull/20837
+template<typename _Tp> inline
+Point_<_Tp>::Point_(const Point_& pt)
+    : x(pt.x), y(pt.y) {}
+#endif
+
 template<typename _Tp> inline
 Point_<_Tp>::Point_(const Size_<_Tp>& sz)
     : x(sz.width), y(sz.height) {}
@@ -1171,6 +1199,15 @@ Point_<_Tp>::Point_(const Size_<_Tp>& sz)
 template<typename _Tp> inline
 Point_<_Tp>::Point_(const Vec<_Tp,2>& v)
     : x(v[0]), y(v[1]) {}
+
+#if (defined(__GNUC__) && __GNUC__ < 5)  // GCC 4.x bug. Details: https://github.com/opencv/opencv/pull/20837
+template<typename _Tp> inline
+Point_<_Tp>& Point_<_Tp>::operator = (const Point_& pt)
+{
+    x = pt.x; y = pt.y;
+    return *this;
+}
+#endif
 
 template<typename _Tp> template<typename _Tp2> inline
 Point_<_Tp>::operator Point_<_Tp2>() const


### PR DESCRIPTION
fixup #20825

Avoid ICE from CentOS 7.x compiler (GCC 4.8.x).

```
modules/imgproc/src/drawing.cpp: In function 'void cv::ellipse(cv::InputOutputArray, cv::Point, cv::Size, double, double, double, const Scalar&, int, int, int)':
modules/imgproc/src/drawing.cpp:1934:1: internal compiler error: in assign_by_spills, at lra-assigns.c:1281
```

Restored implementation of `Point_` copy ctor / assignment operator for GCC 4.8.x

<cut/>

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```