### PR TITLE
Remap large images support

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2401,7 +2401,7 @@ This function cannot operate in-place.
 
 @param src Source image.
 @param dst Destination image. It has the same size as map1 and the same type as src .
-@param map1 The first map of either (x,y) points or just x values having the type CV_16SC2 ,
+@param map1 The first map of either (x,y) points or just x values having the type CV_32SC2, CV_16SC2,
 CV_32FC1, or CV_32FC2. See convertMaps for details on converting a floating point
 representation to fixed-point for speed.
 @param map2 The second map of y values having the type CV_16UC1, CV_32FC1, or none (empty map
@@ -2413,7 +2413,17 @@ borderMode=#BORDER_TRANSPARENT, it means that the pixels in the destination imag
 corresponds to the "outliers" in the source image are not modified by the function.
 @param borderValue Value used in case of a constant border. By default, it is 0.
 @note
-Due to current implementation limitations the size of an input and output images should be less than 32767x32767.
+remap() can support the input and output images with width/height large than 32767 if map1 has type CV_32SC2 or CV_32FC2.
+In other cases the width/height of the input and output images must be less than 32767.
+
+Supported combinations of map types:
+@code
+map1.type() == CV_32FC2 && map2.empty()             // fp32_mapxy
+map1.type() == CV_32FC1 && map2.type() == CV_32FC1  // fp32_mapx_mapy
+map1.type() == CV_16SC2 && map2.empty()             // int16
+map1.type() == CV_32SC2 && map2.empty()             // int32
+map1.type() == CV_16SC2 && map2.type() == CV_16UC1  // fixedPointInt16
+@endcode
  */
 CV_EXPORTS_W void remap( InputArray src, OutputArray dst,
                          InputArray map1, InputArray map2,
@@ -2439,6 +2449,9 @@ the original maps are stored in one 2-channel matrix (only when nninterpolation=
 (see remap ) are converted to a int16 representation (only when nninterpolation=true ).
 
 - \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_16SC2)}\f$. The same as above but
+the original maps are stored in one 2-channel matrix  (only when nninterpolation=true ).
+
+- \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_32SC2)}\f$. The same as above but
 the original maps are stored in one 2-channel matrix  (only when nninterpolation=true ).
 
 - \f$\texttt{(CV_16SC2, CV_16UC1)} \rightarrow \texttt{(CV_16SC2)}\f$. Original fixed-point maps

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2422,7 +2422,7 @@ map1.type() == CV_32FC2 && map2.empty()             // fp32_mapxy
 map1.type() == CV_32FC1 && map2.type() == CV_32FC1  // fp32_mapx_mapy
 map1.type() == CV_16SC2 && map2.empty()             // int16
 map1.type() == CV_32SC2 && map2.empty()             // int32
-map1.type() == CV_16SC2 && map2.type() == CV_16UC1  // fixedPointInt16
+map1.type() == CV_16SC2 && map2.type() == CV_16UC1  // fixedPointQ16_5
 @endcode
  */
 CV_EXPORTS_W void remap( InputArray src, OutputArray dst,

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2392,11 +2392,20 @@ The function remap transforms the source image using the specified map:
 where values of pixels with non-integer coordinates are computed using one of available
 interpolation methods. \f$map_x\f$ and \f$map_y\f$ can be encoded as separate floating-point maps
 in \f$map_1\f$ and \f$map_2\f$ respectively, or interleaved floating-point maps of \f$(x,y)\f$ in
-\f$map_1\f$, or fixed-point maps created by using convertMaps. The reason you might want to
+\f$map_1\f$, or fixed-point maps created by using convertMaps(). The reason you might want to
 convert from floating to fixed-point representations of a map is that they can yield much faster
-(\~2x) remapping operations. In the converted case, \f$map_1\f$ contains pairs (cvFloor(x),
-cvFloor(y)) and \f$map_2\f$ contains indices in a table of interpolation coefficients.
+(\~2x) remapping operations.
+Current implementation fixed-point numbers are denoted as Q16.5 in [Q number format](https://en.wikipedia.org/wiki/Q_(number_format)).
+\f$map_1\f$ contains pairs (cvFloor(x), cvFloor(y)) and \f$map_2\f$ contains 5 fraction bits of x and 5 fraction bits of y.
 
+In the fixed-point case to get fraction bits of \f$x_{i,j}\f$ use:
+@code
+map2.at<unsigned short>(i,j) % 32 // fraction bits value in [0, 31] range
+@endcode
+In the fixed-point case to get fraction bits of \f$y_{i,j}\f$ use:
+@code
+map2.at<unsigned short>(i,j) / 32 // fraction bits value in [0, 31] range
+@endcode
 This function cannot operate in-place.
 
 @param src Source image.

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2433,9 +2433,18 @@ contains the rounded coordinates and the second array (created only when nninter
 contains indices in the interpolation tables.
 
 - \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_16SC2, CV_16UC1)}\f$. The same as above but
-the original maps are stored in one 2-channel matrix.
+the original maps are stored in one 2-channel matrix (only when nninterpolation=false ).
 
-- Reverse conversion. Obviously, the reconstructed floating-point maps will not be exactly the same
+- \f$\texttt{(CV_32FC1, CV_32FC1)} \rightarrow \texttt{(CV_16SC2)}\f$. Original floating-point maps
+(see remap ) are converted to a int16 representation (only when nninterpolation=true ).
+
+- \f$\texttt{(CV_32FC2)} \rightarrow \texttt{(CV_16SC2)}\f$. The same as above but
+the original maps are stored in one 2-channel matrix  (only when nninterpolation=true ).
+
+- \f$\texttt{(CV_16SC2, CV_16UC1)} \rightarrow \texttt{(CV_16SC2)}\f$. Original fixed-point maps
+(see remap ) are converted to a int16 representation (only when nninterpolation=true ).
+
+- Reverse conversion. Obviously, the reconstructed floating-point or fixed-point maps will not be exactly the same
 as the originals.
 
 @param map1 The first input map of type CV_16SC2, CV_32FC1, or CV_32FC2 .

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1856,6 +1856,14 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     {
         outputRemapType = RemapType::fixedPointInt16;
     }
+    else if (dstm1type == CV_32SC2 && nninterpolate)
+    {
+        outputRemapType = RemapType::int32;
+    }
+    else if (dstm1type == CV_32SC2 && !nninterpolate)
+    {
+        outputRemapType = RemapType::fixedPointInt32;
+    }
     if (outputRemapType == RemapType::errorType)
         CV_Error(cv::Error::StsBadSize, errorRemapMessage);
 
@@ -1884,10 +1892,13 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         return;
     }
 
-    if ((inputRemapType == RemapType::int16 || inputRemapType == RemapType::int32) && outputRemapType == RemapType::fixedPointInt16)
+    if ((inputRemapType == RemapType::int16 || inputRemapType == RemapType::int32) &&
+        (outputRemapType == RemapType::fixedPointInt16 || outputRemapType == RemapType::int16 ||
+         outputRemapType == RemapType::fp32_mapxy))
     {
         m1->convertTo(dstmap1, dstmap1.type());
-        dstmap2 = Mat::zeros( size, CV_16UC1);
+        if (outputRemapType == RemapType::fixedPointInt16)
+            dstmap2 = Mat::zeros( size, CV_16UC1);
         return;
     }
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1182,7 +1182,7 @@ public:
                 Mat bufa(_bufa, Rect(0, 0, bcols, brows));
                 for( y1 = 0; y1 < brows; y1++ )
                 {
-                    IdxType* XY = bufxy.ptr<IdxType>(y1);
+                    short* XY = bufxy.ptr<short>(y1);
                     ushort* A = bufa.ptr<ushort>(y1);
 
                     if (remapType == RemapType::fixedPointInt16 || remapType == RemapType::fixedPointInt32)
@@ -1205,7 +1205,6 @@ public:
                     }
                     else if (remapType == RemapType::fp32_mapx_mapy)
                     {
-                        short* XY = bufxy.ptr<short>(y1); // if remapType == RemapType::fp32_mapx_mapy: IdxType == short
                         const float* sX = m1->ptr<float>(y+y1) + x;
                         const float* sY = m2->ptr<float>(y+y1) + x;
 
@@ -1244,7 +1243,6 @@ public:
                     }
                     else if (remapType == RemapType::fp32_mapxy)
                     {
-                        short* XY = bufxy.ptr<short>(y1); // if remapType == RemapType::fp32_mapxy: IdxType == short
                         const float* sXY = m1->ptr<float>(y+y1) + x*2;
                         x1 = 0;
 
@@ -1725,7 +1723,7 @@ void cv::remap( InputArray _src, OutputArray _dst,
         openvx_remap(src, dst, map1, map2, interpolation, borderValue));
 
     bool isLargeImage = ((remapType == RemapType::int32 || remapType == RemapType::fixedPointInt32) ? true : false);
-    CV_Assert( dst.cols < SHRT_MAX && dst.rows < SHRT_MAX && src.cols < SHRT_MAX && src.rows < SHRT_MAX || isLargeImage);
+    CV_Assert( (dst.cols < SHRT_MAX && dst.rows < SHRT_MAX && src.cols < SHRT_MAX && src.rows < SHRT_MAX) || isLargeImage);
     CV_Assert( remapType != RemapType::int16 || interpolation == INTER_NEAREST );
     CV_Assert( !isLargeImage || interpolation == INTER_NEAREST );
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1864,6 +1864,13 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         return;
     }
 
+    if (inputRemapType == RemapType::int16 && outputRemapType == RemapType::fixedPointInt16)
+    {
+        m1->convertTo(dstmap1, dstmap1.type());
+        dstmap2 = Mat::zeros( size, CV_16UC1);
+        return;
+    }
+
     if (inputRemapType == RemapType::fp32_mapxy && outputRemapType == RemapType::int16)
     {
         m1->convertTo(dstmap1, dstmap1.type());
@@ -1890,6 +1897,10 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         size.width *= size.height;
         size.height = 1;
     }
+    CV_Assert((m1type == CV_32FC1 && dstm1type == CV_16SC2) || // fp32_mapx_mapy to int16 or fixedPointInt16
+              (m1type == CV_32FC2 && dstm1type == CV_16SC2 && !nninterpolate) || // fp32_mapxy to int16
+              (m1type == CV_16SC2 && dstm1type == CV_32FC1) || // int16 or fixedPointInt16 to fp32_mapx_mapy
+              (m1type == CV_16SC2 && dstm1type == CV_32FC2));  // int16 or fixedPointInt16 to fp32_mapxy
 
 #if CV_TRY_SSE4_1
     bool useSSE4_1 = CV_CPU_HAS_SUPPORT_SSE4_1;
@@ -2031,8 +2042,6 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
                     }
                 }
             }
-            else // this branch is never called: inputRemapType == RemapType::fp32_mapxy && outputRemapType == RemapType::int16
-                CV_Error( CV_StsNotImplemented, "Unsupported combination of input/output matrices" );
         }
         else if( m1type == CV_16SC2 && dstm1type == CV_32FC1 )
         {
@@ -2130,8 +2139,6 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
                 dst1f[x*2+1] = src1[x*2+1] + (fxy >> INTER_BITS)*scale;
             }
         }
-        else
-            CV_Error( CV_StsNotImplemented, "Unsupported combination of input/output matrices" );
     }
 }
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1704,6 +1704,7 @@ void cv::remap( InputArray _src, OutputArray _dst,
     CV_Assert( !_map1.empty() );
     Mat src = _src.getMat(), map1 = _map1.getMat(), map2 = _map2.getMat();
     const RemapType remapType = check_and_get_remap_type(map1, map2);
+    CV_Assert(remapType != RemapType::fixedPointInt32);
 
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
                ocl_remap(_src, _dst, _map1, _map2, interpolation, borderType, borderValue, remapType))

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1884,7 +1884,7 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
         return;
     }
 
-    if (inputRemapType == RemapType::int16 && outputRemapType == RemapType::fixedPointInt16)
+    if ((inputRemapType == RemapType::int16 || inputRemapType == RemapType::int32) && outputRemapType == RemapType::fixedPointInt16)
     {
         m1->convertTo(dstmap1, dstmap1.type());
         dstmap2 = Mat::zeros( size, CV_16UC1);

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -54,6 +54,7 @@
 #include "opencv2/core/hal/intrin.hpp"
 #include "opencv2/core/openvx/ovx_defs.hpp"
 #include "opencv2/core/softfloat.hpp"
+#include "remap_type.hpp"
 #include "imgwarp.hpp"
 
 using namespace cv;
@@ -1083,10 +1084,10 @@ class RemapInvoker :
 public:
     RemapInvoker(const Mat& _src, Mat& _dst, const Mat *_m1,
                  const Mat *_m2, int _borderType, const Scalar &_borderValue,
-                 int _planar_input, RemapNNFunc _nnfunc, RemapFunc _ifunc, const void *_ctab) :
+                 int _planar_input, RemapNNFunc _nnfunc, RemapFunc _ifunc, const void *_ctab, RemapType _remapType) :
         ParallelLoopBody(), src(&_src), dst(&_dst), m1(_m1), m2(_m2),
         borderType(_borderType), borderValue(_borderValue),
-        planar_input(_planar_input), nnfunc(_nnfunc), ifunc(_ifunc), ctab(_ctab)
+        planar_input(_planar_input), nnfunc(_nnfunc), ifunc(_ifunc), ctab(_ctab), remapType(_remapType)
     {
     }
 
@@ -1113,7 +1114,7 @@ public:
 
                 if( nnfunc )
                 {
-                    if( m1->type() == CV_16SC2 && m2->empty() ) // the data is already in the right format
+                    if( remapType == RemapType::int16 ) // the data is already in the right format
                         bufxy = (*m1)(Rect(x, y, bcols, brows));
                     else if( map_depth != CV_32F )
                     {
@@ -1176,7 +1177,7 @@ public:
                     short* XY = bufxy.ptr<short>(y1);
                     ushort* A = bufa.ptr<ushort>(y1);
 
-                    if( m1->type() == CV_16SC2 && (m2->type() == CV_16UC1 || m2->type() == CV_16SC1) )
+                    if( remapType == RemapType::fixedPointInt16 )
                     {
                         bufxy = (*m1)(Rect(x, y, bcols, brows));
 
@@ -1288,45 +1289,34 @@ private:
     RemapNNFunc nnfunc;
     RemapFunc ifunc;
     const void *ctab;
+    RemapType remapType;
 };
 
 #ifdef HAVE_OPENCL
 
 static bool ocl_remap(InputArray _src, OutputArray _dst, InputArray _map1, InputArray _map2,
-                      int interpolation, int borderType, const Scalar& borderValue)
+                      int interpolation, int borderType, const Scalar& borderValue, RemapType remapType)
 {
     const ocl::Device & dev = ocl::Device::getDefault();
     int cn = _src.channels(), type = _src.type(), depth = _src.depth(),
             rowsPerWI = dev.isIntel() ? 4 : 1;
 
     if (borderType == BORDER_TRANSPARENT || !(interpolation == INTER_LINEAR || interpolation == INTER_NEAREST)
-            || _map1.type() == CV_16SC1 || _map2.type() == CV_16SC1)
+            || _map2.type() == CV_16SC1)
         return false;
 
     UMat src = _src.getUMat(), map1 = _map1.getUMat(), map2 = _map2.getUMat();
-
-    if( (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.empty())) ||
-        (map2.type() == CV_16SC2 && (map1.type() == CV_16UC1 || map1.empty())) )
-    {
-        if (map1.type() != CV_16SC2)
-            std::swap(map1, map2);
-    }
-    else
-        CV_Assert( map1.type() == CV_32FC2 || (map1.type() == CV_32FC1 && map2.type() == CV_32FC1) );
-
     _dst.create(map1.size(), type);
     UMat dst = _dst.getUMat();
 
     String kernelName = "remap";
-    if (map1.type() == CV_32FC2 && map2.empty())
+    if (remapType == RemapType::fp32_mapxy)
         kernelName += "_32FC2";
-    else if (map1.type() == CV_16SC2)
-    {
+    else if (remapType == RemapType::int16)
         kernelName += "_16SC2";
-        if (!map2.empty())
-            kernelName += "_16UC1";
-    }
-    else if (map1.type() == CV_32FC1 && map2.type() == CV_32FC1)
+    else if (remapType == RemapType::fixedPointInt16)
+        kernelName += "_16SC2_16UC1";
+    else if (remapType == RemapType::fp32_mapx_mapy)
         kernelName += "_2_32FC1";
     else
         CV_Error(Error::StsBadArg, "Unsupported map types");
@@ -1701,12 +1691,12 @@ void cv::remap( InputArray _src, OutputArray _dst,
     };
 
     CV_Assert( !_map1.empty() );
-    CV_Assert( _map2.empty() || (_map2.size() == _map1.size()));
+    Mat src = _src.getMat(), map1 = _map1.getMat(), map2 = _map2.getMat();
+    const RemapType remapType = check_and_get_remap_type(map1, map2);
 
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
-               ocl_remap(_src, _dst, _map1, _map2, interpolation, borderType, borderValue))
+               ocl_remap(_src, _dst, _map1, _map2, interpolation, borderType, borderValue, remapType))
 
-    Mat src = _src.getMat(), map1 = _map1.getMat(), map2 = _map2.getMat();
     _dst.create( map1.size(), src.type() );
     Mat dst = _dst.getMat();
 
@@ -1803,22 +1793,12 @@ void cv::remap( InputArray _src, OutputArray _dst,
 
     const Mat *m1 = &map1, *m2 = &map2;
 
-    if( (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1 || map2.empty())) ||
-        (map2.type() == CV_16SC2 && (map1.type() == CV_16UC1 || map1.type() == CV_16SC1 || map1.empty())) )
-    {
-        if( map1.type() != CV_16SC2 )
-            std::swap(m1, m2);
-    }
-    else
-    {
-        CV_Assert( ((map1.type() == CV_32FC2 || map1.type() == CV_16SC2) && map2.empty()) ||
-            (map1.type() == CV_32FC1 && map2.type() == CV_32FC1) );
-        planar_input = map1.channels() == 1;
-    }
+    if (remapType == RemapType::fp32_mapx_mapy)
+        planar_input = true;
 
     RemapInvoker invoker(src, dst, m1, m2,
                          borderType, borderValue, planar_input, nnfunc, ifunc,
-                         ctab);
+                         ctab, remapType);
     parallel_for_(Range(0, dst.rows), invoker, dst.total()/(double)(1<<16));
 }
 
@@ -1830,28 +1810,39 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     CV_INSTRUMENT_REGION();
 
     Mat map1 = _map1.getMat(), map2 = _map2.getMat(), dstmap1, dstmap2;
+    const RemapType inputRemapType = check_and_get_remap_type(map1, map2);
     Size size = map1.size();
     const Mat *m1 = &map1, *m2 = &map2;
-    int m1type = m1->type(), m2type = m2->type();
+    int m1type = m1->type();
 
-    CV_Assert( (m1type == CV_16SC2 && (nninterpolate || m2type == CV_16UC1 || m2type == CV_16SC1)) ||
-               (m2type == CV_16SC2 && (nninterpolate || m1type == CV_16UC1 || m1type == CV_16SC1)) ||
-               (m1type == CV_32FC1 && m2type == CV_32FC1) ||
-               (m1type == CV_32FC2 && m2->empty()) );
-
-    if( m2type == CV_16SC2 )
-    {
-        std::swap( m1, m2 );
-        std::swap( m1type, m2type );
-    }
-
+    RemapType outputRemapType = RemapType::errorType;
     if( dstm1type <= 0 )
         dstm1type = m1type == CV_16SC2 ? CV_32FC2 : CV_16SC2;
     CV_Assert( dstm1type == CV_16SC2 || dstm1type == CV_32FC1 || dstm1type == CV_32FC2 );
+
+    if (dstm1type == CV_32FC1)
+    {
+        outputRemapType = RemapType::fp32_mapx_mapy;
+    }
+    else if (dstm1type == CV_32FC2)
+    {
+        outputRemapType = RemapType::fp32_mapxy;
+    }
+    else if (dstm1type == CV_16SC2 && nninterpolate)
+    {
+        outputRemapType = RemapType::int16;
+    }
+    else if (dstm1type == CV_16SC2 && !nninterpolate)
+    {
+        outputRemapType = RemapType::fixedPointInt16;
+    }
+    if (outputRemapType == RemapType::errorType)
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+
     _dstmap1.create( size, dstm1type );
     dstmap1 = _dstmap1.getMat();
 
-    if( !nninterpolate && dstm1type != CV_32FC2 )
+    if (outputRemapType == RemapType::fp32_mapx_mapy || outputRemapType == RemapType::fixedPointInt16)
     {
         _dstmap2.create( size, dstm1type == CV_16SC2 ? CV_16UC1 : CV_32FC1 );
         dstmap2 = _dstmap2.getMat();
@@ -1859,13 +1850,17 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     else
         _dstmap2.release();
 
-    if( m1type == dstm1type || (nninterpolate &&
-        ((m1type == CV_16SC2 && dstm1type == CV_32FC2) ||
-        (m1type == CV_32FC2 && dstm1type == CV_16SC2))) )
+    if (inputRemapType == outputRemapType)
     {
-        m1->convertTo( dstmap1, dstmap1.type() );
-        if( !dstmap2.empty() && dstmap2.type() == m2->type() )
-            m2->copyTo( dstmap2 );
+        m1->copyTo(dstmap1);
+        if (!dstmap2.empty())
+            m2->copyTo(dstmap2);
+        return;
+    }
+
+    if (inputRemapType == RemapType::fixedPointInt16 && outputRemapType == RemapType::int16)
+    {
+        m1->copyTo(dstmap1);
         return;
     }
 
@@ -1900,13 +1895,13 @@ void cv::convertMaps( InputArray _map1, InputArray _map2,
     {
         const float* src1f = m1->ptr<float>(y);
         const float* src2f = m2->ptr<float>(y);
-        const short* src1 = (const short*)src1f;
-        const ushort* src2 = (const ushort*)src2f;
+        const short* src1 = m1->ptr<short>(y);
+        const ushort* src2 = m2->ptr<ushort>(y);
 
         float* dst1f = dstmap1.ptr<float>(y);
         float* dst2f = dstmap2.ptr<float>(y);
-        short* dst1 = (short*)dst1f;
-        ushort* dst2 = (ushort*)dst2f;
+        short* dst1 = dstmap1.ptr<short>(y);
+        ushort* dst2 = dstmap2.ptr<ushort>(y);
         x = 0;
 
         if( m1type == CV_32FC1 && dstm1type == CV_16SC2 )

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -4,7 +4,9 @@ enum class RemapType {
     fp32_mapxy,
     fp32_mapx_mapy,
     fixedPointInt16,
+    fixedPointInt32,
     int16,
+    int32,
     errorType
 };
 
@@ -26,15 +28,19 @@ inline RemapType get_remap_type(const Mat &map1, const Mat &map2)
     }
     else if (map1.channels() == 2) // int or fixedPointInt
     {
-        if (map2.empty()) // int16
+        if (map2.empty()) // int16 or int32
         {
             if (map1.type() == CV_16SC2) // int16
                 return RemapType::int16;
+            else if (map1.type() == CV_32SC2) // int32
+                return RemapType::int32;
         }
-        else if (map2.channels() == 1) // fixedPointInt16
+        else if (map2.channels() == 1 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1)) // fixedPointInt16 or fixedPointInt32
         {
-            if (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1)) // fixedPointInt16
+            if (map1.type() == CV_16SC2) // fixedPointInt16
                 return RemapType::fixedPointInt16;
+            else if (map1.type() == CV_32SC2) // fixedPointInt32
+                return RemapType::fixedPointInt32;
         }
     }
     return RemapType::errorType;

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -1,6 +1,6 @@
 namespace cv
 {
-enum RemapType {
+enum class RemapType {
     fp32_mapxy,
     fp32_mapx_mapy,
     fixedPointInt16,
@@ -8,7 +8,7 @@ enum RemapType {
     errorType
 };
 
-static const std::string errorRemapMessage =
+const std::string errorRemapMessage =
         "fp32_mapxy: map1 having the type CV_32FC2; map2 is empty\n"
         "fp32_mapx_mapy: map1 having the type CV_32FC1; map2 having the type CV_32FC1\n"
         "fixedPointInt16: map1 having the type CV_16SC2; map2 having the type CV_16UC1 or CV_16SC1\n"
@@ -50,7 +50,7 @@ inline RemapType check_and_get_remap_type(Mat &map1, Mat &map2)
 
     RemapType type = get_remap_type(map1, map2);
     if (type == RemapType::errorType)
-        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage);
     return type;
 }
 }

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -1,5 +1,6 @@
-namespace cv
-{
+namespace cv {
+namespace {
+
 enum class RemapType {
     fp32_mapxy,
     fp32_mapx_mapy,
@@ -59,4 +60,7 @@ inline RemapType check_and_get_remap_type(Mat &map1, Mat &map2)
         CV_Error(cv::Error::StsBadSize, errorRemapMessage);
     return type;
 }
+
+}
+
 }

--- a/modules/imgproc/src/remap_type.hpp
+++ b/modules/imgproc/src/remap_type.hpp
@@ -1,0 +1,56 @@
+namespace cv
+{
+enum RemapType {
+    fp32_mapxy,
+    fp32_mapx_mapy,
+    fixedPointInt16,
+    int16,
+    errorType
+};
+
+static const std::string errorRemapMessage =
+        "fp32_mapxy: map1 having the type CV_32FC2; map2 is empty\n"
+        "fp32_mapx_mapy: map1 having the type CV_32FC1; map2 having the type CV_32FC1\n"
+        "fixedPointInt16: map1 having the type CV_16SC2; map2 having the type CV_16UC1 or CV_16SC1\n"
+        "int16: map1 having the type CV_16SC2; map2 is empty\n"
+        "If map2 isn't empty, map1.size() must be equal to map2.size().\n";
+
+inline RemapType get_remap_type(const Mat &map1, const Mat &map2)
+{
+    if ((map1.depth() == CV_32F && !map1.empty()) || (map2.depth() == CV_32F && !map2.empty())) // fp32_mapxy or fp32_mapx_mapy
+    {
+        if (map1.type() == CV_32FC2 && map2.empty())
+            return RemapType::fp32_mapxy;
+        else if (map1.type() == CV_32FC1 && map2.type() == CV_32FC1)
+            return RemapType::fp32_mapx_mapy;
+    }
+    else if (map1.channels() == 2) // int or fixedPointInt
+    {
+        if (map2.empty()) // int16
+        {
+            if (map1.type() == CV_16SC2) // int16
+                return RemapType::int16;
+        }
+        else if (map2.channels() == 1) // fixedPointInt16
+        {
+            if (map1.type() == CV_16SC2 && (map2.type() == CV_16UC1 || map2.type() == CV_16SC1)) // fixedPointInt16
+                return RemapType::fixedPointInt16;
+        }
+    }
+    return RemapType::errorType;
+}
+
+inline RemapType check_and_get_remap_type(Mat &map1, Mat &map2)
+{
+    CV_Assert(!map1.empty() || !map2.empty());
+    if (map2.channels() == 2 && !map2.empty())
+        std::swap(map1, map2);
+    CV_Assert((map2.empty() && map1.channels() == 2) ||
+              (!map2.empty() && map1.size() == map2.size() && map2.channels() == 1));
+
+    RemapType type = get_remap_type(map1, map2);
+    if (type == RemapType::errorType)
+        CV_Error(cv::Error::StsBadSize, errorRemapMessage.data());
+    return type;
+}
+}

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1572,8 +1572,8 @@ template<typename T>
 void setRandMap(RNG& rng, Mat& mat)
 {
     T* XY = mat.ptr<T>(0);
-    const float scols = mat.cols;
-    const float frows = mat.rows;
+    const float scols = static_cast<float>(mat.cols);
+    const float frows = static_cast<float>(mat.rows);
     for (size_t i = 0; i < mat.total(); ++i)
     {
         XY[0] = static_cast<T>(rng.uniform(0.f, scols));
@@ -1601,7 +1601,8 @@ PARAM_TEST_CASE(ParamConvertMapsTest, std::tuple<int, int>, int, bool, cv::Size)
         nninterpolate = GET_PARAM(2);
         size = GET_PARAM(3);
         RNG rng(0);
-        float scols = size.width, srows = size.height;
+        float scols = static_cast<float>(size.width);
+        float srows = static_cast<float>(size.height);
         if (map1Type > 0)
         {
             map_x.create(size, map1Type);

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1613,7 +1613,7 @@ PARAM_TEST_CASE(ParamConvertMapsTest, std::tuple<int, int>, int, bool)
 };
 
 #define test_float_types std::make_tuple(CV_32FC2, -1), std::make_tuple(CV_32FC1, CV_32FC1)
-#define test_int_types std::make_tuple(CV_16SC2, -1), std::make_tuple(-1, CV_16SC2)
+#define test_int_types std::make_tuple(CV_16SC2, -1), std::make_tuple(-1, CV_16SC2)//, std::make_tuple(CV_32SC2, -1)
 #define test_fixed_point_types std::make_tuple(CV_16SC2, CV_16SC1), std::make_tuple(CV_16SC2, CV_16UC1)
 
 struct Param_fp32 : public ParamConvertMapsTest {};
@@ -1633,7 +1633,7 @@ INSTANTIATE_TEST_CASE_P(/**/, Param_fixedPoint, testing::Combine(Values(
         Values(false)));
 
 INSTANTIATE_TEST_CASE_P(/**/, Param_int16, testing::Combine(Values(
-        test_float_types, test_int_types, test_fixed_point_types
+        test_float_types, test_int_types, test_fixed_point_types, std::make_tuple(CV_32SC2, -1)
         ),
         Values(CV_16SC2),
         Values(true)));

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1568,15 +1568,29 @@ TEST(Imgproc_check_remap_type, test_remap_type_fixed_point)
     ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(map_xy, map_xy_fixed_point));
 }
 
-PARAM_TEST_CASE(ParamConvertMapsTest, std::tuple<int, int>, int, bool)
+template<typename T>
+void setRandMap(RNG& rng, Mat& mat)
+{
+    T* XY = mat.ptr<T>(0);
+    const float scols = mat.cols;
+    const float frows = mat.rows;
+    for (size_t i = 0; i < mat.total(); ++i)
+    {
+        XY[0] = static_cast<T>(rng.uniform(0.f, scols));
+        XY[1] = static_cast<T>(rng.uniform(0.f, frows));
+        XY += 2;
+    }
+}
+
+PARAM_TEST_CASE(ParamConvertMapsTest, std::tuple<int, int>, int, bool, cv::Size)
 {
     int map1Type;
     int map2Type;
     int dst1type;
     bool nninterpolate;
-    const int N = 21;
-    Mat map_x, map_y;
-    Mat src, dst1, dst2;
+    cv::Size size;
+    Mat map_x, map_y, fmap_xy;
+    Mat src, dst_map1, dst_map2;
 
     virtual void SetUp() override
     {
@@ -1584,31 +1598,45 @@ PARAM_TEST_CASE(ParamConvertMapsTest, std::tuple<int, int>, int, bool)
         map1Type = get<0>(types);
         map2Type = get<1>(types);
         dst1type = GET_PARAM(1);
-        nninterpolate = GET_PARAM(2);;
-
+        nninterpolate = GET_PARAM(2);
+        size = GET_PARAM(3);
+        RNG rng(0);
+        float scols = size.width, srows = size.height;
         if (map1Type > 0)
         {
-            map_x.create(N, N, map1Type);
-            randu(map_x, 0., N+0.);
+            map_x.create(size, map1Type);
+            if (map_x.channels() == 2)
+            {
+                if (map_x.type() == CV_32FC2)
+                    setRandMap<float>(rng, map_x);
+                else if (map_x.type() == CV_32SC2)
+                    setRandMap<int>(rng, map_x);
+                else if (map_x.type() == CV_16SC2)
+                    setRandMap<short>(rng, map_x);
+            }
+            else
+            {
+                randu(map_x, 0.f, scols);
+            }
         }
         if (map2Type > 0)
         {
-            map_y.create(N, N, map2Type);
-            if (map_y.depth() == CV_32F)
-                randu(map_y, 0., N+0.);
+            map_y.create(size, map2Type);
+            if (map_y.depth() == CV_32FC1)
+                randu(map_y, 0.f, srows);
             else
                 randu(map_y, 0, 1 << INTER_BITS2); // set fixed point map
         }
-        src.create(N, N, CV_8U);
+        src.create(size, CV_8U);
         randu(src, 0, 256);
+        convertMaps(map_x, map_y, fmap_xy, noArray(), CV_32FC2);
     }
 
     virtual void TearDown() override
     {
-        Mat map_xy, dst_map_xy, emptyMat, res1, res2;
-        convertMaps(map_x, map_y, map_xy, emptyMat, CV_32FC2);
-        convertMaps(dst1, dst2, dst_map_xy, emptyMat, CV_32FC2);
-        EXPECT_LE(cv::norm(map_xy, dst_map_xy, NORM_INF), 1.f);
+        Mat dst_map_xy, res1, res2;
+        convertMaps(dst_map1, dst_map2, dst_map_xy, noArray(), CV_32FC2);
+        EXPECT_LE(cv::norm(fmap_xy, dst_map_xy, NORM_INF), 1.f);
     }
 };
 
@@ -1624,39 +1652,65 @@ INSTANTIATE_TEST_CASE_P(/**/, Param_fp32, testing::Combine(Values(
         test_float_types, test_int_types, test_fixed_point_types
         ),
         Values(CV_32FC2, CV_32FC1),
-        Values(false, true)));
+        Values(false, true),  Values(cv::Size(21, 33)) ));
 
 INSTANTIATE_TEST_CASE_P(/**/, Param_fixedPoint, testing::Combine(Values(
-        test_float_types, test_int_types, test_fixed_point_types
-        ),
-        Values(CV_16SC2),
-        Values(false)));
-
-INSTANTIATE_TEST_CASE_P(/**/, Param_int16, testing::Combine(Values(
         test_float_types, test_int_types, test_fixed_point_types, std::make_tuple(CV_32SC2, -1)
         ),
         Values(CV_16SC2),
-        Values(true)));
+        Values(false), Values(cv::Size(21, 33)) ));
+
+INSTANTIATE_TEST_CASE_P(/**/, Param_int16, testing::Combine(Values(
+        test_float_types, test_int_types, test_fixed_point_types, std::make_tuple(CV_32SC2, -1),
+        std::make_tuple(CV_32SC2, CV_16UC1)
+        ),
+        Values(CV_16SC2),
+        Values(true), Values(cv::Size(21, 33)) ));
 
 TEST_P(Param_fp32, test_convert_maps_to_fp32)
 {
-    convertMaps(map_x, map_y, dst1, dst2, dst1type, nninterpolate);
+    convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
     if (dst1type == CV_32FC2)
-        ASSERT_EQ(RemapType::fp32_mapxy, check_and_get_remap_type(dst1, dst2));
+        ASSERT_EQ(RemapType::fp32_mapxy, check_and_get_remap_type(dst_map1, dst_map2));
     else
-        ASSERT_EQ(RemapType::fp32_mapx_mapy, check_and_get_remap_type(dst1, dst2));
+        ASSERT_EQ(RemapType::fp32_mapx_mapy, check_and_get_remap_type(dst_map1, dst_map2));
 }
 
 TEST_P(Param_fixedPoint, test_convert_maps_to_fixedPointInt16)
 {
-    convertMaps(map_x, map_y, dst1, dst2, dst1type, nninterpolate);
-    ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(dst1, dst2));
+    convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
+    ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(dst_map1, dst_map2));
 }
 
 TEST_P(Param_int16, test_convert_maps_to_Int16)
 {
-    convertMaps(map_x, map_y, dst1, dst2, dst1type, nninterpolate);
-    ASSERT_EQ(RemapType::int16, check_and_get_remap_type(dst1, dst2));
+    convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
+    ASSERT_EQ(RemapType::int16, check_and_get_remap_type(dst_map1, dst_map2));
+}
+
+struct Param_RemapTest : public ParamConvertMapsTest
+{
+    virtual void TearDown() override {}
+};
+
+INSTANTIATE_TEST_CASE_P(/**/, Param_RemapTest, testing::Combine(
+        Values(std::make_tuple(CV_32SC2, -1)),
+        Values(-1),
+        Values(true),
+        Values(cv::Size(8*32767, 33), cv::Size(60, 5*32767), cv::Size(80*32767, 7))
+        ));
+
+TEST_P(Param_RemapTest, large_img_remap)
+{
+    Mat dst, fdst;
+    double mmax, mmin;
+    minMaxLoc(map_x, &mmin, &mmax);
+    EXPECT_GE(mmax, SHRT_MAX);
+
+    remap(src, dst, map_x, noArray(), INTER_NEAREST);
+    convertMaps(map_x, noArray(), fmap_xy, noArray(), CV_32FC2);
+    remap(src, fdst, fmap_xy, noArray(), INTER_NEAREST);
+    EXPECT_LE(cv::norm(dst, fdst, NORM_INF), .1f);
 }
 
 //** @deprecated */

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1627,7 +1627,7 @@ INSTANTIATE_TEST_CASE_P(/**/, Param_fp32, testing::Combine(Values(
         Values(false, true)));
 
 INSTANTIATE_TEST_CASE_P(/**/, Param_fixedPoint, testing::Combine(Values(
-        test_float_types, test_fixed_point_types
+        test_float_types, test_int_types, test_fixed_point_types
         ),
         Values(CV_16SC2),
         Values(false)));

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1542,16 +1542,16 @@ TEST(Imgproc_check_remap_type, test_remap_type_mapxy)
     randu(src, 0, 256);
     Mat map_x(src.size(), CV_32FC1), map_y(src.size(), CV_32FC1);
 
-    ASSERT_EQ(RemapType::fp32_mapx_mapy, check_and_get_remap_type(map_x, map_y));
+    ASSERT_EQ(RemapType::fp32_mapx_mapy, checkAndGetRemapType(map_x, map_y));
 
     Mat map_xy, emptyMat;
     Mat channels[2] = {map_x, map_y};
     merge(channels, 2, map_xy);
 
-    ASSERT_EQ(RemapType::fp32_mapxy, check_and_get_remap_type(map_xy, emptyMat));
+    ASSERT_EQ(RemapType::fp32_mapxy, checkAndGetRemapType(map_xy, emptyMat));
 
     map_xy.convertTo(map_xy, CV_16SC2);
-    ASSERT_EQ(RemapType::int16, check_and_get_remap_type(map_xy, emptyMat));
+    ASSERT_EQ(RemapType::int16, checkAndGetRemapType(map_xy, emptyMat));
 }
 
 TEST(Imgproc_check_remap_type, test_remap_type_fixed_point)
@@ -1562,10 +1562,10 @@ TEST(Imgproc_check_remap_type, test_remap_type_fixed_point)
     randu(src, 0, 256);
     Mat map_xy(src.size(), CV_16SC2), map_xy_fixed_point(src.size(), CV_16SC1);
 
-    ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(map_xy, map_xy_fixed_point));
+    ASSERT_EQ(RemapType::fixedPointQ16_5, checkAndGetRemapType(map_xy, map_xy_fixed_point));
 
     map_xy_fixed_point.convertTo(map_xy_fixed_point, CV_16UC1);
-    ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(map_xy, map_xy_fixed_point));
+    ASSERT_EQ(RemapType::fixedPointQ16_5, checkAndGetRemapType(map_xy, map_xy_fixed_point));
 }
 
 template<typename T>
@@ -1672,21 +1672,21 @@ TEST_P(Param_fp32, test_convert_maps_to_fp32)
 {
     convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
     if (dst1type == CV_32FC2)
-        ASSERT_EQ(RemapType::fp32_mapxy, check_and_get_remap_type(dst_map1, dst_map2));
+        ASSERT_EQ(RemapType::fp32_mapxy, checkAndGetRemapType(dst_map1, dst_map2));
     else
-        ASSERT_EQ(RemapType::fp32_mapx_mapy, check_and_get_remap_type(dst_map1, dst_map2));
+        ASSERT_EQ(RemapType::fp32_mapx_mapy, checkAndGetRemapType(dst_map1, dst_map2));
 }
 
-TEST_P(Param_fixedPoint, test_convert_maps_to_fixedPointInt16)
+TEST_P(Param_fixedPoint, test_convert_maps_to_fixedPointQ16_5)
 {
     convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
-    ASSERT_EQ(RemapType::fixedPointInt16, check_and_get_remap_type(dst_map1, dst_map2));
+    ASSERT_EQ(RemapType::fixedPointQ16_5, checkAndGetRemapType(dst_map1, dst_map2));
 }
 
 TEST_P(Param_int16, test_convert_maps_to_Int16)
 {
     convertMaps(map_x, map_y, dst_map1, dst_map2, dst1type, nninterpolate);
-    ASSERT_EQ(RemapType::int16, check_and_get_remap_type(dst_map1, dst_map2));
+    ASSERT_EQ(RemapType::int16, checkAndGetRemapType(dst_map1, dst_map2));
 }
 
 struct Param_RemapTest : public ParamConvertMapsTest

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -95,7 +95,7 @@ CV_ImageWarpBaseTest::CV_ImageWarpBaseTest() :
     BaseTest(), interpolation(-1),
     src(), dst(), reference_dst()
 {
-    test_case_count = 40;
+    test_case_count = 50;
     ts->set_failed_test_info(cvtest::TS::OK);
 }
 
@@ -742,7 +742,7 @@ void CV_Remap_Test::generate_test_data()
     borderValue = Scalar::all(rng.uniform(0, 255));
 
     // generating the mapx, mapy matrices
-    static const int mapx_types[] = { CV_16SC2, CV_32FC1, CV_32FC2 };
+    static const int mapx_types[] = { CV_16SC2, CV_32SC2, CV_32FC1, CV_32FC2 };
     mapx.create(dst.size(), mapx_types[rng.uniform(0, sizeof(mapx_types) / sizeof(int))]);
     mapy.release();
 
@@ -783,6 +783,18 @@ void CV_Remap_Test::generate_test_data()
                     }
                     break;
                 }
+            }
+        }
+        break;
+
+        case CV_32SC2:
+        {
+            interpolation = INTER_NEAREST;
+            MatIterator_<Vec2i> begin_x = mapx.begin<Vec2i>(), end_x = mapx.end<Vec2i>();
+            for ( ; begin_x != end_x; ++begin_x)
+            {
+                (*begin_x)[0] = static_cast<int>(rng.uniform(static_cast<int>(_n), std::max(src.cols + n - 1, 0)));
+                (*begin_x)[1] = static_cast<int>(rng.uniform(static_cast<int>(_n), std::max(src.rows + n - 1, 0)));
             }
         }
         break;

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -793,9 +793,16 @@ void CV_Remap_Test::generate_test_data()
             MatIterator_<Vec2i> begin_x = mapx.begin<Vec2i>(), end_x = mapx.end<Vec2i>();
             for ( ; begin_x != end_x; ++begin_x)
             {
-                (*begin_x)[0] = static_cast<int>(rng.uniform(static_cast<int>(_n), std::max(src.cols + n - 1, 0)));
-                (*begin_x)[1] = static_cast<int>(rng.uniform(static_cast<int>(_n), std::max(src.rows + n - 1, 0)));
+                (*begin_x)[0] = rng.uniform(0, src.cols);
+                (*begin_x)[1] = rng.uniform(0, src.rows);
             }
+            //if (rng.uniform(0, 2))
+            //{
+            //    mapy.create(dst.size(), CV_16UC1);
+            //    MatIterator_<ushort> begin_y = mapy.begin<ushort>(), end_y = mapy.end<ushort>();
+            //    for ( ; begin_y != end_y; ++begin_y)
+            //        *begin_y = static_cast<ushort>(rng.uniform(0, 1024));
+            //}
         }
         break;
 


### PR DESCRIPTION
This PR add int32 support for remap (so far only **INTER_NEAREST**), add tests and update docs. PR depends on #20911.

**Fixes**
- #4694
- #7544

**Features**
PR uses the remap types from #20911 and add new types :
```
- fp32_mapxy      // map_x.type() == CV_32FC2 && map_y is empty
- fp32_mapx_mapy  // map_x.type() == CV_32FC1 && map_y.type() == CV_32FC1
- fixedPointQ16_5 // map_x.type() == CV_16SC2 && map_y.type() == CV_16UC1
- int16           // map_x.type() == CV_16SC2 && map_y is empty
- int32           // map_x.type() == CV_32SC2 && map_y is empty
- fixedPointQ32_5 // map_x.type() == CV_32SC2 && map_y.type() == CV_16UC1 // Now this type is disabled
- errorType
```
Now `remap()` can support the input and output images with width/height large than 32767 if map1/map2 have these types:
```

- map1.type() == CV_32FC2 && map2.empty()   // fp32_mapxy
- map1.type() == CV_32SC2 && map2.empty()   // int32

```

Look [this local PR](https://github.com/AleksandrPanov/opencv/pull/5/files) to check diff with PR #20911.

In the following PRs:
- add other interpolations;
- enable fixedPointQ32_5;
- support fp32_mapx_mapy for "big" images;
- add full support for int32/fixedPointQ32_5 to convertMaps()

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
