### PR TITLE
Fix KalmanFilter comment error

### DIFF
--- a/modules/video/src/kalman.cpp
+++ b/modules/video/src/kalman.cpp
@@ -96,7 +96,7 @@ const Mat& KalmanFilter::predict(const Mat& control)
     // P'(k) = temp1*At + Q
     gemm(temp1, transitionMatrix, 1, processNoiseCov, 1, errorCovPre, GEMM_2_T);
 
-    // handle the case when there will be measurement before the next predict.
+    // handle the case when there will be no measurement before the next predict.
     statePre.copyTo(statePost);
     errorCovPre.copyTo(errorCovPost);
 


### PR DESCRIPTION
If there will be measurement before the next predict, `statePost` and `errorCovPost` would be assigned to updated value. So I guess these steps are meant to handle the case when no measurement and KF only do the predict step.
```cpp
statePre.copyTo(statePost);
errorCovPre.copyTo(errorCovPost);
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
