### PR TITLE
G-API: Removing G-API test code that is a reflection of ts module

### DIFF
--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -159,7 +159,6 @@ PERF_TEST_P_(BuildPyr_CalcOptFlow_PipelinePerfTest, TestPerformance)
 PERF_TEST_P_(BackgroundSubtractorPerfTest, TestPerformance)
 {
     namespace gvideo = cv::gapi::video;
-    initTestDataPath();
 
     gvideo::BackgroundSubtractorType opType;
     std::string filePath = "";

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -60,20 +60,7 @@ namespace
 
     inline bool initTestDataPathSilent()
     {
-#ifndef WINRT
-        static bool initialized = false;
-        if (!initialized)
-        {
-            // Since G-API has no own test data (yet), it is taken from the common space
-            const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-            if (testDataPath != nullptr) {
-                cvtest::addDataSearchPath(testDataPath);
-                initialized = true;
-            }
-        }
-
-        return initialized;
-#endif // WINRT
+        return true;
     }
 
     inline void initTestDataPath()

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -58,27 +58,6 @@ namespace
         return o;
     }
 
-    inline bool initTestDataPathSilent()
-    {
-        return true;
-    }
-
-    inline void initTestDataPath()
-    {
-        bool initialized = initTestDataPathSilent();
-        GAPI_Assert(initialized &&
-            "OPENCV_TEST_DATA_PATH environment variable is either not set or set incorrectly.");
-    }
-
-    inline void initTestDataPathOrSkip()
-    {
-        bool initialized = initTestDataPathSilent();
-        if (!initialized)
-        {
-            throw cvtest::SkipTestException("Can't find test data");
-        }
-    }
-
     template <typename T> inline void initPointRandU(cv::RNG &rng, cv::Point_<T>& pt)
     {
         GAPI_Assert(std::is_integral<T>::value);
@@ -286,7 +265,6 @@ public:
 
     void initMatFromImage(int type, const std::string& fileName)
     {
-        initTestDataPath();
 
         int channels = (type >> CV_CN_SHIFT) + 1;
         GAPI_Assert(channels == 1 || channels == 3 || channels == 4);
@@ -310,7 +288,6 @@ public:
 
     void initMatsFromImages(int channels, const std::string& pattern, int imgNum)
     {
-        initTestDataPath();
         GAPI_Assert(channels == 1 || channels == 3 || channels == 4);
         const int flags = (channels == 1) ? cv::IMREAD_GRAYSCALE : cv::IMREAD_COLOR;
 

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -92,8 +92,6 @@ TEST_P(BuildPyr_CalcOptFlow_PipelineTest, AccuracyTest)
 #ifdef HAVE_OPENCV_VIDEO
 TEST_P(BackgroundSubtractorTest, AccuracyTest)
 {
-    initTestDataPath();
-
     cv::gapi::video::BackgroundSubtractorType opType;
     double thr = -1;
     std::tie(opType, thr) = typeAndThreshold;

--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -43,10 +43,6 @@ namespace opencv_test
 //----------------------------------------------- Simple tests ------------------------------------------------
 namespace
 {
-    inline void initTestDataPath()
-    {
-    }
-
     G_TYPED_KERNEL(GCountCalls, <cv::GOpaque<int>(GMat)>, "org.opencv.test.count_calls")
     {
         static GOpaqueDesc outMeta(GMatDesc /* in */) { return empty_gopaque_desc(); }
@@ -169,8 +165,6 @@ TEST(StatefulKernel, StateIsMutableInRuntime)
 
 TEST(StatefulKernel, StateIsAutoResetForNewStream)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GOpaque<bool> out = GIsStateUpToDate::on(in);
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
@@ -317,8 +311,6 @@ namespace
 
 TEST(StatefulKernel, StateIsInitViaCompArgsInStreaming)
 {
-    initTestDataPath();
-
     // G-API graph declaration
     cv::GMat in;
     cv::GMat out = GBackSub::on(in);

--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -45,18 +45,6 @@ namespace
 {
     inline void initTestDataPath()
     {
-#ifndef WINRT
-        static bool initialized = false;
-        if (!initialized)
-        {
-            // Since G-API has no own test data (yet), it is taken from the common space
-            const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-            if (testDataPath) {
-                cvtest::addDataSearchPath(testDataPath);
-            }
-            initialized = true;
-        }
-#endif // WINRT
     }
 
     G_TYPED_KERNEL(GCountCalls, <cv::GOpaque<int>(GMat)>, "org.opencv.test.count_calls")

--- a/modules/gapi/test/gapi_graph_meta_tests.cpp
+++ b/modules/gapi/test/gapi_graph_meta_tests.cpp
@@ -13,11 +13,6 @@
 
 namespace opencv_test {
 
-namespace {
-void initTestDataPath() {
-}
-} // anonymous namespace
-
 TEST(GraphMeta, Trad_AccessInput) {
     cv::GMat in;
     cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
@@ -79,8 +74,6 @@ TEST(GraphMeta, Trad_AccessOutput) {
 }
 
 TEST(GraphMeta, Streaming_AccessInput) {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
     cv::GOpaque<int64_t> out2 = cv::gapi::streaming::seq_id(in);
@@ -106,8 +99,6 @@ TEST(GraphMeta, Streaming_AccessInput) {
 }
 
 TEST(GraphMeta, Streaming_AccessOutput) {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::blur(in, cv::Size(3,3));
     cv::GOpaque<int64_t> out2 = cv::gapi::streaming::seq_id(out1);
@@ -139,8 +130,6 @@ TEST(GraphMeta, Streaming_AccessOutput) {
 }
 
 TEST(GraphMeta, Streaming_AccessDesync) {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GOpaque<int64_t> out1 = cv::gapi::streaming::seq_id(in);
     cv::GOpaque<int64_t> out2 = cv::gapi::streaming::timestamp(in);

--- a/modules/gapi/test/gapi_graph_meta_tests.cpp
+++ b/modules/gapi/test/gapi_graph_meta_tests.cpp
@@ -15,18 +15,6 @@ namespace opencv_test {
 
 namespace {
 void initTestDataPath() {
-#ifndef WINRT
-    static bool initialized = false;
-    if (!initialized)
-    {
-        // Since G-API has no own test data (yet), it is taken from the common space
-        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        if (testDataPath != nullptr) {
-            cvtest::addDataSearchPath(testDataPath);
-            initialized = true;
-        }
-    }
-#endif // WINRT
 }
 } // anonymous namespace
 

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -27,18 +27,6 @@ namespace opencv_test
 namespace {
 void initTestDataPath()
 {
-#ifndef WINRT
-    static bool initialized = false;
-    if (!initialized)
-    {
-        // Since G-API has no own test data (yet), it is taken from the common space
-        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        if (testDataPath) {
-            cvtest::addDataSearchPath(testDataPath);
-        }
-        initialized = true;
-    }
-#endif // WINRT
 }
 
 class TestMediaBGR final: public cv::MediaFrame::IAdapter {

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -25,9 +25,6 @@
 namespace opencv_test
 {
 namespace {
-void initTestDataPath()
-{
-}
 
 class TestMediaBGR final: public cv::MediaFrame::IAdapter {
     cv::Mat m_mat;
@@ -1421,7 +1418,6 @@ TEST(Infer, SetInvalidNumberOfRequests)
 
 TEST(Infer, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");
@@ -1489,7 +1485,6 @@ TEST(Infer, TestStreamingInfer)
 
 TEST(InferROI, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");
@@ -1568,7 +1563,6 @@ TEST(InferROI, TestStreamingInfer)
 
 TEST(InferList, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");
@@ -1658,7 +1652,6 @@ TEST(InferList, TestStreamingInfer)
 
 TEST(Infer2, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");
@@ -1749,7 +1742,6 @@ TEST(Infer2, TestStreamingInfer)
 
 TEST(InferEmptyList, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");
@@ -1804,7 +1796,6 @@ TEST(InferEmptyList, TestStreamingInfer)
 
 TEST(Infer2EmptyList, TestStreamingInfer)
 {
-    initTestDataPath();
     initDLDTDataPath();
 
     std::string filepath = findDataFile("cv/video/768x576.avi");

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -85,18 +85,6 @@ namespace opencv_test
 namespace {
 void initTestDataPath()
 {
-#ifndef WINRT
-    static bool initialized = false;
-    if (!initialized)
-    {
-        // Since G-API has no own test data (yet), it is taken from the common space
-        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        if (testDataPath) {
-            cvtest::addDataSearchPath(testDataPath);
-        }
-        initialized = true;
-    }
-#endif // WINRT
 }
 
 // FIXME: taken from the DNN module

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -83,9 +83,6 @@ cv::Mat initMatrixRandU(const int type, const cv::Size& sz_in) {
 namespace opencv_test
 {
 namespace {
-void initTestDataPath()
-{
-}
 
 // FIXME: taken from the DNN module
 void normAssert(cv::InputArray& ref, cv::InputArray& test,
@@ -310,7 +307,6 @@ public:
     cv::Mat in_mat;
 
     ONNXtest() {
-        initTestDataPath();
         env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "test");
         memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
         out_gapi.resize(1);

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -42,18 +42,6 @@ namespace
 {
 void initTestDataPath()
 {
-#ifndef WINRT
-    static bool initialized = false;
-    if (!initialized)
-    {
-        // Since G-API has no own test data (yet), it is taken from the common space
-        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
-        if (testDataPath) {
-            cvtest::addDataSearchPath(testDataPath);
-        }
-        initialized = true;
-    }
-#endif // WINRT
 }
 
 enum class KernelPackage: int

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -40,9 +40,6 @@ namespace opencv_test
 {
 namespace
 {
-void initTestDataPath()
-{
-}
 
 enum class KernelPackage: int
 {
@@ -69,7 +66,6 @@ std::ostream& operator<< (std::ostream &os, const KernelPackage &e)
 struct GAPI_Streaming: public ::testing::TestWithParam<std::tuple<KernelPackage,
                                                                   cv::optional<size_t>>> {
     GAPI_Streaming() {
-        initTestDataPath();
         KernelPackage pkg_kind;
         std::tie(pkg_kind, cap) = GetParam();
         pkg = getKernelPackage(pkg_kind);
@@ -834,8 +830,6 @@ TEST(GAPI_Streaming_Types, XChangeScalar)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Scalar data.
 
-    initTestDataPath();
-
     cv::GMat in;
     cv::GScalar m = cv::gapi::mean(in);
     cv::GMat tmp = cv::gapi::convertTo(in, CV_32F) - m;
@@ -902,8 +896,6 @@ TEST(GAPI_Streaming_Types, XChangeVector)
     // This test verifies if Streaming works when pipeline steps
     // (islands) exchange Vector data.
 
-    initTestDataPath();
-
     cv::GMat in1, in2;
     cv::GMat in = cv::gapi::crop(in1, cv::Rect{0,0,576,576});
     cv::GScalar m = cv::gapi::mean(in);
@@ -968,8 +960,6 @@ TEST(GAPI_Streaming_Types, OutputScalar)
     // This test verifies if Streaming works when pipeline
     // produces scalar data only
 
-    initTestDataPath();
-
     cv::GMat in;
     cv::GScalar out = cv::gapi::mean(in);
     auto sc = cv::GComputation(cv::GIn(in), cv::GOut(out))
@@ -1007,7 +997,6 @@ TEST(GAPI_Streaming_Types, OutputVector)
     // This test verifies if Streaming works when pipeline
     // produces vector data only
 
-    initTestDataPath();
     auto pkg = cv::gapi::kernels<TypesTest::OCVSumV>();
 
     cv::GMat in1, in2;
@@ -1169,7 +1158,6 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
                 return cv::GComputation(cv::GIn(a, b), cv::GOut(c));
             })
     {
-        initTestDataPath();
 
         const auto a_desc = cv::descr_of(m);
         const auto b_desc = cv::descr_of(m);
@@ -1184,7 +1172,6 @@ struct GAPI_Streaming_Unit: public ::testing::Test {
 
 TEST(GAPI_Streaming, TestTwoVideosDifferentLength)
 {
-    initTestDataPath();
     auto desc = cv::GMatDesc{CV_8U,3,{768,576}};
     auto path1 = findDataFile("cv/video/768x576.avi");
     auto path2 = findDataFile("highgui/video/big_buck_bunny.avi");
@@ -1446,8 +1433,6 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Regular)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1479,8 +1464,6 @@ TEST(GAPI_Streaming_Desync, SmokeTest_Streaming)
 
 TEST(GAPI_Streaming_Desync, SmokeTest_Streaming_TwoParts)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat tmp1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
     cv::GMat out1 = cv::gapi::Canny(tmp1, 32, 128, 3);
@@ -1616,8 +1599,6 @@ TEST(GAPI_Streaming_Desync, Negative_CrossOtherDesync_Tier1)
 
 TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 
@@ -1641,8 +1622,6 @@ TEST(GAPI_Streaming_Desync, Negative_SynchronizedPull)
 
 TEST(GAPI_Streaming_Desync, UseSpecialPull)
 {
-    initTestDataPath();
-
     cv::GMat in;
     cv::GMat out1 = cv::gapi::boxFilter(in, -1, cv::Size(3,3));
 
@@ -1799,7 +1778,6 @@ TEST(GAPI_Streaming_Desync, DesyncObjectConsumedByTwoIslandsViaSameDesync) {
 
 TEST(GAPI_Streaming, CopyFrame)
 {
-    initTestDataPath();
     std::string filepath = findDataFile("cv/video/768x576.avi");
 
     cv::GFrame in;
@@ -1838,7 +1816,6 @@ TEST(GAPI_Streaming, CopyFrame)
 
 TEST(GAPI_Streaming, CopyMat)
 {
-    initTestDataPath();
     std::string filepath = findDataFile("cv/video/768x576.avi");
 
     cv::GMat in;
@@ -1875,7 +1852,6 @@ TEST(GAPI_Streaming, CopyMat)
 
 TEST(GAPI_Streaming, Reshape)
 {
-    initTestDataPath();
     std::string filepath = findDataFile("cv/video/768x576.avi");
 
     cv::GFrame in;
@@ -2065,8 +2041,7 @@ TEST_P(GAPI_Accessors_In_Streaming, AccuracyTest)
     auto accessor = gapi_functions[accessType];
     auto fromBGR = ref_functions[std::make_pair(sourceType, accessType)];
 
-    initTestDataPathOrSkip();
-    const std::string& absFilePath = findDataFile(filepath, false);
+    const std::string& absFilePath = findDataFile(filepath);
 
     cv::GFrame in;
     cv::GMat out = accessor(in);
@@ -2117,7 +2092,6 @@ TEST_P(GAPI_Accessors_Meta_In_Streaming, AccuracyTest)
     auto accessor = gapi_functions[accessType];
     auto fromBGR = ref_functions[std::make_pair(sourceType, accessType)];
 
-    initTestDataPathOrSkip();
     const std::string& absFilePath = findDataFile(filepath, false);
 
     cv::GFrame in;
@@ -2316,7 +2290,6 @@ GAPI_OCV_KERNEL(GOcvTestBlur, GTestBlur) {
 };
 
 TEST(GAPI_Streaming, TestDesyncMediaFrame) {
-    initTestDataPath();
     cv::GFrame in;
     auto blurred = GTestBlur::on(in);
     auto desynced = cv::gapi::streaming::desync(blurred);

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -2092,7 +2092,7 @@ TEST_P(GAPI_Accessors_Meta_In_Streaming, AccuracyTest)
     auto accessor = gapi_functions[accessType];
     auto fromBGR = ref_functions[std::make_pair(sourceType, accessType)];
 
-    const std::string& absFilePath = findDataFile(filepath, false);
+    const std::string& absFilePath = findDataFile(filepath);
 
     cv::GFrame in;
     cv::GMat gmat = accessor(in);

--- a/modules/gapi/test/test_main.cpp
+++ b/modules/gapi/test/test_main.cpp
@@ -9,4 +9,4 @@
 
 #include "test_precomp.hpp"
 
-CV_TEST_MAIN("gapi")
+CV_TEST_MAIN("")


### PR DESCRIPTION
This PR sets the second parameter of FindDataFile to false for tests of G-API. This handles the problem with failed tests which aren't skipped.
Also removing `initTestDataPath()` logic.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Build Configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```