### PR TITLE
Add assert to address tf simplifier security concerns

### DIFF
--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -1035,7 +1035,7 @@ void sortByExecutionOrder(tensorflow::GraphDef& net)
         nodesToAdd.pop_back();
 
         permIds.push_back(nodeToAdd);
-
+        CV_Assert(nodeToAdd < edges.size());
         for (int i = 0; i < edges[nodeToAdd].size(); ++i)
         {
             int consumerId = edges[nodeToAdd][i];

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -1571,6 +1571,13 @@ TEST_P(Test_TensorFlow_layers, tf2_permute_nhwc_ncwh)
     runTensorFlowNet("tf2_permute_nhwc_ncwh");
 }
 
+// issue #21852
+TEST_P(Test_TensorFlow_layers, tf_graph_simplifier_buffer_overflow)
+{
+    // This just shouldn't segfault, otherwise it's fine
+    EXPECT_ANY_THROW(readNetFromTensorflow(path("tf_graph_simplifier_buffer_overflow_net.pb")));
+}
+
 TEST_P(Test_TensorFlow_layers, squeeze)
 {
 #if defined(INF_ENGINE_RELEASE)


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/970
Fixes https://github.com/opencv/opencv/issues/21852

Another way of fixing this is to draw inspiration from Rust: use custom vector type with bound checks enabled by [default](https://doc.rust-lang.org/std/vec/struct.Vec.html#indexing), providing [methods](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.get_unchecked) that don't do bounds-checking.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
