### PR TITLE
Update RVV backend for using Clang.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -1435,9 +1435,10 @@ inline scalartype v_reduce_sum(const _Tpvec& a)  \
     return (scalartype)(_wTpvec(res).get0()); \
 }
 
-OPENCV_HAL_IMPL_RVV_REDUCE_SUM_FP(v_float32x4, v_float32x4, vfloat32m1_t, float, f32, f32, 4, fredsum)
+// vfredsum for float has renamed to fredosum, also updated in GNU.
+OPENCV_HAL_IMPL_RVV_REDUCE_SUM_FP(v_float32x4, v_float32x4, vfloat32m1_t, float, f32, f32, 4, fredosum)
 #if CV_SIMD128_64F
-OPENCV_HAL_IMPL_RVV_REDUCE_SUM_FP(v_float64x2, v_float64x2, vfloat64m1_t, double, f64, f64, 2, fredsum)
+OPENCV_HAL_IMPL_RVV_REDUCE_SUM_FP(v_float64x2, v_float64x2, vfloat64m1_t, double, f64, f64, 2, fredosum)
 #endif
 
 

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -587,63 +587,84 @@ OPENCV_HAL_IMPL_RVV_SELF_REINTERPRET(int64x2, s64)
 OPENCV_HAL_IMPL_RVV_SELF_REINTERPRET(float64x2, f64)
 #endif
 
-#define OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(_Tpvec1, _Tpvec2, _nTpvec1, _nTpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2, vl1, vl2) \
+#define OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(_Tpvec1, _Tp1, _Tpvec2, _Tp2, _nTpvec1, _nTpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2, vl1, vl2) \
 inline v_##_Tpvec1 v_reinterpret_as_##suffix1(const v_##_Tpvec2& v) \
 { \
-    return v_##_Tpvec1((_nTpvec1)vle##width2##_v_##nsuffix2##m1(v.val, vl2)); \
+    return v_##_Tpvec1(vreinterpret_v_##nsuffix2##m1_##nsuffix1##m1(v));\
 } \
 inline v_##_Tpvec2 v_reinterpret_as_##suffix2(const v_##_Tpvec1& v) \
 { \
-    return v_##_Tpvec2((_nTpvec2)vle##width1##_v_##nsuffix1##m1(v.val, vl1)); \
+    return v_##_Tpvec2(vreinterpret_v_##nsuffix1##m1_##nsuffix2##m1(v));\
 }
 
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, int8x16, vuint8m1_t, vint8m1_t, u8, s8, u8, i8, 8, 8, 16, 16)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, int16x8, vuint16m1_t, vint16m1_t, u16, s16, u16, i16, 16, 16, 8, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, int32x4, vuint32m1_t, vint32m1_t, u32, s32, u32, i32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, float32x4, vuint32m1_t, vfloat32m1_t, u32, f32, u32, f32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int32x4, float32x4, vint32m1_t, vfloat32m1_t, s32, f32, i32, f32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, int64x2, vuint64m1_t, vint64m1_t, u64, s64, u64, i64, 64, 64, 2, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, uint16x8, vuint8m1_t, vuint16m1_t, u8, u16, u8, u16, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, uint32x4, vuint8m1_t, vuint32m1_t, u8, u32, u8, u32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, uint64x2, vuint8m1_t, vuint64m1_t, u8, u64, u8, u64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, uint32x4, vuint16m1_t, vuint32m1_t, u16, u32, u16, u32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, uint64x2, vuint16m1_t, vuint64m1_t, u16, u64, u16, u64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, uint64x2, vuint32m1_t, vuint64m1_t, u32, u64, u32, u64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int8x16, int16x8, vint8m1_t, vint16m1_t, s8, s16, i8, i16, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int8x16, int32x4, vint8m1_t, vint32m1_t, s8, s32, i8, i32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int8x16, int64x2, vint8m1_t, vint64m1_t, s8, s64, i8, i64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int16x8, int32x4, vint16m1_t, vint32m1_t, s16, s32, i16, i32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int16x8, int64x2, vint16m1_t, vint64m1_t, s16, s64, i16, i64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int32x4, int64x2, vint32m1_t, vint64m1_t, s32, s64, i32, i64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, int16x8, vuint8m1_t, vint16m1_t, u8, s16, u8, i16, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, int32x4, vuint8m1_t, vint32m1_t, u8, s32, u8, i32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, int64x2, vuint8m1_t, vint64m1_t, u8, s64, u8, i64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, int8x16, vuint16m1_t, vint8m1_t, u16, s8, u16, i8, 16, 8, 8, 16)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, int32x4, vuint16m1_t, vint32m1_t, u16, s32, u16, i32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, int64x2, vuint16m1_t, vint64m1_t, u16, s64, u16, i64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, int8x16, vuint32m1_t, vint8m1_t, u32, s8, u32, i8, 32, 8, 4, 16)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, int16x8, vuint32m1_t, vint16m1_t, u32, s16, u32, i16, 32, 16, 4, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, int64x2, vuint32m1_t, vint64m1_t, u32, s64, u32, i64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, int8x16, vuint64m1_t, vint8m1_t, u64, s8, u64, i8, 64, 8, 2, 16)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, int16x8, vuint64m1_t, vint16m1_t, u64, s16, u64, i16, 64, 16, 2, 8)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, int32x4, vuint64m1_t, vint32m1_t, u64, s32, u64, i32, 64, 32, 2, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, float32x4, vuint8m1_t, vfloat32m1_t, u8, f32, u8, f32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, float32x4, vuint16m1_t, vfloat32m1_t, u16, f32, u16, f32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, float32x4, vuint64m1_t, vfloat32m1_t, u64, f32, u64, f32, 64, 32, 2, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int8x16, float32x4, vint8m1_t, vfloat32m1_t, s8, f32, i8, f32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int16x8, float32x4, vint16m1_t, vfloat32m1_t, s16, f32, i16, f32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int64x2, float32x4, vint64m1_t, vfloat32m1_t, s64, f32, i64, f32, 64, 32, 2, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, int8x16, schar, vuint8m1_t, vint8m1_t, u8, s8, u8, i8, 8, 8, 16, 16)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, int16x8, short, vuint16m1_t, vint16m1_t, u16, s16, u16, i16, 16, 16, 8, 8)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, int32x4, int, vuint32m1_t, vint32m1_t, u32, s32, u32, i32, 32, 32, 4, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, float32x4, float, vuint32m1_t, vfloat32m1_t, u32, f32, u32, f32, 32, 32, 4, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, int, float32x4, float, vint32m1_t, vfloat32m1_t, s32, f32, i32, f32, 32, 32, 4, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, uint64, int64x2, int64, vuint64m1_t, vint64m1_t, u64, s64, u64, i64, 64, 64, 2, 2)
 #if CV_SIMD128_64F
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint64x2, float64x2, vuint64m1_t, vfloat64m1_t, u64, f64, u64, f64, 64, 64, 2, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int64x2, float64x2, vint64m1_t, vfloat64m1_t, s64, f64, i64, f64, 64, 64, 2, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint8x16, float64x2, vuint8m1_t, vfloat64m1_t, u8, f64, u8, f64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint16x8, float64x2, vuint16m1_t, vfloat64m1_t, u16, f64, u16, f64, 16, 64, 6, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(uint32x4, float64x2, vuint32m1_t, vfloat64m1_t, u32, f64, u32, f64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int8x16, float64x2, vint8m1_t, vfloat64m1_t, s8, f64, i8, f64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int16x8, float64x2, vint16m1_t, vfloat64m1_t, s16, f64, i16, f64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(int32x4, float64x2, vint32m1_t, vfloat64m1_t, s32, f64, i32, f64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_ONE_TIME_REINTERPRET(float32x4, float64x2, vfloat32m1_t, vfloat64m1_t, f32, f64, f32, f64, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, uint64, float64x2, double, vuint64m1_t, vfloat64m1_t, u64, f64, u64, f64, 64, 64, 2, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int64x2, int64, float64x2, double, vint64m1_t, vfloat64m1_t, s64, f64, i64, f64, 64, 64, 2, 2)
 #endif
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint16x8, ushort, vuint8m1_t, vuint16m1_t, u8, u16, u8, u16, 8, 16, 16, 8)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint32x4, uint, vuint8m1_t, vuint32m1_t, u8, u32, u8, u32, 8, 32, 16, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint64x2, uint64, vuint8m1_t, vuint64m1_t, u8, u64, u8, u64, 8, 64, 16, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, uint32x4, uint, vuint16m1_t, vuint32m1_t, u16, u32, u16, u32, 16, 32, 8, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, uint64x2, uint64, vuint16m1_t, vuint64m1_t, u16, u64, u16, u64, 16, 64, 8, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, uint64x2, uint64, vuint32m1_t, vuint64m1_t, u32, u64, u32, u64, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int16x8, short, vint8m1_t, vint16m1_t, s8, s16, i8, i16, 8, 16, 16, 8)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int32x4, int, vint8m1_t, vint32m1_t, s8, s32, i8, i32, 8, 32, 16, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int64x2, int64, vint8m1_t, vint64m1_t, s8, s64, i8, i64, 8, 64, 16, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, short, int32x4, int, vint16m1_t, vint32m1_t, s16, s32, i16, i32, 16, 32, 8, 4)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, short, int64x2, int64, vint16m1_t, vint64m1_t, s16, s64, i16, i64, 16, 64, 8, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, int, int64x2, int64, vint32m1_t, vint64m1_t, s32, s64, i32, i64, 32, 64, 4, 2)
+
+
+#define OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(_Tpvec1, _Tp1, _Tpvec2, _Tp2, _nTpvec1, _nTpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2, vl1, vl2) \
+inline v_##_Tpvec1 v_reinterpret_as_##suffix1(const v_##_Tpvec2& v) \
+{ \
+    return v_##_Tpvec1(vreinterpret_v_##nsuffix1##width2##m1_##nsuffix1##width1##m1(vreinterpret_v_##nsuffix2##width2##m1_##nsuffix1##width2##m1(v)));\
+} \
+inline v_##_Tpvec2 v_reinterpret_as_##suffix2(const v_##_Tpvec1& v) \
+{ \
+    return v_##_Tpvec2(vreinterpret_v_##nsuffix1##width2##m1_##nsuffix2##width2##m1(vreinterpret_v_##nsuffix1##width1##m1_##nsuffix1##width2##m1(v)));\
+}
+
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int16x8, short, vuint8m1_t, vint16m1_t, u8, s16, u, i, 8, 16, 16, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int32x4, int, vuint8m1_t, vint32m1_t, u8, s32, u, i, 8, 32, 16, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int64x2, int64, vuint8m1_t, vint64m1_t, u8, s64, u, i, 8, 64, 16, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int8x16, schar, vuint16m1_t, vint8m1_t, u16, s8, u, i, 16, 8, 8, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int32x4, int, vuint16m1_t, vint32m1_t, u16, s32, u, i, 16, 32, 8, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int64x2, int64, vuint16m1_t, vint64m1_t, u16, s64, u, i, 16, 64, 8, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int8x16, schar, vuint32m1_t, vint8m1_t, u32, s8, u, i, 32, 8, 4, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int16x8, short, vuint32m1_t, vint16m1_t, u32, s16, u, i, 32, 16, 4, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int64x2, int64, vuint32m1_t, vint64m1_t, u32, s64, u, i, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int8x16, schar, vuint64m1_t, vint8m1_t, u64, s8, u, i, 64, 8, 2, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int16x8, short, vuint64m1_t, vint16m1_t, u64, s16, u, i, 64, 16, 2, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int32x4, int, vuint64m1_t, vint32m1_t, u64, s32, u, i, 64, 32, 2, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, float32x4, float, vuint8m1_t, vfloat32m1_t, u8, f32, u, f, 8, 32, 16, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, float32x4, float, vuint16m1_t, vfloat32m1_t, u16, f32, u, f, 16, 32, 8, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, float32x4, float, vuint64m1_t, vfloat32m1_t, u64, f32, u, f, 64, 32, 2, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, schar, float32x4, float, vint8m1_t, vfloat32m1_t, s8, f32, i, f, 8, 32, 16, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, short, float32x4, float, vint16m1_t, vfloat32m1_t, s16, f32, i, f, 16, 32, 8, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int64x2, int64, float32x4, float, vint64m1_t, vfloat32m1_t, s64, f32, i, f, 64, 32, 2, 4)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, float64x2, double, vuint8m1_t, vfloat64m1_t, u8, f64, u, f, 8, 64, 16, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, float64x2, double, vuint16m1_t, vfloat64m1_t, u16, f64, u, f, 16, 64, 6, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, float64x2, double, vuint32m1_t, vfloat64m1_t, u32, f64, u, f, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, schar, float64x2, double, vint8m1_t, vfloat64m1_t, s8, f64, i, f, 8, 64, 16, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, short, float64x2, double, vint16m1_t, vfloat64m1_t, s16, f64, i, f, 16, 64, 8, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int32x4, int, float64x2, double, vint32m1_t, vfloat64m1_t, s32, f64, i, f, 32, 64, 4, 2)
+
+// Three times reinterpret
+inline v_float32x4 v_reinterpret_as_f32(const v_float64x2& v) \
+{ \
+    return v_float32x4(vreinterpret_v_u32m1_f32m1(vreinterpret_v_u64m1_u32m1(vreinterpret_v_f64m1_u64m1(v))));\
+} \
+inline v_float64x2 v_reinterpret_as_f64(const v_float32x4& v) \
+{ \
+    return v_float64x2(vreinterpret_v_u64m1_f64m1(vreinterpret_v_u32m1_u64m1(vreinterpret_v_f32m1_u32m1(v))));\
+}
 
 ////////////// Extract //////////////
 

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -710,7 +710,7 @@ OPENCV_HAL_IMPL_RVV_EXTRACT_FP(v_float64x2, double, f64, vfmv_f_s_f64m1_f64, 2)
 #define OPENCV_HAL_IMPL_RVV_LOADSTORE_OP(_Tpvec, _nTpvec, _Tp, hvl, vl, width, suffix, vmv) \
 inline _Tpvec v_load(const _Tp* ptr) \
 { \
-    return _Tpvec((_nTpvec)vle8_v_u8m1((uchar*)ptr, 16)); \
+    return _Tpvec(vle##width##_v_##suffix##m1(ptr, vl)); \
 } \
 inline _Tpvec v_load_aligned(const _Tp* ptr) \
 { \
@@ -723,7 +723,7 @@ inline _Tpvec v_load_low(const _Tp* ptr) \
 } \
 inline void v_store(_Tp* ptr, const _Tpvec& a) \
 { \
-    vse8_v_u8m1((uchar*)ptr, vle8_v_u8m1((uchar*)a.val, 16), 16); \
+    vse##width##_v_##suffix##m1(ptr, a, vl); \
 } \
 inline void v_store_aligned(_Tp* ptr, const _Tpvec& a) \
 { \

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -1563,7 +1563,7 @@ inline v_float64x2 v_muladd(const v_float64x2& a, const v_float64x2& b, const v_
 
 ////////////// Check all/any //////////////
 
-// use overloaded vpopc in clang, no casting like (vuint64m1_t) is needed.
+// use overloaded vcpop in clang, no casting like (vuint64m1_t) is needed.
 #ifndef __clang__
 #define OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(_Tpvec, suffix, shift, vl) \
 inline bool v_check_all(const _Tpvec& a) \
@@ -1618,11 +1618,11 @@ inline bool v_check_any(const v_float64x2& a)
 #define OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(_Tpvec, vl) \
 inline bool v_check_all(const _Tpvec& a) \
 { \
-    return vpopc(vmslt(a, 0, vl), vl) == vl; \
+    return vcpop(vmslt(a, 0, vl), vl) == vl; \
 } \
 inline bool v_check_any(const _Tpvec& a) \
 { \
-    return vpopc(vmslt(a, 0, vl), vl) != 0; \
+    return vcpop(vmslt(a, 0, vl), vl) != 0; \
 }
 
 OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(v_int8x16, 16)

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -1563,6 +1563,8 @@ inline v_float64x2 v_muladd(const v_float64x2& a, const v_float64x2& b, const v_
 
 ////////////// Check all/any //////////////
 
+// use overloaded vpopc in clang, no casting like (vuint64m1_t) is needed.
+#ifndef __clang__
 #define OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(_Tpvec, suffix, shift, vl) \
 inline bool v_check_all(const _Tpvec& a) \
 { \
@@ -1612,7 +1614,55 @@ inline bool v_check_all(const v_float64x2& a)
 inline bool v_check_any(const v_float64x2& a)
 { return v_check_any(v_reinterpret_as_u64(a)); }
 #endif
+#else
+#define OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(_Tpvec, vl) \
+inline bool v_check_all(const _Tpvec& a) \
+{ \
+    return vpopc(vmslt(a, 0, vl), vl) == vl; \
+} \
+inline bool v_check_any(const _Tpvec& a) \
+{ \
+    return vpopc(vmslt(a, 0, vl), vl) != 0; \
+}
 
+OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(v_int8x16, 16)
+OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(v_int16x8, 8)
+OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(v_int32x4, 4)
+OPENCV_HAL_IMPL_RVV_CHECK_ALLANY(v_int64x2, 2)
+
+
+inline bool v_check_all(const v_uint8x16& a)
+{ return v_check_all(v_reinterpret_as_s8(a)); }
+inline bool v_check_any(const v_uint8x16& a)
+{ return v_check_any(v_reinterpret_as_s8(a)); }
+
+inline bool v_check_all(const v_uint16x8& a)
+{ return v_check_all(v_reinterpret_as_s16(a)); }
+inline bool v_check_any(const v_uint16x8& a)
+{ return v_check_any(v_reinterpret_as_s16(a)); }
+
+inline bool v_check_all(const v_uint32x4& a)
+{ return v_check_all(v_reinterpret_as_s32(a)); }
+inline bool v_check_any(const v_uint32x4& a)
+{ return v_check_any(v_reinterpret_as_s32(a)); }
+
+inline bool v_check_all(const v_float32x4& a)
+{ return v_check_all(v_reinterpret_as_s32(a)); }
+inline bool v_check_any(const v_float32x4& a)
+{ return v_check_any(v_reinterpret_as_s32(a)); }
+
+inline bool v_check_all(const v_uint64x2& a)
+{ return v_check_all(v_reinterpret_as_s64(a)); }
+inline bool v_check_any(const v_uint64x2& a)
+{ return v_check_any(v_reinterpret_as_s64(a)); }
+
+#if CV_SIMD128_64F
+inline bool v_check_all(const v_float64x2& a)
+{ return v_check_all(v_reinterpret_as_s64(a)); }
+inline bool v_check_any(const v_float64x2& a)
+{ return v_check_any(v_reinterpret_as_s64(a)); }
+#endif
+#endif
 ////////////// abs //////////////
 
 #define OPENCV_HAL_IMPL_RVV_ABSDIFF(_Tpvec, abs) \

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -587,7 +587,7 @@ OPENCV_HAL_IMPL_RVV_SELF_REINTERPRET(int64x2, s64)
 OPENCV_HAL_IMPL_RVV_SELF_REINTERPRET(float64x2, f64)
 #endif
 
-#define OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(_Tpvec1, _Tp1, _Tpvec2, _Tp2, _nTpvec1, _nTpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2, vl1, vl2) \
+#define OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(_Tpvec1, _Tpvec2, suffix1, suffix2, nsuffix1, nsuffix2) \
 inline v_##_Tpvec1 v_reinterpret_as_##suffix1(const v_##_Tpvec2& v) \
 { \
     return v_##_Tpvec1(vreinterpret_v_##nsuffix2##m1_##nsuffix1##m1(v));\
@@ -597,31 +597,31 @@ inline v_##_Tpvec2 v_reinterpret_as_##suffix2(const v_##_Tpvec1& v) \
     return v_##_Tpvec2(vreinterpret_v_##nsuffix1##m1_##nsuffix2##m1(v));\
 }
 
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, int8x16, schar, vuint8m1_t, vint8m1_t, u8, s8, u8, i8, 8, 8, 16, 16)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, int16x8, short, vuint16m1_t, vint16m1_t, u16, s16, u16, i16, 16, 16, 8, 8)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, int32x4, int, vuint32m1_t, vint32m1_t, u32, s32, u32, i32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, float32x4, float, vuint32m1_t, vfloat32m1_t, u32, f32, u32, f32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, int, float32x4, float, vint32m1_t, vfloat32m1_t, s32, f32, i32, f32, 32, 32, 4, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, uint64, int64x2, int64, vuint64m1_t, vint64m1_t, u64, s64, u64, i64, 64, 64, 2, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, int8x16, u8, s8, u8, i8)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, int16x8, u16, s16, u16, i16)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, int32x4, u32, s32, u32, i32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, float32x4, u32, f32, u32, f32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, float32x4, s32, f32, i32, f32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, int64x2, u64, s64, u64, i64)
 #if CV_SIMD128_64F
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, uint64, float64x2, double, vuint64m1_t, vfloat64m1_t, u64, f64, u64, f64, 64, 64, 2, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int64x2, int64, float64x2, double, vint64m1_t, vfloat64m1_t, s64, f64, i64, f64, 64, 64, 2, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint64x2, float64x2, u64, f64, u64, f64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int64x2, float64x2, s64, f64, i64, f64)
 #endif
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint16x8, ushort, vuint8m1_t, vuint16m1_t, u8, u16, u8, u16, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint32x4, uint, vuint8m1_t, vuint32m1_t, u8, u32, u8, u32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uchar, uint64x2, uint64, vuint8m1_t, vuint64m1_t, u8, u64, u8, u64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, uint32x4, uint, vuint16m1_t, vuint32m1_t, u16, u32, u16, u32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, ushort, uint64x2, uint64, vuint16m1_t, vuint64m1_t, u16, u64, u16, u64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint, uint64x2, uint64, vuint32m1_t, vuint64m1_t, u32, u64, u32, u64, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int16x8, short, vint8m1_t, vint16m1_t, s8, s16, i8, i16, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int32x4, int, vint8m1_t, vint32m1_t, s8, s32, i8, i32, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, schar, int64x2, int64, vint8m1_t, vint64m1_t, s8, s64, i8, i64, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, short, int32x4, int, vint16m1_t, vint32m1_t, s16, s32, i16, i32, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, short, int64x2, int64, vint16m1_t, vint64m1_t, s16, s64, i16, i64, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, int, int64x2, int64, vint32m1_t, vint64m1_t, s32, s64, i32, i64, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uint16x8, u8, u16, u8, u16)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uint32x4, u8, u32, u8, u32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint8x16, uint64x2, u8, u64, u8, u64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, uint32x4, u16, u32, u16, u32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint16x8, uint64x2, u16, u64, u16, u64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(uint32x4, uint64x2, u32, u64, u32, u64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, int16x8, s8, s16, i8, i16)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, int32x4, s8, s32, i8, i32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int8x16, int64x2, s8, s64, i8, i64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, int32x4, s16, s32, i16, i32)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int16x8, int64x2, s16, s64, i16, i64)
+OPENCV_HAL_IMPL_RVV_NATIVE_REINTERPRET(int32x4, int64x2, s32, s64, i32, i64)
 
 
-#define OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(_Tpvec1, _Tp1, _Tpvec2, _Tp2, _nTpvec1, _nTpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2, vl1, vl2) \
+#define OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(_Tpvec1, _Tpvec2, suffix1, suffix2, nsuffix1, nsuffix2, width1, width2) \
 inline v_##_Tpvec1 v_reinterpret_as_##suffix1(const v_##_Tpvec2& v) \
 { \
     return v_##_Tpvec1(vreinterpret_v_##nsuffix1##width2##m1_##nsuffix1##width1##m1(vreinterpret_v_##nsuffix2##width2##m1_##nsuffix1##width2##m1(v)));\
@@ -631,30 +631,30 @@ inline v_##_Tpvec2 v_reinterpret_as_##suffix2(const v_##_Tpvec1& v) \
     return v_##_Tpvec2(vreinterpret_v_##nsuffix1##width2##m1_##nsuffix2##width2##m1(vreinterpret_v_##nsuffix1##width1##m1_##nsuffix1##width2##m1(v)));\
 }
 
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int16x8, short, vuint8m1_t, vint16m1_t, u8, s16, u, i, 8, 16, 16, 8)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int32x4, int, vuint8m1_t, vint32m1_t, u8, s32, u, i, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, int64x2, int64, vuint8m1_t, vint64m1_t, u8, s64, u, i, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int8x16, schar, vuint16m1_t, vint8m1_t, u16, s8, u, i, 16, 8, 8, 16)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int32x4, int, vuint16m1_t, vint32m1_t, u16, s32, u, i, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, int64x2, int64, vuint16m1_t, vint64m1_t, u16, s64, u, i, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int8x16, schar, vuint32m1_t, vint8m1_t, u32, s8, u, i, 32, 8, 4, 16)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int16x8, short, vuint32m1_t, vint16m1_t, u32, s16, u, i, 32, 16, 4, 8)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, int64x2, int64, vuint32m1_t, vint64m1_t, u32, s64, u, i, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int8x16, schar, vuint64m1_t, vint8m1_t, u64, s8, u, i, 64, 8, 2, 16)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int16x8, short, vuint64m1_t, vint16m1_t, u64, s16, u, i, 64, 16, 2, 8)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, int32x4, int, vuint64m1_t, vint32m1_t, u64, s32, u, i, 64, 32, 2, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, float32x4, float, vuint8m1_t, vfloat32m1_t, u8, f32, u, f, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, float32x4, float, vuint16m1_t, vfloat32m1_t, u16, f32, u, f, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, uint64, float32x4, float, vuint64m1_t, vfloat32m1_t, u64, f32, u, f, 64, 32, 2, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, schar, float32x4, float, vint8m1_t, vfloat32m1_t, s8, f32, i, f, 8, 32, 16, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, short, float32x4, float, vint16m1_t, vfloat32m1_t, s16, f32, i, f, 16, 32, 8, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int64x2, int64, float32x4, float, vint64m1_t, vfloat32m1_t, s64, f32, i, f, 64, 32, 2, 4)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, uchar, float64x2, double, vuint8m1_t, vfloat64m1_t, u8, f64, u, f, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, ushort, float64x2, double, vuint16m1_t, vfloat64m1_t, u16, f64, u, f, 16, 64, 6, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, uint, float64x2, double, vuint32m1_t, vfloat64m1_t, u32, f64, u, f, 32, 64, 4, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, schar, float64x2, double, vint8m1_t, vfloat64m1_t, s8, f64, i, f, 8, 64, 16, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, short, float64x2, double, vint16m1_t, vfloat64m1_t, s16, f64, i, f, 16, 64, 8, 2)
-OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int32x4, int, float64x2, double, vint32m1_t, vfloat64m1_t, s32, f64, i, f, 32, 64, 4, 2)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, int16x8, u8, s16, u, i, 8, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, int32x4, u8, s32, u, i, 8, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, int64x2, u8, s64, u, i, 8, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, int8x16, u16, s8, u, i, 16, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, int32x4, u16, s32, u, i, 16, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, int64x2, u16, s64, u, i, 16, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, int8x16, u32, s8, u, i, 32, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, int16x8, u32, s16, u, i, 32, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, int64x2, u32, s64, u, i, 32, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, int8x16, u64, s8, u, i, 64, 8)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, int16x8, u64, s16, u, i, 64, 16)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, int32x4, u64, s32, u, i, 64, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, float32x4, u8, f32, u, f, 8, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, float32x4, u16, f32, u, f, 16, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint64x2, float32x4, u64, f32, u, f, 64, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, float32x4, s8, f32, i, f, 8, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, float32x4, s16, f32, i, f, 16, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int64x2, float32x4, s64, f32, i, f, 64, 32)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint8x16, float64x2, u8, f64, u, f, 8, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint16x8, float64x2, u16, f64, u, f, 16, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(uint32x4, float64x2, u32, f64, u, f, 32, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int8x16, float64x2, s8, f64, i, f, 8, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int16x8, float64x2, s16, f64, i, f, 16, 64)
+OPENCV_HAL_IMPL_RVV_TWO_TIMES_REINTERPRET(int32x4, float64x2, s32, f64, i, f, 32, 64)
 
 // Three times reinterpret
 inline v_float32x4 v_reinterpret_as_f32(const v_float64x2& v) \

--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -19,6 +19,8 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 #define CV_SIMD128_64F 1
 
 //////////// Unsupported native intrinsics in C++ ////////////
+// The following types have been defined in clang, but not in GCC yet.
+#ifndef __clang__
 
 struct vuint8mf2_t
 {
@@ -224,6 +226,7 @@ inline vint16mf2_t vwcvt_x_x_v_i16mf2 (vint8mf4_t src, size_t vl)
     }
     return vle16_v_i16mf2(tmp, vl);
 }
+#endif
 
 //////////// Types ////////////
 

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -780,13 +780,13 @@ void fastGEMM( const float* aptr, size_t astep, const float* bptr,
 
             for( int k = 0; k < na; k++ )
             {
-                float32_t a0 = aptr0[k];
-                float32_t a1 = aptr1[k];
-                float32_t a2 = aptr2[k];
-                float32_t a3 = aptr3[k];
-                float32_t a4 = aptr4[k];
-                float32_t a5 = aptr5[k];
-                float32_t a6 = aptr6[k];
+                float a0 = aptr0[k];
+                float a1 = aptr1[k];
+                float a2 = aptr2[k];
+                float a3 = aptr3[k];
+                float a4 = aptr4[k];
+                float a5 = aptr5[k];
+                float a6 = aptr6[k];
 
                 vfloat32m4_t b = vle32_v_f32m4(bptr + k*bstep + n, mvl);
                 d0 = vfmacc_vf_f32m4(d0, a0, b, mvl);
@@ -865,23 +865,23 @@ void fastGEMM1T( const float* vec, const float* weights,
         }
 
         // Calculate the sum of each vector
-        float32_t sum[15];
+        float sum[15];
         vfloat32m1_t zero = vfmv_v_f_f32m1(0, vlm2);
-        sum[0] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs0, zero, vlm2));
-        sum[1] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs1, zero, vlm2));
-        sum[2] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs2, zero, vlm2));
-        sum[3] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs3, zero, vlm2));
-        sum[4] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs4, zero, vlm2));
-        sum[5] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs5, zero, vlm2));
-        sum[6] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs6, zero, vlm2));
-        sum[7] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs7, zero, vlm2));
-        sum[8] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs8, zero, vlm2));
-        sum[9] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs9, zero, vlm2));
-        sum[10] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs10, zero, vlm2));
-        sum[11] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs11, zero, vlm2));
-        sum[12] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs12, zero, vlm2));
-        sum[13] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs13, zero, vlm2));
-        sum[14] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs14, zero, vlm2));
+        sum[0] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs0, zero, vlm2));
+        sum[1] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs1, zero, vlm2));
+        sum[2] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs2, zero, vlm2));
+        sum[3] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs3, zero, vlm2));
+        sum[4] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs4, zero, vlm2));
+        sum[5] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs5, zero, vlm2));
+        sum[6] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs6, zero, vlm2));
+        sum[7] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs7, zero, vlm2));
+        sum[8] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs8, zero, vlm2));
+        sum[9] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs9, zero, vlm2));
+        sum[10] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs10, zero, vlm2));
+        sum[11] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs11, zero, vlm2));
+        sum[12] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs12, zero, vlm2));
+        sum[13] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs13, zero, vlm2));
+        sum[14] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs14, zero, vlm2));
 
         vfloat32m4_t s0 = vfadd_vv_f32m4(vle32_v_f32m4(sum, 15), vle32_v_f32m4(bias + i, 15), 15);
         vse32_v_f32m4(dst + i, s0, 15);
@@ -934,22 +934,22 @@ void fastGEMM1T( const float* vec, const float* weights,
             vs13 = vfmacc_vv_f32m2(vs13, vle32_v_f32m2(wptr + wstep*std::min(13, mvl-1), kvl), v, kvl);
         }
         // Calculate the sum of each vector
-        float32_t sum[14];
+        float sum[14];
         vfloat32m1_t zero = vfmv_v_f_f32m1(0, vlm2);
-        sum[0] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs0, zero, vlm2));
-        sum[1] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs1, zero, vlm2));
-        sum[2] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs2, zero, vlm2));
-        sum[3] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs3, zero, vlm2));
-        sum[4] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs4, zero, vlm2));
-        sum[5] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs5, zero, vlm2));
-        sum[6] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs6, zero, vlm2));
-        sum[7] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs7, zero, vlm2));
-        sum[8] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs8, zero, vlm2));
-        sum[9] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs9, zero, vlm2));
-        sum[10] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs10, zero, vlm2));
-        sum[11] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs11, zero, vlm2));
-        sum[12] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs12, zero, vlm2));
-        sum[13] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m2_f32m1(zero, vs13, zero, vlm2));
+        sum[0] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs0, zero, vlm2));
+        sum[1] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs1, zero, vlm2));
+        sum[2] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs2, zero, vlm2));
+        sum[3] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs3, zero, vlm2));
+        sum[4] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs4, zero, vlm2));
+        sum[5] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs5, zero, vlm2));
+        sum[6] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs6, zero, vlm2));
+        sum[7] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs7, zero, vlm2));
+        sum[8] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs8, zero, vlm2));
+        sum[9] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs9, zero, vlm2));
+        sum[10] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs10, zero, vlm2));
+        sum[11] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs11, zero, vlm2));
+        sum[12] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs12, zero, vlm2));
+        sum[13] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m2_f32m1(zero, vs13, zero, vlm2));
 
         vfloat32m4_t s0 = vfadd_vv_f32m4(vle32_v_f32m4(sum, mvl), vle32_v_f32m4(bias + i, mvl), mvl);
         vse32_v_f32m4(dst + i, s0, mvl);
@@ -1071,31 +1071,31 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
             // compute sum of each vs
             vfloat32m1_t zero = vfmv_v_f_f32m1(0, vlm1Max);
             // vl is required here to be at least FASCONV_BASE_VECSZ, aka 8.
-            float32_t sum0[FASCONV_BASE_VECSZ], sum1[FASCONV_BASE_VECSZ], sum2[FASCONV_BASE_VECSZ];
-            sum0[0] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs00, zero, vlm1Max));
-            sum0[1] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs01, zero, vlm1Max));
-            sum0[2] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs02, zero, vlm1Max));
-            sum0[3] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs03, zero, vlm1Max));
-            sum0[4] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs04, zero, vlm1Max));
-            sum0[5] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs05, zero, vlm1Max));
-            sum0[6] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs06, zero, vlm1Max));
-            sum0[7] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs07, zero, vlm1Max));
-            sum1[0] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs10, zero, vlm1Max));
-            sum1[1] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs11, zero, vlm1Max));
-            sum1[2] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs12, zero, vlm1Max));
-            sum1[3] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs13, zero, vlm1Max));
-            sum1[4] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs14, zero, vlm1Max));
-            sum1[5] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs15, zero, vlm1Max));
-            sum1[6] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs16, zero, vlm1Max));
-            sum1[7] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs17, zero, vlm1Max));
-            sum2[0] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs20, zero, vlm1Max));
-            sum2[1] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs21, zero, vlm1Max));
-            sum2[2] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs22, zero, vlm1Max));
-            sum2[3] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs23, zero, vlm1Max));
-            sum2[4] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs24, zero, vlm1Max));
-            sum2[5] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs25, zero, vlm1Max));
-            sum2[6] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs26, zero, vlm1Max));
-            sum2[7] = vfmv_f_s_f32m1_f32(vfredsum_vs_f32m1_f32m1(zero, vs27, zero, vlm1Max));
+            float sum0[FASCONV_BASE_VECSZ], sum1[FASCONV_BASE_VECSZ], sum2[FASCONV_BASE_VECSZ];
+            sum0[0] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs00, zero, vlm1Max));
+            sum0[1] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs01, zero, vlm1Max));
+            sum0[2] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs02, zero, vlm1Max));
+            sum0[3] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs03, zero, vlm1Max));
+            sum0[4] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs04, zero, vlm1Max));
+            sum0[5] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs05, zero, vlm1Max));
+            sum0[6] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs06, zero, vlm1Max));
+            sum0[7] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs07, zero, vlm1Max));
+            sum1[0] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs10, zero, vlm1Max));
+            sum1[1] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs11, zero, vlm1Max));
+            sum1[2] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs12, zero, vlm1Max));
+            sum1[3] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs13, zero, vlm1Max));
+            sum1[4] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs14, zero, vlm1Max));
+            sum1[5] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs15, zero, vlm1Max));
+            sum1[6] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs16, zero, vlm1Max));
+            sum1[7] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs17, zero, vlm1Max));
+            sum2[0] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs20, zero, vlm1Max));
+            sum2[1] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs21, zero, vlm1Max));
+            sum2[2] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs22, zero, vlm1Max));
+            sum2[3] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs23, zero, vlm1Max));
+            sum2[4] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs24, zero, vlm1Max));
+            sum2[5] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs25, zero, vlm1Max));
+            sum2[6] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs26, zero, vlm1Max));
+            sum2[7] = vfmv_f_s_f32m1_f32(vfredosum_vs_f32m1_f32m1(zero, vs27, zero, vlm1Max));
 
             // if VLEN = 128, so LMUL = 2 for vl = 8.
             // otherwise, VLEN >=256, we only use fist 8 element of the vReg.
@@ -1178,7 +1178,7 @@ static inline void vfloat32m2_load_deinterleave(const float* ptr, vfloat32m2_t& 
     // a = vlmul_trunc_v_f32m4_f32m2(tempa);
     // b = vlmul_trunc_v_f32m4_f32m2(tempb);
     */
-    cv::AutoBuffer<float> cvBuffer(sizeof(float32_t)*vl*2);
+    cv::AutoBuffer<float> cvBuffer(sizeof(float)*vl*2);
     float* buffer = (float*)cvBuffer.data();
     vse32_v_f32m4(buffer, tempa, vl);
     a = vle32_v_f32m2(buffer, vl);

--- a/platforms/linux/riscv64-clang.toolchain.cmake
+++ b/platforms/linux/riscv64-clang.toolchain.cmake
@@ -17,8 +17,11 @@ set(CMAKE_ASM_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
 # Don't run the linker on compiler check
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(CMAKE_C_FLAGS "-march=rv64gcv0p9 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-march=rv64gcv0p9 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CXX_FLAGS}")
+set(CMAKE_C_FLAGS "-march=rv64gcv0p10 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-march=rv64gcv0p10 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CXX_FLAGS}")
+
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}  -O2")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}  -O2")
 
 set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
This patch is going to fix and update the RVV cross-compile using clang.

In terms of support for RVV, Clang/LLVM is more active. With the update of spec and Intrinsic, many new functions have been supported by LLVM, but not in GNU yet. Therefore, for RVV related development in OpenCV, I propose to use clang/LLVM as the compiler.

There are a few differences between the GNU tool-chain and LLVM:

 	1. C-style casting on RVV type is invalid. Clang has checked on it, not in GCC yet.
 	2. Some intrinsic is renamed.
 	3. New instruction/intrinsic. E.g. `vpopc`
 	4. Vector type vxxxmf<n> is implemented.
 	5. Overloaded intrinsic.

For that, the following file is updated:

- `platforms/linux/riscv64-clang.toolchain.cmake` : the CMake file for RVV cross-compile. Modify RVV version in compile flag(0p9 -> 0p10). Addition, add `-O2` to release flag.
-  `modules/dnn/src/layers/layers_common.simd.hpp`: the optimized implementation file for DNN using RVV Native intrinsics. Some types defined in GNU but not with LLVM are modified (float32_t -> float). Rename `vfredsum` to `vfredosum` according to spec.
- `modules/core/include/opencv2/core/hal/intrin_rvv.hpp`: WUI implementation file for RVV. 
  1. Modify `reinterpret` by using RVV native intrinsic.
  2. Use `reinterpret` or rewrite the function to replace C-style conversion, some of them using overloaded intrinsics.
  3. Rename `vfredsum` to `vfredosum`
  4. Disable  vxxxmf<n> when using clang.
 
In order to be compatible with the existing GNU toolchain, most of the changes are wrapped in macros:
```
#ifndef __clang__
// current code work with GNU
#else
// new code work with LLVM
#endif
```
Currently, the RVV draft has been frozen. When both GNU and LLVM are updated to 1.0 and support the same intrinsic (LLVM is already very close), we will no longer need these macros.

This patch is tested on QEMU, both GNU and LLVM toolchain is work.

`qemu-riscv64 -cpu rv64,x-v=true ./bin/opencv_test_core --gtest_filter="hal*"`

Note: Steps for cross-compiling using clang/LLVM
```
git clone https://github.com/llvm/llvm-project.git
mkdir llvm-project/build && cd llvm-project/build
cmake -DLLVM_TARGETS_TO_BUILD="X86;RISCV" -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=RELEASE -G Ninja ../llvm
ninja
ln -s ~/llvm-project/build /opt/rvv-llvm #optional
cd opencv
mkdir opencv/.clang_build && cd opencv/.clang_build
cmake -DWITH_GTK=OFF -DCMAKE_TOOLCHAIN_FILE=../platforms/linux/riscv64-clang.toolchain.cmake ../
make
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
