### PR TITLE
Use YuNet of fixed input shape to fix not-supported-dynamic-zero-shape for FaceDetectorYN

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2614,9 +2614,7 @@ void ONNXImporter::parseShape(LayerParams& layerParams, const opencv_onnx::NodeP
     if (isDynamicShape)
     {
         CV_LOG_ERROR(NULL, "DNN/ONNX(Shape): dynamic 'zero' shapes are not supported, input " << toString(inpShape, node_proto.input(0)));
-        // FIXIT repair assertion
-        // Disabled to pass face detector tests from #20422
-        // CV_Assert(!isDynamicShape);  // not supported
+        CV_Assert(!isDynamicShape);  // not supported
     }
     addConstant(node_proto.output(0), shapeMat);
 }

--- a/modules/objdetect/test/test_face.cpp
+++ b/modules/objdetect/test/test_face.cpp
@@ -78,7 +78,7 @@ TEST(Objdetect_face_detection, regression)
     // }
 
     // Initialize detector
-    std::string model = findDataFile("dnn/onnx/models/yunet-202109.onnx", false);
+    std::string model = findDataFile("dnn/onnx/models/yunet-202202.onnx", false);
     Ptr<FaceDetectorYN> faceDetector = FaceDetectorYN::create(model, "", Size(300, 300));
     faceDetector->setScoreThreshold(0.7f);
 


### PR DESCRIPTION
Related bug report: https://github.com/opencv/opencv/pull/21340#issuecomment-1004621821
opencv_extra PR: TBD

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
