### PR TITLE
GAPI Perf Tests:Workaround for the OpenCV's issue.

### DIFF
--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -436,8 +436,8 @@ PERF_TEST_P_(DivPerfTest, TestPerformance)
     // FIXIT Unstable input data for divide
     initMatsRandU(type, sz, dtype, false);
 
-    //This condition need to workaround bug in OpenCV.
-    //It reinitializes divider matrix without zero values.
+    //This condition need to workaround issue in the OpenCV.
+    //It reinitializes divider matrix without zero values for CV_16S DST type.
     if (dtype == CV_16S && dtype != type)
         cv::randu(in_mat2, cv::Scalar::all(1), cv::Scalar::all(255));
 
@@ -481,6 +481,11 @@ PERF_TEST_P_(DivCPerfTest, TestPerformance)
 
     // FIXIT Unstable input data for divide
     initMatsRandU(type, sz, dtype, false);
+
+    //This condition need as workaround the issue in the OpenCV.
+    //It reinitializes divider scalar without zero values for CV_16S DST type.
+    if (dtype == CV_16S || (type == CV_16S && dtype == -1))
+        cv::randu(sc, cv::Scalar::all(1), cv::Scalar::all(SHRT_MAX));
 
     // OpenCV code ///////////////////////////////////////////////////////////
     cv::divide(in_mat1, sc, out_mat_ocv, scale, dtype);


### PR DESCRIPTION
Workaround for the OpenCV's known issue. The issue is observed for 16S destination type in arithmetical operation.
Linked and resolved issue is "**G-API: Sporadic failures of DivCPerfTestFluid/DivCPerfTest (2022-02-03)**" #21584

<cut/>

Performance report:

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```

