### PR TITLE
Limit the default number of threads.

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -658,7 +658,7 @@ unsigned defaultNumberOfThreads()
     // than 2 threads by default not to overheat the devices
     const unsigned int default_number_of_threads = 2;
 #else
-    const unsigned int default_number_of_threads = (unsigned int)std::max(1, cv::getNumberOfCPUs());
+    const unsigned int default_number_of_threads = (unsigned int)std::max(1, std::min(4, cv::getNumberOfCPUs()));
 #endif
 
     unsigned result = default_number_of_threads;


### PR DESCRIPTION
This is more an RFC I guess.
These days, especially on the cloud, it is not uncommon to have machines with a lot of cores (100+, 200+). OpenCV currently limits the default number of threads to the number of cores which can therefore be a lot. OpenCV actually sometimes ends up spending 3x more time on scheduling than on image processing.
Do we want to limit the default value ? What to: 4/8/16 ?

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
