### PR TITLE
add check_remap_type

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2433,9 +2433,18 @@ contains the rounded coordinates and the second array (created only when nninter
 contains indices in the interpolation tables.
 
 - \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_16SC2, CV_16UC1)}\f$. The same as above but
-the original maps are stored in one 2-channel matrix.
+the original maps are stored in one 2-channel matrix (only when nninterpolation=false ).
 
-- Reverse conversion. Obviously, the reconstructed floating-point maps will not be exactly the same
+- \f$\texttt{(CV_32FC1, CV_32FC1)} \rightarrow \texttt{(CV_16SC2)}\f$. Original floating-point maps
+(see remap ) are converted to a int16 representation (only when nninterpolation=true ).
+
+- \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_16SC2)}\f$. The same as above but
+the original maps are stored in one 2-channel matrix  (only when nninterpolation=true ).
+
+- \f$\texttt{(CV_16SC2, CV_16UC1)} \rightarrow \texttt{(CV_16SC2)}\f$. Original fixed-point maps
+(see remap ) are converted to a int16 representation (only when nninterpolation=true ).
+
+- Reverse conversion. Obviously, the reconstructed floating-point or fixed-point maps will not be exactly the same
 as the originals.
 
 @param map1 The first input map of type CV_16SC2, CV_32FC1, or CV_32FC2 .

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1864,6 +1864,13 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         return;
     }
 
+    if (inputRemapType == RemapType::int16 && outputRemapType == RemapType::fixedPointInt16)
+    {
+        m1->convertTo(dstmap1, dstmap1.type());
+        dstmap2 = Mat::zeros( size, CV_16UC1);
+        return;
+    }
+
     if (inputRemapType == RemapType::fp32_mapxy && outputRemapType == RemapType::int16)
     {
         m1->convertTo(dstmap1, dstmap1.type());
@@ -1890,6 +1897,10 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         size.width *= size.height;
         size.height = 1;
     }
+    CV_Assert((m1type == CV_32FC1 && dstm1type == CV_16SC2) || // fp32_mapx_mapy to int16 or fixedPointInt16
+              (m1type == CV_32FC2 && dstm1type == CV_16SC2 && !nninterpolate) || // fp32_mapxy to int16
+              (m1type == CV_16SC2 && dstm1type == CV_32FC1) || // int16 or fixedPointInt16 to fp32_mapx_mapy
+              (m1type == CV_16SC2 && dstm1type == CV_32FC2));  // int16 or fixedPointInt16 to fp32_mapxy
 
 #if CV_TRY_SSE4_1
     bool useSSE4_1 = CV_CPU_HAS_SUPPORT_SSE4_1;
@@ -2031,8 +2042,6 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
                     }
                 }
             }
-            else // this branch is never called: inputRemapType == RemapType::fp32_mapxy && outputRemapType == RemapType::int16
-                CV_Error( CV_StsNotImplemented, "Unsupported combination of input/output matrices" );
         }
         else if( m1type == CV_16SC2 && dstm1type == CV_32FC1 )
         {
@@ -2130,8 +2139,6 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
                 dst1f[x*2+1] = src1[x*2+1] + (fxy >> INTER_BITS)*scale;
             }
         }
-        else
-            CV_Error( CV_StsNotImplemented, "Unsupported combination of input/output matrices" );
     }
 }
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -54,6 +54,7 @@
 #include "opencv2/core/hal/intrin.hpp"
 #include "opencv2/core/openvx/ovx_defs.hpp"
 #include "opencv2/core/softfloat.hpp"
+#include "remap_type.hpp"
 #include "imgwarp.hpp"
 
 using namespace cv;
@@ -1083,10 +1084,10 @@ class RemapInvoker :
 public:
     RemapInvoker(const Mat& _src, Mat& _dst, const Mat *_m1,
                  const Mat *_m2, int _borderType, const Scalar &_borderValue,
-                 int _planar_input, RemapNNFunc _nnfunc, RemapFunc _ifunc, const void *_ctab) :
+                 int _planar_input, RemapNNFunc _nnfunc, RemapFunc _ifunc, const void *_ctab, RemapType _remapType) :
         ParallelLoopBody(), src(&_src), dst(&_dst), m1(_m1), m2(_m2),
         borderType(_borderType), borderValue(_borderValue),
-        planar_input(_planar_input), nnfunc(_nnfunc), ifunc(_ifunc), ctab(_ctab)
+        planar_input(_planar_input), nnfunc(_nnfunc), ifunc(_ifunc), ctab(_ctab), remapType(_remapType)
     {
     }
 
@@ -1113,7 +1114,7 @@ public:
 
                 if( nnfunc )
                 {
-                    if( m1->type() == CV_16SC2 && m2->empty() ) // the data is already in the right format
+                    if( remapType == RemapType::int16 ) // the data is already in the right format
                         bufxy = (*m1)(Rect(x, y, bcols, brows));
                     else if( map_depth != CV_32F )
                     {
@@ -1176,7 +1177,7 @@ public:
                     short* XY = bufxy.ptr<short>(y1);
                     ushort* A = bufa.ptr<ushort>(y1);
 
-                    if( m1->type() == CV_16SC2 && (m2->type() == CV_16UC1 || m2->type() == CV_16SC1) )
+                    if( remapType == RemapType::fixedPointInt16 )
                     {
                         bufxy = (*m1)(Rect(x, y, bcols, brows));
 
@@ -1288,45 +1289,34 @@ private:
     RemapNNFunc nnfunc;
     RemapFunc ifunc;
     const void *ctab;
+    RemapType remapType;
 };
 
 #ifdef HAVE_OPENCL
 
 static bool ocl_remap(InputArray _src, OutputArray _dst, InputArray _map1, InputArray _map2,
-                      int interpolation, int borderType, const Scalar& borderValue)
+                      int interpolation, int borderType, const Scalar& borderValue, RemapType remapType)
 {
     const ocl::Device & dev = ocl::Device::getDefault();
     int cn = _src.channels(), type = _src.type(), depth = _src.depth(),
             rowsPerWI = dev.isIntel() ? 4 : 1;
 
     if (borderType == BORDER_TRANSPARENT || !(interpolation == INTER_LINEAR || interpolation == INTER_NEAREST)
-            || _map1.type() == CV_16SC1 || _map2.type() == CV_16SC1)
+            || _map2.type() == CV_16SC1)
         return false;
 
     UMat src = _src.getUMat(), map1 = _map1.getUMat(), map2 = _map2.getUMat();
-
-    if( (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.empty())) ||
-        (map2.type() == CV_16SC2 && (map1.type() == CV_16UC1 || map1.empty())) )
-    {
-        if (map1.type() != CV_16SC2)
-            std::swap(map1, map2);
-    }
-    else
-        CV_Assert( map1.type() == CV_32FC2 || (map1.type() == CV_32FC1 && map2.type() == CV_32FC1) );
-
     _dst.create(map1.size(), type);
     UMat dst = _dst.getUMat();
 
     String kernelName = "remap";
-    if (map1.type() == CV_32FC2 && map2.empty())
+    if (remapType == RemapType::fp32_mapxy)
         kernelName += "_32FC2";
-    else if (map1.type() == CV_16SC2)
-    {
+    else if (remapType == RemapType::int16)
         kernelName += "_16SC2";
-        if (!map2.empty())
-            kernelName += "_16UC1";
-    }
-    else if (map1.type() == CV_32FC1 && map2.type() == CV_32FC1)
+    else if (remapType == RemapType::fixedPointInt16)
+        kernelName += "_16SC2_16UC1";
+    else if (remapType == RemapType::fp32_mapx_mapy)
         kernelName += "_2_32FC1";
     else
         CV_Error(Error::StsBadArg, "Unsupported map types");
@@ -1701,12 +1691,12 @@ void cv::remap( InputArray _src, OutputArray _dst,
     };
 
     CV_Assert( !_map1.empty() );
-    CV_Assert( _map2.empty() || (_map2.size() == _map1.size()));
+    Mat src = _src.getMat(), map1 = _map1.getMat(), map2 = _map2.getMat();
+    const RemapType remapType = check_and_get_remap_type(map1, map2);
 
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
-               ocl_remap(_src, _dst, _map1, _map2, interpolation, borderType, borderValue))
+               ocl_remap(_src, _dst, _map1, _map2, interpolation, borderType, borderValue, remapType))
 
-    Mat src = _src.getMat(), map1 = _map1.getMat(), map2 = _map2.getMat();
     _dst.create( map1.size(), src.type() );
     Mat dst = _dst.getMat();
 
@@ -1803,22 +1793,12 @@ void cv::remap( InputArray _src, OutputArray _dst,
 
     const Mat *m1 = &map1, *m2 = &map2;
 
-    if( (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1 || map2.empty())) ||
-        (map2.type() == CV_16SC2 && (map1.type() == CV_16UC1 || map1.type() == CV_16SC1 || map1.empty())) )
-    {
-        if( map1.type() != CV_16SC2 )
-            std::swap(m1, m2);
-    }
-    else
-    {
-        CV_Assert( ((map1.type() == CV_32FC2 || map1.type() == CV_16SC2) && map2.empty()) ||
-            (map1.type() == CV_32FC1 && map2.type() == CV_32FC1) );
-        planar_input = map1.channels() == 1;
-    }
+    if (remapType == RemapType::fp32_mapx_mapy)
+        planar_input = true;
 
     RemapInvoker invoker(src, dst, m1, m2,
                          borderType, borderValue, planar_input, nnfunc, ifunc,
-                         ctab);
+                         ctab, remapType);
     parallel_for_(Range(0, dst.rows), invoker, dst.total()/(double)(1<<16));
 }
 
@@ -1830,28 +1810,39 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     CV_INSTRUMENT_REGION();
 
     Mat map1 = _map1.getMat(), map2 = _map2.getMat(), dstmap1, dstmap2;
+    const RemapType inputRemapType = check_and_get_remap_type(map1, map2);
     Size size = map1.size();
     const Mat *m1 = &map1, *m2 = &map2;
-    int m1type = m1->type(), m2type = m2->type();
+    int m1type = m1->type();
 
-    CV_Assert( (m1type == CV_16SC2 && (nninterpolate || m2type == CV_16UC1 || m2type == CV_16SC1)) ||
-               (m2type == CV_16SC2 && (nninterpolate || m1type == CV_16UC1 || m1type == CV_16SC1)) ||
-               (m1type == CV_32FC1 && m2type == CV_32FC1) ||
-               (m1type == CV_32FC2 && m2->empty()) );
-
-    if( m2type == CV_16SC2 )
-    {
-        std::swap( m1, m2 );
-        std::swap( m1type, m2type );
-    }
-
+    RemapType outputRemapType = RemapType::errorType;
     if( dstm1type <= 0 )
         dstm1type = m1type == CV_16SC2 ? CV_32FC2 : CV_16SC2;
     CV_Assert( dstm1type == CV_16SC2 || dstm1type == CV_32FC1 || dstm1type == CV_32FC2 );
+
+    if (dstm1type == CV_32FC1)
+    {
+        outputRemapType = RemapType::fp32_mapx_mapy;
+    }
+    else if (dstm1type == CV_32FC2)
+    {
+        outputRemapType = RemapType::fp32_mapxy;
+    }
+    else if (dstm1type == CV_16SC2 && nninterpolate)
+    {
+        outputRemapType = RemapType::int16;
+    }
+    else if (dstm1type == CV_16SC2 && !nninterpolate)
+    {
+        outputRemapType = RemapType::fixedPointInt16;
+    }
+    if (outputRemapType == RemapType::errorType)
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+
     _dstmap1.create( size, dstm1type );
     dstmap1 = _dstmap1.getMat();
 
-    if( !nninterpolate && dstm1type != CV_32FC2 )
+    if (outputRemapType == RemapType::fp32_mapx_mapy || outputRemapType == RemapType::fixedPointInt16)
     {
         _dstmap2.create( size, dstm1type == CV_16SC2 ? CV_16UC1 : CV_32FC1 );
         dstmap2 = _dstmap2.getMat();
@@ -1859,13 +1850,17 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     else
         _dstmap2.release();
 
-    if( m1type == dstm1type || (nninterpolate &&
-        ((m1type == CV_16SC2 && dstm1type == CV_32FC2) ||
-        (m1type == CV_32FC2 && dstm1type == CV_16SC2))) )
+    if (inputRemapType == outputRemapType)
     {
-        m1->convertTo( dstmap1, dstmap1.type() );
-        if( !dstmap2.empty() && dstmap2.type() == m2->type() )
-            m2->copyTo( dstmap2 );
+        m1->copyTo(dstmap1);
+        if (!dstmap2.empty())
+            m2->copyTo(dstmap2);
+        return;
+    }
+
+    if (inputRemapType == RemapType::fixedPointInt16 && outputRemapType == RemapType::int16)
+    {
+        m1->copyTo(dstmap1);
         return;
     }
 
@@ -1900,13 +1895,13 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     {
         const float* src1f = m1->ptr<float>(y);
         const float* src2f = m2->ptr<float>(y);
-        const short* src1 = (const short*)src1f;
-        const ushort* src2 = (const ushort*)src2f;
+        const short* src1 = m1->ptr<short>(y);
+        const ushort* src2 = m2->ptr<ushort>(y);
 
         float* dst1f = dstmap1.ptr<float>(y);
         float* dst2f = dstmap2.ptr<float>(y);
-        short* dst1 = (short*)dst1f;
-        ushort* dst2 = (ushort*)dst2f;
+        short* dst1 = dstmap1.ptr<short>(y);
+        ushort* dst2 = dstmap2.ptr<ushort>(y);
         x = 0;
 
         if( m1type == CV_32FC1 && dstm1type == CV_16SC2 )

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -1,6 +1,6 @@
 namespace cv
 {
-enum RemapType {
+enum class RemapType {
     fp32_mapxy,
     fp32_mapx_mapy,
     fixedPointInt16,
@@ -8,7 +8,7 @@ enum RemapType {
     errorType
 };
 
-static const std::string errorRemapMessage =
+const std::string errorRemapMessage =
         "fp32_mapxy: map1 having the type CV_32FC2; map2 is empty\n"
         "fp32_mapx_mapy: map1 having the type CV_32FC1; map2 having the type CV_32FC1\n"
         "fixedPointInt16: map1 having the type CV_16SC2; map2 having the type CV_16UC1 or CV_16SC1\n"
@@ -50,7 +50,7 @@ inline RemapType check_and_get_remap_type(Mat &map1, Mat &map2)
 
     RemapType type = get_remap_type(map1, map2);
     if (type == RemapType::errorType)
-        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage);
     return type;
 }
 }

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -1,0 +1,56 @@
+namespace cv
+{
+enum RemapType {
+    fp32_mapxy,
+    fp32_mapx_mapy,
+    fixedPointInt16,
+    int16,
+    errorType
+};
+
+static const std::string errorRemapMessage =
+        "fp32_mapxy: map1 having the type CV_32FC2; map2 is empty\n"
+        "fp32_mapx_mapy: map1 having the type CV_32FC1; map2 having the type CV_32FC1\n"
+        "fixedPointInt16: map1 having the type CV_16SC2; map2 having the type CV_16UC1 or CV_16SC1\n"
+        "int16: map1 having the type CV_16SC2; map2 is empty\n"
+        "If map2 isn't empty, map1.size() must be equal to map2.size().\n";
+
+inline RemapType get_remap_type(const Mat &map1, const Mat &map2)
+{
+    if ((map1.depth() == CV_32F && !map1.empty()) || (map2.depth() == CV_32F && !map2.empty())) // fp32_mapxy or fp32_mapx_mapy
+    {
+        if (map1.type() == CV_32FC2 && map2.empty())
+            return RemapType::fp32_mapxy;
+        else if (map1.type() == CV_32FC1 && map2.type() == CV_32FC1)
+            return RemapType::fp32_mapx_mapy;
+    }
+    else if (map1.channels() == 2) // int or fixedPointInt
+    {
+        if (map2.empty()) // int16
+        {
+            if (map1.type() == CV_16SC2) // int16
+                return RemapType::int16;
+        }
+        else if (map2.channels() == 1) // fixedPointInt16
+        {
+            if (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1)) // fixedPointInt16
+                return RemapType::fixedPointInt16;
+        }
+    }
+    return RemapType::errorType;
+}
+
+inline RemapType check_and_get_remap_type(Mat &map1, Mat &map2)
+{
+    CV_Assert(!map1.empty() || !map2.empty());
+    if (map2.channels() == 2 && !map2.empty())
+        std::swap(map1, map2);
+    CV_Assert((map2.empty() && map1.channels() == 2) ||
+              (!map2.empty() && map1.size() == map2.size() && map2.channels() == 1));
+
+    RemapType type = get_remap_type(map1, map2);
+    if (type == RemapType::errorType)
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+    return type;
+}
+}

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1627,7 +1627,7 @@ INSTANTIATE_TEST_CASE_P(/**/, Param_fp32, testing::Combine(Values(
         Values(false, true)));
 
 INSTANTIATE_TEST_CASE_P(/**/, Param_fixedPoint, testing::Combine(Values(
-        test_float_types, test_fixed_point_types
+        test_float_types, test_int_types, test_fixed_point_types
         ),
         Values(CV_16SC2),
         Values(false)));


### PR DESCRIPTION
Will help fix:
- #4694
- #7544
- opencv python Alternative to cv2.warpPerspective [#549](https://github.com/opencv/opencv-python/issues/549)

Prepared to add int32 in `remap` (and then `warpAffine`, `warpPerspective`) functions ([PR with remap int32 support](https://github.com/opencv/opencv/pull/20949)).

**Features**

Add new types support for `convertMaps`:
- added the ability to convert from any map type  to any other map type by `convertMaps()`;
- added param tests for `convertMaps()`, for all combinations of types.

Added remap types:
```
- fp32_mapxy      // map_x.type() == CV_32FC2 && map_y is empty
- fp32_mapx_mapy  // map_x.type() == CV_32FC1 && map_y.type() == CV_32FC1
- fixedPointInt16 // map_x.type() == CV_16SC2 && map_y.type() == CV_16UC1
- int16           // map_x.type() == CV_16SC2 && map_y is empty
- errorType
```

To add `int32` (or any other type) just need to add `int32` and `fixedPointInt32` types ([PR with remap int32 support](https://github.com/opencv/opencv/pull/20949)).

**Code coverage**
Master (and 3.4) have some problems with `convertMaps` coverage: [code coverage link](https://pullrequest.opencv.org/buildbot/export/opencv_releases/master_coverage-lin64-debug/20211021-010954_11688/coverage_html/opencv/modules/imgproc/src/imgwarp.cpp.gcov.html).
This PR must fully test `convertMaps`.

**Fixes**
Also to avoid #18407 problem has been added this assert:
`CV_Assert( remapType != RemapType::int16 || interpolation == INTER_NEAREST );`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
