### PR TITLE
dnn(ngraph): fixup get_output_as_single_output_node() replacement patch

### DIFF
--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -330,7 +330,7 @@ public:
 InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(std::move(_node)) {}
 
-InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node)
+InfEngineNgraphNode::InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(_node) {}
 
 InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& nodes,

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -102,7 +102,7 @@ public:
                         std::vector<Mat>& internals);
 
     InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node);
-    InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node);
+    InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node);
 
     void setName(const std::string& name);
 

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -1697,26 +1697,11 @@ CASE(test_spacetodepth)
 CASE(test_spacetodepth_example)
     // no filter
 CASE(test_split_equal_parts_1d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_2d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_default_axis)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_variable_parts_1d)
     // no filter
 CASE(test_split_variable_parts_2d)


### PR DESCRIPTION
fixup #18031
part of fixes from #21564 

Validate:
- [x] 4.x branch

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac

build_image:Custom=ubuntu-openvino-2021.4.2:20.04
Xbuild_image:Custom=ubuntu-openvino-2022.1.0.dev20220131:20.04
build_image:Custom Win=openvino-2021.4.2
build_image:Custom Mac=openvino-2021.4.2

test_modules:Custom=dnn,gapi,python2,python3,java
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_modules:Custom Mac=dnn,gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF

allow_multiple_commits=1
```