### PR TITLE
Added CV_PROP_RW macro to keypoints

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -59,7 +59,7 @@ struct CV_EXPORTS_W_SIMPLE ImageFeatures
 {
     CV_PROP_RW int img_idx;
     CV_PROP_RW Size img_size;
-    std::vector<KeyPoint> keypoints;
+    CV_PROP_RW std::vector<KeyPoint> keypoints;
     CV_PROP_RW UMat descriptors;
     CV_WRAP std::vector<KeyPoint> getKeypoints() { return keypoints; };
 };

--- a/modules/stitching/misc/python/test/test_stitching.py
+++ b/modules/stitching/misc/python/test/test_stitching.py
@@ -28,6 +28,9 @@ class stitching_detail_test(NewOpenCVTests):
         imgFea = cv.detail.computeImageFeatures2(finder,img)
         self.assertIsNotNone(imgFea)
 
+        # Added Test for PR #21180
+        self.assertIsNotNone(imgFea.keypoints)
+
         matcher = cv.detail_BestOf2NearestMatcher(False, 0.3)
         self.assertIsNotNone(matcher)
         matcher = cv.detail_AffineBestOf2NearestMatcher(False, False, 0.3)


### PR DESCRIPTION
As outlined in the feature request in the issue https://github.com/opencv/opencv/issues/21171 : the keypoints field has been made parsable by the bindings.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
