### PR TITLE
remove Imgproc_cvWarpAffine.regression test

### DIFF
--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1137,17 +1137,6 @@ static void check_resize_area(const Mat& expected, const Mat& actual, double tol
 
 ///////////////////////////////////////////////////////////////////////////
 
-TEST(Imgproc_cvWarpAffine, regression)
-{
-    Mat src(Size(100, 100), CV_8UC1);
-    Mat dst(Size(100, 100), CV_8UC1);
-
-    int w = src.cols;
-    int h = src.rows;
-    Mat M = getRotationMatrix2D(Point2f(w*0.5f, h*0.5f), 45.0, 1.0);
-    warpAffine(src, dst, M, Size(w, h));
-}
-
 TEST(Imgproc_fitLine_vector_3d, regression)
 {
     std::vector<Point3f> points_vector;


### PR DESCRIPTION
for the #21459 issue.

alternative to #21848 based on https://github.com/opencv/opencv/pull/21848#issuecomment-1101116161 feedback.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
