### PR TITLE
add argmax and argmin parsing for tensorflow

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2639,7 +2639,7 @@ void TFImporter::parseArg(tensorflow::GraphDef& net, const tensorflow::NodeDef& 
     layerParams.set("axis", axis[0]);
     layerParams.set("op", type == "ArgMax" ? "max" : "min");
     layerParams.set("keepdims", false); //tensorflow doesn't have this atrr, the output's dims minus one(default);
-    
+
     int id = dstNet.addLayer(name, "Arg", layerParams);
     layer_id[name] = id;
     connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2633,10 +2633,8 @@ void TFImporter::parseArg(tensorflow::GraphDef& net, const tensorflow::NodeDef& 
     const std::string& type = layer.op();
 
     Mat dimension = getTensorContent(getConstBlob(layer, value_id, 1));
-    CV_Assert(dimension.rows == 1 && dimension.cols == 1);
-    CV_Assert(dimension.type() == CV_32SC1);
-    int* axis = (int*)dimension.data;
-    layerParams.set("axis", axis[0]);
+    CV_Assert(dimension.total() == 1 && dimension.type() == CV_32SC1);
+    layerParams.set("axis", *dimension.ptr<int>());
     layerParams.set("op", type == "ArgMax" ? "max" : "min");
     layerParams.set("keepdims", false); //tensorflow doesn't have this atrr, the output's dims minus one(default);
 

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -599,6 +599,8 @@ private:
     void parseActivation         (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
     void parseExpandDims         (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
     void parseSquare             (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
+    void parseArg                (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
+
     void parseCustomLayer        (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
 };
 
@@ -677,6 +679,7 @@ const TFImporter::DispatchMap TFImporter::buildDispatchMap()
             dispatch["Elu"] = dispatch["Exp"] = dispatch["Identity"] = dispatch["Relu6"] = &TFImporter::parseActivation;
     dispatch["ExpandDims"] = &TFImporter::parseExpandDims;
     dispatch["Square"] = &TFImporter::parseSquare;
+    dispatch["ArgMax"] = dispatch["ArgMin"] = &TFImporter::parseArg;
 
     return dispatch;
 }
@@ -2622,6 +2625,24 @@ void TFImporter::parseActivation(tensorflow::GraphDef& net, const tensorflow::No
     int id = dstNet.addLayer(name, dnnType, layerParams);
     layer_id[name] = id;
     connectToAllBlobs(layer_id, dstNet, parsePin(layer.input(0)), id, num_inputs);
+}
+
+void TFImporter::parseArg(tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams)
+{
+    const std::string& name = layer.name();
+    const std::string& type = layer.op();
+
+    Mat dimension = getTensorContent(getConstBlob(layer, value_id, 1));
+    CV_Assert(dimension.rows == 1 && dimension.cols == 1);
+    CV_Assert(dimension.type() == CV_32SC1);
+    int* axis = (int*)dimension.data;
+    layerParams.set("axis", axis[0]);
+    layerParams.set("op", type == "ArgMax" ? "max" : "min");
+    layerParams.set("keepdims", false); //tensorflow doesn't have this atrr, the output's dims minus one(default);
+    
+    int id = dstNet.addLayer(name, "Arg", layerParams);
+    layer_id[name] = id;
+    connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
 }
 
 void TFImporter::parseCustomLayer(tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams)

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -185,7 +185,7 @@ TEST_P(Test_TensorFlow_layers, reduce_sum_channel_keep_dims)
     runTensorFlowNet("reduce_sum_channel", false, 0.0, 0.0, false, "_keep_dims");
 }
 
-TEST_P(Test_TensorFlow_layers, ArgLayer) 
+TEST_P(Test_TensorFlow_layers, ArgLayer)
 {
     if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -185,6 +185,14 @@ TEST_P(Test_TensorFlow_layers, reduce_sum_channel_keep_dims)
     runTensorFlowNet("reduce_sum_channel", false, 0.0, 0.0, false, "_keep_dims");
 }
 
+TEST_P(Test_TensorFlow_layers, ArgLayer) 
+{
+    if (backend != DNN_BACKEND_OPENCV || target != DNN_TARGET_CPU)
+        throw SkipTestException("Only CPU is supported");  // FIXIT use tags
+    runTensorFlowNet("argmax");
+    runTensorFlowNet("argmin");
+}
+
 TEST_P(Test_TensorFlow_layers, conv_single_conv)
 {
     runTensorFlowNet("single_conv");


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#946

Add tf_argmax and tf_argmin parsing for dnn.
relates #21208.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
