### PR TITLE
fix AVX compile error

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -2379,7 +2379,7 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& a, v_uint32x8&
     __m256i ab0 = _mm256_loadu_si256((const __m256i*)ptr);
     __m256i ab1 = _mm256_loadu_si256((const __m256i*)(ptr + 8));
 
-    const int sh = 0+2*4+1*16+3*64;
+    enum { sh = 0+2*4+1*16+3*64 };
     __m256i p0 = _mm256_shuffle_epi32(ab0, sh);
     __m256i p1 = _mm256_shuffle_epi32(ab1, sh);
     __m256i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);


### PR DESCRIPTION
This PR fixes OpenCV compilation with enabled AVX intrinsics on some older compilers by ensuring the constant is immediate. This is also now consistent with how the remaining immediates are defined in the header.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
