### PR TITLE
videoio: drop unnecessary offset for accessing video output buffer

### DIFF
--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -92,7 +92,7 @@ public:
                     AMediaFormat_getInt32(mediaFormat.get(), AMEDIAFORMAT_KEY_HEIGHT, &frameHeight);
                     AMediaFormat_getInt32(mediaFormat.get(), AMEDIAFORMAT_KEY_COLOR_FORMAT, &colorFormat);
                     uint8_t* codecBuffer = AMediaCodec_getOutputBuffer(mediaCodec.get(), bufferIndex, &bufferSize);
-                    buffer = std::vector<uint8_t>(codecBuffer + info.offset, codecBuffer + bufferSize);
+                    buffer = std::vector<uint8_t>(codecBuffer, codecBuffer + bufferSize);
                     LOGV("colorFormat: %d", colorFormat);
                     LOGV("buffer size: %zu", bufferSize);
                     LOGV("width (frame): %d", frameWidth);


### PR DESCRIPTION
Fix: #21021

NDK API AMediaCodec_getOutputBuffer() returns MediaCodecBuffer::data()
which is actually ABuffer::data(). The returned buffer address is already
adjusted by offset.

More info:
    ABuffer::base() returns base address without offset
    ABuffer::data() returns base + offset

Change-Id: I2936339ce4fa9acf657a5a7d92adc1275d7b28a1

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
android_pack_config=ndk-18-api-level-21.config.py
```