### PR TITLE
dnn(test): skip failed tests on Vulkan backend

### DIFF
--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -842,6 +842,12 @@ TEST_P(Test_two_inputs, basic)
     Backend backendId = get<0>(get<2>(GetParam()));
     Target targetId = get<1>(get<2>(GetParam()));
 
+    int type1 = get<0>(GetParam());
+    int type2 = get<1>(GetParam());
+
+    if (backendId == DNN_BACKEND_VKCOM && !(type1 == CV_32F && type2 == CV_32F))
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     Net net;
     LayerParams lp;
     lp.type = "Eltwise";
@@ -851,8 +857,8 @@ TEST_P(Test_two_inputs, basic)
     net.connect(0, 1, eltwiseId, 1);  // connect to a second input
 
     int inpSize[] = {1, 2, 3, 4};
-    Mat firstInp(4, &inpSize[0], get<0>(GetParam()));
-    Mat secondInp(4, &inpSize[0], get<1>(GetParam()));
+    Mat firstInp(4, &inpSize[0], type1);
+    Mat secondInp(4, &inpSize[0], type2);
     randu(firstInp, 0, 100);
     randu(secondInp, 0, 100);
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -242,6 +242,9 @@ TEST_P(Test_ONNX_layers, Deconvolution3D)
     if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     testONNXModels("deconv3d");
 }
 
@@ -259,6 +262,9 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_bias)
 
     if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     testONNXModels("deconv3d_bias");
 }
@@ -278,6 +284,9 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_pad)
     if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     testONNXModels("deconv3d_pad");
 }
 
@@ -295,6 +304,9 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_adjpad)
 
     if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     testONNXModels("deconv3d_adjpad");
 }
@@ -383,6 +395,9 @@ TEST_P(Test_ONNX_layers, ReduceMean3D)
 #endif
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     testONNXModels("reduce_mean3d");
 }
@@ -671,6 +686,9 @@ TEST_P(Test_ONNX_layers, MaxPooling3D)
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
 
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     testONNXModels("max_pool3d", npy, 0, 0, false, false);
 }
 
@@ -685,6 +703,9 @@ TEST_P(Test_ONNX_layers, AvePooling3D)
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
 
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     testONNXModels("ave_pool3d");
 }
 
@@ -698,6 +719,9 @@ TEST_P(Test_ONNX_layers, PoolConv3D)
 #endif
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     testONNXModels("pool_conv_3d");
 }
@@ -1776,6 +1800,9 @@ TEST_P(Test_ONNX_nets, Resnet34_kinetics)
 #endif
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     String onnxmodel = findDataFile("dnn/resnet-34_kinetics.onnx", false);
     Mat image0 = imread(findDataFile("dnn/dog416.png"));

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -627,6 +627,9 @@ TEST_P(Test_TensorFlow_layers, MaxPooling3D)
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
 
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+
     runTensorFlowNet("max_pool3d");
 }
 
@@ -640,6 +643,9 @@ TEST_P(Test_TensorFlow_layers, AvePooling3D)
 #endif
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         throw SkipTestException("Only CPU is supported");  // FIXIT use tags
+
+    if (backend == DNN_BACKEND_VKCOM)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     runTensorFlowNet("ave_pool3d");
 }


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_vulkan-lin64/builds/895)

- [x] [Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_linux64-avx2/builds/2126)

```
force_builders_only=Linux AVX2

build_image:Linux AVX2=ubuntu-vulkan:16.04
buildworker:Linux AVX2=linux-4
test_opencl:Linux AVX2=ON
test_filter:Linux AVX2=*
```
