### PR TITLE
videoio(dshow): eliminate build warnings from MSVC-Clang

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -93,8 +93,9 @@ Thanks to:
 #pragma warning(disable: 4995)
 #endif
 
-#ifdef __MINGW32__
-// MinGW does not understand COM interfaces
+#if defined(__clang__)  // clang or MSVC clang
+#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#elif defined(__GNUC__) // MinGW
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #endif
 


### PR DESCRIPTION
```
force_builders=Custom,Custom Win
buildworker:Custom Win=windows-3
test_opencl:Custom Win=ON
build_image:Custom Win=oneapi-2021.4.0-clang
Xbuild_image:Custom Win=oneapi-2021.4.0
Xbuild_image:Custom Win=oneapi-2021.4.0-icc
Xbuild_image:Custom Win=msvs2019-ninja

build_image:Custom=oneapi-2021.4.0
buildworker:Custom=linux-1
```