### PR TITLE
(4.x) highgui: drop invalid cvGetWindowImageRect

### DIFF
--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -129,11 +129,6 @@ CVAPI(int) cvNamedWindow( const char* name, int flags CV_DEFAULT(CV_WINDOW_AUTOS
 CVAPI(void) cvSetWindowProperty(const char* name, int prop_id, double prop_value);
 CVAPI(double) cvGetWindowProperty(const char* name, int prop_id);
 
-#ifdef __cplusplus  // FIXIT remove in OpenCV 4.0
-/* Get window image rectangle coordinates, width and height */
-CVAPI(cv::Rect)cvGetWindowImageRect(const char* name);
-#endif
-
 /* display image within window (highgui windows remember their content) */
 CVAPI(void) cvShowImage( const char* name, const CvArr* image );
 

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -399,13 +399,13 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
 #endif
 }
 
-cv::Rect cvGetWindowImageRect(const char* name)
+cv::Rect cv::getWindowImageRect(const String& winname)
 {
     CV_TRACE_FUNCTION();
-    CV_Assert(name);
+    CV_Assert(!winname.empty());
 
     {
-        auto window = findWindow_(name);
+        auto window = findWindow_(winname);
         if (window)
         {
             return window->getImageRect();
@@ -416,7 +416,7 @@ cv::Rect cvGetWindowImageRect(const char* name)
     auto backend = getCurrentUIBackend();
     if (backend)
     {
-        CV_LOG_WARNING(NULL, "Can't find window with name: '" << name << "'. Do nothing");
+        CV_LOG_WARNING(NULL, "Can't find window with name: '" << winname << "'. Do nothing");
         CV_NOT_FOUND_DEPRECATION;
     }
     else
@@ -427,24 +427,18 @@ cv::Rect cvGetWindowImageRect(const char* name)
 #else
 
     #if defined (HAVE_QT)
-        return cvGetWindowRect_QT(name);
+        return cvGetWindowRect_QT(winname.c_str());
     #elif defined(HAVE_WIN32UI)
-        return cvGetWindowRect_W32(name);
+        return cvGetWindowRect_W32(winname.c_str());
     #elif defined (HAVE_GTK)
-        return cvGetWindowRect_GTK(name);
+        return cvGetWindowRect_GTK(winname.c_str());
     #elif defined (HAVE_COCOA)
-        return cvGetWindowRect_COCOA(name);
+        return cvGetWindowRect_COCOA(winname.c_str());
     #else
         return Rect(-1, -1, -1, -1);
     #endif
 
 #endif
-}
-
-cv::Rect cv::getWindowImageRect(const String& winname)
-{
-    CV_TRACE_FUNCTION();
-    return cvGetWindowImageRect(winname.c_str());
 }
 
 void cv::namedWindow( const String& winname, int flags )


### PR DESCRIPTION
C function can't return C++ object.

relates #10412
relates #20980