### PR TITLE
GAPI Resize: fix rounding of the scaled size

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -504,8 +504,8 @@ namespace imgproc {
             }
             else
             {
-                int outSz_w = static_cast<int>(round(in.size.width  * fx));
-                int outSz_h = static_cast<int>(round(in.size.height * fy));
+                int outSz_w = saturate_cast<int>(in.size.width  * fx);
+                int outSz_h = saturate_cast<int>(in.size.height * fy);
                 GAPI_Assert(outSz_w > 0 && outSz_h > 0);
                 return in.withSize(Size(outSz_w, outSz_h));
             }

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -2333,8 +2333,8 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     MatType type = -1;
     int interp = 1;
     cv::Size sz;
-    double fx = 0.0;
-    double fy = 0.0;
+    double fx = 1.0;
+    double fy = 1.0;
     cv::GCompileArgs compile_args;
     std::tie(cmpF, type, interp, sz, fx, fy, compile_args) = GetParam();
 
@@ -2342,7 +2342,7 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     cv::Scalar mean = cv::Scalar::all(127);
     cv::Scalar stddev = cv::Scalar::all(40.f);
     cv::randn(in_mat1, mean, stddev);
-    cv::Size sz_out = cv::Size(saturate_cast<int>(sz.width *fx), saturate_cast<int>(sz.height*fy));
+    cv::Size sz_out = cv::Size();
     out_mat_gapi = cv::Mat(sz_out, type);
     out_mat_ocv = cv::Mat(sz_out, type);
 

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -353,7 +353,7 @@ INSTANTIATE_TEST_CASE_P(ResizeInSimpleGraphPerfTestFluid, ResizeInSimpleGraphPer
             Values(cv::compile_args(CORE_FLUID, IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ResizeFxFyPerfTestFluid, ResizeFxFyPerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
+    Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC3),
             Values(cv::INTER_LINEAR),
             Values(szSmall128, szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/gpu/gapi_core_perf_tests_gpu.cpp
+++ b/modules/gapi/perf/gpu/gapi_core_perf_tests_gpu.cpp
@@ -320,8 +320,8 @@ INSTANTIATE_TEST_CASE_P(TransposePerfTestGPU, TransposePerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(CV_8UC1, CV_16UC1, CV_16SC1, CV_32FC1,
-                    CV_8UC2, CV_16UC2, CV_16SC2, CV_32FC2,
-                    CV_8UC3, CV_16UC3, CV_16SC3, CV_32FC3),
+                   CV_8UC2, CV_16UC2, CV_16SC2, CV_32FC2,
+                   CV_8UC3, CV_16UC3, CV_16SC3, CV_32FC3),
             Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(ResizePerfTestGPU, ResizePerfTest,
@@ -330,14 +330,14 @@ INSTANTIATE_TEST_CASE_P(ResizePerfTestGPU, ResizePerfTest,
             Values(cv::INTER_NEAREST, cv::INTER_LINEAR, cv::INTER_AREA),
             Values( szSmall128, szVGA, sz720p, sz1080p ),
             Values(cv::Size(64,64),
-                    cv::Size(30,30)),
+                   cv::Size(30,30)),
             Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(ResizeFxFyPerfTestGPU, ResizeFxFyPerfTest,
-    Combine(Values(AbsSimilarPoints(2, 0.05).to_compare_f()),
+    Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_16UC1, CV_16SC1),
             Values(cv::INTER_NEAREST, cv::INTER_LINEAR, cv::INTER_AREA),
-            Values( szSmall128, szVGA, sz720p, sz1080p ),
+            Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(0.5, 0.1),
             Values(0.5, 0.1),
             Values(cv::compile_args(CORE_GPU))));


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/19379
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```