### PR TITLE
Fix VideoCapture::open() brief description

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -751,7 +751,7 @@ public:
      */
     CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY);
 
-    /** @brief  Opens a camera for video capturing
+    /** @brief  Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
 
     @overload
 
@@ -775,7 +775,7 @@ public:
     */
     CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY);
 
-    /** @brief Returns true if video capturing has been initialized already.
+    /** @brief  Opens a camera for video capturing with API Preference and parameters
 
     @overload
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Pull Request Description

The brief descriptions of two VideoCapture::open() overrides seem to be related to other methods instead. 

These are the constructors of VideoCapture, with their proper brief descriptions:

![correct](https://user-images.githubusercontent.com/34423515/159731833-83e62db0-69f3-40f2-9ef7-e3dfa3178ef7.png)

And these are the open() methods, with wrong descriptions underlined:

![wrong2](https://user-images.githubusercontent.com/34423515/159735832-f3e4c697-3913-4fe3-83ef-3bded2da6c8a.png)

This pull request corrects the wrong descriptions, replacing them with a copy of the constructors description.