### PR TITLE
fix markers parse in doc/pattern_tools/gen_pattern.py

### DIFF
--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -171,7 +171,7 @@ def main():
     parser.add_argument("-m", "--markers", help="list of cells with markers for the radon checkerboard. Marker "
                                                 "coordinates as list of numbers: -m 1 2 3 4 means markers in cells "
                                                 "[1, 2] and [3, 4]",
-                        action="store", dest="markers", nargs="+", type=int)
+                        default=argparse.SUPPRESS, action="store", dest="markers", nargs="+", type=int)
     args = parser.parse_args()
 
     show_help = args.show_help
@@ -195,14 +195,16 @@ def main():
                       "A5": [148, 210]}
         page_width = page_sizes[page_size][0]
         page_height = page_sizes[page_size][1]
-    if len(args.markers) % 2 == 1:
-        raise ValueError("The length of the markers array={} must be even".format(len(args.markers)))
-    markers = set()
-    for x, y in zip(args.markers[::2], args.markers[1::2]):
-        if x in range(0, columns) and y in range(0, rows):
-            markers.add((x, y))
-        else:
-            raise ValueError("The marker {},{} is outside the checkerboard".format(x, y))
+    markers = None
+    if p_type == "radon_checkerboard" and "markers" in args:
+        if len(args.markers) % 2 == 1:
+            raise ValueError("The length of the markers array={} must be even".format(len(args.markers)))
+        markers = set()
+        for x, y in zip(args.markers[::2], args.markers[1::2]):
+            if x in range(0, columns) and y in range(0, rows):
+                markers.add((x, y))
+            else:
+                raise ValueError("The marker {},{} is outside the checkerboard".format(x, y))
 
     pm = PatternMaker(columns, rows, output, units, square_size, radius_rate, page_width, page_height, markers)
     # dict for easy lookup of pattern type


### PR DESCRIPTION
Fixes #21026
This PR  is going to fix args parse in `gen_pattern.py`:
- set default value for `markers`
- added condition:`p_type == "radon_checkerboard"  and "markers" in args`

After the fix, [all the tutorial examples](https://docs.opencv.org/4.x/da/d0d/tutorial_camera_calibration_pattern.html) work.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
