### PR TITLE
highgui(gtk): fix onmouse event flags

### DIFF
--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -1881,14 +1881,18 @@ static gboolean icvOnMouse( GtkWidget *widget, GdkEvent *event, gpointer user_da
                (unsigned)pt.y < (unsigned)(image_widget->original_image->height)
             ))
         {
-            state &= gtk_accelerator_get_default_mod_mask();
-            flags |= BIT_MAP(state, GDK_SHIFT_MASK,   CV_EVENT_FLAG_SHIFTKEY) |
-                BIT_MAP(state, GDK_CONTROL_MASK, CV_EVENT_FLAG_CTRLKEY)  |
-                BIT_MAP(state, GDK_MOD1_MASK,    CV_EVENT_FLAG_ALTKEY)   |
-                BIT_MAP(state, GDK_MOD2_MASK,    CV_EVENT_FLAG_ALTKEY)   |
+            // handle non-keyboard (mouse) modifiers first
+            flags |=
                 BIT_MAP(state, GDK_BUTTON1_MASK, CV_EVENT_FLAG_LBUTTON)  |
                 BIT_MAP(state, GDK_BUTTON2_MASK, CV_EVENT_FLAG_MBUTTON)  |
                 BIT_MAP(state, GDK_BUTTON3_MASK, CV_EVENT_FLAG_RBUTTON);
+            // keyboard modifiers
+            state &= gtk_accelerator_get_default_mod_mask();
+            flags |=
+                BIT_MAP(state, GDK_SHIFT_MASK,   CV_EVENT_FLAG_SHIFTKEY) |
+                BIT_MAP(state, GDK_CONTROL_MASK, CV_EVENT_FLAG_CTRLKEY)  |
+                BIT_MAP(state, GDK_MOD1_MASK,    CV_EVENT_FLAG_ALTKEY)   |
+                BIT_MAP(state, GDK_MOD2_MASK,    CV_EVENT_FLAG_ALTKEY);
             window->on_mouse( cv_event, pt.x, pt.y, flags, window->on_mouse_param );
         }
     }


### PR DESCRIPTION
`flags` doesn't pass CV_EVENT_FLAG_LBUTTON / CV_EVENT_FLAG_MBUTTON / CV_EVENT_FLAG_RBUTTON press modifiers during the mouse movement.

Test example: `samples/python/find_obj.py`

---

broken since #20253

Reference: https://docs.gtk.org/gtk3/func.accelerator_get_default_mod_mask.html

> The modifier mask determines which modifiers are considered significant for **keyboard** accelerators.
