### PR TITLE
fix ceil_mode for Average/MaxPooling

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -612,11 +612,23 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto)
     }
 }
 
+void setCeilMode(LayerParams& layerParams)
+{
+    if (layerParams.has("pad_mode"))
+    {
+        layerParams.set("ceil_mode", true);
+    }
+    else if (!layerParams.has("ceil_mode"))
+    {
+        layerParams.set("ceil_mode", false);
+    }
+}
+
 void ONNXImporter::parseMaxPool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "Pooling";
     layerParams.set("pool", "MAX");
-    layerParams.set("ceil_mode", layerParams.has("pad_mode"));
+    setCeilMode(layerParams);
     addLayer(layerParams, node_proto);
 }
 
@@ -624,7 +636,7 @@ void ONNXImporter::parseAveragePool(LayerParams& layerParams, const opencv_onnx:
 {
     layerParams.type = "Pooling";
     layerParams.set("pool", "AVE");
-    layerParams.set("ceil_mode", layerParams.has("pad_mode"));
+    setCeilMode(layerParams);
     layerParams.set("ave_pool_padded_area", framework_name == "pytorch");
     addLayer(layerParams, node_proto);
 }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -614,6 +614,7 @@ void ONNXImporter::handleNode(const opencv_onnx::NodeProto& node_proto)
 
 void setCeilMode(LayerParams& layerParams)
 {
+    // auto_pad attribute is deprecated and uses ceil
     if (layerParams.has("pad_mode"))
     {
         layerParams.set("ceil_mode", true);


### PR DESCRIPTION
Fix for https://github.com/opencv/opencv/issues/21078, tests are coming with https://github.com/opencv/opencv/pull/21088.

AveragePool: https://github.com/onnx/onnx/blob/master/docs/Operators.md#averagepool
MaxPool: https://github.com/onnx/onnx/blob/master/docs/Operators.md#maxpool

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
