### PR TITLE
cartToPolar/polarToCart: disable inplace mode

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -269,6 +269,9 @@ void cartToPolar( InputArray src1, InputArray src2,
 {
     CV_INSTRUMENT_REGION();
 
+    CV_Assert(src1.getObj() != dst1.getObj() && src1.getObj() != dst2.getObj() &&
+              src2.getObj() != dst1.getObj() && src2.getObj() != dst2.getObj());
+
     CV_OCL_RUN(dst1.isUMat() && dst2.isUMat(),
             ocl_cartToPolar(src1, src2, dst1, dst2, angleInDegrees))
 
@@ -562,6 +565,9 @@ void polarToCart( InputArray src1, InputArray src2,
                   OutputArray dst1, OutputArray dst2, bool angleInDegrees )
 {
     CV_INSTRUMENT_REGION();
+
+    CV_Assert(src1.getObj() != dst1.getObj() && src1.getObj() != dst2.getObj() &&
+              src2.getObj() != dst1.getObj() && src2.getObj() != dst2.getObj());
 
     int type = src2.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     CV_Assert((depth == CV_32F || depth == CV_64F) && (src1.empty() || src1.type() == type));

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2396,5 +2396,36 @@ TEST(Core_Magnitude, regression_19506)
     }
 }
 
+TEST(Core_CartPolar, inplace)
+{
+    RNG& rng = TS::ptr()->get_rng();
+    cv::Mat1d A[2] = {cv::Mat1d(10, 10), cv::Mat1d(10, 10)};
+    cv::Mat1d B[2], C[2];
+    cv::UMat uA[2];
+
+    for(int i = 0; i < 2; ++i)
+    {
+        cvtest::randUni(rng, A[i], Scalar::all(-1000), Scalar::all(1000));
+        A[i].copyTo(uA[i]);
+    }
+
+    // Reverse
+    cv::cartToPolar(A[0], A[1], B[0], B[1], false);
+    cv::polarToCart(B[0], B[1], C[0], C[1], false);
+    EXPECT_MAT_NEAR(A[0], C[0], 2);
+    EXPECT_MAT_NEAR(A[1], C[1], 2);
+
+    // Inplace
+    EXPECT_THROW(cv::polarToCart(B[0], B[1], B[0], B[1], false), cv::Exception);
+    EXPECT_THROW(cv::polarToCart(B[0], B[1], B[1], B[0], false), cv::Exception);
+    EXPECT_THROW(cv::cartToPolar(A[0], A[1], A[0], A[1], false), cv::Exception);
+    EXPECT_THROW(cv::cartToPolar(A[0], A[1], A[1], A[0], false), cv::Exception);
+    // Inplace OCL
+    EXPECT_THROW(cv::polarToCart(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
+    EXPECT_THROW(cv::polarToCart(uA[0], uA[1], uA[1], uA[0]), cv::Exception);
+    EXPECT_THROW(cv::cartToPolar(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
+    EXPECT_THROW(cv::cartToPolar(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
+
+}
 
 }} // namespace

--- a/modules/ts/include/opencv2/ts/ocl_test.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_test.hpp
@@ -89,7 +89,7 @@ extern int test_loop_times;
 #define EXPECT_MAT_NORM(mat, eps) \
 do \
 { \
-    EXPECT_LE(TestUtils::checkNorm1(mat), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNorm1(mat), eps) \
 } while ((void)0, 0)
 
 #undef EXPECT_MAT_NEAR
@@ -98,7 +98,7 @@ do \
 { \
     ASSERT_EQ(mat1.type(), mat2.type()); \
     ASSERT_EQ(mat1.size(), mat2.size()); \
-    EXPECT_LE(TestUtils::checkNorm2(mat1, mat2), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNorm2(mat1, mat2), eps) \
         << "Size: " << mat1.size() << std::endl; \
 } while ((void)0, 0)
 
@@ -107,7 +107,7 @@ do \
 { \
     ASSERT_EQ((mat1).type(), (mat2).type()); \
     ASSERT_EQ((mat1).size(), (mat2).size()); \
-    EXPECT_LE(TestUtils::checkNormRelative((mat1), (mat2)), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNormRelative((mat1), (mat2)), eps) \
         << "Size: " << (mat1).size() << std::endl; \
 } while ((void)0, 0)
 
@@ -146,7 +146,7 @@ do \
 { \
     ASSERT_EQ(name ## _roi.type(), u ## name ## _roi.type()); \
     ASSERT_EQ(name ## _roi.size(), u ## name ## _roi.size()); \
-    EXPECT_LE(TestUtils::checkNorm2(name ## _roi, u ## name ## _roi), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNorm2(name ## _roi, u ## name ## _roi), eps) \
         << "Size: " << name ## _roi.size() << std::endl; \
     Point _offset; \
     Size _wholeSize; \
@@ -155,7 +155,7 @@ do \
     _mask(Rect(_offset, name ## _roi.size())).setTo(Scalar::all(0)); \
     ASSERT_EQ(name.type(), u ## name.type()); \
     ASSERT_EQ(name.size(), u ## name.size()); \
-    EXPECT_LE(TestUtils::checkNorm2(name, u ## name, _mask), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNorm2(name, u ## name, _mask), eps) \
         << "Size: " << name ## _roi.size() << std::endl; \
 } while ((void)0, 0)
 
@@ -183,7 +183,7 @@ do \
 { \
     ASSERT_EQ(name ## _roi.type(), u ## name ## _roi.type()); \
     ASSERT_EQ(name ## _roi.size(), u ## name ## _roi.size()); \
-    EXPECT_LE(TestUtils::checkNormRelativeSparse(name ## _roi, u ## name ## _roi), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNormRelativeSparse(name ## _roi, u ## name ## _roi), eps) \
         << "Size: " << name ## _roi.size() << std::endl; \
     Point _offset; \
     Size _wholeSize; \
@@ -192,7 +192,7 @@ do \
     _mask(Rect(_offset, name ## _roi.size())).setTo(Scalar::all(0)); \
     ASSERT_EQ(name.type(), u ## name.type()); \
     ASSERT_EQ(name.size(), u ## name.size()); \
-    EXPECT_LE(TestUtils::checkNormRelativeSparse(name, u ## name, _mask), eps) \
+    EXPECT_LE(cvtest::ocl::TestUtils::checkNormRelativeSparse(name, u ## name, _mask), eps) \
         << "Size: " << name ## _roi.size() << std::endl; \
 } while ((void)0, 0)
 


### PR DESCRIPTION
Resolves #21732

Raise an exception if one of sources is the same as one of destinations since inplace mode works incorrectly (with and without IPP).

```
allow_multiple_commits=1
```