### PR TITLE
Imgproc_cvWarpAffine.regression test: zero-init src matrix

### DIFF
--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1139,8 +1139,8 @@ static void check_resize_area(const Mat& expected, const Mat& actual, double tol
 
 TEST(Imgproc_cvWarpAffine, regression)
 {
-    Mat src(Size(100, 100), CV_8UC1);
-    Mat dst(Size(100, 100), CV_8UC1);
+    Mat src(Size(100, 100), CV_8UC1, cv::Scalar::all(0));
+    Mat dst(Size(100, 100), CV_8UC1, cv::Scalar::all(0));
 
     int w = src.cols;
     int h = src.rows;


### PR DESCRIPTION
for the #21459 issue.

caveat: i currently don't have access to `valgrind` on this computer but based on the

> ... probably relates #21089 (looks like non-initialized input test data)

comment in the issue description and from code reading:
* before #21089 there was a `cvZero(src)` call
* this pull request here proposes to add `cv::Scalar::all(0)` initialisation for `src`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
