### PR TITLE
CMakeLists.txt: Fix typo discovered by codespell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_PIC})
 
 ocv_cmake_hook(PRE_CMAKE_BOOTSTRAP)
 
-# Bootstap CMake system: setup CMAKE_SYSTEM_NAME and other vars
+# Bootstrap CMake system: setup CMAKE_SYSTEM_NAME and other vars
 enable_language(CXX C)
 
 ocv_cmake_hook(POST_CMAKE_BOOTSTRAP)


### PR DESCRIPTION
Typo discovered by #21121 which uses https://pypi.org/project/codespell/

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test, and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
