### PR TITLE
fix transpose onnx layers (permute cuda) for size 1x1x1x1

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/permute.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/permute.hpp
@@ -48,6 +48,20 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                     return false;
                 }();
 
+				if (needsPermute)
+                {
+                    bool allOnes = true;
+                    auto shapeVec = input.shape_as_vector();
+                    for (size_t i = 0; i < shapeVec.size(); i++)
+                        if (shapeVec[i] != 1)
+                        {
+                            allOnes = false;
+                            break;
+                        }
+                    if (allOnes == true)
+                        needsPermute = false;
+                }
+
                 if (needsPermute)
                 {
                     kernels::permute(stream, output, input, order);


### PR DESCRIPTION
**Context**

I have an mxnet model, which I then converted to onnx. The converted onnx model ended up having a transpose layer with a matrix of 1x1x1x1. When running this on **OpenCV 4.5.3** with support for **opencvdnn** and **CUDA 10.1**. I ended up with a crash on permute.hpp which after some debug analysis I found out that the crash was caused by the code not supporting that particular dimension (all ones, 1x1x1x1) for permutation. I made a fix to the code to support this scenario. Please feel free to change the code if you think it could be more optimized.

**PR description**

Fixed bug while infering on custom onnx model in CUDA. Onnx custom model which has a transpose layer (mapped to a permute in CUDA) with the following dimensions: 1x1x1x1. The permute.hpp code does not take into account a possible case of a 1x1x1x1 matrix which then leads to a crash (segmentation fault).

```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```