### PR TITLE
dnn: fix outputs handling with OpenVINO backend

### DIFF
--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -184,7 +184,8 @@ static inline MatShape concat(const MatShape& a, const MatShape& b)
     return c;
 }
 
-static inline std::string toString(const MatShape& shape, const String& name = "")
+template<typename _Tp>
+static inline std::string toString(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::ostringstream ss;
     if (!name.empty())
@@ -195,11 +196,14 @@ static inline std::string toString(const MatShape& shape, const String& name = "
     ss << " ]";
     return ss.str();
 }
-static inline void print(const MatShape& shape, const String& name = "")
+
+template<typename _Tp>
+static inline void print(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::cout << toString(shape, name) << std::endl;
 }
-static inline std::ostream& operator<<(std::ostream &out, const MatShape& shape)
+template<typename _Tp>
+static inline std::ostream& operator<<(std::ostream &out, const std::vector<_Tp>& shape)
 {
     out << toString(shape);
     return out;

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2235,12 +2235,15 @@ struct Net::Impl : public detail::NetImplBase
                 {
                     CV_LOG_DEBUG(NULL, "DNN/IE: wrap layer " << ld.name << "@" << ld.type << " - outputs: " << ld.outputBlobsWrappers.size());
                     node = layer->initNgraph(ld.inputBlobsWrappers, inputNodes);
-                    // FIXIT doesn't work with multiple outputs (set name is applied to the same node)
+#if 0  // FIXIT doesn't work with multiple outputs (set name is applied to the same node)
                     for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
                     {
                         InferenceEngine::DataPtr dataPtr = ngraphDataNode(ld.outputBlobsWrappers[i]);
                         node.dynamicCast<InfEngineNgraphNode>()->setName(dataPtr->getName());
                     }
+#else
+                    node.dynamicCast<InfEngineNgraphNode>()->setName(layer->name);
+#endif
                 }
                 else
                 {

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -330,7 +330,7 @@ public:
 InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(std::move(_node)) {}
 
-InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node)
+InfEngineNgraphNode::InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(_node) {}
 
 InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& nodes,

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -379,16 +379,21 @@ InfEngineNgraphNet::InfEngineNgraphNet(detail::NetImplBase& netImpl, InferenceEn
     device_name = "CPU";
 }
 
-void InfEngineNgraphNet::addOutput(const std::string& name)
+void InfEngineNgraphNet::addOutput(const Ptr<InfEngineNgraphNode>& node)
 {
-    requestedOutputs.push_back(name);
+    CV_Assert(node);
+    CV_Assert(node->node);
+    const std::string& name = node->node->get_friendly_name();
+    requestedOutputs.insert({name, node});
 }
 
 void InfEngineNgraphNet::setNodePtr(std::shared_ptr<ngraph::Node>* ptr) {
     all_nodes.emplace((*ptr)->get_friendly_name(), ptr);
 }
 
- void InfEngineNgraphNet::release() {
+ void InfEngineNgraphNet::release()
+ {
+     // FIXIT release should not be conditional, release ALL
      for (auto& node : components.back()) {
 #if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
          if (!(ngraph::op::is_parameter(node) || ngraph::op::is_output(node) || ngraph::op::is_constant(node)) ) {
@@ -397,7 +402,6 @@ void InfEngineNgraphNet::setNodePtr(std::shared_ptr<ngraph::Node>* ptr) {
 #endif
              auto it = all_nodes.find(node->get_friendly_name());
              if (it != all_nodes.end()) {
-                 unconnectedNodes.erase(*(it->second));
                  it->second->reset();
                  all_nodes.erase(it);
              }
@@ -422,7 +426,8 @@ void InfEngineNgraphNet::dfs(std::shared_ptr<ngraph::Node>& node,
     }
 }
 
-int InfEngineNgraphNet::getNumComponents() {
+int InfEngineNgraphNet::getNumComponents()
+{
     if (!components.empty()) {
         return components.size();
     }
@@ -445,12 +450,14 @@ int InfEngineNgraphNet::getNumComponents() {
 void InfEngineNgraphNet::createNet(Target targetId) {
     if (!hasNetOwner)
     {
-        CV_Assert(!unconnectedNodes.empty());
+        CV_Assert(!requestedOutputs.empty());
         ngraph::ResultVector outs;
-        for (auto& node : unconnectedNodes)
+
+        for (auto output_node_it = requestedOutputs.begin(); output_node_it != requestedOutputs.end(); ++output_node_it)
         {
-            CV_LOG_DEBUG(NULL, "DNN/IE: +network_output[" << outs.size() << "]: name='" << node->get_friendly_name() << "'");
-            auto out = std::make_shared<ngraph::op::Result>(node);
+            CV_LOG_DEBUG(NULL, "DNN/NGRAPH: Add 'Result' output: " << output_node_it->first);
+            CV_Assert(output_node_it->second);
+            auto out = std::make_shared<ngraph::op::Result>(output_node_it->second->node);
             outs.push_back(out);
         }
         CV_Assert_N(!inputs_vec.empty(), !outs.empty());
@@ -576,17 +583,13 @@ void InfEngineNgraphNet::init(Target targetId)
             auto node = ngraph_function->output(i).get_node();
             for (size_t j = 0; j < node->get_input_size(); ++j) {
                 std::string name = node->input_value(j).get_node()->get_friendly_name();
-                auto iter = std::find(requestedOutputs.begin(), requestedOutputs.end(), name);
+                auto iter = requestedOutputs.find(name);
                 if (iter != requestedOutputs.end()) {
                     requestedOutputs.erase(iter);
                     cnn.addOutput(name);
                 }
             }
         }
-    }
-    for (const auto& name : requestedOutputs)
-    {
-        cnn.addOutput(name);
     }
 
     for (const auto& it : cnn.getInputsInfo())
@@ -632,9 +635,6 @@ ngraph::ParameterVector InfEngineNgraphNet::setInputs(const std::vector<cv::Mat>
     return current_inp;
 }
 
-void InfEngineNgraphNet::setUnconnectedNodes(Ptr<InfEngineNgraphNode>& node) {
-    unconnectedNodes.insert(node->node);
-}
 
 void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 {

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -37,7 +37,7 @@ public:
     InfEngineNgraphNet(detail::NetImplBase& netImpl);
     InfEngineNgraphNet(detail::NetImplBase& netImpl, InferenceEngine::CNNNetwork& net);
 
-    void addOutput(const std::string& name);
+    void addOutput(const Ptr<InfEngineNgraphNode>& node);
 
     bool isInitialized();
     void init(Target targetId);
@@ -47,7 +47,6 @@ public:
     void initPlugin(InferenceEngine::CNNNetwork& net);
     ngraph::ParameterVector setInputs(const std::vector<cv::Mat>& inputs, const std::vector<std::string>& names);
 
-    void setUnconnectedNodes(Ptr<InfEngineNgraphNode>& node);
     void addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs);
 
     void createNet(Target targetId);
@@ -88,8 +87,7 @@ public:
 
     InferenceEngine::CNNNetwork cnn;
     bool hasNetOwner;
-    std::vector<std::string> requestedOutputs;
-    std::unordered_set<std::shared_ptr<ngraph::Node>> unconnectedNodes;
+    std::unordered_map<std::string, Ptr<InfEngineNgraphNode> > requestedOutputs;
 
     std::map<std::string, InferenceEngine::TensorDesc> outputsDesc;
 };

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -102,7 +102,7 @@ public:
                         std::vector<Mat>& internals);
 
     InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node);
-    InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node);
+    InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node);
 
     void setName(const std::string& name);
 

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -1697,26 +1697,11 @@ CASE(test_spacetodepth)
 CASE(test_spacetodepth_example)
     // no filter
 CASE(test_split_equal_parts_1d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_2d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_default_axis)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_variable_parts_1d)
     // no filter
 CASE(test_split_variable_parts_2d)


### PR DESCRIPTION
Failed [nightly builds](http://pullrequest.opencv.org/buildbot/builders/master_openvino-skl-lin64/builds/1276):

```
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] Test_ONNX_layers.Convolution_variable_weight/0, where GetParam() = NGRAPH/CPU
[  FAILED  ] Test_ONNX_layers.Conv1d/0, where GetParam() = NGRAPH/CPU
[  FAILED  ] Test_ONNX_layers.Conv1d_bias/0, where GetParam() = NGRAPH/CPU
[  FAILED  ] Test_ONNX_layers.Conv1d_variable_weight/0, where GetParam() = NGRAPH/CPU
[  FAILED  ] Test_ONNX_layers.PoolConv1d/0, where GetParam() = NGRAPH/CPU
```

Validate:
- [x] [4.x branch](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/7264)

<cut/>

```

force_builders=Custom,Custom Win,Custom Mac

build_image:Custom=ubuntu-openvino-2021.4.2:20.04
Xbuild_image:Custom=ubuntu-openvino-2022.1.0.dev20220131:20.04
build_image:Custom Win=openvino-2021.4.2
build_image:Custom Mac=openvino-2021.4.2

test_modules:Custom=dnn,gapi,python2,python3,java
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_modules:Custom Mac=dnn,gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF

allow_multiple_commits=1
```