### PR TITLE
Force cv::Mat for std::cout in dnn

### DIFF
--- a/modules/dnn/src/dnn_common.hpp
+++ b/modules/dnn/src/dnn_common.hpp
@@ -57,7 +57,7 @@ static inline std::string toString(const Mat& blob, const std::string& name = st
     {
         Mat blob_ = blob;
         blob_.dims = 2;  // hack
-        ss << blob_.t();
+        ss << cv::Mat(blob_.t());
     }
     else
     {

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -43,8 +43,8 @@ static void test(Mat& input, Net& net, Backend backendId, Target targetId, bool 
     if (cvtest::debugLevel > 0 || testing::Test::HasFailure())
     {
         std::cout << "l1=" << l1 << "  lInf=" << lInf << std::endl;
-        std::cout << outputDefault.reshape(1, outputDefault.total()).t() << std::endl;
-        std::cout << outputHalide.reshape(1, outputDefault.total()).t() << std::endl;
+        std::cout << cv::Mat(outputDefault.reshape(1, outputDefault.total()).t()) << std::endl;
+        std::cout << cv::Mat(outputHalide.reshape(1, outputDefault.total()).t()) << std::endl;
     }
 }
 


### PR DESCRIPTION
My compiler gets confused with the two overloads:
./modules/core/include/opencv2/core/cvstd.inl.hpp:87:15: note: candidate function
std::ostream& operator << (std::ostream& out, const Mat& mtx)
              ^
./modules/dnn/include/opencv2/dnn/dnn.inl.hpp:301:22: note: candidate function
inline std::ostream &operator<<(std::ostream &stream, const DictValue &dictv)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
