### PR TITLE
(3.4) highgui: drop invalid cvGetWindowImageRect

### DIFF
--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -135,11 +135,6 @@ CVAPI(int) cvNamedWindow( const char* name, int flags CV_DEFAULT(CV_WINDOW_AUTOS
 CVAPI(void) cvSetWindowProperty(const char* name, int prop_id, double prop_value);
 CVAPI(double) cvGetWindowProperty(const char* name, int prop_id);
 
-#ifdef __cplusplus  // FIXIT remove in OpenCV 4.0
-/* Get window image rectangle coordinates, width and height */
-CVAPI(cv::Rect)cvGetWindowImageRect(const char* name);
-#endif
-
 /* display image within window (highgui windows remember their content) */
 CVAPI(void) cvShowImage( const char* name, const CvArr* image );
 

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -191,6 +191,7 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
     }
 }
 
+static
 cv::Rect cvGetWindowImageRect(const char* name)
 {
     if (!name)


### PR DESCRIPTION
return type is C++ template

relates #10412

```
force_builders=Custom Win
buildworker:Custom Win=windows-3
test_opencl:Custom Win=ON
build_image:Custom Win=oneapi-2021.4.0-clang
```