### PR TITLE
dnn(ocl4dnn): add extra checks to convolution layer

### DIFF
--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
@@ -167,6 +167,7 @@ OCL4DNNConvSpatial<Dtype>::OCL4DNNConvSpatial(OCL4DNNConvConfig config)
     channels_   = config.in_shape[dims - spatial_dims - 1];
     num_output_ = config.out_shape[dims - spatial_dims - 1];
     group_ = config.group;
+    CV_CheckGT(group_, 0, "");  // avoid div by zero below
 
     fused_activ_ = OCL4DNN_CONV_FUSED_ACTIV_NONE;
     fused_eltwise_ = false;


### PR DESCRIPTION
relates #20833

- prevent running code over unsupported/non-tested configurations
- prevent integer div by zero
- non-critical message can be suppressed through `OPENCV_OCL4DNN_CONVOLUTION_IGNORE_INPUT_DIMS_4_CHECK=1`

We just emit warnings here and don't call code with unsupported/non-tested parameters.
We need complete reproducer to properly support that case. Please report to #20833 issue your case.

<cut/>

```
force_builders=Custom Win
build_image:Custom Win=openvino-2021.4.1
buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF

build_image:Custom=gstreamer:14.04
buildworker:Custom=linux-4
```