### PR TITLE
Fix wrong MSAN errors.

### DIFF
--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -239,6 +239,19 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
     else if(typeid(fptype) == typeid(double))
         OCV_LAPACK_FUNC(dgesdd)(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)buffer, &lwork, iworkBuf, info);
 
+#if defined(__clang__) && defined(__has_feature) && __has_feature(memory_sanitizer)
+    // Make sure MSAN sees the memory as having been written.
+    // MSAN does not think it has been written because a different language was called.
+    __msan_unpoison(a, a_step * n);
+    __msan_unpoison(buffer, sizeof(fptype) * (lwork + 1));
+    if (u)
+      __msan_unpoison(u, u_step * m);
+    if (vt)
+      __msan_unpoison(vt, v_step * n);
+    if (w)
+      __msan_unpoison(w, sizeof(fptype) * std::min(m, n));
+#endif
+
     if(!(flags & CV_HAL_SVD_NO_UV))
         transpose_square_inplace(vt, ldv, n);
 

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -239,7 +239,8 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
     else if(typeid(fptype) == typeid(double))
         OCV_LAPACK_FUNC(dgesdd)(mode, &m, &n, (double*)a, &lda, (double*)w, (double*)u, &ldu, (double*)vt, &ldv, (double*)buffer, &lwork, iworkBuf, info);
 
-#if defined(__clang__) && defined(__has_feature) && __has_feature(memory_sanitizer)
+#if defined(__clang__) && defined(__has_feature)
+#if __has_feature(memory_sanitizer)
     // Make sure MSAN sees the memory as having been written.
     // MSAN does not think it has been written because a different language was called.
     __msan_unpoison(a, a_step * n);
@@ -250,7 +251,8 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
       __msan_unpoison(vt, v_step * n);
     if (w)
       __msan_unpoison(w, sizeof(fptype) * std::min(m, n));
-#endif
+#endif  // __has_feature(memory_sanitizer)
+#endif  // defined(__clang__) && defined(__has_feature)
 
     if(!(flags & CV_HAL_SVD_NO_UV))
         transpose_square_inplace(vt, ldv, n);


### PR DESCRIPTION
Because Fortran is called in Lapack, MSAN does not think the memory
has been written even though it is the case.
MSAN does no support well cross-language memory analysis.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
