### PR TITLE
Fix out of memory read when using NaN.

### DIFF
--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -1932,9 +1932,12 @@ struct RGB2Lab_f
                     else // scn == 4
                     {
                         v_float32 dummy0, dummy1;
+
                         v_load_deinterleave(src + 0*vsize, rvec0, gvec0, bvec0, dummy0);
                         v_load_deinterleave(src + 4*vsize, rvec1, gvec1, bvec1, dummy1);
                     }
+                    const v_float32 mask_not_nan0 = v_not_nan(rvec0 + gvec0 + bvec0);
+                    const v_float32 mask_not_nan1 = v_not_nan(rvec1 + gvec1 + bvec1);
 
                     if(bIdx)
                     {
@@ -1994,6 +1997,14 @@ struct RGB2Lab_f
                     b_vec0 = v_fma(b_vec0, v256dBase, vm128);
                     b_vec1 = v_fma(b_vec1, v256dBase, vm128);
 
+                    const v_float32 kAllNaN = vx_setall_f32(std::numeric_limits<float>::quiet_NaN());
+                    l_vec0 = v_select(mask_not_nan0, l_vec0, kAllNaN);
+                    a_vec0 = v_select(mask_not_nan0, a_vec0, kAllNaN);
+                    b_vec0 = v_select(mask_not_nan0, b_vec0, kAllNaN);
+                    l_vec1 = v_select(mask_not_nan1, l_vec1, kAllNaN);
+                    a_vec1 = v_select(mask_not_nan1, a_vec1, kAllNaN);
+                    b_vec1 = v_select(mask_not_nan1, b_vec1, kAllNaN);
+
                     v_store_interleave(dst + i + 0*vsize, l_vec0, a_vec0, b_vec0);
                     v_store_interleave(dst + i + 3*vsize, l_vec1, a_vec1, b_vec1);
                 }
@@ -2002,6 +2013,10 @@ struct RGB2Lab_f
 
             for(; i < n; i += 3, src += scn)
             {
+                if (cvIsNaN(src[0] + src[1] + src[2])) {
+                    dst[i] = dst[i + 1] = dst[i + 2] = std::numeric_limits<float>::quiet_NaN();
+                    continue;
+                }
                 float R = clip(src[bIdx]);
                 float G = clip(src[1]);
                 float B = clip(src[bIdx^2]);

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3117,5 +3117,17 @@ TEST(ImgProc_cvtColorTwoPlane, y_plane_padding_differs_from_uv_plane_padding_170
     EXPECT_DOUBLE_EQ(cvtest::norm(rgb_reference_mat, rgb_uv_padded_mat, NORM_INF), .0);
 }
 
+TEST(ImgProc_NaN, RGB2Lab_21111) {
+  const float kNaN = std::numeric_limits<float>::quiet_NaN();
+  cv::Mat3f src(1, 111, Vec3f::all(kNaN)), dst;
+  // Make some entries with only one NaN.
+  src(0, 0) = src(0, 27) = src(0, 81) = src(0, 108) = cv::Vec3f(0, 0, kNaN);
+  src(0, 1) = src(0, 28) = src(0, 82) = src(0, 109) = cv::Vec3f(0, kNaN, 0);
+  src(0, 2) = src(0, 29) = src(0, 83) = src(0, 110) = cv::Vec3f(kNaN, 0, 0);
+  cvtColor(src, dst, COLOR_RGB2Lab);
+  for(int i = 0; i < 20; ++i) {
+    for(int j = 0; j < 3; ++j) EXPECT_TRUE(cvIsNaN(dst(0, i)[j]));
+  }
+}
 
 }} // namespace

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3117,17 +3117,25 @@ TEST(ImgProc_cvtColorTwoPlane, y_plane_padding_differs_from_uv_plane_padding_170
     EXPECT_DOUBLE_EQ(cvtest::norm(rgb_reference_mat, rgb_uv_padded_mat, NORM_INF), .0);
 }
 
-TEST(ImgProc_NaN, RGB2Lab_21111) {
-  const float kNaN = std::numeric_limits<float>::quiet_NaN();
-  cv::Mat3f src(1, 111, Vec3f::all(kNaN)), dst;
-  // Make some entries with only one NaN.
-  src(0, 0) = src(0, 27) = src(0, 81) = src(0, 108) = cv::Vec3f(0, 0, kNaN);
-  src(0, 1) = src(0, 28) = src(0, 82) = src(0, 109) = cv::Vec3f(0, kNaN, 0);
-  src(0, 2) = src(0, 29) = src(0, 83) = src(0, 110) = cv::Vec3f(kNaN, 0, 0);
-  cvtColor(src, dst, COLOR_RGB2Lab);
-  for(int i = 0; i < 20; ++i) {
-    for(int j = 0; j < 3; ++j) EXPECT_TRUE(cvIsNaN(dst(0, i)[j]));
-  }
+TEST(ImgProc_RGB2Lab, NaN_21111)
+{
+    const float kNaN = std::numeric_limits<float>::quiet_NaN();
+    cv::Mat3f src(1, 111, Vec3f::all(kNaN)), dst;
+    // Make some entries with only one NaN.
+    src(0, 0) = src(0, 27) = src(0, 81) = src(0, 108) = cv::Vec3f(0, 0, kNaN);
+    src(0, 1) = src(0, 28) = src(0, 82) = src(0, 109) = cv::Vec3f(0, kNaN, 0);
+    src(0, 2) = src(0, 29) = src(0, 83) = src(0, 110) = cv::Vec3f(kNaN, 0, 0);
+    EXPECT_NO_THROW(cvtColor(src, dst, COLOR_RGB2Lab));
+
+#if 0  // no NaN propagation guarantee
+    for (int i = 0; i < 20; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            EXPECT_TRUE(cvIsNaN(dst(0, i)[j]));
+        }
+    }
+#endif
 }
 
 }} // namespace


### PR DESCRIPTION
If a NaN is sent to RGB2Lab_f::operator() and is read at https://github.com/opencv/opencv/blob/97c6ec6d49cb78321eafe6fa220ff80ebdc5e2f4/modules/imgproc/src/color_lab.cpp#L2005. It is then converted to an int when rounding at https://github.com/opencv/opencv/blob/97c6ec6d49cb78321eafe6fa220ff80ebdc5e2f4/modules/imgproc/src/color_lab.cpp#L2009 which is implementation dependent but can end up being std::numeric_limits<int>::min() on my machine.
When then calling trilinearInterpolate, the index is definitely outside the LUT at https://github.com/opencv/opencv/blob/97c6ec6d49cb78321eafe6fa220ff80ebdc5e2f4/modules/imgproc/src/color_lab.cpp#L1333 which is a security issue.

Yes, normal users should not use NaN, but malicious users will.

Here are the other possible solutions:

- we first scan for any NaN and throw an error is there is any (that should be documented and replicated to the other color conversions)
- add an Assert but that would be per pixel (a DbgAssert would not be called in production code)
- add a default behavior like I did which is the smallest change

Please advise.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
