### PR TITLE
Disable -Wreturn-type-c-linkage under clang-cl

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -48,16 +48,19 @@
 #include "opencv2/core/types_c.h"
 
 #ifdef __cplusplus
-#  ifdef _MSC_VER
-/* disable warning C4190: 'function' has C-linkage specified, but returns UDT 'typename'
-                          which is incompatible with C
+/* disable MSVC warning C4190 / clang-cl -Wreturn-type-c-linkage:
+       'function' has C-linkage specified, but returns UDT 'typename'
+       which is incompatible with C
 
    It is OK to disable it because we only extend few plain structures with
    C++ constructors for simpler interoperability with C++ API of the library
 */
-#    pragma warning(disable:4190)
-#  elif defined __clang__ && __clang_major__ >= 3
+#  if defined(__clang__)
+     // handle clang on Linux and clang-cl (i. e. clang on Windows) first
 #    pragma GCC diagnostic ignored "-Wreturn-type-c-linkage"
+#  elif defined(_MSC_VER)
+     // then handle MSVC
+#    pragma warning(disable:4190)
 #  endif
 #endif
 


### PR DESCRIPTION
clang-cl defines both __clang__ and _MSC_VER, yet uses `#pragma GCC` to disable certain diagnostics.

At the time `-Wreturn-type-c-linkage` was reported by clang-cl.
This PR fixes this behavior by reordering defines.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ + ] I agree to contribute to the project under Apache 2 License.
- [ + ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ + ] The PR is proposed to the proper branch
- [ - ] There is a reference to the original bug report and related work
- [ - ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ - ] The feature is well documented and sample code can be built with the project CMake
