### PR TITLE
G-API: Use different devices processing in streaming pipeline

### DIFF
--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -41,13 +41,13 @@ const std::string keys =
     "{ input                        |                                           | Path to the input demultiplexed video file }"
     "{ output                       |                                           | Path to the output RAW video file. Use .avi extension }"
     "{ facem                        | face-detection-adas-0001.xml              | Path to OpenVINO IE face detection model (.xml) }"
-    "{ faced                        | AUTO                                      | Target device for face detection model (e.g. AUTO, GPU, VPU, ...) }"
-    "{ cfg_params                   | <prop name>:<value>;<prop name>:<value>   | Semicolon separated list of oneVPL mfxVariants which is used for configuring source (see `MFXSetConfigFilterProperty` by https://spec.oneapi.io/versions/latest/elements/oneVPL/source/index.html) }"
+    "{ faced                        | GPU                                       | Target device for face detection model (e.g. AUTO, GPU, VPU, ...) }"
+    "{ cfg_params                   |                                           | Semicolon separated list of oneVPL mfxVariants which is used for configuring source (see `MFXSetConfigFilterProperty` by https://spec.oneapi.io/versions/latest/elements/oneVPL/source/index.html) }"
     "{ streaming_queue_capacity     | 1                                         | Streaming executor queue capacity. Calculated automaticaly if 0 }"
     "{ frames_pool_size             | 0                                         | OneVPL source applies this parameter as preallocated frames pool size}"
     "{ vpp_frames_pool_size         | 0                                         | OneVPL source applies this parameter as preallocated frames pool size for VPP preprocessing results}"
     "{ roi                          | -1,-1,-1,-1                               | Region of interest (ROI) to use for inference. Identified automatically when not set }"
-    "{ source_device                | GPU                                       | choose device for decoding }"
+    "{ source_device                | CPU                                       | choose device for decoding }"
     "{ preproc_device               | CPU                                       | choose device for preprocessing }";
 
 namespace {

--- a/modules/gapi/samples/onevpl_infer_single_roi.cpp
+++ b/modules/gapi/samples/onevpl_infer_single_roi.cpp
@@ -310,10 +310,10 @@ support_matrix resolved_conf{{
                             }
     }};
 
-void print_available_cfg(std::ostream &out,
-                         const std::string &source_device,
-                         const std::string &preproc_device,
-                         const std::string &ie_device_id) {
+static void print_available_cfg(std::ostream &out,
+                                const std::string &source_device,
+                                const std::string &preproc_device,
+                                const std::string &ie_device_id) {
     const std::string source_device_cfg_name("--source_device=");
     const std::string preproc_device_cfg_name("--preproc_device=");
     const std::string ie_cfg_name("--faced=");

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -703,49 +703,6 @@ cv::MediaFrame preprocess_frame_impl(cv::MediaFrame &&in_frame, const std::strin
     return std::move(in_frame);
 }
 
-inline IE::Blob::Ptr extractRemoteBlob(IECallContext& ctx, std::size_t i,
-                                       const std::string &layer_name,
-                                       const cv::util::optional<cv::Rect> &opt_roi,
-                                       cv::MediaFrame* out_keep_alive_frame,
-                                       bool* out_is_preprocessed) {
-    GAPI_Assert(ctx.inShape(i) == cv::GShape::GFRAME &&
-                "Remote blob is supported for MediaFrame only");
-    cv::MediaFrame frame = ctx.inFrame(i);
-    if (ctx.uu.preproc_engine_impl) {
-        GAPI_LOG_DEBUG(nullptr, "Try to use preprocessing for decoded remote frame in remote ctx");
-
-        //TODO
-        frame.blobParams();
-
-        frame = preprocess_frame_impl(std::move(frame), layer_name, ctx, opt_roi,
-                                      out_keep_alive_frame, out_is_preprocessed);
-    }
-
-    // Request params for result frame whatever it got preprocessed or not
-    cv::util::any any_blob_params = frame.blobParams();
-
-    using ParamType = std::pair<InferenceEngine::TensorDesc, InferenceEngine::ParamMap>;
-    using NV12ParamType = std::pair<ParamType, ParamType>;
-
-    NV12ParamType* blob_params = cv::util::any_cast<NV12ParamType>(&any_blob_params);
-    if (blob_params == nullptr) {
-        GAPI_Assert(false && "Incorrect type of blobParams:"
-                             "expected std::pair<ParamType, ParamType>,"
-                             "with ParamType std::pair<InferenceEngine::TensorDesc,"
-                                                      "InferenceEngine::ParamMap >>");
-    }
-
-    //The parameters are TensorDesc and ParamMap for both y and uv blobs
-    auto y_blob = ctx.uu.rctx->CreateBlob(blob_params->first.first, blob_params->first.second);
-    auto uv_blob = ctx.uu.rctx->CreateBlob(blob_params->second.first, blob_params->second.second);
-
-#if INF_ENGINE_RELEASE >= 2021010000
-    return IE::make_shared_blob<IE::NV12Blob>(y_blob, uv_blob);
-#else
-    return IE::make_shared_blob<InferenceEngine::NV12Blob>(y_blob, uv_blob);
-#endif
-}
-
 inline IE::Blob::Ptr extractBlob(IECallContext& ctx,
                                  std::size_t i,
                                  cv::gapi::ie::TraitAs hint,
@@ -753,17 +710,6 @@ inline IE::Blob::Ptr extractBlob(IECallContext& ctx,
                                  const cv::util::optional<cv::Rect> &opt_roi,
                                  cv::MediaFrame* out_keep_alive_frame = nullptr,
                                  bool* out_is_preprocessed = nullptr) {
-    try {
-        if (ctx.uu.rctx != nullptr) {
-            return extractRemoteBlob(ctx, i, layer_name, opt_roi,
-                                     out_keep_alive_frame, out_is_preprocessed);
-        }
-    } catch(const std::exception &ex) {
-        //TODO VPL only
-        GAPI_LOG_DEBUG(nullptr, "Try to fallback to GIE streaming CPU use-case");
-        GAPI_DbgAssert(ctx.uu.preproc_engine_impl && "VPL only scenario");
-    }
-
     switch (ctx.inShape(i)) {
         case cv::GShape::GFRAME: {
             auto frame = ctx.inFrame(i);
@@ -772,6 +718,37 @@ inline IE::Blob::Ptr extractBlob(IECallContext& ctx,
                 frame = preprocess_frame_impl(std::move(frame), layer_name, ctx, opt_roi,
                                               out_keep_alive_frame, out_is_preprocessed);
             }
+
+            // NB: check OV remote device context availability.
+            // if it exist and MediaFrame shares the same device context
+            // then we create a remote blob without memory copy
+            if (ctx.uu.rctx != nullptr) {
+                // Request params for result frame whatever it got preprocessed or not
+                cv::util::any any_blob_params = frame.blobParams();
+                using ParamType = std::pair<InferenceEngine::TensorDesc, InferenceEngine::ParamMap>;
+                using NV12ParamType = std::pair<ParamType, ParamType>;
+
+                NV12ParamType* blob_params = cv::util::any_cast<NV12ParamType>(&any_blob_params);
+                if (blob_params == nullptr) {
+                    GAPI_Assert(false && "Incorrect type of blobParams:"
+                                         "expected std::pair<ParamType, ParamType>,"
+                                         "with ParamType std::pair<InferenceEngine::TensorDesc,"
+                                         "InferenceEngine::ParamMap >>");
+                }
+
+                //The parameters are TensorDesc and ParamMap for both y and uv blobs
+                auto y_blob = ctx.uu.rctx->CreateBlob(blob_params->first.first, blob_params->first.second);
+                auto uv_blob = ctx.uu.rctx->CreateBlob(blob_params->second.first, blob_params->second.second);
+
+#if INF_ENGINE_RELEASE >= 2021010000
+                return IE::make_shared_blob<IE::NV12Blob>(y_blob, uv_blob);
+#else
+                return IE::make_shared_blob<InferenceEngine::NV12Blob>(y_blob, uv_blob);
+#endif
+            }
+
+            // NB: If no OV remote context created then use default MediaFrame accessor approach:
+            // it invokes memory copying operation If GPU MediaFrame come
             ctx.views.emplace_back(new cv::MediaFrame::View(frame.access(cv::MediaFrame::Access::R)));
             return wrapIE(*(ctx.views.back()), frame.desc());
         }

--- a/modules/gapi/src/streaming/onevpl/accelerators/dx11_alloc_resource.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/dx11_alloc_resource.cpp
@@ -96,6 +96,8 @@ void LockAdapter::unlock_write(mfxMemId mid, mfxFrameData &data) {
 
 SharedLock* LockAdapter::set_adaptee(SharedLock* new_impl) {
     SharedLock* old_impl = impl;
+    GAPI_LOG_DEBUG(nullptr, "this: " << this <<
+                            ", old: " << old_impl << ", new: " << new_impl);
     GAPI_DbgAssert(old_impl == nullptr || new_impl == nullptr && "Must not be previous impl");
     impl = new_impl;
     return old_impl;
@@ -184,6 +186,8 @@ void DX11AllocationItem::on_first_in_impl(mfxFrameData *ptr) {
     D3D11_MAP mapType = D3D11_MAP_READ;
     UINT mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
 
+    GAPI_LOG_DEBUG(nullptr, "texture: " << get_texture_ptr() <<
+                            ", subresorce: " << get_subresource());
     shared_device_context->CopySubresourceRegion(get_staging_texture_ptr(), 0,
                                                  0, 0, 0,
                                                  get_texture_ptr(),
@@ -245,8 +249,8 @@ mfxStatus DX11AllocationItem::release_access(mfxFrameData *ptr) {
 }
 
 mfxStatus DX11AllocationItem::shared_access_acquire_unsafe(mfxFrameData *ptr) {
-    GAPI_LOG_DEBUG(nullptr, "acquire READ lock: " << this);
-    GAPI_LOG_DEBUG(nullptr, "texture: " << get_texture_ptr() <<
+    GAPI_LOG_DEBUG(nullptr, "acquire READ lock: " << this <<
+                            ", texture: " << get_texture_ptr() <<
                             ", sub id: " << get_subresource());
     // shared access requires elastic barrier
     // first-in visited thread uses resource mapping on host memory
@@ -257,6 +261,7 @@ mfxStatus DX11AllocationItem::shared_access_acquire_unsafe(mfxFrameData *ptr) {
 
     if (!(ptr->Y && (ptr->UV || (ptr->U && ptr->V)))) {
         GAPI_LOG_WARNING(nullptr, "No any data obtained: " << this);
+        GAPI_DbgAssert(false && "shared access must provide data");
         return MFX_ERR_LOCK_MEMORY;
     }
     GAPI_LOG_DEBUG(nullptr, "READ access granted: " << this);
@@ -264,8 +269,8 @@ mfxStatus DX11AllocationItem::shared_access_acquire_unsafe(mfxFrameData *ptr) {
 }
 
 mfxStatus DX11AllocationItem::shared_access_release_unsafe(mfxFrameData *ptr) {
-    GAPI_LOG_DEBUG(nullptr, "releasing READ lock: " << this);
-    GAPI_LOG_DEBUG(nullptr, "texture: " << get_texture_ptr() <<
+    GAPI_LOG_DEBUG(nullptr, "releasing READ lock: " << this <<
+                            ", texture: " << get_texture_ptr() <<
                             ", sub id: " << get_subresource());
     // releasing shared access requires elastic barrier
     // last-out thread must make memory unmapping then and only then no more
@@ -278,8 +283,8 @@ mfxStatus DX11AllocationItem::shared_access_release_unsafe(mfxFrameData *ptr) {
 }
 
 mfxStatus DX11AllocationItem::exclusive_access_acquire_unsafe(mfxFrameData *ptr) {
-    GAPI_LOG_DEBUG(nullptr, "acquire WRITE lock: " << this);
-    GAPI_LOG_DEBUG(nullptr, "texture: " << get_texture_ptr() <<
+    GAPI_LOG_DEBUG(nullptr, "acquire WRITE lock: " << this <<
+                            ", texture: " << get_texture_ptr() <<
                             ", sub id: " << get_subresource());
     D3D11_MAP mapType = D3D11_MAP_WRITE;
     UINT mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
@@ -321,8 +326,8 @@ mfxStatus DX11AllocationItem::exclusive_access_acquire_unsafe(mfxFrameData *ptr)
 }
 
 mfxStatus DX11AllocationItem::exclusive_access_release_unsafe(mfxFrameData *ptr) {
-    GAPI_LOG_DEBUG(nullptr, "releasing WRITE lock: " << this);
-    GAPI_LOG_DEBUG(nullptr, "texture: " << get_texture_ptr() <<
+    GAPI_LOG_DEBUG(nullptr, "releasing WRITE lock: " << this <<
+                            ", texture: " << get_texture_ptr() <<
                             ", sub id: " << get_subresource());
 
     get_device_ctx_ptr()->Unmap(get_staging_texture_ptr(), 0);

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/cpu_frame_adapter.cpp
@@ -64,7 +64,7 @@ MediaFrame::View VPLMediaFrameCPUAdapter::access(MediaFrame::Access) {
 }
 
 cv::util::any VPLMediaFrameCPUAdapter::blobParams() const {
-    GAPI_Assert("VPLMediaFrameCPUAdapter::blobParams() is not implemented");
+    throw std::runtime_error("VPLMediaFrameCPUAdapter::blobParams() is not implemented");
     return {};
 }
 

--- a/modules/gapi/src/streaming/onevpl/source_priv.cpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.cpp
@@ -314,11 +314,16 @@ std::unique_ptr<VPLAccelerationPolicy> GSource::Priv::initializeHWAccel(std::sha
 
 const std::vector<CfgParam>& GSource::Priv::getDefaultCfgParams()
 {
+#ifdef __WIN32__
     static const std::vector<CfgParam> def_params =
         get_params_from_string<CfgParam>(
                     "mfxImplDescription.Impl: MFX_IMPL_TYPE_HARDWARE\n"
                     "mfxImplDescription.AccelerationMode: MFX_ACCEL_MODE_VIA_D3D11\n");
-
+#else
+    static const std::vector<CfgParam> def_params =
+        get_params_from_string<CfgParam>(
+                    "mfxImplDescription.Impl: MFX_IMPL_TYPE_HARDWARE\n");
+#endif
     return def_params;
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Build Configuration
```
force_builders=XCustom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.3.0:20.04
Xbuild_image:Custom Win=openvino-2021.2.0
build_image:Custom Mac=openvino-2021.2.0

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

build_image:Custom Win=gapi-onevpl-2021.6.0
buildworker:Custom Win=windows-3
build_contrib:Custom Win=OFF
```