### PR TITLE
imgproc: catch NaNs in clip(), use table index debug check

### DIFF
--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -978,8 +978,9 @@ static struct LUVLUT_T {
     const long long int *LvToVpl_b;
 } LUVLUT = {0, 0, 0};
 
+/* NB: no NaN propagation guarantee */
 #define clip(value) \
-    value < 0.0f ? 0.0f : value > 1.0f ? 1.0f : value;
+    value < 0.0f ? 0.0f : value <= 1.0f ? value : 1.0f;
 
 //all constants should be presented through integers to keep bit-exactness
 static const softdouble gammaThreshold    = softdouble(809)/softdouble(20000);    //  0.04045
@@ -1329,6 +1330,10 @@ static inline void trilinearInterpolate(int cx, int cy, int cz, const int16_t* L
     int tx = cx >> (lab_base_shift - lab_lut_shift);
     int ty = cy >> (lab_base_shift - lab_lut_shift);
     int tz = cz >> (lab_base_shift - lab_lut_shift);
+
+    CV_DbgCheck(tx, tx >= 0 && tx < LAB_LUT_DIM, "");
+    CV_DbgCheck(ty, ty >= 0 && ty < LAB_LUT_DIM, "");
+    CV_DbgCheck(tz, tz >= 0 && tz < LAB_LUT_DIM, "");
 
     const int16_t* baseLUT = &LUT[3*8*tx + (3*8*LAB_LUT_DIM)*ty + (3*8*LAB_LUT_DIM*LAB_LUT_DIM)*tz];
     int aa[8], bb[8], cc[8];

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3117,5 +3117,25 @@ TEST(ImgProc_cvtColorTwoPlane, y_plane_padding_differs_from_uv_plane_padding_170
     EXPECT_DOUBLE_EQ(cvtest::norm(rgb_reference_mat, rgb_uv_padded_mat, NORM_INF), .0);
 }
 
+TEST(ImgProc_RGB2Lab, NaN_21111)
+{
+    const float kNaN = std::numeric_limits<float>::quiet_NaN();
+    cv::Mat3f src(1, 111, Vec3f::all(kNaN)), dst;
+    // Make some entries with only one NaN.
+    src(0, 0) = src(0, 27) = src(0, 81) = src(0, 108) = cv::Vec3f(0, 0, kNaN);
+    src(0, 1) = src(0, 28) = src(0, 82) = src(0, 109) = cv::Vec3f(0, kNaN, 0);
+    src(0, 2) = src(0, 29) = src(0, 83) = src(0, 110) = cv::Vec3f(kNaN, 0, 0);
+    EXPECT_NO_THROW(cvtColor(src, dst, COLOR_RGB2Lab));
+
+#if 0  // no NaN propagation guarantee
+    for (int i = 0; i < 20; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            EXPECT_TRUE(cvIsNaN(dst(0, i)[j]));
+        }
+    }
+#endif
+}
 
 }} // namespace


### PR DESCRIPTION
- no NaN propagation guarantee

details #21111
