### PR TITLE
[G-API] Fix bugs in GIEBackend

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -228,7 +228,7 @@ struct IEUnit {
     // for input layers in case ImportNetwork. Since this map is collected in
     // outMeta which is const, need to mark map as mutable.
     using PreProcMap = std::unordered_map<std::string, IE::PreProcessInfo>;
-    mutable PreProcMap preproc_map;
+    PreProcMap preproc_map;
 
     explicit IEUnit(const cv::gapi::ie::detail::ParamDesc &pp)
         : params(pp) {
@@ -961,12 +961,14 @@ struct Infer: public cv::detail::KernelTag {
         } else {
             GAPI_Assert(uu.params.kind == ParamDesc::Kind::Import);
             auto inputs = uu.this_network.GetInputsInfo();
+            // FIXME: This isn't the best place to collect PreProcMap.
+            auto* non_const_prepm = const_cast<IEUnit::PreProcMap*>(&uu.preproc_map);
             for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
                                             ade::util::toRange(in_metas))) {
                 const auto &input_name = std::get<0>(it);
                 auto       &&ii = inputs.at(input_name);
                 const auto & mm = std::get<1>(it);
-                uu.preproc_map.emplace(input_name, configurePreProcInfo(ii, mm));
+                non_const_prepm->emplace(input_name, configurePreProcInfo(ii, mm));
             }
         }
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -942,7 +942,7 @@ struct Infer: public cv::detail::KernelTag {
             for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
                                             ade::util::toRange(in_metas))) {
                     const auto &input_name = std::get<0>(it);
-                    auto       &&ii = inputs.at(input_name);
+                    auto ii = inputs.at(input_name);
                     const auto & mm = std::get<1>(it);
 
                     configureInputInfo(ii, mm);
@@ -967,7 +967,7 @@ struct Infer: public cv::detail::KernelTag {
             for (auto &&it : ade::util::zip(ade::util::toRange(uu.params.input_names),
                                             ade::util::toRange(in_metas))) {
                 const auto &input_name = std::get<0>(it);
-                auto       &&ii = inputs.at(input_name);
+                auto ii = inputs.at(input_name);
                 const auto & mm = std::get<1>(it);
                 non_const_prepm->emplace(input_name, configurePreProcInfo(ii, mm));
             }
@@ -1041,7 +1041,7 @@ struct InferROI: public cv::detail::KernelTag {
         if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             // 0th is ROI, 1st is input image
             const auto &input_name = uu.params.input_names.at(0);
-            auto &&ii = uu.net.getInputsInfo().at(input_name);
+            auto ii = uu.net.getInputsInfo().at(input_name);
             auto &&mm = in_metas.at(1u);
             configureInputInfo(ii, mm);
             if (uu.params.layer_names_to_reshape.find(input_name) !=
@@ -1130,7 +1130,7 @@ struct InferList: public cv::detail::KernelTag {
             std::size_t idx = 1u;
             auto inputs = uu.net.getInputsInfo();
             for (auto &&input_name : uu.params.input_names) {
-                auto       &&ii = inputs.at(input_name);
+                auto ii = inputs.at(input_name);
                 const auto & mm = in_metas[idx++];
                 configureInputInfo(ii, mm);
                 if (uu.params.layer_names_to_reshape.find(input_name) !=

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -244,7 +244,6 @@ struct IEUnit {
             net.setBatchSize(params.batch_size);
         } else if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import) {
             this_plugin = cv::gimpl::ie::wrap::getPlugin(params);
-            this_plugin.SetConfig(params.config);
             this_network = cv::gimpl::ie::wrap::importNetwork(this_plugin, params, rctx);
             if (!params.reshape_table.empty() || !params.layer_names_to_reshape.empty()) {
                 GAPI_LOG_WARNING(NULL, "Reshape isn't supported for imported network");
@@ -294,7 +293,6 @@ struct IEUnit {
         IEUnit* non_const_this = const_cast<IEUnit*>(this);
         if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             non_const_this->this_plugin  = cv::gimpl::ie::wrap::getPlugin(params);
-            non_const_this->this_plugin.SetConfig(params.config);
             non_const_this->this_network = cv::gimpl::ie::wrap::loadNetwork(non_const_this->this_plugin,
                                                                             net, params, rctx);
         }

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -539,7 +539,7 @@ inline IE::Blob::Ptr extractBlob(IECallContext& ctx, std::size_t i) {
 
 
 static void setBlob(InferenceEngine::InferRequest& req,
-                    IE::Blob::Ptr                  blob,
+                    const IE::Blob::Ptr&           blob,
                     const IECallContext&           ctx,
                     const std::size_t              layer_idx) {
     using namespace cv::gapi::ie::detail;

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -99,7 +99,7 @@ IE::Core giewrap::getCore() {
 }
 
 IE::Core giewrap::getPlugin(const GIEParam& params) {
-    auto plugin = giewrap::getCore();
+    giewrap::Plugin plugin;
     if (params.device_id == "CPU" || params.device_id == "FPGA")
     {
         for (auto &&extlib : giewrap::getExtensions(params))

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -106,25 +106,10 @@ static IE::Core create_IE_Core_instance() {
     return core;
 }
 
-static bool init_IE_plugins()
-{
-    // load and hold IE plugins
-    static InferenceEngine::Core* core = new InferenceEngine::Core();  // 'delete' is never called
-    (void)core->GetAvailableDevices();
-    return true;
-}
-
 IE::Core giewrap::getCore() {
     // to make happy memory leak tools use:
     // - OPENCV_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS=0
     // - OPENCV_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND=0
-    static bool param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS =
-        utils::getConfigurationParameterBool(
-                "OPENCV_DNN_INFERENCE_ENGINE_HOLD_PLUGINS", true);
-    static bool init_IE_plugins_ =
-        param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS && init_IE_plugins();
-    CV_UNUSED(init_IE_plugins_);
-
     static bool param_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND =
         utils::getConfigurationParameterBool(
                 "OPENCV_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND",
@@ -138,6 +123,13 @@ IE::Core giewrap::getCore() {
     IE::Core core = param_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND
         ? create_IE_Core_pointer()
         : create_IE_Core_instance();
+
+    static bool param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS =
+        utils::getConfigurationParameterBool(
+                "OPENCV_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS", true);
+    if (param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS) {
+        core.GetAvailableDevices();
+    }
     return core;
 }
 

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -99,7 +99,7 @@ IE::Core giewrap::getCore() {
 }
 
 IE::Core giewrap::getPlugin(const GIEParam& params) {
-    giewrap::Plugin plugin;
+    auto plugin = giewrap::getCore();
     if (params.device_id == "CPU" || params.device_id == "FPGA")
     {
         for (auto &&extlib : giewrap::getExtensions(params))

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -106,7 +106,25 @@ static IE::Core create_IE_Core_instance() {
     return core;
 }
 
+static bool init_IE_plugins()
+{
+    // load and hold IE plugins
+    static InferenceEngine::Core* core = new InferenceEngine::Core();  // 'delete' is never called
+    (void)core->GetAvailableDevices();
+    return true;
+}
+
 IE::Core giewrap::getCore() {
+    // to make happy memory leak tools use:
+    // - OPENCV_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS=0
+    // - OPENCV_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND=0
+    static bool param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS =
+        utils::getConfigurationParameterBool(
+                "OPENCV_DNN_INFERENCE_ENGINE_HOLD_PLUGINS", true);
+    static bool init_IE_plugins_ =
+        param_GAPI_INFERENCE_ENGINE_HOLD_PLUGINS && init_IE_plugins();
+    CV_UNUSED(init_IE_plugins_);
+
     static bool param_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND =
         utils::getConfigurationParameterBool(
                 "OPENCV_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND",

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.cpp
@@ -96,6 +96,10 @@ IE::InferencePlugin giewrap::getPlugin(const GIEParam& params) {
 }
 #else // >= 2019.R2
 
+// NB: Some of IE plugins fail during IE::Core destroying in specific cases.
+// Solution is allocate IE::Core in heap and doesn't destroy it, which cause
+// leak, but fixes tests on CI. This behaviour is configurable by using
+// OPENCV_GAPI_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND=0
 static IE::Core create_IE_Core_pointer() {
     // NB: 'delete' is never called
     static IE::Core* core = new IE::Core();

--- a/modules/gapi/src/backends/ie/giebackend/giewrapper.hpp
+++ b/modules/gapi/src/backends/ie/giebackend/giewrapper.hpp
@@ -34,13 +34,12 @@ using Plugin = IE::InferencePlugin;
 GAPI_EXPORTS IE::InferencePlugin getPlugin(const GIEParam& params);
 GAPI_EXPORTS inline IE::ExecutableNetwork loadNetwork(      IE::InferencePlugin& plugin,
                                                       const IE::CNNNetwork&      net,
-                                                      const GIEParam&) {
-    return plugin.LoadNetwork(net, {}); // FIXME: 2nd parameter to be
-                                        // configurable via the API
+                                                      const GIEParam& params) {
+    return plugin.LoadNetwork(net, params.config);
 }
 GAPI_EXPORTS inline IE::ExecutableNetwork importNetwork(      IE::CNNNetwork& plugin,
-                                                        const GIEParam& param) {
-    return plugin.ImportNetwork(param.model_path, param.device_id, {});
+                                                        const GIEParam& params) {
+    return plugin.ImportNetwork(param.model_path, param.device_id, params.config);
 }
 #else // >= 2019.R2
 using Plugin = IE::Core;
@@ -51,9 +50,9 @@ GAPI_EXPORTS inline IE::ExecutableNetwork loadNetwork(      IE::Core&       core
                                                       const GIEParam& params,
                                                       IE::RemoteContext::Ptr rctx = nullptr) {
     if (rctx != nullptr) {
-        return core.LoadNetwork(net, rctx);
+        return core.LoadNetwork(net, rctx, params.config);
     } else {
-        return core.LoadNetwork(net, params.device_id);
+        return core.LoadNetwork(net, params.device_id, params.config);
     }
 }
 GAPI_EXPORTS inline IE::ExecutableNetwork importNetwork(      IE::Core& core,
@@ -67,9 +66,9 @@ GAPI_EXPORTS inline IE::ExecutableNetwork importNetwork(      IE::Core& core,
             throw std::runtime_error("Could not open file");
         }
         std::istream graphBlob(&blobFile);
-        return core.ImportNetwork(graphBlob, rctx);
+        return core.ImportNetwork(graphBlob, rctx, params.config);
     } else {
-        return core.ImportNetwork(params.model_path, params.device_id, {});
+        return core.ImportNetwork(params.model_path, params.device_id, params.config);
     }
 }
 #endif // INF_ENGINE_RELEASE < 2019020000

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -513,10 +513,10 @@ struct ROIListNV12: public ::testing::Test {
             for (auto &&rc : m_roi_list) {
                 const auto ie_rc = IE::ROI {
                     0u
-                        , static_cast<std::size_t>(rc.x)
-                        , static_cast<std::size_t>(rc.y)
-                        , static_cast<std::size_t>(rc.width)
-                        , static_cast<std::size_t>(rc.height)
+                    , static_cast<std::size_t>(rc.x)
+                    , static_cast<std::size_t>(rc.y)
+                    , static_cast<std::size_t>(rc.width)
+                    , static_cast<std::size_t>(rc.height)
                 };
                 infer_request.SetBlob("data", IE::make_shared_blob(frame_blob, ie_rc));
                 infer_request.Infer();
@@ -576,11 +576,11 @@ struct SingleROI: public ::testing::Test {
             auto infer_request = this_network.CreateInferRequest();
 
             const auto ie_rc = IE::ROI {
-                    0u
-                    , static_cast<std::size_t>(m_roi.x)
-                    , static_cast<std::size_t>(m_roi.y)
-                    , static_cast<std::size_t>(m_roi.width)
-                    , static_cast<std::size_t>(m_roi.height)
+                0u
+                , static_cast<std::size_t>(m_roi.x)
+                , static_cast<std::size_t>(m_roi.y)
+                , static_cast<std::size_t>(m_roi.width)
+                , static_cast<std::size_t>(m_roi.height)
             };
 
             IE::Blob::Ptr roi_blob = IE::make_shared_blob(cv::gapi::ie::util::to_ie(m_in_mat), ie_rc);
@@ -638,11 +638,11 @@ struct SingleROINV12: public ::testing::Test {
             auto blob = cv::gapi::ie::util::to_ie(m_in_y, m_in_uv);
 
             const auto ie_rc = IE::ROI {
-                    0u
-                    , static_cast<std::size_t>(m_roi.x)
-                    , static_cast<std::size_t>(m_roi.y)
-                    , static_cast<std::size_t>(m_roi.width)
-                    , static_cast<std::size_t>(m_roi.height)
+                0u
+                , static_cast<std::size_t>(m_roi.x)
+                , static_cast<std::size_t>(m_roi.y)
+                , static_cast<std::size_t>(m_roi.width)
+                , static_cast<std::size_t>(m_roi.height)
             };
 
             IE::Blob::Ptr roi_blob = IE::make_shared_blob(blob, ie_rc);
@@ -2412,10 +2412,10 @@ TEST(ImportNetwork, InferROI)
         auto infer_request = this_network.CreateInferRequest();
         const auto ie_rc = IE::ROI {
             0u
-                , static_cast<std::size_t>(rect.x)
-                , static_cast<std::size_t>(rect.y)
-                , static_cast<std::size_t>(rect.width)
-                , static_cast<std::size_t>(rect.height)
+            , static_cast<std::size_t>(rect.x)
+            , static_cast<std::size_t>(rect.y)
+            , static_cast<std::size_t>(rect.width)
+            , static_cast<std::size_t>(rect.height)
         };
         IE::Blob::Ptr roi_blob = IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_mat), ie_rc);
         IE::PreProcessInfo info;
@@ -2475,10 +2475,10 @@ TEST(ImportNetwork, InferROINV12)
         auto infer_request = this_network.CreateInferRequest();
         const auto ie_rc = IE::ROI {
             0u
-                , static_cast<std::size_t>(rect.x)
-                , static_cast<std::size_t>(rect.y)
-                , static_cast<std::size_t>(rect.width)
-                , static_cast<std::size_t>(rect.height)
+            , static_cast<std::size_t>(rect.x)
+            , static_cast<std::size_t>(rect.y)
+            , static_cast<std::size_t>(rect.width)
+            , static_cast<std::size_t>(rect.height)
         };
         IE::Blob::Ptr roi_blob =
             IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_y_mat, in_uv_mat), ie_rc);
@@ -2541,10 +2541,10 @@ TEST(ImportNetwork, InferList)
         for (auto &&rc : roi_list) {
             const auto ie_rc = IE::ROI {
                 0u
-                    , static_cast<std::size_t>(rc.x)
-                    , static_cast<std::size_t>(rc.y)
-                    , static_cast<std::size_t>(rc.width)
-                    , static_cast<std::size_t>(rc.height)
+                , static_cast<std::size_t>(rc.x)
+                , static_cast<std::size_t>(rc.y)
+                , static_cast<std::size_t>(rc.width)
+                , static_cast<std::size_t>(rc.height)
             };
             IE::Blob::Ptr roi_blob =
                 IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_mat), ie_rc);
@@ -2618,10 +2618,10 @@ TEST(ImportNetwork, InferListNV12)
         for (auto &&rc : roi_list) {
             const auto ie_rc = IE::ROI {
                 0u
-                    , static_cast<std::size_t>(rc.x)
-                    , static_cast<std::size_t>(rc.y)
-                    , static_cast<std::size_t>(rc.width)
-                    , static_cast<std::size_t>(rc.height)
+                , static_cast<std::size_t>(rc.x)
+                , static_cast<std::size_t>(rc.y)
+                , static_cast<std::size_t>(rc.width)
+                , static_cast<std::size_t>(rc.height)
             };
             IE::Blob::Ptr roi_blob =
                 IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_y_mat, in_uv_mat), ie_rc);
@@ -2695,10 +2695,10 @@ TEST(ImportNetwork, InferList2)
         for (auto &&rc : roi_list) {
             const auto ie_rc = IE::ROI {
                 0u
-                    , static_cast<std::size_t>(rc.x)
-                    , static_cast<std::size_t>(rc.y)
-                    , static_cast<std::size_t>(rc.width)
-                    , static_cast<std::size_t>(rc.height)
+                , static_cast<std::size_t>(rc.x)
+                , static_cast<std::size_t>(rc.y)
+                , static_cast<std::size_t>(rc.width)
+                , static_cast<std::size_t>(rc.height)
             };
             IE::Blob::Ptr roi_blob =
                 IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_mat), ie_rc);
@@ -2772,10 +2772,10 @@ TEST(ImportNetwork, InferList2NV12)
         for (auto &&rc : roi_list) {
             const auto ie_rc = IE::ROI {
                 0u
-                    , static_cast<std::size_t>(rc.x)
-                    , static_cast<std::size_t>(rc.y)
-                    , static_cast<std::size_t>(rc.width)
-                    , static_cast<std::size_t>(rc.height)
+                , static_cast<std::size_t>(rc.x)
+                , static_cast<std::size_t>(rc.y)
+                , static_cast<std::size_t>(rc.width)
+                , static_cast<std::size_t>(rc.height)
             };
             IE::Blob::Ptr roi_blob =
                 IE::make_shared_blob(cv::gapi::ie::util::to_ie(in_y_mat, in_uv_mat), ie_rc);

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2369,7 +2369,7 @@ TEST(ImportNetwork, InferNV12)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
 }
 
-TEST(TestAgeGender, ThrowBlobAndInputPrecisionMismatch)
+TEST(TestAgeGender, DISABLED_ThrowBlobAndInputPrecisionMismatch)
 {
     initDLDTDataPath();
 

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2273,7 +2273,7 @@ TEST(ImportNetwork, Infer)
     initDLDTDataPath();
 
     cv::gapi::ie::detail::ParamDesc params;
-    params.model_path= compileAgeGenderBlob();
+    params.model_path = compileAgeGenderBlob();
     params.device_id = "MYRIAD";
 
     cv::Mat in_mat(320, 240, CV_8UC3);

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2375,7 +2375,7 @@ TEST(TestAgeGender, ThrowBlobAndInputPrecisionMismatch)
 
     cv::gapi::ie::detail::ParamDesc params;
     // NB: Precision for inputs is U8.
-    params.model_path= compileAgeGenderBlob();
+    params.model_path = compileAgeGenderBlob();
     params.device_id = "MYRIAD";
 
     // Configure & run G-API

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2282,7 +2282,6 @@ TEST(TestAgeGenderIE, InferWithBatch)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
 }
 
-
 TEST(ImportNetwork, Infer)
 {
     const std::string device = "MYRIAD";

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2267,7 +2267,8 @@ TEST(TestAgeGenderIE, InferWithBatch)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
 }
 
-TEST(TestAgeGender, ImportNetwork)
+
+TEST(ImportNetwork, Infer)
 {
     initDLDTDataPath();
 
@@ -2315,7 +2316,7 @@ TEST(TestAgeGender, ImportNetwork)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
 }
 
-TEST(TestAgeGender, ImportNetworkNV12)
+TEST(ImportNetwork, InferNV12)
 {
     initDLDTDataPath();
 

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -139,6 +139,20 @@ void setNetParameters(IE::CNNNetwork& net, bool is_nv12 = false) {
     }
 }
 
+void compileBlob(const cv::gapi::ie::detail::ParamDesc& params,
+                 const std::string&                     output,
+                 const IE::Precision&                   ip) {
+    auto plugin = cv::gimpl::ie::wrap::getPlugin(params);
+    auto net    = cv::gimpl::ie::wrap::readNetwork(params);
+    for (auto&& ii : net.getInputsInfo()) {
+        ii.second->setPrecision(ip);
+    }
+    auto this_network = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
+    std::ofstream out_file{output, std::ios::out | std::ios::binary};
+    GAPI_Assert(out_file.is_open());
+    this_network.Export(out_file);
+}
+
 } // anonymous namespace
 
 // TODO: Probably DNN/IE part can be further parametrized with a template
@@ -2230,6 +2244,62 @@ TEST(TestAgeGenderIE, InferWithBatch)
         params.model_path, params.weights_path, params.device_id
     }.cfgOutputLayers({ "age_conv3", "prob" })
      .cfgBatchSize(batch_size);
+
+    comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
+               cv::compile_args(cv::gapi::networks(pp)));
+
+    // Validate with IE itself (avoid DNN module dependency here)
+    normAssert(cv::gapi::ie::util::to_ocv(ie_age),    gapi_age,    "Test age output"   );
+    normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
+}
+
+TEST(TestAgeGender, ImportNetwork)
+{
+    initDLDTDataPath();
+
+    const std::string model_name = "age-gender-recognition-retail-0013";
+    cv::gapi::ie::detail::ParamDesc params;
+    params.model_path   = findDataFile(SUBDIR + model_name + ".xml");
+    params.weights_path = findDataFile(SUBDIR + model_name + ".bin");
+    params.device_id    = "MYRIAD";
+
+    const std::string blob_path = model_name + ".blob";
+
+    compileBlob(params, blob_path, IE::Precision::U8);
+
+    cv::Mat in_mat(320, 240, CV_8UC3);
+    cv::randu(in_mat, 0, 255);
+    cv::Mat gapi_age, gapi_gender;
+
+    // Load & run IE network
+    IE::Blob::Ptr ie_age, ie_gender;
+    {
+        auto plugin = cv::gimpl::ie::wrap::getPlugin(params);
+        cv::gapi::ie::detail::ParamDesc p;
+        p.model_path = blob_path;
+        p.device_id = "MYRIAD";
+        auto this_network  = cv::gimpl::ie::wrap::importNetwork(plugin, p);
+        auto infer_request = this_network.CreateInferRequest();
+        IE::PreProcessInfo info;
+        info.setResizeAlgorithm(IE::RESIZE_BILINEAR);
+        infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(in_mat), info);
+        infer_request.Infer();
+        ie_age    = infer_request.GetBlob("age_conv3");
+        ie_gender = infer_request.GetBlob("prob");
+    }
+
+    // Configure & run G-API
+    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
+    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+
+    cv::GMat in;
+    cv::GMat age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        blob_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" });
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Bugs overview
1. **Outputs map are filled only for `LoadNetwork` case.**
These maps: https://github.com/opencv/opencv/blob/master/modules/gapi/src/backends/ie/giebackend.cpp#L221-L222 are filled only in case LoadNetwork: https://github.com/opencv/opencv/blob/master/modules/gapi/src/backends/ie/giebackend.cpp#L241-L242, but are used by both of them:
https://github.com/opencv/opencv/blob/master/modules/gapi/src/backends/ie/giebackend.cpp#L953
2. **`cv::gapi::ie::Params::pluginConfig(IEConfig)` set config globally to `IE::Core`, but should be set locally within `ExecutableNetwork`:** https://github.com/opencv/opencv/blob/master/modules/gapi/src/backends/ie/giebackend.cpp#L244-L245
3. In case `ImportNetwork` preprocessing should be passed as `ExecutableNetwork::SetBlob` argument, now preprocessing for `NV12` color format is missed. 


### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
