### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ OCV_OPTION(WITH_AVFOUNDATION "Use AVFoundation for Video I/O (iOS/Mac)" ON
 OCV_OPTION(WITH_CAP_IOS "Enable iOS video capture" ON
   VISIBLE_IF IOS
   VERIFY HAVE_CAP_IOS)
-OCV_OPTION(WITH_CAROTENE "Use NVidia carotene acceleration library for ARM platform" ON
+OCV_OPTION(WITH_CAROTENE "Use NVidia carotene acceleration library for ARM platform" (NOT CV_DISABLE_OPTIMIZATION)
   VISIBLE_IF (ARM OR AARCH64) AND NOT IOS)
 OCV_OPTION(WITH_CPUFEATURES "Use cpufeatures Android library" ON
   VISIBLE_IF ANDROID

--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -16,6 +16,19 @@ endif()
 
 # ======================
 
+if(WITH_OPENVINO)
+  find_package(OpenVINO QUIET)
+  if(OpenVINO_FOUND)
+    message(STATUS "OpenVINO FOUND: ${OpenVINO_VERSION}")
+    math(EXPR ver "${OpenVINO_VERSION_MAJOR} * 1000000 + ${OpenVINO_VERSION_MINOR} * 10000 + ${OpenVINO_VERSION_PATCH} * 100")
+    ocv_add_external_target(openvino "" "openvino::runtime" "INF_ENGINE_RELEASE=${ver};HAVE_NGRAPH;HAVE_DNN_NGRAPH;HAVE_INF_ENGINE")
+    set(HAVE_OPENVINO 1)
+    return()
+  endif()
+endif()
+
+# ======================
+
 macro(ocv_ie_find_extra_libraries find_prefix find_suffix)
   file(GLOB libraries "${INF_ENGINE_LIB_DIRS}/${find_prefix}inference_engine*${find_suffix}")
   foreach(full_path IN LISTS libraries)

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -1619,6 +1619,7 @@ function(ocv_add_external_target name inc link def)
   endif()
 endfunction()
 
+
 # Returns the first non-interface target
 function(ocv_get_imported_target imported interface)
   set(__result "${interface}")

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -184,7 +184,8 @@ static inline MatShape concat(const MatShape& a, const MatShape& b)
     return c;
 }
 
-static inline std::string toString(const MatShape& shape, const String& name = "")
+template<typename _Tp>
+static inline std::string toString(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::ostringstream ss;
     if (!name.empty())
@@ -195,11 +196,14 @@ static inline std::string toString(const MatShape& shape, const String& name = "
     ss << " ]";
     return ss.str();
 }
-static inline void print(const MatShape& shape, const String& name = "")
+
+template<typename _Tp>
+static inline void print(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::cout << toString(shape, name) << std::endl;
 }
-static inline std::ostream& operator<<(std::ostream &out, const MatShape& shape)
+template<typename _Tp>
+static inline std::ostream& operator<<(std::ostream &out, const std::vector<_Tp>& shape)
 {
     out << toString(shape);
     return out;

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -330,7 +330,7 @@ public:
 InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(std::move(_node)) {}
 
-InfEngineNgraphNode::InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node)
+InfEngineNgraphNode::InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), node(_node) {}
 
 InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& nodes,
@@ -379,16 +379,21 @@ InfEngineNgraphNet::InfEngineNgraphNet(detail::NetImplBase& netImpl, InferenceEn
     device_name = "CPU";
 }
 
-void InfEngineNgraphNet::addOutput(const std::string& name)
+void InfEngineNgraphNet::addOutput(const Ptr<InfEngineNgraphNode>& node)
 {
-    requestedOutputs.push_back(name);
+    CV_Assert(node);
+    CV_Assert(node->node);
+    const std::string& name = node->node->get_friendly_name();
+    requestedOutputs.insert({name, node});
 }
 
 void InfEngineNgraphNet::setNodePtr(std::shared_ptr<ngraph::Node>* ptr) {
     all_nodes.emplace((*ptr)->get_friendly_name(), ptr);
 }
 
- void InfEngineNgraphNet::release() {
+ void InfEngineNgraphNet::release()
+ {
+     // FIXIT release should not be conditional, release ALL
      for (auto& node : components.back()) {
 #if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
          if (!(ngraph::op::is_parameter(node) || ngraph::op::is_output(node) || ngraph::op::is_constant(node)) ) {
@@ -397,7 +402,6 @@ void InfEngineNgraphNet::setNodePtr(std::shared_ptr<ngraph::Node>* ptr) {
 #endif
              auto it = all_nodes.find(node->get_friendly_name());
              if (it != all_nodes.end()) {
-                 unconnectedNodes.erase(*(it->second));
                  it->second->reset();
                  all_nodes.erase(it);
              }
@@ -422,7 +426,8 @@ void InfEngineNgraphNet::dfs(std::shared_ptr<ngraph::Node>& node,
     }
 }
 
-int InfEngineNgraphNet::getNumComponents() {
+int InfEngineNgraphNet::getNumComponents()
+{
     if (!components.empty()) {
         return components.size();
     }
@@ -445,17 +450,21 @@ int InfEngineNgraphNet::getNumComponents() {
 void InfEngineNgraphNet::createNet(Target targetId) {
     if (!hasNetOwner)
     {
-        CV_Assert(!unconnectedNodes.empty());
+        CV_Assert(!requestedOutputs.empty());
         ngraph::ResultVector outs;
-        for (auto& node : unconnectedNodes)
+
+        for (auto output_node_it = requestedOutputs.begin(); output_node_it != requestedOutputs.end(); ++output_node_it)
         {
-            auto out = std::make_shared<ngraph::op::Result>(node);
+            CV_LOG_DEBUG(NULL, "DNN/NGRAPH: Add 'Result' output: " << output_node_it->first);
+            CV_Assert(output_node_it->second);
+            auto out = std::make_shared<ngraph::op::Result>(output_node_it->second->node);
             outs.push_back(out);
         }
         CV_Assert_N(!inputs_vec.empty(), !outs.empty());
         ngraph_function = std::make_shared<ngraph::Function>(outs, inputs_vec);
 
         int num_comp = getNumComponents();
+        CV_LOG_DEBUG(NULL, "DNN/IE: number of subgraphs: " << num_comp);
         if (num_comp > 1) {
             for (int i = num_comp - 1; i >= 0; --i) {
                 ngraph::ResultVector outputs;
@@ -466,6 +475,7 @@ void InfEngineNgraphNet::createNet(Target targetId) {
 #else
                     if (node->is_parameter()) {
 #endif
+                        CV_LOG_DEBUG(NULL, "DNN/IE: subgraph[" << i << "]: +input[" << inps.size() << "] = '" << node->get_friendly_name() << "'");
                         auto parameter = std::dynamic_pointer_cast<ngraph::op::Parameter>(node);
                         inps.push_back(parameter);
                     }
@@ -474,10 +484,12 @@ void InfEngineNgraphNet::createNet(Target targetId) {
 #else
                     else if (node->is_output()) {
 #endif
+                        CV_LOG_DEBUG(NULL, "DNN/IE: subgraph[" << i << "]: +output[" << outputs.size() << "] = '" << node->get_friendly_name() << "'");
                         auto result = std::dynamic_pointer_cast<ngraph::op::Result>(node);
                         outputs.push_back(result);
                     }
                 }
+                CV_LOG_DEBUG(NULL, "DNN/IE: subgraph[" << i << ": nodes=" << components.back().size() << " inputs=" << inps.size() << " outputs=" << outputs.size());
                 isInit = false;
                 CV_Assert_N(!inps.empty(), !outputs.empty());
                 ngraph_function = std::make_shared<ngraph::Function>(outputs, inps);
@@ -574,17 +586,13 @@ void InfEngineNgraphNet::init(Target targetId)
             auto node = ngraph_function->output(i).get_node();
             for (size_t j = 0; j < node->get_input_size(); ++j) {
                 std::string name = node->input_value(j).get_node()->get_friendly_name();
-                auto iter = std::find(requestedOutputs.begin(), requestedOutputs.end(), name);
+                auto iter = requestedOutputs.find(name);
                 if (iter != requestedOutputs.end()) {
                     requestedOutputs.erase(iter);
                     cnn.addOutput(name);
                 }
             }
         }
-    }
-    for (const auto& name : requestedOutputs)
-    {
-        cnn.addOutput(name);
     }
 
     for (const auto& it : cnn.getInputsInfo())
@@ -630,9 +638,6 @@ ngraph::ParameterVector InfEngineNgraphNet::setInputs(const std::vector<cv::Mat>
     return current_inp;
 }
 
-void InfEngineNgraphNet::setUnconnectedNodes(Ptr<InfEngineNgraphNode>& node) {
-    unconnectedNodes.insert(node->node);
-}
 
 void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 {
@@ -732,10 +737,10 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
                 }
             }
         }
-        if (isHetero)
-            netExec = ie.LoadNetwork(net, "HETERO:" + device_name + ",CPU", config);
-        else
-            netExec = ie.LoadNetwork(net, device_name, config);
+
+        std::string ieDevice = isHetero ? ("HETERO:" + device_name + ",CPU") : device_name;
+        CV_LOG_INFO(NULL, "DNN/IE: Calling LoadNetwork(device=" << ieDevice << ")...");
+        netExec = ie.LoadNetwork(net, ieDevice, config);
     }
     catch (const std::exception& ex)
     {

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -37,7 +37,7 @@ public:
     InfEngineNgraphNet(detail::NetImplBase& netImpl);
     InfEngineNgraphNet(detail::NetImplBase& netImpl, InferenceEngine::CNNNetwork& net);
 
-    void addOutput(const std::string& name);
+    void addOutput(const Ptr<InfEngineNgraphNode>& node);
 
     bool isInitialized();
     void init(Target targetId);
@@ -47,7 +47,6 @@ public:
     void initPlugin(InferenceEngine::CNNNetwork& net);
     ngraph::ParameterVector setInputs(const std::vector<cv::Mat>& inputs, const std::vector<std::string>& names);
 
-    void setUnconnectedNodes(Ptr<InfEngineNgraphNode>& node);
     void addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs);
 
     void createNet(Target targetId);
@@ -88,8 +87,7 @@ public:
 
     InferenceEngine::CNNNetwork cnn;
     bool hasNetOwner;
-    std::vector<std::string> requestedOutputs;
-    std::unordered_set<std::shared_ptr<ngraph::Node>> unconnectedNodes;
+    std::unordered_map<std::string, Ptr<InfEngineNgraphNode> > requestedOutputs;
 
     std::map<std::string, InferenceEngine::TensorDesc> outputsDesc;
 };
@@ -102,7 +100,7 @@ public:
                         std::vector<Mat>& internals);
 
     InfEngineNgraphNode(std::shared_ptr<ngraph::Node>&& _node);
-    InfEngineNgraphNode(std::shared_ptr<ngraph::Node>& _node);
+    InfEngineNgraphNode(const std::shared_ptr<ngraph::Node>& _node);
 
     void setName(const std::string& name);
 

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -1771,26 +1771,11 @@ CASE(test_spacetodepth)
 CASE(test_spacetodepth_example)
     // no filter
 CASE(test_split_equal_parts_1d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_2d)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_equal_parts_default_axis)
-#if INF_ENGINE_VER_MAJOR_EQ(2021040000)
-    SKIP_CPU;
-    // MYRIAD is ok
-    SKIP_OPENCL;
-    SKIP_OPENCL_FP16;
-#endif
+    // no filter
 CASE(test_split_variable_parts_1d)
     // no filter
 CASE(test_split_variable_parts_2d)


### PR DESCRIPTION
#21551 from alalek:cmake_dnn_backport_3.4
#21562 from alalek:cmake_carotene_use_cv_disable_optimization
#21564 from alalek:dnn_fix_openvino_outputs
#21569 from alalek:fixup_18031

Previous "Merge 3.4": #21535

<cut/>

```
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6


force_builders=Custom,Custom Win,Custom Mac

Xbuild_image:Custom=ubuntu-openvino-2021.4.2:20.04
Xbuild_image:Custom=ubuntu-openvino-2022.1.0.dev20220131:20.04
build_image:Custom Win=openvino-2021.4.2
build_image:Custom Mac=openvino-2021.4.2

Xtest_modules:Custom=dnn,gapi,python2,python3,java
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_modules:Custom Mac=dnn,gapi,python2,python3,java

Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=ON
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF
```