### PR TITLE
Add BatchMatMul layer support for tf_importer

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1009,44 +1009,65 @@ void TFImporter::parseMatMul(tensorflow::GraphDef& net, const tensorflow::NodeDe
         }
     }
 
-    int kernel_blob_index = -1;
-    const tensorflow::TensorProto& kernelTensor = getConstBlob(layer, value_id, -1, &kernel_blob_index);
-    const String kernelTensorName = layer.input(kernel_blob_index);
-    std::map<String, Mat>::iterator sharedWeightsIt = sharedWeights.find(kernelTensorName);
-    if (sharedWeightsIt == sharedWeights.end())
-    {
-        blobFromTensor(kernelTensor, layerParams.blobs[0]);
-        releaseTensor(const_cast<tensorflow::TensorProto*>(&kernelTensor));
-        sharedWeights[kernelTensorName] = layerParams.blobs[0];
-    }
-    else
-    {
-        layerParams.blobs[0] = sharedWeightsIt->second;
-    }
-
-    if (kernel_blob_index == 1) { // In this case output is computed by x*W formula - W should be transposed
-        Mat data = layerParams.blobs[0].t();
-        layerParams.blobs[0] = data.clone();
-    }
-
-    layerParams.set("num_output", layerParams.blobs[0].size[0]);
-    if (locPredTransposed)
-    {
-        CV_Assert(layerParams.blobs[0].dims == 2);
-        for (int i = 0; i < layerParams.blobs[0].size[0]; i += 2)
+    bool hasConstBlob = layerParams.blobs.size() == 2 ? true : false;
+    for(int i = 0; i < layer.input_size() && !hasConstBlob; i++) {
+        if (value_id.find(layer.input(i)) != value_id.end())
         {
-            cv::Mat src = layerParams.blobs[0].row(i);
-            cv::Mat dst = layerParams.blobs[0].row(i + 1);
-            std::swap_ranges(src.begin<float>(), src.end<float>(), dst.begin<float>());
+            hasConstBlob = true;
         }
     }
+    if (hasConstBlob)
+    {
+        int kernel_blob_index = -1;
+        const tensorflow::TensorProto& kernelTensor = getConstBlob(layer, value_id, -1, &kernel_blob_index);
+        const String kernelTensorName = layer.input(kernel_blob_index);
+        std::map<String, Mat>::iterator sharedWeightsIt = sharedWeights.find(kernelTensorName);
+        if (sharedWeightsIt == sharedWeights.end())
+        {
+            blobFromTensor(kernelTensor, layerParams.blobs[0]);
+            releaseTensor(const_cast<tensorflow::TensorProto*>(&kernelTensor));
+            sharedWeights[kernelTensorName] = layerParams.blobs[0];
+        }
+        else
+        {
+            layerParams.blobs[0] = sharedWeightsIt->second;
+        }
 
-    int id = dstNet.addLayer(name, "InnerProduct", layerParams);
-    layer_id[name] = id;
+        if (kernel_blob_index == 1) { // In this case output is computed by x*W formula - W should be transposed
+            Mat data = layerParams.blobs[0].t();
+            layerParams.blobs[0] = data.clone();
+        }
 
-    // one input only
-    int input_blob_index = kernel_blob_index == 0 ? 1 : 0;
-    connect(layer_id, dstNet, parsePin(layer.input(input_blob_index)), id, 0);
+        layerParams.set("num_output", layerParams.blobs[0].size[0]);
+        if (locPredTransposed)
+        {
+            CV_Assert(layerParams.blobs[0].dims == 2);
+            for (int i = 0; i < layerParams.blobs[0].size[0]; i += 2)
+            {
+                cv::Mat src = layerParams.blobs[0].row(i);
+                cv::Mat dst = layerParams.blobs[0].row(i + 1);
+                std::swap_ranges(src.begin<float>(), src.end<float>(), dst.begin<float>());
+            }
+        }
+
+        int id = dstNet.addLayer(name, "InnerProduct", layerParams);
+        layer_id[name] = id;
+
+        // one input only
+        int input_blob_index = kernel_blob_index == 0 ? 1 : 0;
+        connect(layer_id, dstNet, parsePin(layer.input(input_blob_index)), id, 0);
+    }
+    else {
+        layerParams.blobs.clear();
+
+        int id = dstNet.addLayer(name, "InnerProduct", layerParams);
+        layer_id[name] = id;
+
+        // two input
+        for(int ii=0; ii<layer.input_size(); ii++){
+            connect(layer_id, dstNet, parsePin(layer.input(ii)), id, ii);
+        }
+    }
     data_layouts[name] = DATA_LAYOUT_PLANAR;
 }
 

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1010,7 +1010,7 @@ void TFImporter::parseMatMul(tensorflow::GraphDef& net, const tensorflow::NodeDe
     }
 
     bool hasConstBlob = false;
-    for(int i = 0; i < layer.input_size() && !hasConstBlob; i++) {
+    for(int i = 0; i < layer.input_size(); i++) {
         if (value_id.find(layer.input(i)) != value_id.end())
         {
             hasConstBlob = true;

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -523,6 +523,14 @@ TEST_P(Test_TensorFlow_layers, matmul)
     double l1 = target == DNN_TARGET_MYRIAD ? 6.1e-3 : default_l1;
     runTensorFlowNet("nhwc_reshape_matmul", false, l1);
     runTensorFlowNet("matmul_layout");
+    runTensorFlowNet("two_inputs_matmul");
+}
+
+TEST_P(Test_TensorFlow_layers, batch_matmul)
+{
+    if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    runTensorFlowNet("batch_matmul");
 }
 
 TEST_P(Test_TensorFlow_layers, reshape)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/940

Batch_matmul means we do matirx multiplication in a batch size.
We noiced that we can implement batch_matmul layer by "InnerProduct" when there is no `const` blob in the input tensors. 

<cut/>

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
