### PR TITLE
dnn: add checks in pooling layer implementation

### DIFF
--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -1113,9 +1113,16 @@ virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inp
             }
             else if (padMode.empty())
             {
-                int addedDims = isPool1D? inpShape.size() : local_kernel.size();
-                for (int i = 0; i < addedDims; i++) {
+                size_t addedDims = isPool1D? inpShape.size() : local_kernel.size();
+                CV_CheckLE(addedDims, inpShape.size(), "");
+                CV_CheckLE(addedDims, pads_begin.size(), "");
+                CV_CheckLE(addedDims, pads_end.size(), "");
+                CV_CheckLE(addedDims, local_kernel.size(), "");
+                CV_CheckLE(addedDims, strides.size(), "");
+                for (int i = 0; i < addedDims; i++)
+                {
                     float dst = (float) (inpShape[i] + pads_begin[i] + pads_end[i] - local_kernel[i]) / strides[i];
+                    CV_CheckGE(dst, 0.0f, "");
                     outShape.push_back(1 + (ceilMode ? ceil(dst) : floor(dst)));
                 }
 


### PR DESCRIPTION
- to avoid out of buffer access

relates #19416 (avoid out of range access)

<cut/>

Before (valgrind):

```
...
[DEBUG:0@5.537] DNN/ONNX: processing node with 1 inputs and 1 outputs: [MaxPool]:(66)
==1070476== Invalid read of size 4
==1070476==    at 0x4AB62B7: cv::dnn::PoolingLayerImpl::getMemoryShapes(std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&, int, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&) const (pooling_layer.cpp:1118)
```

After:

```
...
[DEBUG:0@5.778] DNN/ONNX: processing node with 1 inputs and 1 outputs: [MaxPool]:(66)
[ERROR:0@5.824] DNN/ONNX: ERROR during processing node with 1 inputs and 1 outputs: [MaxPool]:(66)
[ INFO:0@5.825]     Input[0] = '65'
[ INFO:0@5.826]     Output[0] = '66'
unknown file: Failure
C++ exception with description "OpenCV(3.4.17-pre) modules/dnn/src/onnx/onnx_importer.cpp:664: error: (-2:Unspecified error) in function 'handleNode'
> Node [MaxPool]:(66) parse error: OpenCV(3.4.17-pre) modules/dnn/src/layers/pooling_layer.cpp:1117: error: (-2:Unspecified error) in function 'virtual bool cv::dnn::PoolingLayerImpl::getMemoryShapes(const std::vector<std::vector<int> >&, int, std::vector<std::vector<int> >&, std::vector<std::vector<int> >&) const'
> >  (expected: 'addedDims <= inpShape.size()'), where
> >     'addedDims' is 3
> > must be less than or equal to
> >     'inpShape.size()' is 2
> " thrown in the test body.
```