### PR TITLE
[G-API] Fixed Coverity issues

### DIFF
--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -236,7 +236,7 @@ namespace detail
     class VectorRef
     {
         std::shared_ptr<BasicVectorRef> m_ref;
-        cv::detail::OpaqueKind m_kind;
+        cv::detail::OpaqueKind m_kind = cv::detail::OpaqueKind::CV_UNKNOWN;
 
         template<typename T> inline void check() const
         {

--- a/modules/gapi/include/opencv2/gapi/gopaque.hpp
+++ b/modules/gapi/include/opencv2/gapi/gopaque.hpp
@@ -232,7 +232,7 @@ namespace detail
     class OpaqueRef
     {
         std::shared_ptr<BasicOpaqueRef> m_ref;
-        cv::detail::OpaqueKind m_kind;
+        cv::detail::OpaqueKind m_kind = cv::detail::OpaqueKind::CV_UNKNOWN;
 
         template<typename T> inline void check() const
         {

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -84,6 +84,16 @@ typedef unsigned short ushort;
 
 // cvdef.h:
 
+#ifndef CV_ALWAYS_INLINE
+#  if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
+#    define CV_ALWAYS_INLINE inline __attribute__((always_inline))
+#  elif defined(_MSC_VER)
+#    define CV_ALWAYS_INLINE __forceinline
+#  else
+#    define CV_ALWAYS_INLINE inline
+#  endif
+#endif
+
 #define CV_MAT_CN_MASK          ((CV_CN_MAX - 1) << CV_CN_SHIFT)
 #define CV_MAT_CN(flags)        ((((flags) & CV_MAT_CN_MASK) >> CV_CN_SHIFT) + 1)
 #define CV_MAT_TYPE_MASK        (CV_DEPTH_MAX*CV_CN_MAX - 1)

--- a/modules/gapi/include/opencv2/gapi/own/saturate.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/saturate.hpp
@@ -22,13 +22,12 @@ namespace cv { namespace gapi { namespace own {
 //
 //-----------------------------
 
-template<typename DST, typename SRC, typename = cv::util::are_different_t<DST,SRC>>
+template<typename DST, typename SRC,
+         typename = cv::util::are_different_t<DST,SRC>,
+         typename = cv::util::enable_if_t<std::is_integral<DST>::value &&
+                                          std::is_integral<SRC>::value>  >
 static inline DST saturate(SRC x)
 {
-    // only integral types please!
-    GAPI_DbgAssert(std::is_integral<DST>::value &&
-                   std::is_integral<SRC>::value);
-
     if (sizeof(DST) > sizeof(SRC))
         return static_cast<DST>(x);
 

--- a/modules/gapi/include/opencv2/gapi/own/saturate.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/saturate.hpp
@@ -26,7 +26,7 @@ template<typename DST, typename SRC,
          typename = cv::util::enable_if_t<!std::is_same<DST, SRC>::value &&
                                            std::is_integral<DST>::value  &&
                                            std::is_integral<SRC>::value>   >
-static inline DST saturate(SRC x)
+static CV_ALWAYS_INLINE DST saturate(SRC x)
 {
     if (sizeof(DST) > sizeof(SRC))
         return static_cast<DST>(x);
@@ -41,21 +41,21 @@ static inline DST saturate(SRC x)
            static_cast<DST>(x);
 }
 template<typename T>
-static inline T saturate(T x)
+static CV_ALWAYS_INLINE T saturate(T x)
 {
     return x;
 }
 
 template<typename DST, typename SRC, typename R,
          cv::util::enable_if_t<std::is_floating_point<DST>::value, bool> = true >
-static inline DST saturate(SRC x, R)
+static CV_ALWAYS_INLINE DST saturate(SRC x, R)
 {
     return static_cast<DST>(x);
 }
 template<typename DST, typename SRC, typename R,
          cv::util::enable_if_t<std::is_integral<DST>::value &&
-                               std::is_integral<SRC>::value    , bool> = true >
-static inline DST saturate(SRC x, R)
+                               std::is_integral<SRC>::value   , bool> = true >
+static CV_ALWAYS_INLINE DST saturate(SRC x, R)
 {
     return saturate<DST>(x);
 }
@@ -65,7 +65,7 @@ static inline DST saturate(SRC x, R)
 template<typename DST, typename SRC, typename R,
          cv::util::enable_if_t<std::is_integral<DST>::value &&
                                std::is_floating_point<SRC>::value, bool> = true >
-static inline DST saturate(SRC x, R round)
+static CV_ALWAYS_INLINE DST saturate(SRC x, R round)
 {
     int ix = static_cast<int>(round(x));
     return saturate<DST>(ix);

--- a/modules/gapi/include/opencv2/gapi/own/saturate.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/saturate.hpp
@@ -11,9 +11,9 @@
 #include <math.h>
 
 #include <limits>
-#include <type_traits>
 
 #include <opencv2/gapi/own/assert.hpp>
+#include <opencv2/gapi/util/type_traits.hpp>
 
 namespace cv { namespace gapi { namespace own {
 //-----------------------------
@@ -22,15 +22,12 @@ namespace cv { namespace gapi { namespace own {
 //
 //-----------------------------
 
-template<typename DST, typename SRC>
+template<typename DST, typename SRC, typename = cv::util::are_different_t<DST,SRC>>
 static inline DST saturate(SRC x)
 {
     // only integral types please!
     GAPI_DbgAssert(std::is_integral<DST>::value &&
                    std::is_integral<SRC>::value);
-
-    if (std::is_same<DST, SRC>::value)
-        return static_cast<DST>(x);
 
     if (sizeof(DST) > sizeof(SRC))
         return static_cast<DST>(x);
@@ -43,6 +40,11 @@ static inline DST saturate(SRC x)
            x > std::numeric_limits<DST>::max()?
                std::numeric_limits<DST>::max():
            static_cast<DST>(x);
+}
+template<typename T>
+static inline T saturate(T x)
+{
+    return x;
 }
 
 // Note, that OpenCV rounds differently:

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -928,7 +928,7 @@ IIStream& ByteMemoryInStream::operator>> (std::string& str) {
     if (sz == 0u) {
         str.clear();
     } else {
-        str.resize(sz);
+        str.resize(std::size_t(sz));
         for (auto &&i : ade::util::iota(sz)) { *this >> str[i]; }
     }
     return *this;

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -928,7 +928,7 @@ IIStream& ByteMemoryInStream::operator>> (std::string& str) {
     if (sz == 0u) {
         str.clear();
     } else {
-        str.resize(std::size_t(sz));
+        str.resize(static_cast<std::size_t>(sz));
         for (auto &&i : ade::util::iota(sz)) { *this >> str[i]; }
     }
     return *this;

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -2002,7 +2002,7 @@ template<typename DST, typename SRC,
 CV_ALWAYS_INLINE void run_convertto(DST *out, const SRC *in, const int length)
 {
     // manual SIMD if need rounding
-    GAPI_Assert(( std::is_same<SRC,float>::value ));
+    static_assert(std::is_same<SRC,float>::value, "64-bit floating-point source is not supported");
     int l = run_convertto_simd(out, in, length); // cycle index
     // tail of SIMD cycle
     for (; l < length; l++)
@@ -2024,6 +2024,7 @@ template<typename DST, typename SRC,
          cv::util::enable_if_t<std::is_floating_point<DST>::value, bool> = true >
 CV_ALWAYS_INLINE void run_convertto(DST *out, const SRC *in, const int length)
 {
+    static_assert(!std::is_same<SRC,double>::value, "64-bit floating-point source is not supported");
     for (int l = 0; l < length; l++)
     {
         out[l] = static_cast<DST>(in[l]);
@@ -2034,6 +2035,7 @@ template<typename DST, typename SRC>
 CV_ALWAYS_INLINE void run_convertto(DST *out, const SRC *in, const float alpha, const float beta,
                                     const int length)
 {
+    static_assert(!std::is_same<SRC,double>::value, "64-bit floating-point source is not supported");
     // TODO: optimize if alpha and beta and data are integral
     for (int l = 0; l < length; l++)
     {
@@ -2056,7 +2058,7 @@ static void run_convertto(Buffer &dst, const View &src, double _alpha, double _b
     const auto beta  = static_cast<float>( _beta  );
 
     // compute faster if no alpha no beta
-    if (1 == alpha && 0 == beta)
+    if (1.f == alpha && 0.f == beta)
     {
         run_convertto(out, in, length);
     }

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -1957,12 +1957,13 @@ GAPI_FLUID_KERNEL(GFluidLUT, cv::gapi::core::GLUT, false)
 
 #if CV_SIMD128
 template<typename DST, typename SRC>
-CV_ALWAYS_INLINE int run_convertto_simd(DST*, const SRC*, int, int l)
+CV_ALWAYS_INLINE int run_convertto_simd(DST*, const SRC*, int)
 {
-    return l;
+    return 0;
 }
-CV_ALWAYS_INLINE int run_convertto_simd(uchar *out, const float *in, const int length, int l)
+CV_ALWAYS_INLINE int run_convertto_simd(uchar *out, const float *in, const int length)
 {
+    int l = 0;
     for (; l <= length - 16; l += 16)
     {
         v_int32x4 i0, i1, i2, i3;
@@ -1981,8 +1982,9 @@ CV_ALWAYS_INLINE int run_convertto_simd(uchar *out, const float *in, const int l
     }
     return l;
 }
-CV_ALWAYS_INLINE int run_convertto_simd(ushort *out, const float *in, const int length, int l)
+CV_ALWAYS_INLINE int run_convertto_simd(ushort *out, const float *in, const int length)
 {
+    int l = 0;
     for (; l <= length - 8; l += 8)
     {
         v_int32x4 i0, i1;
@@ -2006,7 +2008,7 @@ CV_ALWAYS_INLINE void run_convertto(DST *out, const SRC *in, const int length)
     static_assert(std::is_same<SRC,float>::value, "64-bit floating-point source is not supported");
     int l = 0; // cycle index
 #if CV_SIMD128
-    l = run_convertto_simd(out, in, length, l);
+    l = run_convertto_simd(out, in, length);
 #endif
     // tail of SIMD cycle
     for (; l < length; l++)

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1382,22 +1382,15 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
     });
 }
 
-void cv::gimpl::GStreamingExecutor::destruct() {
-    if (state == State::READY || state == State::RUNNING)
-        stop();
-}
-cv::gimpl::GStreamingExecutor::~GStreamingExecutor() noexcept(false)
+cv::gimpl::GStreamingExecutor::~GStreamingExecutor()
 {
-    if (std::uncaught_exception()) {
-        try {
-            destruct();
-        } catch (const std::logic_error& e) {
-            std::stringstream message;
-            message << "~GStreamingExecutor() threw exception with message '" << e.what() << "'\n";
-            GAPI_LOG_WARNING(NULL, message.str());
-        }
-    } else {
-        destruct();
+    try {
+        if (state == State::READY || state == State::RUNNING)
+            stop();
+    } catch (const std::logic_error& e) {
+        std::stringstream message;
+        message << "~GStreamingExecutor() threw exception with message '" << e.what() << "'\n";
+        GAPI_LOG_WARNING(NULL, message.str());
     }
 }
 

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1389,7 +1389,7 @@ cv::gimpl::GStreamingExecutor::~GStreamingExecutor()
     try {
         if (state == State::READY || state == State::RUNNING)
             stop();
-    } catch (const std::logic_error& e) {
+    } catch (const std::exception& e) {
         std::stringstream message;
         message << "~GStreamingExecutor() threw exception with message '" << e.what() << "'\n";
         GAPI_LOG_WARNING(NULL, message.str());

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1384,6 +1384,8 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
 
 cv::gimpl::GStreamingExecutor::~GStreamingExecutor()
 {
+    // FIXME: this is a temporary try-catch exception hadling.
+    // Need to eliminate throwings from stop()
     try {
         if (state == State::READY || state == State::RUNNING)
             stop();

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1391,7 +1391,7 @@ cv::gimpl::GStreamingExecutor::~GStreamingExecutor() noexcept(false)
     if (std::uncaught_exception()) {
         try {
             destruct();
-        } catch (const std::logic_error e) {
+        } catch (const std::logic_error& e) {
             std::stringstream message;
             message << "~GStreamingExecutor() threw exception with message '" << e.what() << "'\n";
             GAPI_LOG_WARNING(NULL, message.str());

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -105,6 +105,7 @@ public:
 
 class GStreamingExecutor final
 {
+    void destruct();
 protected:
     // GStreamingExecutor is a state machine described as follows
     //
@@ -200,7 +201,8 @@ protected:
 public:
     explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model,
                                 const cv::GCompileArgs &comp_args);
-    ~GStreamingExecutor();
+    ~GStreamingExecutor() noexcept(false); // throwing when a regular destruction fails only;
+                                           // not throwing if the stack is unwinding.
     void setSource(GRunArgs &&args);
     void start();
     bool pull(cv::GRunArgsP &&outs);

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -105,7 +105,6 @@ public:
 
 class GStreamingExecutor final
 {
-    void destruct();
 protected:
     // GStreamingExecutor is a state machine described as follows
     //
@@ -201,8 +200,7 @@ protected:
 public:
     explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model,
                                 const cv::GCompileArgs &comp_args);
-    ~GStreamingExecutor() noexcept(false); // throwing when a regular destruction fails only;
-                                           // not throwing if the stack is unwinding.
+    ~GStreamingExecutor();
     void setSource(GRunArgs &&args);
     void start();
     bool pull(cv::GRunArgsP &&outs);


### PR DESCRIPTION
 - `cv::detail::OpaqueKind m_kind` field of `VectorRef` and `OpaqueRef` is now set to `CV_UNKNOWN` by default
 - added overload for `saturate()` function calls with the same input and output type
   - solved followed Win warnings about Fluid ConvertTo kernel with the same issue
 - sanitized resize value in `ByteMemoryInStream::operator>> (std::string& str)`: `std::string::resize()` method expects `std::size_t` when used to get `uint32_t` instead
 - handled exception throws from ~GStreamingExecutor() by try-catch block (will address this issue further in the future)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```