### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -270,12 +270,12 @@ def createSSDGraph(modelPath, configPath, outputPath):
     addConstNode('concat/axis_flatten', [-1], graph_def)
     addConstNode('PriorBox/concat/axis', [-2], graph_def)
 
-    for label in ['ClassPredictor', 'BoxEncodingPredictor' if box_predictor is 'convolutional' else 'BoxPredictor']:
+    for label in ['ClassPredictor', 'BoxEncodingPredictor' if box_predictor == 'convolutional' else 'BoxPredictor']:
         concatInputs = []
         for i in range(num_layers):
             # Flatten predictions
             flatten = NodeDef()
-            if box_predictor is 'convolutional':
+            if box_predictor == 'convolutional':
                 inpName = 'BoxPredictor_%d/%s/BiasAdd' % (i, label)
             else:
                 if i == 0:
@@ -308,7 +308,7 @@ def createSSDGraph(modelPath, configPath, outputPath):
         priorBox = NodeDef()
         priorBox.name = 'PriorBox_%d' % i
         priorBox.op = 'PriorBox'
-        if box_predictor is 'convolutional':
+        if box_predictor == 'convolutional':
             priorBox.input.append('BoxPredictor_%d/BoxEncodingPredictor/BiasAdd' % i)
         else:
             if i == 0:


### PR DESCRIPTION
Avoid `SyntaxWarning` on Python >= 3.8
```
>>> "convolutional" == "convolutional"
True
>>> "convolutional" is "convolutional"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
```
Related to #21121

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
