### PR TITLE
GAPI FLUID: SIMD for SubRC kernel

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -707,7 +707,7 @@ GAPI_EXPORTS GMat subC(const GMat& src, const GScalar& c, int ddepth = -1);
 /** @brief Calculates the per-element difference between given scalar and the matrix.
 
 The function can be replaced with matrix expressions:
-    \f[\texttt{dst} =  \texttt{val} - \texttt{src}\f]
+    \f[\texttt{dst} =  \texttt{c} - \texttt{src}\f]
 
 Depth of the output matrix is determined by the ddepth parameter.
 If ddepth is set to default -1, the depth of output matrix will be the same as the depth of input matrix.

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -72,11 +72,10 @@ static inline DST sub(SRC1 x, SRC2 y)
     return saturate<DST>(x - y, roundf);
 }
 
-// there is no difference between sub and subr (due to documentation)
 template<typename DST, typename SRC1, typename SRC2>
 static inline DST subr(SRC1 x, SRC2 y)
 {
-    return saturate<DST>(x - y, roundf);
+    return saturate<DST>(y - x, roundf);  // reverse sub
 }
 
 template<typename DST, typename SRC1, typename SRC2>
@@ -984,7 +983,7 @@ static void run_arithm_rs(Buffer &dst, const View &src, const float scalar[4], A
         w = subrc_simd(scalar, in, out, length, chan);
 #endif
         for (; w < length; ++w)
-            out[w] = subr<DST>(scalar[w % chan], in[w]); // [can be replaced by sub]
+            out[w] = subr<DST>(in[w], scalar[w % chan]);
         break;
     }
     // TODO: optimize division

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
@@ -138,6 +138,33 @@ SUBC_SIMD(float, float)
 
 #undef SUBC_SIMD
 
+#define SUBRC_SIMD(SRC, DST)                                              \
+int subrc_simd(const float scalar[], const SRC in[], DST out[],           \
+               const int length, const int chan)                          \
+{                                                                         \
+    CV_CPU_DISPATCH(subrc_simd, (scalar, in, out, length, chan),          \
+                    CV_CPU_DISPATCH_MODES_ALL);                           \
+}
+
+SUBRC_SIMD(uchar, uchar)
+SUBRC_SIMD(ushort, uchar)
+SUBRC_SIMD(short, uchar)
+SUBRC_SIMD(float, uchar)
+SUBRC_SIMD(short, short)
+SUBRC_SIMD(ushort, short)
+SUBRC_SIMD(uchar, short)
+SUBRC_SIMD(float, short)
+SUBRC_SIMD(ushort, ushort)
+SUBRC_SIMD(uchar, ushort)
+SUBRC_SIMD(short, ushort)
+SUBRC_SIMD(float, ushort)
+SUBRC_SIMD(uchar, float)
+SUBRC_SIMD(ushort, float)
+SUBRC_SIMD(short, float)
+SUBRC_SIMD(float, float)
+
+#undef SUBRC_SIMD
+
 #define MULC_SIMD(SRC, DST)                                               \
 int mulc_simd(const SRC in[], const float scalar[], DST out[],            \
               const int length, const int chan, const float scale)        \

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
@@ -106,8 +106,31 @@ SUBC_SIMD(float, float)
 
 #undef SUBC_SIMD
 
-#define MULC_SIMD(SRC, DST)                                                 \
-int mulc_simd(const SRC in[], const float scalar[], DST out[],              \
+#define SUBRC_SIMD(SRC, DST)                                                             \
+int subrc_simd(const float scalar[], const SRC in[], DST out[],                          \
+               const int length, const int chan);
+
+SUBRC_SIMD(uchar, uchar)
+SUBRC_SIMD(ushort, uchar)
+SUBRC_SIMD(short, uchar)
+SUBRC_SIMD(float, uchar)
+SUBRC_SIMD(short, short)
+SUBRC_SIMD(ushort, short)
+SUBRC_SIMD(uchar, short)
+SUBRC_SIMD(float, short)
+SUBRC_SIMD(ushort, ushort)
+SUBRC_SIMD(uchar, ushort)
+SUBRC_SIMD(short, ushort)
+SUBRC_SIMD(float, ushort)
+SUBRC_SIMD(uchar, float)
+SUBRC_SIMD(ushort, float)
+SUBRC_SIMD(short, float)
+SUBRC_SIMD(float, float)
+
+#undef SUBRC_SIMD
+
+#define MULC_SIMD(SRC, DST)                                                              \
+int mulc_simd(const SRC in[], const float scalar[], DST out[],                           \
               const int length, const int chan, const float scale);
 
 MULC_SIMD(uchar, uchar)

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -127,6 +127,28 @@ SUBC_SIMD(float, float)
 
 #undef SUBC_SIMD
 
+#define SUBRC_SIMD(SRC, DST)                                                              \
+int subrc_simd(const float scalar[], const SRC in[], DST out[],                           \
+               const int length, const int chan);
+
+SUBRC_SIMD(uchar, uchar)
+SUBRC_SIMD(ushort, uchar)
+SUBRC_SIMD(short, uchar)
+SUBRC_SIMD(float, uchar)
+SUBRC_SIMD(short, short)
+SUBRC_SIMD(ushort, short)
+SUBRC_SIMD(uchar, short)
+SUBRC_SIMD(float, short)
+SUBRC_SIMD(ushort, ushort)
+SUBRC_SIMD(uchar, ushort)
+SUBRC_SIMD(short, ushort)
+SUBRC_SIMD(float, ushort)
+SUBRC_SIMD(uchar, float)
+SUBRC_SIMD(ushort, float)
+SUBRC_SIMD(short, float)
+SUBRC_SIMD(float, float)
+
+#undef SUBRC_SIMD
 
 #define MULC_SIMD(SRC, DST)                                                              \
 int mulc_simd(const SRC in[], const float scalar[], DST out[],                           \
@@ -905,12 +927,13 @@ MUL_SIMD(float, float)
 
 //-------------------------
 //
-// Fluid kernels: AddC, SubC
+// Fluid kernels: AddC, SubC, SubRC
 //
 //-------------------------
 
 struct add_tag {};
 struct sub_tag {};
+struct subr_tag {};
 struct mul_tag {};
 struct absdiff_tag {};
 
@@ -944,6 +967,11 @@ CV_ALWAYS_INLINE v_float32 oper(add_tag, const v_float32& a, const v_float32& sc
 CV_ALWAYS_INLINE v_float32 oper(sub_tag, const v_float32& a, const v_float32& sc)
 {
     return a - sc;
+}
+
+CV_ALWAYS_INLINE v_float32 oper(subr_tag, const v_float32& a, const v_float32& sc)
+{
+    return sc - a;
 }
 
 CV_ALWAYS_INLINE v_float32 oper(mul_tag, const v_float32& a, const v_float32& sc)
@@ -1217,6 +1245,46 @@ SUBC_SIMD(short, float)
 SUBC_SIMD(float, float)
 
 #undef SUBC_SIMD
+
+//-------------------------------------------------------------------------------------------------
+
+#define SUBRC_SIMD(SRC, DST)                                                        \
+int subrc_simd(const float scalar[], const SRC in[], DST out[],                     \
+               const int length, const int chan)                                    \
+{                                                                                   \
+    switch (chan)                                                                   \
+    {                                                                               \
+    case 1:                                                                         \
+    case 2:                                                                         \
+    case 4:                                                                         \
+        return arithmOpScalar_simd_common(subr_tag{}, in, scalar, out, length);     \
+    case 3:                                                                         \
+        return arithmOpScalar_simd_c3(subr_tag{}, in, scalar, out, length);         \
+    default:                                                                        \
+        GAPI_Assert(chan <= 4);                                                     \
+        break;                                                                      \
+    }                                                                               \
+    return 0;                                                                       \
+}
+
+SUBRC_SIMD(uchar, uchar)
+SUBRC_SIMD(ushort, uchar)
+SUBRC_SIMD(short, uchar)
+SUBRC_SIMD(float, uchar)
+SUBRC_SIMD(short, short)
+SUBRC_SIMD(ushort, short)
+SUBRC_SIMD(uchar, short)
+SUBRC_SIMD(float, short)
+SUBRC_SIMD(ushort, ushort)
+SUBRC_SIMD(uchar, ushort)
+SUBRC_SIMD(short, ushort)
+SUBRC_SIMD(float, ushort)
+SUBRC_SIMD(uchar, float)
+SUBRC_SIMD(ushort, float)
+SUBRC_SIMD(short, float)
+SUBRC_SIMD(float, float)
+
+#undef SUBRC_SIMD
 
 //-------------------------
 //


### PR DESCRIPTION

[Performance report](https://github.com/opencv/opencv/files/7717918/SubRC.SIMD.xlsx)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```