### PR TITLE
GAPI Fluid: SIMD for AddC kernel.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -57,6 +57,7 @@ namespace core {
 
     G_TYPED_KERNEL(GAddC, <GMat(GMat, GScalar, int)>, "org.opencv.core.math.addC") {
         static GMatDesc outMeta(GMatDesc a, GScalarDesc, int ddepth) {
+            GAPI_Assert(a.chan <= 4);
             return a.withDepth(ddepth);
         }
     };

--- a/modules/gapi/perf/common/gapi_core_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests.hpp
@@ -28,7 +28,7 @@ namespace opencv_test
 //------------------------------------------------------------------------------
 
     class AddPerfTest : public TestPerfParams<tuple<cv::Size, MatType, int, cv::GCompileArgs>> {};
-    class AddCPerfTest : public TestPerfParams<tuple<cv::Size, MatType, int, cv::GCompileArgs>> {};
+    class AddCPerfTest : public TestPerfParams<tuple<compare_f, cv::Size, MatType, int, cv::GCompileArgs>> {};
     class SubPerfTest : public TestPerfParams<tuple<cv::Size, MatType, int, cv::GCompileArgs>> {};
     class SubCPerfTest : public TestPerfParams<tuple<cv::Size, MatType, int, cv::GCompileArgs>> {};
     class SubRCPerfTest : public TestPerfParams<tuple<cv::Size, MatType, int, cv::GCompileArgs>> {};

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -61,11 +61,13 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
 
 PERF_TEST_P_(AddCPerfTest, TestPerformance)
 {
-    compare_f cmpF = get<0>(GetParam());
-    Size sz = get<1>(GetParam());
-    MatType type = get<2>(GetParam());
-    int dtype = get<3>(GetParam());
-    cv::GCompileArgs compile_args = get<4>(GetParam());
+    compare_f cmpF;
+    cv::Size sz;
+    MatType type = -1;
+    int dtype = -1;
+    cv::GCompileArgs compile_args;
+
+    std::tie(cmpF, sz, type, dtype, compile_args) = GetParam();
 
     initMatsRandU(type, sz, dtype, false);
 
@@ -87,24 +89,7 @@ PERF_TEST_P_(AddCPerfTest, TestPerformance)
     {
         cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
-#if 0
-    int error = 0;
-    for (int i = 0; i < out_mat_gapi.size().height; i++) {
-        for (int j = 0; j < out_mat_gapi.size().width * out_mat_gapi.channels(); j++) {
-            if ((out_mat_gapi.at<uint8_t>(i, j) != out_mat_ocv.at<uint8_t>(i, j)) &&
-                (cv::abs(out_mat_gapi.at<uint8_t>(i, j) - out_mat_ocv.at<uint8_t>(i, j)) > 0))
-            {
-                std::cout << "Error number: " << error << std::endl << std::endl;
-                std::cout << "row = " << i << "; col = " << j << std::endl;
-                std::cout << "G-API result value = " << (int)out_mat_gapi.at<uint8_t>(i, j) << std::endl;
-                std::cout << "OCV result value = " << (int)out_mat_ocv.at<uint8_t>(i, j) << std::endl;
-                std::cout << "Diff = " << (int)cv::abs(out_mat_gapi.at<uint8_t>(i, j) - out_mat_ocv.at<uint8_t>(i, j))
-                    << std::endl << std::endl;
-                error++;
-            }
-        }
-    }
-#endif
+
     // Comparison ////////////////////////////////////////////////////////////
     {
         EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -61,10 +61,11 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
 
 PERF_TEST_P_(AddCPerfTest, TestPerformance)
 {
-    Size sz = get<0>(GetParam());
-    MatType type = get<1>(GetParam());
-    int dtype = get<2>(GetParam());
-    cv::GCompileArgs compile_args = get<3>(GetParam());
+    compare_f cmpF = get<0>(GetParam());
+    Size sz = get<1>(GetParam());
+    MatType type = get<2>(GetParam());
+    int dtype = get<3>(GetParam());
+    cv::GCompileArgs compile_args = get<4>(GetParam());
 
     initMatsRandU(type, sz, dtype, false);
 
@@ -86,10 +87,28 @@ PERF_TEST_P_(AddCPerfTest, TestPerformance)
     {
         cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
-
+#if 0
+    int error = 0;
+    for (int i = 0; i < out_mat_gapi.size().height; i++) {
+        for (int j = 0; j < out_mat_gapi.size().width * out_mat_gapi.channels(); j++) {
+            if ((out_mat_gapi.at<uint8_t>(i, j) != out_mat_ocv.at<uint8_t>(i, j)) &&
+                (cv::abs(out_mat_gapi.at<uint8_t>(i, j) - out_mat_ocv.at<uint8_t>(i, j)) > 0))
+            {
+                std::cout << "Error number: " << error << std::endl << std::endl;
+                std::cout << "row = " << i << "; col = " << j << std::endl;
+                std::cout << "G-API result value = " << (int)out_mat_gapi.at<uint8_t>(i, j) << std::endl;
+                std::cout << "OCV result value = " << (int)out_mat_ocv.at<uint8_t>(i, j) << std::endl;
+                std::cout << "Diff = " << (int)cv::abs(out_mat_gapi.at<uint8_t>(i, j) - out_mat_ocv.at<uint8_t>(i, j))
+                    << std::endl << std::endl;
+                error++;
+            }
+        }
+    }
+#endif
     // Comparison ////////////////////////////////////////////////////////////
-    // FIXIT unrealiable check: EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-    EXPECT_EQ(out_mat_gapi.size(), sz);
+    {
+        EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
+    }
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_cpu.cpp
@@ -22,7 +22,8 @@ INSTANTIATE_TEST_CASE_P(AddPerfTestCPU, AddPerfTest,
         Values(cv::compile_args(CORE_CPU))));
 
 INSTANTIATE_TEST_CASE_P(AddCPerfTestCPU, AddCPerfTest,
-    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+    Combine(Values(AbsExact().to_compare_f()),
+        Values(szSmall128, szVGA, sz720p, sz1080p),
         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
         Values(-1, CV_8U, CV_16U, CV_32F),
         Values(cv::compile_args(CORE_CPU))));

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -18,11 +18,12 @@ INSTANTIATE_TEST_CASE_P(AddPerfTestFluid, AddPerfTest,
             Values(-1, CV_8U, CV_32F),
             Values(cv::compile_args(CORE_FLUID))));
 
-// INSTANTIATE_TEST_CASE_P(AddCPerfTestFluid, AddCPerfTest,
-//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
-//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-//         Values(-1, CV_8U, CV_16U, CV_32F),
-//         Values(cv::compile_args(CORE_FLUID))));
+ INSTANTIATE_TEST_CASE_P(AddCPerfTestFluid, AddCPerfTest,
+     Combine(Values(Tolerance_FloatRel_IntAbs(1e-6, 1).to_compare_f()),
+         Values(szSmall128, szVGA, sz720p, sz1080p),
+         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+         Values(-1, CV_8U, CV_16U, CV_16S, CV_32F),
+         Values(cv::compile_args(CORE_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(SubPerfTestFluid, SubPerfTest,
     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/gpu/gapi_core_perf_tests_gpu.cpp
+++ b/modules/gapi/perf/gpu/gapi_core_perf_tests_gpu.cpp
@@ -20,7 +20,8 @@ INSTANTIATE_TEST_CASE_P(AddPerfTestGPU, AddPerfTest,
                                 Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(AddCPerfTestGPU, AddCPerfTest,
-                        Combine(Values( szSmall128, szVGA, sz720p, sz1080p ),
+                        Combine(Values(AbsExact().to_compare_f()),
+                                Values( szSmall128, szVGA, sz720p, sz1080p ),
                                 Values( CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1 ),
                                 Values( -1, CV_8U, CV_16U, CV_32F ),
                                 Values(cv::compile_args(CORE_GPU))));

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
@@ -85,6 +85,33 @@ MUL_SIMD(float, float)
 
 #undef MUL_SIMD
 
+#define ADDC_SIMD(SRC, DST)                                               \
+int addc_simd(const SRC in[], const float scalar[], DST out[],            \
+              const int width, const int chan)                            \
+{                                                                         \
+    CV_CPU_DISPATCH(addc_simd, (in, scalar, out, width, chan),            \
+                    CV_CPU_DISPATCH_MODES_ALL);                           \
+}
+
+ADDC_SIMD(uchar, uchar)
+ADDC_SIMD(ushort, uchar)
+ADDC_SIMD(short, uchar)
+ADDC_SIMD(float, uchar)
+ADDC_SIMD(short, short)
+ADDC_SIMD(ushort, short)
+ADDC_SIMD(uchar, short)
+ADDC_SIMD(float, short)
+ADDC_SIMD(ushort, ushort)
+ADDC_SIMD(uchar, ushort)
+ADDC_SIMD(short, ushort)
+ADDC_SIMD(float, ushort)
+ADDC_SIMD(uchar, float)
+ADDC_SIMD(ushort, float)
+ADDC_SIMD(short, float)
+ADDC_SIMD(float, float)
+
+#undef ADDC_SIMD
+
 } // namespace fluid
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
@@ -60,6 +60,29 @@ MUL_SIMD(float, float)
 
 #undef MUL_SIMD
 
+#define ADDC_SIMD(SRC, DST)                                                              \
+int addc_simd(const SRC in[], const float scalar[], DST out[],                           \
+              const int width, const int chan);
+
+ADDC_SIMD(uchar, uchar)
+ADDC_SIMD(ushort, uchar)
+ADDC_SIMD(short, uchar)
+ADDC_SIMD(float, uchar)
+ADDC_SIMD(short, short)
+ADDC_SIMD(ushort, short)
+ADDC_SIMD(uchar, short)
+ADDC_SIMD(float, short)
+ADDC_SIMD(ushort, ushort)
+ADDC_SIMD(uchar, ushort)
+ADDC_SIMD(short, ushort)
+ADDC_SIMD(float, ushort)
+ADDC_SIMD(uchar, float)
+ADDC_SIMD(ushort, float)
+ADDC_SIMD(short, float)
+ADDC_SIMD(float, float)
+
+#undef ADDC_SIMD
+
 }  // namespace fluid
 }  // namespace gapi
 }  // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -160,12 +160,12 @@ CV_ALWAYS_INLINE v_float32 div_op(not_scale_tag, const v_float32& a, const v_flo
     return a / div;
 }
 
-CV_ALWAYS_INLINE void v_store_i16(short* dst, v_int32& res1, v_int32& res2)
+CV_ALWAYS_INLINE void v_store_i16(short* dst, const v_int32& res1, const v_int32& res2)
 {
     vx_store(dst, v_pack(res1, res2));
 }
 
-CV_ALWAYS_INLINE void v_store_i16(ushort* dst, v_int32& res1, v_int32& res2)
+CV_ALWAYS_INLINE void v_store_i16(ushort* dst, const v_int32& res1, const v_int32& res2)
 {
     vx_store(dst, v_pack_u(res1, res2));
 }
@@ -850,6 +850,7 @@ MUL_SIMD(float, float)
 // Fluid kernels: AddC
 //
 //-------------------------
+
 CV_ALWAYS_INLINE void addc_pack_store_c3(short* out_ptr, const v_int32& c1,
                                          const v_int32& c2, const v_int32& c3,
                                          const v_int32& c4, const v_int32& c5,
@@ -871,6 +872,7 @@ CV_ALWAYS_INLINE void addc_pack_store_c3(ushort* out_ptr, const v_int32& c1,
     vx_store(&out_ptr[nlanes], v_pack_u(c3, c4));
     vx_store(&out_ptr[2*nlanes], v_pack_u(c5, c6));
 }
+
 template<typename SRC, typename DST>
 CV_ALWAYS_INLINE
 typename std::enable_if<(std::is_same<DST, ushort>::value ||
@@ -1021,8 +1023,8 @@ addc_simd_c3_impl(const SRC in[], DST out[], const v_float32& s1, const v_float3
 
 template<typename SRC>
 CV_ALWAYS_INLINE int addc_simd_c3_impl(const SRC in[], uchar out[],
-                                           const v_float32& s1, const v_float32& s2,
-                                           const v_float32& s3, const int length)
+                                       const v_float32& s1, const v_float32& s2,
+                                       const v_float32& s3, const int length)
 {
     constexpr int nlanes = v_uint8::nlanes;
     constexpr int chan = 3;


### PR DESCRIPTION
SIMD for GAPI Fluid AddC kernel.

<cut/>

Performance report:

[FluidAddCSIMD.xlsx](https://github.com/opencv/opencv/files/7601676/FluidAddCSIMD.xlsx)

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```
