### PR TITLE
remove const in seamless_cloding APIs for better semantics

### DIFF
--- a/modules/photo/src/seamless_cloning.hpp
+++ b/modules/photo/src/seamless_cloning.hpp
@@ -53,7 +53,7 @@ namespace cv
     class Cloning
     {
         public:
-            void normalClone(const cv::Mat& destination, const cv::Mat &mask, const cv::Mat &wmask, cv::Mat &cloned, int flag);
+            void normalClone(const cv::Mat& destination, const cv::Mat &mask, cv::Mat &wmask, cv::Mat &cloned, int flag);
             void illuminationChange(cv::Mat &I, cv::Mat &mask, cv::Mat &wmask, cv::Mat &cloned, float alpha, float beta);
             void localColorChange(cv::Mat &I, cv::Mat &mask, cv::Mat &wmask, cv::Mat &cloned, float red_mul, float green_mul, float blue_mul);
             void textureFlatten(cv::Mat &I, cv::Mat &mask, cv::Mat &wmask, float low_threshold, float high_threhold, int kernel_size, cv::Mat &cloned);
@@ -61,10 +61,10 @@ namespace cv
         protected:
 
             void initVariables(const cv::Mat &destination, const cv::Mat &binaryMask);
-            void computeDerivatives(const cv::Mat &destination, const cv::Mat &patch, const cv::Mat &binaryMask);
+            void computeDerivatives(const cv::Mat &destination, const cv::Mat &patch, cv::Mat &binaryMask);
             void scalarProduct(cv::Mat mat, float r, float g, float b);
             void poisson(const cv::Mat &destination);
-            void evaluate(const cv::Mat &I, const cv::Mat &wmask, const cv::Mat &cloned);
+            void evaluate(const cv::Mat &I, cv::Mat &wmask, const cv::Mat &cloned);
             void dst(const Mat& src, Mat& dest, bool invert = false);
             void solve(const Mat &img, Mat& mod_diff, Mat &result);
 

--- a/modules/photo/src/seamless_cloning_impl.cpp
+++ b/modules/photo/src/seamless_cloning_impl.cpp
@@ -246,7 +246,7 @@ void Cloning::initVariables(const Mat &destination, const Mat &binaryMask)
         filter_Y[j] = 2.0f * (float)std::cos(scale * (j + 1));
 }
 
-void Cloning::computeDerivatives(const Mat& destination, const Mat &patch, const Mat &binaryMask)
+void Cloning::computeDerivatives(const Mat& destination, const Mat &patch, Mat &binaryMask)
 {
     initVariables(destination, binaryMask);
 
@@ -306,7 +306,7 @@ void Cloning::poisson(const Mat &destination)
     }
 }
 
-void Cloning::evaluate(const Mat &I, const Mat &wmask, const Mat &cloned)
+void Cloning::evaluate(const Mat &I, Mat &wmask, const Mat &cloned)
 {
     bitwise_not(wmask,wmask);
 
@@ -320,7 +320,7 @@ void Cloning::evaluate(const Mat &I, const Mat &wmask, const Mat &cloned)
     merge(output,cloned);
 }
 
-void Cloning::normalClone(const Mat &destination, const Mat &patch, const Mat &binaryMask, Mat &cloned, int flag)
+void Cloning::normalClone(const Mat &destination, const Mat &patch, Mat &binaryMask, Mat &cloned, int flag)
 {
     const int w = destination.cols;
     const int h = destination.rows;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This PR remove some `const` in photo module's seamless cloning APIs, since the `const` decorated masks passed as the second argument for `erode()` would change its content:
![image](https://user-images.githubusercontent.com/3831847/154957317-46978a0d-4ab2-4308-8a93-596a2979c1b1.png)
