### PR TITLE
Add resize layer compatible with ONNX opset13 version

### DIFF
--- a/modules/dnn/src/graph_simplifier.cpp
+++ b/modules/dnn/src/graph_simplifier.cpp
@@ -108,7 +108,7 @@ bool Subgraph::match(const Ptr<ImportGraphWrapper>& net, int nodeId,
 
         for (int j = 0; j < inputNodes.size(); ++j)
         {
-            if (nodes[inputNodes[j]].empty())  // Unknown input node type.
+            if (nodes[inputNodes[j]].empty() || node->getInputName(j).empty())  // Unknown input node type.
                 continue;
             nodeId = getInputNodeId(net, node, j);
             const Ptr<ImportNodeWrapper> inpNode = net->getNode(nodeId);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -885,9 +885,14 @@ TEST_P(Test_ONNX_layers, DynamicResize)
     testONNXModels("dynamic_resize_9", npy, 0, 0, false, true, 2);
     testONNXModels("dynamic_resize_10", npy, 0, 0, false, true, 2);
     testONNXModels("dynamic_resize_11", npy, 0, 0, false, true, 2);
+    testONNXModels("dynamic_resize_13", npy, 0, 0, false, true, 2);
     testONNXModels("dynamic_resize_scale_9", npy, 0, 0, false, true, 2);
     testONNXModels("dynamic_resize_scale_10", npy, 0, 0, false, true, 2);
     testONNXModels("dynamic_resize_scale_11", npy, 0, 0, false, true, 2);
+    testONNXModels("dynamic_resize_scale_13", npy, 0, 0, false, true, 2);
+
+    testONNXModels("resize_size_opset11");
+    testONNXModels("resize_size_opset13");
 }
 
 TEST_P(Test_ONNX_layers, Resize_HumanSeg)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/954

Opset13 has changed resize layer mapping. 
And there may the empty input in the resize node.
Happened when exporting the ONNX model with the 1.9 or later version of pytorch with opset 13, for example the "Resize" in [ AnimeGANv2 model](https://github.com/Kazuhito00/AnimeGANv2-ONNX-Sample/tree/main/model).
More details can be found in the [Test data](https://github.com/opencv/opencv_extra/pull/954).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
opencv_extra=resize_onnx_opset13
```
