### PR TITLE
(3.4) core(OpenCL): add option to abort on OpenCL kernel build failure

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -153,6 +153,17 @@ static bool isRaiseError()
 }
 #endif
 
+static void onOpenCLKernelBuildError()
+{
+    // NB: no need to cache this value
+    bool value = cv::utils::getConfigurationParameterBool("OPENCV_OPENCL_ABORT_ON_BUILD_ERROR", false);
+    if (value)
+    {
+        fprintf(stderr, "Abort on OpenCL kernel build failure!\n");
+        abort();
+    }
+}
+
 #if CV_OPENCL_TRACE_CHECK
 static inline
 void traceOpenCLCheck(cl_int status, const char* message)
@@ -3880,6 +3891,12 @@ struct Program::Impl
                 {
                     CV_OCL_DBG_CHECK(clReleaseProgram(handle));
                     handle = NULL;
+                }
+                if (retval != CL_SUCCESS &&
+                    sourceName_ != "dummy"  // used for testing of compilation flags
+                )
+                {
+                    onOpenCLKernelBuildError();
                 }
             }
 #if CV_OPENCL_VALIDATE_BINARY_PROGRAMS


### PR DESCRIPTION
relates #21356

```
test_opencl:Custom Mac=ON
```