### PR TITLE
Allow to set av_log_set_level to reduce ffmpeg level below AV_LOG_ERROR

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -850,6 +850,7 @@ static void ffmpeg_log_callback(void *ptr, int level, const char *fmt, va_list v
     static bool skip_header = false;
     static int prev_level = -1;
     CV_UNUSED(ptr);
+    if (level>av_log_get_level()) return;
     if (!skip_header || level != prev_level) printf("[OPENCV:FFMPEG:%02d] ", level);
     vprintf(fmt, vargs);
     size_t fmt_len = strlen(fmt);
@@ -866,15 +867,21 @@ class InternalFFMpegRegister
 
     static void initLogger_()
     {
-    #ifndef NO_GETENV
+#ifndef NO_GETENV
         char* debug_option = getenv("OPENCV_FFMPEG_DEBUG");
-        if (debug_option != NULL)
+        char* level_option = getenv("OPENCV_FFMPEG_LOGLEVEL");
+        int level = AV_LOG_VERBOSE;
+        if (level_option != NULL)
         {
-            av_log_set_level(AV_LOG_VERBOSE);
+            level = atoi(level_option);
+        }
+        if ( (debug_option != NULL) || (level_option != NULL) )
+        {
+            av_log_set_level(level);
             av_log_set_callback(ffmpeg_log_callback);
         }
         else
-    #endif
+#endif
         {
             av_log_set_level(AV_LOG_ERROR);
         }


### PR DESCRIPTION
Hi,

I submit this PR in order to allow to reduce de ffmpeg loglevel below ERROR (that is 32).
During H264 decoding it is quite often ffmpeg print lots of error log (like bad SEI parsing) that may not be relevant in production.

This PR allow to set the ffmpeg level through the environment variable `OPENCV_FFMPEG_LOGLEVEL`

Best Regards,
Michel.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
