### PR TITLE
(3.4) imgcodecs: add runtime checks to validate input

### DIFF
--- a/modules/imgcodecs/src/grfmt_pam.cpp
+++ b/modules/imgcodecs/src/grfmt_pam.cpp
@@ -470,7 +470,11 @@ bool PAMDecoder::readHeader()
                     selected_fmt = CV_IMWRITE_PAM_FORMAT_GRAYSCALE;
                 else if (m_channels == 3 && m_maxval < 256)
                     selected_fmt = CV_IMWRITE_PAM_FORMAT_RGB;
+                else
+                    CV_Error(Error::StsError, "Can't determine selected_fmt (IMWRITE_PAM_FORMAT_NULL)");
             }
+            CV_CheckDepth(m_sampledepth, m_sampledepth == CV_8U || m_sampledepth == CV_16U, "");
+            CV_Check(m_channels, m_channels >= 1 && m_channels <= 4, "Unsupported number of channels");
             m_type = CV_MAKETYPE(m_sampledepth, m_channels);
             m_offset = m_strm.getPos();
 
@@ -566,6 +570,10 @@ bool PAMDecoder::readData(Mat& img)
                         m_strm.getBytes( src, src_stride );
                         FillColorRow1( data, src, m_width, palette );
                     }
+                }
+                else
+                {
+                    CV_Error(Error::StsError, cv::format("Unsupported value of target_channels: %d", target_channels));
                 }
             } else {
                 for (int y = 0; y < m_height; y++, data += imp_stride)

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -145,8 +145,8 @@ bool TiffDecoder::checkSignature( const String& signature ) const
 
 int TiffDecoder::normalizeChannelsNumber(int channels) const
 {
-    CV_Assert(channels <= 4);
-    return channels > 4 ? 4 : channels;
+    CV_Check(channels, channels >= 1 && channels <= 4, "Unsupported number of channels");
+    return channels;
 }
 
 ImageDecoder TiffDecoder::newDecoder() const


### PR DESCRIPTION
backport of #21620