### PR TITLE
build: eliminate C4309 warning from protobuf files with MSVS2017

### DIFF
--- a/3rdparty/protobuf/CMakeLists.txt
+++ b/3rdparty/protobuf/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MSVC)
                                        /wd4701 /wd4703     # potentially uninitialized local/pointer variable 'value' used
                                        /wd4505             # unreferenced local function has been removed
   )
-  if(MSVC_VERSION LESS 1910)  # MSVS 2015
+  if(MSVC_VERSION LESS 1920)  # MSVS 2015/2017
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4309)          # 'static_cast': truncation of constant value
   endif()
 else()

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -51,7 +51,7 @@ if(MSVC)
                                        /wd4305 /wd4127 /wd4100 /wd4512 /wd4125 /wd4389 /wd4510 /wd4610
                                        /wd4702 /wd4456 /wd4457 /wd4065 /wd4310 /wd4661 /wd4506
   )
-  if(MSVC_VERSION LESS 1910)  # MSVS 2015, .pb.cc generated files
+  if(MSVC_VERSION LESS 1920)  # MSVS 2015/2017, .pb.cc generated files
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4309)  # 'static_cast': truncation of constant value
   endif()
   if(MSVC_VERSION LESS 1920)  # <MSVS2019, .pb.cc generated files


### PR DESCRIPTION
relates #20998

[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master-win64-vc15/builds/897)

```
force_builders_only=Custom Win
```