### PR TITLE
G-API: MediaFrame input for oclbackend

### DIFF
--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -115,6 +115,10 @@ template<> struct ocl_get_in<cv::GScalar>
 {
     static cv::Scalar get(GOCLContext &ctx, int idx) { return ctx.inVal(idx); }
 };
+template<> struct ocl_get_in<cv::GFrame>
+{
+    static cv::MediaFrame get(GOCLContext &ctx, int idx) { return ctx.inArg<cv::MediaFrame>(idx); }
+};
 template<typename U> struct ocl_get_in<cv::GArray<U> >
 {
     static const std::vector<U>& get(GOCLContext &ctx, int idx) { return ctx.inArg<VectorRef>(idx).rref<U>(); }

--- a/modules/gapi/src/backends/ocl/goclbackend.cpp
+++ b/modules/gapi/src/backends/ocl/goclbackend.cpp
@@ -114,7 +114,8 @@ cv::GArg cv::gimpl::GOCLExecutable::packArg(const GArg &arg)
     GAPI_Assert(   arg.kind != cv::detail::ArgKind::GMAT
               && arg.kind != cv::detail::ArgKind::GSCALAR
               && arg.kind != cv::detail::ArgKind::GARRAY
-              && arg.kind != cv::detail::ArgKind::GOPAQUE);
+              && arg.kind != cv::detail::ArgKind::GOPAQUE
+              && arg.kind != cv::detail::ArgKind::GFRAME);
 
     if (arg.kind != cv::detail::ArgKind::GOBJREF)
     {
@@ -135,7 +136,8 @@ cv::GArg cv::gimpl::GOCLExecutable::packArg(const GArg &arg)
     case GShape::GARRAY:  return GArg(m_res.slot<cv::detail::VectorRef>().at(ref.id));
     // Note: .at() is intentional for GOpaque as object MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
-    case GShape::GOPAQUE:  return GArg(m_res.slot<cv::detail::OpaqueRef>().at(ref.id));
+    case GShape::GOPAQUE: return GArg(m_res.slot<cv::detail::OpaqueRef>().at(ref.id));
+    case GShape::GFRAME:  return GArg(m_res.slot<cv::MediaFrame>().at(ref.id));
     default:
         util::throw_error(std::logic_error("Unsupported GShape type"));
         break;

--- a/modules/gapi/test/gapi_gpu_test.cpp
+++ b/modules/gapi/test/gapi_gpu_test.cpp
@@ -204,6 +204,7 @@ TEST(GPU, Symm7x7_test)
     }
 }
 
+namespace {
 class TestMediaBGR final: public cv::MediaFrame::IAdapter {
     cv::Mat m_mat;
     using Cb = cv::MediaFrame::View::Callback;
@@ -254,6 +255,7 @@ void normAssert(cv::InputArray ref, cv::InputArray test,
     double normInf = cvtest::norm(ref, test, cv::NORM_INF);
     EXPECT_LE(normInf, lInf) << comment;
 }
+} // anonymous
 
 G_API_OP(MF2Umt, <GMat(GFrame)>, "test.MediaFrame_UMt") {
     static GMatDesc outMeta(GFrameDesc d) {


### PR DESCRIPTION
Kernels can get MediaFrame input now.
Part of #21737

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Build configuration
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```