### PR TITLE
python: ensure publishing of subclasses before derived types

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -1178,10 +1178,25 @@ class PythonWrapperGenerator(object):
         classlist1 = [(classinfo.decl_idx, name, classinfo) for name, classinfo in classlist]
         classlist1.sort()
 
+        published_types = set()  # ensure toposort with base classes
         for decl_idx, name, classinfo in classlist1:
             if classinfo.ismap:
                 continue
-            self.code_type_publish.write(classinfo.gen_def(self))
+            def _registerType(classinfo):
+                if classinfo.decl_idx in published_types:
+                    #print(classinfo.decl_idx, classinfo.name, ' - already published')
+                    return
+                published_types.add(classinfo.decl_idx)
+
+                if classinfo.base and classinfo.base in self.classes:
+                    base_classinfo = self.classes[classinfo.base]
+                    #print(classinfo.decl_idx, classinfo.name, ' - request publishing of base type ', base_classinfo.decl_idx, base_classinfo.name)
+                    _registerType(base_classinfo)
+
+                #print(classinfo.decl_idx, classinfo.name, ' - published!')
+                self.code_type_publish.write(classinfo.gen_def(self))
+
+            _registerType(classinfo)
 
 
         # step 3: generate the code for all the global functions


### PR DESCRIPTION
resolves https://github.com/opencv/opencv_contrib/issues/3171

We should not have non-initialized(NULL) base types during types registration (dynamic types registration is required by `LIMITED_API`).

Binding test is very tricky for this case, so it is not added (base and derived classes should be defined in different files)

<cut/>

---

Before (`ImgHashBase` is registered too late):

```
CVPY_TYPE(AverageHash, img_hash_AverageHash, Ptr<cv::img_hash::AverageHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(BlockMeanHash, img_hash_BlockMeanHash, Ptr<cv::img_hash::BlockMeanHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(ColorMomentHash, img_hash_ColorMomentHash, Ptr<cv::img_hash::ColorMomentHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(ImgHashBase, img_hash_ImgHashBase, Ptr<cv::img_hash::ImgHashBase>, Ptr, Algorithm, 0, ".img_hash");
CVPY_TYPE(MarrHildrethHash, img_hash_MarrHildrethHash, Ptr<cv::img_hash::MarrHildrethHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(PHash, img_hash_PHash, Ptr<cv::img_hash::PHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
```

After:

```
CVPY_TYPE(ImgHashBase, img_hash_ImgHashBase, Ptr<cv::img_hash::ImgHashBase>, Ptr, Algorithm, 0, ".img_hash");
CVPY_TYPE(AverageHash, img_hash_AverageHash, Ptr<cv::img_hash::AverageHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(BlockMeanHash, img_hash_BlockMeanHash, Ptr<cv::img_hash::BlockMeanHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(ColorMomentHash, img_hash_ColorMomentHash, Ptr<cv::img_hash::ColorMomentHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(MarrHildrethHash, img_hash_MarrHildrethHash, Ptr<cv::img_hash::MarrHildrethHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(PHash, img_hash_PHash, Ptr<cv::img_hash::PHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");
CVPY_TYPE(RadialVarianceHash, img_hash_RadialVarianceHash, Ptr<cv::img_hash::RadialVarianceHash>, Ptr, img_hash_ImgHashBase, 0, ".img_hash");

```