### PR TITLE
Add distort/undistort test for fisheye::undistortPoints()

### DIFF
--- a/modules/calib3d/perf/perf_undistort.cpp
+++ b/modules/calib3d/perf/perf_undistort.cpp
@@ -27,28 +27,39 @@ PERF_TEST(Undistort, DISABLED_InitInverseRectificationMap)
     SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST(Undistort, fisheye_undistortPoints)
+using PerfIntType = perf::TestBaseWithParam<std::tuple<int>>;
+PERF_TEST_P(PerfIntType, fisheye_undistortPoints,
+                                            (testing::Values(1e2, 1e3, 1e4)))
 {
     const cv::Size imageSize(1280, 800);
 
+    /* Set camera matrix */
     const cv::Matx33d K(558.478087865323,  0, 620.458515360843,
                          0, 560.506767351568, 381.939424848348,
                          0,               0,                1);
 
+    /* Set distortion coefficients */
     Mat D(1, 4, CV_64F);
     theRNG().fill(D, RNG::UNIFORM, -1.e-5, 1.e-5);
 
+    int pointsNumber = std::get<0>(GetParam());
+
+    /* Create two-channel points matrix */
     cv::Mat xy[2] = {};
-    xy[0].create(1000, 1, CV_64F);
+    xy[0].create(pointsNumber, 1, CV_64F);
     theRNG().fill(xy[0], cv::RNG::UNIFORM, 0, imageSize.width); // x
-    xy[1].create(1000, 1, CV_64F);
+    xy[1].create(pointsNumber, 1, CV_64F);
     theRNG().fill(xy[1], cv::RNG::UNIFORM, 0, imageSize.height); // y
 
     cv::Mat points;
     merge(xy, 2, points);
 
+    /* Set fixed iteration number to check only c++ code, not algo convergence */
+    TermCriteria termCriteria(TermCriteria::MAX_ITER, 10, 0);
+
     Mat undistortedPoints;
-    TEST_CYCLE() fisheye::undistortPoints(points, undistortedPoints, K, D);
+    TEST_CYCLE() fisheye::undistortPoints(points, undistortedPoints, K, D, noArray(), noArray(), termCriteria);
+
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/calib3d/perf/perf_undistort.cpp
+++ b/modules/calib3d/perf/perf_undistort.cpp
@@ -29,7 +29,6 @@ PERF_TEST(Undistort, DISABLED_InitInverseRectificationMap)
 
 PERF_TEST(Undistort, fisheye_undistortPoints)
 {
-
     const cv::Size imageSize(1280, 800);
 
     const cv::Matx33d K(558.478087865323,  0, 620.458515360843,

--- a/modules/calib3d/perf/perf_undistort.cpp
+++ b/modules/calib3d/perf/perf_undistort.cpp
@@ -27,4 +27,30 @@ PERF_TEST(Undistort, DISABLED_InitInverseRectificationMap)
     SANITY_CHECK_NOTHING();
 }
 
+PERF_TEST(Undistort, fisheye_undistortPoints)
+{
+
+    const cv::Size imageSize(1280, 800);
+
+    const cv::Matx33d K(558.478087865323,  0, 620.458515360843,
+                         0, 560.506767351568, 381.939424848348,
+                         0,               0,                1);
+
+    Mat D(1, 4, CV_64F);
+    theRNG().fill(D, RNG::UNIFORM, -1.e-5, 1.e-5);
+
+    cv::Mat xy[2] = {};
+    xy[0].create(1000, 1, CV_64F);
+    theRNG().fill(xy[0], cv::RNG::UNIFORM, 0, imageSize.width); // x
+    xy[1].create(1000, 1, CV_64F);
+    theRNG().fill(xy[1], cv::RNG::UNIFORM, 0, imageSize.height); // y
+
+    cv::Mat points;
+    merge(xy, 2, points);
+
+    Mat undistortedPoints;
+    TEST_CYCLE() fisheye::undistortPoints(points, undistortedPoints, K, D);
+    SANITY_CHECK_NOTHING();
+}
+
 } // namespace

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -14,7 +14,6 @@ protected:
     void generateDistCoeffs(Mat& distCoeffs, int count);
 
     double thresh = 1.0e-2;
-    RNG rng;
 };
 
 void UndistortPointsTest::generate3DPointCloud(vector<Point3f>& points, Point3f pmin, Point3f pmax)
@@ -35,10 +34,10 @@ void UndistortPointsTest::generateCameraMatrix(Mat& cameraMatrix)
     const double fcMaxVal = 100;
     cameraMatrix.create(3, 3, CV_64FC1);
     cameraMatrix.setTo(Scalar(0));
-    cameraMatrix.at<double>(0,0) = rng.uniform(fcMinVal, fcMaxVal);
-    cameraMatrix.at<double>(1,1) = rng.uniform(fcMinVal, fcMaxVal);
-    cameraMatrix.at<double>(0,2) = rng.uniform(fcMinVal, fcMaxVal);
-    cameraMatrix.at<double>(1,2) = rng.uniform(fcMinVal, fcMaxVal);
+    cameraMatrix.at<double>(0,0) = theRNG().uniform(fcMinVal, fcMaxVal);
+    cameraMatrix.at<double>(1,1) = theRNG().uniform(fcMinVal, fcMaxVal);
+    cameraMatrix.at<double>(0,2) = theRNG().uniform(fcMinVal, fcMaxVal);
+    cameraMatrix.at<double>(1,2) = theRNG().uniform(fcMinVal, fcMaxVal);
     cameraMatrix.at<double>(2,2) = 1;
 }
 
@@ -46,7 +45,7 @@ void UndistortPointsTest::generateDistCoeffs(Mat& distCoeffs, int count)
 {
     distCoeffs = Mat::zeros(count, 1, CV_64FC1);
     for (int i = 0; i < count; i++)
-        distCoeffs.at<double>(i,0) = rng.uniform(-0.1, 0.1);
+        distCoeffs.at<double>(i,0) = theRNG().uniform(-0.1, 0.1);
 }
 
 TEST_F(UndistortPointsTest, accuracy)
@@ -94,8 +93,7 @@ TEST_F(UndistortPointsTest, stop_criteria)
     Mat distCoeffs = (Mat_<double>(5,1,CV_64F) <<
                       -2.57614020e-01, 8.77086999e-02, -2.56970803e-04, -5.93390389e-04, -1.52194091e-02);
 
-    RNG rng(2);
-    Point2d pt_distorted(rng.uniform(0.0, 1920.0), rng.uniform(0.0, 1080.0));
+    Point2d pt_distorted(theRNG().uniform(0.0, 1920.0), theRNG().uniform(0.0, 1080.0));
 
     std::vector<Point2d> pt_distorted_vec;
     pt_distorted_vec.push_back(pt_distorted);

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -1,6 +1,8 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+#include <opencv2/ts/cuda_test.hpp> // EXPECT_MAT_NEAR
 #include "test_precomp.hpp"
 
 namespace opencv_test { namespace {
@@ -79,9 +81,8 @@ TEST_F(UndistortPointsTest, accuracy)
         Mat p;
         perspectiveTransform(undistortedPoints, p, intrinsics);
         undistortedPoints = p;
-        double diff = cvtest::norm(Mat(realUndistortedPoints), undistortedPoints, NORM_L2);
 
-        EXPECT_LE(diff, thresh);
+        EXPECT_MAT_NEAR(realUndistortedPoints, undistortedPoints.t(), thresh);
     }
 }
 

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -46,7 +46,7 @@ void UndistortPointsTest::generateDistCoeffs(Mat& distCoeffs, int count)
 {
     distCoeffs = Mat::zeros(count, 1, CV_64FC1);
     for (int i = 0; i < count; i++)
-        distCoeffs.at<double>(i,0) = rng.uniform(0.0, 1.0e-3);
+        distCoeffs.at<double>(i,0) = rng.uniform(-0.1, 0.1);
 }
 
 TEST_F(UndistortPointsTest, accuracy)

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -5,30 +5,19 @@
 
 namespace opencv_test { namespace {
 
-class CV_UndistortTest : public cvtest::BaseTest
+class UndistortPointsTest : public ::testing::Test
 {
-public:
-    CV_UndistortTest();
-    ~CV_UndistortTest();
 protected:
-    void run(int);
-private:
     void generate3DPointCloud(vector<Point3f>& points, Point3f pmin = Point3f(-1,
     -1, 5), Point3f pmax = Point3f(1, 1, 10));
     void generateCameraMatrix(Mat& cameraMatrix);
     void generateDistCoeffs(Mat& distCoeffs, int count);
 
-    double thresh;
+    double thresh = 1.0e-2;
     RNG rng;
 };
 
-CV_UndistortTest::CV_UndistortTest()
-{
-    thresh = 1.0e-2;
-}
-CV_UndistortTest::~CV_UndistortTest() {}
-
-void CV_UndistortTest::generate3DPointCloud(vector<Point3f>& points, Point3f pmin, Point3f pmax)
+void UndistortPointsTest::generate3DPointCloud(vector<Point3f>& points, Point3f pmin, Point3f pmax)
 {
     RNG rng_Point = cv::theRNG(); // fix the seed to use "fixed" input 3D points
     for (size_t i = 0; i < points.size(); i++)
@@ -39,7 +28,8 @@ void CV_UndistortTest::generate3DPointCloud(vector<Point3f>& points, Point3f pmi
         points[i] = Point3f(_x, _y, _z);
     }
 }
-void CV_UndistortTest::generateCameraMatrix(Mat& cameraMatrix)
+
+void UndistortPointsTest::generateCameraMatrix(Mat& cameraMatrix)
 {
     const double fcMinVal = 1e-3;
     const double fcMaxVal = 100;
@@ -51,19 +41,22 @@ void CV_UndistortTest::generateCameraMatrix(Mat& cameraMatrix)
     cameraMatrix.at<double>(1,2) = rng.uniform(fcMinVal, fcMaxVal);
     cameraMatrix.at<double>(2,2) = 1;
 }
-void CV_UndistortTest::generateDistCoeffs(Mat& distCoeffs, int count)
+
+void UndistortPointsTest::generateDistCoeffs(Mat& distCoeffs, int count)
 {
     distCoeffs = Mat::zeros(count, 1, CV_64FC1);
     for (int i = 0; i < count; i++)
         distCoeffs.at<double>(i,0) = rng.uniform(0.0, 1.0e-3);
 }
 
-void CV_UndistortTest::run(int /* start_from */)
+TEST_F(UndistortPointsTest, accuracy)
 {
     Mat intrinsics, distCoeffs;
     generateCameraMatrix(intrinsics);
+
     vector<Point3f> points(500);
     generate3DPointCloud(points);
+
     vector<Point2f> projectedPoints;
     projectedPoints.resize(points.size());
 
@@ -71,10 +64,15 @@ void CV_UndistortTest::run(int /* start_from */)
     for (int idx = 0; idx < 3; idx++)
     {
         generateDistCoeffs(distCoeffs, modelMembersCount[idx]);
-        projectPoints(Mat(points), Mat::zeros(3,1,CV_64FC1), Mat::zeros(3,1,CV_64FC1), intrinsics, distCoeffs, projectedPoints);
+
+        projectPoints(Mat(points), Mat::zeros(3,1,CV_64FC1),
+                      Mat::zeros(3,1,CV_64FC1), intrinsics,
+                      distCoeffs, projectedPoints);
 
         vector<Point2f> realUndistortedPoints;
-        projectPoints(Mat(points), Mat::zeros(3,1,CV_64FC1), Mat::zeros(3,1,CV_64FC1), intrinsics,  Mat::zeros(4,1,CV_64FC1), realUndistortedPoints);
+        projectPoints(Mat(points), Mat::zeros(3,1,CV_64FC1),
+                      Mat::zeros(3,1,CV_64FC1), intrinsics,
+                      Mat::zeros(4,1,CV_64FC1), realUndistortedPoints);
 
         Mat undistortedPoints;
         undistortPoints(Mat(projectedPoints), undistortedPoints, intrinsics, distCoeffs);
@@ -83,43 +81,44 @@ void CV_UndistortTest::run(int /* start_from */)
         perspectiveTransform(undistortedPoints, p, intrinsics);
         undistortedPoints = p;
         double diff = cvtest::norm(Mat(realUndistortedPoints), undistortedPoints, NORM_L2);
-        if (diff > thresh)
-        {
-            ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
-            return;
-        }
-        ts->set_failed_test_info(cvtest::TS::OK);
+
+        EXPECT_LE(diff, thresh);
     }
 }
 
-TEST(Calib3d_Undistort, accuracy) { CV_UndistortTest test; test.safe_run(); }
-
-TEST(Calib3d_Undistort, stop_criteria)
+TEST_F(UndistortPointsTest, stop_criteria)
 {
     Mat cameraMatrix = (Mat_<double>(3,3,CV_64F) << 857.48296979, 0, 968.06224829,
                                                         0, 876.71824265, 556.37145899,
                                                         0, 0, 1);
     Mat distCoeffs = (Mat_<double>(5,1,CV_64F) <<
                       -2.57614020e-01, 8.77086999e-02, -2.56970803e-04, -5.93390389e-04, -1.52194091e-02);
+
     RNG rng(2);
     Point2d pt_distorted(rng.uniform(0.0, 1920.0), rng.uniform(0.0, 1080.0));
+
     std::vector<Point2d> pt_distorted_vec;
     pt_distorted_vec.push_back(pt_distorted);
+
     const double maxError = 1e-6;
     TermCriteria criteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 100, maxError);
+
     std::vector<Point2d> pt_undist_vec;
     undistortPoints(pt_distorted_vec, pt_undist_vec, cameraMatrix, distCoeffs, noArray(), noArray(), criteria);
 
-    std::vector<Point2d> pt_redistorted_vec;
     std::vector<Point3d> pt_undist_vec_homogeneous;
-    pt_undist_vec_homogeneous.push_back( Point3d(pt_undist_vec[0].x, pt_undist_vec[0].y, 1.0) );
-    projectPoints(pt_undist_vec_homogeneous, Mat::zeros(3,1,CV_64F), Mat::zeros(3,1,CV_64F), cameraMatrix, distCoeffs, pt_redistorted_vec);
+    pt_undist_vec_homogeneous.emplace_back(pt_undist_vec[0].x, pt_undist_vec[0].y, 1.0 );
+
+    std::vector<Point2d> pt_redistorted_vec;
+    projectPoints(pt_undist_vec_homogeneous, Mat::zeros(3,1,CV_64F),
+                  Mat::zeros(3,1,CV_64F), cameraMatrix, distCoeffs, pt_redistorted_vec);
+
     const double obtainedError = sqrt( pow(pt_distorted.x - pt_redistorted_vec[0].x, 2) + pow(pt_distorted.y - pt_redistorted_vec[0].y, 2) );
 
     ASSERT_LE(obtainedError, maxError);
 }
 
-TEST(undistortPoints, regression_14583)
+TEST_F(UndistortPointsTest, regression_14583)
 {
     const int col = 720;
     // const int row = 540;


### PR DESCRIPTION
Lack of test has allowed error described in [#19138] to be unnoticed.
In addition to random points, four corners and principal center
added to point set

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
