### PR TITLE
Extra imports and an environment for opencv-python package

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -180,9 +180,6 @@ def bootstrap():
 
 bootstrap()
 
-# hotfix for pylint issue (https://github.com/opencv/opencv-python/issues/570)
-from . import getStructuringElement, MORPH_ELLIPSE
-
 # extra imports for a proper autocomplete work in IDE
 from . import gapi
 from . import mat_wrapper

--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -16,6 +16,30 @@ except ImportError:
     print('    pip install numpy')
     raise
 
+# opencv-python package extra environment
+ci_and_not_headless = False
+
+try:
+    # data is generating only for opencv-python package
+    from . import data
+    from .version import ci_build, headless
+
+    ci_and_not_headless = ci_build and not headless
+except:
+    pass
+
+# the Qt plugin is included currently only in the pre-built wheels
+if sys.platform.startswith("linux") and ci_and_not_headless:
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "qt", "plugins"
+    )
+
+# Qt will throw warning on Linux if fonts are not found
+if sys.platform.startswith("linux") and ci_and_not_headless:
+    os.environ["QT_QPA_FONTDIR"] = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "qt", "fonts"
+    )
+
 # TODO
 # is_x64 = sys.maxsize > 2**32
 
@@ -179,3 +203,13 @@ def bootstrap():
 
 
 bootstrap()
+
+# hotfix for pylint issue (https://github.com/opencv/opencv-python/issues/570)
+from . import getStructuringElement, MORPH_ELLIPSE
+
+# extra imports for a proper autocomplete work in IDE
+from . import _registerMatType
+from . import gapi
+from . import mat_wrapper
+from . import misc
+from . import utils

--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -184,7 +184,6 @@ bootstrap()
 from . import getStructuringElement, MORPH_ELLIPSE
 
 # extra imports for a proper autocomplete work in IDE
-from . import _registerMatType
 from . import gapi
 from . import mat_wrapper
 from . import misc

--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -16,30 +16,6 @@ except ImportError:
     print('    pip install numpy')
     raise
 
-# opencv-python package extra environment
-ci_and_not_headless = False
-
-try:
-    # data is generating only for opencv-python package
-    from . import data
-    from .version import ci_build, headless
-
-    ci_and_not_headless = ci_build and not headless
-except:
-    pass
-
-# the Qt plugin is included currently only in the pre-built wheels
-if sys.platform.startswith("linux") and ci_and_not_headless:
-    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "qt", "plugins"
-    )
-
-# Qt will throw warning on Linux if fonts are not found
-if sys.platform.startswith("linux") and ci_and_not_headless:
-    os.environ["QT_QPA_FONTDIR"] = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "qt", "fonts"
-    )
-
 # TODO
 # is_x64 = sys.maxsize > 2**32
 


### PR DESCRIPTION
This PR contains an extra environment from the [script](https://github.com/opencv/opencv-python/blob/master/scripts/__init__.py) in opencv-python repository and extra imports which [are defined after](https://github.com/opencv/opencv-python/blob/master/setup.py#L369-L379) the `opencv-python` package build.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
