### PR TITLE
Integrate NVIDIA OpticalFlow SDK from Contrib repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,9 @@ OCV_OPTION(WITH_VTK "Include VTK library support (and build opencv_viz module ei
 OCV_OPTION(WITH_CUDA "Include NVidia Cuda Runtime support" OFF
   VISIBLE_IF NOT IOS AND NOT WINRT
   VERIFY HAVE_CUDA)
+OCV_OPTION(WITH_NVIDIA_OPTICAL_FLOW_SDK "Include NVIDIA Optical Flow SDK support" ON
+  VISIBLE_IF NOT IOS AND NOT WINRT
+  VERIFY HAVE_CUDA && NOT CUDA_VERSION VERSION_LESS "10.0")
 OCV_OPTION(WITH_CUFFT "Include NVidia Cuda Fast Fourier Transform (FFT) library support" WITH_CUDA
   VISIBLE_IF WITH_CUDA
   VERIFY HAVE_CUFFT)
@@ -1612,6 +1615,12 @@ if(WITH_CUDA OR HAVE_CUDA)
     status("")
     status("  cuDNN:" HAVE_CUDNN THEN "YES (ver ${CUDNN_VERSION})" ELSE NO)
 endif()
+
+if(HAVE_CUDA)
+  status("")
+  status("  NVIDIA OpticalFlow SDK:" HAVE_NVIDIA_OPTICAL_FLOW_SDK THEN "YES (ver ${NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION}.${NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION})" ELSE NO)
+endif()
+
 
 if(WITH_VULKAN OR HAVE_VULKAN)
   status("")

--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -86,6 +86,55 @@ if(CUDA_FOUND)
     endif()
   endif()
 
+  if(WITH_NVIDIA_OPTICAL_FLOW_SDK)
+    if(NVIDIA_OPTICAL_FLOW_SDK)
+      file(STRINGS "${NVIDIA_OPTICAL_FLOW_SDK}/NvOFInterface/nvOpticalFlowCommon.h" NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION_STR
+        REGEX "#define[ \t]+NV_OF_API_MAJOR_VERSION[ \t]+([x0-9a-f]+)" )
+      if(NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION_STR MATCHES "#define[ \t]+NV_OF_API_MAJOR_VERSION[ \t]+([x0-9a-f]+)")
+        set(NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Optical Flow SDK major version")
+      endif()
+
+      file(STRINGS "${NVIDIA_OPTICAL_FLOW_SDK}/NvOFInterface/nvOpticalFlowCommon.h" NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION_STR
+        REGEX "#define[ \t]+NV_OF_API_MINOR_VERSION[ \t]+([x0-9a-f]+)" )
+      if(NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION_STR MATCHES "#define[ \t]+NV_OF_API_MINOR_VERSION[ \t]+([x0-9a-f]+)")
+        set(NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION "${CMAKE_MATCH_1}" CACHE STRING "Optical Flow SDK minor version")
+      endif()
+
+      if(NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION)
+          set(NVIDIA_OPTICAL_FLOW_SDK_INCLUDE "${NVIDIA_OPTICAL_FLOW_SDK}/NvOFInterface")
+          set(HAVE_NVIDIA_OPTICAL_FLOW_SDK 1 CACHE BOOL "Optical Flow SDK found")
+      else()
+          message(STATUS "Cannot recognize NVIDIA Optical Flow SDK")
+      endif()
+    else()
+      set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT "edb50da3cf849840d680249aa6dbef248ebce2ca")
+      set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5 "a73cd48b18dcc0cc8933b30796074191")
+      set(NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH "${OpenCV_BINARY_DIR}/3rdparty/NVIDIAOpticalFlowSDK_2_0_Headers")
+      ocv_download(FILENAME "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}.zip"
+                      HASH ${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_MD5}
+                      URL "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/"
+                      DESTINATION_DIR "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}"
+                      STATUS NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS
+                      ID "NVIDIA_OPTICAL_FLOW"
+                      UNPACK RELATIVE_URL)
+
+      if(NOT NVIDIA_OPTICAL_FLOW_2_0_HEADERS_DOWNLOAD_SUCCESS)
+          message(STATUS "Failed to download NVIDIA_Optical_Flow_2_0 Headers")
+      else()
+          set(NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION 2 CACHE STRING "Optical Flow SDK major version")
+          set(NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION 0 CACHE STRING "Optical Flow SDK minor version")
+          set (NVIDIA_OPTICAL_FLOW_SDK_INCLUDE "${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_PATH}/NVIDIAOpticalFlowSDK-${NVIDIA_OPTICAL_FLOW_2_0_HEADERS_COMMIT}")
+          set(HAVE_NVIDIA_OPTICAL_FLOW_SDK 1 CACHE BOOL "Optical Flow SDK found")
+      endif()
+    endif()
+
+    if(NVIDIA_OPTICAL_FLOW_SDK_FOUND)
+      message(STATUS "Building with NVIDIA Optical Flow API ${NVIDIA_OPTICAL_FLOW_SDK_MAJOR_VERSION}.${NVIDIA_OPTICAL_FLOW_SDK_MINOR_VERSION}")
+    endif()
+
+  endif()
+
+
   message(STATUS "CUDA detected: " ${CUDA_VERSION})
 
   OCV_OPTION(CUDA_ENABLE_DEPRECATED_GENERATION "Enable deprecated generations in the list" OFF)


### PR DESCRIPTION
Merge together with https://github.com/opencv/opencv_contrib/pull/3060
- Allow to use external instance of OpticalFlow SDK
- Reuse SDK in other modules (preparation for stereo)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
