### PR TITLE
GAPI FLUID: Enable dynamic dispatching for Split4

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -2537,27 +2537,18 @@ GAPI_FLUID_KERNEL(GFluidSplit4, cv::gapi::core::GSplit4, false)
 
     static void run(const View &src, Buffer &dst1, Buffer &dst2, Buffer &dst3, Buffer &dst4)
     {
-        const auto *in   =  src.InLine<uchar>(0);
-              auto *out1 = dst1.OutLine<uchar>();
-              auto *out2 = dst2.OutLine<uchar>();
-              auto *out3 = dst3.OutLine<uchar>();
-              auto *out4 = dst4.OutLine<uchar>();
+        const auto *in = src.InLine<uchar>(0);
+        auto *out1     = dst1.OutLine<uchar>();
+        auto *out2     = dst2.OutLine<uchar>();
+        auto *out3     = dst3.OutLine<uchar>();
+        auto *out4     = dst4.OutLine<uchar>();
 
         GAPI_Assert(4 == src.meta().chan);
         int width = src.length();
+        int w = 0;
 
-        int w = 0; // cycle counter
-
-    #if CV_SIMD128
-        for (; w <= width-16; w+=16)
-        {
-            v_uint8x16 a, b, c, d;
-            v_load_deinterleave(&in[4*w], a, b, c, d);
-            v_store(&out1[w], a);
-            v_store(&out2[w], b);
-            v_store(&out3[w], c);
-            v_store(&out4[w], d);
-        }
+    #if CV_SIMD
+        w = split4_simd(in, out1, out2, out3, out4, width);
     #endif
 
         for (; w < width; w++)

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
@@ -214,6 +214,13 @@ int split3_simd(const uchar in[], uchar out1[], uchar out2[],
                     CV_CPU_DISPATCH_MODES_ALL);
 }
 
+int split4_simd(const uchar in[], uchar out1[], uchar out2[],
+                uchar out3[], uchar out4[], const int width)
+{
+    CV_CPU_DISPATCH(split4_simd, (in, out1, out2, out3, out4, width),
+                    CV_CPU_DISPATCH_MODES_ALL);
+}
+
 } // namespace fluid
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
@@ -166,6 +166,9 @@ ABSDIFFC_SIMD(float)
 int split3_simd(const uchar in[], uchar out1[], uchar out2[],
                 uchar out3[], const int width);
 
+int split4_simd(const uchar in[], uchar out1[], uchar out2[],
+                uchar out3[], uchar out4[], const int width);
+
 }  // namespace fluid
 }  // namespace gapi
 }  // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -187,6 +187,9 @@ ABSDIFFC_SIMD(float)
 int split3_simd(const uchar in[], uchar out1[], uchar out2[],
                 uchar out3[], const int width);
 
+int split4_simd(const uchar in[], uchar out1[], uchar out2[],
+                uchar out3[], uchar out4[], const int width);
+
 #ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
 struct scale_tag {};
@@ -1589,6 +1592,29 @@ int split3_simd(const uchar in[], uchar out1[], uchar out2[],
         vx_store(&out1[x], a);
         vx_store(&out2[x], b);
         vx_store(&out3[x], c);
+    }
+    return x;
+}
+
+//-------------------------
+//
+// Fluid kernels: Split4
+//
+//-------------------------
+
+int split4_simd(const uchar in[], uchar out1[], uchar out2[],
+                uchar out3[], uchar out4[], const int width)
+{
+    constexpr int nlanes = v_uint8::nlanes;
+    int x = 0;
+    for (; x <= width - nlanes; x += nlanes)
+    {
+        v_uint8 a, b, c, d;
+        v_load_deinterleave(&in[4 * x], a, b, c, d);
+        vx_store(&out1[x], a);
+        vx_store(&out2[x], b);
+        vx_store(&out3[x], c);
+        vx_store(&out4[x], d);
     }
     return x;
 }

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -1584,14 +1584,26 @@ int split3_simd(const uchar in[], uchar out1[], uchar out2[],
                 uchar out3[], const int width)
 {
     constexpr int nlanes = v_uint8::nlanes;
+    if (width < nlanes)
+        return 0;
+
     int x = 0;
-    for (; x <= width - nlanes; x += nlanes)
+    for (;;)
     {
-        v_uint8 a, b, c;
-        v_load_deinterleave(&in[3 * x], a, b, c);
-        vx_store(&out1[x], a);
-        vx_store(&out2[x], b);
-        vx_store(&out3[x], c);
+        for (; x <= width - nlanes; x += nlanes)
+        {
+            v_uint8 a, b, c;
+            v_load_deinterleave(&in[3 * x], a, b, c);
+            vx_store(&out1[x], a);
+            vx_store(&out2[x], b);
+            vx_store(&out3[x], c);
+        }
+        if (x < width)
+        {
+            x = width - nlanes;
+            continue;
+        }
+        break;
     }
     return x;
 }
@@ -1606,15 +1618,27 @@ int split4_simd(const uchar in[], uchar out1[], uchar out2[],
                 uchar out3[], uchar out4[], const int width)
 {
     constexpr int nlanes = v_uint8::nlanes;
+    if (width < nlanes)
+        return 0;
+
     int x = 0;
-    for (; x <= width - nlanes; x += nlanes)
+    for (;;)
     {
-        v_uint8 a, b, c, d;
-        v_load_deinterleave(&in[4 * x], a, b, c, d);
-        vx_store(&out1[x], a);
-        vx_store(&out2[x], b);
-        vx_store(&out3[x], c);
-        vx_store(&out4[x], d);
+        for (; x <= width - nlanes; x += nlanes)
+        {
+            v_uint8 a, b, c, d;
+            v_load_deinterleave(&in[4 * x], a, b, c, d);
+            vx_store(&out1[x], a);
+            vx_store(&out2[x], b);
+            vx_store(&out3[x], c);
+            vx_store(&out4[x], d);
+        }
+        if (x < width)
+        {
+            x = width - nlanes;
+            continue;
+        }
+        break;
     }
     return x;
 }


### PR DESCRIPTION

[Split4 SIMD .xlsx](https://github.com/opencv/opencv/files/7970580/Split4.SIMD.xlsx)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```