### PR TITLE
G-API: own::Mat size

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -346,10 +346,12 @@ namespace cv { namespace gapi { namespace own {
             return data + step * row + CV_ELEM_SIZE(type()) * col;
         }
 
+
     private:
         //actual memory allocated for storage, or nullptr if object is non owning view to over memory
         std::shared_ptr<uchar> memory;
     };
+
 } //namespace own
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -255,6 +255,10 @@ namespace cv { namespace gapi { namespace own {
             const auto sz = std::accumulate(_dims.begin(), _dims.end(), 1, std::multiplies<int>());
             tmp.memory.reset(new uchar[CV_ELEM_SIZE(_type)*sz], [](uchar * p){delete[] p;});
             tmp.data = tmp.memory.get();
+            // if (_dims.size() > 2) {
+            //     tmp.rows = -1;
+            //     tmp.cols = -1;
+            // }
             *this = std::move(tmp);
             this->size = MatSize(&this->rows, &this->dims);
         }

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -76,7 +76,7 @@ namespace cv { namespace gapi { namespace own {
              */
             int flags = 0;
 
-            //! the number of rows and columns or (-1, -1) when the matrix has more than 2 dimensions
+            //! the number of rows and columns
             int rows = 0, cols = 0;
             //! pointer to the data
             uchar* data = nullptr;
@@ -255,10 +255,6 @@ namespace cv { namespace gapi { namespace own {
             const auto sz = std::accumulate(_dims.begin(), _dims.end(), 1, std::multiplies<int>());
             tmp.memory.reset(new uchar[CV_ELEM_SIZE(_type)*sz], [](uchar * p){delete[] p;});
             tmp.data = tmp.memory.get();
-            // if (_dims.size() > 2) {
-            //     tmp.rows = -1;
-            //     tmp.cols = -1;
-            // }
             *this = std::move(tmp);
             this->size = MatSize(&this->rows, &this->dims);
         }

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -157,7 +157,7 @@ struct MatSize
 {
     MatSize() = default;
     explicit MatSize(int* _p, std::vector<int>* _dims_p) : p(_p), dims_p(_dims_p) {}
-    int dims() const
+    size_t dims() const
     {
         GAPI_DbgAssert(p[0] == -1 && p[1] == -1);
         return dims_p->size();
@@ -211,14 +211,14 @@ struct MatSize
 inline std::ostream& operator<<(std::ostream& o, const MatSize& s)
 {
     const auto dims = s.dims();
-    if (dims <= 2)
+    if (dims <= 2u)
     {
         o << "[" << s().width << " x " << s().height << "]";
     }
     else
     {
         o << "[";
-        for (int i = 0; i < dims; ++i)
+        for (size_t i = 0; i < dims; ++i)
         {
             o << s.dims_p->at(i);
             if (i != dims - 1) o << " x ";

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -9,6 +9,7 @@
 #define OPENCV_GAPI_TYPES_HPP
 
 #include <algorithm>              // std::max, std::min
+#include <vector>
 #include <opencv2/gapi/own/assert.hpp>
 #include <ostream>
 
@@ -156,7 +157,6 @@ struct MatSize
 {
     MatSize() = default;
     explicit MatSize(int* _p, std::vector<int>* _dims_p) : p(_p), dims_p(_dims_p) {}
-    #if !defined(GAPI_STANDALONE)
     int dims() const
     {
         GAPI_DbgAssert(p[0] == -1 && p[1] == -1);
@@ -195,13 +195,14 @@ struct MatSize
     }
     bool operator == (const MatSize& sz) const
     {
-        return (this->p[0] == sz[0] && this->p[1] == sz[1] && *this->dims_p == *sz.dims_p);
+        return ((this->p[0] == sz[0]) &&
+                (this->p[1] == sz[1]) &&
+                (*(this->dims_p) == *sz.dims_p));
     }
     bool operator != (const MatSize& sz) const
     {
         return !(*this == sz);
     }
-    #endif // !defined(GAPI_STANDALONE)
 
     int* p;
     std::vector<int>* dims_p;

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -12,7 +12,6 @@
 #include <vector>
 #include <opencv2/gapi/own/assert.hpp>
 #include <ostream>
-#include <iostream>
 
 namespace cv
 {
@@ -153,8 +152,6 @@ struct MatSize
     explicit MatSize(int* _p, std::vector<int>* _dims_p) : p(_p), dims_p(_dims_p) {}
     size_t dims() const
     {
-        GAPI_DbgAssert(p[0] == -1 && p[1] == -1);
-        std::cout << p[0] << std::endl;
         return dims_p->size();
     }
     Size operator()() const

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <opencv2/gapi/own/assert.hpp>
 #include <ostream>
+#include <iostream>
 
 namespace cv
 {
@@ -115,13 +116,6 @@ public:
         height = rhs.height;
         return *this;
     }
-    //! the area (width*height)
-    int area() {
-        const int result = width * height;
-        GAPI_DbgAssert(!std::numeric_limits<int>::is_integer
-            || width == 0 || result / width == height); // make sure the result fits in the return value
-        return result;
-    }
 #endif // !defined(GAPI_STANDALONE)
 
     int width  = 0;
@@ -160,6 +154,7 @@ struct MatSize
     size_t dims() const
     {
         GAPI_DbgAssert(p[0] == -1 && p[1] == -1);
+        std::cout << p[0] << std::endl;
         return dims_p->size();
     }
     Size operator()() const
@@ -193,13 +188,13 @@ struct MatSize
             return p[i];
         }
     }
-    bool operator == (const MatSize& sz) const
+    bool operator==(const MatSize& sz) const
     {
         return ((this->p[0] == sz[0]) &&
                 (this->p[1] == sz[1]) &&
                 (*(this->dims_p) == *sz.dims_p));
     }
-    bool operator != (const MatSize& sz) const
+    bool operator!=(const MatSize& sz) const
     {
         return !(*this == sz);
     }

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -109,6 +109,55 @@ TEST(OwnMat, Create3chan)
     ASSERT_FALSE(m.empty());
 }
 
+TEST(OwnMat, OwnMatSize)
+{
+    auto size = cv::Size{32,16};
+    Mat m;
+    m.create(size, CV_8UC3);
+
+    std::cout << m.size << std::endl;
+
+    ASSERT_EQ(m.size().width, 32);
+    ASSERT_EQ(m.size().height, 16);
+    ASSERT_EQ(m.size(), size);
+    ASSERT_EQ(m.size[0], 16);
+    ASSERT_EQ(m.size[1], 32);
+}
+
+TEST(OwnMat, OwnMatNDSize)
+{
+    Dims dims = {1,3,32,16};
+    Mat m;
+    m.create(dims, CV_32F);
+
+    std::cout << m.size << std::endl;
+
+    ASSERT_EQ(m.size.dims(), 4);
+    ASSERT_EQ(m.size[0], 1);
+    ASSERT_EQ(m.size[1], 3);
+    ASSERT_EQ(m.size[2], 32);
+    ASSERT_EQ(m.size[3], 16);
+}
+
+TEST(OwnMat, OwnMatOperators)
+{
+    Dims dims1 = {1,3,32,16};
+    Dims dims2 = {1,3,16,32};
+    auto size = cv::Size{32,16};
+
+    Mat m1, m2, m3, m4;
+
+    m1.create(dims1, CV_32F);
+    m2.create(dims2, CV_32F);
+    m3.create(size, CV_8UC3);
+    m4.create(size, CV_8UC3);
+
+    ASSERT_FALSE(m1.size == m2.size);
+    ASSERT_TRUE(m1.size != m2.size);
+    ASSERT_TRUE(m3.size == m4.size);
+    ASSERT_FALSE(m3.size != m4.size);
+}
+
 struct NonEmptyMat {
     cv::gapi::own::Size size{32,16};
     Mat m;

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -115,8 +115,6 @@ TEST(OwnMat, OwnMatSize)
     Mat m;
     m.create(size, CV_8UC3);
 
-    std::cout << m.size << std::endl;
-
     ASSERT_EQ(m.size().width, 32);
     ASSERT_EQ(m.size().height, 16);
     ASSERT_EQ(m.size(), size);
@@ -130,9 +128,7 @@ TEST(OwnMat, OwnMatNDSize)
     Mat m;
     m.create(dims, CV_32F);
 
-    std::cout << m.size << std::endl;
-
-    ASSERT_EQ(m.size.dims(), 4);
+    ASSERT_EQ(m.size.dims(), 4u);
     ASSERT_EQ(m.size[0], 1);
     ASSERT_EQ(m.size[1], 3);
     ASSERT_EQ(m.size[2], 32);


### PR DESCRIPTION
The same MatSize structure for GAPI's own::Mat

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Magic commands:
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
