### PR TITLE
videoio: added explicit gst-audio dependency for windows

### DIFF
--- a/modules/videoio/cmake/detect_gstreamer.cmake
+++ b/modules/videoio/cmake/detect_gstreamer.cmake
@@ -44,6 +44,10 @@ if(NOT HAVE_GSTREAMER AND WIN32)
     NAMES gstvideo gstvideo-1.0
     PATHS ${env_paths}
     PATH_SUFFIXES "lib")
+  find_library(GSTREAMER_audio_LIBRARY
+    NAMES  gstaudio gstaudio-1.0
+    PATHS ${env_paths}
+    PATH_SUFFIXES "lib")
 
   find_library(GSTREAMER_glib_LIBRARY
     NAMES glib-2.0
@@ -63,6 +67,7 @@ if(NOT HAVE_GSTREAMER AND WIN32)
       AND GSTREAMER_pbutils_LIBRARY
       AND GSTREAMER_riff_LIBRARY
       AND GSTREAMER_video_LIBRARY
+      AND GSTREAMER_audio_LIBRARY
       AND GSTREAMER_glib_LIBRARY
       AND GSTREAMER_gobject_LIBRARY)
     file(STRINGS "${GSTREAMER_gst_INCLUDE_DIR}/gst/gstversion.h" ver_strings REGEX "#define +GST_VERSION_(MAJOR|MINOR|MICRO|NANO).*")
@@ -77,6 +82,7 @@ if(NOT HAVE_GSTREAMER AND WIN32)
       ${GSTREAMER_app_LIBRARY}
       ${GSTREAMER_riff_LIBRARY}
       ${GSTREAMER_video_LIBRARY}
+      ${GSTREAMER_audio_LIBRARY}
       ${GSTREAMER_pbutils_LIBRARY}
       ${GSTREAMER_glib_LIBRARY}
       ${GSTREAMER_gobject_LIBRARY})

--- a/modules/videoio/cmake/detect_gstreamer.cmake
+++ b/modules/videoio/cmake/detect_gstreamer.cmake
@@ -45,7 +45,7 @@ if(NOT HAVE_GSTREAMER AND WIN32)
     PATHS ${env_paths}
     PATH_SUFFIXES "lib")
   find_library(GSTREAMER_audio_LIBRARY
-    NAMES  gstaudio gstaudio-1.0
+    NAMES gstaudio gstaudio-1.0
     PATHS ${env_paths}
     PATH_SUFFIXES "lib")
 


### PR DESCRIPTION
resolves #21393

Resolves windows build error when building with GStreamer by adding the gst-audio dependency.

```
cap_gstreamer.obj : error LNK2019: unresolved external symbol __imp_gst_audio_info_from_caps referenced in function "public: bool __cdecl cv::GStreamerCapture::grabAudioFrame (void)" (?grabAudioFrame@GStreamerCapture@cv@@QEAA_NXZ)
```

Extends PR opencv#21294 and adds in the solution provided by opencv#21393 for windows.