### PR TITLE
G-API: Fix warning in giebackend

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -618,6 +618,7 @@ size_t IECallContext::releaseKeepAliveFrame(req_key_t key) {
         }
         elapsed_count = keep_alive_pp_frames.size();
     }
+    cv::util::suppress_unused_warning(prev_slot);
     GAPI_LOG_DEBUG(nullptr, "Release keep alive frame, slot: " << prev_slot <<
                             ", reserved frames count: " << elapsed_count);
     return elapsed_count;


### PR DESCRIPTION
A warning arisen from https://github.com/opencv/opencv/pull/21688

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom

build_image:Custom=ubuntu-openvino-2021.4.2:20.04
test_modules:Custom=dnn,gapi,python2,python3,java
buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```