### PR TITLE
kmeans: assertion "There can't be more clusters than elements"

### DIFF
--- a/modules/core/src/kmeans.cpp
+++ b/modules/core/src/kmeans.cpp
@@ -240,7 +240,7 @@ double cv::kmeans( InputArray _data, int K,
 
     attempts = std::max(attempts, 1);
     CV_Assert( data0.dims <= 2 && type == CV_32F && K > 0 );
-    CV_CheckGE(N, K, "Number of clusters should be more than number of elements");
+    CV_CheckGE(N, K, "There can't be more clusters than elements");
 
     Mat data(N, dims, CV_32F, data0.ptr(), isrow ? dims * sizeof(float) : static_cast<size_t>(data0.step));
 


### PR DESCRIPTION
Related to [this Stack Overflow question](https://stackoverflow.com/questions/70632193/error-message-in-opencv-number-of-clusters-should-be-more-than-number-of-elemen), the assertion _message_ of which greatly surprised me.

Someone please consider if this makes sense. It's so strange that I question my perception. `N` is the number of elements, `K` is the number of clusters.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
