### PR TITLE
python binding for matches and inliers_mask attributes of cv2.detail_MatchesInfo class

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -104,8 +104,8 @@ struct CV_EXPORTS_W_SIMPLE MatchesInfo
 
     CV_PROP_RW int src_img_idx;
     CV_PROP_RW int dst_img_idx;       //!< Images indices (optional)
-    std::vector<DMatch> matches;
-    std::vector<uchar> inliers_mask;    //!< Geometrically consistent matches mask
+    CV_PROP_RW std::vector<DMatch> matches;
+    CV_PROP_RW std::vector<uchar> inliers_mask;    //!< Geometrically consistent matches mask
     CV_PROP_RW int num_inliers;                    //!< Number of geometrically consistent matches
     CV_PROP_RW Mat H;                              //!< Estimated transformation
     CV_PROP_RW double confidence;                  //!< Confidence two images are from the same panorama

--- a/modules/stitching/misc/python/test/test_stitching.py
+++ b/modules/stitching/misc/python/test/test_stitching.py
@@ -118,5 +118,22 @@ class stitching_compose_panorama_args(NewOpenCVTests):
         assert result == 0
 
 
+class stitching_matches_info_test(NewOpenCVTests):
+
+    def test_simple(self):
+        finder = cv.ORB.create()
+        img1 = self.get_sample('stitching/a1.png')
+        img2 = self.get_sample('stitching/a2.png')
+
+        img_feat1 = cv.detail.computeImageFeatures2(finder, img1)
+        img_feat2 = cv.detail.computeImageFeatures2(finder, img2)
+
+        matcher = cv.detail.BestOf2NearestMatcher_create()
+        matches_info = matcher.apply(img_feat1, img_feat2)
+
+        self.assertIsNotNone(matches_info.matches)
+        self.assertIsNotNone(matches_info.inliers_mask)
+
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
In respect to the issue  #21364, the pull request makes **matches** and **inliers_mask** attributes of the **cv2.detail_MatchesInfo** class accessible from python interface. By this way, developers could be able to make  changes on the computed matches.

### Pull Request Readiness Checklist

- [Yes] I agree to contribute to the project under Apache 2 License.
- [Yes] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [Yes] The PR is proposed to the proper branch
- [Yes] There is a reference to the original bug report and related work