### PR TITLE
Use `#pragma message` instead of `#warning` for non-GCC compilers

### DIFF
--- a/modules/gapi/include/opencv2/gapi/util/any.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/any.hpp
@@ -31,7 +31,11 @@ namespace internal
 #if defined(__GXX_RTTI) || defined(_CPPRTTI)
        return dynamic_cast<T>(operand);
 #else
-    #warning used static cast instead of dynamic because RTTI is disabled
+#ifdef __GNUC__
+#warning used static cast instead of dynamic because RTTI is disabled
+#else
+#pragma message("WARNING: used static cast instead of dynamic because RTTI is disabled")
+#endif
        return static_cast<T>(operand);
 #endif
     }


### PR DESCRIPTION
`#warning` directive is not supported in MSVC and will cause a C1021 error.
Therefore a compile error occurs when using G-API in a project where RTTI is disabled.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
