### PR TITLE
Fixed handling of new stream, especially for stateful OCV kernels

### DIFF
--- a/modules/gapi/src/backends/cpu/gcpubackend.cpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.cpp
@@ -27,6 +27,7 @@
 #include "api/gbackend_priv.hpp" // FIXME: Make it part of Backend SDK!
 
 #include "utils/itt.hpp"
+#include "logger.hpp"
 
 // FIXME: Is there a way to take a typed graph (our GModel),
 // and create a new typed graph _ATOP_ of that (by extending with a couple of
@@ -188,18 +189,23 @@ void cv::gimpl::GCPUExecutable::makeReshape() {
 void cv::gimpl::GCPUExecutable::reshape(ade::Graph&, const GCompileArgs& args) {
     m_compileArgs = args;
     makeReshape();
-    // Signal to reset stateful kernels` state.
-    // There can be no handleNewStream() call to set this flag
-    // if user didn't call GCompiled`s prepareForNewStream()
-    m_newStreamStarted = true;
+    // TODO: Add an input meta sensitivity flag to stateful kernels.
+    // When reshape() happens, reset state for meta-sensitive kernels only
+    if (!m_nodesToStates.empty()) {
+        std::call_once(m_warnFlag,
+            [](){
+                GAPI_LOG_WARNING(NULL,
+                    "\nGCPUExecutable::reshape was called. Resetting states of stateful kernels.");
+            });
+        setupKernelStates();
+    }
 }
 
 void cv::gimpl::GCPUExecutable::handleNewStream()
 {
-    // Signal to reset stateful kernels` state.
-    // No need to call reshape() here since it'll
-    // be called automatically if input meta was changed
-    m_newStreamStarted = true;
+    // In case if new video-stream happens - for each stateful kernel
+    // call 'setup' user callback to re-initialize state.
+    setupKernelStates();
 }
 
 void cv::gimpl::GCPUExecutable::run(std::vector<InObj>  &&input_objs,
@@ -227,14 +233,6 @@ void cv::gimpl::GCPUExecutable::run(std::vector<InObj>  &&input_objs,
             // and should be excluded, but now we just don't support it
             magazine::resetInternalData(m_res, desc);
         }
-    }
-
-    // In case if new video-stream happens - for each stateful kernel
-    // call 'setup' user callback to re-initialize state.
-    if (m_newStreamStarted)
-    {
-        setupKernelStates();
-        m_newStreamStarted = false;
     }
 
     // OpenCV backend execution is not a rocket science at all.

--- a/modules/gapi/src/backends/cpu/gcpubackend.cpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.cpp
@@ -113,8 +113,6 @@ cv::gimpl::GCPUExecutable::GCPUExecutable(const ade::Graph &g,
         }
     }
     makeReshape();
-    // For each stateful kernel call 'setup' user callback to initialize state.
-    setupKernelStates();
 }
 
 // FIXME: Document what it does

--- a/modules/gapi/src/backends/cpu/gcpubackend.hpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.hpp
@@ -56,8 +56,8 @@ class GCPUExecutable final: public GIslandExecutable
     // Actual data of all resources in graph (both internal and external)
     Mag m_res;
 
-    // Flag which identifies if new stream was started
-    bool m_newStreamStarted = false;
+    // A flag for call_once() (used for log warnings)
+    std::once_flag m_warnFlag;
 
     GArg packArg(const GArg &arg);
     void setupKernelStates();

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -30,7 +30,7 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
     // 1. Allocate all internal resources first (NB - CPU plugin doesn't do it)
     // 2. Put input/output GComputation arguments to the storage
     // 3. For every Island, prepare vectors of input/output parameter descs
-    // 4. Ask every IslandExecutable to prepate its internal states for new coming stream
+    // 4. Ask every GIslandExecutable to prepate its internal states for a new stream
     // 5. Iterate over a list of operations (sorted in the topological order)
     // 6. For every operation, form a list of input/output data objects
     // 7. Run GIslandExecutable
@@ -383,7 +383,7 @@ void cv::gimpl::GExecutor::run(cv::gimpl::GRuntimeArgs &&args)
         magazine::resetInternalData(m_res, data);
     }
 
-    // Ask every IslandExecutable to prepate its internal states for new coming stream (4)
+    // Ask every GIslandExecutable to prepate its internal states for a new stream (4)
     std::call_once(m_prep_flag, [this](){ this->prepareForNewStream(); });
 
     // Run the script (5)

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -83,6 +83,9 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
             break;
         } // switch(kind)
     } // for(gim nodes)
+
+    // (4)
+    prepareForNewStream();
 }
 
 namespace cv {
@@ -382,9 +385,6 @@ void cv::gimpl::GExecutor::run(cv::gimpl::GRuntimeArgs &&args)
         const auto& data = m_gm.metadata(sd.data_nh).get<Data>();
         magazine::resetInternalData(m_res, data);
     }
-
-    // Ask every GIslandExecutable to prepate its internal states for a new stream (4)
-    std::call_once(m_prep_flag, [this](){ this->prepareForNewStream(); });
 
     // Run the script (5)
     for (auto &op : m_ops)

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -30,7 +30,7 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
     // 1. Allocate all internal resources first (NB - CPU plugin doesn't do it)
     // 2. Put input/output GComputation arguments to the storage
     // 3. For every Island, prepare vectors of input/output parameter descs
-    // 4. Ask every GIslandExecutable to prepate its internal states for a new stream
+    // 4. Ask every GIslandExecutable to prepare its internal states for a new stream
     // 5. Iterate over a list of operations (sorted in the topological order)
     // 6. For every operation, form a list of input/output data objects
     // 7. Run GIslandExecutable

--- a/modules/gapi/src/executor/gexecutor.hpp
+++ b/modules/gapi/src/executor/gexecutor.hpp
@@ -12,6 +12,7 @@
 
 #include <utility> // tuple, required by magazine
 #include <unordered_map> // required by magazine
+#include <mutex> // required by std::once_flag
 
 #include <ade/graph.hpp>
 
@@ -77,6 +78,8 @@ protected:
         ade::NodeHandle data_nh;
     };
     std::vector<DataDesc> m_slots;
+
+    std::once_flag m_prep_flag;
 
     class Input;
     class Output;

--- a/modules/gapi/src/executor/gexecutor.hpp
+++ b/modules/gapi/src/executor/gexecutor.hpp
@@ -12,7 +12,6 @@
 
 #include <utility> // tuple, required by magazine
 #include <unordered_map> // required by magazine
-#include <mutex> // required by std::once_flag
 
 #include <ade/graph.hpp>
 
@@ -78,8 +77,6 @@ protected:
         ade::NodeHandle data_nh;
     };
     std::vector<DataDesc> m_slots;
-
-    std::once_flag m_prep_flag;
 
     class Input;
     class Output;

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1452,7 +1452,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
             }
         }
     };
-    bool islandsRecompiled = false;
+
     const auto new_meta = cv::descr_of(ins); // 0
     if (gm.metadata().contains<OriginalInputMeta>()) // (1)
     {
@@ -1474,8 +1474,6 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
             }
             update_int_metas(); // (7)
             m_reshapable = util::make_optional(is_reshapable);
-
-            islandsRecompiled = true;
         }
         else // (8)
         {
@@ -1597,14 +1595,8 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         island_meta_info = GIslandModel::traceIslandName(op.nh, m_gim);
 #endif // OPENCV_WITH_ITT
 
-        // If Island Executable is recompiled, all its stuff including internal kernel states
-        // are recreated and re-initialized automatically.
-        // But if not, we should notify Island Executable about new started stream to let it update
-        // its internal variables.
-        if (!islandsRecompiled)
-        {
-            op.isl_exec->handleNewStream();
-        }
+        // Notify island executable about new coming stream to let it update its internal variables.
+        op.isl_exec->handleNewStream();
 
         m_threads.emplace_back(islandActorThread,
                                op.in_objects,

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1595,7 +1595,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         island_meta_info = GIslandModel::traceIslandName(op.nh, m_gim);
 #endif // OPENCV_WITH_ITT
 
-        // Notify island executable about new coming stream to let it update its internal variables.
+        // Notify island executable about a new stream to let it update its internal variables.
         op.isl_exec->handleNewStream();
 
         m_threads.emplace_back(islandActorThread,


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2021.4.1:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.4.1

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

There is a stateful kernel in OCV which can preserve the state to work with it. Once new stream happens we should re-initialize the state from the scratch. For the Streaming G-API mode, re-initialization is called automatically once new stream happened, for Regular G-API mode user should take care of it.

To update OCV stateful kernels for a new stream, `handleNewStream()` should be called on the `GCPUExecutable` instance.
In the Streaming mode, `GStreamingExecutor::setSource()` method handles that, as it is indeed responsible for configuration of the executor for a new stream and notifying other peers about it.
In the Regular mode, user should call `prepareForNewStream()` on `GCompiled` instance.

## BUG description
Problem was in that, that in streaming G-API mode, on the first graph run, kernels' states initialization is called twice for the `GComputation` compiled with metadata.
Main root cause here is that kernel states initialization isn't ran just in response to `GCPUExecutable::handleNewStream()`. It is also called upon the `GCPUExecutable` instantiation -- in the `GCPUExecutable` constructor.
So, firstly, kernel states are initialized in `GCPUExecutable` constructor called at graph compilation stage **if the metadatas are passed**. And, secondly, during the first run, they will also be re-initialized by `GStreamingExecutor::setSource()` call, notifying about new happened stream and called `GCPUExecutable::handleNewStream()`.

It wasn't the case for graphs compiled without meta, because the `GCompiler::compileStreaming()` call doesn't launch `GCPUExecutable` constructor in case if metadata is not provided.
But, `GStreamingExectutor::setSource()` calls `GCPUExecutable` constructor.
In `GStreamingExecutor::setSource()` execution goes to islands recompilation or graph reshape in case if there is no original metadata. Reshape was not the case for OCV backend until recently and execution always falls to the islands recompilation. Islands recompilation will call the `GCPUExecutable` constructor and setup kernel states.
But after that, there is a check in `GStreamingExecutor::setSource()` if re-compilation was called or not and if called, then no notification about new stream will be sent to the peers and no second call to kernel states re-initialization will happen.

There are 2 problems here:
- not unified notifying mechanism of the new stream from `GStreamingExecutor` in different scenarios. What will happened if multiple backends will handle `handleNewStream()` call and not only OCV?
- `GStreamingExecutor` knows something about independent backends(that OCV backend calls states initialization in constructor) and acts based on this knowledge leading to tight coupling between backend component and itself.

## Solution

Solution was:
1) To unify notification mechanism and call `handleNewStream()` unconditionally in `GStreamingExecutor::setSource()`.
2) Unify kernel states initialization calling conditions - only in response to `handleNewStream()` call.
3) For the Regular G-API mode, there is no code which notifies about new stream (because it is user responsibility to let G-API graph know that previous call to `apply()` was for previous stream and new call to `apply()` is already for new one). But, G-API needs somehow say about new stream for the first time, to prepare all the stuff before execution. Because there were no previous calls to `apply()` and everything is clear, G-API can notify internal components itself about new stream.
So, call to the `prepareForNewStream()` was added to the `GExecutor::run()` method under condition that it will be called only once.