### PR TITLE
fixed bug: opencv read tif file convert Palette color image as grayscale image

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -303,7 +303,12 @@ bool TiffDecoder::readHeader()
                     result = true;
                     break;
                 case 8:
-                    m_type = CV_MAKETYPE(CV_8U, !isGrayScale ? wanted_channels : 1);
+                    //Palette color, the value of the component is used as an index into the red,
+                    //green and blue curves in the ColorMap field to retrieve an RGB triplet that defines the color.
+                    if(photometric == PHOTOMETRIC_PALETTE)
+                        m_type = CV_MAKETYPE(CV_8U, 3);
+                    else
+                        m_type = CV_MAKETYPE(CV_8U, !isGrayScale ? wanted_channels : 1);
                     result = true;
                     break;
                 case 16:

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -219,6 +219,16 @@ TEST(Imgcodecs_Tiff, readWrite_32FC3_RAW)
     EXPECT_EQ(0, remove(filenameOutput.c_str()));
 }
 
+TEST(Imgcodecs_Tiff, read_palette_color_image)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filenameInput = root + "readwrite/test_palette_color_image.tif";
+
+    const Mat img = cv::imread(filenameInput, IMREAD_UNCHANGED);
+    ASSERT_FALSE(img.empty());
+    ASSERT_EQ(CV_8UC3, img.type());
+}
+
 
 //==================================================================================================
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/931

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs
opencv_extra=master
```