### PR TITLE
fix: correctly check neon flags for QNX platform

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -129,7 +129,7 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
 #if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__
 #  include <unistd.h>
 #  include <fcntl.h>
-#if defined __QNXNTO__
+#if defined __QNX__
 #  include <sys/elf.h>
 #else
 #  include <elf.h>
@@ -545,7 +545,7 @@ struct HWFeatures
         }
     #endif // CV_CPUID_X86
 
-    #if defined __ANDROID__ || defined __linux__ || defined __FreeBSD__ || defined __QNXNTO__
+    #if defined __ANDROID__ || defined __linux__ || defined __FreeBSD__ || defined __QNX__
     #ifdef __aarch64__
         have[CV_CPU_NEON] = true;
         have[CV_CPU_FP16] = true;


### PR DESCRIPTION
### Pull Request Readiness Checklist



- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] Reference to original bug report and related work:  https://github.com/opencv/opencv/issues/20899
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
