### PR TITLE
Changed type of face_detection_args to uint64_t

### DIFF
--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -306,7 +306,7 @@ int main(int argc, char *argv[]) {
         < custom::OCVLocateROI
         , custom::OCVBBoxes>();
     auto networks = cv::gapi::networks(face_net);
-    auto face_detection_args = cv::compile_args(networks, kernels);
+    uint64_t face_detection_args = cv::compile_args(networks, kernels);
     if (streaming_queue_capacity != 0) {
         face_detection_args += cv::compile_args(cv::gapi::streaming::queue_capacity{ streaming_queue_capacity });
     }


### PR DESCRIPTION
Addressing the issue https://github.com/opencv/opencv/issues/21225 

Changed type of face_detection_args to uint64_t because the compiler was inferring the type of face_detection_args as std::size_t and giving requires narrowing conversion error on msvs compilers.

Hopefully this fixes it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Linux x64,Docs,Linux32,Win32
```