### PR TITLE
`ocl_resize`: use `resizeLN` integer path for 16U

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3320,7 +3320,8 @@ static bool ocl_resize( InputArray _src, OutputArray _dst, Size dsize,
         char buf[2][32];
 
         // integer path is slower because of CPU part, so it's disabled
-        if (depth == CV_8U && ((void)0, 0))
+        // except in case of 16U depth, where other path gives invalid results
+        if (depth == CV_16U)
         {
             AutoBuffer<uchar> _buffer((dsize.width + dsize.height)*(sizeof(int) + sizeof(short)*2));
             int* xofs = (int*)_buffer.data(), * yofs = xofs + dsize.width;


### PR DESCRIPTION
As described in https://github.com/opencv/opencv/issues/21198, the `resizeLN` kernel *without* `INTER_LINEAR_INTEGER` gives invalid results for `CV_16U` depth.

This pull request works around the issue by enabling the `INTER_LINEAR_INTEGER` path for `CV_16U`.

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
