### PR TITLE
G-API: Cleaning samples

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -28,14 +28,6 @@ namespace gimpl
 {
     // Forward-declare an internal class
     class GCPUExecutable;
-
-    namespace render
-    {
-    namespace ocv
-    {
-        class GRenderExecutable;
-    }
-    }
 } // namespace gimpl
 
 namespace gapi
@@ -133,7 +125,6 @@ protected:
     std::unordered_map<std::size_t, GRunArgP> m_results;
 
     friend class gimpl::GCPUExecutable;
-    friend class gimpl::render::ocv::GRenderExecutable;
 };
 
 class GAPI_EXPORTS GCPUKernel

--- a/modules/gapi/samples/gaze_estimation.cpp
+++ b/modules/gapi/samples/gaze_estimation.cpp
@@ -9,6 +9,7 @@
 #include <opencv2/gapi/streaming/cap.hpp>
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include <opencv2/highgui.hpp> // CommandLineParser
+#include <opencv2/gapi/infer/parsers.hpp>
 
 const std::string about =
     "This is an OpenCV-based version of Gaze Estimation example";
@@ -58,16 +59,6 @@ G_API_OP(Size, <GSize(cv::GMat)>, "custom.gapi.size") {
     }
 };
 
-G_API_OP(ParseSSD,
-         <GRects(cv::GMat, GSize, bool)>,
-         "custom.gaze_estimation.parseSSD") {
-    static cv::GArrayDesc outMeta( const cv::GMatDesc &
-                                 , const cv::GOpaqueDesc &
-                                 , bool) {
-        return cv::empty_array_desc();
-    }
-};
-
 // Left/Right eye per every face
 G_API_OP(ParseEyes,
          <std::tuple<GRects, GRects>(GMats, GRects, GSize)>,
@@ -91,27 +82,6 @@ G_API_OP(ProcessPoses,
     }
 };
 
-void adjustBoundingBox(cv::Rect& boundingBox) {
-    auto w = boundingBox.width;
-    auto h = boundingBox.height;
-
-    boundingBox.x -= static_cast<int>(0.067 * w);
-    boundingBox.y -= static_cast<int>(0.028 * h);
-
-    boundingBox.width += static_cast<int>(0.15 * w);
-    boundingBox.height += static_cast<int>(0.13 * h);
-
-    if (boundingBox.width < boundingBox.height) {
-        auto dx = (boundingBox.height - boundingBox.width);
-        boundingBox.x -= dx / 2;
-        boundingBox.width += dx;
-    } else {
-        auto dy = (boundingBox.width - boundingBox.height);
-        boundingBox.y -= dy / 2;
-        boundingBox.height += dy;
-    }
-}
-
 void gazeVectorToGazeAngles(const cv::Point3f& gazeVector,
                                   cv::Point2f& gazeAngles) {
     auto r = cv::norm(gazeVector);
@@ -127,55 +97,6 @@ void gazeVectorToGazeAngles(const cv::Point3f& gazeVector,
 GAPI_OCV_KERNEL(OCVSize, Size) {
     static void run(const cv::Mat &in, cv::Size &out) {
         out = in.size();
-    }
-};
-
-GAPI_OCV_KERNEL(OCVParseSSD, ParseSSD) {
-    static void run(const cv::Mat &in_ssd_result,
-                    const cv::Size &upscale,
-                    const bool filter_out_of_bounds,
-                    std::vector<cv::Rect> &out_objects) {
-        const auto &in_ssd_dims = in_ssd_result.size;
-        CV_Assert(in_ssd_dims.dims() == 4u);
-
-        const int MAX_PROPOSALS = in_ssd_dims[2];
-        const int OBJECT_SIZE   = in_ssd_dims[3];
-        CV_Assert(OBJECT_SIZE  == 7); // fixed SSD object size
-
-        const cv::Rect surface({0,0}, upscale);
-        out_objects.clear();
-
-        const float *data = in_ssd_result.ptr<float>();
-        for (int i = 0; i < MAX_PROPOSALS; i++) {
-            const float image_id   = data[i * OBJECT_SIZE + 0];
-            const float label      = data[i * OBJECT_SIZE + 1];
-            const float confidence = data[i * OBJECT_SIZE + 2];
-            const float rc_left    = data[i * OBJECT_SIZE + 3];
-            const float rc_top     = data[i * OBJECT_SIZE + 4];
-            const float rc_right   = data[i * OBJECT_SIZE + 5];
-            const float rc_bottom  = data[i * OBJECT_SIZE + 6];
-            (void) label;
-            if (image_id < 0.f) {
-                break;    // marks end-of-detections
-            }
-            if (confidence < 0.5f) {
-                continue; // skip objects with low confidence
-            }
-            cv::Rect rc;  // map relative coordinates to the original image scale
-            rc.x      = static_cast<int>(rc_left   * upscale.width);
-            rc.y      = static_cast<int>(rc_top    * upscale.height);
-            rc.width  = static_cast<int>(rc_right  * upscale.width)  - rc.x;
-            rc.height = static_cast<int>(rc_bottom * upscale.height) - rc.y;
-            adjustBoundingBox(rc);                // TODO: new option?
-
-            const auto clipped_rc = rc & surface; // TODO: new option?
-            if (filter_out_of_bounds) {
-                if (clipped_rc.area() != rc.area()) {
-                    continue;
-                }
-            }
-            out_objects.emplace_back(clipped_rc);
-        }
     }
 };
 
@@ -335,11 +256,10 @@ int main(int argc, char *argv[])
         cmd.printMessage();
         return 0;
     }
-
     cv::GMat in;
     cv::GMat faces = cv::gapi::infer<custom::Faces>(in);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
-    cv::GArray<cv::Rect> faces_rc = custom::ParseSSD::on(faces, sz, true);
+    cv::GArray<cv::Rect> faces_rc = cv::gapi::parseSSD(faces, sz, 0.5f, true, true);
     cv::GArray<cv::GMat> angles_y, angles_p, angles_r;
     std::tie(angles_y, angles_p, angles_r) = cv::gapi::infer<custom::HeadPose>(faces_rc, in);
     cv::GArray<cv::GMat> heads_pos = custom::ProcessPoses::on(angles_y, angles_p, angles_r);
@@ -386,7 +306,6 @@ int main(int argc, char *argv[])
     }.cfgInputLayers({"left_eye_image", "right_eye_image", "head_pose_angles"});
 
     auto kernels = cv::gapi::kernels< custom::OCVSize
-                                    , custom::OCVParseSSD
                                     , custom::OCVParseEyes
                                     , custom::OCVProcessPoses>();
     auto networks = cv::gapi::networks(face_net, head_net, landmarks_net, gaze_net);

--- a/modules/gapi/samples/infer_ie_onnx_hybrid.cpp
+++ b/modules/gapi/samples/infer_ie_onnx_hybrid.cpp
@@ -156,7 +156,6 @@ int main(int argc, char *argv[])
 
     auto in_src = cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(input);
     pipeline.setSource(cv::gin(in_src));
-    pipeline.start();
 
     cv::util::optional<cv::Mat>               out_frame;
     cv::util::optional<std::vector<cv::Rect>> out_faces;
@@ -167,8 +166,13 @@ int main(int argc, char *argv[])
     std::vector<cv::Mat>  last_emotions;
 
     cv::VideoWriter writer;
+    cv::TickMeter tm;
+    std::size_t frames = 0u;
 
+    tm.start();
+    pipeline.start();
     while (pipeline.pull(cv::gout(out_frame, out_faces, out_emotions))) {
+        ++frames;
         if (out_faces && out_emotions) {
             last_faces = *out_faces;
             last_emotions = *out_emotions;
@@ -191,5 +195,7 @@ int main(int argc, char *argv[])
             cv::waitKey(1);
         }
     }
+    tm.stop();
+    std::cout << "Processed " << frames << " frames" << " (" << frames / tm.getTimeSec() << " FPS)" << std::endl;
     return 0;
 }

--- a/modules/gapi/samples/infer_single_roi.cpp
+++ b/modules/gapi/samples/infer_single_roi.cpp
@@ -154,16 +154,16 @@ int main(int argc, char *argv[])
     cv::GStreamingCompiled pipeline;
     auto inputs = cv::gin(cv::gapi::wip::make_src<cv::gapi::wip::GCaptureSource>(input));
 
+    cv::GMat in;
+    cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
     if (opt_roi.has_value()) {
         // Use the value provided by user
         std::cout << "Will run inference for static region "
                   << opt_roi.value()
                   << " only"
                   << std::endl;
-        cv::GMat in;
         cv::GOpaque<cv::Rect> in_roi;
         auto blob = cv::gapi::infer<custom::FaceDetector>(in_roi, in);
-        cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
         cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, sz, 0.5f, true, true);
         auto  out = cv::gapi::wip::draw::render3ch(in, custom::BBoxes::on(rcs, in_roi));
         pipeline  = cv::GComputation(cv::GIn(in, in_roi), cv::GOut(out))
@@ -175,10 +175,8 @@ int main(int argc, char *argv[])
         // Automatically detect ROI to infer. Make it output parameter
         std::cout << "ROI is not set or invalid. Locating it automatically"
                   << std::endl;
-        cv::GMat in;
         cv::GOpaque<cv::Rect> roi = custom::LocateROI::on(in);
         auto blob = cv::gapi::infer<custom::FaceDetector>(roi, in);
-        cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
         cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, sz, 0.5f, true, true);
         auto  out = cv::gapi::wip::draw::render3ch(in, custom::BBoxes::on(rcs, roi));
         pipeline  = cv::GComputation(cv::GIn(in), cv::GOut(out))

--- a/modules/gapi/samples/infer_single_roi.cpp
+++ b/modules/gapi/samples/infer_single_roi.cpp
@@ -13,6 +13,7 @@
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include <opencv2/gapi/streaming/cap.hpp>
 #include <opencv2/highgui.hpp>
+#include <opencv2/gapi/infer/parsers.hpp>
 
 const std::string keys =
     "{ h help |                              | Print this help message }"
@@ -69,33 +70,15 @@ using GRect       = cv::GOpaque<cv::Rect>;
 using GSize       = cv::GOpaque<cv::Size>;
 using GPrims      = cv::GArray<cv::gapi::wip::draw::Prim>;
 
-G_API_OP(GetSize, <GSize(cv::GMat)>, "sample.custom.get-size") {
-    static cv::GOpaqueDesc outMeta(const cv::GMatDesc &) {
-        return cv::empty_gopaque_desc();
-    }
-};
-
 G_API_OP(LocateROI, <GRect(cv::GMat)>, "sample.custom.locate-roi") {
     static cv::GOpaqueDesc outMeta(const cv::GMatDesc &) {
         return cv::empty_gopaque_desc();
     }
 };
 
-G_API_OP(ParseSSD, <GDetections(cv::GMat, GRect, GSize)>, "sample.custom.parse-ssd") {
-    static cv::GArrayDesc outMeta(const cv::GMatDesc &, const cv::GOpaqueDesc &, const cv::GOpaqueDesc &) {
-        return cv::empty_array_desc();
-    }
-};
-
 G_API_OP(BBoxes, <GPrims(GDetections, GRect)>, "sample.custom.b-boxes") {
     static cv::GArrayDesc outMeta(const cv::GArrayDesc &, const cv::GOpaqueDesc &) {
         return cv::empty_array_desc();
-    }
-};
-
-GAPI_OCV_KERNEL(OCVGetSize, GetSize) {
-    static void run(const cv::Mat &in, cv::Size &out) {
-        out = {in.cols, in.rows};
     }
 };
 
@@ -121,55 +104,6 @@ GAPI_OCV_KERNEL(OCVLocateROI, LocateROI) {
                            , sqside
                            , sqside
                            };
-    }
-};
-
-GAPI_OCV_KERNEL(OCVParseSSD, ParseSSD) {
-    static void run(const cv::Mat &in_ssd_result,
-                    const cv::Rect &in_roi,
-                    const cv::Size &in_parent_size,
-                    std::vector<cv::Rect> &out_objects) {
-        const auto &in_ssd_dims = in_ssd_result.size;
-        CV_Assert(in_ssd_dims.dims() == 4u);
-
-        const int MAX_PROPOSALS = in_ssd_dims[2];
-        const int OBJECT_SIZE   = in_ssd_dims[3];
-        CV_Assert(OBJECT_SIZE  == 7); // fixed SSD object size
-
-        const cv::Size up_roi = in_roi.size();
-        const cv::Rect surface({0,0}, in_parent_size);
-
-        out_objects.clear();
-
-        const float *data = in_ssd_result.ptr<float>();
-        for (int i = 0; i < MAX_PROPOSALS; i++) {
-            const float image_id   = data[i * OBJECT_SIZE + 0];
-            const float label      = data[i * OBJECT_SIZE + 1];
-            const float confidence = data[i * OBJECT_SIZE + 2];
-            const float rc_left    = data[i * OBJECT_SIZE + 3];
-            const float rc_top     = data[i * OBJECT_SIZE + 4];
-            const float rc_right   = data[i * OBJECT_SIZE + 5];
-            const float rc_bottom  = data[i * OBJECT_SIZE + 6];
-            (void) label; // unused
-
-            if (image_id < 0.f) {
-                break;    // marks end-of-detections
-            }
-            if (confidence < 0.5f) {
-                continue; // skip objects with low confidence
-            }
-
-            // map relative coordinates to the original image scale
-            // taking the ROI into account
-            cv::Rect rc;
-            rc.x      = static_cast<int>(rc_left   * up_roi.width);
-            rc.y      = static_cast<int>(rc_top    * up_roi.height);
-            rc.width  = static_cast<int>(rc_right  * up_roi.width)  - rc.x;
-            rc.height = static_cast<int>(rc_bottom * up_roi.height) - rc.y;
-            rc.x += in_roi.x;
-            rc.y += in_roi.y;
-            out_objects.emplace_back(rc & surface);
-        }
     }
 };
 
@@ -211,9 +145,7 @@ int main(int argc, char *argv[])
         cmd.get<std::string>("faced"),   // device specifier
     };
     auto kernels = cv::gapi::kernels
-        < custom::OCVGetSize
-        , custom::OCVLocateROI
-        , custom::OCVParseSSD
+        <custom::OCVLocateROI
         , custom::OCVBBoxes>();
     auto networks = cv::gapi::networks(face_net);
 
@@ -231,7 +163,8 @@ int main(int argc, char *argv[])
         cv::GMat in;
         cv::GOpaque<cv::Rect> in_roi;
         auto blob = cv::gapi::infer<custom::FaceDetector>(in_roi, in);
-        auto  rcs = custom::ParseSSD::on(blob, in_roi, custom::GetSize::on(in));
+        cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
+        cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, sz, 0.5f, true, true);
         auto  out = cv::gapi::wip::draw::render3ch(in, custom::BBoxes::on(rcs, in_roi));
         pipeline  = cv::GComputation(cv::GIn(in, in_roi), cv::GOut(out))
             .compileStreaming(cv::compile_args(kernels, networks));
@@ -245,7 +178,8 @@ int main(int argc, char *argv[])
         cv::GMat in;
         cv::GOpaque<cv::Rect> roi = custom::LocateROI::on(in);
         auto blob = cv::gapi::infer<custom::FaceDetector>(roi, in);
-        auto  rcs = custom::ParseSSD::on(blob, roi, custom::GetSize::on(in));
+        cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(in);
+        cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, sz, 0.5f, true, true);
         auto  out = cv::gapi::wip::draw::render3ch(in, custom::BBoxes::on(rcs, roi));
         pipeline  = cv::GComputation(cv::GIn(in), cv::GOut(out))
             .compileStreaming(cv::compile_args(kernels, networks));

--- a/modules/gapi/samples/infer_single_roi.cpp
+++ b/modules/gapi/samples/infer_single_roi.cpp
@@ -188,17 +188,15 @@ int main(int argc, char *argv[])
     pipeline.start();
 
     cv::Mat out;
-    int framesCount = 0;
-    cv::TickMeter t;
-    t.start();
+    size_t frames = 0u;
+    cv::TickMeter tm;
+    tm.start();
     while (pipeline.pull(cv::gout(out))) {
         cv::imshow("Out", out);
         cv::waitKey(1);
-        framesCount++;
+        ++frames;
     }
-    t.stop();
-    std::cout << "Elapsed time: " << t.getTimeSec() << std::endl;
-    std::cout << "FPS: " << framesCount / (t.getTimeSec() ? t.getTimeSec() : 1) << std::endl;
-    std::cout << "framesCount: " << framesCount << std::endl;
+    tm.stop();
+    std::cout << "Processed " << frames << " frames" << " (" << frames / tm.getTimeSec() << " FPS)" << std::endl;
     return 0;
 }

--- a/modules/gapi/samples/infer_ssd_onnx.cpp
+++ b/modules/gapi/samples/infer_ssd_onnx.cpp
@@ -14,6 +14,7 @@
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include <opencv2/gapi/streaming/cap.hpp>
 #include <opencv2/highgui.hpp>
+#include <opencv2/gapi/infer/parsers.hpp>
 
 namespace custom {
 
@@ -23,71 +24,12 @@ using GDetections = cv::GArray<cv::Rect>;
 using GSize       = cv::GOpaque<cv::Size>;
 using GPrims      = cv::GArray<cv::gapi::wip::draw::Prim>;
 
-G_API_OP(GetSize, <GSize(cv::GMat)>, "sample.custom.get-size") {
-    static cv::GOpaqueDesc outMeta(const cv::GMatDesc &) {
-        return cv::empty_gopaque_desc();
-    }
-};
-G_API_OP(ParseSSD, <GDetections(cv::GMat, GSize)>, "sample.custom.parse-ssd") {
-    static cv::GArrayDesc outMeta(const cv::GMatDesc &, const cv::GOpaqueDesc &) {
-        return cv::empty_array_desc();
-    }
-};
 G_API_OP(BBoxes, <GPrims(GDetections)>, "sample.custom.b-boxes") {
     static cv::GArrayDesc outMeta(const cv::GArrayDesc &) {
         return cv::empty_array_desc();
     }
 };
 
-GAPI_OCV_KERNEL(OCVGetSize, GetSize) {
-    static void run(const cv::Mat &in, cv::Size &out) {
-        out = {in.cols, in.rows};
-    }
-};
-GAPI_OCV_KERNEL(OCVParseSSD, ParseSSD) {
-    static void run(const cv::Mat &in_ssd_result,
-                    const cv::Size &in_parent_size,
-                    std::vector<cv::Rect> &out_objects) {
-        const auto &in_ssd_dims = in_ssd_result.size;
-        CV_Assert(in_ssd_dims.dims() == 4u);
-
-        const int MAX_PROPOSALS = in_ssd_dims[2];
-        const int OBJECT_SIZE   = in_ssd_dims[3];
-
-        CV_Assert(OBJECT_SIZE  == 7); // fixed SSD object size
-
-        const cv::Rect surface({0,0}, in_parent_size);
-
-        out_objects.clear();
-
-        const float *data = in_ssd_result.ptr<float>();
-        for (int i = 0; i < MAX_PROPOSALS; i++) {
-            const float image_id   = data[i * OBJECT_SIZE + 0];
-            const float label      = data[i * OBJECT_SIZE + 1];
-            const float confidence = data[i * OBJECT_SIZE + 2];
-            const float rc_left    = data[i * OBJECT_SIZE + 3];
-            const float rc_top     = data[i * OBJECT_SIZE + 4];
-            const float rc_right   = data[i * OBJECT_SIZE + 5];
-            const float rc_bottom  = data[i * OBJECT_SIZE + 6];
-            (void) label; // unused
-
-            if (image_id < 0.f) {
-                break;    // marks end-of-detections
-            }
-            if (confidence < 0.5f) {
-                continue; // skip objects with low confidence
-            }
-
-            // map relative coordinates to the original image scale
-            cv::Rect rc;
-            rc.x      = static_cast<int>(rc_left   * in_parent_size.width);
-            rc.y      = static_cast<int>(rc_top    * in_parent_size.height);
-            rc.width  = static_cast<int>(rc_right  * in_parent_size.width)  - rc.x;
-            rc.height = static_cast<int>(rc_bottom * in_parent_size.height) - rc.y;
-            out_objects.emplace_back(rc & surface);
-        }
-    }
-};
 GAPI_OCV_KERNEL(OCVBBoxes, BBoxes) {
     // This kernel converts the rectangles into G-API's
     // rendering primitives
@@ -151,7 +93,6 @@ void remap_ssd_ports(const std::unordered_map<std::string, cv::Mat> &onnx,
 }
 } // anonymous namespace
 
-
 const std::string keys =
     "{ h help | | Print this help message }"
     "{ input  | | Path to the input video file }"
@@ -175,15 +116,14 @@ int main(int argc, char *argv[])
     auto obj_net = cv::gapi::onnx::Params<custom::ObjDetector>{obj_model_path}
         .cfgOutputLayers({"detection_output"})
         .cfgPostProc({cv::GMatDesc{CV_32F, {1,1,200,7}}}, remap_ssd_ports);
-    auto kernels = cv::gapi::kernels< custom::OCVGetSize
-                                    , custom::OCVParseSSD
-                                    , custom::OCVBBoxes>();
+    auto kernels = cv::gapi::kernels<custom::OCVBBoxes>();
     auto networks = cv::gapi::networks(obj_net);
 
     // Now build the graph
     cv::GMat in;
     auto blob = cv::gapi::infer<custom::ObjDetector>(in);
-    auto  rcs = custom::ParseSSD::on(blob, custom::GetSize::on(in));
+    cv::GOpaque<cv::Size> size = cv::gapi::streaming::size(in);
+    cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, size, 0.5f, true, true);
     auto  out = cv::gapi::wip::draw::render3ch(in, custom::BBoxes::on(rcs));
     cv::GStreamingCompiled pipeline = cv::GComputation(cv::GIn(in), cv::GOut(out))
         .compileStreaming(cv::compile_args(kernels, networks));

--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -343,8 +343,8 @@ int main(int argc, char *argv[]) {
     pipeline.setSource(std::move(cap));
     pipeline.start();
 
-    int framesCount = 0;
-    cv::TickMeter t;
+    size_t frames = 0u;
+    cv::TickMeter tm;
     cv::VideoWriter writer;
     if (!output.empty() && !writer.isOpened()) {
         const auto sz = cv::Size{frame_descr.size.width, frame_descr.size.height};
@@ -353,20 +353,17 @@ int main(int argc, char *argv[]) {
     }
 
     cv::Mat outMat;
-    t.start();
+    tm.start();
     while (pipeline.pull(cv::gout(outMat))) {
         cv::imshow("Out", outMat);
         cv::waitKey(1);
         if (!output.empty()) {
             writer << outMat;
         }
-        framesCount++;
+        ++frames;
     }
-    t.stop();
-    std::cout << "Elapsed time: " << t.getTimeSec() << std::endl;
-    std::cout << "FPS: " << framesCount /  t.getTimeSec() << std::endl;
-    std::cout << "framesCount: " << framesCount << std::endl;
-
+    tm.stop();
+    std::cout << "Processed " << frames << " frames" << " (" << frames / tm.getTimeSec() << " FPS)" << std::endl;
     return 0;
 }
 

--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -13,6 +13,7 @@
 #include <opencv2/gapi/streaming/onevpl/source.hpp>
 #include <opencv2/gapi/streaming/onevpl/data_provider_interface.hpp>
 #include <opencv2/highgui.hpp> // CommandLineParser
+#include <opencv2/gapi/infer/parsers.hpp>
 
 #ifdef HAVE_INF_ENGINE
 #include <inference_engine.hpp> // ParamMap
@@ -126,12 +127,6 @@ G_API_OP(LocateROI, <GRect(GSize)>, "sample.custom.locate-roi") {
     }
 };
 
-G_API_OP(ParseSSD, <GDetections(cv::GMat, GRect, GSize)>, "sample.custom.parse-ssd") {
-    static cv::GArrayDesc outMeta(const cv::GMatDesc &, const cv::GOpaqueDesc &, const cv::GOpaqueDesc &) {
-        return cv::empty_array_desc();
-    }
-};
-
 G_API_OP(BBoxes, <GPrims(GDetections, GRect)>, "sample.custom.b-boxes") {
     static cv::GArrayDesc outMeta(const cv::GArrayDesc &, const cv::GOpaqueDesc &) {
         return cv::empty_array_desc();
@@ -160,55 +155,6 @@ GAPI_OCV_KERNEL(OCVLocateROI, LocateROI) {
                            , sqside
                            , sqside
                            };
-    }
-};
-
-GAPI_OCV_KERNEL(OCVParseSSD, ParseSSD) {
-    static void run(const cv::Mat &in_ssd_result,
-                    const cv::Rect &in_roi,
-                    const cv::Size &in_parent_size,
-                    std::vector<cv::Rect> &out_objects) {
-        const auto &in_ssd_dims = in_ssd_result.size;
-        CV_Assert(in_ssd_dims.dims() == 4u);
-
-        const int MAX_PROPOSALS = in_ssd_dims[2];
-        const int OBJECT_SIZE   = in_ssd_dims[3];
-        CV_Assert(OBJECT_SIZE  == 7); // fixed SSD object size
-
-        const cv::Size up_roi = in_roi.size();
-        const cv::Rect surface({0,0}, in_parent_size);
-
-        out_objects.clear();
-
-        const float *data = in_ssd_result.ptr<float>();
-        for (int i = 0; i < MAX_PROPOSALS; i++) {
-            const float image_id   = data[i * OBJECT_SIZE + 0];
-            const float label      = data[i * OBJECT_SIZE + 1];
-            const float confidence = data[i * OBJECT_SIZE + 2];
-            const float rc_left    = data[i * OBJECT_SIZE + 3];
-            const float rc_top     = data[i * OBJECT_SIZE + 4];
-            const float rc_right   = data[i * OBJECT_SIZE + 5];
-            const float rc_bottom  = data[i * OBJECT_SIZE + 6];
-            (void) label; // unused
-
-            if (image_id < 0.f) {
-                break;    // marks end-of-detections
-            }
-            if (confidence < 0.5f) {
-                continue; // skip objects with low confidence
-            }
-
-            // map relative coordinates to the original image scale
-            // taking the ROI into account
-            cv::Rect rc;
-            rc.x      = static_cast<int>(rc_left   * up_roi.width);
-            rc.y      = static_cast<int>(rc_top    * up_roi.height);
-            rc.width  = static_cast<int>(rc_right  * up_roi.width)  - rc.x;
-            rc.height = static_cast<int>(rc_bottom * up_roi.height) - rc.y;
-            rc.x += in_roi.x;
-            rc.y += in_roi.y;
-            out_objects.emplace_back(rc & surface);
-        }
     }
 };
 
@@ -350,7 +296,6 @@ int main(int argc, char *argv[]) {
 
     auto kernels = cv::gapi::kernels
         < custom::OCVLocateROI
-        , custom::OCVParseSSD
         , custom::OCVBBoxes>();
     auto networks = cv::gapi::networks(face_net);
 
@@ -379,7 +324,7 @@ int main(int argc, char *argv[]) {
     auto size = cv::gapi::streaming::size(in);
     auto roi = custom::LocateROI::on(size);
     auto blob = cv::gapi::infer<custom::FaceDetector>(roi, in);
-    auto rcs = custom::ParseSSD::on(blob, roi, size);
+    cv::GArray<cv::Rect> rcs = cv::gapi::parseSSD(blob, size, 0.5f, true, true);
     auto out_frame = cv::gapi::wip::draw::renderFrame(in, custom::BBoxes::on(rcs, roi));
     auto out = cv::gapi::streaming::BGR(out_frame);
 

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -171,7 +171,7 @@ int main(int argc, char *argv[]) {
     cv::TickMeter tm;
     cv::Mat outMat;
 
-    int frames = 0;
+    std::size_t frames = 0u;
     tm.start();
     pipeline.start();
     while (pipeline.pull(cv::gout(outMat))) {
@@ -186,6 +186,6 @@ int main(int argc, char *argv[]) {
         }
     }
     tm.stop();
-    std::cout << "Mean FPS is " << float(frames) / tm.getAvgTimeSec() << std::endl;
+    std::cout << "Processed " << frames << " frames" << " (" << frames / tm.getTimeSec() << " FPS)" << std::endl;
     return 0;
 }

--- a/modules/gapi/samples/semantic_segmentation.cpp
+++ b/modules/gapi/samples/semantic_segmentation.cpp
@@ -147,8 +147,8 @@ int main(int argc, char *argv[]) {
     cv::GMat in;
     cv::GMat out_blob = cv::gapi::infer<SemSegmNet>(in);
     cv::GMat post_proc_out = custom::PostProcessing::on(in, out_blob);
-    cv::GMat blending_in = in * 0.3;
-    cv::GMat blending_out = post_proc_out * 0.7;
+    cv::GMat blending_in = in * 0.3f;
+    cv::GMat blending_out = post_proc_out * 0.7f;
     cv::GMat out = blending_in + blending_out;
 
     cv::GStreamingCompiled pipeline = cv::GComputation(cv::GIn(in), cv::GOut(out))


### PR DESCRIPTION
Cleaning G-API samples.
Removed ParseSSD custom kernels. cv::gapi::parseSSD instead.
Added graph operations for semantic segmentation instead operations in a kernel.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Build Configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```