### PR TITLE
fixed an error ------Context::p is protected whinin this context

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2352,7 +2352,7 @@ class OpenCLSVMBufferPoolImpl;
 
 struct Context::Impl
 {
-    static Context::Impl* get(Context& context) { return context.p; }
+    static Context::Impl* get(Context& context) { return context.getImpl(); }
 
     typedef std::deque<Context::Impl*> container_t;
     static container_t& getGlobalContainer()
@@ -3084,7 +3084,7 @@ namespace svm {
 
 const SVMCapabilities getSVMCapabilitites(const ocl::Context& context)
 {
-    Context::Impl* i = context.p;
+    Context::Impl* i = context.getImpl();
     CV_Assert(i);
     if (!i->svmInitialized)
         i->svmInit();
@@ -3093,7 +3093,7 @@ const SVMCapabilities getSVMCapabilitites(const ocl::Context& context)
 
 CV_EXPORTS const SVMFunctions* getSVMFunctions(const ocl::Context& context)
 {
-    Context::Impl* i = context.p;
+    Context::Impl* i = context.getImpl();
     CV_Assert(i);
     CV_Assert(i->svmInitialized); // getSVMCapabilitites() must be called first
     CV_Assert(i->svmFunctions.fn_clSVMAlloc != NULL);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
