### PR TITLE
fix Clip, LeakyReLU, LRN, Split defaults

### DIFF
--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -80,7 +80,7 @@ public:
         if (size % 2 != 1 || size <= 0)
             CV_Error(Error::StsBadArg, "LRN layer supports only positive odd values for local_size");
 
-        alpha = params.get<double>("alpha", 1);
+        alpha = params.get<double>("alpha", 0.0001);
         beta = params.get<double>("beta", 0.75);
         bias = params.get<double>("bias", 1);
         normBySize = params.get<bool>("norm_by_size", true);

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -920,6 +920,7 @@ void ONNXImporter::parseSplit(LayerParams& layerParams, const opencv_onnx::NodeP
         layerParams.set("num_split", node_proto.output_size());
     }
     layerParams.type = "Slice";
+    layerParams.set("axis", layerParams.get<float>("axis", 0));
     addLayer(layerParams, node_proto);
 }
 
@@ -1184,15 +1185,15 @@ void ONNXImporter::parseImageScaler(LayerParams& layerParams, const opencv_onnx:
 void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "ReLU6";
-    replaceLayerParam(layerParams, "min", "min_value");
-    replaceLayerParam(layerParams, "max", "max_value");
+    layerParams.set("min_value", layerParams.get<float>("min", -FLT_MAX));
+    layerParams.set("max_value", layerParams.get<float>("max", FLT_MAX));
     addLayer(layerParams, node_proto);
 }
 
 void ONNXImporter::parseLeakyRelu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "ReLU";
-    replaceLayerParam(layerParams, "alpha", "negative_slope");
+    layerParams.set("negative_slope", layerParams.get<float>("alpha", 0.01));
     addLayer(layerParams, node_proto);
 }
 


### PR DESCRIPTION
A few fixes for https://github.com/opencv/opencv/issues/21078, tests are coming to 4.x with https://github.com/opencv/opencv/pull/21088

Clip default min and max: https://github.com/onnx/onnx/blob/master/docs/Operators.md#clip
LeakyReLU default alpha: https://github.com/onnx/onnx/blob/master/docs/Operators.md#leakyrelu
LRN default alpha: https://github.com/onnx/onnx/blob/master/docs/Operators.md#lrn
Split default axis: https://github.com/onnx/onnx/blob/master/docs/Operators.md#split

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
