### PR TITLE
fix: wrong reference counter after module initialization

### DIFF
--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -602,10 +602,18 @@ class Arguments(NewOpenCVTests):
                         msg="Module is not generated for nested namespace")
         self.assertTrue(hasattr(cv.utils.nested, "testEchoBooleanFunction"),
                         msg="Function in nested module is not available")
-        self.assertEqual(sys.getrefcount(cv.utils.nested), 2,
-                         msg="Nested submodule lifetime should be managed by "
-                         "the parent module so the reference count should be "
-                         "2, because `getrefcount` temporary increases it.")
+
+        # Nested submodule is managed by the global submodules dictionary
+        # and parent native module
+        expected_ref_count = 2
+
+        # `getrefcount` temporary increases reference counter by 1
+        actual_ref_count = sys.getrefcount(cv.utils.nested) - 1
+
+        self.assertEqual(actual_ref_count, expected_ref_count,
+                         msg="Nested submodule reference counter has wrong value\n"
+                         "Expected: {}. Actual: {}".format(expected_ref_count, actual_ref_count))
+
         for flag in (True, False):
             self.assertEqual(flag, cv.utils.nested.testEchoBooleanFunction(flag),
                              msg="Function in nested module returns wrong result")


### PR DESCRIPTION
relates #21478

Fix for the module reference counter after discovering the Python interpreter shutdown issue during  #21489.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
