### PR TITLE
GAPI Fluid: Dynamic dispatching for Add kernel.

### DIFF
--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -28,8 +28,8 @@ INSTANTIATE_TEST_CASE_P(SqrtPerfTestFluid, SqrtPerfTest,
 INSTANTIATE_TEST_CASE_P(AddPerfTestFluid, AddPerfTest,
     Combine(Values(Tolerance_FloatRel_IntAbs(1e-6, 1).to_compare_f()),
             Values(szSmall128, szVGA, sz720p, sz1080p),
-            Values(CV_8UC1, CV_8UC3, CV_16SC1, CV_32FC1),
-            Values(-1, CV_8U, CV_32F),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+            Values(-1, CV_8U, CV_16U, CV_16S, CV_32F),
             Values(cv::compile_args(CORE_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(AddCPerfTestFluid, AddCPerfTest,

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
@@ -290,6 +290,33 @@ int merge4_simd(const uchar in1[], const uchar in2[], const uchar in3[],
                     CV_CPU_DISPATCH_MODES_ALL);
 }
 
+#define ADD_SIMD(SRC, DST)                                                    \
+int add_simd(const SRC in1[], const SRC in2[], DST out[], const int length)   \
+{                                                                             \
+                                                                              \
+        CV_CPU_DISPATCH(add_simd, (in1, in2, out, length),                    \
+                        CV_CPU_DISPATCH_MODES_ALL);                           \
+}
+
+ADD_SIMD(uchar, uchar)
+ADD_SIMD(ushort, uchar)
+ADD_SIMD(short, uchar)
+ADD_SIMD(float, uchar)
+ADD_SIMD(short, short)
+ADD_SIMD(ushort, short)
+ADD_SIMD(uchar, short)
+ADD_SIMD(float, short)
+ADD_SIMD(ushort, ushort)
+ADD_SIMD(uchar, ushort)
+ADD_SIMD(short, ushort)
+ADD_SIMD(float, ushort)
+ADD_SIMD(uchar, float)
+ADD_SIMD(ushort, float)
+ADD_SIMD(short, float)
+ADD_SIMD(float, float)
+
+#undef ADD_SIMD
+
 } // namespace fluid
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
@@ -222,6 +222,28 @@ int merge3_simd(const uchar in1[], const uchar in2[], const uchar in3[],
 int merge4_simd(const uchar in1[], const uchar in2[], const uchar in3[],
                 const uchar in4[], uchar out[], const int width);
 
+#define ADD_SIMD(SRC, DST)                                                     \
+int add_simd(const SRC in1[], const SRC in2[], DST out[], const int length);
+
+ADD_SIMD(uchar, uchar)
+ADD_SIMD(ushort, uchar)
+ADD_SIMD(short, uchar)
+ADD_SIMD(float, uchar)
+ADD_SIMD(short, short)
+ADD_SIMD(ushort, short)
+ADD_SIMD(uchar, short)
+ADD_SIMD(float, short)
+ADD_SIMD(ushort, ushort)
+ADD_SIMD(uchar, ushort)
+ADD_SIMD(short, ushort)
+ADD_SIMD(float, ushort)
+ADD_SIMD(uchar, float)
+ADD_SIMD(ushort, float)
+ADD_SIMD(short, float)
+ADD_SIMD(float, float)
+
+#undef ADD_SIMD
+
 }  // namespace fluid
 }  // namespace gapi
 }  // namespace cv


### PR DESCRIPTION
- Move SIMD of the Add kernel to enable dynamic dispatching.
- Add support of new combination of types.

<cut/>

Performance:
[FluidAddSIMD.xlsx](https://github.com/opencv/opencv/files/8219348/FluidAddSIMD.xlsx)

```
force_builders=Linux AVX2,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```
