### PR TITLE
Fix libva dynamic loading

### DIFF
--- a/modules/core/src/va_wrapper.impl.hpp
+++ b/modules/core/src/va_wrapper.impl.hpp
@@ -15,18 +15,33 @@ typedef VAStatus (*FN_vaDestroyImage)(VADisplay dpy, VAImageID image);
 typedef VAStatus (*FN_vaMapBuffer)(VADisplay dpy, VABufferID buf_id, void **pbuf);
 typedef VAStatus (*FN_vaSyncSurface)(VADisplay dpy, VASurfaceID render_target);
 typedef VAStatus (*FN_vaUnmapBuffer)(VADisplay dpy, VABufferID buf_id);
+typedef int (*FN_vaMaxNumImageFormats)(VADisplay dpy);
+typedef VAStatus (*FN_vaQueryImageFormats)(VADisplay dpy, VAImageFormat *format_list, int *num_formats);
+typedef VAStatus (*FN_vaCreateImage)(VADisplay dpy, VAImageFormat *format, int width, int height, VAImage *image);
+typedef VAStatus (*FN_vaPutImage)(VADisplay dpy, VASurfaceID surface, VAImageID image, int src_x, int src_y, unsigned int src_width, unsigned int src_height, int dest_x, int dest_y, unsigned int dest_width, unsigned int dest_height);
+typedef VAStatus (*FN_vaGetImage)(VADisplay dpy, VASurfaceID surface, int x, int y, unsigned int width, unsigned int height, VAImageID image);
 
 static FN_vaDeriveImage fn_vaDeriveImage = NULL;
 static FN_vaDestroyImage fn_vaDestroyImage = NULL;
 static FN_vaMapBuffer fn_vaMapBuffer = NULL;
 static FN_vaSyncSurface fn_vaSyncSurface = NULL;
 static FN_vaUnmapBuffer fn_vaUnmapBuffer = NULL;
+static FN_vaMaxNumImageFormats fn_vaMaxNumImageFormats = NULL;
+static FN_vaQueryImageFormats fn_vaQueryImageFormats = NULL;
+static FN_vaCreateImage fn_vaCreateImage = NULL;
+static FN_vaPutImage fn_vaPutImage = NULL;
+static FN_vaGetImage fn_vaGetImage = NULL;
 
 #define vaDeriveImage fn_vaDeriveImage
 #define vaDestroyImage fn_vaDestroyImage
 #define vaMapBuffer fn_vaMapBuffer
 #define vaSyncSurface fn_vaSyncSurface
 #define vaUnmapBuffer fn_vaUnmapBuffer
+#define vaMaxNumImageFormats fn_vaMaxNumImageFormats
+#define vaQueryImageFormats fn_vaQueryImageFormats
+#define vaCreateImage fn_vaCreateImage
+#define vaPutImage fn_vaPutImage
+#define vaGetImage fn_vaGetImage
 
 
 static std::shared_ptr<cv::plugin::impl::DynamicLib> loadLibVA()
@@ -76,6 +91,11 @@ static void init_libva()
         VA_LOAD_SYMBOL(vaMapBuffer);
         VA_LOAD_SYMBOL(vaSyncSurface);
         VA_LOAD_SYMBOL(vaUnmapBuffer);
+        VA_LOAD_SYMBOL(vaMaxNumImageFormats);
+        VA_LOAD_SYMBOL(vaQueryImageFormats);
+        VA_LOAD_SYMBOL(vaCreateImage);
+        VA_LOAD_SYMBOL(vaPutImage);
+        VA_LOAD_SYMBOL(vaGetImage);
         initialized = true;
     }
     if (!library)


### PR DESCRIPTION
After #21538 libopencv_core started to explicitly link with libva. We wanted to keep this dependency optional and load it dynamically at runtime.

Before patch:
```
$ ldd lib/libopencv_core.so
        linux-vdso.so.1 (0x00007ffdbf3d9000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fd4a6c0b000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fd4a69ec000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fd4a67e4000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd4a65c7000)
        libva.so.2 => /usr/lib/x86_64-linux-gnu/libva.so.2 (0x00007fd4a63a6000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fd4a601d000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fd4a5c7f000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fd4a5a67000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd4a5676000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fd4a800d000)
```
After patch:
```
$ ldd lib/libopencv_core.so
        linux-vdso.so.1 (0x00007ffc763e6000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f08d7924000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f08d7705000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f08d74fd000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f08d72e0000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f08d6f57000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f08d6bb9000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f08d69a1000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f08d65b0000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f08d8d26000)
```

@edman007, if possible, could you please check your scenarios with this patch?