### PR TITLE
Workflow to use a self-hosted Github runner on Linux x86_64 for 3.4 branch

### DIFF
--- a/.github/workflows/PR-3.4-U20.yaml
+++ b/.github/workflows/PR-3.4-U20.yaml
@@ -6,24 +6,29 @@ on:
       - 3.4
 
 env:
-  EXTRA_CMAKE_OPTIONS: '-DBUILD_DOCS=ON -DPYTHON_DEFAULT_EXECUTABLE=/usr/bin/python3 -DBUILD_EXAMPLES=ON -DOPENCV_ENABLE_NONFREE=ON -DENABLE_CCACHE=OFF'
-  OPENCV_TEST_DATA_PATH: '/opencv_extra/testdata'
-  OPENCV_DOCKER_WORKDIR: '/__w/opencv/opencv'
+  EXTRA_CMAKE_OPTIONS: '-DBUILD_DOCS=ON -DPYTHON_DEFAULT_EXECUTABLE=/usr/bin/python3 -DOPENCV_DOWNLOAD_PATH=/home/ci/binaries_cache -DBUILD_EXAMPLES=ON -DOPENCV_ENABLE_NONFREE=ON'
   PR_AUTHOR: ${{ github.event.pull_request.user.login }}
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
-  ANT_HOME: '/usr/share/ant'
+  ANT_HOME: /usr/share/ant
+  GIT_CACHE_DOCKER: /home/ci/git_cache
   PYTHONPATH: /opencv-build/python_loader:$PYTHONPATH
+  OPENCV_TEST_DATA_PATH: /opencv_extra/testdata
+  OPENCV_DOCKER_WORKDIR: /opencv
 
 jobs:
   BuildAndTest:
-    runs-on: ubuntu-20.04
+    runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
         shell: bash
     container:
       image: quay.io/asenyaev/opencv-ubuntu:20.04
+      volumes:
+        - /home/opencv-cn/git_cache:/home/ci/git_cache
+        - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
+        - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: PR info
       run: |
@@ -31,13 +36,9 @@ jobs:
         echo "Source branch name: ${{ env.SOURCE_BRANCH_NAME }}"
         echo "Target branch name: ${{ env.TARGET_BRANCH_NAME }}"
     - name: Clean
-      run: find . -mindepth 1 -delete
+      run: find ${{ env.OPENCV_DOCKER_WORKDIR }} -mindepth 1 -delete
     - name: Fetch opencv
-      uses: actions/checkout@v3
-      with:
-        repository: opencv/opencv
-        ref: ${{ env.TARGET_BRANCH_NAME }}
-        fetch-depth: 0
+      run: git clone --branch ${{ env.TARGET_BRANCH_NAME }} --reference ${{ env.GIT_CACHE_DOCKER }}/opencv.git https://github.com/opencv/opencv.git ${{ env.OPENCV_DOCKER_WORKDIR }}
     - name: Merge opencv with ${{ env.SOURCE_BRANCH_NAME }} branch
       run: |
         cd ${{ env.OPENCV_DOCKER_WORKDIR }}
@@ -46,7 +47,7 @@ jobs:
         git config user.name "opencv.ci"
         git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
     - name: Clone opencv_extra
-      run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --depth 1 https://github.com/opencv/opencv_extra.git /opencv_extra
+      run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --reference ${{ env.GIT_CACHE_DOCKER }}/opencv_extra.git --depth 1 https://github.com/opencv/opencv_extra.git /opencv_extra
     - name: Configure OpenCV
       run: |
         cd /opencv-build
@@ -129,12 +130,16 @@ jobs:
       run: cd /opencv-build && cmake --build . --config release --target check_pylint -- -j4
 
   BuildContrib:
-    runs-on: ubuntu-20.04
+    runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
         shell: bash
     container:
       image: quay.io/asenyaev/opencv-ubuntu:20.04
+      volumes:
+        - /home/opencv-cn/git_cache:/home/ci/git_cache
+        - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
+        - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: PR info
       run: |
@@ -142,13 +147,9 @@ jobs:
         echo "Source branch name: ${{ env.SOURCE_BRANCH_NAME }}"
         echo "Target branch name: ${{ env.TARGET_BRANCH_NAME }}"
     - name: Clean
-      run: find . -mindepth 1 -delete
+      run: find ${{ env.OPENCV_DOCKER_WORKDIR }} -mindepth 1 -delete
     - name: Fetch opencv
-      uses: actions/checkout@v3
-      with:
-        repository: opencv/opencv
-        ref: ${{ env.TARGET_BRANCH_NAME }}
-        fetch-depth: 0
+      run: git clone --branch ${{ env.TARGET_BRANCH_NAME }} --reference ${{ env.GIT_CACHE_DOCKER }}/opencv.git https://github.com/opencv/opencv.git ${{ env.OPENCV_DOCKER_WORKDIR }}
     - name: Merge opencv with a test branch
       run: |
         cd ${{ env.OPENCV_DOCKER_WORKDIR }}
@@ -157,7 +158,7 @@ jobs:
         git config user.name "opencv.ci"
         git pull -v "https://github.com/${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
     - name: Clone opencv_contrib
-      run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --depth 1 https://github.com/opencv/opencv_contrib.git /opencv_contrib
+      run: git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --reference ${{ env.GIT_CACHE_DOCKER }}/opencv_contrib.git --depth 1 https://github.com/opencv/opencv_contrib.git /opencv_contrib
     - name: Configure OpenCV Contrib
       run: |
         cd /opencv-contrib-build


### PR DESCRIPTION
This PR changes a workflow to use a self-hosted GitHub runner on Linux x86_64 for 3.4 branch with ccache support.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
