### PR TITLE
ffmpeg/3.4: update FFmpeg wrapper 2021.12

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/3.4_20211005
-# Binaries were created for OpenCV: 95c1d2a8872b222f32bd88db9f1efcbd9f70a9cf
-ocv_update(FFMPEG_BINARIES_COMMIT "0bf6c0753d435d2c82c03c48db0c6e18ac79976c")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "55c25bbc13e4a12d4339b70d3b76987f")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "67caee9231c6843483b4de9815d6526e")
+# Binaries branch name: ffmpeg/3.4_20211220
+# Binaries were created for OpenCV: a22dd28e0272ec0f1cfee8811d3f5f0392827c65
+ocv_update(FFMPEG_BINARIES_COMMIT "5a7644ec3940c6eed41c6ebb5a0602a5615fdb3f")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "8ad9de6f1f2ca77786748d1f3a4e83ea")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "2c670f068252e7cd28d3883993dc1d6e")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "3b90f67f4b429e77d3da36698cef700c")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -67,6 +67,10 @@
 #ifndef CV_UNUSED  // Required for standalone compilation mode (OpenCV defines this in base.hpp)
 #define CV_UNUSED(name) (void)name
 #endif
+#ifndef CV_Assert  // Required for standalone compilation mode (OpenCV defines this in base.hpp)
+#include <assert.h>
+#define CV_Assert(expr) assert(expr)
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Merge with 3rdparty: https://github.com/opencv/opencv_3rdparty/pull/70

FFmpeg 3.4.9

previous update: #20808

```
allow_multiple_commits=1
```