### PR TITLE
cmake: fix opencv_java location in case of Win32 Ninja builds

### DIFF
--- a/modules/java/jni/CMakeLists.txt
+++ b/modules/java/jni/CMakeLists.txt
@@ -16,6 +16,8 @@ endforeach()
 set(__type MODULE)
 if(BUILD_FAT_JAVA_LIB)
   set(__type SHARED) # samples link to libopencv_java
+elseif(WIN32 AND CMAKE_GENERATOR MATCHES "Ninja")
+  set(__type SHARED)  # avoid placing .dll into lib/... location
 elseif(APPLE)
   set(CMAKE_SHARED_MODULE_SUFFIX ".dylib")  # Java is not able to load .so files
 endif()


### PR DESCRIPTION
"MODULE" uses `/out:lib\opencv_java3416.dll`. In this location there is no way to find opencv_core DLLs.

```
force_builders=Custom Win
buildworker:Custom Win=windows-3
test_opencl:Custom Win=ON
build_image:Custom Win=msvs2019-ninja
```