### PR TITLE
Fix matching points viewing in asift.py sample

### DIFF
--- a/samples/python/find_obj.py
+++ b/samples/python/find_obj.py
@@ -86,6 +86,7 @@ def explore_match(win, img1, img2, kp_pairs, status = None, H = None):
 
     if status is None:
         status = np.ones(len(kp_pairs), np.bool_)
+        status = status.reshape((len(kp_pairs), 1))
     p1, p2 = [], []  # python 2 / python 3 change of zip unpacking
     for kpp in kp_pairs:
         p1.append(np.int32(kpp[0].pt))


### PR DESCRIPTION
This PR fixes IndexError that occurs when running asift.py sample and trying to see matching points pairs. The error is caused by incorrect array shape in draw method from find_obj.py.
