### PR TITLE
release: OpenCV 4.5.5

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    5
 #define CV_VERSION_REVISION 5
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 4.5.5

relates #21281


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world455.dll (vc14)](https://www.virustotal.com/gui/file/95c909d2a741732cccdf64ca21b7fbcbc2ee6e2b4f5434912a61b50e12b96d74)
[opencv_world455d.dll (vc14)](https://www.virustotal.com/gui/file/c9efe3d4a9cdab27761f26ebd29cd6a159f0dbaa6c08c52fc5e51a9f6c13f2a9) 
[opencv_world455.dll (vc15)](https://www.virustotal.com/gui/file/f281767a1ed3b9cf045da9304a66af73fc90c7942b905b98e53f18512be2738e)
[opencv_world455d.dll (vc15)](https://www.virustotal.com/gui/file/cec3940af60c31c696b5af9e22742aff187b2d696df963b7e84874b1fbb9f0e8)

[opencv_videoio_ffmpeg455_64.dll](https://www.virustotal.com/gui/file/865bd4199488cbf8d5d19082292de1556a652b6ad0ec82ac560c673f2ac91e6c)

</details>
