### PR TITLE
Add Square layer support for tf_importer

### DIFF
--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -670,6 +670,13 @@ TEST_P(Test_TensorFlow_layers, batch_matmul)
     runTensorFlowNet("batch_matmul");
 }
 
+TEST_P(Test_TensorFlow_layers, square)
+{
+    if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    runTensorFlowNet("square");
+}
+
 TEST_P(Test_TensorFlow_layers, reshape)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2021040000)


### PR DESCRIPTION
**Merge with extra:** [opencv/opencv_extra#943](https://github.com/opencv/opencv_extra/pull/943)

The square layer is used to square each element. We noiced that we can implement square layer by "Eltwise"  by connecting the input twice to it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
