### PR TITLE
Objective-C wrapper header fix-ups to avoid clashes with system macros

### DIFF
--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -78,6 +78,26 @@
             "(void)divide:(double)scale src2:(Mat*)src2 dst:(Mat*)dst dtype:(int)dtype" : { "src2" : {"name" : "src"} }
         }
     },
+    "header_fix" : {
+        "Core": {
+            "pow" : {
+                "prolog" : "#pragma push_macro(\"pow\")\n#undef pow",
+                "epilog" : "#pragma pop_macro(\"pow\")"
+            },
+            "sqrt" : {
+                "prolog" : "#pragma push_macro(\"sqrt\")\n#undef sqrt",
+                "epilog" : "#pragma pop_macro(\"sqrt\")"
+            },
+            "exp" : {
+                "prolog" : "#pragma push_macro(\"exp\")\n#undef exp",
+                "epilog" : "#pragma pop_macro(\"exp\")"
+            },
+            "log" : {
+                "prolog" : "#pragma push_macro(\"log\")\n#undef log",
+                "epilog" : "#pragma pop_macro(\"log\")"
+            }
+        }
+    },
     "type_dict" : {
         "Algorithm": {
             "objc_type": "Algorithm*"


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work

Alternative fix for #21725

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework-test
buildworker:Custom Mac=macosx-2
```