### PR TITLE
Fix H clamping for very small negative values.

### DIFF
--- a/modules/imgproc/src/color_hsv.simd.hpp
+++ b/modules/imgproc/src/color_hsv.simd.hpp
@@ -955,12 +955,11 @@ struct HLS2RGB_f
                 float p1 = 2*l - p2;
 
                 h *= hscale;
-                if( h < 0 )
-                    do h += 6; while( h < 0 );
-                else if( h >= 6 )
-                    do h -= 6; while( h >= 6 );
+                // We need both loops to clamp (e.g. for h == -1e-40).
+                while( h < 0 ) h += 6;
+                while( h >= 6 ) h -= 6;
 
-                assert( 0 <= h && h < 6 );
+                CV_DbgAssert( 0 <= h && h < 6 );
                 sector = cvFloor(h);
                 h -= sector;
 


### PR DESCRIPTION
In case of very small negative h (e.g. -1e-40), with the current implementation,
you will go through the first condition and end up with h = 6.f, and will miss
the second condition.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
