### PR TITLE
GAPI: Move GKernelPackage to cv namespace

### DIFF
--- a/doc/tutorials/gapi/anisotropic_segmentation/porting_anisotropic_segmentation.markdown
+++ b/doc/tutorials/gapi/anisotropic_segmentation/porting_anisotropic_segmentation.markdown
@@ -295,7 +295,7 @@ and specify it to G-API:
 
 In G-API, kernels (or operation implementations) are objects. Kernels are
 organized into collections, or _kernel packages_, represented by class
-cv::gapi::GKernelPackage. The main purpose of a kernel package is to
+cv::GKernelPackage. The main purpose of a kernel package is to
 capture which kernels we would like to use in our graph, and pass it
 as a _graph compilation option_:
 

--- a/modules/gapi/include/opencv2/gapi/cpu/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/core.hpp
@@ -16,7 +16,7 @@ namespace gapi {
 namespace core {
 namespace cpu {
 
-GAPI_EXPORTS_W cv::gapi::GKernelPackage kernels();
+GAPI_EXPORTS_W cv::GKernelPackage kernels();
 
 } // namespace cpu
 } // namespace core

--- a/modules/gapi/include/opencv2/gapi/fluid/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/core.hpp
@@ -13,7 +13,7 @@
 
 namespace cv { namespace gapi { namespace core { namespace fluid {
 
-GAPI_EXPORTS_W cv::gapi::GKernelPackage kernels();
+GAPI_EXPORTS_W cv::GKernelPackage kernels();
 
 }}}}
 

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -410,9 +410,13 @@ namespace std
     };
 } // namespace std
 
-
 namespace cv {
+    class GAPI_EXPORTS_W_SIMPLE GKernelPackage;
+
 namespace gapi {
+    GAPI_EXPORTS cv::GKernelPackage combine(const cv::GKernelPackage  &lhs,
+                                            const cv::GKernelPackage  &rhs);
+
     /// @private
     class GFunctor
     {
@@ -427,6 +431,7 @@ namespace gapi {
     private:
         const char* m_id;
     };
+} // namespace gapi
 
     /** \addtogroup gapi_compile_args
      * @{
@@ -463,7 +468,7 @@ namespace gapi {
     {
 
         /// @private
-        using M = std::unordered_map<std::string, std::pair<GBackend, GKernelImpl>>;
+        using M = std::unordered_map<std::string, std::pair<cv::gapi::GBackend, cv::GKernelImpl>>;
 
         /// @private
         M m_id_kernels;
@@ -500,10 +505,8 @@ namespace gapi {
         }
 
     public:
-        void include(const GFunctor& functor)
-        {
-            m_id_kernels[functor.id()] = std::make_pair(functor.backend(), functor.impl());
-        }
+        void include(const cv::gapi::GFunctor& functor);
+
         /**
          * @brief Returns total number of kernels
          * in the package (across all backends included)
@@ -555,7 +558,7 @@ namespace gapi {
          *
          * @param backend backend which kernels to remove
          */
-        void remove(const GBackend& backend);
+        void remove(const cv::gapi::GBackend& backend);
 
         /**
          * @brief Remove all kernels implementing the given API from
@@ -595,7 +598,7 @@ namespace gapi {
          *
          */
         template<typename KAPI>
-        GBackend lookup() const
+        cv::gapi::GBackend lookup() const
         {
             return lookup(KAPI::id()).first;
         }
@@ -621,18 +624,14 @@ namespace gapi {
          * @param backend backend associated with the kernel
          * @param kernel_id a name/id of the kernel
          */
-        void include(const cv::gapi::GBackend& backend, const std::string& kernel_id)
-        {
-            removeAPI(kernel_id);
-            m_id_kernels[kernel_id] = std::make_pair(backend, GKernelImpl{{}, {}});
-        }
+        void include(const cv::gapi::GBackend& backend, const std::string& kernel_id);
 
         /**
          * @brief Lists all backends which are included into package
          *
          * @return vector of backends
          */
-        std::vector<GBackend> backends() const;
+        std::vector<cv::gapi::GBackend> backends() const;
 
         // TODO: Doxygen bug -- it wants me to place this comment
         // here, not below.
@@ -643,9 +642,17 @@ namespace gapi {
          * @param rhs "Right-hand-side" package in the process
          * @return a new kernel package.
          */
-        friend GAPI_EXPORTS GKernelPackage combine(const GKernelPackage  &lhs,
-                                                   const GKernelPackage  &rhs);
+        friend GAPI_EXPORTS GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,
+                                                             const GKernelPackage  &rhs);
     };
+    /** @} */
+
+namespace gapi {
+    using GKernelPackage = cv::GKernelPackage; // Keep backward compatibility
+
+    /** \addtogroup gapi_compile_args
+     * @{
+     */
 
     /**
      * @brief Create a kernel package object containing kernels
@@ -695,10 +702,6 @@ namespace gapi {
 
     /** @} */
 
-    // FYI - this function is already commented above
-    GAPI_EXPORTS GKernelPackage combine(const GKernelPackage  &lhs,
-                                        const GKernelPackage  &rhs);
-
     /**
      * @brief Combines multiple G-API kernel packages into one
      *
@@ -710,7 +713,7 @@ namespace gapi {
      * @return The resulting kernel package
      */
     template<typename... Ps>
-    GKernelPackage combine(const GKernelPackage &a, const GKernelPackage &b, Ps&&... rest)
+    cv::GKernelPackage combine(const cv::GKernelPackage &a, const cv::GKernelPackage &b, Ps&&... rest)
     {
         return combine(a, combine(b, rest...));
     }
@@ -733,7 +736,7 @@ namespace gapi {
 
 namespace detail
 {
-    template<> struct CompileArgTag<cv::gapi::GKernelPackage>
+    template<> struct CompileArgTag<cv::GKernelPackage>
     {
         static const char* tag() { return "gapi.kernel_package"; }
     };

--- a/modules/gapi/include/opencv2/gapi/ocl/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/core.hpp
@@ -16,7 +16,7 @@ namespace gapi {
 namespace core {
 namespace ocl {
 
-        GAPI_EXPORTS_W cv::gapi::GKernelPackage kernels();
+GAPI_EXPORTS_W cv::GKernelPackage kernels();
 
 } // namespace ocl
 } // namespace core

--- a/modules/gapi/include/opencv2/gapi/plaidml/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/plaidml/core.hpp
@@ -13,7 +13,7 @@
 
 namespace cv { namespace gapi { namespace core { namespace plaidml {
 
-GAPI_EXPORTS cv::gapi::GKernelPackage kernels();
+GAPI_EXPORTS cv::GKernelPackage kernels();
 
 }}}}
 

--- a/modules/gapi/include/opencv2/gapi/render/render.hpp
+++ b/modules/gapi/include/opencv2/gapi/render/render.hpp
@@ -177,7 +177,7 @@ namespace render
 {
 namespace ocv
 {
-    GAPI_EXPORTS_W cv::gapi::GKernelPackage kernels();
+    GAPI_EXPORTS_W cv::GKernelPackage kernels();
 
 } // namespace ocv
 } // namespace render

--- a/modules/gapi/include/opencv2/gapi/streaming/format.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/format.hpp
@@ -13,7 +13,7 @@ namespace cv {
 namespace gapi {
 namespace streaming {
 
-GAPI_EXPORTS cv::gapi::GKernelPackage kernels();
+GAPI_EXPORTS cv::GKernelPackage kernels();
 
 G_API_OP(GBGR, <GMat(GFrame)>, "org.opencv.streaming.BGR")
 {

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -11,7 +11,7 @@
 #include <opencv2/gapi/python/python.hpp>
 
 // NB: Python wrapper replaces :: with _ for classes
-using gapi_GKernelPackage           = cv::gapi::GKernelPackage;
+using gapi_GKernelPackage           = cv::GKernelPackage;
 using gapi_GNetPackage              = cv::gapi::GNetPackage;
 using gapi_ie_PyParams              = cv::gapi::ie::PyParams;
 using gapi_wip_IStreamSource_Ptr    = cv::Ptr<cv::gapi::wip::IStreamSource>;
@@ -829,7 +829,7 @@ static GMetaArgs run_py_meta(cv::detail::PyObjectHolder out_meta,
 static PyObject* pyopencv_cv_gapi_kernels(PyObject* , PyObject* py_args, PyObject*)
 {
     using namespace cv;
-    gapi::GKernelPackage pkg;
+    GKernelPackage pkg;
     Py_ssize_t size = PyTuple_Size(py_args);
 
     for (int i = 0; i < size; ++i)

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -5,7 +5,7 @@ namespace cv
 {
 struct GAPI_EXPORTS_W_SIMPLE GCompileArg
 {
-    GAPI_WRAP GCompileArg(gapi::GKernelPackage arg);
+    GAPI_WRAP GCompileArg(GKernelPackage arg);
     GAPI_WRAP GCompileArg(gapi::GNetPackage arg);
     GAPI_WRAP GCompileArg(gapi::streaming::queue_capacity arg);
 };

--- a/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests_inl.hpp
@@ -130,7 +130,7 @@ PERF_TEST_P_(BuildPyr_CalcOptFlow_PipelinePerfTest, TestPerformance)
 
     auto customKernel  = gapi::kernels<GCPUMinScalar>();
     auto kernels       = gapi::combine(customKernel,
-                                       params.compileArgs[0].get<gapi::GKernelPackage>());
+                                       params.compileArgs[0].get<GKernelPackage>());
     params.compileArgs = compile_args(kernels);
 
     OptFlowLKTestOutput outOCV  { outPtsOCV,  outStatusOCV,  outErrOCV };

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -62,7 +62,7 @@ void cv::gapi::GBackend::Priv::addMetaSensitiveBackendPasses(ade::ExecutionEngin
     // which are sensitive to metadata
 }
 
-cv::gapi::GKernelPackage cv::gapi::GBackend::Priv::auxiliaryKernels() const
+cv::GKernelPackage cv::gapi::GBackend::Priv::auxiliaryKernels() const
 {
     return {};
 }

--- a/modules/gapi/src/api/gbackend_priv.hpp
+++ b/modules/gapi/src/api/gbackend_priv.hpp
@@ -66,7 +66,7 @@ public:
     // they are called when meta information becomes available.
     virtual void addMetaSensitiveBackendPasses(ade::ExecutionEngineSetupContext &);
 
-    virtual cv::gapi::GKernelPackage auxiliaryKernels() const;
+    virtual cv::GKernelPackage auxiliaryKernels() const;
 
     // Ask backend if it has a custom control over island fusion process
     // This method is quite redundant but there's nothing better fits

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -18,7 +18,7 @@
 #include "api/gbackend_priv.hpp"
 
 // GKernelPackage public implementation ////////////////////////////////////////
-void cv::gapi::GKernelPackage::remove(const cv::gapi::GBackend& backend)
+void cv::GKernelPackage::remove(const cv::gapi::GBackend& backend)
 {
     std::vector<std::string> id_deleted_kernels;
     for (const auto& p : m_id_kernels)
@@ -35,27 +35,38 @@ void cv::gapi::GKernelPackage::remove(const cv::gapi::GBackend& backend)
     }
 }
 
-bool cv::gapi::GKernelPackage::includesAPI(const std::string &id) const
+void cv::GKernelPackage::include(const cv::gapi::GFunctor& functor)
+{
+    m_id_kernels[functor.id()] = std::make_pair(functor.backend(), functor.impl());
+}
+
+void cv::GKernelPackage::include(const cv::gapi::GBackend& backend, const std::string& kernel_id)
+{
+    removeAPI(kernel_id);
+    m_id_kernels[kernel_id] = std::make_pair(backend, GKernelImpl{{}, {}});
+}
+
+bool cv::GKernelPackage::includesAPI(const std::string &id) const
 {
     return ade::util::contains(m_id_kernels, id);
 }
 
-void cv::gapi::GKernelPackage::removeAPI(const std::string &id)
+void cv::GKernelPackage::removeAPI(const std::string &id)
 {
     m_id_kernels.erase(id);
 }
 
-std::size_t cv::gapi::GKernelPackage::size() const
+std::size_t cv::GKernelPackage::size() const
 {
     return m_id_kernels.size();
 }
 
-const std::vector<cv::GTransform> &cv::gapi::GKernelPackage::get_transformations() const
+const std::vector<cv::GTransform> &cv::GKernelPackage::get_transformations() const
 {
     return m_transformations;
 }
 
-std::vector<std::string> cv::gapi::GKernelPackage::get_kernel_ids() const
+std::vector<std::string> cv::GKernelPackage::get_kernel_ids() const
 {
     std::vector<std::string> ids;
     for (auto &&id : m_id_kernels)
@@ -65,13 +76,13 @@ std::vector<std::string> cv::gapi::GKernelPackage::get_kernel_ids() const
     return ids;
 }
 
-cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,
-                                           const GKernelPackage  &rhs)
+cv::GKernelPackage cv::gapi::combine(const cv::GKernelPackage  &lhs,
+                                     const cv::GKernelPackage  &rhs)
 {
 
         // If there is a collision, prefer RHS to LHS
         // since RHS package has a precedense, start with its copy
-        GKernelPackage result(rhs);
+        cv::GKernelPackage result(rhs);
         // now iterate over LHS package and put kernel if and only
         // if there's no such one
         for (const auto& kernel : lhs.m_id_kernels)
@@ -88,7 +99,7 @@ cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,
 }
 
 std::pair<cv::gapi::GBackend, cv::GKernelImpl>
-cv::gapi::GKernelPackage::lookup(const std::string &id) const
+cv::GKernelPackage::lookup(const std::string &id) const
 {
     auto kernel_it = m_id_kernels.find(id);
     if (kernel_it != m_id_kernels.end())
@@ -99,7 +110,7 @@ cv::gapi::GKernelPackage::lookup(const std::string &id) const
     util::throw_error(std::logic_error("Kernel " + id + " was not found"));
 }
 
-std::vector<cv::gapi::GBackend> cv::gapi::GKernelPackage::backends() const
+std::vector<cv::gapi::GBackend> cv::GKernelPackage::backends() const
 {
     using kernel_type = std::pair<std::string, std::pair<cv::gapi::GBackend, cv::GKernelImpl>>;
     std::unordered_set<cv::gapi::GBackend> unique_set;

--- a/modules/gapi/src/backends/common/gmetabackend.cpp
+++ b/modules/gapi/src/backends/common/gmetabackend.cpp
@@ -113,6 +113,6 @@ struct InGraphMetaKernel final: public cv::detail::KernelTag {
 
 } // anonymous namespace
 
-cv::gapi::GKernelPackage cv::gimpl::meta::kernels() {
+cv::GKernelPackage cv::gimpl::meta::kernels() {
     return cv::gapi::kernels<InGraphMetaKernel>();
 }

--- a/modules/gapi/src/backends/common/gmetabackend.hpp
+++ b/modules/gapi/src/backends/common/gmetabackend.hpp
@@ -7,7 +7,7 @@ namespace cv {
 namespace gimpl {
 namespace meta {
 
-cv::gapi::GKernelPackage kernels();
+cv::GKernelPackage kernels();
 
 } // namespace meta
 } // namespace gimpl

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -720,7 +720,7 @@ GAPI_OCV_KERNEL(GCPUSizeMF, cv::gapi::streaming::GSizeMF)
     }
 };
 
-cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
+cv::GKernelPackage cv::gapi::core::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
         <  GCPUAdd

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -613,7 +613,7 @@ GAPI_OCV_KERNEL(GCPUNV12toBGRp, cv::gapi::imgproc::GNV12toBGRp)
     }
 };
 
-cv::gapi::GKernelPackage cv::gapi::imgproc::cpu::kernels()
+cv::GKernelPackage cv::gapi::imgproc::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
         < GCPUFilter2D

--- a/modules/gapi/src/backends/cpu/gcpustereo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpustereo.cpp
@@ -70,14 +70,14 @@ GAPI_OCV_KERNEL_ST(GCPUStereo, cv::gapi::calib3d::GStereo, StereoSetup)
     }
 };
 
-cv::gapi::GKernelPackage cv::gapi::calib3d::cpu::kernels() {
+cv::GKernelPackage cv::gapi::calib3d::cpu::kernels() {
     static auto pkg = cv::gapi::kernels<GCPUStereo>();
     return pkg;
 }
 
 #else
 
-cv::gapi::GKernelPackage cv::gapi::calib3d::cpu::kernels()
+cv::GKernelPackage cv::gapi::calib3d::cpu::kernels()
 {
     return GKernelPackage();
 }

--- a/modules/gapi/src/backends/cpu/gcpuvideo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuvideo.cpp
@@ -174,7 +174,7 @@ GAPI_OCV_KERNEL_ST(GCPUKalmanFilterNoControl, cv::gapi::video::GKalmanFilterNoCo
     }
 };
 
-cv::gapi::GKernelPackage cv::gapi::video::cpu::kernels()
+cv::GKernelPackage cv::gapi::video::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
         < GCPUBuildOptFlowPyramid
@@ -189,7 +189,7 @@ cv::gapi::GKernelPackage cv::gapi::video::cpu::kernels()
 
 #else
 
-cv::gapi::GKernelPackage cv::gapi::video::cpu::kernels()
+cv::GKernelPackage cv::gapi::video::cpu::kernels()
 {
     return GKernelPackage();
 }

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -3079,7 +3079,7 @@ GAPI_FLUID_KERNEL(GFluidSqrt, cv::gapi::core::GSqrt, false)
 } // namespace gapi
 } // namespace cv
 
-cv::gapi::GKernelPackage cv::gapi::core::fluid::kernels()
+cv::GKernelPackage cv::gapi::core::fluid::kernels()
 {
     using namespace cv::gapi::fluid;
 

--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -1825,7 +1825,7 @@ GAPI_FLUID_KERNEL(GFluidBayerGR2RGB, cv::gapi::imgproc::GBayerGR2RGB, false)
 } // namespace gapi
 } // namespace cv
 
-cv::gapi::GKernelPackage cv::gapi::imgproc::fluid::kernels()
+cv::GKernelPackage cv::gapi::imgproc::fluid::kernels()
 {
     using namespace cv::gapi::fluid;
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -1456,7 +1456,7 @@ namespace {
             return EPtr{new cv::gimpl::ie::GIEExecutable(graph, nodes)};
         }
 
-        virtual cv::gapi::GKernelPackage auxiliaryKernels() const override {
+        virtual cv::GKernelPackage auxiliaryKernels() const override {
             return cv::gapi::kernels< cv::gimpl::ie::Infer
                                     , cv::gimpl::ie::InferROI
                                     , cv::gimpl::ie::InferList

--- a/modules/gapi/src/backends/ocl/goclcore.cpp
+++ b/modules/gapi/src/backends/ocl/goclcore.cpp
@@ -531,7 +531,7 @@ GAPI_OCL_KERNEL(GOCLTranspose, cv::gapi::core::GTranspose)
     }
 };
 
-cv::gapi::GKernelPackage cv::gapi::core::ocl::kernels()
+cv::GKernelPackage cv::gapi::core::ocl::kernels()
 {
     static auto pkg = cv::gapi::kernels
         <  GOCLAdd

--- a/modules/gapi/src/backends/ocl/goclimgproc.cpp
+++ b/modules/gapi/src/backends/ocl/goclimgproc.cpp
@@ -266,7 +266,7 @@ GAPI_OCL_KERNEL(GOCLRGB2GrayCustom, cv::gapi::imgproc::GRGB2GrayCustom)
 };
 
 
-cv::gapi::GKernelPackage cv::gapi::imgproc::ocl::kernels()
+cv::GKernelPackage cv::gapi::imgproc::ocl::kernels()
 {
     static auto pkg = cv::gapi::kernels
         < GOCLFilter2D

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -1147,7 +1147,7 @@ namespace {
             return EPtr{new cv::gimpl::onnx::GONNXExecutable(graph, nodes)};
         }
 
-        virtual cv::gapi::GKernelPackage auxiliaryKernels() const override {
+        virtual cv::GKernelPackage auxiliaryKernels() const override {
             return cv::gapi::kernels< cv::gimpl::onnx::Infer
                                     , cv::gimpl::onnx::InferROI
                                     , cv::gimpl::onnx::InferList

--- a/modules/gapi/src/backends/plaidml/gplaidmlcore.cpp
+++ b/modules/gapi/src/backends/plaidml/gplaidmlcore.cpp
@@ -47,7 +47,7 @@ GAPI_PLAIDML_LOGICAL_OP(GPlaidMLOr , cv::gapi::core::GOr , |)
 GAPI_PLAIDML_ARITHMETIC_OP(GPlaidMLAdd, cv::gapi::core::GAdd, +);
 GAPI_PLAIDML_ARITHMETIC_OP(GPlaidMLSub, cv::gapi::core::GSub, -);
 
-cv::gapi::GKernelPackage cv::gapi::core::plaidml::kernels()
+cv::GKernelPackage cv::gapi::core::plaidml::kernels()
 {
     static auto pkg = cv::gapi::kernels<GPlaidMLAdd, GPlaidMLSub, GPlaidMLAnd, GPlaidMLXor, GPlaidMLOr>();
     return pkg;
@@ -55,7 +55,7 @@ cv::gapi::GKernelPackage cv::gapi::core::plaidml::kernels()
 
 #else // HAVE_PLAIDML
 
-cv::gapi::GKernelPackage cv::gapi::core::plaidml::kernels()
+cv::GKernelPackage cv::gapi::core::plaidml::kernels()
 {
     // Still provide this symbol to avoid linking issues
     util::throw_error(std::runtime_error("G-API has been compiled without PlaidML2 support"));

--- a/modules/gapi/src/backends/render/grenderocv.cpp
+++ b/modules/gapi/src/backends/render/grenderocv.cpp
@@ -193,7 +193,7 @@ GAPI_OCV_KERNEL_ST(RenderFrameOCVImpl, cv::gapi::wip::draw::GRenderFrame, Render
 };
 
 
-cv::gapi::GKernelPackage cv::gapi::render::ocv::kernels()
+cv::GKernelPackage cv::gapi::render::ocv::kernels()
 {
     const static auto pkg = cv::gapi::kernels<RenderBGROCVImpl, RenderNV12OCVImpl, RenderFrameOCVImpl>();
     return pkg;

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -193,7 +193,7 @@ void Copy::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
     out.post(std::move(out_arg));
 }
 
-cv::gapi::GKernelPackage cv::gimpl::streaming::kernels()
+cv::GKernelPackage cv::gimpl::streaming::kernels()
 {
     return cv::gapi::kernels<Copy>();
 }
@@ -414,14 +414,14 @@ void GOCVUV::Actor::extractRMat(const cv::MediaFrame& frame, cv::RMat& rmat)
     }
 }
 
-cv::gapi::GKernelPackage cv::gapi::streaming::kernels()
+cv::GKernelPackage cv::gapi::streaming::kernels()
 {
     return cv::gapi::kernels<GOCVBGR, GOCVY, GOCVUV>();
 }
 
 #else
 
-cv::gapi::GKernelPackage cv::gapi::streaming::kernels()
+cv::GKernelPackage cv::gapi::streaming::kernels()
 {
     // Still provide this symbol to avoid linking issues
     util::throw_error(std::runtime_error("cv::gapi::streaming::kernels() isn't supported in standalone"));

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.hpp
@@ -15,7 +15,7 @@ namespace cv {
 namespace gimpl {
 namespace streaming {
 
-cv::gapi::GKernelPackage kernels();
+cv::GKernelPackage kernels();
 
 struct GCopy final : public cv::detail::NoTag
 {

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -53,18 +53,18 @@
 
 namespace
 {
-    cv::gapi::GKernelPackage getKernelPackage(cv::GCompileArgs &args)
+    cv::GKernelPackage getKernelPackage(cv::GCompileArgs &args)
     {
-        auto withAuxKernels = [](const cv::gapi::GKernelPackage& pkg) {
-            cv::gapi::GKernelPackage aux_pkg;
+        auto withAuxKernels = [](const cv::GKernelPackage& pkg) {
+            cv::GKernelPackage aux_pkg;
             for (const auto &b : pkg.backends()) {
-                aux_pkg = combine(aux_pkg, b.priv().auxiliaryKernels());
+                aux_pkg = cv::gapi::combine(aux_pkg, b.priv().auxiliaryKernels());
             }
             // Always include built-in meta<> and copy implementation
-            return combine(pkg,
-                           aux_pkg,
-                           cv::gimpl::meta::kernels(),
-                           cv::gimpl::streaming::kernels());
+            return cv::gapi::combine(pkg,
+                                     aux_pkg,
+                                     cv::gimpl::meta::kernels(),
+                                     cv::gimpl::streaming::kernels());
         };
 
         auto has_use_only = cv::gapi::getCompileArg<cv::gapi::use_only>(args);
@@ -73,18 +73,18 @@ namespace
 
         static auto ocv_pkg =
 #if !defined(GAPI_STANDALONE)
-            combine(cv::gapi::core::cpu::kernels(),
-                    cv::gapi::imgproc::cpu::kernels(),
-                    cv::gapi::video::cpu::kernels(),
-                    cv::gapi::render::ocv::kernels(),
-                    cv::gapi::streaming::kernels());
+            cv::gapi::combine(cv::gapi::core::cpu::kernels(),
+                              cv::gapi::imgproc::cpu::kernels(),
+                              cv::gapi::video::cpu::kernels(),
+                              cv::gapi::render::ocv::kernels(),
+                              cv::gapi::streaming::kernels());
 #else
-            cv::gapi::GKernelPackage();
+            cv::GKernelPackage();
 #endif // !defined(GAPI_STANDALONE)
 
-        auto user_pkg = cv::gapi::getCompileArg<cv::gapi::GKernelPackage>(args);
-        auto user_pkg_with_aux = withAuxKernels(user_pkg.value_or(cv::gapi::GKernelPackage{}));
-        return combine(ocv_pkg, user_pkg_with_aux);
+        auto user_pkg = cv::gapi::getCompileArg<cv::GKernelPackage>(args);
+        auto user_pkg_with_aux = withAuxKernels(user_pkg.value_or(cv::GKernelPackage{}));
+        return cv::gapi::combine(ocv_pkg, user_pkg_with_aux);
     }
 
     cv::gapi::GNetPackage getNetworkPackage(cv::GCompileArgs &args)
@@ -110,8 +110,8 @@ namespace
     }
 
     template<typename C>
-    cv::gapi::GKernelPackage auxKernelsFrom(const C& c) {
-        cv::gapi::GKernelPackage result;
+    cv::GKernelPackage auxKernelsFrom(const C& c) {
+        cv::GKernelPackage result;
         for (const auto &b : c) {
             result = cv::gapi::combine(result, b.priv().auxiliaryKernels());
         }
@@ -121,7 +121,7 @@ namespace
     using adeGraphs = std::vector<std::unique_ptr<ade::Graph>>;
 
     // Creates ADE graphs (patterns and substitutes) from pkg's transformations
-    void makeTransformationGraphs(const cv::gapi::GKernelPackage& pkg,
+    void makeTransformationGraphs(const cv::GKernelPackage& pkg,
                                   adeGraphs& patterns,
                                   adeGraphs& substitutes) {
         const auto& transforms = pkg.get_transformations();
@@ -142,7 +142,7 @@ namespace
         }
     }
 
-    void checkTransformations(const cv::gapi::GKernelPackage& pkg,
+    void checkTransformations(const cv::GKernelPackage& pkg,
                               const adeGraphs& patterns,
                               const adeGraphs& substitutes) {
         const auto& transforms = pkg.get_transformations();

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -26,7 +26,7 @@ class GAPI_EXPORTS GCompiler
     GCompileArgs             m_args;
     ade::ExecutionEngine     m_e;
 
-    cv::gapi::GKernelPackage m_all_kernels;
+    cv::GKernelPackage       m_all_kernels;
     cv::gapi::GNetPackage    m_all_networks;
 
     // Patterns built from transformations

--- a/modules/gapi/src/compiler/passes/kernels.cpp
+++ b/modules/gapi/src/compiler/passes/kernels.cpp
@@ -157,7 +157,7 @@ void cv::gimpl::passes::bindNetParams(ade::passes::PassContext &ctx,
 // kernels, but if not, they are handled by the framework itself in
 // its optimization/execution passes.
 void cv::gimpl::passes::resolveKernels(ade::passes::PassContext   &ctx,
-                                       const gapi::GKernelPackage &kernels)
+                                       const GKernelPackage &kernels)
 {
     std::unordered_set<cv::gapi::GBackend> active_backends;
 
@@ -220,7 +220,7 @@ void cv::gimpl::passes::resolveKernels(ade::passes::PassContext   &ctx,
     gr.metadata().set(ActiveBackends{active_backends});
 }
 
-void cv::gimpl::passes::expandKernels(ade::passes::PassContext &ctx, const gapi::GKernelPackage &kernels)
+void cv::gimpl::passes::expandKernels(ade::passes::PassContext &ctx, const GKernelPackage &kernels)
 {
     GModel::Graph gr(ctx.graph);
 

--- a/modules/gapi/src/compiler/passes/passes.hpp
+++ b/modules/gapi/src/compiler/passes/passes.hpp
@@ -23,11 +23,11 @@ namespace ade {
     }
 }
 
-namespace cv {
-
 // Forward declarations - internal
-namespace gapi {
+namespace cv {
     class GKernelPackage;
+
+namespace gapi {
     struct GNetPackage;
 }  // namespace gapi
 
@@ -52,20 +52,20 @@ void inferMeta(ade::passes::PassContext &ctx, bool meta_is_initialized);
 void storeResultingMeta(ade::passes::PassContext &ctx);
 
 void expandKernels(ade::passes::PassContext &ctx,
-                   const gapi::GKernelPackage& kernels);
+                   const GKernelPackage& kernels);
 
 void bindNetParams(ade::passes::PassContext   &ctx,
                    const gapi::GNetPackage    &networks);
 
 void resolveKernels(ade::passes::PassContext   &ctx,
-                    const gapi::GKernelPackage &kernels);
+                    const GKernelPackage &kernels);
 
 void fuseIslands(ade::passes::PassContext &ctx);
 void syncIslandTags(ade::passes::PassContext &ctx);
 void topoSortIslands(ade::passes::PassContext &ctx);
 
 void applyTransformations(ade::passes::PassContext &ctx,
-                          const gapi::GKernelPackage &pkg,
+                          const GKernelPackage &pkg,
                           const std::vector<std::unique_ptr<ade::Graph>> &preGeneratedPatterns);
 
 void addStreaming(ade::passes::PassContext &ctx);

--- a/modules/gapi/src/compiler/passes/transformations.cpp
+++ b/modules/gapi/src/compiler/passes/transformations.cpp
@@ -99,7 +99,7 @@ bool tryToSubstitute(ade::Graph& main,
 }  // anonymous namespace
 
 void applyTransformations(ade::passes::PassContext& ctx,
-                          const gapi::GKernelPackage& pkg,
+                          const GKernelPackage& pkg,
                           const std::vector<std::unique_ptr<ade::Graph>>& patterns)
 {
     const auto& transforms = pkg.get_transformations();

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -78,7 +78,7 @@ TEST_P(BuildPyr_CalcOptFlow_PipelineTest, AccuracyTest)
 
     auto customKernel  = gapi::kernels<GCPUMinScalar>();
     auto kernels       = gapi::combine(customKernel,
-                                       params.compileArgs[0].get<gapi::GKernelPackage>());
+                                       params.compileArgs[0].get<GKernelPackage>());
     params.compileArgs = compile_args(kernels);
 
     OptFlowLKTestOutput outOCV  { outPtsOCV,  outStatusOCV,  outErrOCV };

--- a/modules/gapi/test/gapi_basic_hetero_tests.cpp
+++ b/modules/gapi/test/gapi_basic_hetero_tests.cpp
@@ -153,9 +153,9 @@ namespace
 struct GAPIHeteroTest: public ::testing::Test
 {
     cv::GComputation m_comp;
-    cv::gapi::GKernelPackage m_ocv_kernels;
-    cv::gapi::GKernelPackage m_fluid_kernels;
-    cv::gapi::GKernelPackage m_hetero_kernels;
+    cv::GKernelPackage m_ocv_kernels;
+    cv::GKernelPackage m_fluid_kernels;
+    cv::GKernelPackage m_hetero_kernels;
 
     cv::Mat m_in_mat;
     cv::Mat m_out_mat;
@@ -210,7 +210,7 @@ TEST_F(GAPIHeteroTest, TestBoth)
 struct GAPIBigHeteroTest : public ::testing::TestWithParam<std::array<int, 9>>
 {
     cv::GComputation m_comp;
-    cv::gapi::GKernelPackage m_kernels;
+    cv::GKernelPackage m_kernels;
 
     cv::Mat m_in_mat;
     cv::Mat m_out_mat1;

--- a/modules/gapi/test/gapi_compile_args_tests.cpp
+++ b/modules/gapi/test/gapi_compile_args_tests.cpp
@@ -44,14 +44,14 @@ GAPI_OCV_KERNEL(GOCVTestOp, GTestOp)
 
 TEST(GetCompileArgTest, PredefinedArgs)
 {
-    cv::gapi::GKernelPackage pkg = cv::gapi::kernels<GOCVTestOp>();
+    cv::GKernelPackage pkg = cv::gapi::kernels<GOCVTestOp>();
     cv::GCompileArg arg0 { pkg },
                     arg1 { cv::gapi::use_only { pkg } },
                     arg2 { cv::graph_dump_path { "fake_path" } };
 
     GCompileArgs compArgs { arg0, arg1, arg2 };
 
-    auto kernelPkgOpt = cv::gapi::getCompileArg<cv::gapi::GKernelPackage>(compArgs);
+    auto kernelPkgOpt = cv::gapi::getCompileArg<cv::GKernelPackage>(compArgs);
     GAPI_Assert(kernelPkgOpt.has_value());
     EXPECT_NO_THROW(kernelPkgOpt.value().lookup("org.opencv.test.test_op"));
 

--- a/modules/gapi/test/gapi_fluid_resize_test.cpp
+++ b/modules/gapi/test/gapi_fluid_resize_test.cpp
@@ -364,7 +364,7 @@ static auto fluidResizeTestPackage = [](int interpolation, cv::Size szIn, cv::Si
     default: CV_Assert(false);  \
     }
 
-    GKernelPackage pkg;
+    cv::GKernelPackage pkg;
     switch (interpolation)
     {
     case INTER_NEAREST: RESIZE_SWITCH(NN); break;

--- a/modules/gapi/test/gapi_fluid_test_kernels.cpp
+++ b/modules/gapi/test/gapi_fluid_test_kernels.cpp
@@ -602,7 +602,7 @@ GMat merge3_4lpi(const GMat& src1, const GMat& src2, const GMat& src3)
     return TMerge3_4lpi::on(src1, src2, src3);
 }
 
-cv::gapi::GKernelPackage fluidTestPackage = cv::gapi::kernels
+cv::GKernelPackage fluidTestPackage = cv::gapi::kernels
         <FAddSimple
         ,FAddCSimple
         ,FAddScalar

--- a/modules/gapi/test/gapi_fluid_test_kernels.hpp
+++ b/modules/gapi/test/gapi_fluid_test_kernels.hpp
@@ -130,7 +130,7 @@ G_TYPED_KERNEL(TCalcHist, <GArray<int>(GMat)>, "test.ocv.calc_hist")
 GMat merge3_4lpi(const GMat& src1, const GMat& src2, const GMat& src3);
 std::tuple<GMat, GMat, GMat> split3_4lpi(const GMat& src);
 
-extern cv::gapi::GKernelPackage fluidTestPackage;
+extern cv::GKernelPackage fluidTestPackage;
 
 } // namespace gapi_test_kernels
 } // namespace cv

--- a/modules/gapi/test/gapi_gpu_test.cpp
+++ b/modules/gapi/test/gapi_gpu_test.cpp
@@ -146,7 +146,7 @@ namespace cv
             }
         };
 
-        cv::gapi::GKernelPackage gpuTestPackage = cv::gapi::kernels
+        cv::GKernelPackage gpuTestPackage = cv::gapi::kernels
             <GGPUSymm7x7_test
             >();
 

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -168,7 +168,7 @@ TEST(KernelPackageTransform, CreatePackage)
 
 TEST(KernelPackageTransform, Include)
 {
-    cv::gapi::GKernelPackage pkg;
+    cv::GKernelPackage pkg;
     pkg.include<gmat_in_gmat_out>();
     pkg.include<gmat2_in_gmat_out>();
     pkg.include<gmat2_in_gmat3_out>();

--- a/modules/gapi/test/internal/gapi_int_executor_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_executor_tests.cpp
@@ -152,7 +152,7 @@ struct GExecutorReshapeTest: public ::testing::Test
     GMockExecutable                   island2;
     std::shared_ptr<GMockBackendImpl> backend_impl2;
     cv::gapi::GBackend                backend2;
-    cv::gapi::GKernelPackage          pkg;
+    cv::GKernelPackage                pkg;
     cv::Mat                           in_mat1, in_mat2, out_mat;;
 };
 

--- a/modules/gapi/test/rmat/rmat_integration_tests.cpp
+++ b/modules/gapi/test/rmat/rmat_integration_tests.cpp
@@ -113,10 +113,10 @@ struct RMatIntTestStreaming : public RMatIntTestBase<RMatAdapterT>
 };
 
 struct OcvKernels {
-    cv::gapi::GKernelPackage kernels() { return cv::gapi::imgproc::cpu::kernels(); }
+    cv::GKernelPackage kernels() { return cv::gapi::imgproc::cpu::kernels(); }
 };
 struct FluidKernels {
-    cv::gapi::GKernelPackage kernels() { return cv::gapi::imgproc::fluid::kernels(); }
+    cv::GKernelPackage kernels() { return cv::gapi::imgproc::fluid::kernels(); }
 };
 
 struct RMatIntTestCpuRef : public

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -67,7 +67,7 @@ struct GAPI_Streaming: public ::testing::TestWithParam<std::tuple<KernelPackage,
         return cap;
     }
 
-    cv::gapi::GKernelPackage getKernelPackage(KernelPackage pkg_kind)
+    cv::GKernelPackage getKernelPackage(KernelPackage pkg_kind)
     {
         using namespace cv::gapi;
         switch (pkg_kind)
@@ -111,7 +111,7 @@ struct GAPI_Streaming: public ::testing::TestWithParam<std::tuple<KernelPackage,
         return args;
     }
 
-    cv::gapi::GKernelPackage pkg;
+    cv::GKernelPackage       pkg;
     cv::optional<size_t>     cap;
 };
 
@@ -1062,7 +1062,7 @@ struct GAPI_Streaming_TemplateTypes: ::testing::Test {
     cv::GMat blur;
     cv::GArray<int> vec;
     cv::GOpaque<int> opq;
-    cv::gapi::GKernelPackage pkg;
+    cv::GKernelPackage pkg;
     cv::Mat in_mat;
 };
 

--- a/samples/cpp/tutorial_code/gapi/doc_snippets/api_ref_snippets.cpp
+++ b/samples/cpp/tutorial_code/gapi/doc_snippets/api_ref_snippets.cpp
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
     //! [graph_decl_apply]
 
     //! [apply_with_param]
-    cv::gapi::GKernelPackage kernels = cv::gapi::combine
+    cv::GKernelPackage kernels = cv::gapi::combine
         (cv::gapi::core::fluid::kernels(),
          cv::gapi::imgproc::fluid::kernels());
     sobelEdge.apply(input, output, cv::compile_args(kernels));
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
     cv::imwrite(argv[2], output);
 
     //! [kernels_snippet]
-    cv::gapi::GKernelPackage pkg = cv::gapi::kernels
+    cv::GKernelPackage pkg = cv::gapi::kernels
         < CustomAdd
         , CustomFilter2D
         , CustomRGB2YUV

--- a/samples/cpp/tutorial_code/gapi/porting_anisotropic_image_segmentation/porting_anisotropic_image_segmentation_gapi_fluid.cpp
+++ b/samples/cpp/tutorial_code/gapi/porting_anisotropic_image_segmentation/porting_anisotropic_image_segmentation_gapi_fluid.cpp
@@ -63,7 +63,7 @@ int main()
     //! [kernel_pkg_proper]
     //! [kernel_pkg]
     // Prepare the kernel package and run the graph
-    cv::gapi::GKernelPackage fluid_kernels = cv::gapi::combine        // Define a custom kernel package:
+    cv::GKernelPackage fluid_kernels = cv::gapi::combine              // Define a custom kernel package:
         (cv::gapi::core::fluid::kernels(),                            // ...with Fluid Core kernels
          cv::gapi::imgproc::fluid::kernels());                        // ...and Fluid ImgProc kernels
     //! [kernel_pkg]


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```