### PR TITLE
(4.x) videoio(ffmpeg): avoid memory leaks

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2496,17 +2496,13 @@ double CvVideoWriter_FFMPEG::getProperty(int propId) const
 /// close video output stream and free associated memory
 void CvVideoWriter_FFMPEG::close()
 {
-    // nothing to do if already released
-    if ( !picture )
-        return;
-
     /* no more frame to compress. The codec has a latency of a few
        frames if using B frames, so we get the last frames by
        passing the same picture again */
     // TODO -- do we need to account for latency here?
 
     /* write the trailer, if any */
-    if(ok && oc)
+    if (picture && ok && oc)
     {
 #if LIBAVFORMAT_BUILD < CALC_FFMPEG_VERSION(57, 0, 0)
         if (!(oc->oformat->flags & AVFMT_RAWPICTURE))
@@ -2529,7 +2525,7 @@ void CvVideoWriter_FFMPEG::close()
     }
 
     // free pictures
-    if( context->pix_fmt != input_pix_fmt)
+    if (picture && context && context->pix_fmt != input_pix_fmt)
     {
         if(picture->data[0])
             free(picture->data[0]);
@@ -2540,8 +2536,14 @@ void CvVideoWriter_FFMPEG::close()
     if (input_picture)
         av_free(input_picture);
 
+#ifdef CV_FFMPEG_CODECPAR
+    avcodec_free_context(&context);
+#else
     /* close codec */
-    avcodec_close(context);
+    if (context)  // fixed after https://github.com/FFmpeg/FFmpeg/commit/3e1f507f3e8f16b716aa115552d243b48ae809bd
+        avcodec_close(context);
+    context = NULL;
+#endif
 
     av_free(outbuf);
 
@@ -2935,10 +2937,7 @@ bool CvVideoWriter_FFMPEG::open( const char * filename, int fourcc,
 #endif
 
 #ifdef CV_FFMPEG_CODECPAR
-        if (context)
-        {
-            avcodec_free_context(&context);
-        }
+        avcodec_free_context(&context);
 #endif
         context = icv_configure_video_stream_FFMPEG(oc, video_st, codec,
                                               width, height, (int) (bitrate + 0.5),


### PR DESCRIPTION
Resolves these valgrind reports (caused by incomplete error handling bailout code in `open()`):

<cut/>

```
==940136== 11,040 bytes in 12 blocks are definitely lost in loss record 271 of 273
==940136==    at 0x4849803: memalign (vg_replace_malloc.c:1516)
==940136==    by 0x484991F: posix_memalign (vg_replace_malloc.c:1688)
==940136==    by 0x540583E: av_malloc (mem.c:104)
==940136==    by 0x4E96783: avcodec_alloc_context3 (options.c:143)
==940136==    by 0x4A3498B: icv_configure_video_stream_FFMPEG(AVFormatContext*, AVStream*, AVCodec const*, int, int, int, double, AVPixelFormat, int) (cap_ffmpeg_impl.hpp:2111)
==940136==    by 0x4A374E8: CvVideoWriter_FFMPEG::open(char const*, int, double, int, int, cv::VideoWriterParameters const&) (cap_ffmpeg_impl.hpp:2944)
==940136==    by 0x4A37FE2: cvCreateVideoWriterWithParams_FFMPEG(char const*, int, double, int, int, cv::VideoWriterParameters const&) (cap_ffmpeg_impl.hpp:3139)
==940136==    by 0x4A38BAD: cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, double, cv::Size_<int>, cv::VideoWriterParameters const&) (cap_ffmpeg.cpp:206)
==940136==    by 0x4A388B5: cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy::CvVideoWriter_FFMPEG_proxy(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, double, cv::Size_<int>, cv::VideoWriterParameters const&) (cap_ffmpeg.cpp:183)
==940136==    by 0x4A3C123: void __gnu_cxx::new_allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>::construct<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (new_allocator.h:162)
==940136==    by 0x4A3BDFF: void std::allocator_traits<std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy> >::construct<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>&, cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (alloc_traits.h:516)
==940136==    by 0x4A3BA80: std::_Sp_counted_ptr_inplace<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (shared_ptr_base.h:519)


==947062== 5,338 (1,504 direct, 3,834 indirect) bytes in 1 blocks are definitely lost in loss record 319 of 322
==947062==    at 0x4849803: memalign (vg_replace_malloc.c:1516)
==947062==    by 0x484991F: posix_memalign (vg_replace_malloc.c:1688)
==947062==    by 0x9553D44: av_malloc (in /usr/lib64/libavutil.so.56.70.100)
==947062==    by 0x93F4F64: avformat_alloc_context (in /usr/lib64/libavformat.so.58.76.100)
==947062==    by 0x48E27DF: CvVideoWriter_FFMPEG::open(char const*, int, double, int, int, cv::VideoWriterParameters const&) (cap_ffmpeg_impl.hpp:2746)
==947062==    by 0x48E3AA7: cvCreateVideoWriterWithParams_FFMPEG(char const*, int, double, int, int, cv::VideoWriterParameters const&) (cap_ffmpeg_impl.hpp:3133)
==947062==    by 0x48E4671: cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, double, cv::Size_<int>, cv::VideoWriterParameters const&) (cap_ffmpeg.cpp:206)
==947062==    by 0x48E4379: cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy::CvVideoWriter_FFMPEG_proxy(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, double, cv::Size_<int>, cv::VideoWriterParameters const&) (cap_ffmpeg.cpp:183)
==947062==    by 0x48E8727: void __gnu_cxx::new_allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>::construct<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (new_allocator.h:162)
==947062==    by 0x48E83F3: void std::allocator_traits<std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy> >::construct<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>&, cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (alloc_traits.h:516)
==947062==    by 0x48E7F3C: std::_Sp_counted_ptr_inplace<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (shared_ptr_base.h:519)
==947062==    by 0x48E77DA: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy, std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&>(cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy*&, std::_Sp_alloc_shared_tag<std::allocator<cv::(anonymous namespace)::CvVideoWriter_FFMPEG_proxy> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int const&, double const&, cv::Size_<int> const&, cv::VideoWriterParameters const&) (shared_ptr_base.h:650)
```


```
build_contrib:Custom=OFF
build_contrib:Custom Win=OFF

build_shared:Custom=OFF
build_examples:Custom=OFF

build_image:Linux AVX2=ubuntu:20.04

Xbuild_image:Win64=msvs2019

force_builders=Custom,Custom Win,Linux AVX2
Xbuild_image:Custom=centos:7
build_image:Custom=ubuntu:20.04
Xbuild_image:Custom=gstreamer:16.04
buildworker:Custom=linux-1,linux-4,linux-6
test_opencl:Custom=ON

build_image:Custom Win=ffmpeg
Xbuild_image:Custom Win=ffmpeg-plugin
buildworker:Custom Win=windows-2
test_modules:Custom Win=videoio
test_opencl:Custom Win=ON
```
