### PR TITLE
release: OpenCV 3.4.16

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 16
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.16

relates #20806


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3416.dll (vc14)](https://www.virustotal.com/gui/file/0d9d0103fd8fd8f3d02f450f4f058286111dae0ef2af795e80200387c528bad0)
[opencv_world3416d.dll (vc14)](https://www.virustotal.com/gui/file/3dbea7c408fe35138f9fb5d1b3a794e2b5f28a0c461f358b0bf6c752a84ba21d)
[opencv_world3416.dll (vc15)](https://www.virustotal.com/gui/file/2f49914dbe266db26a28ce537b0d96d3ef7e6de1c230eeb751f8c551df32ce20)
[opencv_world3416d.dll (vc15)](https://www.virustotal.com/gui/file/c260f0f919f1762c235cf11f99892c819c316dfef07e54f3b2d620150d63fc79)

[opencv_ffmpeg3416_64.dll](https://www.virustotal.com/gui/file/19c320c14b498a547570006d698d49dcc425df639f5655dbbfd347ba4b4ee083)

</details>
