### PR TITLE
Make cv::VideoCapture::get return cv::CAP_PROP_UNKNOWN (-1) for unsupported properties.

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -129,6 +129,7 @@ enum VideoCaptureAPIs {
  @sa videoio_flags_others, VideoCapture::get(), VideoCapture::set()
 */
 enum VideoCaptureProperties {
+       CAP_PROP_UNKNOWN        =-1,
        CAP_PROP_POS_MSEC       =0, //!< Current position of the video file in milliseconds.
        CAP_PROP_POS_FRAMES     =1, //!< 0-based index of the frame to be decoded/captured next. When the index i is set in RAW mode (CAP_PROP_FORMAT == -1) this will seek to the key frame k, where k <= i.
        CAP_PROP_POS_AVI_RATIO  =2, //!< Relative position of the video file: 0=start of the film, 1=end of the film.
@@ -999,7 +1000,7 @@ public:
 
     @param propId Property identifier from cv::VideoCaptureProperties (eg. cv::CAP_PROP_POS_MSEC, cv::CAP_PROP_POS_FRAMES, ...)
     or one from @ref videoio_flags_others
-    @return Value for the specified property. Value -1 is returned when querying a property that is
+    @return Value for the specified property. Value cv::CAP_PROP_UNKNOWN is returned when querying a property that is
     not supported by the backend used by the VideoCapture instance.
 
     @note Reading / writing properties involves many layers. Some unexpected result might happens

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -999,7 +999,7 @@ public:
 
     @param propId Property identifier from cv::VideoCaptureProperties (eg. cv::CAP_PROP_POS_MSEC, cv::CAP_PROP_POS_FRAMES, ...)
     or one from @ref videoio_flags_others
-    @return Value for the specified property. Value 0 is returned when querying a property that is
+    @return Value for the specified property. Value -1 is returned when querying a property that is
     not supported by the backend used by the VideoCapture instance.
 
     @note Reading / writing properties involves many layers. Some unexpected result might happens

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -129,7 +129,7 @@ enum VideoCaptureAPIs {
  @sa videoio_flags_others, VideoCapture::get(), VideoCapture::set()
 */
 enum VideoCaptureProperties {
-       CAP_PROP_UNKNOWN        =-1,
+       CAP_PROP_UNKNOWN        =-1, //!< Returned by VideoCapture::get if the requested property is unknown or unsupported
        CAP_PROP_POS_MSEC       =0, //!< Current position of the video file in milliseconds.
        CAP_PROP_POS_FRAMES     =1, //!< 0-based index of the frame to be decoded/captured next. When the index i is set in RAW mode (CAP_PROP_FORMAT == -1) this will seek to the key frame k, where k <= i.
        CAP_PROP_POS_AVI_RATIO  =2, //!< Relative position of the video file: 0=start of the film, 1=end of the film.
@@ -214,6 +214,7 @@ enum VideoCaptureProperties {
  @sa VideoWriter::get(), VideoWriter::set()
 */
 enum VideoWriterProperties {
+  VIDEOWRITER_PROP_UNKNOWN = -1, //!< Returned by VideoWriter::get if the requested property is unknown or unsupported
   VIDEOWRITER_PROP_QUALITY = 1,    //!< Current quality (0..100%) of the encoded videostream. Can be adjusted dynamically in some codecs.
   VIDEOWRITER_PROP_FRAMEBYTES = 2, //!< (Read-only): Size of just encoded video frame. Note that the encoding order may be different from representation order.
   VIDEOWRITER_PROP_NSTRIPES = 3,   //!< Number of stripes for parallel encoding. -1 for auto detection.

--- a/modules/videoio/misc/python/test/test_videoio.py
+++ b/modules/videoio/misc/python/test/test_videoio.py
@@ -45,6 +45,7 @@ class Bindings(NewOpenCVTests):
         with open(self.find_file("cv/video/768x576.avi"), "rb") as f:
             cap = cv.VideoCapture(f, api_pref, [])
             self.assertTrue(cap.isOpened())
+            self.assertEqual(cv.CAP_PROP_UNKNOWN, cap.get(-1))
             hasFrame, frame = cap.read()
             self.assertTrue(hasFrame)
             self.assertEqual(frame.shape, (576, 768, 3))

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -540,10 +540,10 @@ public:
     }
     double getProperty(int prop) const CV_OVERRIDE
     {
-        double val = -1;
+        double val = CAP_PROP_UNKNOWN;
         if (plugin_api_->v0.Capture_getProperty)
             if (CV_ERROR_OK != plugin_api_->v0.Capture_getProperty(capture_, prop, &val))
-                val = -1;
+                val = CAP_PROP_UNKNOWN;
         return val;
     }
     bool setProperty(int prop, double val) CV_OVERRIDE
@@ -664,10 +664,10 @@ public:
     }
     double getProperty(int prop) const CV_OVERRIDE
     {
-        double val = -1;
+        double val = CAP_PROP_UNKNOWN;
         if (plugin_api_->v0.Writer_getProperty)
             if (CV_ERROR_OK != plugin_api_->v0.Writer_getProperty(writer_, prop, &val))
-                val = -1;
+                val = CAP_PROP_UNKNOWN;
         return val;
     }
     bool setProperty(int prop, double val) CV_OVERRIDE

--- a/modules/videoio/src/backend_plugin_legacy.impl.hpp
+++ b/modules/videoio/src/backend_plugin_legacy.impl.hpp
@@ -49,10 +49,10 @@ public:
     }
     double getProperty(int prop) const CV_OVERRIDE
     {
-        double val = -1;
+        double val = CAP_PROP_UNKNOWN;
         if (plugin_api_->v0.Capture_getProperty)
             if (CV_ERROR_OK != plugin_api_->v0.Capture_getProperty(capture_, prop, &val))
-                val = -1;
+                val = CAP_PROP_UNKNOWN;
         return val;
     }
     bool setProperty(int prop, double val) CV_OVERRIDE
@@ -161,10 +161,10 @@ public:
     }
     double getProperty(int prop) const CV_OVERRIDE
     {
-        double val = -1;
+        double val = CAP_PROP_UNKNOWN;
         if (plugin_api_->v0.Writer_getProperty)
             if (CV_ERROR_OK != plugin_api_->v0.Writer_getProperty(writer_, prop, &val))
-                val = -1;
+                val = CAP_PROP_UNKNOWN;
         return val;
     }
     bool setProperty(int prop, double val) CV_OVERRIDE

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -623,7 +623,7 @@ double VideoCapture::get(int propId) const
         }
         return static_cast<double>(api);
     }
-    return !icap.empty() ? icap->getProperty(propId) : 0;
+    return !icap.empty() ? icap->getProperty(propId) : -1.0;
 }
 
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -619,11 +619,11 @@ double VideoCapture::get(int propId) const
         }
         if (api <= 0)
         {
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         return static_cast<double>(api);
     }
-    return !icap.empty() ? icap->getProperty(propId) : -1.0;
+    return !icap.empty() ? icap->getProperty(propId) : static_cast<double>(CAP_PROP_UNKNOWN);
 }
 
 
@@ -848,7 +848,7 @@ double VideoWriter::get(int propId) const
     {
         return iwriter->getProperty(propId);
     }
-    return 0.;
+    return CAP_PROP_UNKNOWN;
 }
 
 String VideoWriter::getBackendName() const

--- a/modules/videoio/src/cap_android_camera.cpp
+++ b/modules/videoio/src/cap_android_camera.cpp
@@ -358,7 +358,7 @@ public:
                 break;
         }
         // unknown parameter or value not available
-        return -1;
+        return CAP_PROP_UNKNOWN;
     }
 
     bool setProperty(int property_id, double value) CV_OVERRIDE

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -736,7 +736,7 @@ public:
         fd = -1;
     }
 
-    virtual double getProperty(int) const CV_OVERRIDE { return CAP_PROP_UNKNOWN; }
+    virtual double getProperty(int) const CV_OVERRIDE { return VIDEOWRITER_PROP_UNKNOWN; }
     virtual bool setProperty(int, double) CV_OVERRIDE { return false; }
     virtual bool isOpened() const CV_OVERRIDE { return NULL != encoder; }
 };

--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -236,7 +236,7 @@ public:
         }
 
         // unknown parameter or value not available
-        return -1;
+        return CAP_PROP_UNKNOWN;
     }
 
     bool setProperty(int property_id, double value) CV_OVERRIDE
@@ -736,7 +736,7 @@ public:
         fd = -1;
     }
 
-    virtual double getProperty(int) const CV_OVERRIDE { return 0.; }
+    virtual double getProperty(int) const CV_OVERRIDE { return CAP_PROP_UNKNOWN; }
     virtual bool setProperty(int, double) CV_OVERRIDE { return false; }
     virtual bool isOpened() const CV_OVERRIDE { return NULL != encoder; }
 };

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -501,7 +501,7 @@ double CvCaptureCAM_Aravis::getProperty( int property_id ) const
         }
         break;
     }
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 double CvCaptureCAM_Aravis::getExpectedMidGrey(ArvPixelFormat fmt) const

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -526,7 +526,7 @@ double CvCaptureCAM::getProperty(int property_id) const{
             return mCaptureDevice.torchMode;
 
         default:
-            return 0;
+            return -1.0;
     }
 
 

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -526,7 +526,7 @@ double CvCaptureCAM::getProperty(int property_id) const{
             return mCaptureDevice.torchMode;
 
         default:
-            return -1.0;
+            return cv::CAP_PROP_UNKNOWN;
     }
 
 
@@ -1061,7 +1061,7 @@ bool CvCaptureFile::retrieveFrame(int, cv::OutputArray arr) {
 }
 
 double CvCaptureFile::getProperty(int property_id) const{
-    if (mAsset == nil) return 0;
+    if (mAsset == nil) return cv::CAP_PROP_UNKNOWN;
 
     CMTime t;
 
@@ -1069,7 +1069,7 @@ double CvCaptureFile::getProperty(int property_id) const{
         case cv::CAP_PROP_POS_MSEC:
             return mFrameTimestamp.value * 1000.0 / mFrameTimestamp.timescale;
         case cv::CAP_PROP_POS_FRAMES:
-            return mAssetTrack.nominalFrameRate > 0 ? mFrameNum : 0;
+            return mAssetTrack.nominalFrameRate > 0 ? mFrameNum : cv::CAP_PROP_UNKNOWN;
         case cv::CAP_PROP_POS_AVI_RATIO:
             t = [mAsset duration];
             return (mFrameTimestamp.value * t.timescale) / double(mFrameTimestamp.timescale * t.value);
@@ -1092,7 +1092,7 @@ double CvCaptureFile::getProperty(int property_id) const{
             break;
     }
 
-    return 0;
+    return cv::CAP_PROP_UNKNOWN;
 }
 
 bool CvCaptureFile::setProperty(int property_id, double value) {

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -476,7 +476,7 @@ double CvCaptureCAM::getProperty(int property_id) const{
 
     CMFormatDescriptionRef format = mCaptureDevice.activeFormat.formatDescription;
     CMVideoDimensions s1 = CMVideoFormatDescriptionGetDimensions(format);
-    double retval = 0;
+    double retval = -1.0;
 
     switch (property_id) {
         case cv::CAP_PROP_FRAME_WIDTH:

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -476,7 +476,7 @@ double CvCaptureCAM::getProperty(int property_id) const{
 
     CMFormatDescriptionRef format = mCaptureDevice.activeFormat.formatDescription;
     CMVideoDimensions s1 = CMVideoFormatDescriptionGetDimensions(format);
-    double retval = -1.0;
+    double retval = cv::CAP_PROP_UNKNOWN;
 
     switch (property_id) {
         case cv::CAP_PROP_FRAME_WIDTH:
@@ -985,7 +985,7 @@ bool CvCaptureFile::retrieveFrame_(int, cv::OutputArray arr) {
 }
 
 double CvCaptureFile::getProperty_(int property_id) const{
-    if (mAsset == nil) return 0;
+    if (mAsset == nil) return cv::CAP_PROP_UNKNOWN;
 
     CMTime t;
 
@@ -1016,7 +1016,7 @@ double CvCaptureFile::getProperty_(int property_id) const{
             break;
     }
 
-    return 0;
+    return cv::CAP_PROP_UNKNOWN;
 }
 
 bool CvCaptureFile::setProperty_(int property_id, double value) {

--- a/modules/videoio/src/cap_dc1394_v2.cpp
+++ b/modules/videoio/src/cap_dc1394_v2.cpp
@@ -523,7 +523,7 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId) const
         return fps;
     case CAP_PROP_RECTIFICATION:
         CV_LOG_WARNING(NULL, "cap_dc1394: rectification support has been removed from videoio module");
-        return 0;
+        return CAP_PROP_UNKNOWN;
     case CAP_PROP_WHITE_BALANCE_BLUE_U:
         if (dc1394_feature_whitebalance_get_value(dcCam,
                                                   &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
@@ -555,7 +555,7 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId) const
                 &fs.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
               return feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value;
     }
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool CvCaptureCAM_DC1394_v2_CPP::setProperty(int propId, double value)

--- a/modules/videoio/src/cap_dc1394_v2.cpp
+++ b/modules/videoio/src/cap_dc1394_v2.cpp
@@ -555,7 +555,7 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId) const
                 &fs.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
               return feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value;
     }
-    return -1; // the value of the feature can be 0, so returning 0 as an error is wrong
+    return -1.0;
 }
 
 bool CvCaptureCAM_DC1394_v2_CPP::setProperty(int propId, double value)

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -1431,7 +1431,7 @@ int videoInput::getWidth(int id) const
         return VDList[id] ->width;
     }
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 
 }
 
@@ -1448,7 +1448,7 @@ int videoInput::getHeight(int id) const
         return VDList[id] ->height;
     }
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 
 }
 
@@ -1463,7 +1463,7 @@ int videoInput::getFourcc(int id) const
         return getFourccFromMediaSubtype(VDList[id]->videoType);
     }
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 
 }
 
@@ -1477,14 +1477,14 @@ double videoInput::getFPS(int id) const
         }
     }
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 
 }
 
 int videoInput::getChannel(int deviceID) const
 {
     if (!isDeviceSetup(deviceID))
-        return 0;
+        return CAP_PROP_UNKNOWN;
     return VDList[deviceID]->storeConn;
 }
 
@@ -1500,7 +1500,7 @@ int videoInput::getSize(int id) const
         return VDList[id] ->videoSize;
     }
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 
 }
 
@@ -2406,7 +2406,7 @@ int videoInput::getVideoPropertyFromCV(int cv_property){
         case CAP_PROP_GAIN:
             return VideoProcAmp_Gain;
     }
-    return -1;
+    return CAP_PROP_UNKNOWN;
 }
 
 int videoInput::getCameraPropertyFromCV(int cv_property){
@@ -2437,7 +2437,7 @@ int videoInput::getCameraPropertyFromCV(int cv_property){
         default:
             break;
     }
-    return -1;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool videoInput::isDeviceDisconnected(int deviceNumber)
@@ -3359,7 +3359,7 @@ int videoInput::property_window_count(int idx)
     if (isDeviceSetup(idx))
         return (int)InterlockedCompareExchange(&VDList[idx]->property_window_count, 0L, 0L);
 
-    return 0;
+    return CAP_PROP_UNKNOWN;
 }
 
 namespace cv
@@ -3457,7 +3457,7 @@ double VideoCapture_DShow::getProperty(int propIdx) const
         break;
     }
     // unknown parameter or value not available
-    return -1;
+    return CAP_PROP_UNKNOWN;
 }
 bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
 {

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -88,7 +88,7 @@ public:
 
     virtual double getProperty_(int propId) const CV_OVERRIDE
     {
-        return ffmpegCapture ? icvGetCaptureProperty_FFMPEG_p(ffmpegCapture, propId) : 0;
+        return ffmpegCapture ? icvGetCaptureProperty_FFMPEG_p(ffmpegCapture, propId) : static_cast<double>(CAP_PROP_UNKNOWN);
     }
     virtual bool setProperty_(int propId, double value) CV_OVERRIDE
     {
@@ -238,7 +238,7 @@ public:
 
     virtual double getProperty(int propId) const CV_OVERRIDE {
         if(!ffmpegWriter)
-            return 0;
+            return CAP_PROP_UNKNOWN;
         return ffmpegWriter->getProperty(propId);
     }
 

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -238,7 +238,7 @@ public:
 
     virtual double getProperty(int propId) const CV_OVERRIDE {
         if(!ffmpegWriter)
-            return CAP_PROP_UNKNOWN;
+            return VIDEOWRITER_PROP_UNKNOWN;
         return ffmpegWriter->getProperty(propId);
     }
 

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2100,7 +2100,7 @@ static inline double getCodecIdFourcc(const AVCodecID codec_id)
 
 double CvCapture_FFMPEG::getProperty( int property_id ) const
 {
-    if( !video_st || (!rawMode && !context) ) return 0;
+    if( !video_st || (!rawMode && !context) ) return CAP_PROP_UNKNOWN;
 
     switch( property_id )
     {
@@ -2129,7 +2129,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         if (fourcc != -1) return fourcc;
         const double codec_tag = (double)video_st->CV_FFMPEG_CODEC_FIELD->codec_tag;
         if (codec_tag) return codec_tag;
-        else return -1;
+        else return CAP_PROP_UNKNOWN;
     }
     case CAP_PROP_SAR_NUM:
         return _opencv_ffmpeg_get_sample_aspect_ratio(ic->streams[video_stream]).num;
@@ -2143,11 +2143,11 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         AVPixelFormat pix_fmt = video_st->codec->pix_fmt;
 #endif
         unsigned int fourcc_tag = avcodec_pix_fmt_to_codec_tag(pix_fmt);
-        return (fourcc_tag == 0) ? -1.0 : (double)fourcc_tag;
+        return (fourcc_tag == 0) ? static_cast<double>(CAP_PROP_UNKNOWN) : (double)fourcc_tag;
     }
     case CAP_PROP_FORMAT:
         if (rawMode)
-            return -1;
+            return CAP_PROP_UNKNOWN;
         else if (!convertRGB)
             return CV_8UC1;
         else if (enableAlpha)
@@ -2181,6 +2181,8 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
     case CAP_PROP_N_THREADS:
         if (!rawMode)
             return static_cast<double>(context->thread_count);
+        else
+            return 0;
         break;
     case CAP_PROP_PTS:
         return static_cast<double>(pts_in_fps_time_base);
@@ -2190,7 +2192,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         break;
     }
 
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 double CvCapture_FFMPEG::r2d(AVRational r) const
@@ -3007,7 +3009,7 @@ double CvVideoWriter_FFMPEG::getProperty(int propId) const
         return static_cast<double>(use_opencl);
     }
 #endif
-    return 0;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool CvVideoWriter_FFMPEG::setProperty(int property_id, double value)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2143,7 +2143,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         AVPixelFormat pix_fmt = video_st->codec->pix_fmt;
 #endif
         unsigned int fourcc_tag = avcodec_pix_fmt_to_codec_tag(pix_fmt);
-        return (fourcc_tag == 0) ? (double)-1 : (double)fourcc_tag;
+        return (fourcc_tag == 0) ? -1.0 : (double)fourcc_tag;
     }
     case CAP_PROP_FORMAT:
         if (rawMode)
@@ -2190,7 +2190,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         break;
     }
 
-    return 0;
+    return -1.0;
 }
 
 double CvCapture_FFMPEG::r2d(AVRational r) const

--- a/modules/videoio/src/cap_gphoto2.cpp
+++ b/modules/videoio/src/cap_gphoto2.cpp
@@ -576,7 +576,7 @@ CameraWidget * DigitalCameraCapture::getGenericProperty(int propertyId,
         case CAP_PROP_VIEWFINDER:
             return findWidgetByName(PROP_VIEWFINDER);
     }
-    output = -1.0;
+    output = CAP_PROP_UNKNOWN;
     return NULL;
 }
 
@@ -587,7 +587,7 @@ CameraWidget * DigitalCameraCapture::getGenericProperty(int propertyId,
 double DigitalCameraCapture::getProperty(int propertyId) const
 {
     CameraWidget * widget = NULL;
-    double output = -1.0;
+    double output = CAP_PROP_UNKNOWN;
     if (propertyId < 0)
     {
         widget = getWidget(-propertyId);
@@ -601,10 +601,10 @@ double DigitalCameraCapture::getProperty(int propertyId) const
                 return preview;
             case CAP_PROP_GPHOTO2_WIDGET_ENUMERATE:
                 if (rootWidget == NULL)
-                    return 0;
+                    return CAP_PROP_UNKNOWN;
                 return (intptr_t) widgetInfo.c_str();
             case CAP_PROP_GPHOTO2_RELOAD_CONFIG:
-                return 0; // Trigger, only by set
+                return CAP_PROP_UNKNOWN; // Trigger, only by set
             case CAP_PROP_GPHOTO2_RELOAD_ON_CHANGE:
                 return reloadOnChange;
             case CAP_PROP_GPHOTO2_COLLECT_MSGS:
@@ -643,7 +643,7 @@ double DigitalCameraCapture::getProperty(int propertyId) const
                         return i;
                     }
                 }
-                return -1.0;
+                return CAP_PROP_UNKNOWN;
             }
             case GP_WIDGET_TOGGLE:
             {
@@ -670,7 +670,7 @@ double DigitalCameraCapture::getProperty(int propertyId) const
         char buf[128] = "";
         snprintf(buf, sizeof(buf), "cannot get property: %d", propertyId);
         message(WARNING, (const char *) buf, e);
-        return -1.0;
+        return CAP_PROP_UNKNOWN;
     }
 }
 

--- a/modules/videoio/src/cap_gphoto2.cpp
+++ b/modules/videoio/src/cap_gphoto2.cpp
@@ -576,6 +576,7 @@ CameraWidget * DigitalCameraCapture::getGenericProperty(int propertyId,
         case CAP_PROP_VIEWFINDER:
             return findWidgetByName(PROP_VIEWFINDER);
     }
+    output = -1.0;
     return NULL;
 }
 
@@ -586,7 +587,7 @@ CameraWidget * DigitalCameraCapture::getGenericProperty(int propertyId,
 double DigitalCameraCapture::getProperty(int propertyId) const
 {
     CameraWidget * widget = NULL;
-    double output = 0;
+    double output = -1.0;
     if (propertyId < 0)
     {
         widget = getWidget(-propertyId);
@@ -642,7 +643,7 @@ double DigitalCameraCapture::getProperty(int propertyId) const
                         return i;
                     }
                 }
-                return -1;
+                return -1.0;
             }
             case GP_WIDGET_TOGGLE:
             {
@@ -669,7 +670,7 @@ double DigitalCameraCapture::getProperty(int propertyId) const
         char buf[128] = "";
         snprintf(buf, sizeof(buf), "cannot get property: %d", propertyId);
         message(WARNING, (const char *) buf, e);
-        return 0;
+        return -1.0;
     }
 }
 

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1856,7 +1856,7 @@ double GStreamerCapture::getProperty(int propId) const
 
     if(!pipeline) {
         CV_WARN("GStreamer: no pipeline");
-        return -1.0;
+        return CAP_PROP_UNKNOWN;
     }
 
     switch(propId)
@@ -1868,14 +1868,14 @@ double GStreamerCapture::getProperty(int propId) const
         {
             if (isPosFramesEmulated)
                 return emulatedFrameNumber;
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         format = GST_FORMAT_DEFAULT;
         status = gst_element_query_position(sink.get(), CV_GST_FORMAT(format), &value);
         if(!status) {
             handleMessage(pipeline);
             CV_WARN("GStreamer: unable to query position of stream");
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         return value;
     case CAP_PROP_POS_AVI_RATIO:
@@ -1884,7 +1884,7 @@ double GStreamerCapture::getProperty(int propId) const
         if(!status) {
             handleMessage(pipeline);
             CV_WARN("GStreamer: unable to query position of stream");
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         return ((double) value) / GST_FORMAT_PERCENT_MAX;
     case CAP_PROP_FRAME_WIDTH:
@@ -1918,7 +1918,7 @@ double GStreamerCapture::getProperty(int propId) const
         if(!sink)
         {
             CV_WARN("there is no sink yet");
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         return gst_app_sink_get_max_buffers(GST_APP_SINK(sink.get()));
     case CAP_PROP_AUDIO_TOTAL_CHANNELS:
@@ -1931,26 +1931,26 @@ double GStreamerCapture::getProperty(int propId) const
         return audioBaseIndex;
     case CAP_PROP_AUDIO_TOTAL_STREAMS:
         CV_LOG_ONCE_WARNING(NULL, "OpenCV | GStreamer: CAP_PROP_AUDIO_TOTAL_STREAMS property is not supported");
-        return 0;
+        return CAP_PROP_UNKNOWN;
     case CAP_PROP_AUDIO_POS:
         return audioSamplePosInSamples;
     case CAP_PROP_AUDIO_SHIFT_NSEC:
         CV_LOG_ONCE_WARNING(NULL, "OpenCV | GStreamer: CAP_PROP_AUDIO_SHIFT_NSEC property is not supported");
-        return 0;
+        return CAP_PROP_UNKNOWN;
     case CAP_PROP_OPEN_TIMEOUT_MSEC:
         return GST_TIME_AS_MSECONDS(openTimeout);
     case CAP_PROP_READ_TIMEOUT_MSEC:
 #if FULL_GST_VERSION >= VERSION_NUM(1,10,0)
         return GST_TIME_AS_MSECONDS(readTimeout);
 #else
-        return 0;
+        return CAP_PROP_UNKNOWN;
 #endif
     default:
         CV_WARN("unhandled property: " << propId);
         break;
     }
 
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 /*!
@@ -2768,7 +2768,7 @@ double CvVideoWriter_GStreamer::getProperty(int propId) const
     {
         return static_cast<double>(hw_device);
     }
-    return 0;
+    return CAP_PROP_UNKNOWN;
 }
 
 Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourcc, double fps,

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1856,7 +1856,7 @@ double GStreamerCapture::getProperty(int propId) const
 
     if(!pipeline) {
         CV_WARN("GStreamer: no pipeline");
-        return 0;
+        return -1.0;
     }
 
     switch(propId)
@@ -1868,14 +1868,14 @@ double GStreamerCapture::getProperty(int propId) const
         {
             if (isPosFramesEmulated)
                 return emulatedFrameNumber;
-            return 0; // TODO getProperty() "unsupported" value should be changed
+            return -1.0;
         }
         format = GST_FORMAT_DEFAULT;
         status = gst_element_query_position(sink.get(), CV_GST_FORMAT(format), &value);
         if(!status) {
             handleMessage(pipeline);
             CV_WARN("GStreamer: unable to query position of stream");
-            return 0;
+            return -1.0;
         }
         return value;
     case CAP_PROP_POS_AVI_RATIO:
@@ -1884,7 +1884,7 @@ double GStreamerCapture::getProperty(int propId) const
         if(!status) {
             handleMessage(pipeline);
             CV_WARN("GStreamer: unable to query position of stream");
-            return 0;
+            return -1.0;
         }
         return ((double) value) / GST_FORMAT_PERCENT_MAX;
     case CAP_PROP_FRAME_WIDTH:
@@ -1918,7 +1918,7 @@ double GStreamerCapture::getProperty(int propId) const
         if(!sink)
         {
             CV_WARN("there is no sink yet");
-            return 0;
+            return -1.0;
         }
         return gst_app_sink_get_max_buffers(GST_APP_SINK(sink.get()));
     case CAP_PROP_AUDIO_TOTAL_CHANNELS:
@@ -1950,7 +1950,7 @@ double GStreamerCapture::getProperty(int propId) const
         break;
     }
 
-    return 0;
+    return -1.0;
 }
 
 /*!

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -2768,7 +2768,7 @@ double CvVideoWriter_GStreamer::getProperty(int propId) const
     {
         return static_cast<double>(hw_device);
     }
-    return CAP_PROP_UNKNOWN;
+    return VIDEOWRITER_PROP_UNKNOWN;
 }
 
 Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourcc, double fps,

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -383,7 +383,7 @@ public:
     void close();
 
     ~CvVideoWriter_Images() CV_OVERRIDE { close(); }
-    double getProperty(int) const CV_OVERRIDE { return CAP_PROP_UNKNOWN; }
+    double getProperty(int) const CV_OVERRIDE { return VIDEOWRITER_PROP_UNKNOWN; }
     bool setProperty( int, double ) CV_OVERRIDE; // FIXIT doesn't work: IVideoWriter interface only!
     bool isOpened() const CV_OVERRIDE { return !filename_pattern.empty(); }
     bool write( InputArray ) CV_OVERRIDE;

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -141,7 +141,7 @@ double CvCapture_Images::getProperty(int id) const
     {
     case cv::CAP_PROP_POS_MSEC:
         CV_WARN("collections of images don't have framerates");
-        return 0;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_POS_FRAMES:
         return currentframe;
     case cv::CAP_PROP_FRAME_COUNT:
@@ -154,12 +154,12 @@ double CvCapture_Images::getProperty(int id) const
         return frame.rows;
     case cv::CAP_PROP_FPS:
         CV_WARN("collections of images don't have framerates");
-        return 1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_FOURCC:
         CV_WARN("collections of images don't have 4-character codes");
-        return 0;
+        return CAP_PROP_UNKNOWN;
     }
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool CvCapture_Images::setProperty(int id, double value)
@@ -383,7 +383,7 @@ public:
     void close();
 
     ~CvVideoWriter_Images() CV_OVERRIDE { close(); }
-    double getProperty(int) const CV_OVERRIDE { return 0; }
+    double getProperty(int) const CV_OVERRIDE { return CAP_PROP_UNKNOWN; }
     bool setProperty( int, double ) CV_OVERRIDE; // FIXIT doesn't work: IVideoWriter interface only!
     bool isOpened() const CV_OVERRIDE { return !filename_pattern.empty(); }
     bool write( InputArray ) CV_OVERRIDE;

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -159,7 +159,7 @@ double CvCapture_Images::getProperty(int id) const
         CV_WARN("collections of images don't have 4-character codes");
         return 0;
     }
-    return 0;
+    return -1.0;
 }
 
 bool CvCapture_Images::setProperty(int id, double value)

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -190,7 +190,7 @@ class IVideoCapture
 {
 public:
     virtual ~IVideoCapture() {}
-    virtual double getProperty(int) const { return 0; }
+    virtual double getProperty(int) const { return CAP_PROP_UNKNOWN; }
     virtual bool setProperty(int, double) { return false; }
     virtual bool grabFrame() = 0;
     virtual bool retrieveFrame(int, OutputArray) = 0;
@@ -202,7 +202,7 @@ class IVideoWriter
 {
 public:
     virtual ~IVideoWriter() {}
-    virtual double getProperty(int) const { return 0; }
+    virtual double getProperty(int) const { return CAP_PROP_UNKNOWN; }
     virtual bool setProperty(int, double) { return false; }
     virtual bool isOpened() const = 0;
     virtual bool write(InputArray) = 0;

--- a/modules/videoio/src/cap_librealsense.cpp
+++ b/modules/videoio/src/cap_librealsense.cpp
@@ -29,7 +29,7 @@ VideoCapture_LibRealsense::~VideoCapture_LibRealsense(){}
 
 double VideoCapture_LibRealsense::getProperty(int propIdx) const
 {
-    double propValue = 0.0;
+    double propValue = CAP_PROP_UNKNOWN;
 
     const int purePropIdx = propIdx & ~CAP_INTELPERC_GENERATORS_MASK;
     if((propIdx & CAP_INTELPERC_GENERATORS_MASK) == CAP_INTELPERC_IMAGE_GENERATOR)
@@ -54,7 +54,7 @@ double VideoCapture_LibRealsense::getProperty(int propIdx) const
 
 double VideoCapture_LibRealsense::getImageGeneratorProperty(int propIdx) const
 {
-    double propValue = 0.0;
+    double propValue = CAP_PROP_UNKNOWN;
     const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
     if(!profile)
     {
@@ -79,7 +79,7 @@ double VideoCapture_LibRealsense::getImageGeneratorProperty(int propIdx) const
 
 double VideoCapture_LibRealsense::getDepthGeneratorProperty(int propIdx) const
 {
-    double propValue = 0.0;
+    double propValue = CAP_PROP_UNKNOWN;
     const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
     const rs2::depth_sensor sensor = mPipe.get_active_profile().get_device().first<rs2::depth_sensor>();
     if(!profile || !sensor)
@@ -114,7 +114,7 @@ double VideoCapture_LibRealsense::getDepthGeneratorProperty(int propIdx) const
 
 double VideoCapture_LibRealsense::getIrGeneratorProperty(int propIdx) const
 {
-    double propValue = 0.0;
+    double propValue = CAP_PROP_UNKNOWN;
     const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_INFRARED).as<rs2::video_stream_profile>();
     if(!profile)
     {
@@ -139,7 +139,7 @@ double VideoCapture_LibRealsense::getIrGeneratorProperty(int propIdx) const
 
 double VideoCapture_LibRealsense::getCommonProperty(int propIdx) const
 {
-    double propValue = 0.0;
+    double propValue = CAP_PROP_UNKNOWN;
     const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
     const rs2::depth_sensor sensor = mPipe.get_active_profile().get_device().first<rs2::depth_sensor>();
     if(!profile || !sensor)

--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -137,7 +137,7 @@ double VideoCapture_IntelMFX::getProperty(int prop) const
     if (!good)
     {
         MSG(cerr << "MFX: can not call getProperty(), backend has not been initialized" << endl);
-        return 0;
+        return CAP_PROP_UNKNOWN;
     }
     switch (prop)
     {
@@ -147,7 +147,7 @@ double VideoCapture_IntelMFX::getProperty(int prop) const
             return frameSize.height;
         default:
             MSG(cerr << "MFX: unsupported property" << endl);
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
     }
 }
 

--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -147,7 +147,7 @@ double VideoCapture_IntelMFX::getProperty(int prop) const
             return frameSize.height;
         default:
             MSG(cerr << "MFX: unsupported property" << endl);
-            return 0;
+            return -1.0;
     }
 }
 

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -192,7 +192,7 @@ VideoWriter_IntelMFX::~VideoWriter_IntelMFX()
 double VideoWriter_IntelMFX::getProperty(int) const
 {
     MSG(cerr << "MFX: getProperty() is not implemented" << endl);
-    return 0;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool VideoWriter_IntelMFX::setProperty(int, double)

--- a/modules/videoio/src/cap_mjpeg_decoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_decoder.cpp
@@ -131,9 +131,8 @@ double MotionJpegCapture::getProperty(int property) const
         case CAP_PROP_FRAME_COUNT:
             return (double)m_mjpeg_frames.size();
         case CAP_PROP_FORMAT:
-            return 0;
         default:
-            return 0;
+            return -1.0;
     }
 }
 

--- a/modules/videoio/src/cap_mjpeg_decoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_decoder.cpp
@@ -132,7 +132,7 @@ double MotionJpegCapture::getProperty(int property) const
             return (double)m_mjpeg_frames.size();
         case CAP_PROP_FORMAT:
         default:
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
     }
 }
 

--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -514,11 +514,11 @@ public:
         if( propId == VIDEOWRITER_PROP_FRAMEBYTES )
         {
             bool isEmpty = container.isEmptyFrameSize();
-            return isEmpty ? 0. : container.atFrameSize(container.countFrameSize() - 1);
+            return isEmpty ? static_cast<double>(CAP_PROP_UNKNOWN) : container.atFrameSize(container.countFrameSize() - 1);
         }
         if( propId == VIDEOWRITER_PROP_NSTRIPES )
             return nstripes;
-        return 0.;
+        return static_cast<double>(CAP_PROP_UNKNOWN);
     }
 
     bool setProperty(int propId, double value) CV_OVERRIDE

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -2290,7 +2290,7 @@ double CvCapture_MSMF::getProperty( int property_id ) const
         default:
             break;
         }
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 template <typename CtrlT>
@@ -2764,7 +2764,7 @@ double CvVideoWriter_MSMF::getProperty(int propId) const
     {
         return static_cast<double>(va_device);
     }
-    return 0;
+    return CAP_PROP_UNKNOWN;
 }
 
 cv::Ptr<cv::IVideoWriter> cv::cvCreateVideoWriter_MSMF( const std::string& filename, int fourcc,

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -2764,7 +2764,7 @@ double CvVideoWriter_MSMF::getProperty(int propId) const
     {
         return static_cast<double>(va_device);
     }
-    return CAP_PROP_UNKNOWN;
+    return VIDEOWRITER_PROP_UNKNOWN;
 }
 
 cv::Ptr<cv::IVideoWriter> cv::cvCreateVideoWriter_MSMF( const std::string& filename, int fourcc,

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -2290,7 +2290,7 @@ double CvCapture_MSMF::getProperty( int property_id ) const
         default:
             break;
         }
-    return -1;
+    return -1.0;
 }
 
 template <typename CtrlT>

--- a/modules/videoio/src/cap_obsensor_capture.cpp
+++ b/modules/videoio/src/cap_obsensor_capture.cpp
@@ -216,7 +216,7 @@ bool VideoCapture_obsensor::retrieveFrame(int outputType, OutputArray frame)
 }
 
 double VideoCapture_obsensor::getProperty(int propIdx) const {
-    double rst = 0.0;
+    double rst = CAP_PROP_UNKNOWN;
     propIdx = propIdx & (~CAP_OBSENSOR_GENERATORS_MASK);
     // int gen = propIdx & CAP_OBSENSOR_GENERATORS_MASK;
     switch (propIdx)

--- a/modules/videoio/src/cap_obsensor_liborbbec.cpp
+++ b/modules/videoio/src/cap_obsensor_liborbbec.cpp
@@ -121,7 +121,7 @@ VideoCapture_obsensor::~VideoCapture_obsensor(){
 
 double VideoCapture_obsensor::getProperty(int propIdx) const
 {
-    double rst = 0.0;
+    double rst = CAP_PROP_UNKNOWN;
     propIdx = propIdx & (~CAP_OBSENSOR_GENERATORS_MASK);
     switch (propIdx)
     {

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -421,7 +421,7 @@ bool CvCapture_OpenNI2::readCamerasParams()
 
 double CvCapture_OpenNI2::getProperty( int propIdx ) const
 {
-    double propValue = 0;
+    double propValue = CAP_PROP_UNKNOWN;
 
     if( isOpened() )
     {
@@ -478,7 +478,7 @@ bool CvCapture_OpenNI2::setProperty( int propIdx, double propValue )
 
 double CvCapture_OpenNI2::getCommonProperty( int propIdx ) const
 {
-    double propValue = -1.0;
+    double propValue = CAP_PROP_UNKNOWN;
 
     switch( propIdx )
     {
@@ -576,13 +576,13 @@ double CvCapture_OpenNI2::getDepthGeneratorProperty( int propIdx ) const
     case CAP_PROP_OPENNI_BASELINE :
         if(baseline <= 0)
             if (!const_cast<CvCapture_OpenNI2*>(this)->readCamerasParams())
-                return 0;
+                return CAP_PROP_UNKNOWN;
         propValue = baseline;
         break;
     case CAP_PROP_OPENNI_FOCAL_LENGTH :
         if(depthFocalLength_VGA <= 0)
             if (!const_cast<CvCapture_OpenNI2*>(this)->readCamerasParams())
-                return 0;
+                return CAP_PROP_UNKNOWN;
         propValue = (double)depthFocalLength_VGA;
         break;
     case CAP_PROP_OPENNI_REGISTRATION :

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -478,7 +478,7 @@ bool CvCapture_OpenNI2::setProperty( int propIdx, double propValue )
 
 double CvCapture_OpenNI2::getCommonProperty( int propIdx ) const
 {
-    double propValue = 0;
+    double propValue = -1.0;
 
     switch( propIdx )
     {

--- a/modules/videoio/src/cap_pvapi.cpp
+++ b/modules/videoio/src/cap_pvapi.cpp
@@ -256,7 +256,7 @@ double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
         PvAttrEnumGet(Camera.Handle,"MulticastEnable",mEnable,sizeof(mEnable),NULL);
         if (strcmp(mEnable, "Off") == 0)
         {
-            return -1;
+            return -1.0;
         }
         else
         {

--- a/modules/videoio/src/cap_pvapi.cpp
+++ b/modules/videoio/src/cap_pvapi.cpp
@@ -256,7 +256,7 @@ double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
         PvAttrEnumGet(Camera.Handle,"MulticastEnable",mEnable,sizeof(mEnable),NULL);
         if (strcmp(mEnable, "Off") == 0)
         {
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         else
         {
@@ -286,7 +286,7 @@ double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
         else if (strcmp(triggerMode, "Software")==0)
             return 4.0;
         else
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
     case CAP_PROP_PVAPI_DECIMATIONHORIZONTAL:
         PvAttrUint32Get(Camera.Handle, "DecimationHorizontal", &nTemp);
         return (double)nTemp;
@@ -319,7 +319,7 @@ double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
         else if (strcmp(pixelFormat, "Bgra32")==0)
             return 8.0;
     }
-    return -1.0;
+    return CAP_PROP_UNKNOWN;
 }
 
 bool CvCaptureCAM_PvAPI::setProperty( int property_id, double value )

--- a/modules/videoio/src/cap_ueye.cpp
+++ b/modules/videoio/src/cap_ueye.cpp
@@ -159,7 +159,7 @@ VideoCapture_uEye::VideoCapture_uEye(int camera)
 
 double VideoCapture_uEye::getProperty(int property_id) const
 {
-    auto value = 0.;
+    auto value = CAP_PROP_UNKNOWN;
     switch (property_id)
     {
     case CAP_PROP_FRAME_WIDTH:

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1842,7 +1842,7 @@ double CvCaptureCAM_V4L::getProperty(int property_id) const
         sp.type = type;
         if (!tryIoctl(VIDIOC_G_PARM, &sp)) {
             CV_LOG_WARNING(NULL, "VIDEOIO(V4L2:" << deviceName << "): Unable to get camera FPS");
-            return -1;
+            return -1.0;
         }
         return sp.parm.capture.timeperframe.denominator / (double)sp.parm.capture.timeperframe.numerator;
     }
@@ -1859,12 +1859,12 @@ double CvCaptureCAM_V4L::getProperty(int property_id) const
         __u32 v4l2id;
         if(!controlInfo(property_id, v4l2id, range))
             return -1.0;
-        int value = 0;
+        int value = -1;
         if(!icvControl(v4l2id, value, false))
             return -1.0;
         if (normalizePropRange && compatibleRange(property_id))
             return ((double)value - range.start) / range.size();
-        return  value;
+        return (double) value;
     }
     }
 }

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1647,15 +1647,15 @@ static inline int capPropertyToV4L2(int prop)
 {
     switch (prop) {
     case cv::CAP_PROP_FPS:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_FOURCC:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_FRAME_COUNT:
         return V4L2_CID_MPEG_VIDEO_B_FRAMES;
     case cv::CAP_PROP_FORMAT:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_MODE:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_BRIGHTNESS:
         return V4L2_CID_BRIGHTNESS;
     case cv::CAP_PROP_CONTRAST:
@@ -1669,13 +1669,13 @@ static inline int capPropertyToV4L2(int prop)
     case cv::CAP_PROP_EXPOSURE:
         return V4L2_CID_EXPOSURE_ABSOLUTE;
     case cv::CAP_PROP_CONVERT_RGB:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_WHITE_BALANCE_BLUE_U:
         return V4L2_CID_BLUE_BALANCE;
     case cv::CAP_PROP_RECTIFICATION:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_MONOCHROME:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_SHARPNESS:
         return V4L2_CID_SHARPNESS;
     case cv::CAP_PROP_AUTO_EXPOSURE:
@@ -1685,9 +1685,9 @@ static inline int capPropertyToV4L2(int prop)
     case cv::CAP_PROP_TEMPERATURE:
         return V4L2_CID_WHITE_BALANCE_TEMPERATURE;
     case cv::CAP_PROP_TRIGGER:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_TRIGGER_DELAY:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_WHITE_BALANCE_RED_V:
         return V4L2_CID_RED_BALANCE;
     case cv::CAP_PROP_ZOOM:
@@ -1695,7 +1695,7 @@ static inline int capPropertyToV4L2(int prop)
     case cv::CAP_PROP_FOCUS:
         return V4L2_CID_FOCUS_ABSOLUTE;
     case cv::CAP_PROP_GUID:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_ISO_SPEED:
         return V4L2_CID_ISO_SENSITIVITY;
     case cv::CAP_PROP_BACKLIGHT:
@@ -1709,9 +1709,9 @@ static inline int capPropertyToV4L2(int prop)
     case cv::CAP_PROP_IRIS:
         return V4L2_CID_IRIS_ABSOLUTE;
     case cv::CAP_PROP_SETTINGS:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_BUFFERSIZE:
-        return -1;
+        return CAP_PROP_UNKNOWN;
     case cv::CAP_PROP_AUTOFOCUS:
         return V4L2_CID_FOCUS_AUTO;
     case cv::CAP_PROP_SAR_NUM:
@@ -1725,7 +1725,7 @@ static inline int capPropertyToV4L2(int prop)
     default:
         break;
     }
-    return -1;
+    return CAP_PROP_UNKNOWN;
 }
 
 static inline bool compatibleRange(int property_id)
@@ -1842,7 +1842,7 @@ double CvCaptureCAM_V4L::getProperty(int property_id) const
         sp.type = type;
         if (!tryIoctl(VIDIOC_G_PARM, &sp)) {
             CV_LOG_WARNING(NULL, "VIDEOIO(V4L2:" << deviceName << "): Unable to get camera FPS");
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         }
         return sp.parm.capture.timeperframe.denominator / (double)sp.parm.capture.timeperframe.numerator;
     }
@@ -1858,10 +1858,10 @@ double CvCaptureCAM_V4L::getProperty(int property_id) const
         cv::Range range;
         __u32 v4l2id;
         if(!controlInfo(property_id, v4l2id, range))
-            return -1.0;
-        int value = -1;
+            return CAP_PROP_UNKNOWN;
+        int value = CAP_PROP_UNKNOWN;
         if(!icvControl(v4l2id, value, false))
-            return -1.0;
+            return CAP_PROP_UNKNOWN;
         if (normalizePropRange && compatibleRange(property_id))
             return ((double)value - range.start) / range.size();
         return (double) value;

--- a/modules/videoio/src/cap_winrt_capture.hpp
+++ b/modules/videoio/src/cap_winrt_capture.hpp
@@ -50,7 +50,7 @@ namespace cv {
         virtual ~VideoCapture_WinRT() {}
 
         // from base class IVideoCapture
-        virtual double getProperty(int) { return 0; }
+        virtual double getProperty(int) { return CAP_PROP_UNKNOWN; }
         virtual bool setProperty(int, double);
         virtual bool grabFrame();
         virtual bool retrieveFrame(int channel, cv::OutputArray outArray);

--- a/modules/videoio/src/cap_ximea.cpp
+++ b/modules/videoio/src/cap_ximea.cpp
@@ -1010,7 +1010,7 @@ bool CvCaptureCAM_XIMEA::setProperty( int property_id, double value )
 double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
 {
     XI_RETURN stat = XI_OK;
-    double getPropVal = 0;
+    double getPropVal = -1.0;
     int ival = 0;
     float fval = 0;
     string ximea_param = "";
@@ -1019,7 +1019,7 @@ double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
     if(hmv == NULL)
     {
         errMsg("CvCaptureCAM_XIMEA::getProperty", XI_INVALID_HANDLE);
-        return 0;
+        return -1.0;
     }
 
     // convert OCV property id to XIMEA id if necessary
@@ -1625,7 +1625,7 @@ double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
     default:
         // report invalid parameter as it is not of string type
         errMsg("CvCaptureCAM_XIMEA::getProperty", XI_UNKNOWN_PARAM);
-        return 0;
+        return -1.0;
     }
 
     switch(value_type)

--- a/modules/videoio/src/cap_ximea.cpp
+++ b/modules/videoio/src/cap_ximea.cpp
@@ -1010,7 +1010,7 @@ bool CvCaptureCAM_XIMEA::setProperty( int property_id, double value )
 double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
 {
     XI_RETURN stat = XI_OK;
-    double getPropVal = -1.0;
+    double getPropVal = CAP_PROP_UNKNOWN;
     int ival = 0;
     float fval = 0;
     string ximea_param = "";
@@ -1019,7 +1019,7 @@ double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
     if(hmv == NULL)
     {
         errMsg("CvCaptureCAM_XIMEA::getProperty", XI_INVALID_HANDLE);
-        return -1.0;
+        return CAP_PROP_UNKNOWN;
     }
 
     // convert OCV property id to XIMEA id if necessary
@@ -1625,7 +1625,7 @@ double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
     default:
         // report invalid parameter as it is not of string type
         errMsg("CvCaptureCAM_XIMEA::getProperty", XI_UNKNOWN_PARAM);
-        return -1.0;
+        return CAP_PROP_UNKNOWN;
     }
 
     switch(value_type)
@@ -1646,6 +1646,7 @@ double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
     default:
         // unknown value type selected
         errMsg("CvCaptureCAM_XIMEA::getProperty", XI_WRONG_PARAM_TYPE);
+        getPropVal = CAP_PROP_UNKNOWN;
     }
     return getPropVal;
 }

--- a/modules/videoio/src/cap_xine.cpp
+++ b/modules/videoio/src/cap_xine.cpp
@@ -221,7 +221,7 @@ class XINECapture : public IVideoCapture
         case CAP_PROP_FPS: return frame_rate;
         case CAP_PROP_FOURCC: return (double)xine_get_stream_info(stream, XINE_STREAM_INFO_VIDEO_FOURCC);
         }
-        return 0;
+        return -1.0;
     }
 
     bool setProperty(int property_id, double value) CV_OVERRIDE

--- a/modules/videoio/src/cap_xine.cpp
+++ b/modules/videoio/src/cap_xine.cpp
@@ -213,15 +213,15 @@ class XINECapture : public IVideoCapture
 
         switch (property_id)
         {
-        case CAP_PROP_POS_MSEC: return res ? pos_t : 0;
+        case CAP_PROP_POS_MSEC: return res ? pos_t : CAP_PROP_UNKNOWN;
         case CAP_PROP_POS_FRAMES: return frame_number;
-        case CAP_PROP_POS_AVI_RATIO: return length && res ? pos_l / 65535.0 : 0.0;
+        case CAP_PROP_POS_AVI_RATIO: return length && res ? pos_l / 65535.0 : CAP_PROP_UNKNOWN;
         case CAP_PROP_FRAME_WIDTH: return size.width;
         case CAP_PROP_FRAME_HEIGHT: return size.height;
         case CAP_PROP_FPS: return frame_rate;
         case CAP_PROP_FOURCC: return (double)xine_get_stream_info(stream, XINE_STREAM_INFO_VIDEO_FOURCC);
         }
-        return -1.0;
+        return CAP_PROP_UNKNOWN;
     }
 
     bool setProperty(int property_id, double value) CV_OVERRIDE

--- a/modules/videoio/test/test_gstreamer.cpp
+++ b/modules/videoio/test/test_gstreamer.cpp
@@ -26,6 +26,8 @@ TEST_P(videoio_gstreamer, read_check)
     ASSERT_NO_THROW(cap.open(pipeline.str(), CAP_GSTREAMER));
     ASSERT_TRUE(cap.isOpened());
 
+    EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
+
     Mat buffer, decode_frame, gray_frame, rgb_frame;
     for (int i = 0; i < count_frames; ++i)
     {

--- a/modules/videoio/test/test_images.cpp
+++ b/modules/videoio/test/test_images.cpp
@@ -143,6 +143,7 @@ TEST(videoio_images, write_returns_status)
     col.generate(1);
     VideoWriter wri(col.getFirstFilename(), CAP_IMAGES, 0, 0, col.getFrame(0).size());
     ASSERT_TRUE(wri.isOpened());
+    EXPECT_EQ(CAP_PROP_UNKNOWN, wri.get(CV__CAP_PROP_LATEST));
 
     const Mat frame = col.getFrame(0);
 
@@ -345,6 +346,7 @@ TEST_P(videoio_image_seq_start, open)
         ASSERT_TRUE(cap.open(pattern, apiPref,
                              { CAP_PROP_IMAGE_SEQ_START, start }));
         ASSERT_TRUE(cap.isOpened());
+        EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
         for (size_t idx = 0; idx < count; ++idx)
         {
             Mat img;

--- a/modules/videoio/test/test_v4l2.cpp
+++ b/modules/videoio/test/test_v4l2.cpp
@@ -169,6 +169,7 @@ TEST(videoio_ffmpeg, camera_index)
     ASSERT_TRUE(cap.open(0, CAP_FFMPEG));
     Mat frame;
     ASSERT_TRUE(cap.read(frame));
+    EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
     ASSERT_FALSE(frame.empty());
 }
 

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -64,6 +64,14 @@ public:
             std::cout << "SKIP test: backend " << apiPref << " can't open the video: " << video_file << std::endl;
             return;
         }
+
+// TODO: Requires FFmpeg wrapper rebuild for Windows
+#ifdef _WIN32
+        if (apiPref != CAP_FFMPEG)
+            EXPECT_EQ(CAP_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
+#else
+        EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
+#endif
         int n_frames = -1;
         EXPECT_NO_THROW(n_frames = (int)cap.get(CAP_PROP_FRAME_COUNT));
         if (n_frames > 0)
@@ -528,6 +536,15 @@ TEST_P(Videoio_Writer, write_nothing)
     VideoWriter writer;
     EXPECT_NO_THROW(writer.open(video_file, apiPref, fourcc, fps, frame_size, true));
     ASSERT_TRUE(writer.isOpened());
+
+// TODO: Requires FFmpeg wrapper rebuild for Windows
+#ifdef _WIN32
+    if (apiPref != CAP_FFMPEG)
+        EXPECT_EQ(CAP_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
+#else
+    EXPECT_EQ(cv::VIDEOWRITER_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
+#endif
+
 #if 0  // no frames
     cv::Mat m(frame_size, CV_8UC3, Scalar::all(127));
     writer << m;

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -68,7 +68,7 @@ public:
 // TODO: Requires FFmpeg wrapper rebuild for Windows
 #ifdef _WIN32
         if (apiPref != CAP_FFMPEG)
-            EXPECT_EQ(CAP_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
+            EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
 #else
         EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
 #endif


### PR DESCRIPTION
The return value indicating an unsupported property is not consistent across backends.

I stumbled on this issue because my code was determining if a property value is valid if it's non-zero (like the documentation says), which worked fine on macOS, but not on Android.

For example, auto-exposure is not supported on macOS, so get() returns 0. But it is supported on Android and 0 means auto-exposure is off.

I think -1 is the better return value to indicate unsupported properties.

I made changes to all the backends. I think I got every case. This breaks API compatibility for some backends, so I based this on branch 3.4.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
