### PR TITLE
fix findMinEnclosingTriangle

### DIFF
--- a/modules/imgproc/src/min_enclosing_triangle.cpp
+++ b/modules/imgproc/src/min_enclosing_triangle.cpp
@@ -317,8 +317,9 @@ namespace minEnclosingTriangle {
 */
 static void findMinEnclosingTriangle(cv::InputArray points,
                                      CV_OUT cv::OutputArray triangle, CV_OUT double &area) {
-    std::vector<cv::Point2f> resultingTriangle, polygon;
     CV_Assert(!points.empty());
+    std::vector<cv::Point2f> resultingTriangle;
+    cv::Mat polygon;
     convexHull(points, polygon, true, true);
     findMinEnclosingTriangle(polygon, resultingTriangle, area);
     cv::Mat(resultingTriangle).copyTo(triangle);

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -2457,5 +2457,38 @@ TEST(Imgproc_minAreaRect, reproducer_19769)
     EXPECT_TRUE(checkMinAreaRect(rr, contour)) << rr.center << " " << rr.size << " " << rr.angle;
 }
 
+TEST(Imgproc_minEnclosingTriangle, regression_17585)
+{
+    const int N = 3;
+    float pts_[N][2] = { {0, 0}, {0, 1}, {1, 1} };
+    cv::Mat points(N, 2, CV_32FC1, static_cast<void*>(pts_));
+    vector<Point2f> triangle;
+
+    EXPECT_NO_THROW(minEnclosingTriangle(points, triangle));
+}
+
+TEST(Imgproc_minEnclosingTriangle, regression_20890)
+{
+    vector<Point> points;
+    points.push_back(Point(0, 0));
+    points.push_back(Point(0, 1));
+    points.push_back(Point(1, 1));
+    vector<Point2f> triangle;
+
+    EXPECT_NO_THROW(minEnclosingTriangle(points, triangle));
+}
+
+TEST(Imgproc_minEnclosingTriangle, regression_mat_with_diff_channels)
+{
+    const int N = 3;
+    float pts_[N][2] = { {0, 0}, {0, 1}, {1, 1} };
+    cv::Mat points1xN(1, N, CV_32FC2, static_cast<void*>(pts_));
+    cv::Mat pointsNx1(N, 1, CV_32FC2, static_cast<void*>(pts_));
+    vector<Point2f> triangle;
+
+    EXPECT_NO_THROW(minEnclosingTriangle(points1xN, triangle));
+    EXPECT_NO_THROW(minEnclosingTriangle(pointsNx1, triangle));
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
Fixes #20890
Add test for #20676

There was problem in this lines:

```
std::vector<cv::Point2f> resultingTriangle, polygon;
convexHull(points, polygon, true, true);
```
`convexHull` use same type for `points` and `hull`(variable `polygon` in this case). If the types are different, a problem occurs.
Using `cv::Mat` fix this problem.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
