### PR TITLE
Check buffer size when frameWidth * frameHeight bigger than allocated buffer size

### DIFF
--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -109,7 +109,7 @@ public:
                             frameHeight = 1080;
                             LOGV("Buffer size is too small, force using height = %d", frameHeight);
                         }
-                        else if(bufferSize == 3110400 &&  frameWidth == 1088 && frameHeight == 1920)
+                        else if(bufferSize == 3110400 && frameWidth == 1088 && frameHeight == 1920)
                         {
                             frameWidth = 1080;
                             LOGV("Buffer size is too small, force using width = %d", frameWidth);

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -97,7 +97,29 @@ public:
                     LOGV("buffer size: %zu", bufferSize);
                     LOGV("width (frame): %d", frameWidth);
                     LOGV("height (frame): %d", frameHeight);
-                    if (info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM) {
+                    if (frameWidth * frameHeight * 3 / 2 > bufferSize)
+                    {
+                        if (bufferSize == 3110400 && (frameWidth == 1920 && frameHeight == 1088) ||  frameWidth == 1088 && frameHeight == 1920)
+                        {
+                            if (frameWidth == 1920 && frameHeight == 1088)
+                            {
+                                frameHeight = 1080;
+                                LOGV("Buffer size is too small, force using height = %d", frameHeight);
+                            }
+                            else
+                            {
+                                frameWidth = 1080;
+                                LOGV("Buffer size is too small, force using width = %d", frameWidth);
+                            }
+                        }
+                        else
+                        {
+                            LOGE("Buffer size is too small. Frame is ignored. Enable verbose logging to see actual values of parameters");
+                            return false;
+                        }
+                    }
+                    if (info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM)
+                    {
                         LOGV("output EOS");
                         sawOutputEOS = true;
                     }

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -102,7 +102,7 @@ public:
                         LOGV("output EOS");
                         sawOutputEOS = true;
                     }
-                    if (frameWidth * frameHeight * 3 / 2 > bufferSize)
+                    if ((size_t)frameWidth * frameHeight * 3 / 2 > bufferSize)
                     {
                         if (bufferSize == 3110400 && frameWidth == 1920 && frameHeight == 1088)
                         {

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -105,7 +105,7 @@ public:
                     if (frameWidth * frameHeight * 3 / 2 > bufferSize)
                     {
                         if (bufferSize == 3110400 && frameWidth == 1920 && frameHeight == 1088)
-                        {   
+                        {
                             frameHeight = 1080;
                             LOGV("Buffer size is too small, force using height = %d", frameHeight);
                         }

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -97,31 +97,28 @@ public:
                     LOGV("buffer size: %zu", bufferSize);
                     LOGV("width (frame): %d", frameWidth);
                     LOGV("height (frame): %d", frameHeight);
+                    if (info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM)
+                    {
+                        LOGV("output EOS");
+                        sawOutputEOS = true;
+                    }
                     if (frameWidth * frameHeight * 3 / 2 > bufferSize)
                     {
-                        if (bufferSize == 3110400 && (frameWidth == 1920 && frameHeight == 1088) ||  frameWidth == 1088 && frameHeight == 1920)
+                        if (bufferSize == 3110400 && frameWidth == 1920 && frameHeight == 1088)
+                        {   
+                            frameHeight = 1080;
+                            LOGV("Buffer size is too small, force using height = %d", frameHeight);
+                        }
+                        else if(bufferSize == 3110400 &&  frameWidth == 1088 && frameHeight == 1920)
                         {
-                            if (frameWidth == 1920 && frameHeight == 1088)
-                            {
-                                frameHeight = 1080;
-                                LOGV("Buffer size is too small, force using height = %d", frameHeight);
-                            }
-                            else
-                            {
-                                frameWidth = 1080;
-                                LOGV("Buffer size is too small, force using width = %d", frameWidth);
-                            }
+                            frameWidth = 1080;
+                            LOGV("Buffer size is too small, force using width = %d", frameWidth);
                         }
                         else
                         {
                             LOGE("Buffer size is too small. Frame is ignored. Enable verbose logging to see actual values of parameters");
                             return false;
                         }
-                    }
-                    if (info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM)
-                    {
-                        LOGV("output EOS");
-                        sawOutputEOS = true;
                     }
                     AMediaCodec_releaseOutputBuffer(mediaCodec.get(), bufferIndex, info.size != 0);
                     return true;


### PR DESCRIPTION
- issue nubmer #21149 report, some android 12 device, allocated bufferSize is too small for the retrieve frame, so change logic for debugging
- when this debugging successful in android studio environment, I will change logic about check bufferSize for the work well in any android environment (any sdk version including 31 - android12)

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Android pack,docs
android_pack_config=ndk-18-api-level-24.config.py
```