### PR TITLE
Replaced distutils module to sysconfig

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -177,7 +177,7 @@ if(NOT ${found})
 
     if(NOT ANDROID AND NOT IOS)
       if(CMAKE_HOST_UNIX)
-        execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_python_lib())"
+        execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_path('purelib'))"
                         RESULT_VARIABLE _cvpy_process
                         OUTPUT_VARIABLE _std_packages_path
                         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -177,7 +177,7 @@ if(NOT ${found})
 
     if(NOT ANDROID AND NOT IOS)
       if(CMAKE_HOST_UNIX)
-        execute_process(COMMAND ${_executable} -c "from distutils.sysconfig import *; print(get_python_lib())"
+        execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_python_lib())"
                         RESULT_VARIABLE _cvpy_process
                         OUTPUT_VARIABLE _std_packages_path
                         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -63,7 +63,7 @@ else()
   if("${${PYTHON}_VERSION_MAJOR}" STREQUAL "2")
     set(__python_ext_suffix_var "SO")
   endif()
-  execute_process(COMMAND ${${PYTHON}_EXECUTABLE} -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('${__python_ext_suffix_var}'))"
+  execute_process(COMMAND ${${PYTHON}_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_var('${__python_ext_suffix_var}'))"
                   RESULT_VARIABLE PYTHON_CVPY_PROCESS
                   OUTPUT_VARIABLE CVPY_SUFFIX
                   OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This PR fixes following issue https://github.com/opencv/opencv/issues/21141.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
