### PR TITLE
core: avoid using of 'check' identifier

### DIFF
--- a/modules/core/include/opencv2/core/cvstd_wrapper.hpp
+++ b/modules/core/include/opencv2/core/cvstd_wrapper.hpp
@@ -42,11 +42,11 @@ struct has_parenthesis_operator
 {
 private:
     template<typename T>
-    static CV_CONSTEXPR std::true_type check(typename std::is_same<typename std::decay<decltype(std::declval<T>().operator()(std::declval<Args>()...))>::type, Ret>::type*);
+    static CV_CONSTEXPR std::true_type has_parenthesis_operator_check(typename std::is_same<typename std::decay<decltype(std::declval<T>().operator()(std::declval<Args>()...))>::type, Ret>::type*);
 
-    template<typename> static CV_CONSTEXPR std::false_type check(...);
+    template<typename> static CV_CONSTEXPR std::false_type has_parenthesis_operator_check(...);
 
-    typedef decltype(check<C>(0)) type;
+    typedef decltype(has_parenthesis_operator_check<C>(0)) type;
 
 public:
 #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)


### PR DESCRIPTION
resolves #17261

Avoid problem which comes from invalid external 'check' macro definition.
Hopefully it is internal identifier and it is not a part of our public API.