### PR TITLE
core: ensure 'int' result from CV_POPCNT_U64(x)

### DIFF
--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -55,7 +55,7 @@
 #  ifdef _MSC_VER
 #    include <nmmintrin.h>
 #    if defined(_M_X64)
-#      define CV_POPCNT_U64 _mm_popcnt_u64
+#      define CV_POPCNT_U64 (int)_mm_popcnt_u64
 #    endif
 #    define CV_POPCNT_U32 _mm_popcnt_u32
 #  else


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_opt-avx512_noICV-win64-vc16/builds/0)

```
buildworker:Custom Win=windows-3
build_image:Custom Win=msvs2019
CPU_BASELINE:Custom Win=AVX512_SKX
```