### PR TITLE
videoio(ffmpeg): fix memory leak through sw_picture

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1519,7 +1519,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
 #if USE_AV_HW_CODECS
     if (sw_picture != picture)
     {
-        av_frame_unref(sw_picture);
+        av_frame_free(&sw_picture);
     }
 #endif
     return true;


### PR DESCRIPTION
resolves #21696

- [x] Validated:

```
==54702== 8,040 bytes in 15 blocks are definitely lost in loss record 307 of 310
==54702==    at 0x4849803: memalign (vg_replace_malloc.c:1516)
==54702==    by 0x484991F: posix_memalign (vg_replace_malloc.c:1688)
==54702==    by 0x9A34D44: av_malloc (in /usr/lib64/libavutil.so.56.70.100)
==54702==    by 0x9A3503D: av_mallocz (in /usr/lib64/libavutil.so.56.70.100)
==54702==    by 0x9A2055F: av_frame_alloc (in /usr/lib64/libavutil.so.56.70.100)
==54702==    by 0x48DEADE: CvCapture_FFMPEG::retrieveFrame(int, unsigned char**, int*, int*, int*, int*) (cap_ffmpeg_impl.hpp:1444)
==54702==    by 0x48E360E: cvRetrieveFrame_FFMPEG (cap_ffmpeg_impl.hpp:2957)
==54702==    by 0x48E3A07: cv::(anonymous namespace)::CvCapture_FFMPEG_proxy::retrieveFrame(int, cv::_OutputArray const&) (cap_ffmpeg.cpp:106)
==54702==    by 0x48789E4: cv::VideoCapture::retrieve(cv::_OutputArray const&, int) (cap.cpp:361)
==54702==    by 0x4878AFB: cv::VideoCapture::read(cv::_OutputArray const&) (cap.cpp:376)
==54702==    by 0x48D570: opencv_test::videocapture_acceleration_read_Test::Body() (test_video_io.cpp:746)
==54702==    by 0x48C545: opencv_test::videocapture_acceleration_read_Test::TestBody() (test_video_io.cpp:670)
```

<cut/>

```
build_contrib:Custom=OFF
build_contrib:Custom Win=OFF

build_shared:Custom=OFF
build_examples:Custom=OFF

build_image:Linux AVX2=ubuntu:20.04

Xbuild_image:Win64=msvs2019

force_builders=Custom,Custom Win,Linux AVX2
Xbuild_image:Custom=centos:7
Xbuild_image:Custom=ubuntu:20.04
build_image:Custom=gstreamer:16.04
buildworker:Custom=linux-1,linux-4,linux-6
test_opencl:Custom=ON

build_image:Custom Win=ffmpeg
Xbuild_image:Custom Win=ffmpeg-plugin
buildworker:Custom Win=windows-2
test_modules:Custom Win=videoio
test_opencl:Custom Win=ON
```