### PR TITLE
G-API: Disable Windows warnings with 4996 code

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -32,11 +32,8 @@ if(MSVC)
   if(MSVC_VERSION LESS 1910)
     # Disable obsolete warning C4503 popping up on MSVC << 15 2017
     # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=vs-2019
-    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4503)
-  endif()
-  if (OPENCV_GAPI_INF_ENGINE AND NOT INF_ENGINE_RELEASE VERSION_GREATER "2021000000")
-    # Disable IE deprecated code warning C4996 for releases < 2021.1
-    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4996)
+    # and IE deprecated code warning C4996
+    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4503 /wd4996)
   endif()
 endif()
 


### PR DESCRIPTION
The PR handles problem with Windows [warnings](https://pullrequest.opencv.org/buildbot/builders/master_openvino-win64/builds/858/steps/compile%20release/logs/warnings%20%2812%29).
There are "deprecated" warnings on build.
IE has `IInterfaces` which are wrapped with `Interfaces`.  For example: `IInferRequest` and `InferRequest`:
https://docs.openvino.ai/latest/deprecated.html
G-API module doesn't use `IInterfaces` (`IInferRequest`, `IExecutableNetwork`...) so warnings can't be solved with changing of API usage.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Build configuration
```
force_builders=XCustom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1-vc14
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

```