### PR TITLE
fix: handle possible PyModule_AddObject failure

### DIFF
--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -229,7 +229,12 @@ PyObject* pyopencv_from(const TYPE& src)                                        
             ERROR_HANDLER; \
         } \
         CVPY_TYPE_INCREF(pyopencv_##NAME##_TypePtr); \
-        PyModule_AddObject(m, #WNAME, (PyObject *)pyopencv_##NAME##_TypePtr); \
+        if (PyModule_AddObject(m, #WNAME, (PyObject *)pyopencv_##NAME##_TypePtr) < 0) \
+        { \
+            printf("Failed to register a new type: " #WNAME  ", base (" #BASE ")\n"); \
+            Py_DECREF(pyopencv_##NAME##_TypePtr); \
+            ERROR_HANDLER; \
+        } \
     }
 
 //==================================================================================================
@@ -302,10 +307,15 @@ PyObject* pyopencv_from(const TYPE& src)                                        
         pyopencv_##NAME##_TypePtr = PyType_FromSpecWithBases(&pyopencv_##NAME##_Spec, bases); \
         if (!pyopencv_##NAME##_TypePtr) \
         { \
-            printf("Failed to init: " #WNAME ", base (" #BASE ")" "\n"); \
+            printf("Failed to create type from spec: " #WNAME ", base (" #BASE ")\n"); \
             ERROR_HANDLER; \
         } \
-        PyModule_AddObject(m, #NAME, (PyObject *)pyopencv_##NAME##_TypePtr); \
+        if (PyModule_AddObject(m, #WNAME, (PyObject *)pyopencv_##NAME##_TypePtr) < 0) \
+        { \
+            printf("Failed to register a new type: " #WNAME  ", base (" #BASE ")\n"); \
+            Py_DECREF(pyopencv_##NAME##_TypePtr); \
+            ERROR_HANDLER; \
+        } \
     }
 
 // Debug module load:


### PR DESCRIPTION
Comment from Python documentation:
> Unlike other functions that steal references, `PyModule_AddObject()` only decrements the reference count of value on success.
> This means that its return value must be checked, and calling code must `Py_DECREF()` value manually on error.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
