### PR TITLE
add BackgroundSubtractor(KNN|MOG2).getDefaultName() implementation

### DIFF
--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -214,6 +214,8 @@ public:
         }
     }
 
+    virtual String getDefaultName() const CV_OVERRIDE { return "BackgroundSubtractor_KNN"; }
+
     virtual int getHistory() const CV_OVERRIDE { return history; }
     virtual void setHistory(int _nframes) CV_OVERRIDE { history = _nframes; }
 

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -236,6 +236,8 @@ public:
         }
     }
 
+    virtual String getDefaultName() const CV_OVERRIDE { return "BackgroundSubtractor_MOG2"; }
+
     virtual int getHistory() const CV_OVERRIDE { return history; }
     virtual void setHistory(int _nframes) CV_OVERRIDE { history = _nframes; }
 


### PR DESCRIPTION
### Problem

The KNN and MOG2 background subtractors extend the `Algorithm` class but don't override the `getDefaultName()` method (which returns `my_object`).

* https://github.com/opencv/opencv/blob/4.5.5/modules/core/src/algorithm.cpp#L80-L84

### Proposed solution

Add override for the method, avoiding the `.` character in the name because persistence disallows it in key names.

* https://github.com/opencv/opencv/blob/4.5.5/modules/core/src/persistence_json.cpp#L223-L224
* https://github.com/opencv/opencv/blob/4.5.5/modules/core/src/persistence_yml.cpp#L260-L261

### Usage code snippet

```
#include <opencv2/opencv.hpp>

int main(int argc, char* argv[])
{
    std::cout << cv::createBackgroundSubtractorKNN()->getDefaultName() << std::endl;
    cv::createBackgroundSubtractorKNN()->save("knn.algo");

    std::cout << cv::createBackgroundSubtractorMOG2()->getDefaultName() << std::endl;
    cv::createBackgroundSubtractorMOG2()->save("mog2.algo");

    return 0;
}
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
