### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/modules/ts/misc/chart.py
+++ b/modules/ts/misc/chart.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import testlog_parser, sys, os, xml, re
 from table_formatter import *
 from optparse import OptionParser
@@ -116,7 +117,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     if len(args) != 1:
-        print >> sys.stderr, "Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml"
+        print("Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml", file=sys.stderr)
         exit(1)
 
     options.generateHtml = detectHtmlOutputType(options.format)
@@ -136,7 +137,7 @@ if __name__ == "__main__":
     args[0] = os.path.basename(args[0])
 
     if not tests:
-        print >> sys.stderr, "Error - no tests matched"
+        print("Error - no tests matched", file=sys.stderr)
         exit(1)
 
     argsnum = len(tests[0][1])
@@ -156,26 +157,26 @@ if __name__ == "__main__":
             names1.add(sn)
         if sn == sname:
             if len(pair[1]) != argsnum:
-                print >> sys.stderr, "Error - unable to create chart tables for functions having different argument numbers"
+                print("Error - unable to create chart tables for functions having different argument numbers", file=sys.stderr)
                 sys.exit(1)
             for i in range(argsnum):
                 arglists[i][pair[1][i]] = 1
 
     if names1 or len(names) != 1:
-        print >> sys.stderr, "Error - unable to create tables for functions from different test suits:"
+        print("Error - unable to create tables for functions from different test suits:", file=sys.stderr)
         i = 1
         for name in sorted(names):
-            print >> sys.stderr, "%4s:   %s" % (i, name)
+            print("%4s:   %s" % (i, name), file=sys.stderr)
             i += 1
         if names1:
-            print >> sys.stderr, "Other suits in this log (can not be chosen):"
+            print("Other suits in this log (can not be chosen):", file=sys.stderr)
             for name in sorted(names1):
-                print >> sys.stderr, "%4s:   %s" % (i, name)
+                print("%4s:   %s" % (i, name), file=sys.stderr)
                 i += 1
         sys.exit(1)
 
     if argsnum < 2:
-        print >> sys.stderr, "Error - tests from %s have less than 2 parameters" % sname
+        print("Error - tests from %s have less than 2 parameters" % sname, file=sys.stderr)
         exit(1)
 
     for i in range(argsnum):

--- a/modules/ts/misc/report.py
+++ b/modules/ts/misc/report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import testlog_parser, sys, os, xml, re, glob
 from table_formatter import *
 from optparse import OptionParser
@@ -14,7 +15,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     if len(args) < 1:
-        print >> sys.stderr, "Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml"
+        print("Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml", file=sys.stderr)
         exit(0)
 
     options.generateHtml = detectHtmlOutputType(options.format)

--- a/modules/ts/misc/summary.py
+++ b/modules/ts/misc/summary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import testlog_parser, sys, os, xml, glob, re
 from table_formatter import *
 from optparse import OptionParser
@@ -26,7 +27,7 @@ def getSetName(tset, idx, columns, short = True):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print >> sys.stderr, "Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml [<log_name2>.xml ...]"
+        print("Usage:\n", os.path.basename(sys.argv[0]), "<log_name1>.xml [<log_name2>.xml ...]", file=sys.stderr)
         exit(0)
 
     parser = OptionParser()


### PR DESCRIPTION
### Pull Request Readiness Checklist
Python syntax errors discovered by #21121
Closes #21122
```
futurize -f libfuturize.fixes.fix_print_with_import -w \
    ./modules/ts/misc/report.py \
    ./modules/ts/misc/summary.py \
    ./modules/ts/misc/chart.py
```
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test, and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
