### PR TITLE
Fixed url for a fork (4.x branch)

### DIFF
--- a/.github/workflows/PR-4.x-U20.yaml
+++ b/.github/workflows/PR-4.x-U20.yaml
@@ -10,6 +10,7 @@ env:
   OPENCV_TEST_DATA_PATH: '/opencv_extra/testdata'
   OPENCV_DOCKER_WORKDIR: '/__w/opencv/opencv'
   PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+  PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
   ANT_HOME: '/usr/share/ant'
@@ -43,7 +44,7 @@ jobs:
         git config --global --add safe.directory ${{ env.OPENCV_DOCKER_WORKDIR }}
         git config user.email "opencv.ci"
         git config user.name "opencv.ci"
-        git pull -v "https://github.com/${{ env.PR_AUTHOR }}/opencv" "${{ env.SOURCE_BRANCH_NAME }}"
+        git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
     - name: Clone opencv_extra
       run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --depth 1 https://github.com/opencv/opencv_extra.git /opencv_extra
     - name: Configure OpenCV
@@ -150,7 +151,7 @@ jobs:
         git config --global --add safe.directory ${{ env.OPENCV_DOCKER_WORKDIR }}
         git config user.email "opencv.ci"
         git config user.name "opencv.ci"
-        git pull -v "https://github.com/${{ env.PR_AUTHOR }}/opencv" "${{ env.SOURCE_BRANCH_NAME }}"
+        git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
     - name: Clone opencv_contrib
       run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --depth 1 https://github.com/opencv/opencv_contrib.git /opencv_contrib
     - name: Configure OpenCV Contrib

--- a/.github/workflows/timvx_backend_tests.yml
+++ b/.github/workflows/timvx_backend_tests.yml
@@ -5,16 +5,17 @@ on:
     branches: [ 4.x ]
     types: [ labeled, opened, synchronize, reopened ]
 
+env:
+  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+  PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
+  SOURCE_BRANCH_NAME: ${{ github.head_ref }}
+  TARGET_BRANCH_NAME: ${{ github.base_ref }}
 
 jobs:
   x86-simulator-build-test:
     runs-on: ubuntu-20.04
     # Docker image from https://hub.docker.com/r/yuentau/ocv_ubuntu
     container: docker.io/yuentau/ocv_ubuntu:20.04
-    env:
-      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-      SOURCE_BRANCH_NAME: ${{ github.head_ref }}
-      TARGET_BRANCH_NAME: ${{ github.base_ref }}
     steps:
       - name: info
         run: |
@@ -37,7 +38,7 @@ jobs:
           cd opencv
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
-          git pull -v "https://github.com/${{ env.PR_AUTHOR }}/opencv" "${{ env.SOURCE_BRANCH_NAME }}" --allow-unrelated-histories
+          git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
       - name: configure
         run: |
           cmake -B build -DWITH_TIMVX=ON -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON -DBUILD_PERF_TESTS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=OFF -DWITH_OPENCL=OFF opencv
@@ -50,10 +51,6 @@ jobs:
       group: khadas-vim3
       cancel-in-progress: false
     runs-on: [self-hosted, Linux, ARM64, khadas-vim3]
-    env:
-      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-      SOURCE_BRANCH_NAME: ${{ github.head_ref }}
-      TARGET_BRANCH_NAME: ${{ github.base_ref }}
     steps:
       - name: info
         run: |
@@ -76,7 +73,7 @@ jobs:
           cd opencv
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
-          git pull -v "https://github.com/${{ env.PR_AUTHOR }}/opencv" "${{ env.SOURCE_BRANCH_NAME }}" --allow-unrelated-histories
+          git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
       - name: fetch opencv_extra
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR fixes an issue when the fork repository has another name ([example](https://github.com/opencv/opencv/runs/6064424452?check_suite_focus=true#step:6:11)).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
