### PR TITLE
G-API: oneVPL - Implement simple MFP demux provider with auto provider selector

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -179,6 +179,7 @@ set(gapi_srcs
     src/streaming/onevpl/engine/processing_engine_base.cpp
     src/streaming/onevpl/engine/decode/decode_engine_legacy.cpp
     src/streaming/onevpl/engine/decode/decode_session.cpp
+    src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
 
     src/streaming/onevpl/cfg_param_device_selector.cpp
     src/streaming/onevpl/device_selector_interface.cpp

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -180,6 +180,7 @@ set(gapi_srcs
     src/streaming/onevpl/engine/decode/decode_engine_legacy.cpp
     src/streaming/onevpl/engine/decode/decode_session.cpp
     src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+    src/streaming/onevpl/data_provider_dispatcher.cpp
 
     src/streaming/onevpl/cfg_param_device_selector.cpp
     src/streaming/onevpl/device_selector_interface.cpp

--- a/modules/gapi/include/opencv2/gapi/streaming/onevpl/data_provider_interface.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/onevpl/data_provider_interface.hpp
@@ -7,6 +7,7 @@
 #ifndef GAPI_STREAMING_ONEVPL_ONEVPL_DATA_PROVIDER_INTERFACE_HPP
 #define GAPI_STREAMING_ONEVPL_ONEVPL_DATA_PROVIDER_INTERFACE_HPP
 #include <exception>
+#include <limits>
 #include <string>
 
 #include <opencv2/gapi/own/exports.hpp> // GAPI_EXPORTS
@@ -29,6 +30,15 @@ private:
     std::string reason;
 };
 
+struct GAPI_EXPORTS DataProviderUnsupportedException : public DataProviderException {
+    DataProviderUnsupportedException(const std::string& desription);
+    virtual ~DataProviderUnsupportedException();
+    virtual const char* what() const noexcept override;
+
+private:
+    std::string reason;
+};
+
 /**
  * @brief Public interface allows to customize extraction of video stream data
  * used by onevpl::GSource instead of reading stream from file (by default).
@@ -42,7 +52,27 @@ private:
 struct GAPI_EXPORTS IDataProvider {
     using Ptr = std::shared_ptr<IDataProvider>;
 
-    virtual ~IDataProvider() {}
+    enum class CodecID : uint16_t {
+        AVC,
+        HEVC,
+        MPEG2,
+        VC1,
+        VP9,
+        AV1,
+        JPEG,
+
+        UNCOMPRESSED = std::numeric_limits<uint16_t>::max()
+    };
+
+    static const char *to_cstr(CodecID codec);
+
+    virtual ~IDataProvider() = default;
+
+    /**
+     * The function is used by onevpl::GSource to extract codec id from data
+     *
+     */
+    virtual CodecID get_codec() const = 0;
 
     /**
      * The function is used by onevpl::GSource to extract binary data stream from @ref IDataProvider

--- a/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
@@ -10,6 +10,7 @@
 #include <opencv2/gapi/util/variant.hpp>
 
 #include "streaming/onevpl/cfg_param_device_selector.hpp"
+#include "streaming/onevpl/cfg_params_parser.hpp"
 #include "streaming/onevpl/utils.hpp"
 #include "logger.hpp"
 
@@ -36,45 +37,6 @@ namespace cv {
 namespace gapi {
 namespace wip {
 namespace onevpl {
-
-// TODO Will be changed on generic function from `onevpl_param_parser` as soons as feature merges
-static mfxVariant cfg_param_to_mfx_variant(const CfgParam& accel_param) {
-    mfxVariant ret;
-    const CfgParam::value_t& accel_val = accel_param.get_value();
-    if (!cv::util::holds_alternative<std::string>(accel_val)) {
-        // expected string or uint32_t as value
-        if (!cv::util::holds_alternative<uint32_t>(accel_val)) {
-            throw std::logic_error("Incorrect value type of \"mfxImplDescription.AccelerationMode\" "
-                                   " std::string is expected" );
-        }
-        ret.Type = MFX_VARIANT_TYPE_U32;
-        ret.Data.U32 = cv::util::get<uint32_t>(accel_val);
-        return ret;
-    }
-
-    const std::string& accel_val_str = cv::util::get<std::string>(accel_val);
-    ret.Type = MFX_VARIANT_TYPE_U32;
-    if (accel_val_str == "MFX_ACCEL_MODE_NA") {
-        ret.Data.U32 = MFX_ACCEL_MODE_NA;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_D3D9") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_D3D9;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_D3D11") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_D3D11;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_VAAPI") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_VAAPI_DRM_MODESET") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI_DRM_MODESET;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_VAAPI_GLX") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI_GLX;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_VAAPI_X11") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI_X11;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_VAAPI_WAYLAND") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI_WAYLAND;
-    } else if (accel_val_str == "MFX_ACCEL_MODE_VIA_HDDLUNITE") {
-        ret.Data.U32 = MFX_ACCEL_MODE_VIA_HDDLUNITE;
-    }
-    return ret;
-}
 
 CfgParamDeviceSelector::CfgParamDeviceSelector(const CfgParams& cfg_params) :
     suggested_device(IDeviceSelector::create<Device>(nullptr, "CPU", AccelType::HOST)),

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
@@ -4,6 +4,8 @@
 //
 // Copyright (C) 2021 Intel Corporation
 
+#ifdef HAVE_ONEVPL
+
 #include "streaming/onevpl/data_provider_dispatcher.hpp"
 #include "streaming/onevpl/file_data_provider.hpp"
 #include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
@@ -63,3 +65,4 @@ IDataProvider::Ptr DataProviderDispatcher::create(const std::string& file_path,
 } // namespace wip
 } // namespace gapi
 } // namespace cv
+#endif // HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
@@ -28,8 +28,7 @@ IDataProvider::Ptr DataProviderDispatcher::create(const std::string& file_path,
         std::find_if(cfg_params.begin(), cfg_params.end(), [] (const CfgParam& value) {
             return value.get_name() == "mfxImplDescription.mfxDecoderDescription.decoder.CodecID";
         });
-    if (codec_it != cfg_params.end())
-    {
+    if (codec_it != cfg_params.end()) {
         GAPI_LOG_DEBUG(nullptr, "Dispatcher found \"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\""
                                 " so try on raw data provider at first");
 

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
@@ -1,0 +1,68 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#include <opencv2/gapi/streaming/onevpl/cfg_params.hpp>
+
+#include "streaming/onevpl/data_provider_dispatcher.hpp"
+#include "streaming/onevpl/file_data_provider.hpp"
+#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
+#include "logger.hpp"
+
+namespace cv {
+namespace gapi {
+namespace wip {
+namespace onevpl {
+
+IDataProvider::Ptr DataProviderDispatcher::create(const std::string& file_path,
+                                                  const std::vector<CfgParam> cfg_params) {
+    GAPI_LOG_INFO(nullptr, "try select suitable IDataProvider for source: " <<
+                           file_path);
+
+    IDataProvider::Ptr provider;
+
+    // Look-up CodecId from input params
+    // If set then raw data provider is preferred
+    GAPI_LOG_DEBUG(nullptr, "try find explicit cfg param\"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\"");
+    auto codec_it =
+        std::find_if(cfg_params.begin(), cfg_params.end(), [] (const CfgParam& value) {
+            return value.get_name() == "mfxImplDescription.mfxDecoderDescription.decoder.CodecID";
+        });
+    if (codec_it != cfg_params.end())
+    {
+        GAPI_LOG_DEBUG(nullptr, "Dispatcher found \"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\""
+                                " so try on raw data provider at first");
+
+        try {
+            provider = std::make_shared<FileDataProvider>(file_path, cfg_params);
+            GAPI_LOG_INFO(nullptr, "raw data provider created");
+        } catch (const DataProviderUnsupportedException& ex) {
+            GAPI_LOG_INFO(nullptr, "raw data provider creation is failed, reason: " <<
+                                    ex.what());
+        }
+    }
+
+    if (!provider) {
+        GAPI_LOG_DEBUG(nullptr, "Try on MFP data provider");
+        try {
+            provider = std::make_shared<MFPDemuxDataProvider>(file_path);
+            GAPI_LOG_INFO(nullptr, "MFP data provider created");
+        } catch (const DataProviderUnsupportedException& ex) {
+            GAPI_LOG_INFO(nullptr, "raw data provider creation is failed, reason: " <<
+                                   ex.what());
+        }
+    }
+
+    // final check
+    if (!provider) {
+        GAPI_LOG_WARNING(nullptr, "Cannot find suitable data provider");
+        throw DataProviderUnsupportedException("Unsupported source or configuration parameters");;
+    }
+    return provider;
+}
+} // namespace onevpl
+} // namespace wip
+} // namespace gapi
+} // namespace cv

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.cpp
@@ -4,8 +4,6 @@
 //
 // Copyright (C) 2021 Intel Corporation
 
-#include <opencv2/gapi/streaming/onevpl/cfg_params.hpp>
-
 #include "streaming/onevpl/data_provider_dispatcher.hpp"
 #include "streaming/onevpl/file_data_provider.hpp"
 #include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
@@ -15,7 +15,7 @@ namespace gapi {
 namespace wip {
 namespace onevpl {
 
-struct DataProviderDispatcher {
+struct GAPI_EXPORTS DataProviderDispatcher {
 
     static IDataProvider::Ptr create(const std::string& file_path,
                                      const std::vector<CfgParam> codec_params = {});

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
@@ -1,0 +1,27 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP
+#define GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP
+
+#include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
+#include <opencv2/gapi/streaming/onevpl/cfg_params.hpp>
+
+namespace cv {
+namespace gapi {
+namespace wip {
+namespace onevpl {
+
+struct DataProviderDispatcher {
+
+    static IDataProvider::Ptr create(const std::string& file_path,
+                                     const std::vector<CfgParam> codec_params = {});
+};
+} // namespace onevpl
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+#endif // GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP

--- a/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_dispatcher.hpp
@@ -7,6 +7,7 @@
 #ifndef GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP
 #define GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP
 
+#ifdef HAVE_ONEVPL
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
 #include <opencv2/gapi/streaming/onevpl/cfg_params.hpp>
 
@@ -24,4 +25,5 @@ struct GAPI_EXPORTS DataProviderDispatcher {
 } // namespace wip
 } // namespace gapi
 } // namespace cv
+#endif // HAVE_ONEVPL
 #endif // GAPI_STREAMING_ONEVPL_DATA_PROVIDER_DISPATCHER_HPP

--- a/modules/gapi/src/streaming/onevpl/data_provider_interface_exception.cpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_interface_exception.cpp
@@ -7,14 +7,47 @@ namespace cv {
 namespace gapi {
 namespace wip {
 namespace onevpl {
-DataProviderSystemErrorException::DataProviderSystemErrorException(int error_code, const std::string& desription) {
-    reason = desription + ", error: " + std::to_string(error_code) + ", desctiption: " + strerror(error_code);
+DataProviderSystemErrorException::DataProviderSystemErrorException(int error_code,
+                                                                   const std::string& description) {
+    reason = description + ", error: " + std::to_string(error_code) + ", description: " + strerror(error_code);
 }
 
 DataProviderSystemErrorException::~DataProviderSystemErrorException() = default;
 
 const char* DataProviderSystemErrorException::what() const noexcept {
     return reason.c_str();
+}
+
+DataProviderUnsupportedException::DataProviderUnsupportedException(const std::string& description) {
+    reason = description;
+}
+
+DataProviderUnsupportedException::~DataProviderUnsupportedException() = default;
+
+const char* DataProviderUnsupportedException::what() const noexcept {
+    return reason.c_str();
+}
+
+
+const char *IDataProvider::to_cstr(IDataProvider::CodecID codec) {
+    switch(codec) {
+        case IDataProvider::CodecID::AVC:
+            return "AVC";
+        case IDataProvider::CodecID::HEVC:
+            return "HEVC";
+        case IDataProvider::CodecID::MPEG2:
+            return "MPEG2";
+        case IDataProvider::CodecID::VC1:
+            return "VC1";
+        case IDataProvider::CodecID::VP9:
+            return "VP9";
+        case IDataProvider::CodecID::AV1:
+            return "AV1";
+        case IDataProvider::CodecID::JPEG:
+            return "JPEG";
+        default:
+            return "<unsupported>";
+    }
 }
 } // namespace onevpl
 } // namespace wip

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -258,7 +258,7 @@ const char* GetGUIDNameConst(const GUID& guid)
     IF_EQUAL_RETURN(guid, MFAudioFormat_AAC); //              WAVE_FORMAT_MPEG_HEAAC
     IF_EQUAL_RETURN(guid, MFAudioFormat_ADTS); //             WAVE_FORMAT_MPEG_ADTS_AAC
 
-    return NULL;
+    return "<unknown>";
 }
 
 IDataProvider::CodecID convert_to_CodecId(const GUID& guid) {

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -7,8 +7,6 @@
 #include <errno.h>
 #ifdef _WIN32
 #define NOMINMAX
-#include <atlstr.h> //TODO If you see it then put comment to remove it, please
-
 #include <mfapi.h>
 #include <mfidl.h>
 #include <mfreadwrite.h>
@@ -20,12 +18,11 @@
 #include <wmcodecdsp.h>
 #undef NOMINMAX
 
-#pragma comment(lib,"Mf.lib")
-#pragma comment(lib,"Mfuuid.lib")
-#pragma comment(lib,"Mfplat.lib")
+#pragma comment(lib, "Mf.lib")
+#pragma comment(lib, "Mfuuid.lib")
+#pragma comment(lib, "Mfplat.lib")
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "mfreadwrite.lib")
-#pragma comment(lib, "mfuuid") //???
 #endif // _WIN32
 
 #include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
@@ -37,7 +34,10 @@ namespace wip {
 namespace onevpl {
 #ifdef _WIN32
 HRESULT create_media_source(const std::string& url, IMFMediaSource **ppSource) {
-    CStringW sURL(url.c_str());
+    wchar_t sURL[MAX_PATH];
+    GAPI_Assert(url.size() < MAX_PATH && "Windows MAX_PATH limit was exceeded");
+    size_t ret_url_lenght = 0;
+    mbstowcs_s(&ret_url_lenght, sURL, url.data(), url.size());
 
     HRESULT hr = S_OK;
 

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -1,0 +1,332 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+#include <errno.h>
+#include <atlstr.h>
+
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+#include <mfobjects.h>
+#include <mfidl.h>
+#include <mftransform.h>
+#include <mferror.h>
+#include <wmcontainer.h>
+#include <wmcodecdsp.h>
+
+#include <fstream>
+
+#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
+
+#pragma comment(lib,"Mf.lib")
+#pragma comment(lib,"Mfuuid.lib")
+#pragma comment(lib,"Mfplat.lib")
+#pragma comment(lib, "shlwapi.lib")
+#pragma comment(lib, "mfreadwrite.lib")
+
+
+#pragma comment(lib, "mfuuid") //???
+
+
+namespace cv {
+namespace gapi {
+namespace wip {
+namespace onevpl {
+
+inline HRESULT CreateMediaSource(const std::string& url, IMFMediaSource **ppSource)
+    {
+        CStringW sURL(url.c_str());
+
+        HRESULT hr = S_OK;
+
+        IMFSourceResolver   *pSourceResolver = nullptr;
+        IUnknown            *pSourceUnk = nullptr;
+
+        // Create the source resolver.
+        if (SUCCEEDED(hr))
+        {
+            hr = MFCreateSourceResolver(&pSourceResolver);
+        } else {
+            throw DataProviderSystemErrorException(HRESULT_CODE(hr),
+                                                   "cannot create MFCreateSourceResolver");
+        }
+
+        // Use the source resolver to create the media source.
+        if (SUCCEEDED(hr))
+        {
+            MF_OBJECT_TYPE ObjectType = MF_OBJECT_INVALID;
+
+            hr = pSourceResolver->CreateObjectFromURL(
+                sURL,                       // URL of the source.
+                MF_RESOLUTION_MEDIASOURCE,  // Create a source object.
+                nullptr,                       // Optional property store.
+                &ObjectType,                // Receives the created object type.
+                &pSourceUnk                 // Receives a pointer to the media source.
+                );
+        } else {
+            throw DataProviderSystemErrorException(HRESULT_CODE(hr),
+                                                   "cannot create CreateObjectFromURL");
+        }
+
+        // Get the IMFMediaSource interface from the media source.
+        if (SUCCEEDED(hr))
+        {
+            hr = pSourceUnk->QueryInterface(__uuidof(IMFMediaSource), (void**)ppSource);
+        } else {
+            throw DataProviderSystemErrorException(HRESULT_CODE(hr),
+                                                   "cannot query IMFMediaSource");
+        }
+
+        // Clean up
+        if (pSourceResolver) {
+            pSourceResolver->Release();
+            pSourceResolver = nullptr;
+        }
+        if (pSourceUnk) {
+            pSourceUnk->Release();
+            pSourceUnk = nullptr;
+        }
+
+        return hr;
+    }
+
+MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) :
+    source_handle(fopen(file_path.c_str(), "rb"), &fclose) {
+    if (!source_handle) {
+        throw DataProviderSystemErrorException(errno,
+                                               "MFPDemuxDataProvider: cannot open source file: " + file_path);
+    }
+
+    HRESULT hr = S_OK;
+    hr = MFStartup(MF_VERSION);
+    if (FAILED(hr)) {
+        throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot initialize MFStartup");
+    }
+
+    source_ptr = nullptr;
+    hr = CreateMediaSource(file_path, &source_ptr);
+    if (FAILED(hr)) {
+        throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot create IMFMediaSource");
+    }
+
+///////////////////
+    IMFAttributes   *pAttributes = nullptr;
+    IMFMediaType    *pType = nullptr;
+    reader = nullptr;
+
+    //
+    // Create the source reader.
+    //
+
+    // Create an attribute store to hold initialization settings.
+
+    if (SUCCEEDED(hr)) {
+        hr = MFCreateAttributes(&pAttributes, 2);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = pAttributes->SetUINT32(MF_READWRITE_DISABLE_CONVERTERS, TRUE);
+    }
+
+    // Set the callback pointer.
+    /*if (SUCCEEDED(hr))
+    {
+        hr = pAttributes->SetUnknown(
+            MF_SOURCE_READER_ASYNC_CALLBACK,
+            this
+            );
+    }*/
+
+    if (SUCCEEDED(hr)) {
+        hr = MFCreateSourceReaderFromMediaSource(
+            source_ptr,
+            pAttributes,
+            &reader
+            );
+    } else {
+        throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot create MFCreateSourceReaderFromMediaSource");
+    }
+
+    // Try to find a suitable output type.
+    if (SUCCEEDED(hr)) {
+        for (DWORD i = 0; ; i++) {
+            hr = reader->GetNativeMediaType(
+                (DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+                i,
+                &pType
+                );
+
+            if (FAILED(hr)) { break; }
+
+            /////////////////////
+            BOOL bFound = FALSE;
+            GUID subtype = { 0 };
+
+            hr = pType->GetGUID(MF_MT_SUBTYPE, &subtype);
+
+            if (FAILED(hr)) {
+                break;
+            }
+            /////////////////////
+
+
+            pType->Release();
+            pType = nullptr;
+
+            if (SUCCEEDED(hr)) {
+                // Found an output type.
+                break;
+            }
+        }
+    }
+
+    if (SUCCEEDED(hr)) {
+        // Ask for the first sample.
+        hr = reader->ReadSample(
+            (DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+            0,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+            );
+    } else {
+        throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot ReadSample");
+    }
+
+
+    MFT_REGISTER_TYPE_INFO tinfo;
+    tinfo.guidMajorType = MFMediaType_Video;
+    tinfo.guidSubtype = MFVideoFormat_MPEG2;
+
+    CLSID *pDecoderCLSIDs = NULL;   // Pointer to an array of CLISDs.
+    UINT32 cDecoderCLSIDs = 0;   // Size of the array.
+
+
+    uint32_t flags = MFT_ENUM_FLAG_ALL;
+    IMFActivate** activate = nullptr;
+	UINT32 count = 0;
+
+    hr = MFTEnumEx(MFT_CATEGORY_DEMULTIPLEXER, flags, &tinfo, NULL, &activate, &count);
+    /*hr = MFTEnum(
+            MFT_CATEGORY_DEMULTIPLEXER,
+            flags,                  // Reserved
+            NULL,             // Input type to match. (Encoded type.)
+            NULL,               // Output type to match. (Don't care.)
+            &pDecoderCLSIDs,    // Receives a pointer to an array of CLSIDs.
+            &cDecoderCLSIDs     // Receives the size of the array.
+            ));*/
+
+    std::wfstream out(L"MFT.txt", std::ios_base::out | std::ios_base::trunc);
+
+    if (SUCCEEDED(hr) )
+    {
+        out << "Success, count: " << count << std::endl;
+			for (int i = 0; i < count; ++i)
+			{
+				UINT32 l = 0;
+				UINT32 l1 = 0;
+				activate[i]->GetStringLength(MFT_FRIENDLY_NAME_Attribute, &l);
+				std::unique_ptr<wchar_t[]> name(new wchar_t[l + 1]);
+				memset(name.get(), 0, l + 1);
+				hr = activate[i]->GetString(MFT_FRIENDLY_NAME_Attribute, name.get(), l + 1, &l1);
+				out << name.get() << std::endl;
+				activate[i]->Release();
+			}
+			//CoTaskMemFree(activate);
+    } else {
+        out <<HRESULT_CODE(hr);
+    }
+
+}
+
+MFPDemuxDataProvider::~MFPDemuxDataProvider() {
+    if (reader) {
+        reader->Release();
+        reader = nullptr;
+    }
+
+    if (source_ptr) {
+        source_ptr->Shutdown();
+        source_ptr = nullptr;
+    }
+
+    (void)MFShutdown();
+}
+
+size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_data) {
+    if (empty()) {
+        return 0;
+    }
+    DWORD       dwFlags = 0;
+    BYTE        *pBitmapData = NULL;    // Bitmap data
+    DWORD       cbBitmapData = 0;       // Size of data, in bytes
+    IMFMediaBuffer *pBuffer = 0;
+    IMFSample *pSample = NULL;
+
+    HRESULT     hr = S_OK;
+    hr = reader->ReadSample(
+            (DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+            0,
+            NULL,
+            &dwFlags,
+            NULL,
+            &pSample
+            );
+
+    if (FAILED(hr)) {
+        throw DataProviderSystemErrorException (HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - cannot ReadSample");
+    }
+
+    if (dwFlags & MF_SOURCE_READERF_ENDOFSTREAM)
+    {
+        reader->Release();
+        reader = nullptr;
+    }
+
+    if (dwFlags & MF_SOURCE_READERF_CURRENTMEDIATYPECHANGED)
+    {
+        // Type change. Get the new format.
+        //hr = GetVideoFormat(&m_format);
+        throw DataProviderSystemErrorException (HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - TODO");
+    }
+
+    if (pSample == NULL)
+    {
+        throw DataProviderSystemErrorException (HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - sample is NULL");
+    }
+
+    // We got a sample. Hold onto it.
+    pSample->AddRef();
+
+    hr = pSample->ConvertToContiguousBuffer(&pBuffer);
+
+    if (FAILED(hr))
+    {
+        throw DataProviderSystemErrorException (HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - ConvertToContiguousBuffer failed");
+    }
+
+    hr = pBuffer->Lock(&pBitmapData, NULL, &cbBitmapData);
+    if (FAILED(hr))
+    {
+        throw DataProviderSystemErrorException (HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - canno Lock buffer");
+    }
+
+    if (pBitmapData)
+    {
+        memcpy(out_data, pBitmapData, std::min<size_t>(cbBitmapData, out_data_bytes_size));
+        pBuffer->Unlock();
+    }
+    pBuffer->Release();
+    pSample->Release();
+    return cbBitmapData;
+}
+
+bool MFPDemuxDataProvider::empty() const {
+    return !reader;
+}
+} // namespace onevpl
+} // namespace wip
+} // namespace gapi
+} // namespace cv

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -391,7 +391,8 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) :
         ComPtrGuard<IMFMediaType> media_type = createCOMPtrGuard(media_type_tmp);
         GUID subtype;
         if (SUCCEEDED(media_type->GetGUID(MF_MT_SUBTYPE, &subtype))) {
-            GAPI_LOG_DEBUG(nullptr, " video type:" << GetGUIDNameConst(subtype));
+            GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                                    "video type: " << GetGUIDNameConst(subtype));
 
             std::string is_codec_supported("unsupported, skip...");
             try {

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -33,7 +33,7 @@ namespace gapi {
 namespace wip {
 namespace onevpl {
 #ifdef _WIN32
-HRESULT create_media_source(const std::string& url, IMFMediaSource **ppSource) {
+static HRESULT create_media_source(const std::string& url, IMFMediaSource **ppSource) {
     wchar_t sURL[MAX_PATH];
     GAPI_Assert(url.size() < MAX_PATH && "Windows MAX_PATH limit was exceeded");
     size_t ret_url_lenght = 0;
@@ -106,7 +106,7 @@ HRESULT create_media_source(const std::string& url, IMFMediaSource **ppSource) {
 #define IF_EQUAL_RETURN(param, val) if(val == param) return #val
 #endif
 
-const char* GetGUIDNameConst(const GUID& guid)
+static const char* GetGUIDNameConst(const GUID& guid)
 {
     IF_EQUAL_RETURN(guid, MF_MT_MAJOR_TYPE);
     IF_EQUAL_RETURN(guid, MF_MT_MAJOR_TYPE);
@@ -261,7 +261,7 @@ const char* GetGUIDNameConst(const GUID& guid)
     return "<unknown>";
 }
 
-IDataProvider::CodecID convert_to_CodecId(const GUID& guid) {
+static IDataProvider::CodecID convert_to_CodecId(const GUID& guid) {
     if (guid== MFVideoFormat_H264) {
         return IDataProvider::CodecID::AVC;
     } else if (guid == MFVideoFormat_H265 ||

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.cpp
@@ -4,9 +4,10 @@
 //
 // Copyright (C) 2021 Intel Corporation
 #ifdef HAVE_ONEVPL
-#ifdef _WIN32
 #include <errno.h>
-#include <atlstr.h>
+#ifdef _WIN32
+#define NOMINMAX
+#include <atlstr.h> //TODO If you see it then put comment to remove it, please
 
 #include <mfapi.h>
 #include <mfidl.h>
@@ -17,6 +18,7 @@
 #include <mferror.h>
 #include <wmcontainer.h>
 #include <wmcodecdsp.h>
+#undef NOMINMAX
 
 #pragma comment(lib,"Mf.lib")
 #pragma comment(lib,"Mfuuid.lib")
@@ -94,7 +96,193 @@ HRESULT CreateMediaSource(const std::string& url, IMFMediaSource **ppSource) {
     return hr;
 }
 
-MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
+/*
+ * The next part of converting GUID into string was copied and modified from
+ * https://docs.microsoft.com/en-us/windows/win32/medfound/media-type-debugging-code
+ */
+#ifndef IF_EQUAL_RETURN
+#define IF_EQUAL_RETURN(param, val) if(val == param) return #val
+#endif
+
+const char* GetGUIDNameConst(const GUID& guid)
+{
+    IF_EQUAL_RETURN(guid, MF_MT_MAJOR_TYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_MAJOR_TYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_SUBTYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_ALL_SAMPLES_INDEPENDENT);
+    IF_EQUAL_RETURN(guid, MF_MT_FIXED_SIZE_SAMPLES);
+    IF_EQUAL_RETURN(guid, MF_MT_COMPRESSED);
+    IF_EQUAL_RETURN(guid, MF_MT_SAMPLE_SIZE);
+    IF_EQUAL_RETURN(guid, MF_MT_WRAPPED_TYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_NUM_CHANNELS);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_SAMPLES_PER_SECOND);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_FLOAT_SAMPLES_PER_SECOND);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_AVG_BYTES_PER_SECOND);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_BLOCK_ALIGNMENT);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_BITS_PER_SAMPLE);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_VALID_BITS_PER_SAMPLE);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_SAMPLES_PER_BLOCK);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_CHANNEL_MASK);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_FOLDDOWN_MATRIX);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_WMADRC_PEAKREF);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_WMADRC_PEAKTARGET);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_WMADRC_AVGREF);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_WMADRC_AVGTARGET);
+    IF_EQUAL_RETURN(guid, MF_MT_AUDIO_PREFER_WAVEFORMATEX);
+    IF_EQUAL_RETURN(guid, MF_MT_AAC_PAYLOAD_TYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_AAC_AUDIO_PROFILE_LEVEL_INDICATION);
+    IF_EQUAL_RETURN(guid, MF_MT_FRAME_SIZE);
+    IF_EQUAL_RETURN(guid, MF_MT_FRAME_RATE);
+    IF_EQUAL_RETURN(guid, MF_MT_FRAME_RATE_RANGE_MAX);
+    IF_EQUAL_RETURN(guid, MF_MT_FRAME_RATE_RANGE_MIN);
+    IF_EQUAL_RETURN(guid, MF_MT_PIXEL_ASPECT_RATIO);
+    IF_EQUAL_RETURN(guid, MF_MT_DRM_FLAGS);
+    IF_EQUAL_RETURN(guid, MF_MT_PAD_CONTROL_FLAGS);
+    IF_EQUAL_RETURN(guid, MF_MT_SOURCE_CONTENT_HINT);
+    IF_EQUAL_RETURN(guid, MF_MT_VIDEO_CHROMA_SITING);
+    IF_EQUAL_RETURN(guid, MF_MT_INTERLACE_MODE);
+    IF_EQUAL_RETURN(guid, MF_MT_TRANSFER_FUNCTION);
+    IF_EQUAL_RETURN(guid, MF_MT_VIDEO_PRIMARIES);
+    IF_EQUAL_RETURN(guid, MF_MT_CUSTOM_VIDEO_PRIMARIES);
+    IF_EQUAL_RETURN(guid, MF_MT_YUV_MATRIX);
+    IF_EQUAL_RETURN(guid, MF_MT_VIDEO_LIGHTING);
+    IF_EQUAL_RETURN(guid, MF_MT_VIDEO_NOMINAL_RANGE);
+    IF_EQUAL_RETURN(guid, MF_MT_GEOMETRIC_APERTURE);
+    IF_EQUAL_RETURN(guid, MF_MT_MINIMUM_DISPLAY_APERTURE);
+    IF_EQUAL_RETURN(guid, MF_MT_PAN_SCAN_APERTURE);
+    IF_EQUAL_RETURN(guid, MF_MT_PAN_SCAN_ENABLED);
+    IF_EQUAL_RETURN(guid, MF_MT_AVG_BITRATE);
+    IF_EQUAL_RETURN(guid, MF_MT_AVG_BIT_ERROR_RATE);
+    IF_EQUAL_RETURN(guid, MF_MT_MAX_KEYFRAME_SPACING);
+    IF_EQUAL_RETURN(guid, MF_MT_DEFAULT_STRIDE);
+    IF_EQUAL_RETURN(guid, MF_MT_PALETTE);
+    IF_EQUAL_RETURN(guid, MF_MT_USER_DATA);
+    IF_EQUAL_RETURN(guid, MF_MT_AM_FORMAT_TYPE);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG_START_TIME_CODE);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG2_PROFILE);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG2_LEVEL);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG2_FLAGS);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG_SEQUENCE_HEADER);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_AAUX_SRC_PACK_0);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_AAUX_CTRL_PACK_0);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_AAUX_SRC_PACK_1);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_AAUX_CTRL_PACK_1);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_VAUX_SRC_PACK);
+    IF_EQUAL_RETURN(guid, MF_MT_DV_VAUX_CTRL_PACK);
+    IF_EQUAL_RETURN(guid, MF_MT_ARBITRARY_HEADER);
+    IF_EQUAL_RETURN(guid, MF_MT_ARBITRARY_FORMAT);
+    IF_EQUAL_RETURN(guid, MF_MT_IMAGE_LOSS_TOLERANT);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG4_SAMPLE_DESCRIPTION);
+    IF_EQUAL_RETURN(guid, MF_MT_MPEG4_CURRENT_SAMPLE_ENTRY);
+    IF_EQUAL_RETURN(guid, MF_MT_ORIGINAL_4CC);
+    IF_EQUAL_RETURN(guid, MF_MT_ORIGINAL_WAVE_FORMAT_TAG);
+
+    // Media types
+
+    IF_EQUAL_RETURN(guid, MFMediaType_Audio);
+    IF_EQUAL_RETURN(guid, MFMediaType_Video);
+    IF_EQUAL_RETURN(guid, MFMediaType_Protected);
+    IF_EQUAL_RETURN(guid, MFMediaType_SAMI);
+    IF_EQUAL_RETURN(guid, MFMediaType_Script);
+    IF_EQUAL_RETURN(guid, MFMediaType_Image);
+    IF_EQUAL_RETURN(guid, MFMediaType_HTML);
+    IF_EQUAL_RETURN(guid, MFMediaType_Binary);
+    IF_EQUAL_RETURN(guid, MFMediaType_FileTransfer);
+
+    IF_EQUAL_RETURN(guid, MFVideoFormat_AI44); //     FCC('AI44')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_ARGB32); //   D3DFMT_A8R8G8B8
+    IF_EQUAL_RETURN(guid, MFVideoFormat_AV1);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_AYUV); //     FCC('AYUV')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_DV25); //     FCC('dv25')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_DV50); //     FCC('dv50')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_DVH1); //     FCC('dvh1')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_DVSD); //     FCC('dvsd')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_DVSL); //     FCC('dvsl')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_H264); //     FCC('H264')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_H265);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_HEVC);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_HEVC_ES);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_I420); //     FCC('I420')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_IYUV); //     FCC('IYUV')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_M4S2); //     FCC('M4S2')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MJPG);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MP43); //     FCC('MP43')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MP4S); //     FCC('MP4S')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MP4V); //     FCC('MP4V')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MPG1); //     FCC('MPG1')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MSS1); //     FCC('MSS1')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_MSS2); //     FCC('MSS2')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_NV11); //     FCC('NV11')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_NV12); //     FCC('NV12')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_P010); //     FCC('P010')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_P016); //     FCC('P016')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_P210); //     FCC('P210')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_P216); //     FCC('P216')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_RGB24); //    D3DFMT_R8G8B8
+    IF_EQUAL_RETURN(guid, MFVideoFormat_RGB32); //    D3DFMT_X8R8G8B8
+    IF_EQUAL_RETURN(guid, MFVideoFormat_RGB555); //   D3DFMT_X1R5G5B5
+    IF_EQUAL_RETURN(guid, MFVideoFormat_RGB565); //   D3DFMT_R5G6B5
+    IF_EQUAL_RETURN(guid, MFVideoFormat_RGB8);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_UYVY); //     FCC('UYVY')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_v210); //     FCC('v210')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_v410); //     FCC('v410')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_WMV1); //     FCC('WMV1')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_WMV2); //     FCC('WMV2')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_WMV3); //     FCC('WMV3')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_WVC1); //     FCC('WVC1')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_VP90);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y210); //     FCC('Y210')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y216); //     FCC('Y216')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y410); //     FCC('Y410')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y416); //     FCC('Y416')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y41P);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_Y41T);
+    IF_EQUAL_RETURN(guid, MFVideoFormat_YUY2); //     FCC('YUY2')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_YV12); //     FCC('YV12')
+    IF_EQUAL_RETURN(guid, MFVideoFormat_YVYU);
+
+    IF_EQUAL_RETURN(guid, MFAudioFormat_PCM); //              WAVE_FORMAT_PCM
+    IF_EQUAL_RETURN(guid, MFAudioFormat_Float); //            WAVE_FORMAT_IEEE_FLOAT
+    IF_EQUAL_RETURN(guid, MFAudioFormat_DTS); //              WAVE_FORMAT_DTS
+    IF_EQUAL_RETURN(guid, MFAudioFormat_Dolby_AC3_SPDIF); //  WAVE_FORMAT_DOLBY_AC3_SPDIF
+    IF_EQUAL_RETURN(guid, MFAudioFormat_DRM); //              WAVE_FORMAT_DRM
+    IF_EQUAL_RETURN(guid, MFAudioFormat_WMAudioV8); //        WAVE_FORMAT_WMAUDIO2
+    IF_EQUAL_RETURN(guid, MFAudioFormat_WMAudioV9); //        WAVE_FORMAT_WMAUDIO3
+    IF_EQUAL_RETURN(guid, MFAudioFormat_WMAudio_Lossless); // WAVE_FORMAT_WMAUDIO_LOSSLESS
+    IF_EQUAL_RETURN(guid, MFAudioFormat_WMASPDIF); //         WAVE_FORMAT_WMASPDIF
+    IF_EQUAL_RETURN(guid, MFAudioFormat_MSP1); //             WAVE_FORMAT_WMAVOICE9
+    IF_EQUAL_RETURN(guid, MFAudioFormat_MP3); //              WAVE_FORMAT_MPEGLAYER3
+    IF_EQUAL_RETURN(guid, MFAudioFormat_MPEG); //             WAVE_FORMAT_MPEG
+    IF_EQUAL_RETURN(guid, MFAudioFormat_AAC); //              WAVE_FORMAT_MPEG_HEAAC
+    IF_EQUAL_RETURN(guid, MFAudioFormat_ADTS); //             WAVE_FORMAT_MPEG_ADTS_AAC
+
+    return NULL;
+}
+
+IDataProvider::CodecID convert_to_CodecId(const GUID& guid) {
+    if (guid== MFVideoFormat_H264) {
+        return IDataProvider::CodecID::AVC;
+    } else if (guid == MFVideoFormat_H265 ||
+               guid == MFVideoFormat_HEVC ||
+               guid == MFVideoFormat_HEVC_ES) {
+        return IDataProvider::CodecID::HEVC;
+    } else if (guid == MFAudioFormat_MPEG) {
+        return IDataProvider::CodecID::MPEG2;
+    } else if (guid == MFVideoFormat_WVC1) {
+        return IDataProvider::CodecID::VC1;
+    } else if (guid == MFVideoFormat_VP90) {
+        return IDataProvider::CodecID::VP9;
+    } else if (guid == MFVideoFormat_AV1) {
+        return IDataProvider::CodecID::AV1;
+    } else if (guid == MFVideoFormat_MJPG) {
+        return IDataProvider::CodecID::JPEG;
+    }
+    throw std::runtime_error(std::string("unsupported codec type: ") +
+                             GetGUIDNameConst(guid));
+}
+
+MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) :
+codec(CodecID::UNCOMPRESSED) {
     HRESULT hr = S_OK;
     hr = MFStartup(MF_VERSION);
     if (FAILED(hr)) {
@@ -102,18 +290,16 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
     }
 
     source_ptr = nullptr;
-    GAPI_LOG_INFO(nullptr, "IDataProvider: " << this <<
-                            " - initializing, URI " << file_path);
+    GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                           " initializing, URI " << file_path);
     hr = CreateMediaSource(file_path, &source_ptr);
     if (FAILED(hr)) {
         throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot create IMFMediaSource");
     }
 
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - start creating source attributes");
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            " start creating source attributes");
     IMFAttributes *pAttributes = nullptr;
-    IMFMediaType *pType = nullptr;
-
     hr = MFCreateAttributes(&pAttributes, 2);
 
     if (FAILED(hr)) {
@@ -131,8 +317,8 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
             );
     }*/
 
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - is getting presentation description");
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "is getting presentation description");
     IMFPresentationDescriptor* descriptor = nullptr;
     hr = source_ptr->CreatePresentationDescriptor(&descriptor);
     if (FAILED(hr)) {
@@ -144,20 +330,67 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
     DWORD stream_count = 0;
     BOOL is_stream_selected = false;
     descriptor->GetStreamDescriptorCount(&stream_count);
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - received stream count: " << stream_count);
-    for( DWORD stream_index = 0; stream_index < stream_count; stream_index++) {
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "received stream count: " << stream_count);
+    for (DWORD stream_index = 0;
+        stream_index < stream_count && !is_stream_selected; stream_index++) {
         IMFStreamDescriptor *stream_descriptor = nullptr;
         descriptor->GetStreamDescriptorByIndex(stream_index, &is_stream_selected,
                                                &stream_descriptor);
+
+        is_stream_selected = false; // deselect until find supported stream
+        IMFMediaTypeHandler *handler = nullptr;
+        stream_descriptor->GetMediaTypeHandler(&handler);
+        if (handler) {
+            GUID guidMajorType;
+            if (SUCCEEDED(handler->GetMajorType(&guidMajorType))) {
+
+                if (MFMediaType_Video == guidMajorType) {
+                    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                                            "video stream detected by index: " << stream_index);
+                    IMFMediaType *pMediaType = nullptr;
+                    handler->GetCurrentMediaType(&pMediaType);
+                    if (pMediaType) {
+                        GUID subtype;
+                        if (SUCCEEDED(pMediaType->GetGUID(MF_MT_SUBTYPE, &subtype))) {
+                            GAPI_LOG_DEBUG(nullptr, " video type:" << GetGUIDNameConst(subtype));
+
+                            std::string is_codec_supported("unsupported, skip...");
+                            try {
+                                codec = convert_to_CodecId(subtype);
+                                is_stream_selected = true;
+                                is_codec_supported = "selected!";
+                            } catch (...) {
+                            }
+
+                            GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                                          " by URI: " << file_path <<
+                                          ", video stream index: " << stream_index <<
+                                          ", codec: " << GetGUIDNameConst(subtype) <<
+                                          " - " << is_codec_supported)
+                        }
+                        pMediaType->Release();
+                        pMediaType = nullptr;
+                    }
+                }
+            }
+            handler->Release();
+            handler = nullptr;
+        }
+        stream_descriptor->Release();
     }
     if (descriptor) {
         descriptor->Release();
         descriptor = nullptr;
     }
 
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - is creating media source");
+    if (!is_stream_selected) {
+        GAPI_LOG_INFO(nullptr, "[" << this << "] couldn't select video stream with supported params");
+        throw DataProviderUnsupportedException("couldn't find supported video stream");
+    }
+
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "is creating media source");
     reader = nullptr;
     hr = MFCreateSourceReaderFromMediaSource(source_ptr, pAttributes,
                                              &reader);
@@ -165,40 +398,8 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
         throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot create MFCreateSourceReaderFromMediaSource");
     }
 
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - created IMFSourceReader: " << reader);
-    // Try to find a suitable output type.
-    if (SUCCEEDED(hr)) {
-        for (DWORD i = 0; ; i++) {
-            hr = reader->GetNativeMediaType(
-                (DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
-                i,
-                &pType
-                );
-
-            if (FAILED(hr)) { break; }
-
-            /////////////////////
-            BOOL bFound = FALSE;
-            GUID subtype = { 0 };
-
-            hr = pType->GetGUID(MF_MT_SUBTYPE, &subtype);
-
-            if (FAILED(hr)) {
-                break;
-            }
-            /////////////////////
-
-
-            pType->Release();
-            pType = nullptr;
-
-            if (SUCCEEDED(hr)) {
-                // Found an output type.
-                break;
-            }
-        }
-    }
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "created IMFSourceReader: " << reader);
 
     if (SUCCEEDED(hr)) {
         // Ask for the first sample.
@@ -213,13 +414,13 @@ MFPDemuxDataProvider::MFPDemuxDataProvider(const std::string& file_path) {
     } else {
         throw DataProviderSystemErrorException(HRESULT_CODE(hr), "Cannot ReadSample");
     }
-    GAPI_LOG_INFO(nullptr, "IDataProvider: " << this <<
-                            " - initialized");
+    GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                            "initialized");
 }
 
 MFPDemuxDataProvider::~MFPDemuxDataProvider() {
-    GAPI_LOG_INFO(nullptr, "IDataProvider: " << this <<
-                            " - deinitializing");
+    GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                            "deinitializing");
     if (reader) {
         reader->Release();
         reader = nullptr;
@@ -231,8 +432,12 @@ MFPDemuxDataProvider::~MFPDemuxDataProvider() {
     }
 
     (void)MFShutdown();
-    GAPI_LOG_INFO(nullptr, "IDataProvider: " << this <<
-                            " - deinitialized");
+    GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                           "deinitialized");
+}
+
+MFPDemuxDataProvider::CodecID MFPDemuxDataProvider::get_codec() const {
+    return codec;
 }
 
 size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_data) {
@@ -240,8 +445,8 @@ size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_da
         return 0;
     }
 
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - dst bytes count: " << out_data_bytes_size <<
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "dst bytes count: " << out_data_bytes_size <<
                             ", dst: " << out_data);
 
     BYTE *mapped_buffer_data = nullptr;
@@ -252,8 +457,8 @@ size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_da
 
     HRESULT hr = S_OK;
     do {
-        GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - retrieve sample from source");
+        GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                                "retrieve sample from source");
         hr = reader->ReadSample((DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
                                 0,
                                 nullptr,
@@ -266,8 +471,7 @@ size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_da
         }
 
         if (retrieved_stream_flag & MF_SOURCE_READERF_ENDOFSTREAM) {
-            GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - EOF");
+            GAPI_LOG_DEBUG(nullptr, "[" << this << "] EOF");
             reader->Release();
             reader = nullptr;
         }
@@ -275,16 +479,16 @@ size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_da
         if (retrieved_stream_flag & MF_SOURCE_READERF_CURRENTMEDIATYPECHANGED){
             // Type change. Get the new format.
             //hr = GetVideoFormat(&m_format);
-            GAPI_LOG_WARNING(nullptr, "IDataProvider: " << this <<
-                            " - Media type changing is UNSUPPORTED");
+            GAPI_LOG_WARNING(nullptr, "[" << this << "] " <<
+                                      "media type changing is UNSUPPORTED");
             throw DataProviderSystemErrorException(HRESULT_CODE(hr), "MFPDemuxDataProvider::fetch_data - TODO");
         }
     }
     while (!retrieved_sample && !empty());
 
     if (retrieved_sample) {
-        GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                                " - sample retrieved");
+        GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                                "sample retrieved");
 
         retrieved_sample->AddRef();
         hr = retrieved_sample->ConvertToContiguousBuffer(&contiguous_buffer);
@@ -300,16 +504,17 @@ size_t MFPDemuxDataProvider::fetch_data(size_t out_data_bytes_size, void* out_da
 
         if (mapped_buffer_data)
         {
-            GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - fetch buffer from mapped data with size: " << mapped_buffer_size);
+            GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                           "fetch buffer from mapped data with size: " <<
+                           mapped_buffer_size);
             memcpy(out_data, mapped_buffer_data, std::min<size_t>(mapped_buffer_size, out_data_bytes_size));
             contiguous_buffer->Unlock();
         }
         contiguous_buffer->Release();
         retrieved_sample->Release();
     }
-    GAPI_LOG_DEBUG(nullptr, "IDataProvider: " << this <<
-                            " - bytes fetched: " << mapped_buffer_size);
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "bytes fetched: " << mapped_buffer_size);
     return mapped_buffer_size;
 }
 

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
@@ -8,24 +8,27 @@
 #define GAPI_STREAMING_ONEVPL_DEMUX_MFP_DATA_PROVIDER_HPP
 #include <stdio.h>
 
+#ifdef HAVE_ONEVPL
+#ifdef _WIN32
+#define NOMINMAX
+#include <atlbase.h>
+#undef NOMINMAX
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
 
-class IMFMediaSource;
-class IMFSourceReader;
+struct IMFMediaSource;
+struct IMFSourceReader;
+
 namespace cv {
 namespace gapi {
 namespace wip {
 namespace onevpl {
 struct GAPI_EXPORTS MFPDemuxDataProvider : public IDataProvider {
-
-    using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
     MFPDemuxDataProvider(const std::string& file_path);
     ~MFPDemuxDataProvider();
 
     size_t fetch_data(size_t out_data_bytes_size, void* out_data) override;
     bool empty() const override;
 private:
-    file_ptr source_handle;
     IMFMediaSource *source_ptr;
     IMFSourceReader *reader;
 };
@@ -34,4 +37,21 @@ private:
 } // namespace gapi
 } // namespace cv
 
+#else // _WIN32
+namespace cv {
+namespace gapi {
+namespace wip {
+namespace onevpl {
+struct GAPI_EXPORTS MFPDemuxDataProvider : public IDataProvider {
+    MFPDemuxDataProvider(const std::string&);
+    size_t fetch_data(size_t, void*) override;
+    bool empty() const override;
+};
+} // namespace onevpl
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // _WIN32
+#endif // HAVE_ONEVPL
 #endif // GAPI_STREAMING_ONEVPL_DEMUX_MFP_DATA_PROVIDER_HPP

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
@@ -14,6 +14,7 @@
 #include <atlbase.h>
 #undef NOMINMAX
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
+#include "streaming/onevpl/utils.hpp"
 
 struct IMFMediaSource;
 struct IMFSourceReader;
@@ -30,8 +31,8 @@ struct GAPI_EXPORTS MFPDemuxDataProvider : public IDataProvider {
     size_t fetch_data(size_t out_data_bytes_size, void* out_data) override;
     bool empty() const override;
 private:
-    IMFMediaSource *source_ptr;
-    IMFSourceReader *reader;
+    ComPtrGuard<IMFMediaSource> source;
+    ComPtrGuard<IMFSourceReader> source_reader;
 
     CodecID codec;
 };

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
@@ -1,0 +1,37 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifndef GAPI_STREAMING_ONEVPL_DEMUX_MFP_DATA_PROVIDER_HPP
+#define GAPI_STREAMING_ONEVPL_DEMUX_MFP_DATA_PROVIDER_HPP
+#include <stdio.h>
+
+#include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
+
+class IMFMediaSource;
+class IMFSourceReader;
+namespace cv {
+namespace gapi {
+namespace wip {
+namespace onevpl {
+struct GAPI_EXPORTS MFPDemuxDataProvider : public IDataProvider {
+
+    using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
+    MFPDemuxDataProvider(const std::string& file_path);
+    ~MFPDemuxDataProvider();
+
+    size_t fetch_data(size_t out_data_bytes_size, void* out_data) override;
+    bool empty() const override;
+private:
+    file_ptr source_handle;
+    IMFMediaSource *source_ptr;
+    IMFSourceReader *reader;
+};
+} // namespace onevpl
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // GAPI_STREAMING_ONEVPL_DEMUX_MFP_DATA_PROVIDER_HPP

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
@@ -26,11 +26,14 @@ struct GAPI_EXPORTS MFPDemuxDataProvider : public IDataProvider {
     MFPDemuxDataProvider(const std::string& file_path);
     ~MFPDemuxDataProvider();
 
+    CodecID get_codec() const override;
     size_t fetch_data(size_t out_data_bytes_size, void* out_data) override;
     bool empty() const override;
 private:
     IMFMediaSource *source_ptr;
     IMFSourceReader *reader;
+
+    CodecID codec;
 };
 } // namespace onevpl
 } // namespace wip

--- a/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/demux/mfp_demux_data_provider.hpp
@@ -10,9 +10,6 @@
 
 #ifdef HAVE_ONEVPL
 #ifdef _WIN32
-#define NOMINMAX
-#include <atlbase.h>
-#undef NOMINMAX
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
 #include "streaming/onevpl/utils.hpp"
 

--- a/modules/gapi/src/streaming/onevpl/engine/processing_engine_base.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/processing_engine_base.cpp
@@ -107,7 +107,8 @@ mfxStatus ReadEncodedStream(mfxBitstream &bs, std::shared_ptr<IDataProvider>& da
     if (!data_provider) {
         return MFX_ERR_MORE_DATA;
     }
-
+    GAPI_LOG_DEBUG(nullptr, "bitstream before fetch, DataOffset: " << bs.DataOffset <<
+                            ", DataLength: " << bs.DataLength);
     mfxU8 *p0 = bs.Data;
     mfxU8 *p1 = bs.Data + bs.DataOffset;
     if (bs.DataOffset > bs.MaxLength - 1) {
@@ -122,6 +123,8 @@ mfxStatus ReadEncodedStream(mfxBitstream &bs, std::shared_ptr<IDataProvider>& da
     bs.DataOffset = 0;
     bs.DataLength += static_cast<mfxU32>(data_provider->fetch_data(bs.MaxLength - bs.DataLength,
                                                                    bs.Data + bs.DataLength));
+    GAPI_LOG_DEBUG(nullptr, "bitstream after fetch, DataOffset: " << bs.DataOffset <<
+                            ", DataLength: " << bs.DataLength);
     if (bs.DataLength == 0)
         return MFX_ERR_MORE_DATA;
 

--- a/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
@@ -3,24 +3,88 @@
 // of this distribution and at http://opencv.org/license.html.
 //
 // Copyright (C) 2021 Intel Corporation
+
 #include <errno.h>
 
 #include "streaming/onevpl/file_data_provider.hpp"
+#include "streaming/onevpl/cfg_params_parser.hpp"
+#include "logger.hpp"
 
 namespace cv {
 namespace gapi {
 namespace wip {
 namespace onevpl {
 
-FileDataProvider::FileDataProvider(const std::string& file_path) :
-    source_handle(fopen(file_path.c_str(), "rb"), &fclose) {
+#ifdef HAVE_ONEVPL
+FileDataProvider::FileDataProvider(const std::string& file_path,
+                                   const std::vector<CfgParam> codec_params) :
+    source_handle(nullptr, &fclose) {
+
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "check codec Id from CfgParam, total param count: " <<
+                            codec_params.size());
+    auto codec_it =
+        std::find_if(codec_params.begin(), codec_params.end(), [] (const CfgParam& value) {
+            return value.get_name() == "mfxImplDescription.mfxDecoderDescription.decoder.CodecID";
+        });
+    if (codec_it == codec_params.end())
+    {
+        GAPI_LOG_WARNING(nullptr, "[" << this << "] " <<
+                                  "\"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\" "
+                                  "is absent, total param count" << codec_params.size());
+        return;
+    }
+
+    mfxVariant requested_codec = cfg_param_to_mfx_variant(*codec_it);
+    switch(requested_codec.Data.U32) {
+        case MFX_CODEC_AVC:
+            codec = IDataProvider::CodecID::AVC;
+            break;
+        case MFX_CODEC_HEVC:
+            codec = IDataProvider::CodecID::HEVC;
+            break;
+        case MFX_CODEC_MPEG2:
+            codec = IDataProvider::CodecID::MPEG2;
+            break;
+        case MFX_CODEC_VC1:
+            codec = IDataProvider::CodecID::AVC;
+            break;
+        case MFX_CODEC_VP9:
+            codec = IDataProvider::CodecID::VP9;
+            break;
+        case MFX_CODEC_AV1:
+            codec = IDataProvider::CodecID::AV1;
+            break;
+        case MFX_CODEC_JPEG:
+            codec = IDataProvider::CodecID::JPEG;
+            break;
+        default:
+            GAPI_LOG_WARNING(nullptr, "[" << this << "] " <<
+                                      "unsupported CodecId requested: " << requested_codec.Data.U32 <<
+                                      " check CfgParam \"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\"");
+            throw DataProviderUnsupportedException{
+                "unsupported \"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\""
+                " requested for demultiplexed raw data"
+            };
+    }
+
+    GAPI_LOG_DEBUG(nullptr, "[" << this << "] " <<
+                            "opening file: " << file_path);
+    source_handle.reset(fopen(file_path.c_str(), "rb"));
     if (!source_handle) {
         throw DataProviderSystemErrorException(errno,
                                                "FileDataProvider: cannot open source file: " + file_path);
     }
+
+    GAPI_LOG_INFO(nullptr, "[" << this << "] " <<
+                            "file: " << file_path << " opened, codec requested: " << to_cstr(codec));
 }
 
 FileDataProvider::~FileDataProvider() = default;
+
+FileDataProvider::CodecID FileDataProvider::get_codec() const {
+    return codec;
+}
 
 size_t FileDataProvider::fetch_data(size_t out_data_bytes_size, void* out_data) {
     if (empty()) {
@@ -41,6 +105,29 @@ size_t FileDataProvider::fetch_data(size_t out_data_bytes_size, void* out_data) 
 bool FileDataProvider::empty() const {
     return !source_handle;
 }
+
+#else
+
+FileDataProvider::FileDataProvider(const std::string&,
+                                   const std::vector<CfgParam>) :
+    source_handle(nullptr, &fclose) {
+    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+}
+
+FileDataProvider::~FileDataProvider() = default;
+
+FileDataProvider::CodecID FileDataProvider::get_codec() const {
+    return codec;
+}
+
+size_t FileDataProvider::fetch_data(size_t, void*) {
+    return 0;
+}
+
+bool FileDataProvider::empty() const {
+    return true;
+}
+#endif // HAVE_ONEVPL
 } // namespace onevpl
 } // namespace wip
 } // namespace gapi

--- a/modules/gapi/src/streaming/onevpl/file_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/file_data_provider.hpp
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
+#include <opencv2/gapi/streaming/onevpl/cfg_params.hpp>
 
 namespace cv {
 namespace gapi {
@@ -17,13 +18,16 @@ namespace onevpl {
 struct FileDataProvider : public IDataProvider {
 
     using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
-    FileDataProvider(const std::string& file_path);
+    FileDataProvider(const std::string& file_path,
+                     const std::vector<CfgParam> codec_params = {});
     ~FileDataProvider();
 
+    CodecID get_codec() const override;
     size_t fetch_data(size_t out_data_bytes_size, void* out_data) override;
     bool empty() const override;
 private:
     file_ptr source_handle;
+    CodecID codec;
 };
 } // namespace onevpl
 } // namespace wip

--- a/modules/gapi/src/streaming/onevpl/source.cpp
+++ b/modules/gapi/src/streaming/onevpl/source.cpp
@@ -37,8 +37,8 @@ GSource::GSource(const std::string& filePath,
 GSource::GSource(const std::string& filePath,
                  const CfgParams& cfg_params,
                  std::shared_ptr<IDeviceSelector> selector) :
-    GSource(std::make_shared<MFPDemuxDataProvider>(filePath), cfg_params, selector) {
-    //GSource(std::make_shared<FileDataProvider>(filePath), cfg_params, selector) {
+    //GSource(std::make_shared<MFPDemuxDataProvider>(filePath), cfg_params, selector) {
+    GSource(std::make_shared<FileDataProvider>(filePath, cfg_params), cfg_params, selector) {
     if (filePath.empty()) {
         util::throw_error(std::logic_error("Cannot create 'GSource' on empty source file name"));
     }

--- a/modules/gapi/src/streaming/onevpl/source.cpp
+++ b/modules/gapi/src/streaming/onevpl/source.cpp
@@ -8,6 +8,7 @@
 
 #include "streaming/onevpl/source_priv.hpp"
 #include "streaming/onevpl/file_data_provider.hpp"
+#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
 #include "streaming/onevpl/cfg_param_device_selector.hpp"
 
 namespace cv {
@@ -36,7 +37,8 @@ GSource::GSource(const std::string& filePath,
 GSource::GSource(const std::string& filePath,
                  const CfgParams& cfg_params,
                  std::shared_ptr<IDeviceSelector> selector) :
-    GSource(std::make_shared<FileDataProvider>(filePath), cfg_params, selector) {
+    GSource(std::make_shared<MFPDemuxDataProvider>(filePath), cfg_params, selector) {
+    //GSource(std::make_shared<FileDataProvider>(filePath), cfg_params, selector) {
     if (filePath.empty()) {
         util::throw_error(std::logic_error("Cannot create 'GSource' on empty source file name"));
     }

--- a/modules/gapi/src/streaming/onevpl/source.cpp
+++ b/modules/gapi/src/streaming/onevpl/source.cpp
@@ -7,8 +7,7 @@
 #include <opencv2/gapi/streaming/onevpl/source.hpp>
 
 #include "streaming/onevpl/source_priv.hpp"
-#include "streaming/onevpl/file_data_provider.hpp"
-#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
+#include "streaming/onevpl/data_provider_dispatcher.hpp"
 #include "streaming/onevpl/cfg_param_device_selector.hpp"
 
 namespace cv {
@@ -37,8 +36,7 @@ GSource::GSource(const std::string& filePath,
 GSource::GSource(const std::string& filePath,
                  const CfgParams& cfg_params,
                  std::shared_ptr<IDeviceSelector> selector) :
-    //GSource(std::make_shared<MFPDemuxDataProvider>(filePath), cfg_params, selector) {
-    GSource(std::make_shared<FileDataProvider>(filePath, cfg_params), cfg_params, selector) {
+    GSource(DataProviderDispatcher::create(filePath, cfg_params), cfg_params, selector) {
     if (filePath.empty()) {
         util::throw_error(std::logic_error("Cannot create 'GSource' on empty source file name"));
     }

--- a/modules/gapi/src/streaming/onevpl/source_priv.cpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.cpp
@@ -273,6 +273,15 @@ DecoderParams GSource::Priv::create_decoder_from_file(const CfgParam& decoder_cf
         }
     } while (sts == MFX_ERR_MORE_DATA && !provider->empty());
 
+    if (MFX_ERR_NONE != sts) {
+        GAPI_LOG_WARNING(nullptr, "cannot decode header from provider: " << provider.get()
+                                  << ". Make sure data source is valid and/or "
+                                  "\"mfxImplDescription.mfxDecoderDescription.decoder.CodecID\""
+                                  " has correct value in case of demultiplexed raw input");
+         throw std::runtime_error("Error decode header, error: " +
+                                  mfxstatus_to_string(sts));
+    }
+
     // Input parameters finished, now initialize decode
     sts = MFXVideoDECODE_Init(mfx_session, &mfxDecParams);
     if (MFX_ERR_NONE != sts) {

--- a/modules/gapi/src/streaming/onevpl/source_priv.cpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.cpp
@@ -61,7 +61,7 @@ int codec_id_to_mfx(IDataProvider::CodecID codec) {
         case IDataProvider::CodecID::JPEG:
             return MFX_CODEC_JPEG;
         default:
-            GAPI_Assert(false, "Unsupported CodecId");
+            GAPI_Assert(false && "Unsupported CodecId");
     }
 }
 

--- a/modules/gapi/src/streaming/onevpl/source_priv.hpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.hpp
@@ -35,6 +35,8 @@ namespace onevpl {
 struct VPLAccelerationPolicy;
 class ProcessingEngineBase;
 
+int GAPI_EXPORTS codec_id_to_mfx(IDataProvider::CodecID codec);
+
 struct GSource::Priv
 {
     explicit Priv(std::shared_ptr<IDataProvider> provider,

--- a/modules/gapi/src/streaming/onevpl/source_priv.hpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.hpp
@@ -49,7 +49,7 @@ struct GSource::Priv
     GMetaArg descr_of() const;
 private:
     Priv();
-    DecoderParams create_decoder_from_file(const CfgParam& decoder,
+    DecoderParams create_decoder_from_file(uint32_t decoder_id,
                                            std::shared_ptr<IDataProvider> provider);
     std::unique_ptr<VPLAccelerationPolicy> initializeHWAccel();
 

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -290,6 +290,10 @@ struct StreamDataProvider : public cv::gapi::wip::onevpl::IDataProvider {
         EXPECT_TRUE(in);
     }
 
+    CodecID get_codec() const override {
+        return CodecID::HEVC;
+    }
+
     size_t fetch_data(size_t out_data_size, void* out_data_buf) override {
         data_stream.read(reinterpret_cast<char*>(out_data_buf), out_data_size);
         return (size_t)data_stream.gcount();
@@ -2266,7 +2270,7 @@ TEST(OneVPL_Source, Init)
     std::stringstream stream(std::ios_base::in | std::ios_base::out | std::ios_base::binary);
     EXPECT_TRUE(stream.write(reinterpret_cast<char*>(const_cast<unsigned char *>(hevc_header)),
                              sizeof(hevc_header)));
-    std::shared_ptr<cv::gapi::wip::onevpl::IDataProvider> stream_data_provider = std::make_shared<StreamDataProvider>(stream);
+    auto stream_data_provider = std::make_shared<StreamDataProvider>(stream);
 
     cv::Ptr<cv::gapi::wip::IStreamSource> cap;
     bool cap_created = false;

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -444,7 +444,7 @@ TEST(OneVPL_Source_ProcessingEngine, Init)
     engine.get_frame(frame);
 }
 
-TEST(OneVPL_Source_MFP, enumerate)
+TEST(OneVPL_Source_MFP, decode_header)
 {
     using namespace cv::gapi::wip::onevpl;
     MFPDemuxDataProvider provider("C:\\Users\\sivanov\\github\\opencv_extra\\testdata\\highgui\\video\\sample_322x242_15frames.yuv420p.libx264.mp4");

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -443,59 +443,6 @@ TEST(OneVPL_Source_ProcessingEngine, Init)
     cv::gapi::wip::Data frame;
     engine.get_frame(frame);
 }
-
-TEST(OneVPL_Source_MFP, decode_header)
-{
-    using namespace cv::gapi::wip::onevpl;
-    MFPDemuxDataProvider provider("C:\\Users\\sivanov\\github\\opencv_extra\\testdata\\highgui\\video\\sample_322x242_15frames.yuv420p.libx264.mp4");
-
-    mfxLoader mfx_handle = MFXLoad();
-
-    mfxConfig cfg_inst_0 = MFXCreateConfig(mfx_handle);
-    EXPECT_TRUE(cfg_inst_0);
-    mfxVariant mfx_param_0;
-    mfx_param_0.Type = MFX_VARIANT_TYPE_U32;
-    mfx_param_0.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
-    EXPECT_EQ(MFXSetConfigFilterProperty(cfg_inst_0,(mfxU8 *)"mfxImplDescription.Impl",
-                                                    mfx_param_0), MFX_ERR_NONE);
-
-    mfxConfig cfg_inst_1 = MFXCreateConfig(mfx_handle);
-    EXPECT_TRUE(cfg_inst_1);
-    mfxVariant mfx_param_1;
-    mfx_param_1.Type = MFX_VARIANT_TYPE_U32;
-    mfx_param_1.Data.U32 = MFX_CODEC_AVC;
-    EXPECT_EQ(MFXSetConfigFilterProperty(cfg_inst_1,(mfxU8 *)"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",
-                                                    mfx_param_1), MFX_ERR_NONE);
-
-    // create session
-    mfxSession mfx_session{};
-    mfxStatus sts = MFXCreateSession(mfx_handle, 0, &mfx_session);
-    EXPECT_EQ(MFX_ERR_NONE, sts);
-
-    // create proper bitstream
-    mfxBitstream bitstream{};
-    const int BITSTREAM_BUFFER_SIZE = 2000000;
-    bitstream.MaxLength = BITSTREAM_BUFFER_SIZE;
-    bitstream.Data = (mfxU8 *)calloc(bitstream.MaxLength, sizeof(mfxU8));
-    EXPECT_TRUE(bitstream.Data);
-
-    // simulate read stream
-    bitstream.DataOffset = 0;
-    bitstream.DataLength = BITSTREAM_BUFFER_SIZE;
-    bitstream.DataLength = provider.fetch_data(bitstream.DataLength, bitstream.Data);
-    bitstream.CodecId = MFX_CODEC_AVC;
-
-    // prepare dec params
-    mfxVideoParam mfxDecParams {};
-    mfxDecParams.mfx.CodecId = bitstream.CodecId;
-    mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
-    sts = MFXVideoDECODE_DecodeHeader(mfx_session, &bitstream, &mfxDecParams);
-    EXPECT_EQ(MFX_ERR_NONE, sts);
-    MFXVideoDECODE_Close(mfx_session);
-
-    MFXClose(mfx_session);
-    MFXUnload(mfx_handle);
-}
 }
 } // namespace opencv_test
 #endif // HAVE_ONEVPL

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -38,6 +38,8 @@
 #include "streaming/onevpl/engine/processing_engine_base.hpp"
 #include "streaming/onevpl/engine/engine_session.hpp"
 
+#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
+
 namespace opencv_test
 {
 namespace
@@ -440,6 +442,12 @@ TEST(OneVPL_Source_ProcessingEngine, Init)
 
     cv::gapi::wip::Data frame;
     engine.get_frame(frame);
+}
+
+TEST(OneVPL_Source_MFP, enumerate)
+{
+    cv::gapi::wip::onevpl::MFPDemuxDataProvider provider("C:\\Users\\sivanov\\github\\opencv_extra\\testdata\\highgui\\video\\big_buck_bunny.mp4");
+    (void) provider;
 }
 }
 } // namespace opencv_test

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_core_test.cpp
@@ -446,8 +446,55 @@ TEST(OneVPL_Source_ProcessingEngine, Init)
 
 TEST(OneVPL_Source_MFP, enumerate)
 {
-    cv::gapi::wip::onevpl::MFPDemuxDataProvider provider("C:\\Users\\sivanov\\github\\opencv_extra\\testdata\\highgui\\video\\big_buck_bunny.mp4");
-    (void) provider;
+    using namespace cv::gapi::wip::onevpl;
+    MFPDemuxDataProvider provider("C:\\Users\\sivanov\\github\\opencv_extra\\testdata\\highgui\\video\\sample_322x242_15frames.yuv420p.libx264.mp4");
+
+    mfxLoader mfx_handle = MFXLoad();
+
+    mfxConfig cfg_inst_0 = MFXCreateConfig(mfx_handle);
+    EXPECT_TRUE(cfg_inst_0);
+    mfxVariant mfx_param_0;
+    mfx_param_0.Type = MFX_VARIANT_TYPE_U32;
+    mfx_param_0.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
+    EXPECT_EQ(MFXSetConfigFilterProperty(cfg_inst_0,(mfxU8 *)"mfxImplDescription.Impl",
+                                                    mfx_param_0), MFX_ERR_NONE);
+
+    mfxConfig cfg_inst_1 = MFXCreateConfig(mfx_handle);
+    EXPECT_TRUE(cfg_inst_1);
+    mfxVariant mfx_param_1;
+    mfx_param_1.Type = MFX_VARIANT_TYPE_U32;
+    mfx_param_1.Data.U32 = MFX_CODEC_AVC;
+    EXPECT_EQ(MFXSetConfigFilterProperty(cfg_inst_1,(mfxU8 *)"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",
+                                                    mfx_param_1), MFX_ERR_NONE);
+
+    // create session
+    mfxSession mfx_session{};
+    mfxStatus sts = MFXCreateSession(mfx_handle, 0, &mfx_session);
+    EXPECT_EQ(MFX_ERR_NONE, sts);
+
+    // create proper bitstream
+    mfxBitstream bitstream{};
+    const int BITSTREAM_BUFFER_SIZE = 2000000;
+    bitstream.MaxLength = BITSTREAM_BUFFER_SIZE;
+    bitstream.Data = (mfxU8 *)calloc(bitstream.MaxLength, sizeof(mfxU8));
+    EXPECT_TRUE(bitstream.Data);
+
+    // simulate read stream
+    bitstream.DataOffset = 0;
+    bitstream.DataLength = BITSTREAM_BUFFER_SIZE;
+    bitstream.DataLength = provider.fetch_data(bitstream.DataLength, bitstream.Data);
+    bitstream.CodecId = MFX_CODEC_AVC;
+
+    // prepare dec params
+    mfxVideoParam mfxDecParams {};
+    mfxDecParams.mfx.CodecId = bitstream.CodecId;
+    mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
+    sts = MFXVideoDECODE_DecodeHeader(mfx_session, &bitstream, &mfxDecParams);
+    EXPECT_EQ(MFX_ERR_NONE, sts);
+    MFXVideoDECODE_Close(mfx_session);
+
+    MFXClose(mfx_session);
+    MFXUnload(mfx_handle);
 }
 }
 } // namespace opencv_test

--- a/modules/gapi/test/streaming/gapi_streaming_vpl_data_provider.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_vpl_data_provider.cpp
@@ -1,0 +1,127 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021 Intel Corporation
+
+#ifdef HAVE_ONEVPL
+
+#include "../test_precomp.hpp"
+
+#include "../common/gapi_tests_common.hpp"
+#include "streaming/onevpl/data_provider_dispatcher.hpp"
+#include "streaming/onevpl/file_data_provider.hpp"
+#include "streaming/onevpl/demux/mfp_demux_data_provider.hpp"
+#include "streaming/onevpl/source_priv.hpp"
+
+namespace opencv_test
+{
+namespace
+{
+using source_t = std::string;
+using valid_t = bool;
+using array_element_t = std::tuple<source_t, valid_t>;
+
+array_element_t files[] = {
+    array_element_t {"highgui/video/VID00003-20100701-2204.3GP", false},
+    array_element_t {"highgui/video/VID00003-20100701-2204.avi", false},
+    array_element_t {"highgui/video/VID00003-20100701-2204.mpg", false},
+    array_element_t {"highgui/video/VID00003-20100701-2204.wmv", false},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.libaom-av1.mp4", true},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.libvpx-vp9.mp4", true},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.libx264.avi", true},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.libx264.mp4", true},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.libx265.mp4", true},
+    array_element_t {"highgui/video/sample_322x242_15frames.yuv420p.mjpeg.mp4", true},
+    array_element_t {"highgui/video/big_buck_bunny.h264", false},
+    array_element_t {"highgui/video/big_buck_bunny.h265", false}
+};
+
+// Read encoded stream from file
+mfxStatus ReadEncodedStream(mfxBitstream &bs,
+                            cv::gapi::wip::onevpl::IDataProvider& data_provider) {
+    mfxU8 *p0 = bs.Data;
+    mfxU8 *p1 = bs.Data + bs.DataOffset;
+    if (bs.DataOffset > bs.MaxLength - 1) {
+        return MFX_ERR_NOT_ENOUGH_BUFFER;
+    }
+    if (bs.DataLength + bs.DataOffset > bs.MaxLength) {
+        return MFX_ERR_NOT_ENOUGH_BUFFER;
+    }
+
+    std::copy_n(p1, bs.DataLength, p0);
+
+    bs.DataOffset = 0;
+    bs.DataLength += static_cast<mfxU32>(data_provider.fetch_data(bs.MaxLength - bs.DataLength,
+                                                                   bs.Data + bs.DataLength));
+    if (bs.DataLength == 0)
+        return MFX_ERR_MORE_DATA;
+
+    return MFX_ERR_NONE;
+}
+
+
+class OneVPLSourceMFPDispatcherTest : public ::testing::TestWithParam<array_element_t> {};
+
+TEST_P(OneVPLSourceMFPDispatcherTest, open_and_decode_file)
+{
+    if (!initTestDataPathSilent()) {
+        throw SkipTestException("env variable OPENCV_TEST_DATA_PATH was not configured");
+    }
+    using namespace cv::gapi::wip::onevpl;
+
+    // create demultiplexed data provider
+
+    source_t path = findDataFile(std::get<0>(GetParam()), false);
+    valid_t should_decode = std::get<1>(GetParam());
+    MFPDemuxDataProvider provider(path);
+
+    //
+    mfxLoader mfx_handle = MFXLoad();
+
+    mfxConfig cfg_inst_0 = MFXCreateConfig(mfx_handle);
+    EXPECT_TRUE(cfg_inst_0);
+    mfxVariant mfx_param_0;
+    mfx_param_0.Type = MFX_VARIANT_TYPE_U32;
+    mfx_param_0.Data.U32 = codec_id_to_mfx(provider.get_codec());
+    EXPECT_EQ(MFXSetConfigFilterProperty(cfg_inst_0,(mfxU8 *)"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",
+                                                    mfx_param_0), MFX_ERR_NONE);
+
+    // create session
+    mfxSession mfx_session{};
+    mfxStatus sts = MFXCreateSession(mfx_handle, 0, &mfx_session);
+    EXPECT_EQ(MFX_ERR_NONE, sts);
+
+    // create proper bitstream
+    mfxBitstream bitstream{};
+    const int BITSTREAM_BUFFER_SIZE = 2000000;
+    bitstream.MaxLength = BITSTREAM_BUFFER_SIZE;
+    bitstream.CodecId = mfx_param_0.Data.U32;
+    bitstream.Data = (mfxU8 *)calloc(bitstream.MaxLength, sizeof(mfxU8));
+    EXPECT_TRUE(bitstream.Data);
+
+    // prepare dec params
+    mfxVideoParam mfxDecParams {};
+    mfxDecParams.mfx.CodecId = bitstream.CodecId;
+    mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
+    do {
+        sts = ReadEncodedStream(bitstream, provider);
+        EXPECT_EQ(MFX_ERR_NONE,sts);
+        sts = MFXVideoDECODE_DecodeHeader(mfx_session, &bitstream, &mfxDecParams);
+        EXPECT_TRUE(MFX_ERR_NONE == sts || MFX_ERR_MORE_DATA == sts);
+    } while (sts == MFX_ERR_MORE_DATA && !provider.empty());
+
+    EXPECT_EQ(MFX_ERR_NONE, sts);
+
+    MFXVideoDECODE_Close(mfx_session);
+    MFXClose(mfx_session);
+    MFXUnload(mfx_handle);
+}
+
+
+INSTANTIATE_TEST_CASE_P(MFP_VPL_DecodeHeaderTests, OneVPLSourceMFPDispatcherTest,
+                        testing::ValuesIn(files));
+}
+} // namespace opencv_test
+
+#endif // HAVE_ONEVPL


### PR DESCRIPTION
Implement new media source provider by using Microsoft Media Foundation which carry out video stream demultiplexing.
IDataProvider updated and it responsible for getting CodecID based on its owning source data
Implemented DataProviderDispatcher which try on specific provider for oneVPL source based on cfg params and file format


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Build Configuration

```
force_builders=XCustom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuild_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

build_image:Custom Win=gapi-onevpl-2021.6.0
buildworker:Custom Win=windows-3
build_contrib:Custom Win=OFF
```