### PR TITLE
(3.4) dnn: support outputs registration under new names

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -489,6 +489,18 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
          */
         void connect(int outLayerId, int outNum, int inpLayerId, int inpNum);
 
+        /** @brief Registers network output with name
+         *
+         *  Function may create additional 'Identity' layer.
+         *
+         *  @param outputName identifier of the output
+         *  @param layerId identifier of the second layer
+         *  @param outputPort number of the second layer input
+         *
+         *  @returns index of bound layer (the same as layerId or newly created)
+         */
+        int registerOutput(const std::string& outputName, int layerId, int outputPort);
+
         /** @brief Sets outputs names of the network input pseudo layer.
          *
          * Each net always has special own the network input pseudo layer with id=0.
@@ -610,10 +622,14 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         CV_WRAP inline Mat getParam(const String& layerName, int numParam = 0) const { return getParam(getLayerId(layerName), numParam); }
 
         /** @brief Returns indexes of layers with unconnected outputs.
+         *
+         * FIXIT: Rework API to registerOutput() approach, deprecate this call
          */
         CV_WRAP std::vector<int> getUnconnectedOutLayers() const;
 
         /** @brief Returns names of layers with unconnected outputs.
+         *
+         * FIXIT: Rework API to registerOutput() approach, deprecate this call
          */
         CV_WRAP std::vector<String> getUnconnectedOutLayersNames() const;
 

--- a/modules/dnn/test/test_onnx_conformance.cpp
+++ b/modules/dnn/test/test_onnx_conformance.cpp
@@ -1171,10 +1171,10 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
     }
 
     std::vector<String> layerNames = net.getUnconnectedOutLayersNames();
-    std::vector< std::vector<Mat> > outputs_;
+    std::vector<Mat> outputs;
     try
     {
-        net.forward(outputs_, layerNames);
+        net.forward(outputs, layerNames);
     }
     catch (...)
     {
@@ -1182,8 +1182,7 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
         applyTestTag(CV_TEST_TAG_DNN_ERROR_FORWARD);
         throw;
     }
-    ASSERT_GE(outputs_.size(), 1);
-    const std::vector<Mat>& outputs = outputs_[0];
+    ASSERT_GE(outputs.size(), 1);
 
     if (checkLayersFallbacks && checkFallbacks(net))
     {


### PR DESCRIPTION
continues #21490

TODO:
- [ ] (backlog) add test with validation of ONNX output names (query / forward)
- [ ] (backlog) emit compatibility message

```
allow_multiple_commits=1
```