### PR TITLE
parallelize some core loop of TIFF decoding

### DIFF
--- a/modules/imgcodecs/perf/perf_main.cpp
+++ b/modules/imgcodecs/perf/perf_main.cpp
@@ -8,35 +8,3 @@
 #endif
 
 CV_PERF_TEST_MAIN(imgcodecs)
-
-namespace opencv_test
-{
-
-using namespace perf;
-
-#define TYPICAL_MAT_SIZES_TIFF_DECODE  cv::Size(128, 128), cv::Size(256, 256), cv::Size(512, 512), cv::Size(1024, 1024)
-#define TYPICAL_MAT_TYPES_TIFF_DECODE  CV_8UC1, CV_8UC3, CV_16UC1, CV_16UC3
-#define TYPICAL_MATS_TIFF_DECODE       testing::Combine( testing::Values( TYPICAL_MAT_SIZES_TIFF_DECODE), testing::Values( TYPICAL_MAT_TYPES_TIFF_DECODE) )
-
-PERF_TEST_P(Size_MatType, tiffDecode, TYPICAL_MATS_TIFF_DECODE)
-{
-    cv::Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
-
-    cv::Mat src = Mat(sz, type);
-    cv::Mat dst = Mat(sz, type);
-    cv::randu(src, 0, (CV_MAT_DEPTH(type) == CV_16U) ? 65535 : 255);
-    std::vector<uchar> buf;
-    cv::imencode(".tiff", src, buf);
-
-    declare.in(src, WARMUP_RNG).out(dst);
-
-    TEST_CYCLE()
-    {
-      cv::imdecode(buf, cv::IMREAD_UNCHANGED, &dst);
-    }
-
-    SANITY_CHECK(dst);
-}
-
-}

--- a/modules/imgcodecs/perf/perf_main.cpp
+++ b/modules/imgcodecs/perf/perf_main.cpp
@@ -8,3 +8,35 @@
 #endif
 
 CV_PERF_TEST_MAIN(imgcodecs)
+
+namespace opencv_test
+{
+
+using namespace perf;
+
+#define TYPICAL_MAT_SIZES_TIFF_DECODE  cv::Size(128, 128), cv::Size(256, 256), cv::Size(512, 512), cv::Size(1024, 1024)
+#define TYPICAL_MAT_TYPES_TIFF_DECODE  CV_8UC1, CV_8UC3, CV_16UC1, CV_16UC3
+#define TYPICAL_MATS_TIFF_DECODE       testing::Combine( testing::Values( TYPICAL_MAT_SIZES_TIFF_DECODE), testing::Values( TYPICAL_MAT_TYPES_TIFF_DECODE) )
+
+PERF_TEST_P(Size_MatType, tiffDecode, TYPICAL_MATS_TIFF_DECODE)
+{
+    cv::Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+
+    cv::Mat src = Mat(sz, type);
+    cv::Mat dst = Mat(sz, type);
+    cv::randu(src, 0, (CV_MAT_DEPTH(type) == CV_16U) ? 65535 : 255);
+    std::vector<uchar> buf;
+    cv::imencode(".tiff", src, buf);
+
+    declare.in(src, WARMUP_RNG).out(dst);
+
+    TEST_CYCLE()
+    {
+      cv::imdecode(buf, cv::IMREAD_UNCHANGED, &dst);
+    }
+
+    SANITY_CHECK(dst);
+}
+
+}

--- a/modules/imgcodecs/perf/perf_tiff.cpp
+++ b/modules/imgcodecs/perf/perf_tiff.cpp
@@ -1,0 +1,36 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+
+using namespace perf;
+
+#define TYPICAL_MAT_SIZES_TIFF_DECODE  cv::Size(128, 128), cv::Size(256, 256), cv::Size(512, 512), cv::Size(640, 480), cv::Size(1024, 1024), cv::Size(1280, 720), cv::Size(1920, 1080)
+#define TYPICAL_MAT_TYPES_TIFF_DECODE  CV_8UC1, CV_8UC3, CV_16UC1, CV_16UC3
+#define TYPICAL_MATS_TIFF_DECODE       testing::Combine( testing::Values( TYPICAL_MAT_SIZES_TIFF_DECODE), testing::Values( TYPICAL_MAT_TYPES_TIFF_DECODE) )
+
+PERF_TEST_P(Size_MatType, tiffDecode, TYPICAL_MATS_TIFF_DECODE)
+{
+    cv::Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+
+    cv::Mat src = Mat(sz, type);
+    cv::Mat dst = Mat(sz, type);
+    cv::randu(src, 0, (CV_MAT_DEPTH(type) == CV_16U) ? 65535 : 255);
+    std::vector<uchar> buf;
+    cv::imencode(".tiff", src, buf);
+
+    declare.in(src, WARMUP_RNG).out(dst);
+
+    TEST_CYCLE()
+    {
+      cv::imdecode(buf, cv::IMREAD_UNCHANGED, &dst);
+    }
+
+    SANITY_CHECK(dst);
+}
+
+}

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -714,7 +714,7 @@ bool  TiffDecoder::readData( Mat& img )
                             const int rowsPerPacket = std::max(1, static_cast<int>(minimalBytesPerPacket/(ncn * tile_width0 * sizeof(uchar))));
                             const int rowsPacketsCount = divUp(tile_height, rowsPerPacket);
                             const Range all(0, tile_height);
-                            parallel_for_(all, [=,&img](const cv::Range& range) -> void {
+                            parallel_for_(all, [&](const cv::Range& range) -> void {
                                     for (int i = range.start; i < range.end; ++i)
                                     //for (int i = 0; i < tile_height; ++i)
                                     {
@@ -762,7 +762,7 @@ bool  TiffDecoder::readData( Mat& img )
                             const int rowsPerPacket = std::max(1, static_cast<int>(minimalBytesPerPacket/(ncn * tile_width0 * sizeof(uchar))));
                             const int rowsPacketsCount = divUp(tile_height, rowsPerPacket);
                             const Range all(0, tile_height);
-                            parallel_for_(all, [=,&img](const cv::Range& range) -> void {
+                            parallel_for_(all, [&](const cv::Range& range) -> void {
                                     for (int i = range.start; i < range.end; ++i)
                                     //for (int i = 0; i < tile_height; ++i)
                                     {


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Some inner loop of TIFF decoding is very easy to parallelize.
It can be interesting especially since #21701

The parallelized loop does not contain any libTIFF API call that could bring a hidden thread safety failure.
A minimal packet size is considered to accept the overhead of parallel task launch.

I am not sure that committing big tiffs in opencv_extra repository would be a good idea, so I just post my timings and the perf code here :
(Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz Windows 7 64b)

The timings :
A few timings are slowers, for images <= 256x256. But for small image sizes, those timings are pretty unstable because there are close to a few µs per image. In that case, it seems that even if parallel_for ends up with a single stripe, there must be an overhead due to the lambda function.
It might worth it anyway considering  the overall improvement.

```
				original	with patch	
1000 x decode			ms		ms	
<tiff_128x128_8UC1.tif>		81,717437	51,819599	-36,59 %
<tiff_256x256_8UC1.tif>		239,64348	155,762186	-35,00 %
<tiff_512x512_8UC1.tif>		912,076734	605,742149	-33,59 %
<tiff_1024x1024_8UC1.tif>	3520,660103	2764,982218	-21,46 %
<tiff_128x128_10UC1.tif>	80,05107	37,649361	-52,97 %
<tiff_256x256_10UC1.tif>	225,729957	144,866338	-35,82 %
<tiff_512x512_10UC1.tif>	813,341579	237,709014	-70,77 %
<tiff_1024x1024_10UC1.tif>	3683,324549	1743,841985	-52,66 %
<tiff_128x128_12UC1.tif>	74,030803	54,819628	-25,95 %
<tiff_256x256_12UC1.tif>	234,304845	183,115079	-21,85 %
<tiff_512x512_12UC1.tif>	1208,067606	284,91003	-76,42 %
<tiff_1024x1024_12UC1.tif>	4487,550489	1526,076151	-65,99 %
<tiff_128x128_14UC1.tif>	59,623205	51,130853	-14,24 %
<tiff_256x256_14UC1.tif>	176,5552	176,069662	-0,28 %
<tiff_512x512_14UC1.tif>	982,139848	251,194775	-74,42 %
<tiff_1024x1024_14UC1.tif>	3436,365561	1417,049082	-58,76 %
<tiff_128x128_16UC1.tif>	21,627478	34,601518	59,99 % <= worse
<tiff_256x256_16UC1.tif>	32,276288	44,318813	37,31 % <= worse
<tiff_512x512_16UC1.tif>	309,261471	112,17424	-63,73 %
<tiff_1024x1024_16UC1.tif>	1016,122918	952,882658	-6,22 %
<tiff_128x128_8UC3.tif>		93,750854	116,183197	23,93 % <= worse
<tiff_256x256_8UC3.tif>		278,687125	348,515155	25,06 % <= worse
<tiff_512x512_8UC3.tif>		1270,658965	1312,60075	3,30 % <= worse
<tiff_1024x1024_8UC3.tif>	3922,59861	3273,483393	-16,55 %
<tiff_128x128_10UC3.tif>	150,516901	84,530196	-43,84 %
<tiff_256x256_10UC3.tif>	537,984911	377,735631	-29,79 %
<tiff_512x512_10UC3.tif>	2821,451421	1235,642207	-56,21 %
<tiff_1024x1024_10UC3.tif>	10485,459206	3973,749101	-62,10 %
<tiff_128x128_12UC3.tif>	257,97437	86,32805	-66,54 %
<tiff_256x256_12UC3.tif>	757,248625	247,152804	-67,36 %
<tiff_512x512_12UC3.tif>	3664,673477	1253,983627	-65,78 %
<tiff_1024x1024_12UC3.tif>	13564,626574	3951,47699	-70,87 %
<tiff_128x128_14UC3.tif>	158,296885	80,171173	-49,35 %
<tiff_256x256_14UC3.tif>	566,992502	216,299544	-61,85 %
<tiff_512x512_14UC3.tif>	2875,859225	1179,355152	-58,99 %
<tiff_1024x1024_14UC3.tif>	10719,376417	3741,45585	-65,10 %
<tiff_128x128_16UC3.tif>	47,43297	46,10443	-2,80 %
<tiff_256x256_16UC3.tif>	124,363906	83,367581	-32,96 %
<tiff_512x512_16UC3.tif>	782,24242	522,335293	-33,23 %
<tiff_1024x1024_16UC3.tif>	3210,075785	2161,683409	-32,66 %
```

The perf code :

```
{
    std::vector<std::string> filenames = {
      "tiff_128x128_8UC1.tif",
      "tiff_256x256_8UC1.tif",
      "tiff_512x512_8UC1.tif",
      "tiff_1024x1024_8UC1.tif",
      "tiff_128x128_10UC1.tif",
      "tiff_256x256_10UC1.tif",
      "tiff_512x512_10UC1.tif",
      "tiff_1024x1024_10UC1.tif",
      "tiff_128x128_12UC1.tif",
      "tiff_256x256_12UC1.tif",
      "tiff_512x512_12UC1.tif",
      "tiff_1024x1024_12UC1.tif",
      "tiff_128x128_14UC1.tif",
      "tiff_256x256_14UC1.tif",
      "tiff_512x512_14UC1.tif",
      "tiff_1024x1024_14UC1.tif",
      "tiff_128x128_16UC1.tif",
      "tiff_256x256_16UC1.tif",
      "tiff_512x512_16UC1.tif",
      "tiff_1024x1024_16UC1.tif",
      "tiff_128x128_8UC3.tif",
      "tiff_256x256_8UC3.tif",
      "tiff_512x512_8UC3.tif",
      "tiff_1024x1024_8UC3.tif",
      "tiff_128x128_10UC3.tif",
      "tiff_256x256_10UC3.tif",
      "tiff_512x512_10UC3.tif",
      "tiff_1024x1024_10UC3.tif",
      "tiff_128x128_12UC3.tif",
      "tiff_256x256_12UC3.tif",
      "tiff_512x512_12UC3.tif",
      "tiff_1024x1024_12UC3.tif",
      "tiff_128x128_14UC3.tif",
      "tiff_256x256_14UC3.tif",
      "tiff_512x512_14UC3.tif",
      "tiff_1024x1024_14UC3.tif",
      "tiff_128x128_16UC3.tif",
      "tiff_256x256_16UC3.tif",
      "tiff_512x512_16UC3.tif",
      "tiff_1024x1024_16UC3.tif",
    };
    for(const auto& filename : filenames)
    {
      std::string filepath = "D:\\test_data\\Test images\\TIFF\\"+filename;
      //preload the bytes to avoid including I/O in the decoding timing
      FILE* fp = fopen(filepath.c_str(), "rb");
      fseek(fp, 0, SEEK_END);
      const auto fileSize = ftell(fp);
      fseek(fp, 0, SEEK_SET);
      std::vector<unsigned char> bytes(fileSize);
      fread(bytes.data(), sizeof(unsigned char), fileSize, fp);
      fclose(fp);
      constexpr const size_t nbIters = 1000;
      double totalMs = 0;
      cv::Mat refMat;
      //iteration 0 will just be a warmup.
      for(unsigned int i = 0 ; i<=nbIters ; ++i)
      {
        cv::Mat tmpMat;
        cv::Mat& dstMat = !i ? refMat : tmpMat;
        const auto ref = cv::getTickCount();
        dstMat = cv::imdecode(bytes, cv::IMREAD_UNCHANGED);
        const auto now = cv::getTickCount();
        if (i>0)
        {
          //thread safety failures might be detected by comparing the decoded mat to the first one
          CV_Assert(cv::norm(refMat.reshape(1), dstMat.reshape(1), cv::NORM_INF) == 0);
          totalMs += 1000.*(now-ref)/cv::getTickFrequency();
        }//end if (i>0)
      }
      std::cout << nbIters << "x decode <" << filename << ">\t" << refMat.size() << "\t: " << totalMs << "ms" << std::endl;
    }
```

