### PR TITLE
dnn: fix ReduceLayer implementation, update OpenVINO tests

### DIFF
--- a/modules/dnn/src/layers/reduce_layer.cpp
+++ b/modules/dnn/src/layers/reduce_layer.cpp
@@ -25,6 +25,7 @@ class ReduceLayerImpl CV_FINAL : public ReduceLayer
 public:
     ReduceLayerImpl(const LayerParams& params)
     {
+        setParamsFrom(params);
         // set reduce type
         CV_Assert(params.has("reduce"));
         String typeString = toLowerCase(params.get<String>("reduce"));

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -1267,7 +1267,10 @@ CASE(test_reduce_l1_negative_axes_keep_dims_example)
 CASE(test_reduce_l1_negative_axes_keep_dims_random)
     // no filter
 CASE(test_reduce_l2_default_axes_keepdims_example)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+        default_l1 = 0.01f;  // Expected: (normL1) <= (l1), actual: 0.00490189 vs 0.004)
+#endif
 CASE(test_reduce_l2_default_axes_keepdims_random)
     // no filter
 CASE(test_reduce_l2_do_not_keepdims_example)
@@ -1291,7 +1294,10 @@ CASE(test_reduce_log_sum_default)
 CASE(test_reduce_log_sum_desc_axes)
     // no filter
 CASE(test_reduce_log_sum_exp_default_axes_keepdims_example)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+        default_l1 = 0.01f;  // Expected: (normL1) <= (l1), actual: 0.00671387 vs 0.004
+#endif
 CASE(test_reduce_log_sum_exp_default_axes_keepdims_random)
     // no filter
 CASE(test_reduce_log_sum_exp_do_not_keepdims_example)
@@ -1357,21 +1363,47 @@ CASE(test_reduce_min_negative_axes_keepdims_example)
 CASE(test_reduce_min_negative_axes_keepdims_random)
     // no filter
 CASE(test_reduce_prod_default_axes_keepdims_example)
-    // no filter
+#if SKIP_SET_1
+    SKIP_MYRIAD;  // accuracy (Expected: (normL1) <= (l1), actual: inf vs 0.004)
+#endif
 CASE(test_reduce_prod_default_axes_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 5;  // Expected: (normL1) <= (l1), actual: 2.66211 vs 0.004  |ref| = 24621.337890625
+        default_lInf = 5;  // Expected: (normInf) <= (lInf), actual: 2.66211 vs 0.02  |ref| = 24621.337890625
+    }
+#endif
 CASE(test_reduce_prod_do_not_keepdims_example)
     // no filter
 CASE(test_reduce_prod_do_not_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.01f;  // Expected: (normL1) <= (l1), actual: 0.00436729 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0201836 vs 0.02
+    }
+#endif
 CASE(test_reduce_prod_keepdims_example)
     // no filter
 CASE(test_reduce_prod_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.01f;  // Expected: (normL1) <= (l1), actual: 0.00436729 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0201836 vs 0.02
+    }
+#endif
 CASE(test_reduce_prod_negative_axes_keepdims_example)
     // no filter
 CASE(test_reduce_prod_negative_axes_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.01f;  // Expected: (normL1) <= (l1), actual: 0.00436729 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0201836 vs 0.02
+    }
+#endif
 CASE(test_reduce_sum_default_axes_keepdims_example)
     // no filter
 CASE(test_reduce_sum_default_axes_keepdims_random)
@@ -1395,19 +1427,40 @@ CASE(test_reduce_sum_negative_axes_keepdims_random)
 CASE(test_reduce_sum_square_default_axes_keepdims_example)
     // no filter
 CASE(test_reduce_sum_square_default_axes_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+        default_l1 = 0.05f;  // Expected: (normL1) <= (l1), actual: 0.0183411 vs 0.004
+#endif
 CASE(test_reduce_sum_square_do_not_keepdims_example)
     // no filter
 CASE(test_reduce_sum_square_do_not_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.05f;  // Expected: (normL1) <= (l1), actual: 0.010789 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0290298 vs 0.02
+    }
+#endif
 CASE(test_reduce_sum_square_keepdims_example)
     // no filter
 CASE(test_reduce_sum_square_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.05f;  // Expected: (normL1) <= (l1), actual: 0.010789 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0290298 vs 0.02
+    }
+#endif
 CASE(test_reduce_sum_square_negative_axes_keepdims_example)
     // no filter
 CASE(test_reduce_sum_square_negative_axes_keepdims_random)
-    // no filter
+#if SKIP_SET_1
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        default_l1 = 0.05f;  // Expected: (normL1) <= (l1), actual: 0.010789 vs 0.004
+        default_lInf = 0.05f;  // Expected: (normInf) <= (lInf), actual: 0.0290298 vs 0.02
+    }
+#endif
 CASE(test_reflect_pad)
     // no filter
 CASE(test_relu)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -358,7 +358,18 @@ TEST_P(Test_ONNX_layers, ReduceSum)
 TEST_P(Test_ONNX_layers, ReduceMax)
 {
     testONNXModels("reduce_max");
+}
+TEST_P(Test_ONNX_layers, ReduceMax_axis_0)
+{
     testONNXModels("reduce_max_axis_0");
+}
+TEST_P(Test_ONNX_layers, ReduceMax_axis_1)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2021040000)
+    // [ GENERAL_ERROR ]  AssertionFailed: !out.networkInputs.empty()
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_MYRIAD)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+#endif
     testONNXModels("reduce_max_axis_1");
 }
 
@@ -378,10 +389,28 @@ TEST_P(Test_ONNX_layers, ArgLayer)
 
 TEST_P(Test_ONNX_layers, Scale)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2021040000)
+    // Ngraph operation Reshape with name ReduceMean_0 has dynamic output shape on 0 port, but CPU plug-in supports only static shape
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+#endif
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2021040000)
+    // accuracy
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_MYRIAD)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+#endif
     testONNXModels("scale");
+}
+
+TEST_P(Test_ONNX_layers, Scale_broadcast)
+{
     testONNXModels("scale_broadcast", npy, 0, 0, false, true, 3);
+}
+
+TEST_P(Test_ONNX_layers, Scale_broadcast_mid)
+{
     testONNXModels("scale_broadcast_mid", npy, 0, 0, false, true, 2);
 }
 


### PR DESCRIPTION
fixup #21601

Error message:

```
ie_ngraph.cpp:359: error: (-215:Assertion failed) !cvLayer->name.empty() in function 'InfEngineNgraphNode'
```

<cut/>

```
force_builders_only=Custom,Custom Win

build_image:Custom=ubuntu-openvino-2021.4.2:20.04
test_modules:Custom=dnn,python2,python3,java
buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*


build_image:Custom Win=openvino-2021.4.2
Xbuild_image:Custom Win=openvino-2022.1.0
buildworker:Custom Win=windows-3
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules:Custom Win=dnn,gapi,python2,python3,java
test_opencl:Custom Win=ON
build_contrib:Custom Win=OFF
```