### PR TITLE
Fix calculation of GpuMat::dataend

### DIFF
--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -184,11 +184,8 @@ void cv::cuda::GpuMat::create(int _rows, int _cols, int _type)
         if (esz * cols == step)
             flags |= Mat::CONTINUOUS_FLAG;
 
-        int64 _nettosize = static_cast<int64>(step) * rows;
-        size_t nettosize = static_cast<size_t>(_nettosize);
-
         datastart = data;
-        dataend = data + nettosize;
+        dataend = data + step * (rows - 1) + cols * esz;
 
         if (refcount)
             *refcount = 1;

--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -63,6 +63,7 @@ namespace cvtest
     // GpuMat create
 
     cv::cuda::GpuMat createMat(cv::Size size, int type, bool useRoi = false);
+    cv::cuda::GpuMat createMat(cv::Size size, int type, cv::Size& size0, cv::Point& ofs, bool useRoi = false);
     cv::cuda::GpuMat loadMat(const cv::Mat& m, bool useRoi = false);
 
     //////////////////////////////////////////////////////////////////////

--- a/modules/ts/src/cuda_test.cpp
+++ b/modules/ts/src/cuda_test.cpp
@@ -91,7 +91,13 @@ namespace cvtest
 
     GpuMat createMat(Size size, int type, bool useRoi)
     {
-        Size size0 = size;
+        Size size0; Point ofs;
+        return createMat(size, type, size0, ofs, useRoi);
+    }
+
+    GpuMat createMat(Size size, int type, Size& size0, Point& ofs, bool useRoi)
+    {
+        size0 = size;
 
         if (useRoi)
         {
@@ -100,9 +106,10 @@ namespace cvtest
         }
 
         GpuMat d_m(size0, type);
-
-        if (size0 != size)
-            d_m = d_m(Rect((size0.width - size.width) / 2, (size0.height - size.height) / 2, size.width, size.height));
+        if (size0 != size) {
+            ofs = Point((size0.width - size.width) / 2, (size0.height - size.height) / 2);
+            d_m = d_m(Rect(ofs, size));
+        }
 
         return d_m;
     }


### PR DESCRIPTION
`GpuMat::dataend()` is incorrectly calculated in [GpuMat::create()](url) meaning that `locateROI(wholeSize,ofs)` currently returns the stride in `wholeSize` instead of the width of the ROI when the `GpuMat` constructor has to allocate device memory internally.

The test case https://github.com/opencv/opencv_contrib/pull/3168 requres a modification to `createMat()` to return `wholeSize` and `ofs`.

This PR will cause cudafilters test cases to fail until https://github.com/opencv/opencv_contrib/pull/3167 is merged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4,linux-6
build_image:Custom=ubuntu-cuda:18.04
```