### PR TITLE
videoio: fix grabFrame() in cap_android_camera.cpp

### DIFF
--- a/modules/videoio/src/cap_android_camera.cpp
+++ b/modules/videoio/src/cap_android_camera.cpp
@@ -313,7 +313,7 @@ public:
             if (fourCC == FOURCC_UNKNOWN) {
                 fourCC = FOURCC_NV21;
             }
-        } else if ( (uvPixelStride == 1) && (vPixel == uPixel + uLen) && (yLen == frameWidth * frameHeight) && (uLen == yLen / 4) && (vLen == uLen) ) {
+        } else if ( (uvPixelStride == 1) && (uPixel == vPixel + vLen) && (yLen == frameWidth * frameHeight) && (uLen == yLen / 4) && (vLen == uLen) ) {
             colorFormat = COLOR_FormatYUV420Planar;
             if (fourCC == FOURCC_UNKNOWN) {
                 fourCC = FOURCC_YV12;
@@ -327,7 +327,7 @@ public:
 
         buffer.clear();
         buffer.insert(buffer.end(), yPixel, yPixel + yLen);
-        buffer.insert(buffer.end(), uPixel, uPixel + yLen / 2);
+        buffer.insert(buffer.end(), vPixel, vPixel + yLen / 2);
         return true;
     }
 


### PR DESCRIPTION
In the NV21 and YV12 formats, "V (Cr)" is placed before "U (Cb)".
NV21: YYYYYYYY VUVU
YV12: YYYYYYYY VVUU
https://www.itread01.com/content/1542704886.html
https://developer.android.com/reference/android/graphics/ImageFormat#NV21
https://developer.android.com/reference/android/graphics/ImageFormat#YV12

Test Device : Pixel(NV21), Pixel3a(NV21)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
android_pack_config=ndk-18-api-level-24.config.py
```