### PR TITLE
apple/build_xcframework.py: fix incorrect catalyst archs

### DIFF
--- a/platforms/apple/build_xcframework.py
+++ b/platforms/apple/build_xcframework.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         macos_archs = "x86_64,arm64"
     print('Using MacOS ARCHS={}'.format(macos_archs))
 
-    catalyst_archs = args.macos_archs
+    catalyst_archs = args.catalyst_archs
     if not catalyst_archs and not args.build_only_specified_archs:
         # Supply defaults
         catalyst_archs = "x86_64,arm64"


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
