### PR TITLE
python: use '((x,y), (w,h), angle)' in std::vector<RotatedRect>

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -104,6 +104,21 @@ String dumpRotatedRect(const RotatedRect& argument)
 }
 
 CV_WRAP static inline
+RotatedRect testRotatedRect(float x, float y, float w, float h, float angle)
+{
+    return RotatedRect(Point2f(x, y), Size2f(w, h), angle);
+}
+
+CV_WRAP static inline
+std::vector<RotatedRect> testRotatedRectVector(float x, float y, float w, float h, float angle)
+{
+    std::vector<RotatedRect> result;
+    for (int i = 0; i < 10; i++)
+        result.push_back(RotatedRect(Point2f(x + i, y + 2 * i), Size2f(w, h), angle + 10 * i));
+    return result;
+}
+
+CV_WRAP static inline
 String dumpRange(const Range& argument)
 {
     if (argument == Range::all())

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -518,6 +518,10 @@ template <class T>
 struct IsRepresentableAsMatDataType<T, typename VoidType<typename DataType<T>::channel_type>::type> : TrueType
 {
 };
+
+// https://github.com/opencv/opencv/issues/20930
+template <> struct IsRepresentableAsMatDataType<RotatedRect, void> : FalseType {};
+
 } // namespace traits
 
 typedef std::vector<uchar> vector_uchar;

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -583,6 +583,18 @@ class Arguments(NewOpenCVTests):
         self.assertEqual(ints.dtype, np.int32, "Vector of integers has wrong elements type")
         self.assertEqual(ints.shape, expected_shape, "Vector of integers has wrong shape.")
 
+    def test_result_rotated_rect_issue_20930(self):
+        rr = cv.utils.testRotatedRect(10, 20, 100, 200, 45)
+        self.assertTrue(isinstance(rr, tuple), msg=type(rr))
+        self.assertEqual(len(rr), 3)
+
+        rrv = cv.utils.testRotatedRectVector(10, 20, 100, 200, 45)
+        self.assertTrue(isinstance(rrv, tuple), msg=type(rrv))
+        self.assertEqual(len(rrv), 10)
+
+        rr = rrv[0]
+        self.assertTrue(isinstance(rr, tuple), msg=type(rrv))
+        self.assertEqual(len(rr), 3)
 
 class SamplesFindFile(NewOpenCVTests):
 


### PR DESCRIPTION
resolves #20930

/cc @UnaNancyOwen @berak