### PR TITLE
Adapt remote inference to operate with NV12 blobs

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -19,6 +19,8 @@
 #include <functional>
 #include <unordered_set>
 #include <atomic>
+#include <tuple>
+
 
 #include <ade/util/algorithm.hpp>
 
@@ -507,18 +509,29 @@ inline IE::Blob::Ptr extractRemoteBlob(IECallContext& ctx, std::size_t i) {
     cv::util::any any_blob_params = ctx.inFrame(i).blobParams();
     auto ie_core = cv::gimpl::ie::wrap::getCore();
 
-    using ParamType = std::pair<InferenceEngine::TensorDesc,
-                                InferenceEngine::ParamMap>;
+    using ParamType = std::pair<std::pair<InferenceEngine::TensorDesc,
+                                 InferenceEngine::ParamMap>,
+                                 std::pair<InferenceEngine::TensorDesc,
+                                 InferenceEngine::ParamMap>>;
 
     ParamType* blob_params = cv::util::any_cast<ParamType>(&any_blob_params);
     if (blob_params == nullptr) {
         GAPI_Assert(false && "Incorrect type of blobParams: "
-                              "expected std::pair<InferenceEngine::TensorDesc,"
-                                                 "InferenceEngine::ParamMap>");
+                              "expected std::tuple<InferenceEngine::TensorDesc,"
+                                                  "InferenceEngine::ParamMap,"
+                                                  "InferenceEngine::TensorDesc,"
+                                                  "InferenceEngine::ParamMap>");
     }
 
-    return ctx.uu.rctx->CreateBlob(blob_params->first,
-                                   blob_params->second);
+    auto y_blob = ctx.uu.rctx->CreateBlob(blob_params->first.first, blob_params->first.second);
+    auto uv_blob = ctx.uu.rctx->CreateBlob(blob_params->second.first, blob_params->second.second);
+
+#if INF_ENGINE_RELEASE >= 2021010000
+    return IE::make_shared_blob<IE::NV12Blob>(y_blob, uv_blob);
+#else
+    return IE::make_shared_blob<InferenceEngine::NV12Blob>(y_blob, uv_blob);
+#endif
+
 }
 
 inline IE::Blob::Ptr extractBlob(IECallContext& ctx,

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -509,20 +509,18 @@ inline IE::Blob::Ptr extractRemoteBlob(IECallContext& ctx, std::size_t i) {
     cv::util::any any_blob_params = ctx.inFrame(i).blobParams();
     auto ie_core = cv::gimpl::ie::wrap::getCore();
 
-    using ParamType = std::pair<std::pair<InferenceEngine::TensorDesc,
-                                 InferenceEngine::ParamMap>,
-                                 std::pair<InferenceEngine::TensorDesc,
-                                 InferenceEngine::ParamMap>>;
+    using ParamType = std::pair<InferenceEngine::TensorDesc, InferenceEngine::ParamMap>;
+    using NV12ParamType = std::pair<ParamType, ParamType>;
 
-    ParamType* blob_params = cv::util::any_cast<ParamType>(&any_blob_params);
+    NV12ParamType* blob_params = cv::util::any_cast<NV12ParamType>(&any_blob_params);
     if (blob_params == nullptr) {
-        GAPI_Assert(false && "Incorrect type of blobParams: "
-                              "expected std::tuple<InferenceEngine::TensorDesc,"
-                                                  "InferenceEngine::ParamMap,"
-                                                  "InferenceEngine::TensorDesc,"
-                                                  "InferenceEngine::ParamMap>");
+        GAPI_Assert(false && "Incorrect type of blobParams:"
+                             "expected std::pair<ParamType, ParamType>,"
+                             "with ParamType std::pair<InferenceEngine::TensorDesc,"
+                                                      "InferenceEngine::ParamMap >>");
     }
 
+    //The parameters are TensorDesc and ParamMap for both y and uv blobs
     auto y_blob = ctx.uu.rctx->CreateBlob(blob_params->first.first, blob_params->first.second);
     auto uv_blob = ctx.uu.rctx->CreateBlob(blob_params->second.first, blob_params->second.second);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
