### PR TITLE
fix Emscripten build when FFMPEG is avaliable

### DIFF
--- a/modules/videoio/misc/plugin_ffmpeg/CMakeLists.txt
+++ b/modules/videoio/misc/plugin_ffmpeg/CMakeLists.txt
@@ -6,10 +6,8 @@ include("${OpenCV_SOURCE_DIR}/cmake/OpenCVPluginStandalone.cmake")
 # scan dependencies
 set(WITH_FFMPEG ON)
 
-if (EMSCRIPTEN)
-  set(OPENCV_FFMPEG_SKIP_BUILD_CHECK OFF)
-else()
-  set(OPENCV_FFMPEG_SKIP_BUILD_CHECK ON)
+if(EMSCRIPTEN AND NOT DEFINED OPENCV_FFMPEG_SKIP_BUILD_CHECK)
+  set(OPENCV_FFMPEG_SKIP_BUILD_CHECK ON)  # try_compile doesn't work properly with Emscripten
 endif()
 include("${OpenCV_SOURCE_DIR}/modules/videoio/cmake/init.cmake")
 

--- a/modules/videoio/misc/plugin_ffmpeg/CMakeLists.txt
+++ b/modules/videoio/misc/plugin_ffmpeg/CMakeLists.txt
@@ -5,7 +5,12 @@ include("${OpenCV_SOURCE_DIR}/cmake/OpenCVPluginStandalone.cmake")
 
 # scan dependencies
 set(WITH_FFMPEG ON)
-set(OPENCV_FFMPEG_SKIP_BUILD_CHECK ON)
+
+if (EMSCRIPTEN)
+  set(OPENCV_FFMPEG_SKIP_BUILD_CHECK OFF)
+else()
+  set(OPENCV_FFMPEG_SKIP_BUILD_CHECK ON)
+endif()
 include("${OpenCV_SOURCE_DIR}/modules/videoio/cmake/init.cmake")
 
 set(OPENCV_PLUGIN_DEPS core imgproc imgcodecs)


### PR DESCRIPTION
skip OPENCV_FFMPEG_SKIP_BUILD_CHECK by default when building for Emscripten, .js + .html cannot be executed and produce check results

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
