### PR TITLE
TiffEncoder write support more depth type

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -717,7 +717,7 @@ ImageEncoder TiffEncoder::newEncoder() const
 
 bool TiffEncoder::isFormatSupported( int depth ) const
 {
-    return depth == CV_8U || depth == CV_16U || depth == CV_32F || depth == CV_64F;
+    return depth == CV_8U || depth == CV_8S || depth == CV_16U || depth == CV_16S || depth == CV_32S || depth == CV_32F || depth == CV_64F;
 }
 
 void  TiffEncoder::writeTag( WLByteStream& strm, TiffTag tag,
@@ -861,7 +861,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         int width = img.cols, height = img.rows;
         int type = img.type();
         int depth = CV_MAT_DEPTH(type);
-        CV_CheckType(type, depth == CV_8U || depth == CV_16U || depth == CV_32F || depth == CV_64F, "");
+        CV_CheckType(type, depth == CV_8U || depth == CV_8S || depth == CV_16U || depth == CV_16S || depth == CV_32S || depth == CV_32F || depth == CV_64F, "");
         CV_CheckType(type, channels >= 1 && channels <= 4, "");
 
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width));
@@ -884,19 +884,28 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         int page_compression = compression;
 
         int bitsPerChannel = -1;
+        uint16 sample_format = SAMPLEFORMAT_INT;
         switch (depth)
         {
             case CV_8U:
+                sample_format = SAMPLEFORMAT_UINT;
+            case CV_8S:
             {
                 bitsPerChannel = 8;
                 break;
             }
+
             case CV_16U:
+                sample_format = SAMPLEFORMAT_UINT;
+            case CV_16S:
             {
                 bitsPerChannel = 16;
                 break;
             }
+
             case CV_32F:
+                sample_format = SAMPLEFORMAT_IEEEFP;
+            case CV_32S:
             {
                 bitsPerChannel = 32;
                 page_compression = COMPRESSION_NONE;
@@ -906,6 +915,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
             {
                 bitsPerChannel = 64;
                 page_compression = COMPRESSION_NONE;
+                sample_format = SAMPLEFORMAT_IEEEFP;
                 break;
             }
             default:
@@ -931,7 +941,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG));
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, rowsPerStrip));
 
-        CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, depth >= CV_32F ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
+        CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, sample_format));
 
         if (page_compression != COMPRESSION_NONE)
         {
@@ -1030,7 +1040,7 @@ bool  TiffEncoder::write( const Mat& img, const std::vector<int>& params)
     int type = img.type();
     int depth = CV_MAT_DEPTH(type);
 
-    CV_CheckType(type, depth == CV_8U || depth == CV_16U || depth == CV_32F || depth == CV_64F, "");
+    CV_CheckType(type, depth == CV_8U || depth == CV_8S || depth == CV_16U || depth == CV_16S || depth == CV_32S || depth == CV_32F || depth == CV_64F, "");
 
     std::vector<Mat> img_vec;
     img_vec.push_back(img);

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -889,6 +889,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         {
             case CV_8U:
                 sample_format = SAMPLEFORMAT_UINT;
+                /* FALLTHRU */
             case CV_8S:
             {
                 bitsPerChannel = 8;
@@ -897,6 +898,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
 
             case CV_16U:
                 sample_format = SAMPLEFORMAT_UINT;
+                /* FALLTHRU */
             case CV_16S:
             {
                 bitsPerChannel = 16;
@@ -905,6 +907,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
 
             case CV_32F:
                 sample_format = SAMPLEFORMAT_IEEEFP;
+                /* FALLTHRU */
             case CV_32S:
             {
                 bitsPerChannel = 32;

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -150,15 +150,14 @@ TEST(Imgcodecs_Tiff, decode_infinite_rowsperstrip)
 TEST(Imgcodecs_Tiff, readWrite_unsigned)
 {
     const string root = cvtest::TS::ptr()->get_data_path();
-    const string filenameInput = root + "readwrite/gray_8u.tiff";
+    const string filenameInput = root + "readwrite/gray_8u.tif";
     const string filenameOutput = cv::tempfile(".tiff");
     const Mat img = cv::imread(filenameInput, IMREAD_UNCHANGED);
     ASSERT_FALSE(img.empty());
     ASSERT_EQ(CV_8UC1, img.type());
 
     Mat matS8;
-    img.copyTo(matS8);
-    matS8.flags |= CV_8SC1;	//hard code set type as CV_8SC1 for testing.
+    img.convertTo(matS8, CV_8SC1);
 
     ASSERT_TRUE(cv::imwrite(filenameOutput, matS8));
     const Mat img2 = cv::imread(filenameOutput, IMREAD_UNCHANGED);

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -147,6 +147,27 @@ TEST(Imgcodecs_Tiff, decode_infinite_rowsperstrip)
     EXPECT_EQ(0, remove(filename.c_str()));
 }
 
+TEST(Imgcodecs_Tiff, readWrite_unsigned)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filenameInput = root + "readwrite/gray_8u.tiff";
+    const string filenameOutput = cv::tempfile(".tiff");
+    const Mat img = cv::imread(filenameInput, IMREAD_UNCHANGED);
+    ASSERT_FALSE(img.empty());
+    ASSERT_EQ(CV_8UC1, img.type());
+
+    Mat matS8;
+    img.copyTo(matS8);
+    matS8.flags |= CV_8SC1;	//hard code set type as CV_8SC1 for testing.
+
+    ASSERT_TRUE(cv::imwrite(filenameOutput, matS8));
+    const Mat img2 = cv::imread(filenameOutput, IMREAD_UNCHANGED);
+    ASSERT_EQ(img2.type(), matS8.type());
+    ASSERT_EQ(img2.size(), matS8.size());
+    EXPECT_LE(cvtest::norm(matS8, img2, NORM_INF | NORM_RELATIVE), 1e-3);
+    EXPECT_EQ(0, remove(filenameOutput.c_str()));
+}
+
 TEST(Imgcodecs_Tiff, readWrite_32FC1)
 {
     const string root = cvtest::TS::ptr()->get_data_path();


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/955

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
opencv_extra=master
```