### PR TITLE
Bug fixes and feature support in stitching_detailed.py

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -324,7 +324,10 @@ def main():
                 is_work_scale_set = True
             img = cv.resize(src=full_img, dsize=None, fx=work_scale, fy=work_scale, interpolation=cv.INTER_LINEAR_EXACT)
         if is_seam_scale_set is False:
-            seam_scale = min(1.0, np.sqrt(seam_megapix * 1e6 / (full_img.shape[0] * full_img.shape[1])))
+            if seam_megapix > 0:
+                seam_scale = min(1.0, np.sqrt(seam_megapix * 1e6 / (full_img.shape[0] * full_img.shape[1])))
+            else:
+                seam_scale = 1.0
             seam_work_aspect = seam_scale / work_scale
             is_seam_scale_set = True
         img_feat = cv.detail.computeImageFeatures2(finder, img)
@@ -345,9 +348,9 @@ def main():
     img_names_subset = []
     full_img_sizes_subset = []
     for i in range(len(indices)):
-        img_names_subset.append(img_names[indices[i, 0]])
-        img_subset.append(images[indices[i, 0]])
-        full_img_sizes_subset.append(full_img_sizes[indices[i, 0]])
+        img_names_subset.append(img_names[indices[i]])
+        img_subset.append(images[indices[i]])
+        full_img_sizes_subset.append(full_img_sizes[indices[i]])
     images = img_subset
     img_names = img_names_subset
     full_img_sizes = full_img_sizes_subset
@@ -479,7 +482,7 @@ def main():
                 blender = cv.detail.Blender_createDefault(cv.detail.Blender_NO)
             elif blend_type == "multiband":
                 blender = cv.detail_MultiBandBlender()
-                blender.setNumBands((np.log(blend_width) / np.log(2.) - 1.).astype(np.int))
+                blender.setNumBands((np.log(blend_width) / np.log(2.) - 1.).astype(np.int32))
             elif blend_type == "feather":
                 blender = cv.detail_FeatherBlender()
                 blender.setSharpness(1. / blend_width)
@@ -513,6 +516,5 @@ def main():
 
 
 if __name__ == '__main__':
-    print(__doc__)
     main()
     cv.destroyAllWindows()


### PR DESCRIPTION
###  Critical bugs fixed:
- `seam_finder.find()` returns None and overwrites `masks_warped`
- `indices` is only 1-dimensional

### Nice-to-have bugs fixed:
- avoid invalid value in sqrt and subsequent runtime warning
- avoid printing help string on each run (use argparse builtin behavior)

### New features:
- added graphcut seam finder support

### Test Summary:
Tested on Ubuntu 20.04 with python 3.8.10 and opencv-python-contrib 4.5.5.62

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
