### PR TITLE
(4.x) Merge 3.4

### DIFF
--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -684,7 +684,8 @@ VSX_IMPL_LOAD_L8(vec_double2, double)
 #endif
 
 // absolute difference
-#ifndef vec_absd
+#ifndef _ARCH_PWR9
+#   undef vec_absd
 #   define vec_absd(a, b) vec_sub(vec_max(a, b), vec_min(a, b))
 #endif
 

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -909,7 +909,8 @@ static bool ipp_calchist(const Mat &image, Mat &hist, int histSize, const float*
 #endif
 
     // IPP_DISABLE_HISTOGRAM - https://github.com/opencv/opencv/issues/11544
-    if (uniform && (ranges[0][1] - ranges[0][0]) != histSize)
+    // and https://github.com/opencv/opencv/issues/21595
+    if ((uniform && (ranges[0][1] - ranges[0][0]) != histSize) || abs(ranges[0][0]) != cvFloor(ranges[0][0]))
         return false;
 
     Mat ihist = hist;

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -1993,6 +1993,38 @@ TEST(Imgproc_Hist_Calc, badarg)
     EXPECT_NO_THROW(cv::calcBackProject(&img, 1, channels, hist, backProj, NULL, 1, true));
 }
 
+TEST(Imgproc_Hist_Calc, IPP_ranges_with_equal_exponent_21595)
+{
+    const int channels[] = { 0 };
+    float range1[] = { -0.5f, 1.5f };
+    const float* ranges[] = { range1 };
+    const int hist_size[] = { 2 };
+
+    uint8_t m[1][6] = { { 0, 1, 0, 1 , 1, 1 } };
+    cv::Mat images_u = Mat(1, 6, CV_8UC1, m);
+    cv::Mat histogram_u;
+    cv::calcHist(&images_u, 1, channels, noArray(), histogram_u, 1, hist_size, ranges);
+
+    ASSERT_EQ(histogram_u.at<float>(0), 2.f) << "0 not counts correctly, res: " << histogram_u.at<float>(0);
+    ASSERT_EQ(histogram_u.at<float>(1), 4.f) << "1 not counts correctly, res: " << histogram_u.at<float>(0);
+}
+
+TEST(Imgproc_Hist_Calc, IPP_ranges_with_nonequal_exponent_21595)
+{
+    const int channels[] = { 0 };
+    float range1[] = { -1.3f, 1.5f };
+    const float* ranges[] = { range1 };
+    const int hist_size[] = { 3 };
+
+    uint8_t m[1][6] = { { 0, 1, 0, 1 , 1, 1 } };
+    cv::Mat images_u = Mat(1, 6, CV_8UC1, m);
+    cv::Mat histogram_u;
+    cv::calcHist(&images_u, 1, channels, noArray(), histogram_u, 1, hist_size, ranges);
+
+    ASSERT_EQ(histogram_u.at<float>(0), 0.f) << "not equal to zero, res: " << histogram_u.at<float>(0);
+    ASSERT_EQ(histogram_u.at<float>(1), 2.f) << "0 not counts correctly, res: " << histogram_u.at<float>(1);
+    ASSERT_EQ(histogram_u.at<float>(2), 4.f) << "1 not counts correctly, res: " << histogram_u.at<float>(2);
+}
 
 }} // namespace
 /* End Of File */

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -383,7 +383,7 @@ public:
          };
     enum DescriptorStorageFormat { DESCR_FORMAT_COL_BY_COL, DESCR_FORMAT_ROW_BY_ROW };
 
-    /**@brief Creates the HOG descriptor and detector with default params.
+    /**@brief Creates the HOG descriptor and detector with default parameters.
 
     aqual to HOGDescriptor(Size(64,128), Size(16,16), Size(8,8), Size(8,8), 9 )
     */
@@ -419,6 +419,8 @@ public:
     {}
 
     /** @overload
+
+    Creates the HOG descriptor and detector and loads HOGDescriptor parameters and coefficients for the linear SVM classifier from a file.
     @param filename The file name containing HOGDescriptor properties and coefficients for the linear SVM classifier.
     */
     CV_WRAP HOGDescriptor(const String& filename)
@@ -457,19 +459,19 @@ public:
     */
     CV_WRAP virtual void setSVMDetector(InputArray svmdetector);
 
-    /** @brief Reads HOGDescriptor parameters from a cv::FileNode.
+    /** @brief Reads HOGDescriptor parameters and coefficients for the linear SVM classifier from a file node.
     @param fn File node
     */
     virtual bool read(FileNode& fn);
 
-    /** @brief Stores HOGDescriptor parameters in a cv::FileStorage.
+    /** @brief Stores HOGDescriptor parameters and coefficients for the linear SVM classifier in a file storage.
     @param fs File storage
     @param objname Object name
     */
     virtual void write(FileStorage& fs, const String& objname) const;
 
-    /** @brief loads HOGDescriptor parameters and coefficients for the linear SVM classifier from a file.
-    @param filename Path of the file to read.
+    /** @brief loads HOGDescriptor parameters and coefficients for the linear SVM classifier from a file
+    @param filename Name of the file to read.
     @param objname The optional name of the node to read (if empty, the first top-level node will be used).
     */
     CV_WRAP virtual bool load(const String& filename, const String& objname = String());
@@ -542,13 +544,14 @@ public:
     @param winStride Window stride. It must be a multiple of block stride.
     @param padding Padding
     @param scale Coefficient of the detection window increase.
-    @param finalThreshold Final threshold
+    @param groupThreshold Coefficient to regulate the similarity threshold. When detected, some objects can be covered
+    by many rectangles. 0 means not to perform grouping.
     @param useMeanshiftGrouping indicates grouping algorithm
     */
     CV_WRAP virtual void detectMultiScale(InputArray img, CV_OUT std::vector<Rect>& foundLocations,
                                   CV_OUT std::vector<double>& foundWeights, double hitThreshold = 0,
                                   Size winStride = Size(), Size padding = Size(), double scale = 1.05,
-                                  double finalThreshold = 2.0,bool useMeanshiftGrouping = false) const;
+                                  double groupThreshold = 2.0, bool useMeanshiftGrouping = false) const;
 
     /** @brief Detects objects of different sizes in the input image. The detected objects are returned as a list
     of rectangles.
@@ -560,13 +563,14 @@ public:
     @param winStride Window stride. It must be a multiple of block stride.
     @param padding Padding
     @param scale Coefficient of the detection window increase.
-    @param finalThreshold Final threshold
+    @param groupThreshold Coefficient to regulate the similarity threshold. When detected, some objects can be covered
+    by many rectangles. 0 means not to perform grouping.
     @param useMeanshiftGrouping indicates grouping algorithm
     */
     virtual void detectMultiScale(InputArray img, CV_OUT std::vector<Rect>& foundLocations,
                                   double hitThreshold = 0, Size winStride = Size(),
                                   Size padding = Size(), double scale = 1.05,
-                                  double finalThreshold = 2.0, bool useMeanshiftGrouping = false) const;
+                                  double groupThreshold = 2.0, bool useMeanshiftGrouping = false) const;
 
     /** @brief  Computes gradients and quantized gradient orientations.
     @param img Matrix contains the image to be computed

--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -1886,7 +1886,7 @@ static bool ocl_detectMultiScale(InputArray _img, std::vector<Rect> &found_locat
 void HOGDescriptor::detectMultiScale(
     InputArray _img, std::vector<Rect>& foundLocations, std::vector<double>& foundWeights,
     double hitThreshold, Size winStride, Size padding,
-    double scale0, double finalThreshold, bool useMeanshiftGrouping) const
+    double scale0, double groupThreshold, bool useMeanshiftGrouping) const
 {
     CV_INSTRUMENT_REGION();
 
@@ -1912,7 +1912,7 @@ void HOGDescriptor::detectMultiScale(
 
     CV_OCL_RUN(_img.dims() <= 2 && _img.type() == CV_8UC1 && scale0 > 1 && winStride.width % blockStride.width == 0 &&
         winStride.height % blockStride.height == 0 && padding == Size(0,0) && _img.isUMat(),
-        ocl_detectMultiScale(_img, foundLocations, levelScale, hitThreshold, winStride, finalThreshold, oclSvmDetector,
+        ocl_detectMultiScale(_img, foundLocations, levelScale, hitThreshold, winStride, groupThreshold, oclSvmDetector,
         blockSize, cellSize, nbins, blockStride, winSize, gammaCorrection, L2HysThreshold, (float)getWinSigma(), free_coef, signedGradient));
 
     std::vector<Rect> allCandidates;
@@ -1933,21 +1933,21 @@ void HOGDescriptor::detectMultiScale(
     std::copy(tempWeights.begin(), tempWeights.end(), back_inserter(foundWeights));
 
     if ( useMeanshiftGrouping )
-        groupRectangles_meanshift(foundLocations, foundWeights, foundScales, finalThreshold, winSize);
+        groupRectangles_meanshift(foundLocations, foundWeights, foundScales, groupThreshold, winSize);
     else
-        groupRectangles(foundLocations, foundWeights, (int)finalThreshold, 0.2);
+        groupRectangles(foundLocations, foundWeights, (int)groupThreshold, 0.2);
     clipObjects(imgSize, foundLocations, 0, &foundWeights);
 }
 
 void HOGDescriptor::detectMultiScale(InputArray img, std::vector<Rect>& foundLocations,
     double hitThreshold, Size winStride, Size padding,
-    double scale0, double finalThreshold, bool useMeanshiftGrouping) const
+    double scale0, double groupThreshold, bool useMeanshiftGrouping) const
 {
     CV_INSTRUMENT_REGION();
 
     std::vector<double> foundWeights;
     detectMultiScale(img, foundLocations, foundWeights, hitThreshold, winStride,
-                padding, scale0, finalThreshold, useMeanshiftGrouping);
+                padding, scale0, groupThreshold, useMeanshiftGrouping);
 }
 
 std::vector<float> HOGDescriptor::getDefaultPeopleDetector()

--- a/modules/stitching/src/seam_finders.cpp
+++ b/modules/stitching/src/seam_finders.cpp
@@ -587,8 +587,8 @@ void DpSeamFinder::computeGradients(const Mat &image1, const Mat &image2)
 bool DpSeamFinder::hasOnlyOneNeighbor(int comp)
 {
     std::set<std::pair<int, int> >::iterator begin, end;
-    begin = lower_bound(edges_.begin(), edges_.end(), std::make_pair(comp, std::numeric_limits<int>::min()));
-    end = upper_bound(edges_.begin(), edges_.end(), std::make_pair(comp, std::numeric_limits<int>::max()));
+    begin = edges_.lower_bound(std::make_pair(comp, std::numeric_limits<int>::min()));
+    end = edges_.upper_bound(std::make_pair(comp, std::numeric_limits<int>::max()));
     return ++begin == end;
 }
 


### PR DESCRIPTION
#21598 from KaurkerDevourer:patch-1
#21606 from sturkmen72:hog_update
#21614 from alalek:fix_build_power8_vec_absd
~~#21617 from mshabunin:disable-onnx-tests-34~~ (backport)
~~#21622 from alalek:imgcodecs_checks_3.4~~ (backport)
#21635 from DumDereDum:issue_21595_3.4
~~#21639 from georgthegreat:patch-1~~ (not applicable)

Previous "Merge 3.4": #21596

<cut/>

<details>

```
buildworker:Win64 OpenCL=windows-2
Xbuildworker:Custom=linux-1,linux-2,linux-4,linux-6
buildworker:Docs=linux-4,linux-6
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-4,linux-6
Xbuild_image:Custom=javascript-simd
Xbuild_image:Custom=powerpc64le
Xbuild_image:Custom=ubuntu-openvino-2019r3.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2020.4.0:16.04
Xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.2.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.4.0:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.4.1:20.04
Xbuild_image:Custom=ubuntu-openvino-2021.4.2:20.04
Xbuildworker:Custom=linux-1
Xbuild_image:Custom=ubuntu-vulkan:16.04
Xbuildworker:Custom=linux-4
Xbuild_image:Custom=fedora:28
Xbuild_image:Custom=ubuntu-cuda:16.04
Xbuild_image:Custom=ubuntu-clang:18.04
Xbuild_image:Custom=ubuntu:20.04
Xbuildworker:Custom=linux-1
Xbuild_image:Custom=javascript-simd
Xbuild_image:Custom=mips64el

Xbuild_image:Custom Mac=openvino-2019r3.0
Xbuild_image:Custom Mac=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.4.0
Xbuild_image:Custom Mac=openvino-2021.1.0
Xbuild_image:Custom Mac=openvino-2021.2.0
Xbuild_image:Custom Mac=openvino-2021.3.0
Xbuild_image:Custom Mac=openvino-2021.4.0
Xbuild_image:Custom Mac=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.2
test_modules:Custom Mac=dnn,gapi,python2,python3,java

Xbuild_image:Custom Win=openvino-2019r3.0
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Win=openvino-2020.4.0
Xbuild_image:Custom Win=openvino-2021.1.0
Xbuild_image:Custom Win=openvino-2021.2.0
Xbuild_image:Custom Win=openvino-2021.3.0
Xbuild_image:Custom Win=openvino-2021.4.0
Xbuild_image:Custom Win=openvino-2021.4.1
build_image:Custom Win=openvino-2021.4.2
buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF
Xbuild_image:Custom Win=msvs2017
Xbuild_image:Custom Win=msvs2019
```

</details>
