### PR TITLE
Use NaN-safe clip function.

### DIFF
--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -2979,9 +2979,9 @@ struct RGB2Luvfloat
         for( ; i < n; i++, src += scn, dst += 3 )
         {
             float R = src[0], G = src[1], B = src[2];
-            R = std::min(std::max(R, 0.f), 1.f);
-            G = std::min(std::max(G, 0.f), 1.f);
-            B = std::min(std::max(B, 0.f), 1.f);
+            R = clip(R);
+            G = clip(G);
+            B = clip(B);
             if( gammaTab )
             {
                 R = splineInterpolate(R*gscale, gammaTab, GAMMA_TAB_SIZE);
@@ -3205,9 +3205,9 @@ struct Luv2RGBfloat
             float G = X*C3 + Y*C4 + Z*C5;
             float B = X*C6 + Y*C7 + Z*C8;
 
-            R = std::min(std::max(R, 0.f), 1.f);
-            G = std::min(std::max(G, 0.f), 1.f);
-            B = std::min(std::max(B, 0.f), 1.f);
+            R = clip(R);
+            G = clip(G);
+            B = clip(B);
 
             if( gammaTab )
             {

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3203,6 +3203,8 @@ TEST(ImgProc_RGB2Lab, NaN_21111)
     src(0, 1) = src(0, 28) = src(0, 82) = src(0, 109) = cv::Vec3f(0, kNaN, 0);
     src(0, 2) = src(0, 29) = src(0, 83) = src(0, 110) = cv::Vec3f(kNaN, 0, 0);
     EXPECT_NO_THROW(cvtColor(src, dst, COLOR_RGB2Lab));
+    EXPECT_NO_THROW(cvtColor(src, dst, COLOR_RGB2Luv));
+    EXPECT_NO_THROW(cvtColor(src, dst, COLOR_Luv2RGB));
 
 #if 0  // no NaN propagation guarantee
     for (int i = 0; i < 20; ++i)


### PR DESCRIPTION
This is a follow-up on #21111 .

BTW, may I suggest to add a v_clamp to HAL that would be NaN safe ? _mm_min_ss does not seem to be according to https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=SSE,SSE2,SSE3,SSSE3,SSE4_1,SSE4_2&text=min_ss&ig_expand=4786

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
