### PR TITLE
Friendlier error messages when image path does not exist: Add warning message to imread()

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -226,8 +226,10 @@ static ImageDecoder findDecoder( const String& filename ) {
     FILE* f= fopen( filename.c_str(), "rb" );
 
     /// in the event of a failure, return an empty image decoder
-    if( !f )
+    if( !f ) {
+        CV_LOG_WARNING(NULL, "imread_('" << filename << "'): can't open/read file: check file path/integrity");
         return ImageDecoder();
+    }
 
     // read the file signature
     String signature(maxlen, ' ');

--- a/modules/photo/src/seamless_cloning.cpp
+++ b/modules/photo/src/seamless_cloning.cpp
@@ -67,6 +67,7 @@ static Mat checkMask(InputArray _mask, Size size)
 void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point p, OutputArray _blend, int flags)
 {
     CV_INSTRUMENT_REGION();
+    CV_Assert(!_src.empty());
 
     const Mat src  = _src.getMat();
     const Mat dest = _dst.getMat();


### PR DESCRIPTION
resolves #20167  
Add a warning message using CV_LOG_WARNING() to imread().
Add a src check using CV_Assert() to seamlessClone().
These changes would help using imread() and seamlessClone(). Change in imread would especially help to new users when they can make mistakes with path.

Signed-off-by: nickjackolson <metedurlu@gmail.com>

<cut/>

System Info:
- Linux pop-os 5.13.0-7614-generic 14  x86_64 x86_64 x86_64 GNU/Linux
- cmake version 3.16.3
- g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0

### Pull Request Readiness Checklist

- [ + ] I agree to contribute to the project under Apache 2 License.
- [ + ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ + ] The PR is proposed to proper branch
- [ + ] There is reference to original bug report and related work
- [ + ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ + ] The feature is well documented and sample code can be built with the project CMake

```
allow_multiple_commits=1
```