### PR TITLE
dnn(onnx): debug dump of inputs/outputs/initializers in importer

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -636,7 +636,7 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }
 
-Mat getMatFromTensor(opencv_onnx::TensorProto& tensor_proto)
+Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
 {
     if (tensor_proto.raw_data().empty() && tensor_proto.float_data().empty() &&
         tensor_proto.double_data().empty() && tensor_proto.int64_data().empty())

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.hpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.hpp
@@ -31,7 +31,7 @@ void convertInt64ToInt32(const T1& src, T2& dst, int size)
     }
 }
 
-Mat getMatFromTensor(opencv_onnx::TensorProto& tensor_proto);
+Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto);
 
 CV__DNN_EXPERIMENTAL_NS_END
 }}  // namespace dnn, namespace cv


### PR DESCRIPTION

BTW, Peak memory usage (`readNetFromONNX("resnet-34_kinetics.onnx")`, `/usr/bin/time` output):
- before: `822832maxresident`
- after: `548984maxresident`