### PR TITLE
cmake: find_package with QUIET

### DIFF
--- a/samples/cpp/tutorial_code/core/parallel_backend/CMakeLists.txt
+++ b/samples/cpp/tutorial_code/core/parallel_backend/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT OPENCV_EXAMPLES_SKIP_PARALLEL_BACKEND_TBB
     AND NOT OPENCV_EXAMPLES_SKIP_TBB
     AND NOT OPENCV_EXAMPLE_SKIP_TBB  # deprecated (to be removed in OpenCV 5.0)
 )
-  find_package(TBB)
+  find_package(TBB QUIET)
   if(NOT TBB_FOUND)
     find_path(TBB_INCLUDE_DIR NAMES "tbb/tbb.h")
     find_library(TBB_LIBRARY NAMES "tbb")


### PR DESCRIPTION
relates #20940

Avoid CMake messages like these:
```
CMake Warning at cpp/tutorial_code/core/parallel_backend/CMakeLists.txt:23 (find_package):
  By not providing "FindTBB.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "TBB", but
  CMake did not find one.
```