### PR TITLE
dnn(ocl4dnn): fix LRN layer accuracy problems

### DIFF
--- a/modules/dnn/src/opencl/ocl4dnn_lrn.cl
+++ b/modules/dnn/src/opencl/ocl4dnn_lrn.cl
@@ -64,36 +64,37 @@ __kernel void TEMPLATE(lrn_full_no_scale,Dtype)(const int nthreads, __global con
     const int step = height * width;
     __global const Dtype* in_off = in + offset;
     __global Dtype* out_off = out + offset;
-    KERNEL_ARG_DTYPE scale_val;
     int head = 0;
     const int pre_pad = (size - 1) / 2;
     const int post_pad = size - pre_pad - 1;
-    KERNEL_ARG_DTYPE accum_scale = 0;
+    float accum_scale = 0;
     // fill the scale at [n, :, h, w]
     // accumulate values
     while (head < post_pad && head < channels) {
-      accum_scale += in_off[head * step] * in_off[head * step];
+      float v = in_off[head * step];
+      accum_scale += v * v;
       ++head;
     }
     // both add and subtract
     while (head < channels) {
-      accum_scale += in_off[head * step] * in_off[head * step];
+      float v = in_off[head * step];
+      accum_scale += v * v;
       if (head - size >= 0) {
-        accum_scale -= in_off[(head - size) * step]
-            * in_off[(head - size) * step];
+        v = in_off[(head - size) * step];
+        accum_scale -= v * v;
       }
-      scale_val = k + accum_scale * alpha_over_size;
-      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr(scale_val, negative_beta);
+      float scale_val = k + accum_scale * alpha_over_size;
+      out_off[(head - post_pad) * step] = (Dtype)((float)in_off[(head - post_pad) * step] * native_powr(scale_val, negative_beta));
       ++head;
     }
     // subtract only
     while (head < channels + post_pad) {
       if (head - size >= 0) {
-        accum_scale -= in_off[(head - size) * step]
-            * in_off[(head - size) * step];
+        float v = in_off[(head - size) * step];
+        accum_scale -= v * v;
       }
-      scale_val = k + accum_scale * alpha_over_size;
-      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr(scale_val, negative_beta);
+      float scale_val = k + accum_scale * alpha_over_size;
+      out_off[(head - post_pad) * step] = (Dtype)((float)in_off[(head - post_pad) * step] * native_powr(scale_val, negative_beta));
       ++head;
     }
   }

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -198,7 +198,7 @@ TEST_P(Reproducibility_AlexNet, Accuracy)
     ASSERT_EQ(inLayerShapes[0][3], 227);
 
     const float l1 = 1e-5;
-    const float lInf = (targetId == DNN_TARGET_OPENCL_FP16) ? 3e-3 : 1e-4;
+    const float lInf = (targetId == DNN_TARGET_OPENCL_FP16) ? 4e-3 : 1e-4;
 
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setPreferableTarget(targetId);


### PR DESCRIPTION
- FP16 intermediate computation is not accurate and may provide NaN values

resolves #21004

<cut/>

Validated on Ice Lake CPU (i5-1035G1) with test filter (3.4.16): `--gtest_filter=*:-*vgg16/1:*RCNN_zf/1:*Mask_RCNN/1`

---

i7-6700K failed tests (both Linux/Windows):
```
[ RUN      ] Reproducibility_AlexNet.Accuracy/1, where GetParam() = (false, OCL_FP16)
/build/precommit_opencl_linux/3.4/opencv/modules/dnn/test/test_common.impl.hpp:69: Failure
Expected: (normInf) <= (lInf), actual: 0.00360501 vs 0.003
  |ref| = 0.64178860187530518
[  FAILED  ] Reproducibility_AlexNet.Accuracy/1, where GetParam() = (false, OCL_FP16) (299 ms)
...
[ RUN      ] Reproducibility_AlexNet.Accuracy/4, where GetParam() = (true, OCL_FP16)
/build/precommit_opencl_linux/3.4/opencv/modules/dnn/test/test_common.impl.hpp:69: Failure
Expected: (normInf) <= (lInf), actual: 0.00360501 vs 0.003
  |ref| = 0.64178860187530518
[  FAILED  ] Reproducibility_AlexNet.Accuracy/4, where GetParam() = (true, OCL_FP16) (387 ms)
```

---

```
force_builders=Custom Win
build_image:Custom Win=openvino-2021.4.1
buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF
```