### PR TITLE
(3.4) highgui: fix Win32 with OPENGL=ON

### DIFF
--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -163,6 +163,10 @@ if(APPLE)
   add_apple_compiler_options(${the_module})
 endif()
 
+if(HAVE_WIN32UI AND HAVE_OPENGL AND OPENGL_LIBRARIES)
+  ocv_target_link_libraries(${the_module} PRIVATE "${OPENGL_LIBRARIES}")
+endif()
+
 if(MSVC AND NOT BUILD_SHARED_LIBS AND BUILD_WITH_STATIC_CRT)
   set_target_properties(${the_module} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:atlsd.lib /NODEFAULTLIB:libcmt.lib /DEBUG")
 endif()


### PR DESCRIPTION
resolves #21299
relates #21213

/cc @LaurentBerger 
4.x patch is next... Done: #21303

<cut/>

```
buildworker:Custom Win=windows-3
build_image:Custom Win=msvs2019-opengl
```