### PR TITLE
GAPI Fluid: Resize F32C1 scalar version.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -497,9 +497,7 @@ namespace imgproc {
     };
 
     G_TYPED_KERNEL(GResize, <GMat(GMat,Size,double,double,int)>, "org.opencv.imgproc.transform.resize") {
-        static GMatDesc outMeta(GMatDesc in, Size sz, double fx, double fy, int interp) {
-            GAPI_Assert((in.depth == CV_8U && in.chan == 3) || (in.depth == CV_32F && in.chan == 1));
-            GAPI_Assert(interp == cv::INTER_LINEAR);
+        static GMatDesc outMeta(GMatDesc in, Size sz, double fx, double fy, int /*interp*/) {
             if (sz.width != 0 && sz.height != 0)
             {
                 return in.withSize(sz);
@@ -509,7 +507,7 @@ namespace imgproc {
                 int outSz_w = saturate_cast<int>(in.size.width  * fx);
                 int outSz_h = saturate_cast<int>(in.size.height * fy);
                 GAPI_Assert(outSz_w > 0 && outSz_h > 0);
-                return in.withType(in.depth, in.chan).withSize(Size(outSz_w, outSz_h));
+                return in.withSize(Size(outSz_w, outSz_h));
             }
         }
     };

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -497,7 +497,9 @@ namespace imgproc {
     };
 
     G_TYPED_KERNEL(GResize, <GMat(GMat,Size,double,double,int)>, "org.opencv.imgproc.transform.resize") {
-        static GMatDesc outMeta(GMatDesc in, Size sz, double fx, double fy, int /*interp*/) {
+        static GMatDesc outMeta(GMatDesc in, Size sz, double fx, double fy, int interp) {
+            GAPI_Assert((in.depth == CV_8U && in.chan == 3) || (in.depth == CV_32F && in.chan == 1));
+            GAPI_Assert(interp == cv::INTER_LINEAR);
             if (sz.width != 0 && sz.height != 0)
             {
                 return in.withSize(sz);
@@ -507,7 +509,7 @@ namespace imgproc {
                 int outSz_w = saturate_cast<int>(in.size.width  * fx);
                 int outSz_h = saturate_cast<int>(in.size.height * fy);
                 GAPI_Assert(outSz_w > 0 && outSz_h > 0);
-                return in.withSize(Size(outSz_w, outSz_h));
+                return in.withType(in.depth, in.chan).withSize(Size(outSz_w, outSz_h));
             }
         }
     };

--- a/modules/gapi/include/opencv2/gapi/own/assert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/assert.hpp
@@ -18,6 +18,7 @@
 #if !defined(GAPI_STANDALONE)
 #include <opencv2/core/base.hpp>
 #define GAPI_Assert CV_Assert
+#define GAPI_Error CV_Error
 
 #if defined _DEBUG || defined CV_STATIC_ANALYSIS
 #  define GAPI_DbgAssert CV_DbgAssert
@@ -42,7 +43,6 @@ namespace detail
 
 #define GAPI_Assert(expr) \
 { if (!(expr)) ::detail::assert_abort(#expr, __LINE__, __FILE__, __func__); }
-
 
 #ifdef NDEBUG
 #  define GAPI_DbgAssert(expr) GAPI_DbgAssertNoOp(expr)

--- a/modules/gapi/include/opencv2/gapi/own/assert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/assert.hpp
@@ -18,7 +18,6 @@
 #if !defined(GAPI_STANDALONE)
 #include <opencv2/core/base.hpp>
 #define GAPI_Assert CV_Assert
-#define GAPI_Error CV_Error
 
 #if defined _DEBUG || defined CV_STATIC_ANALYSIS
 #  define GAPI_DbgAssert CV_DbgAssert

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
@@ -200,7 +200,7 @@ INSTANTIATE_TEST_CASE_P(RGB2LabPerfTestFluid, RGB2LabPerfTest,
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ResizePerfTestFluid, ResizePerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
             Values(CV_8UC3, CV_32FC1),
             Values(cv::INTER_LINEAR),
             Values(szSmall128, szVGA, sz720p, sz1080p),
@@ -216,15 +216,15 @@ INSTANTIATE_TEST_CASE_P(BottleneckKernelsPerfTestFluid, BottleneckKernelsConstIn
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ResizeInSimpleGraphPerfTestFluid, ResizeInSimpleGraphPerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
-            Values(CV_8UC3),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
+            Values(CV_8UC3, CV_32FC1),
             Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(0.5),
             Values(0.5),
             Values(cv::compile_args(cv::gapi::combine(IMGPROC_FLUID, CORE_FLUID)))));
 
 INSTANTIATE_TEST_CASE_P(ResizeFxFyPerfTestFluid, ResizeFxFyPerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
             Values(CV_8UC3, CV_32FC1),
             Values(cv::INTER_LINEAR),
             Values(szSmall128, szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
@@ -200,8 +200,8 @@ INSTANTIATE_TEST_CASE_P(RGB2LabPerfTestFluid, RGB2LabPerfTest,
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ResizePerfTestFluid, ResizePerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
-            Values(CV_8UC3),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
+            Values(CV_8UC3, CV_32FC1),
             Values(cv::INTER_LINEAR),
             Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(cv::Size(64, 64),
@@ -216,7 +216,7 @@ INSTANTIATE_TEST_CASE_P(BottleneckKernelsPerfTestFluid, BottleneckKernelsConstIn
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ResizeInSimpleGraphPerfTestFluid, ResizeInSimpleGraphPerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
             Values(CV_8UC3),
             Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(0.5),
@@ -224,8 +224,8 @@ INSTANTIATE_TEST_CASE_P(ResizeInSimpleGraphPerfTestFluid, ResizeInSimpleGraphPer
             Values(cv::compile_args(cv::gapi::combine(IMGPROC_FLUID, CORE_FLUID)))));
 
 INSTANTIATE_TEST_CASE_P(ResizeFxFyPerfTestFluid, ResizeFxFyPerfTest,
-    Combine(Values(Tolerance_FloatRel_IntAbs(1e-5, 1).to_compare_f()),
-            Values(CV_8UC3),
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-2, 1).to_compare_f()),
+            Values(CV_8UC3, CV_32FC1),
             Values(cv::INTER_LINEAR),
             Values(szSmall128, szVGA, sz720p, sz1080p),
             Values(0.5, 0.25, 2),

--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -2198,7 +2198,7 @@ GAPI_FLUID_KERNEL(GFluidResize, cv::gapi::imgproc::GResize, true)
        }
        else
        {
-           GAPI_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
+           CV_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
        }
    }
 
@@ -2225,7 +2225,7 @@ GAPI_FLUID_KERNEL(GFluidResize, cv::gapi::imgproc::GResize, true)
         }
         else
         {
-            GAPI_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
+            CV_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
         }
     }
 };

--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -1954,10 +1954,18 @@ struct MapperUnit {
     I index0, index1;
 };
 
-inline static uint8_t calc(short alpha0, uint8_t src0, short alpha1, uint8_t src1) {
+CV_ALWAYS_INLINE uint8_t resize_calc_revert_fixedpoint(short alpha0, uint8_t src0, short alpha1, uint8_t src1)
+{
     constexpr static const int half = 1 << 14;
     return (src0 * alpha0 + src1 * alpha1 + half) >> 15;
 }
+
+CV_ALWAYS_INLINE float resize_main_calculation(float alpha0, float src0, float alpha1, float src1)
+{
+    return src0 * alpha0 + src1 * alpha1;
+}
+
+namespace linear {
 struct Mapper {
     constexpr static const int ONE = 1 << 15;
     typedef short alpha_type;
@@ -1982,6 +1990,33 @@ struct Mapper {
         return u;
     }
 };
+}  // namespace linear
+
+namespace linear32f {
+struct Mapper {
+    typedef float alpha_type;
+    typedef int   index_type;
+    constexpr static const float unity = 1;
+
+    typedef MapperUnit<float, int> Unit;
+
+    static inline Unit map(double ratio, int start, int max, int outCoord) {
+        float f = static_cast<float>((outCoord + 0.5) * ratio - 0.5);
+        int s = cvFloor(f);
+        f -= s;
+
+        Unit u;
+
+        u.index0 = std::max(s - start, 0);
+        u.index1 = ((std::fabs(f) <= FLT_EPSILON) || s + 1 >= max) ? s - start : s - start + 1;
+
+        u.alpha0 = 1.f - f;
+        u.alpha1 =       f;
+
+        return u;
+    }
+};
+}  // namespace linear32f
 
 template<typename T, class Mapper, int numChan>
 CV_ALWAYS_INLINE void calcRowLinearC(const cv::gapi::fluid::View  & in,
@@ -2054,15 +2089,15 @@ CV_ALWAYS_INLINE void calcRowLinearC(const cv::gapi::fluid::View  & in,
             for (int c = 0; c < numChan; c++) {
                 auto idx0 = numChan*sx0 + c;
                 auto idx1 = numChan*sx1 + c;
-                T tmp0 = calc(beta0, src0[l][idx0], beta1, src1[l][idx0]);
-                T tmp1 = calc(beta0, src0[l][idx1], beta1, src1[l][idx1]);
-                dst[l][numChan * x + c] = calc(alpha0, tmp0, alpha1, tmp1);
+                T tmp0 = resize_calc_revert_fixedpoint(beta0, src0[l][idx0], beta1, src1[l][idx0]);
+                T tmp1 = resize_calc_revert_fixedpoint(beta0, src0[l][idx1], beta1, src1[l][idx1]);
+                dst[l][numChan * x + c] = resize_calc_revert_fixedpoint(alpha0, tmp0, alpha1, tmp1);
             }
         }
     }
 }
 
-template<typename T, class Mapper>
+template<class Mapper>
 CV_ALWAYS_INLINE void calcRowLinear(const cv::gapi::fluid::View& in,
                                     cv::gapi::fluid::Buffer& out,
                                     cv::gapi::fluid::Buffer& scratch)
@@ -2080,8 +2115,8 @@ CV_ALWAYS_INLINE void calcRowLinear(const cv::gapi::fluid::View& in,
 
     GAPI_DbgAssert(lpi <= 4);
 
-    LinearScratchDesc<T, Mapper, 1> scr(inSz.width, inSz.height, outSz.width,
-                                        outSz.height, scratch.OutLineB());
+    LinearScratchDesc<float, Mapper, 1> scr(inSz.width, inSz.height, outSz.width,
+                                            outSz.height, scratch.OutLineB());
 
     const auto* alpha = scr.alpha;
     const auto* mapsx = scr.mapsx;
@@ -2089,17 +2124,17 @@ CV_ALWAYS_INLINE void calcRowLinear(const cv::gapi::fluid::View& in,
     const auto* mapsy = scr.mapsy;
 
     const auto* beta = beta0 + outY;
-    const T* src0[4];
-    const T* src1[4];
-    T* dst[4];
+    const float* src0[4];
+    const float* src1[4];
+    float* dst[4];
 
     for (int l = 0; l < lpi; ++l)
     {
         auto index0 = mapsy[outY + l] - inY;
         auto index1 = mapsy[outSz.height + outY + l] - inY;
-        src0[l] = in.InLine<const T>(index0);
-        src1[l] = in.InLine<const T>(index1);
-        dst[l] = out.OutLine<T>(l);
+        src0[l] = in.InLine<const float>(index0);
+        src1[l] = in.InLine<const float>(index1);
+        dst[l] = out.OutLine<float>(l);
     }
 
     using alpha_type = typename Mapper::alpha_type;
@@ -2115,9 +2150,9 @@ CV_ALWAYS_INLINE void calcRowLinear(const cv::gapi::fluid::View& in,
             auto alpha1 = saturate_cast<alpha_type>(unity - alpha[x]);
             auto sx0 = mapsx[x];
             auto sx1 = sx0 + 1;
-            T tmp0 = calc(b0, src0[l][sx0], b1, src1[l][sx0]);
-            T tmp1 = calc(b0, src0[l][sx1], b1, src1[l][sx1]);
-            dst[l][x] = calc(alpha0, tmp0, alpha1, tmp1);
+            float tmp0 = resize_main_calculation(b0, src0[l][sx0], b1, src1[l][sx0]);
+            float tmp1 = resize_main_calculation(b0, src0[l][sx1], b1, src1[l][sx1]);
+            dst[l][x] = resize_main_calculation(alpha0, tmp0, alpha1, tmp1);
         }
     }
 }
@@ -2133,9 +2168,12 @@ GAPI_FLUID_KERNEL(GFluidResize, cv::gapi::imgproc::GResize, true)
     constexpr static const short ONE = INTER_RESIZE_COEF_SCALE;
 
    static void initScratch(const cv::GMatDesc& in,
-                           cv::Size outSz, double fx, double fy, int /*interp*/,
+                           cv::Size outSz, double fx, double fy, int interp,
                            cv::gapi::fluid::Buffer &scratch)
    {
+       GAPI_Assert((in.depth == CV_8U && in.chan == 3) ||
+                   (in.depth == CV_32F && in.chan == 1));
+       GAPI_Assert(interp == cv::INTER_LINEAR);
        int outSz_w;
        int outSz_h;
        if (outSz.width == 0 || outSz.height == 0)
@@ -2150,17 +2188,17 @@ GAPI_FLUID_KERNEL(GFluidResize, cv::gapi::imgproc::GResize, true)
        }
        cv::Size outSize(outSz_w, outSz_h);
 
-       if (in.chan == 3)
+       if (in.depth == CV_8U && in.chan == 3)
        {
-           initScratchLinear<uchar, Mapper, 3>(in, outSize, scratch, LPI);
+           initScratchLinear<uchar, linear::Mapper, 3>(in, outSize, scratch, LPI);
        }
-       else if (in.chan == 4)
+       else if (in.depth == CV_32F && in.chan == 1)
        {
-           initScratchLinear<uchar, Mapper, 4>(in, outSize, scratch, LPI);
+           initScratchLinear<float, linear32f::Mapper, 1>(in, outSize, scratch, LPI);
        }
-       else if (in.chan == 1)
+       else
        {
-           initScratchLinear<float, Mapper, 1>(in, outSize, scratch, LPI);
+           GAPI_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
        }
    }
 
@@ -2168,27 +2206,26 @@ GAPI_FLUID_KERNEL(GFluidResize, cv::gapi::imgproc::GResize, true)
     {}
 
     static void run(const cv::gapi::fluid::View& in, cv::Size /*sz*/, double /*fx*/,
-                    double /*fy*/, int /*interp*/, cv::gapi::fluid::Buffer& out,
+                    double /*fy*/, int interp, cv::gapi::fluid::Buffer& out,
                     cv::gapi::fluid::Buffer& scratch)
     {
+        GAPI_Assert((in.meta().depth == CV_8U && in.meta().chan == 3) ||
+                    (in.meta().depth == CV_32F && in.meta().chan == 1));
+        GAPI_Assert(interp == cv::INTER_LINEAR);
         const int channels = in.meta().chan;
         const int depth = in.meta().depth;
 
         if (depth == CV_8U && channels == 3)
         {
-            calcRowLinearC<uint8_t, Mapper, 3>(in, out, scratch);
-        }
-        else if (depth == CV_8U && channels == 4)
-        {
-            calcRowLinearC<uint8_t, Mapper, 4>(in, out, scratch);
+            calcRowLinearC<uint8_t, linear::Mapper, 3>(in, out, scratch);
         }
         else if (depth == CV_32F && channels == 1)
         {
-            calcRowLinear<float, Mapper>(in, out, scratch);
+            calcRowLinear<linear32f::Mapper>(in, out, scratch);
         }
         else
         {
-            CV_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
+            GAPI_Error(cv::Error::StsBadArg, "unsupported combination of type and number of channel");
         }
     }
 };


### PR DESCRIPTION
Resize F32C1 scalar version.

<cut/>

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```