### PR TITLE
Fix memory leak when using dynamically allocated FeatherBlender

### DIFF
--- a/modules/stitching/src/blenders.cpp
+++ b/modules/stitching/src/blenders.cpp
@@ -179,6 +179,10 @@ void FeatherBlender::blend(InputOutputArray dst, InputOutputArray dst_mask)
     normalizeUsingWeightMap(dst_weight_map_, dst_);
     compare(dst_weight_map_, WEIGHT_EPS, dst_mask_, CMP_GT);
     Blender::blend(dst, dst_mask);
+    
+    dst_mask_.release();
+    weight_map_.release();
+    dst_weight_map_.release();
 }
 
 


### PR DESCRIPTION
Feather blender will not release internal Mats after a blend. Doing a free or delete on the FeatherBlender object will not release the memory, and there are no internal class members to release the memory. This fix now allows for repeated calls to feather blender without runaway memory overflow.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [y] I agree to contribute to the project under Apache 2 License.
- [y] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [y] The PR is proposed to the proper branch
- [n] There is a reference to the original bug report and related work
- [n] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [y] The feature is well documented and sample code can be built with the project CMake
