### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/doc/js_tutorials/js_assets/js_camshift.html
+++ b/doc/js_tutorials/js_assets/js_camshift.html
@@ -77,7 +77,7 @@ cv.normalize(roiHist, roiHist, 0, 255, cv.NORM_MINMAX);
 // delete useless mats.
 roi.delete(); hsvRoi.delete(); mask.delete(); low.delete(); high.delete(); hsvRoiVec.delete();
 
-// Setup the termination criteria, either 10 iteration or move by atleast 1 pt
+// Setup the termination criteria, either 10 iteration or move by at least 1 pt
 let termCrit = new cv.TermCriteria(cv.TERM_CRITERIA_EPS | cv.TERM_CRITERIA_COUNT, 10, 1);
 
 let hsv = new cv.Mat(video.height, video.width, cv.CV_8UC3);

--- a/doc/js_tutorials/js_assets/js_meanshift.html
+++ b/doc/js_tutorials/js_assets/js_meanshift.html
@@ -77,7 +77,7 @@ cv.normalize(roiHist, roiHist, 0, 255, cv.NORM_MINMAX);
 // delete useless mats.
 roi.delete(); hsvRoi.delete(); mask.delete(); low.delete(); high.delete(); hsvRoiVec.delete();
 
-// Setup the termination criteria, either 10 iteration or move by atleast 1 pt
+// Setup the termination criteria, either 10 iteration or move by at least 1 pt
 let termCrit = new cv.TermCriteria(cv.TERM_CRITERIA_EPS | cv.TERM_CRITERIA_COUNT, 10, 1);
 
 let hsv = new cv.Mat(video.height, video.width, cv.CV_8UC3);

--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -55,7 +55,7 @@ if(HAVE_QT)
       QT5_ADD_RESOURCES(_RCC_OUTFILES ${CMAKE_CURRENT_LIST_DIR}/src/window_QT.qrc)
       QT5_WRAP_CPP(_MOC_OUTFILES ${CMAKE_CURRENT_LIST_DIR}/src/window_QT.h)
     else()
-      message(FATAL_ERROR "Unsuported QT version: ${QT_VERSION_MAJOR}")
+      message(FATAL_ERROR "Unsupported QT version: ${QT_VERSION_MAJOR}")
     endif()
 
     list(APPEND highgui_srcs

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -484,7 +484,7 @@ class JSWrapperGenerator(object):
                 arg_types.append(arg_type)
                 unwrapped_arg_types.append(arg_type)
 
-            # Function attribure
+            # Function attribute
             func_attribs = ''
             if '*' in ''.join(arg_types):
                 func_attribs += ', allow_raw_pointers()'
@@ -679,7 +679,7 @@ class JSWrapperGenerator(object):
                     def_args.append(arg.defval)
                 arg_types.append(orig_arg_types[-1])
 
-            # Function attribure
+            # Function attribute
             func_attribs = ''
             if '*' in ''.join(orig_arg_types):
                 func_attribs += ', allow_raw_pointers()'

--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     path = args.build_path
     try:
         if not os.path.isdir(path):
-            raise Err("Not a directory (should contain CMakeCache.txt ot test executables)")
+            raise Err("Not a directory (should contain CMakeCache.txt to test executables)")
         cache = CMakeCache(args.configuration)
         fname = os.path.join(path, "CMakeCache.txt")
 

--- a/platforms/winpack_dldt/build_package.py
+++ b/platforms/winpack_dldt/build_package.py
@@ -163,7 +163,7 @@ class BuilderDLDT:
         self.config = config
 
         cpath = self.config.dldt_config
-        log.info('DLDT build configration: %s', cpath)
+        log.info('DLDT build configuration: %s', cpath)
         if not os.path.exists(cpath):
             cpath = os.path.join(SCRIPT_DIR, cpath)
             if not os.path.exists(cpath):
@@ -573,5 +573,5 @@ if __name__ == "__main__":
     try:
         main()
     except:
-        log.info('FATAL: Error occured. To investigate problem try to change logging level using LOGLEVEL=DEBUG environment variable.')
+        log.info('FATAL: Error occurred. To investigate problem try to change logging level using LOGLEVEL=DEBUG environment variable.')
         raise

--- a/samples/dnn/dasiamrpn_tracker.py
+++ b/samples/dnn/dasiamrpn_tracker.py
@@ -226,7 +226,7 @@ def main():
     mark = True
     drawing = False
     cx, cy, w, h = 0.0, 0.0, 0, 0
-    # Fucntion for drawing during videostream
+    # Function for drawing during videostream
     def get_bb(event, x, y, flag, param):
         nonlocal point1, point2, cx, cy, w, h, drawing, mark
 

--- a/samples/dnn/siamrpnpp.py
+++ b/samples/dnn/siamrpnpp.py
@@ -300,7 +300,7 @@ class SiamRPNTracker:
         # clip boundary
         cx, cy, width, height = self._bbox_clip(cx, cy, width, height, img.shape[:2])
 
-        # udpate state
+        # update state
         self.center_pos = np.array([cx, cy])
         self.w = width
         self.h = height

--- a/samples/python/tutorial_code/video/meanshift/camshift.py
+++ b/samples/python/tutorial_code/video/meanshift/camshift.py
@@ -24,7 +24,7 @@ mask = cv.inRange(hsv_roi, np.array((0., 60.,32.)), np.array((180.,255.,255.)))
 roi_hist = cv.calcHist([hsv_roi],[0],mask,[180],[0,180])
 cv.normalize(roi_hist,roi_hist,0,255,cv.NORM_MINMAX)
 
-# Setup the termination criteria, either 10 iteration or move by atleast 1 pt
+# Setup the termination criteria, either 10 iteration or move by at least 1 pt
 term_crit = ( cv.TERM_CRITERIA_EPS | cv.TERM_CRITERIA_COUNT, 10, 1 )
 
 while(1):

--- a/samples/python/tutorial_code/video/meanshift/meanshift.py
+++ b/samples/python/tutorial_code/video/meanshift/meanshift.py
@@ -24,7 +24,7 @@ mask = cv.inRange(hsv_roi, np.array((0., 60.,32.)), np.array((180.,255.,255.)))
 roi_hist = cv.calcHist([hsv_roi],[0],mask,[180],[0,180])
 cv.normalize(roi_hist,roi_hist,0,255,cv.NORM_MINMAX)
 
-# Setup the termination criteria, either 10 iteration or move by atleast 1 pt
+# Setup the termination criteria, either 10 iteration or move by at least 1 pt
 term_crit = ( cv.TERM_CRITERIA_EPS | cv.TERM_CRITERIA_COUNT, 10, 1 )
 
 while(1):


### PR DESCRIPTION
### Pull Request Readiness Checklist
Like #21128 
Typos discovered by #21121 which uses https://pypi.org/project/codespell/
```
codespell --count --ignore-words-list=activ,hist,halfs,ist,lod,msdos,numer \
    --skip="./3rdparty/*,*.bib,*.c,*.cc,*.cl,*.clj,*.cmake,*.cpp,*.cu,*.h,*.hpp,*.java,*.json,*.markdown,*.proto,*.svg,*.txt,*.xml"
```
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test, and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
