### PR TITLE
Add CMake option to install pip metadata when Python bindings are installed just by CMake

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -230,6 +230,30 @@ if(NOT OPENCV_SKIP_PYTHON_LOADER)
   install(FILES "${__python_loader_install_tmp_path}/cv2/${__target_config}" DESTINATION "${OPENCV_PYTHON_INSTALL_PATH}/cv2/" COMPONENT python)
 endif()  # NOT OPENCV_SKIP_PYTHON_LOADER
 
+# Install pip metadata files to ensure that opencv installed via CMake is listed by pip list
+# See https://packaging.python.org/specifications/recording-installed-packages/
+# and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+option(OPENCV_PYTHON_PIP_METADATA_INSTALL "Use CMake to install Python pip metadata. Set to off if some other tool already installs it." OFF)
+mark_as_advanced(OPENCV_PYTHON_PIP_METADATA_INSTALL)
+set(OPENCV_PYTHON_PIP_METADATA_INSTALLER "cmake" CACHE STRING "Specify the string to identify the pip Installer. Default: cmake, change this if you are using another tool.")
+mark_as_advanced(OPENCV_PYTHON_PIP_METADATA_INSTALLER)
+if(OPENCV_PYTHON_PIP_METADATA_INSTALL)
+  if(WIN32)
+    set(NEW_LINE "\n\r")
+  else()
+    set(NEW_LINE "\n")
+  endif()
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/METADATA "")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Metadata-Version: 2.1${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Name: opencv-python${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${OPENCV_VERSION}${NEW_LINE}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/INSTALLER "${OPENCV_PYTHON_PIP_METADATA_INSTALLER}${NEW_LINE}")
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/METADATA" "${CMAKE_CURRENT_BINARY_DIR}/INSTALLER"
+    DESTINATION ${OPENCV_PYTHON_INSTALL_PATH}/opencv_python-${OPENCV_VERSION}.dist-info
+    COMPONENT python)
+endif()
+
 unset(PYTHON_SRC_DIR)
 unset(PYTHON_CVPY_PROCESS)
 unset(CVPY_SUFFIX)


### PR DESCRIPTION
When OpenCV's Python bindings are installed only via CMake by enabling the appropriate CMake option, the `opencv-python` package is not listed by `pip list` .

This is not problematic until a user tries to install a Python library that depends on `opencv-python` via  `pip install .` . In that case, the Python `opencv-python` package already available in the system is ignored, and the PyPI version of `opencv-python` is installed itself. 

This PR adds the CMake logic to generate the necessary `METADATA` and `INSTALLER` Python files so that even when just installed via cmake, the `opencv-python` python package can be listed by `pip list` .

This logic is disabled by default, but can be enabled by the option `OPENCV_PYTHON_PIP_METADATA_INSTALL`, to avoid conflicts with existing installation script of Python bindings in https://github.com/opencv/opencv-python that generate these metadata files via `setup.py`.

This PR originated from https://github.com/conda-forge/opencv-feedstock/issues/299 and has been validated in https://github.com/conda-forge/opencv-feedstock/pull/300, but it can be useful for all downstream packagers of OpenCV's python bindings. For example, Debian's [`python3-opencv`](https://packages.debian.org/sid/python3-opencv) is affected by the same problem. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
