### PR TITLE
BUGFIX in sample falsecolor.cpp | Fix trackbar position settings

### DIFF
--- a/samples/cpp/falsecolor.cpp
+++ b/samples/cpp/falsecolor.cpp
@@ -16,14 +16,14 @@ struct ParamColorMap {
 String winName="False color";
 static const String ColorMaps[] = { "Autumn", "Bone", "Jet", "Winter", "Rainbow", "Ocean", "Summer", "Spring",
                                     "Cool", "HSV", "Pink", "Hot", "Parula", "Magma", "Inferno", "Plasma", "Viridis",
-                                    "Cividis", "Twilight", "Twilight Shifted", "Turbo", "User defined (random)" };
+                                    "Cividis", "Twilight", "Twilight Shifted", "Turbo", "Deep Green", "User defined (random)" };
 
 static void TrackColorMap(int x, void *r)
 {
     ParamColorMap *p = (ParamColorMap*)r;
     Mat dst;
     p->iColormap= x;
-    if (x == COLORMAP_TURBO + 1)
+    if (x == COLORMAP_DEEPGREEN + 1)
     {
         Mat lutRND(256, 1, CV_8UC3);
         randu(lutRND, Scalar(0, 0, 0), Scalar(255, 255, 255));
@@ -97,10 +97,10 @@ int main(int argc, char** argv)
 
     imshow("Gray image",img);
     namedWindow(winName);
-    createTrackbar("colormap", winName,&p.iColormap,1,TrackColorMap,(void*)&p);
+    createTrackbar("colormap", winName, NULL, COLORMAP_DEEPGREEN + 1, TrackColorMap, (void*)&p);
     setTrackbarMin("colormap", winName, COLORMAP_AUTUMN);
-    setTrackbarMax("colormap", winName, COLORMAP_TURBO+1);
-    setTrackbarPos("colormap", winName, -1);
+    setTrackbarMax("colormap", winName, COLORMAP_DEEPGREEN + 1);
+    setTrackbarPos("colormap", winName, COLORMAP_AUTUMN);
 
     TrackColorMap(0, (void*)&p);
 


### PR DESCRIPTION
There are two values that provoke unintended behaviour when running the sample code _falsecolor.cpp_.
First instance is trying to set the tracker position to -1 and that throws and out of bounds exception.
The second instance sets the maximum tracker position to 1 which only allows the two colormaps to be applied the first and the last.

There is an issue that could be closed after this PR is merged. (#21002)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
