### PR TITLE
Fixed issue #20880, QRDetect::searchHorizontalLines() boundary condition will skip the matched qrcode near the end

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -200,7 +200,7 @@ vector<Vec3d> QRDetect::searchHorizontalLines()
             }
         }
         pixels_position.push_back(width_bin_barcode - 1);
-        for (size_t i = 2; i < pixels_position.size() - 4; i+=2)
+        for (size_t i = 2; i < pixels_position.size() - 2; i+=2)
         {
             test_lines[0] = static_cast<double>(pixels_position[i - 1] - pixels_position[i - 2]);
             test_lines[1] = static_cast<double>(pixels_position[i    ] - pixels_position[i - 1]);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
