### PR TITLE
Optimize cv::applyColorMap() for simple case

### DIFF
--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -797,14 +797,19 @@ namespace colormap
             CV_Error(Error::StsAssert, "cv::LUT only supports tables of size 256.");
         if (userColor.type() != CV_8UC1 && userColor.type() != CV_8UC3)
             CV_Error(Error::StsAssert, "cv::LUT only supports tables CV_8UC1 or CV_8UC3.");
-        if (src.isMat() && userColor.isMat() && (src.type() == CV_8UC1))
+        if (src.isMat() && userColor.isMat() && ((src.type() == CV_8UC1) || (src.type() == CV_8UC3)))
         {
             const cv::Mat srcMat = src.getMat();
+            cv::Mat srcGray;
+            if (srcMat.channels() == 1)
+              srcGray = srcMat;
+            else
+              cv::cvtColor(srcMat, srcGray, cv::COLOR_BGR2GRAY);
             cv::Mat userColorMat = userColor.getMat();
             dst.create(src.size(), userColor.type());
             cv::Mat dstMat = dst.getMat();
             const size_t elemSize = userColorMat.elemSize();
-            srcMat.forEach<unsigned char>([&](unsigned char& pixel, const int* position) -> void {
+            srcGray.forEach<unsigned char>([&](unsigned char& pixel, const int* position) -> void {
                 const int row = position[0];
                 const int col = position[1];
                 memcpy(dstMat.data+row*dstMat.step+col*elemSize, userColorMat.data+pixel*userColorMat.step, elemSize);

--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -763,7 +763,7 @@ namespace colormap
         else if (lut_type == CV_8UC3) {
             Vec3b localLUT[256];//small performance improvement by bringing the full LUT locally first
             _lut.copyTo(cv::Mat(256, 1, lut_type, localLUT));
-            srcGray.forEach<unsigned char>([](unsigned char& pixel, const int* position) -> void {
+            srcGray.forEach<unsigned char>([&](unsigned char& pixel, const int* position) -> void {
                 const int row = position[0];
                 const int col = position[1];
                 dstMat.at<Vec3b>(row, col) = localLUT[pixel];

--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -797,9 +797,24 @@ namespace colormap
             CV_Error(Error::StsAssert, "cv::LUT only supports tables of size 256.");
         if (userColor.type() != CV_8UC1 && userColor.type() != CV_8UC3)
             CV_Error(Error::StsAssert, "cv::LUT only supports tables CV_8UC1 or CV_8UC3.");
-        colormap::UserColorMap cm(userColor.getMat());
-
-        cm(src, dst);
+        if (src.isMat() && userColor.isMat() && (src.type() == CV_8UC1))
+        {
+            const cv::Mat srcMat = src.getMat();
+            cv::Mat userColorMat = userColor.getMat();
+            dst.create(src.size(), userColor.type());
+            cv::Mat dstMat = dst.getMat();
+            const size_t elemSize = userColorMat.elemSize();
+            srcMat.forEach<unsigned char>([&](unsigned char& pixel, const int* position) -> void {
+                const int row = position[0];
+                const int col = position[1];
+                memcpy(dstMat.data+row*dstMat.step+col*elemSize, userColorMat.data+pixel*userColorMat.step, elemSize);
+                });
+        }
+        else
+        {
+            colormap::UserColorMap cm(userColor.getMat());
+            cm(src, dst);
+        }
     }
 
 }

--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -812,7 +812,7 @@ namespace colormap
             srcGray.forEach<unsigned char>([&](unsigned char& pixel, const int* position) -> void {
                 const int row = position[0];
                 const int col = position[1];
-                memcpy(dstMat.data+row*dstMat.step+col*elemSize, userColorMat.data+pixel*userColorMat.step, elemSize);
+                memcpy(dstMat.ptr(row, col), userColorMat.ptr(pixel, 0), elemSize);
                 });
         }
         else


### PR DESCRIPTION
proposal for #21640
For regular cv::Mat CV_8UC1 src, applying the colormap is simpler than calling the cv::LUT() mechanism.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
