### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ ocv_cmake_hook(CMAKE_INIT)
 
 # must go before the project()/enable_language() commands
 ocv_update(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configs" FORCE)
+if(NOT DEFINED CMAKE_BUILD_TYPE
+    AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE
+)
+  message(STATUS "'Release' build type is used by default. Use CMAKE_BUILD_TYPE to specify build type (Release or Debug)")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build")
+endif()
 if(DEFINED CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${CMAKE_CONFIGURATION_TYPES}")
 endif()
@@ -610,10 +616,6 @@ endif()
 # ----------------------------------------------------------------------------
 # OpenCV compiler and linker options
 # ----------------------------------------------------------------------------
-# In case of Makefiles if the user does not setup CMAKE_BUILD_TYPE, assume it's Release:
-if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja" AND "${CMAKE_BUILD_TYPE}" STREQUAL "")
-  set(CMAKE_BUILD_TYPE Release)
-endif()
 
 ocv_cmake_hook(POST_CMAKE_BUILD_OPTIONS)
 

--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -241,7 +241,7 @@ if(X86 OR X86_64)
     ocv_intel_compiler_optimization_option(FP16 "-mavx" "/arch:AVX")
     ocv_intel_compiler_optimization_option(AVX "-mavx" "/arch:AVX")
     ocv_intel_compiler_optimization_option(FMA3 "" "")
-    ocv_intel_compiler_optimization_option(POPCNT "" "")
+    ocv_intel_compiler_optimization_option(POPCNT "-mpopcnt" "")  # -mpopcnt is available since ICC 19.0.0
     ocv_intel_compiler_optimization_option(SSE4_2 "-msse4.2" "/arch:SSE4.2")
     ocv_intel_compiler_optimization_option(SSE4_1 "-msse4.1" "/arch:SSE4.1")
     ocv_intel_compiler_optimization_option(SSE3 "-msse3" "/arch:SSE3")

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -719,6 +719,8 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #  elif __cplusplus >= 201703L
 //   available when compiler is C++17 compliant
 #    define CV_NODISCARD_STD [[nodiscard]]
+#  elif defined(__INTEL_COMPILER)
+     // see above, available when C++17 is enabled
 #  elif defined(_MSC_VER) && _MSC_VER >= 1911 && _MSVC_LANG >= 201703L
 //   available with VS2017 v15.3+ with /std:c++17 or higher; works on functions and classes
 #    define CV_NODISCARD_STD [[nodiscard]]

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -244,7 +244,7 @@ struct v_uint64x2
     explicit v_uint64x2(__m128i v) : val(v) {}
     v_uint64x2(uint64 v0, uint64 v1)
     {
-#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64)
+#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64) && !defined(__clang__)
         val = _mm_setr_epi64x((int64_t)v0, (int64_t)v1);
 #elif defined(__GNUC__)
         val = _mm_setr_epi64((__m64)v0, (__m64)v1);
@@ -278,7 +278,7 @@ struct v_int64x2
     explicit v_int64x2(__m128i v) : val(v) {}
     v_int64x2(int64 v0, int64 v1)
     {
-#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64)
+#if defined(_MSC_VER) && _MSC_VER >= 1920/*MSVS 2019*/ && defined(_M_X64) && !defined(__clang__)
         val = _mm_setr_epi64x((int64_t)v0, (int64_t)v1);
 #elif defined(__GNUC__)
         val = _mm_setr_epi64((__m64)v0, (__m64)v1);

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -47,12 +47,15 @@
 
 #include "opencv2/core/hal/interface.h"
 
-#if defined __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined _MSC_VER
-#  pragma warning( push )
-#  pragma warning( disable: 4100 )
+#if defined(__clang__)  // clang or MSVC clang
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 //! @addtogroup core_hal_interface
@@ -731,10 +734,12 @@ inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, i
 //! @}
 
 
-#if defined __GNUC__
-#  pragma GCC diagnostic pop
-#elif defined _MSC_VER
-#  pragma warning( pop )
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
 #include "hal_internal.hpp"

--- a/modules/features2d/src/hal_replacement.hpp
+++ b/modules/features2d/src/hal_replacement.hpp
@@ -44,12 +44,15 @@
 
 #include "opencv2/core/hal/interface.h"
 
-#if defined __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined _MSC_VER
-#  pragma warning( push )
-#  pragma warning( disable: 4100 )
+#if defined(__clang__)  // clang or MSVC clang
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 //! @addtogroup features2d_hal_interface
@@ -103,10 +106,12 @@ inline int hal_ni_FAST(const uchar* src_data, size_t src_step, int width, int he
 //! @}
 
 
-#if defined __GNUC__
-#  pragma GCC diagnostic pop
-#elif defined _MSC_VER
-#  pragma warning( pop )
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
 #include "custom_hal.hpp"

--- a/modules/imgproc/src/hal_replacement.hpp
+++ b/modules/imgproc/src/hal_replacement.hpp
@@ -48,12 +48,15 @@
 #include "opencv2/core/hal/interface.h"
 #include "opencv2/imgproc/hal/interface.h"
 
-#if defined __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-parameter"
-#elif defined _MSC_VER
-#  pragma warning( push )
-#  pragma warning( disable: 4100 )
+#if defined(__clang__)  // clang or MSVC clang
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 //! @addtogroup imgproc_hal_interface
@@ -809,10 +812,12 @@ inline int hal_ni_canny(const uchar* src_data, size_t src_step, uchar* dst_data,
 
 //! @}
 
-#if defined __GNUC__
-#  pragma GCC diagnostic pop
-#elif defined _MSC_VER
-#  pragma warning( pop )
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
 #include "custom_hal.hpp"


### PR DESCRIPTION
~~#20958 from noahstier:3.4_tvl1_optimization~~
#20960 from alalek:fix_icc_support_3.4
#20961 from alalek:fix_msvc_clang
#20967 from alalek:fix_msvc_clang_unused_parameter
~~#20969 from alalek:fix_msvc_clang_warning_noreturn~~
#20971 from alalek:cmake_build_type_use_release
~~#20980 from alalek:highgui_fix_cvGetWindowImageRect_3.4~~

(4.x) Merge 3.4
Previous "Merge 3.4": #20928

<cut/>

<details>

```
buildworker:Win64 OpenCL=windows-2
Xbuildworker:Custom=linux-1,linux-2,linux-4,linux-6
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6
Xbuild_image:Custom=javascript-simd
Xbuild_image:Custom=powerpc64le
Xbuild_image:Custom=ubuntu-openvino-2019r3.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2020.4.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.2.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.4.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.4.1:20.04
Xbuildworker:Custom=linux-1
Xbuild_image:Custom=ubuntu-vulkan:16.04
Xbuildworker:Custom=linux-4
Xbuild_image:Custom=fedora:28
Xbuild_image:Custom=ubuntu-cuda:16.04
Xbuild_image:Custom=ubuntu-clang:18.04
Xbuild_image:Custom=ubuntu:20.04
Xbuildworker:Custom=linux-1
Xbuild_image:Custom=javascript-simd
Xbuild_image:Custom=mips64el

Xbuild_image:Custom Mac=openvino-2019r3.0
Xbuild_image:Custom Mac=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.4.0
Xbuild_image:Custom Mac=openvino-2021.1.0
Xbuild_image:Custom Mac=openvino-2021.2.0
Xbuild_image:Custom Mac=openvino-2021.3.0
Xbuild_image:Custom Mac=openvino-2021.4.0
build_image:Custom Mac=openvino-2021.4.1
test_modules:Custom Mac=dnn,gapi,python2,python3,java

Xbuild_image:Custom Win=openvino-2019r3.0
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Win=openvino-2020.4.0
Xbuild_image:Custom Win=openvino-2021.1.0
Xbuild_image:Custom Win=openvino-2021.2.0
Xbuild_image:Custom Win=openvino-2021.3.0
Xbuild_image:Custom Win=openvino-2021.4.0
build_image:Custom Win=openvino-2021.4.1
buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF
Xbuild_image:Custom Win=msvs2017
Xbuild_image:Custom Win=msvs2019
```

</details>
