### PR TITLE
samples: fix build without threading support

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -120,6 +120,7 @@ else()
   find_package(Threads)
 endif()
 if((TARGET Threads::Threads OR HAVE_THREADS) AND NOT OPENCV_EXAMPLES_DISABLE_THREADS)
+  set(HAVE_THREADS 1)
   add_definitions(-DHAVE_THREADS=1)
 endif()
 

--- a/samples/cpp/tutorial_code/videoio/orbbec_astra/orbbec_astra.cpp
+++ b/samples/cpp/tutorial_code/videoio/orbbec_astra/orbbec_astra.cpp
@@ -4,6 +4,17 @@
 
 #include <list>
 #include <iostream>
+
+
+#if !defined(HAVE_THREADS)
+int main()
+{
+    std::cout << "This sample is built without threading support. Sample code is disabled." << std::endl;
+    return 0;
+}
+#else
+
+
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -200,3 +211,5 @@ int main()
 
     return 0;
 }
+
+#endif

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -5,7 +5,11 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
-#ifdef CV_CXX11
+#if defined(CV_CXX11) && defined(HAVE_THREADS)
+#define USE_THREADS 1
+#endif
+
+#ifdef USE_THREADS
 #include <mutex>
 #include <thread>
 #include <queue>
@@ -56,7 +60,7 @@ void drawPred(int classId, float conf, int left, int top, int right, int bottom,
 
 void callback(int pos, void* userdata);
 
-#ifdef CV_CXX11
+#ifdef USE_THREADS
 template <typename T>
 class QueueFPS : public std::queue<T>
 {
@@ -106,7 +110,7 @@ private:
     TickMeter tm;
     std::mutex mutex;
 };
-#endif  // CV_CXX11
+#endif  // USE_THREADS
 
 int main(int argc, char** argv)
 {
@@ -171,7 +175,7 @@ int main(int argc, char** argv)
     else
         cap.open(parser.get<int>("device"));
 
-#ifdef CV_CXX11
+#ifdef USE_THREADS
     bool process = true;
 
     // Frames capturing thread
@@ -271,7 +275,7 @@ int main(int argc, char** argv)
     framesThread.join();
     processingThread.join();
 
-#else  // CV_CXX11
+#else  // USE_THREADS
     if (asyncNumReq)
         CV_Error(Error::StsNotImplemented, "Asynchronous forward is supported only with Inference Engine backend.");
 
@@ -302,7 +306,7 @@ int main(int argc, char** argv)
 
         imshow(kWinName, frame);
     }
-#endif  // CV_CXX11
+#endif  // USE_THREADS
     return 0;
 }
 


### PR DESCRIPTION
Usage:
```
cmake <opencv_src>/samples -DOpenCV_DIR=<opencv_install> -DOPENCV_EXAMPLES_DISABLE_THREADS=1
```

```
build_image:Custom=ubuntu:20.04
buildworker:Custom=linux-3
```