### PR TITLE
 Update Clang toolchain for RVV.

### DIFF
--- a/platforms/linux/riscv64-clang.toolchain.cmake
+++ b/platforms/linux/riscv64-clang.toolchain.cmake
@@ -17,8 +17,8 @@ set(CMAKE_ASM_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
 # Don't run the linker on compiler check
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(CMAKE_C_FLAGS "-march=rv64gcv0p10 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-march=rv64gcv0p10 -menable-experimental-extensions --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CXX_FLAGS}")
+set(CMAKE_C_FLAGS "-march=rv64gcv --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-march=rv64gcv --gcc-toolchain=${RISCV_GCC_INSTALL_ROOT} -w ${CXX_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}  -O2")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}  -O2")


### PR DESCRIPTION
With the release of RISC-V Vector spec 1.0 and the release of Clang 14.0, we can use `-march=rv64gcv` as compile flag instead of `-march=rv64gcv0p10` and `-menable-experimental-extensions` is not needed anymore. So this patch is going to update the toolchain file to adapt the newest changing.

Note:
For now, Clang/LLVM toolchain also need GNU-toolchain for binutils(linker) and glibc. and only the very latest release binutils(2.38) will support rvv 1.0, which has not include/update in current [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain), so we have to update it manully by using following commands:
``` bash
cd riscv-gnu-toolchain/riscv-binutils && \
git checkout riscv-binutils-2.38 && \
cd .. && \
make linux
```
I also have a docker file for the new rvv-clang toolchain:
<details>
<summary>Dockerfile</summary>

``` dockerfile
FROM ubuntu:20.04

# CMake PPA to get modern CMake
RUN apt-get update && \
    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ca-certificates \
        apt-transport-https \
        gnupg \
        software-properties-common \
        wget && \
    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
    apt-get clean

RUN apt-get update && \
    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        gcc \
        g++ \
        git \
        make \
        ninja-build \
        cmake \
        ccache \
        python3 \
        gcc-multilib \
        autoconf \
        automake \
        autotools-dev \
        curl \
        libmpc-dev \
        libmpfr-dev \
        libgmp-dev \
        libglfw3-dev \
        gawk \
        build-essential \
        bison \
        flex \
        texinfo \
        gperf \
        libtool \
        patchutils \
        bc \
        zlib1g-dev \
        libexpat-dev \
        pkg-config \
        libglib2.0-dev && \
    apt-get clean

# GNU toolchain
https://github.com/sifive/qemu.git && cd - && \
RUN mkdir /riscv && cd /riscv && \
    git clone https://github.com/riscv/riscv-gnu-toolchain.git && \
    cd riscv-gnu-toolchain && \
    git config --global http.sslVerify false && \
    git checkout rvv-intrinsic && \
    git submodule update --init --recursive && \
    cd riscv-binutils && \
    git checkout riscv-binutils-2.38

RUN mkdir /opt/RISCV && cd /riscv/riscv-gnu-toolchain && ./configure --prefix=/opt/RISCV && \
    make linux -j16 && \
    make build-qemu -j16 && \
    cd ..


# LLVM toolchain
RUN cd /riscv  && \
    git clone https://github.com/llvm/llvm-project.git && \
    mkdir llvm-project/build && cd llvm-project/build && \
    git checkout llvmorg-14.0.0-rc1 && \
    cmake -DLLVM_PARALLEL_LINK_JOBS=2 -DLLVM_TARGETS_TO_BUILD="X86;RISCV" -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=RELEASE ../llvm && \
    make -j16 && \
    ln -s /riscv/llvm-project/build /opt/rvv-llvm && \
    cd ..

USER root

CMD bash

```
</details>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
