### PR TITLE
fix for confusing Assertion in imshow 

### DIFF
--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -963,6 +963,8 @@ void cv::imshow( const String& winname, InputArray _img )
 {
     CV_TRACE_FUNCTION();
 
+    const Size size = _img.size();
+    CV_Assert(size.width>0 && size.height>0);
     {
         cv::AutoLock lock(cv::getWindowMutex());
         cleanupClosedWindows_();
@@ -995,9 +997,7 @@ void cv::imshow( const String& winname, InputArray _img )
         }
     }
 
-    const Size size = _img.size();
 #ifndef HAVE_OPENGL
-    CV_Assert(size.width>0 && size.height>0);
     {
         Mat img = _img.getMat();
         CvMat c_img = cvMat(img);
@@ -1005,7 +1005,6 @@ void cv::imshow( const String& winname, InputArray _img )
     }
 #else
     const double useGl = getWindowProperty(winname, WND_PROP_OPENGL);
-    CV_Assert(size.width>0 && size.height>0);
 
     if (useGl <= 0)
     {


### PR DESCRIPTION
actually calling `imshow` with an empty Mat gives confusing Assertion
`OpenCV(4.5.5-dev) D:\GitHub\opencv\modules\imgproc\src\color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cv::cvtColor'`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
