### PR TITLE
fix bug: wrong output dimension when "keep_dims" is false in pooling layer.

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2248,7 +2248,7 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
             else
             {
                 // To keep correct order after squeeze dims we first need to change layout from NCHW to NHWC
-                std::string poolingName = name+"/Pooling";
+                std::string poolingName = name + "/Pooling";
                 CV_Assert(layer_id.find(poolingName) == layer_id.end());
                 int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
                 layer_id[poolingName] = id;
@@ -2261,8 +2261,7 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
                 addPermuteLayer(order, permName, inpId);
 
                 LayerParams squeezeLp;
-                std::string squeezeName = name;
-                CV_Assert(layer_id.find(squeezeName) == layer_id.end());
+                const std::string& squeezeName = name;
                 squeezeLp.set("axis", indices.at<int>(0));
                 squeezeLp.set("end_axis", indices.at<int>(0) + 1);
                 int squeezeId = dstNet.addLayer(squeezeName, "Flatten", squeezeLp);
@@ -2280,7 +2279,8 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
             layerParams.set("pool", pool_type);
             layerParams.set("kernel_h", 1);
             layerParams.set("global_pooling_w", true);
-            std::string poolingName = name+"/Pooling";
+            std::string poolingName = name + "/Pooling";
+            CV_Assert(layer_id.find(poolingName) == layer_id.end());
             int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
             layer_id[poolingName] = id;
             connect(layer_id, dstNet, Pin(permName), id, 0);
@@ -2288,8 +2288,7 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
             if (!keepDims)
             {
                 LayerParams squeezeLp;
-                std::string squeezeName = name;
-                CV_Assert(layer_id.find(squeezeName) == layer_id.end());
+                const std::string& squeezeName = name;
                 int channel_id = 3; // TF NHWC layout
                 squeezeLp.set("axis", channel_id - 1);
                 squeezeLp.set("end_axis", channel_id);
@@ -2310,7 +2309,7 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
 
         layerParams.set("pool", pool_type);
         layerParams.set("global_pooling", true);
-        
+
         if (keepDims)
         {
             int id = dstNet.addLayer(name, "Pooling", layerParams);
@@ -2319,13 +2318,13 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
         }
         else
         {
-            std::string poolingName = name+"/Pooling";
+            std::string poolingName = name + "/Pooling";
+            CV_Assert(layer_id.find(poolingName) == layer_id.end());
             int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
             layer_id[poolingName] = id;
             connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
             LayerParams flattenLp;
-            std::string flattenName = name;
-            CV_Assert(layer_id.find(flattenName) == layer_id.end());
+            const std::string& flattenName = name;
             int flattenId = dstNet.addLayer(flattenName, "Flatten", flattenLp);
             layer_id[flattenName] = flattenId;
             connect(layer_id, dstNet, Pin(poolingName), flattenId, 0);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2238,7 +2238,8 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
                 layerParams.set("pool", pool_type);
                 layerParams.set(axis == 2 ? "kernel_w" : "kernel_h", 1);
                 layerParams.set(axis == 2 ? "global_pooling_h" : "global_pooling_w", true);
-                std::string poolingName = name+"/origin";
+                std::string poolingName = name+"/Pooling";
+                CV_Assert(layer_id.find(poolingName) == layer_id.end());
                 int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
                 layer_id[poolingName] = id;
                 connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2142,6 +2142,7 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
     const std::string& type = layer.op();
     const int num_inputs = layer.input_size();
     std::string pool_type = cv::toLowerCase(type);
+    DataLayout layout = getDataLayout(name, data_layouts);
 
     if (pool_type == "mean")
     {
@@ -2205,6 +2206,16 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
 
         if (!keepDims)
         {
+            if (layout == DATA_LAYOUT_NHWC)
+            {
+                LayerParams permLP;
+                int order[] = {0, 2, 3, 1};  // From OpenCV's NCHW to NHWC.
+                std::string permName = name + "/nhwc";
+                Pin inpId = Pin(layerShapeName);
+                addPermuteLayer(order, permName, inpId);
+                layerShapeName = permName;
+            }
+
             LayerParams squeezeLp;
             std::string squeezeName = name + "/squeeze";
             CV_Assert(layer_id.find(squeezeName) == layer_id.end());
@@ -2224,10 +2235,12 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
         int axis = toNCHW(indices.at<int>(0));
         if (axis == 2 || axis == 3)
         {
-            if (keepDims) {
-                layerParams.set("pool", pool_type);
-                layerParams.set(axis == 2 ? "kernel_w" : "kernel_h", 1);
-                layerParams.set(axis == 2 ? "global_pooling_h" : "global_pooling_w", true);
+            layerParams.set("pool", pool_type);
+            layerParams.set(axis == 2 ? "kernel_w" : "kernel_h", 1);
+            layerParams.set(axis == 2 ? "global_pooling_h" : "global_pooling_w", true);
+
+            if (keepDims)
+            {
                 int id = dstNet.addLayer(name, "Pooling", layerParams);
                 layer_id[name] = id;
                 connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
@@ -2235,9 +2248,6 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
             else
             {
                 // To keep correct order after squeeze dims we first need to change layout from NCHW to NHWC
-                layerParams.set("pool", pool_type);
-                layerParams.set(axis == 2 ? "kernel_w" : "kernel_h", 1);
-                layerParams.set(axis == 2 ? "global_pooling_h" : "global_pooling_w", true);
                 std::string poolingName = name+"/Pooling";
                 CV_Assert(layer_id.find(poolingName) == layer_id.end());
                 int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
@@ -2264,32 +2274,34 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
         {
             int order[] = {0, 2, 3, 1};  // From OpenCV's NCHW to NHWC.
             Pin inpId = parsePin(layer.input(0));
-            addPermuteLayer(order, name + "/nhwc", inpId);
+            std::string permName = name + "/nhwc";
+            addPermuteLayer(order, permName, inpId);
 
             layerParams.set("pool", pool_type);
             layerParams.set("kernel_h", 1);
             layerParams.set("global_pooling_w", true);
-            int id = dstNet.addLayer(name, "Pooling", layerParams);
-            layer_id[name] = id;
-            connect(layer_id, dstNet, inpId, id, 0);
+            std::string poolingName = name+"/Pooling";
+            int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
+            layer_id[poolingName] = id;
+            connect(layer_id, dstNet, Pin(permName), id, 0);
 
             if (!keepDims)
             {
                 LayerParams squeezeLp;
-                std::string squeezeName = name + "/squeeze";
+                std::string squeezeName = name;
                 CV_Assert(layer_id.find(squeezeName) == layer_id.end());
                 int channel_id = 3; // TF NHWC layout
                 squeezeLp.set("axis", channel_id - 1);
                 squeezeLp.set("end_axis", channel_id);
                 int squeezeId = dstNet.addLayer(squeezeName, "Flatten", squeezeLp);
                 layer_id[squeezeName] = squeezeId;
-                connect(layer_id, dstNet, Pin(name), squeezeId, 0);
+                connect(layer_id, dstNet, Pin(poolingName), squeezeId, 0);
             }
             else
             {
                 int order[] = {0, 3, 1, 2};  // From NHWC to OpenCV's NCHW.
-                Pin inpId = parsePin(name);
-                addPermuteLayer(order, name + "/nchw", inpId);
+                Pin inpId = parsePin(poolingName);
+                addPermuteLayer(order, name, inpId);
             }
         }
     } else {
@@ -2298,18 +2310,26 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
 
         layerParams.set("pool", pool_type);
         layerParams.set("global_pooling", true);
-        int id = dstNet.addLayer(name, "Pooling", layerParams);
-        layer_id[name] = id;
-        connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
-
-        if (!keepDims)
+        
+        if (keepDims)
         {
+            int id = dstNet.addLayer(name, "Pooling", layerParams);
+            layer_id[name] = id;
+            connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
+        }
+        else
+        {
+            std::string poolingName = name+"/Pooling";
+            int id = dstNet.addLayer(poolingName, "Pooling", layerParams);
+            layer_id[poolingName] = id;
+            connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
             LayerParams flattenLp;
-            std::string flattenName = name + "/flatten";
+            std::string flattenName = name;
             CV_Assert(layer_id.find(flattenName) == layer_id.end());
             int flattenId = dstNet.addLayer(flattenName, "Flatten", flattenLp);
             layer_id[flattenName] = flattenId;
-            connect(layer_id, dstNet, Pin(name), flattenId, 0);
+            connect(layer_id, dstNet, Pin(poolingName), flattenId, 0);
+            data_layouts[name] = DATA_LAYOUT_PLANAR;
         }
     }
 }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2245,22 +2245,18 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
 
                 LayerParams permLP;
                 int order[] = {0, 2, 3, 1};  // From OpenCV's NCHW to NHWC.
-                std::string permName = name + "/nchw";
+                std::string permName = name + "/nhwc";
                 Pin inpId = Pin(poolingName);
                 addPermuteLayer(order, permName, inpId);
 
                 LayerParams squeezeLp;
-                std::string squeezeName = name + "/squeeze";
+                std::string squeezeName = name;
                 CV_Assert(layer_id.find(squeezeName) == layer_id.end());
                 squeezeLp.set("axis", indices.at<int>(0));
                 squeezeLp.set("end_axis", indices.at<int>(0) + 1);
                 int squeezeId = dstNet.addLayer(squeezeName, "Flatten", squeezeLp);
                 layer_id[squeezeName] = squeezeId;
                 connect(layer_id, dstNet, Pin(permName), squeezeId, 0);
-
-                int recoverOrder[] = {0, 2, 1};  // From NCH,NCW to NHC, NWC.
-                Pin squeezePin = Pin(squeezeName);
-                addPermuteLayer(recoverOrder, name, squeezePin, 3);
             }
         }
         else if (axis == 1)

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2258,7 +2258,6 @@ void TFImporter::parseMean(tensorflow::GraphDef& net, const tensorflow::NodeDef&
                 layer_id[squeezeName] = squeezeId;
                 connect(layer_id, dstNet, Pin(permName), squeezeId, 0);
 
-            
                 int recoverOrder[] = {0, 2, 1};  // From NCH,NCW to NHC, NWC.
                 Pin squeezePin = Pin(squeezeName);
                 addPermuteLayer(recoverOrder, name, squeezePin, 3);

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -413,6 +413,11 @@ TEST_P(Test_TensorFlow_layers, pooling_reduce_sum)
     runTensorFlowNet("reduce_sum");  // a SUM pooling over all spatial dimensions.
 }
 
+TEST_P(Test_TensorFlow_layers, pooling_reduce_sum2)
+{
+    runTensorFlowNet("reduce_sum2"); // a SUM pooling over all spatial dimensions.
+}
+
 TEST_P(Test_TensorFlow_layers, max_pool_grad)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -420,9 +420,9 @@ TEST_P(Test_TensorFlow_layers, pooling_reduce_sum2)
     {
         for (int i = 0; i < sizeof(axises)/sizeof(axises[0]); ++i)
         {
-            runTensorFlowNet(cv::format("reduce_sum_[%d]_%s", axises[i], (keepdims ? "True" : "False")));
+            runTensorFlowNet(cv::format("reduce_sum_%d_%s", axises[i], (keepdims ? "True" : "False")));
         }
-        runTensorFlowNet(cv::format("reduce_sum_[1, 2]_%s", keepdims ? "True" : "False"));
+        runTensorFlowNet(cv::format("reduce_sum_1_2_%s", keepdims ? "True" : "False"));
     }
 }
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -415,19 +415,35 @@ TEST_P(Test_TensorFlow_layers, pooling_reduce_sum)
 
 TEST_P(Test_TensorFlow_layers, pooling_reduce_sum2)
 {
-    std::vector<std::vector<int>> axises = {{0}, {1}, {2}, {3}, {1, 2}};
-
-    for (const auto& axis : axises)
+    int axises[] = {0, 1, 2, 3};
+    for (int i = 0; i<sizeof(axises)/sizeof(axises[0]); i++)
     {
         for (int keepdims = 0; keepdims <= 1; ++keepdims)
         {
             std::stringstream ss;
-            ss << "reduce_sum_[" << axis[0];
-            if (axis.size() > 1)
+            ss << "reduce_sum_[" << axises[i] << "]_" << (keepdims ? "True" : "False");
+            std::cout << ss.str() << std::endl;
+            try
             {
-                ss << ", " << axis[1];
+                runTensorFlowNet(ss.str());
             }
-            ss << "]_" << (keepdims ? "True" : "False");
+            catch (const std::exception& e)
+            {
+                std::cout << e.what() << std::endl;
+            }
+        }
+    }
+}
+
+TEST_P(Test_TensorFlow_layers, pooling_reduce_sum3)
+{
+    int axises[][2] = {{1, 2}};  // two axises
+    for (int i = 0; i<sizeof(axises)/sizeof(axises[0]); i++)
+    {
+        for (int keepdims = 0; keepdims <= 1; ++keepdims)
+        {
+            std::stringstream ss;
+            ss << "reduce_sum_[" << axises[i][0] << ", " << axises[i][1] << "]_" << (keepdims ? "True" : "False");
             std::cout << ss.str() << std::endl;
             try
             {

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -416,44 +416,13 @@ TEST_P(Test_TensorFlow_layers, pooling_reduce_sum)
 TEST_P(Test_TensorFlow_layers, pooling_reduce_sum2)
 {
     int axises[] = {0, 1, 2, 3};
-    for (int i = 0; i<sizeof(axises)/sizeof(axises[0]); i++)
+    for (int keepdims = 0; keepdims <= 1; ++keepdims)
     {
-        for (int keepdims = 0; keepdims <= 1; ++keepdims)
+        for (int i = 0; i < sizeof(axises)/sizeof(axises[0]); ++i)
         {
-            std::stringstream ss;
-            ss << "reduce_sum_[" << axises[i] << "]_" << (keepdims ? "True" : "False");
-            std::cout << ss.str() << std::endl;
-            try
-            {
-                runTensorFlowNet(ss.str());
-            }
-            catch (const std::exception& e)
-            {
-                std::cout << e.what() << std::endl;
-            }
+            runTensorFlowNet(cv::format("reduce_sum_[%d]_%s", axises[i], (keepdims ? "True" : "False")));
         }
-    }
-}
-
-TEST_P(Test_TensorFlow_layers, pooling_reduce_sum3)
-{
-    int axises[][2] = {{1, 2}};  // two axises
-    for (int i = 0; i<sizeof(axises)/sizeof(axises[0]); i++)
-    {
-        for (int keepdims = 0; keepdims <= 1; ++keepdims)
-        {
-            std::stringstream ss;
-            ss << "reduce_sum_[" << axises[i][0] << ", " << axises[i][1] << "]_" << (keepdims ? "True" : "False");
-            std::cout << ss.str() << std::endl;
-            try
-            {
-                runTensorFlowNet(ss.str());
-            }
-            catch (const std::exception& e)
-            {
-                std::cout << e.what() << std::endl;
-            }
-        }
+        runTensorFlowNet(cv::format("reduce_sum_[1, 2]_%s", keepdims ? "True" : "False"));
     }
 }
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -415,7 +415,30 @@ TEST_P(Test_TensorFlow_layers, pooling_reduce_sum)
 
 TEST_P(Test_TensorFlow_layers, pooling_reduce_sum2)
 {
-    runTensorFlowNet("reduce_sum2"); // a SUM pooling over all spatial dimensions.
+    std::vector<std::vector<int>> axises = {{0}, {1}, {2}, {3}, {1, 2}};
+
+    for (const auto& axis : axises)
+    {
+        for (int keepdims = 0; keepdims <= 1; ++keepdims)
+        {
+            std::stringstream ss;
+            ss << "reduce_sum_[" << axis[0];
+            if (axis.size() > 1)
+            {
+                ss << ", " << axis[1];
+            }
+            ss << "]_" << (keepdims ? "True" : "False");
+            std::cout << ss.str() << std::endl;
+            try
+            {
+                runTensorFlowNet(ss.str());
+            }
+            catch (const std::exception& e)
+            {
+                std::cout << e.what() << std::endl;
+            }
+        }
+    }
 }
 
 TEST_P(Test_TensorFlow_layers, max_pool_grad)


### PR DESCRIPTION
 **Merge with extra**: https://github.com/opencv/opencv_extra/pull/932

### Pull Request Readiness Checklist

Fixed bug in #20896：When parsing a pooling layer in dnn/tensorflow. If keep_dims is false, the  additional "nhwc" layer and "squeeze" layer will be lost. Because the final "squeeze" layer name is not the original layer name. 

Solution: 
Change the final output layer's name to the orignal **pooling** layer's name.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
opencv_extra=tf_pooling
```