### PR TITLE
core(SIMD): update int64 SSE constructor

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -244,7 +244,13 @@ struct v_uint64x2
     explicit v_uint64x2(__m128i v) : val(v) {}
     v_uint64x2(uint64 v0, uint64 v1)
     {
+#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64)
+        val = _mm_setr_epi64x((int64_t)v0, (int64_t)v1);
+#elif defined(__GNUC__)
+        val = _mm_setr_epi64((__m64)v0, (__m64)v1);
+#else
         val = _mm_setr_epi32((int)v0, (int)(v0 >> 32), (int)v1, (int)(v1 >> 32));
+#endif
     }
 
     uint64 get0() const
@@ -272,7 +278,13 @@ struct v_int64x2
     explicit v_int64x2(__m128i v) : val(v) {}
     v_int64x2(int64 v0, int64 v1)
     {
+#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64)
+        val = _mm_setr_epi64x((int64_t)v0, (int64_t)v1);
+#elif defined(__GNUC__)
+        val = _mm_setr_epi64((__m64)v0, (__m64)v1);
+#else
         val = _mm_setr_epi32((int)v0, (int)(v0 >> 32), (int)v1, (int)(v1 >> 32));
+#endif
     }
 
     int64 get0() const

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -373,6 +373,23 @@ template<typename R> struct TheTest
             EXPECT_EQ((LaneType)12, vx_setall_res2_[i]);
         }
 
+#if CV_SIMD_WIDTH == 16
+        {
+            uint64 a = CV_BIG_INT(0x7fffffffffffffff);
+            uint64 b = (uint64)CV_BIG_INT(0xcfffffffffffffff);
+            v_uint64x2 uint64_vec(a, b);
+            EXPECT_EQ(a, uint64_vec.get0());
+            EXPECT_EQ(b, v_extract_n<1>(uint64_vec));
+        }
+        {
+            int64 a = CV_BIG_INT(0x7fffffffffffffff);
+            int64 b = CV_BIG_INT(-1);
+            v_int64x2 int64_vec(a, b);
+            EXPECT_EQ(a, int64_vec.get0());
+            EXPECT_EQ(b, v_extract_n<1>(int64_vec));
+        }
+#endif
+
         return *this;
     }
 


### PR DESCRIPTION
GCC/Clang/MSVC 64/32-bit: https://godbolt.org/z/EEGeWMhW8

[MSVS 2015](http://pullrequest.opencv.org/buildbot/builders/precommit_windows64/builds/31066) / [MSVS 2017](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_windows/builds/2717) have failed tests.
[MSVS 2015 32-bit](http://pullrequest.opencv.org/buildbot/builders/precommit_windows32/builds/13441) is OK.
[MSVS 2019](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_windows/builds/2720) is OK.

So `#if defined(_MSC_VER)` is replaced with extra `_MSC_VER >= 1920/*MSVS 2019*/` check

<cut/>

```
[ RUN      ] Imgproc_ResizeExact.accuracy
C:\build\precommit_opencl\3.4\opencv\modules\ts\src\ts.cpp(616): error: Failed

	failure reason: Bad accuracy
	test case #23
	seed: 1fa8f6d088b407b0
-----------------------------------
	LOG:
input/output: Too big difference (=135 > 16) at (0, 0)
input array 0 type=8uC3, size=(6, 17)
input/output array 0 type=8uC3, size=(42, 119)
test_case_idx = 23

-----------------------------------
	CONSOLE: ...
-----------------------------------

[  FAILED  ] Imgproc_ResizeExact.accuracy (4 ms)
```

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1

build_image:Custom Win=msvs2019
buildworker:Custom Win=windows-3
```