### PR TITLE
G-API: Suppress ngraph warnings for MSVS2015 (4268)

### DIFF
--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -30,7 +30,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4100)
 # if _MSC_VER < 1910
-#  pragma warning(disable:4268) // Disable warnings of ngraph. OpenVINO recommends use MSVS 2019.
+#  pragma warning(disable:4268) // Disable warnings of ngraph. OpenVINO recommends to use MSVS 2019.
+#  pragma warning(disable:4800)
 # endif
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -29,6 +29,9 @@
 #elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4100)
+# if _MSC_VER < 1900
+#  pragma warning(disable:4268) // Disable warnings of ngraph. OpenVINO recommends use MSVS 2019.
+# endif
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -29,7 +29,7 @@
 #elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4100)
-# if _MSC_VER < 1900
+# if _MSC_VER < 1910
 #  pragma warning(disable:4268) // Disable warnings of ngraph. OpenVINO recommends use MSVS 2019.
 # endif
 #elif defined(__GNUC__)


### PR DESCRIPTION
Relates #21134

OpenVINO recommends to use MSVS 2019.  Warnings (4268) are disabled.

```
force_builders=Custom Win
build_image:Custom Win=openvino-2021.4.2-vc14
test_modules:Custom Win=dnn,gapi,python2,python3,java
```