### PR TITLE
Fix #21366

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -1570,7 +1570,7 @@ namespace cv{
 #define CONDITION_S img_row[c - 1] > 0
 #define CONDITION_X img_row[c] > 0
 
-#define ACTION_1 // nothing to do
+#define ACTION_1 img_labels_row[c] = 0;
 #define ACTION_2 img_labels_row[c] = label; \
                     P_[label] = label; \
                     label = label + 1;
@@ -1831,7 +1831,7 @@ namespace cv{
 
             std::vector<LabelT> P_(Plength, 0);
             LabelT* P = P_.data();
-            //P[0] = 0;
+            P[0] = 0;
             LabelT lunique = 1;
 
             // First scan
@@ -1851,7 +1851,7 @@ namespace cv{
 #define CONDITION_S img_row[c - 1] > 0
 #define CONDITION_X img_row[c] > 0
 
-#define ACTION_1 // nothing to do
+#define ACTION_1 img_labels_row[c] = 0;
 #define ACTION_2 img_labels_row[c] = lunique; \
                                      P[lunique] = lunique;        \
                                      lunique = lunique + 1; // new label

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -789,5 +789,16 @@ TEST(Imgproc_ConnectedComponents, single_column)
 }
 
 
+TEST(Imgproc_ConnectedComponents, 4conn_regression_21366)
+{
+    Mat src = Mat::zeros(Size(10, 10), CV_8UC1);
+    {
+        Mat labels, stats, centroids;
+        EXPECT_NO_THROW(cv::connectedComponentsWithStats(src, labels, stats, centroids, 4));
+    }
+}
+
+
+
 }
 } // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Pull Request Description

Fixes bug referenced in issue #21366, regarding CCL algorithms LabelingBolelli4C and LabelingBolelli4CParallel.
