### PR TITLE
G-API: Added reshape() functionality to CPU backend

### DIFF
--- a/modules/gapi/src/backends/cpu/gcpubackend.hpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2022 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GCPUBACKEND_HPP
@@ -33,7 +33,7 @@ class GCPUExecutable final: public GIslandExecutable
 {
     const ade::Graph &m_g;
     GModel::ConstGraph m_gm;
-    const cv::GCompileArgs m_compileArgs;
+    cv::GCompileArgs m_compileArgs;
 
     struct OperationInfo
     {
@@ -51,6 +51,7 @@ class GCPUExecutable final: public GIslandExecutable
 
     // List of all resources in graph (both internal and external)
     std::vector<ade::NodeHandle> m_dataNodes;
+    std::vector<ade::NodeHandle> m_opNodes;
 
     // Actual data of all resources in graph (both internal and external)
     Mag m_res;
@@ -61,19 +62,15 @@ class GCPUExecutable final: public GIslandExecutable
     GArg packArg(const GArg &arg);
     void setupKernelStates();
 
+    void makeReshape();
+
 public:
     GCPUExecutable(const ade::Graph                   &graph,
                    const cv::GCompileArgs             &compileArgs,
                    const std::vector<ade::NodeHandle> &nodes);
 
-    virtual inline bool canReshape() const override { return false; }
-    virtual inline void reshape(ade::Graph&, const GCompileArgs&) override
-    {
-        // FIXME: CPU plugin is in fact reshapeable (as it was initially,
-        // even before outMeta() has been introduced), so this limitation
-        // should be dropped.
-        util::throw_error(std::logic_error("GCPUExecutable::reshape() should never be called"));
-    }
+    virtual inline bool canReshape() const override { return true; }
+    virtual void reshape(ade::Graph&, const GCompileArgs&) override;
 
     virtual void handleNewStream() override;
 

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2018-2022 Intel Corporation
 
 
 #include "precomp.hpp"
@@ -954,7 +954,7 @@ namespace
         GFluidModel fg(graph);
         for (const auto& node : g.nodes())
         {
-            if (g.metadata(node).get<NodeType>().t == NodeType::DATA)
+            if (fg.metadata(node).contains<FluidData>())
             {
                 auto& fd = fg.metadata(node).get<FluidData>();
                 fd.latency         = 0;


### PR DESCRIPTION
### Summary

* Added reshape functionality to CPU backend
* Fixed fluid heterogeneous reshape

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Build configuration

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
