### PR TITLE
LAPACK_xxx is the universal way to go for lapack >= 3.40 with c/c++ i…

### DIFF
--- a/cmake/checks/lapack_check.cpp
+++ b/cmake/checks/lapack_check.cpp
@@ -1,21 +1,26 @@
 #include <complex.h>
 #include "opencv_lapack.h"
 
-#ifndef LAPACK_GLOBAL
-// If lapack version <= 3.4.0
-#ifdef LAPACK_NAME
-// If lapack version == 3.4.0
-#define LAPACK_GLOBAL(name,NAME) LAPACK_NAME(name,NAME)
+#if defined(LAPACK_GLOBAL)
+/* This means LAPACK is netlib's reference implementation with version > 3.4.0 */
+#define OCV_LAPACK_GLOBAL(name,NAME) LAPACK_GLOBAL(name,NAME)
+#elif defined(LAPACK_NAME)
+/* This means LAPACK is netlib's reference implementation version 3.4.0 */
+#define OCV_LAPACK_GLOBAL(name,NAME) LAPACK_NAME(name,NAME)
 #else
-// If lapack version < 3.4.0
-#error Developper needs to figure this out as both LAPACK_GLOBAL and LAPACK_NAME are undefined
-#endif
+/* This means 1 of 2 things:
+ *  - either LAPACK is netlib's reference implementation with version < 3.4.0
+ *  - or another LAPACK implementation is used (Apple's Accelerate for instance)
+ *
+ *  Fall back to what opencv always assumed until now
+ */
+#define OCV_LAPACK_GLOBAL(name,NAME) name##_
 #endif
 
-static char* check_fn1 = (char*)LAPACK_GLOBAL(sgesv,SGESV);
-static char* check_fn2 = (char*)LAPACK_GLOBAL(sposv,SPOSV);
-static char* check_fn3 = (char*)LAPACK_GLOBAL(spotrf,SPOTRF);
-static char* check_fn4 = (char*)LAPACK_GLOBAL(sgesdd,SGESDD);
+static char* check_fn1 = (char*)OCV_LAPACK_GLOBAL(sgesv,SGESV);
+static char* check_fn2 = (char*)OCV_LAPACK_GLOBAL(sposv,SPOSV);
+static char* check_fn3 = (char*)OCV_LAPACK_GLOBAL(spotrf,SPOTRF);
+static char* check_fn4 = (char*)OCV_LAPACK_GLOBAL(sgesdd,SGESDD);
 
 int main(int argc, char* argv[])
 {

--- a/cmake/checks/lapack_check.cpp
+++ b/cmake/checks/lapack_check.cpp
@@ -2,12 +2,12 @@
 #include "opencv_lapack.h"
 
 #ifndef LAPACK_GLOBAL
-// If lapack version <= 3.4.0 
+// If lapack version <= 3.4.0
 #ifdef LAPACK_NAME
 // If lapack version == 3.4.0
 #define LAPACK_GLOBAL(name,NAME) LAPACK_NAME(name,NAME)
 #else
-// If lapack version < 3.4.0 
+// If lapack version < 3.4.0
 #error Developper needs to figure this out as both LAPACK_GLOBAL and LAPACK_NAME are undefined
 #endif
 #endif

--- a/cmake/checks/lapack_check.cpp
+++ b/cmake/checks/lapack_check.cpp
@@ -1,10 +1,21 @@
 #include <complex.h>
 #include "opencv_lapack.h"
 
-static char* check_fn1 = (char*)sgesv_;
-static char* check_fn2 = (char*)sposv_;
-static char* check_fn3 = (char*)spotrf_;
-static char* check_fn4 = (char*)sgesdd_;
+#ifndef LAPACK_GLOBAL
+// If lapack version <= 3.4.0 
+#ifdef LAPACK_NAME
+// If lapack version == 3.4.0
+#define LAPACK_GLOBAL(name,NAME) LAPACK_NAME(name,NAME)
+#else
+// If lapack version < 3.4.0 
+#error Developper needs to figure this out as both LAPACK_GLOBAL and LAPACK_NAME are undefined
+#endif
+#endif
+
+static char* check_fn1 = (char*)LAPACK_GLOBAL(sgesv,SGESV);
+static char* check_fn2 = (char*)LAPACK_GLOBAL(sposv,SPOSV);
+static char* check_fn3 = (char*)LAPACK_GLOBAL(spotrf,SPOTRF);
+static char* check_fn4 = (char*)LAPACK_GLOBAL(sgesdd,SGESDD);
 
 int main(int argc, char* argv[])
 {

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -110,9 +110,9 @@ lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int*
         if(n == 1 && b_step == sizeof(fptype))
         {
             if(typeid(fptype) == typeid(float))
-                sgesv_(&m, &n, (float*)a, &lda, piv, (float*)b, &m, info);
+                LAPACK_sgesv(&m, &n, (float*)a, &lda, piv, (float*)b, &m, info);
             else if(typeid(fptype) == typeid(double))
-                dgesv_(&m, &n, (double*)a, &lda, piv, (double*)b, &m, info);
+                LAPACK_dgesv(&m, &n, (double*)a, &lda, piv, (double*)b, &m, info);
         }
         else
         {
@@ -122,9 +122,9 @@ lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int*
             transpose(b, ldb, tmpB, m, m, n);
 
             if(typeid(fptype) == typeid(float))
-                sgesv_(&m, &n, (float*)a, &lda, piv, (float*)tmpB, &m, info);
+                LAPACK_sgesv(&m, &n, (float*)a, &lda, piv, (float*)tmpB, &m, info);
             else if(typeid(fptype) == typeid(double))
-                dgesv_(&m, &n, (double*)a, &lda, piv, (double*)tmpB, &m, info);
+                LAPACK_dgesv(&m, &n, (double*)a, &lda, piv, (double*)tmpB, &m, info);
 
             transpose(tmpB, m, b, ldb, n, m);
             delete[] tmpB;
@@ -133,9 +133,9 @@ lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int*
     else
     {
         if(typeid(fptype) == typeid(float))
-            sgetrf_(&m, &m, (float*)a, &lda, piv, info);
+            LAPACK_sgetrf(&m, &m, (float*)a, &lda, piv, info);
         else if(typeid(fptype) == typeid(double))
-            dgetrf_(&m, &m, (double*)a, &lda, piv, info);
+            LAPACK_dgetrf(&m, &m, (double*)a, &lda, piv, info);
     }
 
     if(*info == 0)
@@ -163,9 +163,9 @@ lapack_Cholesky(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n
         if(n == 1 && b_step == sizeof(fptype))
         {
             if(typeid(fptype) == typeid(float))
-                sposv_(L, &m, &n, (float*)a, &lda, (float*)b, &m, &lapackStatus);
+                LAPACK_sposv(L, &m, &n, (float*)a, &lda, (float*)b, &m, &lapackStatus);
             else if(typeid(fptype) == typeid(double))
-                dposv_(L, &m, &n, (double*)a, &lda, (double*)b, &m, &lapackStatus);
+                LAPACK_dposv(L, &m, &n, (double*)a, &lda, (double*)b, &m, &lapackStatus);
         }
         else
         {
@@ -174,9 +174,9 @@ lapack_Cholesky(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n
             transpose(b, ldb, tmpB, m, m, n);
 
             if(typeid(fptype) == typeid(float))
-                sposv_(L, &m, &n, (float*)a, &lda, (float*)tmpB, &m, &lapackStatus);
+                LAPACK_sposv(L, &m, &n, (float*)a, &lda, (float*)tmpB, &m, &lapackStatus);
             else if(typeid(fptype) == typeid(double))
-                dposv_(L, &m, &n, (double*)a, &lda, (double*)tmpB, &m, &lapackStatus);
+                LAPACK_dposv(L, &m, &n, (double*)a, &lda, (double*)tmpB, &m, &lapackStatus);
 
             transpose(tmpB, m, b, ldb, n, m);
             delete[] tmpB;
@@ -185,9 +185,9 @@ lapack_Cholesky(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n
     else
     {
         if(typeid(fptype) == typeid(float))
-            spotrf_(L, &m, (float*)a, &lda, &lapackStatus);
+            LAPACK_spotrf(L, &m, (float*)a, &lda, &lapackStatus);
         else if(typeid(fptype) == typeid(double))
-            dpotrf_(L, &m, (double*)a, &lda, &lapackStatus);
+            LAPACK_dpotrf(L, &m, (double*)a, &lda, &lapackStatus);
     }
 
     if(lapackStatus == 0) *info = true;
@@ -227,17 +227,17 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
     }
 
     if(typeid(fptype) == typeid(float))
-        sgesdd_(mode, &m, &n, (float*)a, &lda, (float*)w, (float*)u, &ldu, (float*)vt, &ldv, (float*)&work1, &lwork, iworkBuf, info);
+        LAPACK_sgesdd(mode, &m, &n, (float*)a, &lda, (float*)w, (float*)u, &ldu, (float*)vt, &ldv, (float*)&work1, &lwork, iworkBuf, info);
     else if(typeid(fptype) == typeid(double))
-        dgesdd_(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)&work1, &lwork, iworkBuf, info);
+        LAPACK_dgesdd(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)&work1, &lwork, iworkBuf, info);
 
     lwork = (int)round(work1); //optimal buffer size
     fptype* buffer = new fptype[lwork + 1];
 
     if(typeid(fptype) == typeid(float))
-        sgesdd_(mode, &m, &n, (float*)a, &lda, (float*)w, (float*)u, &ldu, (float*)vt, &ldv, (float*)buffer, &lwork, iworkBuf, info);
+        LAPACK_sgesdd(mode, &m, &n, (float*)a, &lda, (float*)w, (float*)u, &ldu, (float*)vt, &ldv, (float*)buffer, &lwork, iworkBuf, info);
     else if(typeid(fptype) == typeid(double))
-        dgesdd_(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)buffer, &lwork, iworkBuf, info);
+        LAPACK_dgesdd(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)buffer, &lwork, iworkBuf, info);
 
     if(!(flags & CV_HAL_SVD_NO_UV))
         transpose_square_inplace(vt, ldv, n);
@@ -288,18 +288,18 @@ lapack_QR(fptype* a, size_t a_step, int m, int n, int k, fptype* b, size_t b_ste
         if (k == 1 && b_step == sizeof(fptype))
         {
             if (typeid(fptype) == typeid(float))
-                sgels_(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)b, &m, (float*)&work1, &lwork, info);
+                LAPACK_sgels(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)b, &m, (float*)&work1, &lwork, info);
             else if (typeid(fptype) == typeid(double))
-                dgels_(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)b, &m, (double*)&work1, &lwork, info);
+                LAPACK_dgels(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)b, &m, (double*)&work1, &lwork, info);
 
             lwork = cvRound(work1); //optimal buffer size
             std::vector<fptype> workBufMemHolder(lwork + 1);
             fptype* buffer = &workBufMemHolder.front();
 
             if (typeid(fptype) == typeid(float))
-                sgels_(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)b, &m, (float*)buffer, &lwork, info);
+                LAPACK_sgels(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)b, &m, (float*)buffer, &lwork, info);
             else if (typeid(fptype) == typeid(double))
-                dgels_(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)b, &m, (double*)buffer, &lwork, info);
+                LAPACK_dgels(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)b, &m, (double*)buffer, &lwork, info);
         }
         else
         {
@@ -309,18 +309,18 @@ lapack_QR(fptype* a, size_t a_step, int m, int n, int k, fptype* b, size_t b_ste
             transpose(b, ldb, tmpB, m, m, k);
 
             if (typeid(fptype) == typeid(float))
-                sgels_(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)tmpB, &m, (float*)&work1, &lwork, info);
+                LAPACK_sgels(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)tmpB, &m, (float*)&work1, &lwork, info);
             else if (typeid(fptype) == typeid(double))
-                dgels_(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)tmpB, &m, (double*)&work1, &lwork, info);
+                LAPACK_dgels(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)tmpB, &m, (double*)&work1, &lwork, info);
 
             lwork = cvRound(work1); //optimal buffer size
             std::vector<fptype> workBufMemHolder(lwork + 1);
             fptype* buffer = &workBufMemHolder.front();
 
             if (typeid(fptype) == typeid(float))
-                sgels_(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)tmpB, &m, (float*)buffer, &lwork, info);
+                LAPACK_sgels(mode, &m, &n, &k, (float*)tmpA, &ldtmpA, (float*)tmpB, &m, (float*)buffer, &lwork, info);
             else if (typeid(fptype) == typeid(double))
-                dgels_(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)tmpB, &m, (double*)buffer, &lwork, info);
+                LAPACK_dgels(mode, &m, &n, &k, (double*)tmpA, &ldtmpA, (double*)tmpB, &m, (double*)buffer, &lwork, info);
 
             transpose(tmpB, m, b, ldb, k, m);
         }
@@ -328,18 +328,18 @@ lapack_QR(fptype* a, size_t a_step, int m, int n, int k, fptype* b, size_t b_ste
     else
     {
         if (typeid(fptype) == typeid(float))
-            sgeqrf_(&m, &n, (float*)tmpA, &ldtmpA, (float*)dst, (float*)&work1, &lwork, info);
+            LAPACK_sgeqrf(&m, &n, (float*)tmpA, &ldtmpA, (float*)dst, (float*)&work1, &lwork, info);
         else if (typeid(fptype) == typeid(double))
-            dgeqrf_(&m, &n, (double*)tmpA, &ldtmpA, (double*)dst, (double*)&work1, &lwork, info);
+            LAPACK_dgeqrf(&m, &n, (double*)tmpA, &ldtmpA, (double*)dst, (double*)&work1, &lwork, info);
 
         lwork = cvRound(work1); //optimal buffer size
         std::vector<fptype> workBufMemHolder(lwork + 1);
         fptype* buffer = &workBufMemHolder.front();
 
         if (typeid(fptype) == typeid(float))
-            sgeqrf_(&m, &n, (float*)tmpA, &ldtmpA, (float*)dst, (float*)buffer, &lwork, info);
+            LAPACK_sgeqrf(&m, &n, (float*)tmpA, &ldtmpA, (float*)dst, (float*)buffer, &lwork, info);
         else if (typeid(fptype) == typeid(double))
-            dgeqrf_(&m, &n, (double*)tmpA, &ldtmpA, (double*)dst, (double*)buffer, &lwork, info);
+            LAPACK_dgeqrf(&m, &n, (double*)tmpA, &ldtmpA, (double*)dst, (double*)buffer, &lwork, info);
     }
 
     if (m == n)


### PR DESCRIPTION
…nterface.

This is an alternate solution to #21116 (explained by https://github.com/opencv/opencv/pull/21114#issuecomment-986286233) 
It works on my gentoo box... doing a pull request to test it here on th ebuildbot. If it works it seems better/cleaner than #21114 to me as it uses lapack's "unpreprocessed" function names and relies on lapack's preprocessor macros to do all the magic...

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
