### PR TITLE
[G-API] Fix issue of getting 1D Mat out of RMat::View

### DIFF
--- a/modules/gapi/src/api/rmat.cpp
+++ b/modules/gapi/src/api/rmat.cpp
@@ -41,7 +41,7 @@ View::View(const cv::GMatDesc& desc, uchar* data, size_t step, DestroyCallback&&
     : m_desc(checkDesc(desc))
     , m_data(data)
     , m_steps([this, step](){
-        // GAPI_Assert(m_desc.dims.empty());
+        GAPI_Assert(m_desc.dims.empty());
         auto steps = defaultSteps(m_desc);
         if (step != 0u) {
             steps[0] = step;

--- a/modules/gapi/src/api/rmat.cpp
+++ b/modules/gapi/src/api/rmat.cpp
@@ -41,7 +41,7 @@ View::View(const cv::GMatDesc& desc, uchar* data, size_t step, DestroyCallback&&
     : m_desc(checkDesc(desc))
     , m_data(data)
     , m_steps([this, step](){
-        GAPI_Assert(m_desc.dims.empty());
+        // GAPI_Assert(m_desc.dims.empty());
         auto steps = defaultSteps(m_desc);
         if (step != 0u) {
             steps[0] = step;

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -29,7 +29,8 @@ namespace gimpl {
         } else {
             cv::Mat m(v.dims(), v.type(), v.ptr(), v.steps().data());
             if (v.dims().size() == 1) {
-                // FIXME: The only way to get 1D Mat out of RMat
+                // FIXME: cv::Mat() constructor will set m.dims to 2;
+                // To obtain 1D Mat, we have to set m.dims back to 1 manually
                 m.dims = 1;
             }
             return m;

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -24,8 +24,16 @@ namespace gimpl {
 
     inline cv::Mat asMat(RMat::View& v) {
 #if !defined(GAPI_STANDALONE)
-        return v.dims().empty() ? cv::Mat(v.rows(), v.cols(), v.type(), v.ptr(), v.step())
-                                : cv::Mat(v.dims(), v.type(), v.ptr(), v.steps().data());
+        if (v.dims().empty()) {
+            return cv::Mat(v.rows(), v.cols(), v.type(), v.ptr(), v.step());
+        } else {
+            cv::Mat m(v.dims(), v.type(), v.ptr(), v.steps().data());
+            if (v.dims().size() == 1) {
+                // FIXME: The only way to get 1D Mat out of RMat
+                m.dims = 1;
+            }
+            return m;
+        }
 #else
         // FIXME: add a check that steps are default
         return v.dims().empty() ? cv::Mat(v.rows(), v.cols(), v.type(), v.ptr(), v.step())

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -49,7 +49,10 @@ namespace gimpl {
         }
         return RMat::View(cv::descr_of(m), m.data, steps, std::move(cb));
 #else
-        return RMat::View(cv::descr_of(m), m.data, m.step, std::move(cb));
+        return m.dims.empty()
+            ? RMat::View(cv::descr_of(m), m.data, m.step, std::move(cb))
+            // Own Mat doesn't support n-dimensional steps so default ones are used in this case
+            : RMat::View(cv::descr_of(m), m.data, RMat::View::stepsT{}, std::move(cb));
 #endif
     }
 

--- a/modules/gapi/test/rmat/rmat_view_tests.cpp
+++ b/modules/gapi/test/rmat/rmat_view_tests.cpp
@@ -268,4 +268,13 @@ TEST_F(RMatViewCallbackTest, MagazineInteraction) {
     mag.slot<View>().erase(rc);
     EXPECT_EQ(1, callbackCalls);
 }
+
+TEST(RMatView, Access1DMat) {
+    cv::Mat m({1}, CV_32FC1);
+    m.dims = 1;
+    auto rmat = cv::make_rmat<cv::gimpl::RMatOnMat>(m);
+    auto view = rmat.access(cv::RMat::Access::R);
+    auto out = cv::gimpl::asMat(view);
+    EXPECT_EQ(1, out.dims);
+}
 } // namespace opencv_test


### PR DESCRIPTION
 - fixed issue due to auto-changing `mat.dims` to `2` in `cv::Mat` constructors even if source Mat's `dims == 1`
 - added test
 - fixed for standalone too (needed changes in `asView()` logic)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```