### PR TITLE
G-API: Fix Win32 build: uint64_t ->size_t

### DIFF
--- a/modules/gapi/include/opencv2/gapi/streaming/onevpl/cfg_params.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/onevpl/cfg_params.hpp
@@ -61,7 +61,7 @@ struct GAPI_EXPORTS CfgParam {
      *
      */
     static constexpr const char *frames_pool_size_name() { return "frames_pool_size"; }
-    static CfgParam create_frames_pool_size(uint64_t value);
+    static CfgParam create_frames_pool_size(size_t value);
 
     /**
      * @brief acceleration_mode_name

--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -196,8 +196,8 @@ int main(int argc, char *argv[]) {
     std::string file_path = cmd.get<std::string>("input");
     const std::string output = cmd.get<std::string>("output");
     const auto face_model_path = cmd.get<std::string>("facem");
-    const auto streaming_queue_capacity = cmd.get<uint64_t>("streaming_queue_capacity");
-    const auto source_queue_capacity = cmd.get<uint64_t>("frames_pool_size");
+    const auto streaming_queue_capacity = cmd.get<size_t>("streaming_queue_capacity");
+    const auto source_queue_capacity = cmd.get<size_t>("frames_pool_size");
 
     // check ouput file extension
     if (!output.empty()) {

--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -196,8 +196,8 @@ int main(int argc, char *argv[]) {
     std::string file_path = cmd.get<std::string>("input");
     const std::string output = cmd.get<std::string>("output");
     const auto face_model_path = cmd.get<std::string>("facem");
-    const auto streaming_queue_capacity = cmd.get<size_t>("streaming_queue_capacity");
-    const auto source_queue_capacity = cmd.get<size_t>("frames_pool_size");
+    const auto streaming_queue_capacity = cmd.get<uint32_t>("streaming_queue_capacity");
+    const auto source_queue_capacity = cmd.get<uint32_t>("frames_pool_size");
 
     // check ouput file extension
     if (!output.empty()) {

--- a/modules/gapi/src/streaming/onevpl/cfg_params.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_params.cpp
@@ -89,6 +89,7 @@ CfgParam::~CfgParam() = default;
 CfgParam CfgParam::create_frames_pool_size(size_t value) {
     // NB: cast to uint64_t because CfgParam inner variant works over
     // uint64_t instead of size_t and mirrored VPL types variety
+    // but size_t looks more friendly for C++ high-level development
     return CfgParam::create(CfgParam::frames_pool_size_name(),
                             static_cast<uint64_t>(value), false);
 }

--- a/modules/gapi/src/streaming/onevpl/cfg_params.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_params.cpp
@@ -86,8 +86,11 @@ CfgParam::CfgParam (const std::string& param_name, value_t&& param_value, bool i
 
 CfgParam::~CfgParam() = default;
 
-CfgParam CfgParam::create_frames_pool_size(uint64_t value) {
-    return CfgParam::create(CfgParam::frames_pool_size_name(), value, false);
+CfgParam CfgParam::create_frames_pool_size(size_t value) {
+    // NB: cast to uint64_t because CfgParam inner variant works over
+    // uint64_t instead of size_t and mirrored VPL types variety
+    return CfgParam::create(CfgParam::frames_pool_size_name(),
+                            static_cast<uint64_t>(value), false);
 }
 
 CfgParam CfgParam::create_acceleration_mode(uint32_t value) {


### PR DESCRIPTION
Fix for issue 
https://github.com/opencv/opencv/issues/21225

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux x64,Docs,Linux32,Win32, Mac
```