### PR TITLE
tvl1 cuda optflow optimization

### DIFF
--- a/modules/cudaoptflow/src/tvl1flow.cpp
+++ b/modules/cudaoptflow/src/tvl1flow.cpp
@@ -162,7 +162,9 @@ namespace
         GpuMat p32_buf;
 
         GpuMat diff_buf;
-        GpuMat norm_buf;
+
+        GpuMat diff_sum_dev;
+        Mat diff_sum_host;
     };
 
     void OpticalFlowDual_TVL1_Impl::calc(InputArray _frame0, InputArray _frame1, InputOutputArray _flow, Stream& stream)
@@ -361,8 +363,11 @@ namespace
                 estimateU(I1wx, I1wy, grad, rho_c, p11, p12, p21, p22, p31, p32, u1, u2, u3, diff, l_t, static_cast<float>(theta_), gamma_, calcError, stream);
                 if (calcError)
                 {
+                    cuda::calcSum(diff, diff_sum_dev, cv::noArray(), _stream);
+                    diff_sum_dev.download(diff_sum_host, _stream);
                     _stream.waitForCompletion();
-                    error = cuda::sum(diff, norm_buf)[0];
+
+                    error = diff_sum_host.at<double>(0,0);
                     prevError = error;
                 }
                 else


### PR DESCRIPTION
These changes have already been made in the master branch of opencv_contrib, see https://github.com/opencv/opencv_contrib/pull/3089

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:16.04
```