### PR TITLE
build: fix GCC12 compilation

### DIFF
--- a/modules/core/src/persistence_base64.cpp
+++ b/modules/core/src/persistence_base64.cpp
@@ -164,7 +164,7 @@ size_t base64_decode(char const * src, char * dst, size_t off, size_t cnt)
 bool base64_valid(uint8_t const * src, size_t off, size_t cnt)
 {
     /* check parameters */
-    if (src == 0 || src + off == 0)
+    if (src == 0)
         return false;
     if (cnt == 0U)
         cnt = std::strlen(reinterpret_cast<char const *>(src));


### PR DESCRIPTION
relates #21496

Error message (`-Werror=address`):
```
modules/core/src/persistence_base64.cpp: In function ‘bool base64::base64_valid(const uint8_t*, size_t, size_t)’:
modules/core/src/persistence_base64.cpp:167:31: error: comparing the result of pointer addition ‘(src + ((sizetype)off))’ and NULL [-Werror=address]
  167 |     if (src == 0 || src + off == 0)
      |                     ~~~~~~~~~~^~~~
```

- [x] Validated with `fedora:rawhide` docker image