### PR TITLE
Undefine common macros that conflict with Swift method names

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -1170,7 +1170,7 @@ class ObjectiveCWrapperGenerator(object):
                     objc_name = fi.objc_name if not constructor else ("init" + ("With" + (args[0].name[0].upper() + args[0].name[1:]) if len(args) > 0 else ""))
                 )
 
-            method_declarations.write( Template(
+            method_declaration = Template(
 """$prototype$swift_name$deprecation_decl;
 
 """
@@ -1179,6 +1179,20 @@ class ObjectiveCWrapperGenerator(object):
                     swift_name = " NS_SWIFT_NAME(" + fi.swift_name + "(" + build_swift_signature(args) + "))" if not constructor else "",
                     deprecation_decl = " DEPRECATED_ATTRIBUTE" if fi.deprecated else ""
                 )
+
+            # Undefine common macros that conflict with method names
+            method_declarations.write( Template(
+"""#pragma push_macro("$swift_name")
+#undef $swift_name
+
+$method_declaration
+#pragma pop_macro("$swift_name")
+
+"""
+                ).substitute(
+                    swift_name = fi.swift_name,
+                    method_declaration = method_declaration
+                ) if fi.swift_name in ["sqrt", "pow", "exp", "log"] else method_declaration
             )
 
             method_implementations.write( Template(


### PR DESCRIPTION
This pull request fixes #21725.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
