### PR TITLE
Fix convertFromD3D11Texture2D is not working with NVIDIA GPU

### DIFF
--- a/modules/core/src/directx.cpp
+++ b/modules/core/src/directx.cpp
@@ -1385,6 +1385,7 @@ void convertFromD3D11Texture2D(ID3D11Texture2D* pD3D11Texture2D, OutputArray dst
     OpenCL_D3D11_NV* impl_nv = ctx.getUserContext<OpenCL_D3D11_NV>().get();
     if (impl_nv) {
         __convertFromD3D11Texture2DNV(pD3D11Texture2D,dst);
+        return;
     }
 #endif
     OpenCL_D3D11* impl = ctx.getUserContext<OpenCL_D3D11>().get();


### PR DESCRIPTION
Fix #20517

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
