### PR TITLE
Fixed threshold(THRESH_TOZERO) at imgproc(IPP)

### DIFF
--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -764,12 +764,6 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
     CV_IPP_CHECK()
     {
         IppiSize sz = { roi.width, roi.height };
-
-        int *thresh_hex = reinterpret_cast<int*>(&thresh);
-        int onebit = 0x00000001;
-        (*thresh_hex) += onebit;
-        float  thresh_flt = *reinterpret_cast<float*>(thresh_hex);
-
         switch( type )
         {
         case THRESH_TRUNC:
@@ -781,7 +775,7 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
             setIppErrorStatus();
             break;
         case THRESH_TOZERO:
-            if (0 <= CV_INSTRUMENT_FUN_IPP(ippiThreshold_LTVal_32f_C1R, src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh_flt, 0))
+            if (0 <= CV_INSTRUMENT_FUN_IPP(ippiThreshold_LTVal_32f_C1R, src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, nextafterf(thresh, std::numeric_limits<float>::infinity()), 0))
             {
                 CV_IMPL_ADD(CV_IMPL_IPP);
                 return;

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -764,6 +764,12 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
     CV_IPP_CHECK()
     {
         IppiSize sz = { roi.width, roi.height };
+
+        int *thresh_hex = reinterpret_cast<int*>(&thresh);
+        int onebit = 0x00000001;
+        (*thresh_hex) += onebit;
+        float  thresh_flt = *reinterpret_cast<float*>(thresh_hex);
+
         switch( type )
         {
         case THRESH_TRUNC:
@@ -774,16 +780,14 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
             }
             setIppErrorStatus();
             break;
-#if 0  // details: https://github.com/opencv/opencv/pull/16085
         case THRESH_TOZERO:
-            if (0 <= CV_INSTRUMENT_FUN_IPP(ippiThreshold_LTVal_32f_C1R, src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh + FLT_EPSILON, 0))
+            if (0 <= CV_INSTRUMENT_FUN_IPP(ippiThreshold_LTVal_32f_C1R, src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh_flt, 0))
             {
                 CV_IMPL_ADD(CV_IMPL_IPP);
                 return;
             }
             setIppErrorStatus();
             break;
-#endif
         case THRESH_TOZERO_INV:
             if (0 <= CV_INSTRUMENT_FUN_IPP(ippiThreshold_GTVal_32f_C1R, src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0))
             {

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -446,10 +446,10 @@ TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_16085)
 TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_21258)
 {
     Size sz(16, 16);
-    int val =  0x5fffffff;   //all bits in mantissa are 1
-    Mat input(sz, CV_32F, Scalar::all(*reinterpret_cast<float*>(&val)));
+    float val =  1.84467441e+19 * 1.9999998807907104;   //0x5fffffff, all bits in mantissa are 1
+    Mat input(sz, CV_32F, Scalar::all(val));
     Mat result;
-    cv::threshold(input, result, *reinterpret_cast<float*>(&val), 0.0, THRESH_TOZERO);
+    cv::threshold(input, result, val, 0.0, THRESH_TOZERO);
     EXPECT_EQ(0, cv::norm(result, NORM_INF));
 }
 

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -443,4 +443,34 @@ TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_16085)
     EXPECT_EQ(0, cv::norm(result, NORM_INF));
 }
 
+TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_21258)
+{
+    Size sz(16, 16);
+    int val =  0x5fffffff;   //all bits in mantissa are 1
+    Mat input(sz, CV_32F, Scalar::all(*reinterpret_cast<float*>(&val)));
+    Mat result;
+    cv::threshold(input, result, *reinterpret_cast<float*>(&val), 0.0, THRESH_TOZERO);
+    EXPECT_EQ(0, cv::norm(result, NORM_INF));
+}
+
+TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_21258_Min)
+{
+    Size sz(16, 16);
+    float min_val = -std::numeric_limits<float>::max();
+    Mat input(sz, CV_32F, Scalar::all(min_val));
+    Mat result;
+    cv::threshold(input, result, min_val, 0.0, THRESH_TOZERO);
+    EXPECT_EQ(0, cv::norm(result, NORM_INF));
+}
+
+TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_21258_Max)
+{
+    Size sz(16, 16);
+    float max_val = std::numeric_limits<float>::max();
+    Mat input(sz, CV_32F, Scalar::all(max_val));
+    Mat result;
+    cv::threshold(input, result, max_val, 0.0, THRESH_TOZERO);
+    EXPECT_EQ(0, cv::norm(result, NORM_INF));
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -446,7 +446,7 @@ TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_16085)
 TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_21258)
 {
     Size sz(16, 16);
-    float val =  1.84467441e+19 * 1.9999998807907104;   //0x5fffffff, all bits in mantissa are 1
+    float val = nextafterf(16.0f, 0.0f);  // 0x417fffff, all bits in mantissa are 1
     Mat input(sz, CV_32F, Scalar::all(val));
     Mat result;
     cv::threshold(input, result, val, 0.0, THRESH_TOZERO);


### PR DESCRIPTION
Fix of the issue [#16085](https://github.com/opencv/opencv/pull/16085).
The problem appeared in the case when source element is equal to the threshold (float data type). Due to the difference between OpenCV and IPP function implementations we have to compare source element with the floating point value next to the threshold (thresh + eps), not the threshold itself; eps value was updated.

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=centos:7
```