### PR TITLE
Fixed out-of-bounds read in parallel version of ippGaussianBlur()

### DIFF
--- a/modules/imgproc/CMakeLists.txt
+++ b/modules/imgproc/CMakeLists.txt
@@ -14,7 +14,7 @@ ocv_add_dispatched_file(undistort SSE2 AVX2)
 ocv_define_module(imgproc opencv_core WRAP java python js)
 
 ocv_check_environment_variables(OPENCV_IPP_GAUSSIAN_BLUR)
-option(OPENCV_IPP_GAUSSIAN_BLUR "Enable IPP optimizations for GaussianBlur (+8Mb in binary size)" OFF)
+option(OPENCV_IPP_GAUSSIAN_BLUR "Enable IPP optimizations for GaussianBlur (+8Mb in binary size)" ON)
 if(OPENCV_IPP_GAUSSIAN_BLUR)
   ocv_append_source_file_compile_definitions(${CMAKE_CURRENT_SOURCE_DIR}/src/smooth.dispatch.cpp "ENABLE_IPP_GAUSSIAN_BLUR=1")
 endif()

--- a/modules/imgproc/CMakeLists.txt
+++ b/modules/imgproc/CMakeLists.txt
@@ -14,7 +14,7 @@ ocv_add_dispatched_file(undistort SSE2 AVX2)
 ocv_define_module(imgproc opencv_core WRAP java python js)
 
 ocv_check_environment_variables(OPENCV_IPP_GAUSSIAN_BLUR)
-option(OPENCV_IPP_GAUSSIAN_BLUR "Enable IPP optimizations for GaussianBlur (+8Mb in binary size)" ON)
+option(OPENCV_IPP_GAUSSIAN_BLUR "Enable IPP optimizations for GaussianBlur (+8Mb in binary size)" OFF)
 if(OPENCV_IPP_GAUSSIAN_BLUR)
   ocv_append_source_file_compile_definitions(${CMAKE_CURRENT_SOURCE_DIR}/src/smooth.dispatch.cpp "ENABLE_IPP_GAUSSIAN_BLUR=1")
 endif()

--- a/modules/imgproc/src/smooth.dispatch.cpp
+++ b/modules/imgproc/src/smooth.dispatch.cpp
@@ -566,7 +566,7 @@ static bool ipp_GaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
         if (IPP_DISABLE_GAUSSIAN_BLUR_32FC4_1TH && (threads == 1 && src.type() == CV_32FC4))
             return false;
 
-        if(IPP_GAUSSIANBLUR_PARALLEL && threads > 1) {
+        if(IPP_GAUSSIANBLUR_PARALLEL && threads > 1 && iwSrc.m_size.height/(threads * 4) >= ksize.height/2) {
             bool ok;
             ipp_gaussianBlurParallel invoker(iwSrc, iwDst, ksize.width, (float) sigma1, ippBorder, &ok);
 

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2355,5 +2355,16 @@ TEST(Imgproc, filter_empty_src_16857)
     EXPECT_TRUE(dst2.empty());
 }
 
+TEST(Imgproc_GaussianBlur, regression_11303)
+{
+    cv::Mat dst;
+    int width = 2115;
+    int height = 211;
+    double sigma = 8.64421;
+    cv::Mat src(cv::Size(width, height), CV_32F, 1);
+    cv::GaussianBlur(src, dst, cv::Size(), sigma, sigma);
+    EXPECT_EQ(0, cv::norm(src, dst, NORM_L2));
+}
+
 
 }} // namespace

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2363,7 +2363,7 @@ TEST(Imgproc_GaussianBlur, regression_11303)
     double sigma = 8.64421;
     cv::Mat src(cv::Size(width, height), CV_32F, 1);
     cv::GaussianBlur(src, dst, cv::Size(), sigma, sigma);
-    EXPECT_EQ(0, cv::norm(src, dst, NORM_L2));
+    EXPECT_LE(cv::norm(src, dst, NORM_L2), 1e-3);
 }
 
 


### PR DESCRIPTION
Fixed issue [#11303](https://github.com/opencv/opencv/issues/11303).
The problem was the following: in the parallel version of the function in case when kernelSize/2 is bigger than a height of a tile,  out-of-bounds read happens when the second and the one before the last tiles are processed.
Now sequential mode is used in such cases.