### PR TITLE
docs: correct normalize factor in gaussian pyramid tutorial

### DIFF
--- a/doc/tutorials/imgproc/pyramids/pyramids.markdown
+++ b/doc/tutorials/imgproc/pyramids/pyramids.markdown
@@ -47,7 +47,7 @@ Theory
 -   To produce layer \f$(i+1)\f$ in the Gaussian pyramid, we do the following:
     -   Convolve \f$G_{i}\f$ with a Gaussian kernel:
 
-        \f[\frac{1}{16} \begin{bmatrix} 1 & 4 & 6 & 4 & 1  \\ 4 & 16 & 24 & 16 & 4  \\ 6 & 24 & 36 & 24 & 6  \\ 4 & 16 & 24 & 16 & 4  \\ 1 & 4 & 6 & 4 & 1 \end{bmatrix}\f]
+        \f[\frac{1}{256} \begin{bmatrix} 1 & 4 & 6 & 4 & 1  \\ 4 & 16 & 24 & 16 & 4  \\ 6 & 24 & 36 & 24 & 6  \\ 4 & 16 & 24 & 16 & 4  \\ 1 & 4 & 6 & 4 & 1 \end{bmatrix}\f]
 
     -   Remove every even-numbered row and column.
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

## PR Notes
This PR change `16` to `256` for the gaussian pyramid tutorial. The tutorial use a 5x5 filter with elements sum up to 256, thus to normalize, the factor to be divided should be 256 instead of 16.


To verify if 256 is correct and 16 is not, I come up with the following test code locally, re-implement the pyramid down, and 256 is verified to be correct, 16 not correct.
```c++
void pyramidDown(const Mat& src, Mat& dst, const Size& _dsz = Size(),
        int  borderType = BORDER_DEFAULT
    )
{
    CV_Assert(borderType != BORDER_CONSTANT);
    Size dsz;
    if (_dsz.empty()) {
        fprintf(stderr, "!! dsz empty()\n");
        int src_width = src.size().width;
        int src_height = src.size().height;
        dsz.width = ( src_width + 1 ) / 2;
        dsz.height = ( src_height + 1 ) / 2;
    } else {
        fprintf(stderr, "!! dsz not empty()\n");
        dsz = _dsz;
    }

    float kernel_data[] = {
        1,  4,  6,  4,  1,
        4, 16, 24, 16,  4,
        6, 24, 36, 24,  6,
        4, 16, 24, 16,  4,
        1,  4,  6,  4,  1
    };
    Mat kernel(5, 5, CV_32FC1, kernel_data);
    kernel = kernel / 256;
    int ddepth = -1;
    Mat temp;
    filter2D(src, temp, ddepth, kernel);
    resize(temp, dst, Size(), 0.5, 0.5, INTER_NEAREST);
}
```