### PR TITLE
dnn: do not try to rebuilt network during setInput()

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -1339,6 +1339,11 @@ struct Net::Impl : public detail::NetImplBase
 #endif
             clear();
 
+            if (hasDynamicShapes)
+            {
+                updateLayersShapes();
+            }
+
             this->blobsToKeep = blobsToKeep_;
 
             allocateLayers(blobsToKeep_);
@@ -3886,13 +3891,8 @@ void Net::setInput(InputArray blob, const String& name, double scalefactor, cons
     bool oldShape = prevShape == blobShape;
 
     blob_.copyTo(impl->netInputLayer->inputsData[pin.oid]);
-    if (!oldShape) {
+    if (!oldShape)
         ld.outputBlobs[pin.oid] = impl->netInputLayer->inputsData[pin.oid];
-        if (impl->hasDynamicShapes)
-        {
-            impl->updateLayersShapes();
-        }
-    }
 
     if (!ld.outputBlobsWrappers[pin.oid].empty())
     {


### PR DESCRIPTION
- this doesn't make sense in case of multiple inputs

relates #18145

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac

build_image:Custom=ubuntu-openvino-2021.4.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.2.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2021.4.2
Xbuild_image:Custom Win=openvino-2021.3.0-vc16
build_image:Custom Mac=openvino-2021.4.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

buildworker:Custom Win=windows-3
test_opencl:Custom Win=ON
test_bigdata:Custom Win=1
test_filter:Custom Win=*
```