### PR TITLE
Add normal estimation and region growing algorithm for point cloud

### DIFF
--- a/modules/3d/doc/3d.bib
+++ b/modules/3d/doc/3d.bib
@@ -105,7 +105,5 @@
   volume={35},
   pages={248--253},
   editor={H.G. Maas and D. Schneider},
-  booktitle={ISPRS 2006 : Proceedings of the ISPRS commission V symposium Vol. 35, part 6 : image engineering and vision metrology, Dresden, Germany 25-27 September 2006",
-  publisher = "International Society for Photogrammetry and Remote Sensing (ISPRS)},
-  note={ISPRS commission V symposium : image engineering and vision metrology, ISPRS 2006 ; Conference date: 25-09-2006 Through 27-09-2006}
+  booktitle={ISPRS 2006 : Proceedings of the ISPRS commission V symposium Vol. 35, part 6 : image engineering and vision metrology, Dresden, Germany 25-27 September 2006}
 }

--- a/modules/3d/doc/3d.bib
+++ b/modules/3d/doc/3d.bib
@@ -96,3 +96,17 @@
   year={1981},
   publisher={ACM New York, NY, USA}
 }
+
+@inproceedings{Rabbani2006SegmentationOP,
+  title = "Segmentation of point clouds using smoothness constraints",
+  keywords = "ADLIB-ART-1373, EOS",
+  author = "T. Rabbani and {van den Heuvel}, F.A. and G. Vosselman",
+  year = "2006",
+  language = "English",
+  volume = "35",
+  pages = "248--253",
+  editor = "H.G. Maas and D. Schneider",
+  booktitle = "ISPRS 2006 : Proceedings of the ISPRS commission V symposium Vol. 35, part 6 : image engineering and vision metrology, Dresden, Germany 25-27 September 2006",
+  publisher = "International Society for Photogrammetry and Remote Sensing (ISPRS)",
+  note = "ISPRS commission V symposium : image engineering and vision metrology, ISPRS 2006 ; Conference date: 25-09-2006 Through 27-09-2006",
+}

--- a/modules/3d/doc/3d.bib
+++ b/modules/3d/doc/3d.bib
@@ -98,15 +98,14 @@
 }
 
 @inproceedings{Rabbani2006SegmentationOP,
-  title = "Segmentation of point clouds using smoothness constraints",
-  keywords = "ADLIB-ART-1373, EOS",
-  author = "T. Rabbani and {van den Heuvel}, F.A. and G. Vosselman",
-  year = "2006",
-  language = "English",
-  volume = "35",
-  pages = "248--253",
-  editor = "H.G. Maas and D. Schneider",
-  booktitle = "ISPRS 2006 : Proceedings of the ISPRS commission V symposium Vol. 35, part 6 : image engineering and vision metrology, Dresden, Germany 25-27 September 2006",
-  publisher = "International Society for Photogrammetry and Remote Sensing (ISPRS)",
-  note = "ISPRS commission V symposium : image engineering and vision metrology, ISPRS 2006 ; Conference date: 25-09-2006 Through 27-09-2006",
+  title={Segmentation of point clouds using smoothness constraints},
+  keywords={ADLIB-ART-1373, EOS},
+  author={Tahir Rabbani and Frank van den Heuvel and George Vosselman},
+  year={2006},
+  volume={35},
+  pages={248--253},
+  editor={H.G. Maas and D. Schneider},
+  booktitle={ISPRS 2006 : Proceedings of the ISPRS commission V symposium Vol. 35, part 6 : image engineering and vision metrology, Dresden, Germany 25-27 September 2006",
+  publisher = "International Society for Photogrammetry and Remote Sensing (ISPRS)},
+  note={ISPRS commission V symposium : image engineering and vision metrology, ISPRS 2006 ; Conference date: 25-09-2006 Through 27-09-2006}
 }

--- a/modules/3d/include/opencv2/3d/ptcloud.hpp
+++ b/modules/3d/include/opencv2/3d/ptcloud.hpp
@@ -262,12 +262,12 @@ CV_EXPORTS int farthestPointSampling(OutputArray sampled_point_flags, InputArray
         float sampled_scale, float dist_lower_limit = 0, RNG *rng = nullptr);
 
 /**
- * @brief Estimate the normal and curvature of each point in point cloud from KNN results.
+ * @brief Estimate the normal and curvature of each point in point cloud from NN results.
  *
- * Normal Estimation Algorithm:
- * + Input: K nearest neighbor of a specific point: \f$pt_set\f$
+ * Normal estimation by PCA:
+ * + Input: Nearest neighbor points of a specific point: \f$ pt\_set \f$
  * + Step:
- *     1. Calculate the \f$ mean(\bar{x},\bar{y},\bar{z}) \f$ of pt_set;
+ *     1. Calculate the \f$ mean(\bar{x},\bar{y},\bar{z}) \f$ of \f$ pt\_set \f$;
  *     2. A 3x3 covariance matrix \f$ cov \f$ is obtained by \f$ mean^T \cdot mean \f$;
  *     3. Calculate the eigenvalues(\f$ λ_2 \ge λ_1 \ge λ_0 \f$) and corresponding
  *        eigenvectors(\f$ v_2, v_1, v_0 \f$) of \f$ cov \f$;
@@ -275,40 +275,20 @@ CV_EXPORTS int farthestPointSampling(OutputArray sampled_point_flags, InputArray
  *        \f$ \frac{λ_0}{λ_0 + λ_1 + λ_2} \f$ is the curvature of the specific point;
  * + Output: Normal and curvature of the specific point.
  *
- * @param[out] normals Normal of each point, vector of Point3f or Mat of size Nx3.
- * @param[out] curvatures Curvature of each point, vector or Mat.
- * @param input_pts Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
- * @param knn_idx Index of K nearest neighbors of all points. The first nearest point of each point
- *                is itself. Only support Mat with layout NxK/KxN in memory space.
- * @param k The number of neighbors including itself. Setting 0 will use the number from knn_idx.
+ * @param[out] normals Normal of each point, support vector<Point3f> and Mat of size Nx3.
+ * @param[out] curvatures Curvature of each point, support vector<float> and Mat.
+ * @param input_pts Original point cloud, support vector<Point3f> and Mat of size Nx3/3xN.
+ * @param nn_idx Index information of nearest neighbors of all points. The first nearest neighbor of
+ *               each point is itself. Support vector<vector<int>>, vector<Mat> and Mat of size NxK.
+ *               If the information in a row is [0, 2, 1, -5, -1, 4, 7 ... negative number], it will
+ *               use only non-negative indexes until it meets a negative number or bound of this row
+ *               i.e. [0, 2, 1].
+ * @param max_neighbor_num The maximum number of neighbors want to use including itself. Setting to
+ *               a non-positive number or default will use the information from nn_idx.
  */
 
 CV_EXPORTS void normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts,
-        InputArray knn_idx, int k = 0);
-
-/**
- * @brief KNN search in point cloud by KDTree.
- *
- * Get the index and distance result of KNN search in point cloud by using the KDTree in flann library.
- *
- * @param[out] knn_idx Index of K nearest neighbors of all points. The first nearest point of each
- *                     point is itself. Only support Mat with layout NxK in memory space. If this
- *                     result is not needed, it is recommended to pass noArray(), which will not
- *                     cause the corresponding memory consumption.
- * @param[out] knn_dist Distance of K nearest neighbors of all points. Only support Mat with layout
- *                      NxK in memory space. If this result is not needed, it is recommended to pass
- *                      noArray(), which will not cause the corresponding memory consumption.
- * @param input_pts  Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
- * @param k The number of neighbors including itself, default value is 30.
- * @param kdtree_params Optional flann::KDTreeIndexParams() used for building KDTree;
- *                      if it is nullptr, default is used instead.
- * @param search_params Optional flann::SearchParams() used for searching the K nearest neighbors;
- *                      if it is nullptr, default is used instead.
- * @sa KDTreeIndexParams, SearchParams
- */
-CV_EXPORTS void getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist,
-        InputArray input_pts, int k = 30, flann::KDTreeIndexParams *kdtree_params = nullptr,
-        flann::SearchParams *search_params = nullptr);
+        InputArrayOfArrays nn_idx, int max_neighbor_num = 0);
 
 /**
  * @brief Region Growing algorithm in 3D point cloud.
@@ -333,35 +313,44 @@ public:
     //-------------------------- SEGMENT -----------------------
 
     /**
-     * @brief Execute segmentation using the Region Growing Algorithm.
+     * @brief Execute segmentation using the Region Growing algorithm.
      *
+     * @param[out] regions_idx Index information of all points in each region, support
+     *               vector<vector<int>>, vector<Mat>.
      * @param[out] labels The label corresponds to the model number, 0 means it does not belong to
-     *                    any model, range [0, Number of final resultant models obtained].
-     * @param input_pts Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
-     * @param normals Normal of each point, vector of Point3f or Mat of size Nx3/3xN.
-     * @param knn_idx Index of K nearest neighbors of all points. The first nearest point of each
-     *                point is itself. Only support Mat with layout NxK/KxN in memory space.
-     *
+     *               any model, range [0, Number of final resultant models obtained]. Support
+     *               vector<int> and Mat.
+     * @param input_pts Original point cloud, support vector<Point3f> and Mat of size Nx3/3xN.
+     * @param normals Normal of each point, support vector<Point3f> and Mat of size Nx3.
+     * @param nn_idx Index information of nearest neighbors of all points. The first nearest
+     *               neighbor of each point is itself. Support vector<vector<int>>, vector<Mat> and
+     *               Mat of size NxK. If the information in a row is
+     *               [0, 2, 1, -5, -1, 4, 7 ... negative number]
+     *               it will use only non-negative indexes until it meets a negative number or bound
+     *               of this row i.e. [0, 2, 1].
      * @return Number of final resultant regions obtained by segmentation.
      */
     virtual int
-    segment(OutputArray labels, InputArray input_pts, InputArray normals, InputArray knn_idx) = 0;
+    segment(OutputArrayOfArrays regions_idx, OutputArray labels, InputArray input_pts,
+            InputArray normals, InputArrayOfArrays nn_idx) = 0;
 
     //-------------------------- Getter and Setter -----------------------
 
     //! Set the minimum size of region.
+    //！Setting to a non-positive number or default will be unlimited.
     virtual void setMinSize(int min_size) = 0;
 
     //! Get the minimum size of region.
     virtual int getMinSize() const = 0;
 
     //! Set the maximum size of region.
+    //！Setting to a non-positive number or default will be unlimited.
     virtual void setMaxSize(int max_size) = 0;
 
     //! Get the maximum size of region.
     virtual int getMaxSize() const = 0;
 
-    //! Set whether to use the smoothness mode.
+    //! Set whether to use the smoothness mode. Default will be true.
     //! If true it will check the angle between the normal of the current point and the normal of its neighbor.
     //! Otherwise, it will check the angle between the normal of the seed point and the normal of current neighbor.
     virtual void setSmoothModeFlag(bool smooth_mode) = 0;
@@ -370,12 +359,13 @@ public:
     virtual bool getSmoothModeFlag() const = 0;
 
     //! Set threshold value of the angle between normals, the input value is in radian.
+    //！Default will be 30(degree)*PI/180.
     virtual void setSmoothnessThreshold(double smoothness_thr) = 0;
 
     //! Get threshold value of the angle between normals.
     virtual double getSmoothnessThreshold() const = 0;
 
-    //! Set threshold value of curvature.
+    //! Set threshold value of curvature. Default will be 0.05.
     //! Only points with curvature less than the threshold will be considered to belong to the same region.
     //! If the curvature of each point is not set, this option will not work.
     virtual void setCurvatureThreshold(double curvature_thr) = 0;
@@ -383,17 +373,25 @@ public:
     //! Get threshold value of curvature.
     virtual double getCurvatureThreshold() const = 0;
 
-    //! Set the number of neighbors including itself. Setting 0 will use the number from knn_idx.
-    virtual void setNumberOfNeighbors(int k) = 0;
+    //! Set the maximum number of neighbors want to use including itself.
+    //! Setting to a non-positive number or default will use the information from nn_idx.
+    virtual void setMaxNumberOfNeighbors(int max_neighbor_num) = 0;
 
-    //! Get the number of neighbors including itself.
-    virtual int getNumberOfNeighbors() const = 0;
+    //! Get the maximum number of neighbors including itself.
+    virtual int getMaxNumberOfNeighbors() const = 0;
 
     //! Set the maximum number of regions you want.
+    //！Setting to a non-positive number or default will be unlimited.
     virtual void setNumberOfRegions(int region_num) = 0;
 
     //! Get the maximum number of regions you want.
     virtual int getNumberOfRegions() const = 0;
+
+    //! Set whether the results need to be sorted in descending order by the number of points.
+    virtual void setNeedSort(bool need_sort_) = 0;
+
+    //! Get whether the results need to be sorted you have set.
+    virtual bool getNeedSort() const = 0;
 
     //! Set the seed points, it will grow according to the seeds.
     //! If noArray() is set, the default method will be used:
@@ -404,7 +402,7 @@ public:
     //! Get the seed points.
     virtual void getSeeds(OutputArray seeds) const = 0;
 
-    //! Set the curvature of each point, support vector<float> and mat with Nx1/1xN. If not, you can set it to noArray().
+    //! Set the curvature of each point, support vector<float> and Mat. If not, you can set it to noArray().
     virtual void setCurvatures(InputArray curvatures) = 0;
 
     //! Get the curvature of each point if you have set.

--- a/modules/3d/include/opencv2/3d/ptcloud.hpp
+++ b/modules/3d/include/opencv2/3d/ptcloud.hpp
@@ -264,7 +264,7 @@ CV_EXPORTS int farthestPointSampling(OutputArray sampled_point_flags, InputArray
 /**
  * @brief Estimate the normal and curvature of each point in point cloud from KNN results.
  *
- * Estimate Algorithm:
+ * Normal Estimation Algorithm:
  * + Input: K nearest neighbor of a specific point: \f$pt_set\f$
  * + Step:
  *     1. Calculate the \f$ mean \f$ in pt_set;
@@ -277,10 +277,10 @@ CV_EXPORTS int farthestPointSampling(OutputArray sampled_point_flags, InputArray
  *
  * @param[out] normals Normal of each point, vector of Point3f or Mat of size Nx3.
  * @param[out] curvatures Curvature of each point, vector or Mat.
- * @param input_pts Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
- * @param knn_idx Index of K nearest neighbors of all points. The first nearest point of each point
- *                is itself. Support Mat or vector of vector with layout NxK/KxN in memory space.
- * @param k The number of neighbors including itself. setting 0 will use the K obtained from knn_idx.
+ * @param input_pts_ Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
+ * @param knn_idx_ Index of K nearest neighbors of all points. The first nearest point of each point
+ *                is itself. Only support Mat with layout NxK/KxN in memory space.
+ * @param k The number of neighbors including itself. Setting 0 will use the number from knn_idx_.
  */
 
 CV_EXPORTS void
@@ -293,14 +293,13 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
  * Get the index and distance result of KNN search in point cloud by using the KDTree in flann library.
  *
  * @param[out] knn_idx Index of K nearest neighbors of all points. The first nearest point of each
- *                     point is itself. Support Mat or vector of vector with layout NxK in memory
- *                     space. If this result is not needed, it is recommended to pass noArray(),
- *                     which will not cause the corresponding memory consumption.
- * @param[out] knn_dist Distance of K nearest neighbors of all points. Support Mat or vector of
- *                      vector with layout NxK in memory space. If this result is not needed, it is
- *                      recommended to pass noArray(), which will not cause the corresponding
- *                      memory consumption.
- * @param input_pts  Original point cloud, vector of Point3 or Mat of size Nx3/3xN.
+ *                     point is itself. Only support Mat with layout NxK in memory space. If this
+ *                     result is not needed, it is recommended to pass noArray(), which will not
+ *                     cause the corresponding memory consumption.
+ * @param[out] knn_dist Distance of K nearest neighbors of all points. Only support Mat with layout
+ *                      NxK in memory space. If this result is not needed, it is recommended to pass
+ *                      noArray(), which will not cause the corresponding memory consumption.
+ * @param input_pts_  Original point cloud, vector of Point3f or Mat of size Nx3/3xN.
  * @param k The number of neighbors including itself, default value is 30.
  * @param kdtree_params Optional flann::KDTreeIndexParams() used for building KDTree;
  *                      if it is nullptr, default is used instead.
@@ -318,15 +317,13 @@ class CV_EXPORTS RegionGrowing3D : public Algorithm
 public:
     //-------------------------- CREATE -----------------------
 
-    static Ptr<RegionGrowing3D>
-    create(float smoothness_thr = 30.f / 180.f * 3.1415926f, float curvature_thr = 0.05f);
+    static Ptr<RegionGrowing3D> create();
 
     //-------------------------- SEGMENT -----------------------
 
     /**
      */
-    virtual int
-    segment(OutputArray labels) = 0;
+    virtual int segment(OutputArray labels, InputArray input_pts, InputArray normals, InputArray knn_idx) = 0;
 
     //-------------------------- Getter and Setter -----------------------
 
@@ -349,16 +346,16 @@ public:
     virtual bool getSmoothModeFlag() const = 0;
 
     //! Set
-    virtual void setSmoothnessThreshold(float smoothness_thr) = 0;
+    virtual void setSmoothnessThreshold(double smoothness_thr) = 0;
 
     //! Get
-    virtual float getSmoothnessThreshold() const = 0;
+    virtual double getSmoothnessThreshold() const = 0;
 
     //! Set
-    virtual void setCurvatureThreshold(float curvature_thr) = 0;
+    virtual void setCurvatureThreshold(double curvature_thr) = 0;
 
     //! Get
-    virtual float getCurvatureThreshold() const = 0;
+    virtual double getCurvatureThreshold() const = 0;
 
     //! Set
     virtual void setNumberOfNeighbors(int k) = 0;
@@ -373,20 +370,16 @@ public:
     virtual int getNumberOfRegions() const = 0;
 
     //! Set
-    virtual void setPtcloud(InputArray input_pts) = 0;
-
-    //! Set
-    virtual void setKnnIdx(InputArray knn_idx) = 0;
-
-    //! Set
     virtual void setSeeds(InputArray seeds) = 0;
 
-    //! Set
-    virtual void setNormals(InputArray normals) = 0;
+    //! Get
+    virtual void getSeeds(OutputArray seeds) const = 0;
 
     //! Set
     virtual void setCurvatures(InputArray curvatures) = 0;
 
+    //! Get
+    virtual void getCurvatures(OutputArray curvatures) const = 0;
 };
 //! @} _3d
 } //end namespace cv

--- a/modules/3d/include/opencv2/3d/ptcloud.hpp
+++ b/modules/3d/include/opencv2/3d/ptcloud.hpp
@@ -388,7 +388,7 @@ public:
     virtual int getNumberOfRegions() const = 0;
 
     //! Set whether the results need to be sorted in descending order by the number of points.
-    virtual void setNeedSort(bool need_sort_) = 0;
+    virtual void setNeedSort(bool need_sort) = 0;
 
     //! Get whether the results need to be sorted you have set.
     virtual bool getNeedSort() const = 0;

--- a/modules/3d/include/opencv2/3d/ptcloud.hpp
+++ b/modules/3d/include/opencv2/3d/ptcloud.hpp
@@ -8,8 +8,6 @@
 #ifndef OPENCV_3D_PTCLOUD_HPP
 #define OPENCV_3D_PTCLOUD_HPP
 
-#include "opencv2/flann.hpp"
-
 namespace cv {
 
 //! @addtogroup _3d

--- a/modules/3d/src/ptcloud/normal_estimation.cpp
+++ b/modules/3d/src/ptcloud/normal_estimation.cpp
@@ -1,0 +1,141 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "ptcloud_utils.hpp"
+
+namespace cv {
+
+//! @addtogroup _3d
+//! @{
+
+void
+normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts, InputArray knn_idx, int k)
+{
+    Mat ori_pts;
+    getPointsMatFromInputArray(input_pts, ori_pts, 0);
+    int pts_size = ori_pts.rows;
+
+    if (input_pts.channels() == 3 && normals.isVector())
+    {
+        // std::vector<cv::Point3f>
+        normals.create(1, pts_size, CV_32FC3);
+    }
+    else
+    {
+        // cv::Mat
+        normals.create(pts_size, 3, CV_32F);
+    }
+
+    curvatures.create(pts_size, 1, CV_32F);
+
+    // Convert layout of data in memory space to NxK.
+    Mat _knn_idx;
+    if(knn_idx.rows() < knn_idx.cols()){
+        transpose(knn_idx.getMat(), _knn_idx);
+    }else{
+        _knn_idx = knn_idx.getMat();
+    }
+
+    if(k == 0) k = _knn_idx.cols;
+
+    CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
+    CV_CheckGE(_knn_idx.cols, k, "The number of neighbors of KNN search result should be grater than or equal to that of normal estimation.");
+    CV_CheckEQ(pts_size, _knn_idx.rows, "The number of points in the KNN search result should be equal to that in the point cloud.");
+
+    const float *ori_pts_ptr = (float *) ori_pts.data;
+    const int *_knn_idx_ptr = (int *) _knn_idx.data;
+    float *normals_ptr = (float *) normals.getMat().data;
+    float *curvatures_ptr = (float *) curvatures.getMat().data;
+
+    parallel_for_(Range(0, pts_size), [&](const Range &range) {
+        int i = range.start;
+        Mat pt_set(k, 3, CV_32F);
+        // Copy the nearest k points to pt_set
+        float *pt_set_ptr = (float *) pt_set.data;
+        long ik = (long)i * k;
+        for (int j = 0; j < k; ++j)
+        {
+            int idx = _knn_idx_ptr[ik + j];
+            const float *ori_pts_ptr_base = ori_pts_ptr + 3 * idx;
+            float *pt_set_ptr_base = pt_set_ptr + 3 * j;
+            pt_set_ptr_base[0] = ori_pts_ptr_base[0];
+            pt_set_ptr_base[1] = ori_pts_ptr_base[1];
+            pt_set_ptr_base[2] = ori_pts_ptr_base[2];
+        }
+
+        Mat mean;
+        // Calculate the mean of point set
+        reduce(pt_set, mean, 0, REDUCE_AVG);
+        // Use PCA to get eigenvalues and eigenvectors of point set
+        PCA pca(pt_set, mean, PCA::DATA_AS_ROW);
+
+        const float *eigenvectors_ptr = (float *) pca.eigenvectors.data;
+        float *normals_ptr_base = normals_ptr + 3 * i;
+        normals_ptr_base[0] = eigenvectors_ptr[6];
+        normals_ptr_base[1] = eigenvectors_ptr[7];
+        normals_ptr_base[2] = eigenvectors_ptr[8];
+
+        const float *eigenvalues_ptr = (float *) pca.eigenvalues.data;
+        curvatures_ptr[i] = eigenvalues_ptr[2] / (eigenvalues_ptr[0] + eigenvalues_ptr[1] + eigenvalues_ptr[2]);
+    });
+}
+
+void
+getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArray input_pts, int k,
+        flann::KDTreeIndexParams *kdtree_params, flann::SearchParams *search_params)
+{
+    Mat ori_pts;
+    getPointsMatFromInputArray(input_pts, ori_pts, 0);
+    int pts_size = ori_pts.rows;
+
+    CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
+    CV_CheckGE(pts_size, k, "The point cloud size should be greater than or equal to the number of neighbors.");
+
+    // Build KDTree for knn search
+    flann::KDTreeIndexParams *kdtree_params_ = kdtree_params ? kdtree_params : new flann::KDTreeIndexParams();
+    flann::SearchParams *search_params_ = search_params ? search_params : new flann::SearchParams();
+    flann::Index tree(ori_pts, *kdtree_params_);
+
+    bool need_knn_idx = &knn_idx != &noArray();
+    bool need_knn_dist = &knn_dist != &noArray();
+
+    if(need_knn_idx){
+        knn_idx.create(pts_size, k, CV_32S);
+    }
+
+    if(need_knn_dist){
+        knn_dist.create(pts_size, k, CV_32F);
+    }
+
+    int *knn_idx_ptr = (int *) knn_idx.getMat().data;
+    float *knn_dist_ptr = (float *) knn_dist.getMat().data;
+
+    parallel_for_(Range(0, pts_size), [&](const Range &range) {
+        int i = range.start;
+        Mat idx_set(1, k, CV_32S), dist_set(1, k, CV_32F);
+        tree.knnSearch(ori_pts.row(i), idx_set, dist_set, k, *search_params_);
+
+        const int *idx_set_ptr = (int *) idx_set.data;
+        const float *dist_set_ptr = (float *) dist_set.data;
+        long ik = (long) i * k;
+        // Copy result of knn search to _knn_idx
+        if(need_knn_idx){
+            for (int j = 0; j < k; ++j)
+            {
+                knn_idx_ptr[ik + j] = idx_set_ptr[j];
+            }
+        }
+        // Copy result of knn search to _knn_dist
+        if(need_knn_dist){
+            for (int j = 0; j < k; ++j)
+            {
+                knn_dist_ptr[ik + j] = dist_set_ptr[j];
+            }
+        }
+    });
+}
+
+//! @} _3d
+} //end namespace cv

--- a/modules/3d/src/ptcloud/normal_estimation.cpp
+++ b/modules/3d/src/ptcloud/normal_estimation.cpp
@@ -139,12 +139,12 @@ getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArra
         long ik = (long) i * k;
 
         if (need_knn_idx){
-            // Copy result of knn search to _knn_idx
+            // Copy result of knn search to knn_idx
             for (int j = 0; j < k; ++j) knn_idx_ptr[ik + j] = idx_set_ptr[j];
         }
 
         if (need_knn_dist){
-            // Copy result of knn search to _knn_dist
+            // Copy result of knn search to knn_dist
             for (int j = 0; j < k; ++j) knn_dist_ptr[ik + j] = dist_set_ptr[j];
         }
     });

--- a/modules/3d/src/ptcloud/normal_estimation.cpp
+++ b/modules/3d/src/ptcloud/normal_estimation.cpp
@@ -14,11 +14,17 @@ namespace cv {
 
 void
 normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts_,
-        InputArray knn_idx_, int k)
+        InputArrayOfArrays nn_idx_, int max_neighbor_num_)
 {
     Mat ori_pts;
     getPointsMatFromInputArray(input_pts_, ori_pts, 0);
     int pts_size = ori_pts.rows;
+
+    std::vector<Mat> nn_idx;
+    nn_idx_.getMatVector(nn_idx);
+
+    CV_CheckEQ((int) nn_idx.size(), pts_size,
+            "The point number of NN search result should be equal to the size of the point cloud.");
 
     if (normals.channels() == 3 && normals.isVector())
     {
@@ -33,56 +39,33 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
 
     curvatures.create(pts_size, 1, CV_32F);
 
-    Mat knn_idx;
-    if (knn_idx_.rows() < knn_idx_.cols())
-    {
-        // Convert layout of data in memory space to NxK
-        transpose(knn_idx_.getMat(), knn_idx);
-    }
-    else
-    {
-        knn_idx = knn_idx_.getMat();
-    }
+    int max_neighbor_num = max_neighbor_num_ <= 0 ? INT_MAX : max_neighbor_num_;
 
-    if (!knn_idx.isContinuous())
-    {
-        knn_idx = knn_idx.clone();
-    }
-
-    if (k == 0)
-    {
-        k = knn_idx.cols;
-    }
-
-    CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
-    CV_CheckGE(knn_idx.cols, k,
-            "The number of neighbors of KNN search result should be grater than or equal to that of normal estimation.");
-    CV_CheckEQ(pts_size, knn_idx.rows,
-            "The number of points in the KNN search result should be equal to that in the point cloud.");
-
-    const float *ori_pts_ptr = (float *) ori_pts.data;
-    const int *knn_idx_ptr = (int *) knn_idx.data;
     float *normals_ptr = (float *) normals.getMat().data;
     float *curvatures_ptr = (float *) curvatures.getMat().data;
 
     parallel_for_(Range(0, pts_size), [&](const Range &range) {
-        for (int i = range.start; i < range.end; i++)
+        // Index of current nearest neighbor point
+        int cur_nei_idx;
+        for (int i = range.start; i < range.end; ++i)
         {
-            const int *knn_idx_ptr_base = knn_idx_ptr + i * k;
-            Mat pt_set(k, 3, CV_32F);
-            // Copy the nearest k points to pt_set
-            float *pt_set_ptr = (float *) pt_set.data;
-            for (int j = 0; j < k; ++j)
+            // The maximum size that may be used for this row
+            int bound = max_neighbor_num > nn_idx[i].cols ? nn_idx[i].cols : max_neighbor_num;
+            const int *nn_idx_ptr_base = (int *) nn_idx[i].data;
+            // The first point should be itself
+            Mat pt_set(ori_pts.row(i));
+            // Push the nearest neighbor points to pt_set
+            for (int j = 1; j < bound; ++j)
             {
-                const float *ori_pts_ptr_base = ori_pts_ptr + 3 * knn_idx_ptr_base[j];
-                float *pt_set_ptr_base = pt_set_ptr + 3 * j;
-                pt_set_ptr_base[0] = ori_pts_ptr_base[0];
-                pt_set_ptr_base[1] = ori_pts_ptr_base[1];
-                pt_set_ptr_base[2] = ori_pts_ptr_base[2];
+                cur_nei_idx = nn_idx_ptr_base[j];
+                // If the index is less than 0,
+                // the nn_idx of this row will no longer have any information.
+                if (cur_nei_idx < 0) break;
+                pt_set.push_back(ori_pts.row(cur_nei_idx));
             }
 
             Mat mean;
-            // Calculate the mean of point set, use "reduce" is faster than default method in PCA
+            // Calculate the mean of point set, use "reduce()" is faster than default method in PCA
             reduce(pt_set, mean, 0, REDUCE_AVG);
             // Use PCA to get eigenvalues and eigenvectors of pt_set
             PCA pca(pt_set, mean, PCA::DATA_AS_ROW);
@@ -96,66 +79,6 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
             const float *eigenvalues_ptr = (float *) pca.eigenvalues.data;
             curvatures_ptr[i] = eigenvalues_ptr[2] /
                                 (eigenvalues_ptr[0] + eigenvalues_ptr[1] + eigenvalues_ptr[2]);
-        }
-    });
-}
-
-void
-getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArray input_pts_, int k,
-        flann::KDTreeIndexParams *kdtree_params_, flann::SearchParams *search_params_)
-{
-    Mat ori_pts;
-    getPointsMatFromInputArray(input_pts_, ori_pts, 0);
-    int pts_size = ori_pts.rows;
-
-    CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
-    CV_CheckGE(pts_size, k,
-            "The point cloud size should be greater than or equal to the number of neighbors.");
-
-    // Build KDTree for knn search
-    flann::KDTreeIndexParams *kdtree_params = kdtree_params_ ? kdtree_params_
-                                                             : new flann::KDTreeIndexParams();
-    flann::SearchParams *search_params = search_params_ ? search_params_
-                                                        : new flann::SearchParams();
-    flann::Index tree(ori_pts, *kdtree_params);
-
-    bool need_knn_idx = &knn_idx != &noArray();
-    bool need_knn_dist = &knn_dist != &noArray();
-    // Create knn_idx or knn_dist to save the results of KNN search
-    if (need_knn_idx)
-    {
-        knn_idx.create(pts_size, k, CV_32S);
-    }
-
-    if (need_knn_dist)
-    {
-        knn_dist.create(pts_size, k, CV_32F);
-    }
-
-    int *knn_idx_ptr = (int *) knn_idx.getMat().data;
-    float *knn_dist_ptr = (float *) knn_dist.getMat().data;
-
-    parallel_for_(Range(0, pts_size), [&](const Range &range) {
-        for (int i = range.start; i < range.end; ++i)
-        {
-            Mat idx_set(1, k, CV_32S), dist_set(1, k, CV_32F);
-            tree.knnSearch(ori_pts.row(i), idx_set, dist_set, k, *search_params);
-
-            if (need_knn_idx)
-            {
-                const int *idx_set_ptr = (int *) idx_set.data;
-                int *knn_idx_ptr_base = knn_idx_ptr + i * k;
-                // Copy result of knn search to knn_idx
-                for (int j = 0; j < k; ++j) knn_idx_ptr_base[j] = idx_set_ptr[j];
-            }
-
-            if (need_knn_dist)
-            {
-                const float *dist_set_ptr = (float *) dist_set.data;
-                float *knn_dist_ptr_base = knn_dist_ptr + i * k;
-                // Copy result of knn search to knn_dist
-                for (int j = 0; j < k; ++j) knn_dist_ptr_base[j] = dist_set_ptr[j];
-            }
         }
     });
 }

--- a/modules/3d/src/ptcloud/normal_estimation.cpp
+++ b/modules/3d/src/ptcloud/normal_estimation.cpp
@@ -44,7 +44,10 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
         knn_idx = knn_idx_.getMat();
     }
 
-    if (k == 0) k = knn_idx.cols;
+    if (k == 0)
+    {
+        k = knn_idx.cols;
+    }
 
     CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
     CV_CheckGE(knn_idx.cols, k,
@@ -113,8 +116,15 @@ getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArra
     bool need_knn_idx = &knn_idx != &noArray();
     bool need_knn_dist = &knn_dist != &noArray();
     // Create knn_idx or knn_dist to save the results of KNN search
-    if (need_knn_idx) knn_idx.create(pts_size, k, CV_32S);
-    if (need_knn_dist) knn_dist.create(pts_size, k, CV_32F);
+    if (need_knn_idx)
+    {
+        knn_idx.create(pts_size, k, CV_32S);
+    }
+
+    if (need_knn_dist)
+    {
+        knn_dist.create(pts_size, k, CV_32F);
+    }
 
     int *knn_idx_ptr = (int *) knn_idx.getMat().data;
     float *knn_dist_ptr = (float *) knn_dist.getMat().data;
@@ -128,12 +138,15 @@ getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArra
         const float *dist_set_ptr = (float *) dist_set.data;
         long ik = (long) i * k;
 
-        if (need_knn_idx)
+        if (need_knn_idx){
             // Copy result of knn search to _knn_idx
             for (int j = 0; j < k; ++j) knn_idx_ptr[ik + j] = idx_set_ptr[j];
-        if (need_knn_dist)
+        }
+
+        if (need_knn_dist){
             // Copy result of knn search to _knn_dist
             for (int j = 0; j < k; ++j) knn_dist_ptr[ik + j] = dist_set_ptr[j];
+        }
     });
 }
 

--- a/modules/3d/src/ptcloud/normal_estimation.cpp
+++ b/modules/3d/src/ptcloud/normal_estimation.cpp
@@ -1,6 +1,8 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
 
 #include "../precomp.hpp"
 #include "ptcloud_utils.hpp"
@@ -11,13 +13,14 @@ namespace cv {
 //! @{
 
 void
-normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts, InputArray knn_idx, int k)
+normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts_,
+        InputArray knn_idx_, int k)
 {
     Mat ori_pts;
-    getPointsMatFromInputArray(input_pts, ori_pts, 0);
+    getPointsMatFromInputArray(input_pts_, ori_pts, 0);
     int pts_size = ori_pts.rows;
 
-    if (input_pts.channels() == 3 && normals.isVector())
+    if (normals.channels() == 3 && normals.isVector())
     {
         // std::vector<cv::Point3f>
         normals.create(1, pts_size, CV_32FC3);
@@ -30,22 +33,27 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
 
     curvatures.create(pts_size, 1, CV_32F);
 
-    // Convert layout of data in memory space to NxK.
-    Mat _knn_idx;
-    if(knn_idx.rows() < knn_idx.cols()){
-        transpose(knn_idx.getMat(), _knn_idx);
-    }else{
-        _knn_idx = knn_idx.getMat();
+    Mat knn_idx;
+    if (knn_idx_.rows() < knn_idx_.cols())
+    {
+        // Convert layout of data in memory space to NxK
+        transpose(knn_idx_.getMat(), knn_idx);
+    }
+    else
+    {
+        knn_idx = knn_idx_.getMat();
     }
 
-    if(k == 0) k = _knn_idx.cols;
+    if (k == 0) k = knn_idx.cols;
 
     CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
-    CV_CheckGE(_knn_idx.cols, k, "The number of neighbors of KNN search result should be grater than or equal to that of normal estimation.");
-    CV_CheckEQ(pts_size, _knn_idx.rows, "The number of points in the KNN search result should be equal to that in the point cloud.");
+    CV_CheckGE(knn_idx.cols, k,
+            "The number of neighbors of KNN search result should be grater than or equal to that of normal estimation.");
+    CV_CheckEQ(pts_size, knn_idx.rows,
+            "The number of points in the KNN search result should be equal to that in the point cloud.");
 
     const float *ori_pts_ptr = (float *) ori_pts.data;
-    const int *_knn_idx_ptr = (int *) _knn_idx.data;
+    const int *knn_idx_ptr = (int *) knn_idx.data;
     float *normals_ptr = (float *) normals.getMat().data;
     float *curvatures_ptr = (float *) curvatures.getMat().data;
 
@@ -54,10 +62,10 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
         Mat pt_set(k, 3, CV_32F);
         // Copy the nearest k points to pt_set
         float *pt_set_ptr = (float *) pt_set.data;
-        long ik = (long)i * k;
+        long ik = (long) i * k;
         for (int j = 0; j < k; ++j)
         {
-            int idx = _knn_idx_ptr[ik + j];
+            int idx = knn_idx_ptr[ik + j];
             const float *ori_pts_ptr_base = ori_pts_ptr + 3 * idx;
             float *pt_set_ptr_base = pt_set_ptr + 3 * j;
             pt_set_ptr_base[0] = ori_pts_ptr_base[0];
@@ -68,7 +76,7 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
         Mat mean;
         // Calculate the mean of point set
         reduce(pt_set, mean, 0, REDUCE_AVG);
-        // Use PCA to get eigenvalues and eigenvectors of point set
+        // Use PCA to get eigenvalues and eigenvectors of pt_set
         PCA pca(pt_set, mean, PCA::DATA_AS_ROW);
 
         const float *eigenvectors_ptr = (float *) pca.eigenvectors.data;
@@ -78,36 +86,35 @@ normalEstimate(OutputArray normals, OutputArray curvatures, InputArray input_pts
         normals_ptr_base[2] = eigenvectors_ptr[8];
 
         const float *eigenvalues_ptr = (float *) pca.eigenvalues.data;
-        curvatures_ptr[i] = eigenvalues_ptr[2] / (eigenvalues_ptr[0] + eigenvalues_ptr[1] + eigenvalues_ptr[2]);
+        curvatures_ptr[i] =
+                eigenvalues_ptr[2] / (eigenvalues_ptr[0] + eigenvalues_ptr[1] + eigenvalues_ptr[2]);
     });
 }
 
 void
-getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArray input_pts, int k,
-        flann::KDTreeIndexParams *kdtree_params, flann::SearchParams *search_params)
+getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArray input_pts_, int k,
+        flann::KDTreeIndexParams *kdtree_params_, flann::SearchParams *search_params_)
 {
     Mat ori_pts;
-    getPointsMatFromInputArray(input_pts, ori_pts, 0);
+    getPointsMatFromInputArray(input_pts_, ori_pts, 0);
     int pts_size = ori_pts.rows;
 
     CV_CheckGE(k, 2, "The number of neighbors should be greater than 2.");
-    CV_CheckGE(pts_size, k, "The point cloud size should be greater than or equal to the number of neighbors.");
+    CV_CheckGE(pts_size, k,
+            "The point cloud size should be greater than or equal to the number of neighbors.");
 
     // Build KDTree for knn search
-    flann::KDTreeIndexParams *kdtree_params_ = kdtree_params ? kdtree_params : new flann::KDTreeIndexParams();
-    flann::SearchParams *search_params_ = search_params ? search_params : new flann::SearchParams();
-    flann::Index tree(ori_pts, *kdtree_params_);
+    flann::KDTreeIndexParams *kdtree_params = kdtree_params_ ? kdtree_params_
+                                                             : new flann::KDTreeIndexParams();
+    flann::SearchParams *search_params = search_params_ ? search_params_
+                                                        : new flann::SearchParams();
+    flann::Index tree(ori_pts, *kdtree_params);
 
     bool need_knn_idx = &knn_idx != &noArray();
     bool need_knn_dist = &knn_dist != &noArray();
-
-    if(need_knn_idx){
-        knn_idx.create(pts_size, k, CV_32S);
-    }
-
-    if(need_knn_dist){
-        knn_dist.create(pts_size, k, CV_32F);
-    }
+    // Create knn_idx or knn_dist to save the results of KNN search
+    if (need_knn_idx) knn_idx.create(pts_size, k, CV_32S);
+    if (need_knn_dist) knn_dist.create(pts_size, k, CV_32F);
 
     int *knn_idx_ptr = (int *) knn_idx.getMat().data;
     float *knn_dist_ptr = (float *) knn_dist.getMat().data;
@@ -115,25 +122,18 @@ getKNNSearchResultsByKDTree(OutputArray knn_idx, OutputArray knn_dist, InputArra
     parallel_for_(Range(0, pts_size), [&](const Range &range) {
         int i = range.start;
         Mat idx_set(1, k, CV_32S), dist_set(1, k, CV_32F);
-        tree.knnSearch(ori_pts.row(i), idx_set, dist_set, k, *search_params_);
+        tree.knnSearch(ori_pts.row(i), idx_set, dist_set, k, *search_params);
 
         const int *idx_set_ptr = (int *) idx_set.data;
         const float *dist_set_ptr = (float *) dist_set.data;
         long ik = (long) i * k;
-        // Copy result of knn search to _knn_idx
-        if(need_knn_idx){
-            for (int j = 0; j < k; ++j)
-            {
-                knn_idx_ptr[ik + j] = idx_set_ptr[j];
-            }
-        }
-        // Copy result of knn search to _knn_dist
-        if(need_knn_dist){
-            for (int j = 0; j < k; ++j)
-            {
-                knn_dist_ptr[ik + j] = dist_set_ptr[j];
-            }
-        }
+
+        if (need_knn_idx)
+            // Copy result of knn search to _knn_idx
+            for (int j = 0; j < k; ++j) knn_idx_ptr[ik + j] = idx_set_ptr[j];
+        if (need_knn_dist)
+            // Copy result of knn search to _knn_dist
+            for (int j = 0; j < k; ++j) knn_dist_ptr[ik + j] = dist_set_ptr[j];
     });
 }
 

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -1,0 +1,111 @@
+#include "../precomp.hpp"
+#include "region_growing_3d.hpp"
+#include "opencv2/3d/ptcloud.hpp"
+
+#include "queue"
+
+namespace cv {
+//    namespace _3d {
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////  RegionGrowing3DImpl  //////////////////////////////////////
+
+int
+RegionGrowing3DImpl::segment(OutputArray labels)
+{
+    int pts_size = input_pts.rows;
+
+    CV_CheckGE(max_size, min_size,
+            "The maximum size should be grater than or equal to the minimum size.");
+    CV_CheckGE(knn_idx.cols, k,
+            "The number of neighbors of KNN search result should be grater than or equal to that of region growing.");
+    CV_CheckGE(pts_size, max(seeds.rows, seeds.cols),
+            "The number of seed should be less than or equal to the number of points in the point cloud.");
+    CV_CheckEQ(pts_size, knn_idx.rows,
+            "The number of points in the KNN search result should be equal to that in the point cloud.");
+    CV_CheckEQ(pts_size, max(normals.rows, normals.cols),
+            "The number of points in the normals should be equal to that in the point cloud.");
+    CV_CheckEQ(pts_size, max(curvatures.rows, curvatures.cols),
+            "The number of points in the curvatures should be equal to that in the point cloud.");
+
+    if (k == 0) k = knn_idx.cols;
+
+    // Set labels to zero
+    Mat _labels = Mat::zeros(pts_size, 1, CV_32S);
+    // If no seed point is set, curvature sorting is used by default
+    if (seeds.empty()) sortIdx(curvatures, seeds, SORT_EVERY_COLUMN + SORT_ASCENDING);
+
+    const int *seeds_ptr = (int *) seeds.data;
+    const float *curvatures_ptr = (float *) curvatures.data;
+
+    int flag = 1;
+    for (int i = 0; i < pts_size; i++)
+    {
+        int *labels_ptr = (int *) _labels.data;
+        int cur_seed = seeds_ptr[i];
+        int region_size = 1;
+
+        // If the number of regions is satisfied then stop running
+        if (flag > region_num) break;
+        // If current seed has been grown then grow the next one
+        if (labels_ptr[cur_seed] != 0) continue;
+        // Filter out seeds with curvature greater than the threshold
+        if (curvatures_ptr[cur_seed] > curvature_thr) break;
+
+        Mat base_normal;
+        if (!smooth_mode) base_normal = normals.row(cur_seed);
+
+        Mat labels_tmp;
+        _labels.copyTo(labels_tmp);
+        int *labels_tmp_ptr = (int *) labels_tmp.data;
+        labels_tmp_ptr[cur_seed] = flag;
+
+        std::queue<int> grow_list;
+        grow_list.push(cur_seed);
+
+        while (!grow_list.empty())
+        {
+            int cur_idx = grow_list.front();
+            grow_list.pop();
+            if (smooth_mode) base_normal = normals.row(cur_idx);
+
+            const int *pt_knn_ptr = (int *) knn_idx.row(cur_idx).data;
+            for (int j = 0; j < k; j++)
+            {
+                int cur_neighbor_idx = pt_knn_ptr[j];
+                // If current point has been grown then grow the next one
+                if (labels_tmp_ptr[cur_neighbor_idx] != 0) continue;
+                // Filter out points with curvature greater than the threshold
+                if (curvatures_ptr[cur_neighbor_idx] > curvature_thr) continue;
+
+                Mat cur_normal = normals.row(cur_neighbor_idx);
+                float n12 = (float) base_normal.dot(cur_normal);
+                float n1m = (float) base_normal.dot(base_normal);
+                float n2m = (float) cur_normal.dot(cur_normal);
+                float cos_smoothness_thr = std::cos(smoothness_thr);
+                // If the smoothness threshold is satisfied, this neighbor will be pushed to the growth list
+                if (n12 * n12 / (n1m * n2m) > cos_smoothness_thr * cos_smoothness_thr)
+                {
+                    labels_tmp_ptr[cur_neighbor_idx] = flag;
+                    grow_list.push(cur_neighbor_idx);
+                    region_size++;
+                }
+            }
+            // Check if the current region size are less than the maximum size
+            if (region_size > max_size) break;
+        }
+
+        // Check if the current region size are within the range
+        if (min_size <= region_size && region_size <= max_size)
+        {
+            swap(_labels, labels_tmp);
+            flag++;
+        }
+    }
+
+    _labels.copyTo(labels);
+    return flag - 1;
+}
+
+//    } // _3d::
+}  // cv::

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -1,8 +1,15 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+
 #include "../precomp.hpp"
 #include "region_growing_3d.hpp"
 #include "opencv2/3d/ptcloud.hpp"
 
-#include "queue"
+#include <queue>
+#include <numeric>
 
 namespace cv {
 //    namespace _3d {
@@ -10,47 +17,79 @@ namespace cv {
 /////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////  RegionGrowing3DImpl  //////////////////////////////////////
 
-int
-RegionGrowing3DImpl::segment(OutputArray labels)
+int RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArray normals_,
+        InputArray knn_idx_)
 {
-    int pts_size = input_pts.rows;
+    Mat ori_pts, normals, knn_idx;
+    getPointsMatFromInputArray(input_pts_, ori_pts, 0);
+    getPointsMatFromInputArray(normals_, normals, 0);
+    if (knn_idx_.rows() < knn_idx_.cols())
+    {
+        // Convert layout of data in memory space to NxK
+        transpose(knn_idx_.getMat(), knn_idx);
+    }
+    else
+    {
+        knn_idx = knn_idx_.getMat();
+    }
+
+    if (k == 0) k = knn_idx.cols;
+
+    int pts_size = ori_pts.rows;
+    bool has_curvatures = !curvatures.empty();
+    bool has_seeds = !seeds.empty();
 
     CV_CheckGE(max_size, min_size,
             "The maximum size should be grater than or equal to the minimum size.");
     CV_CheckGE(knn_idx.cols, k,
             "The number of neighbors of KNN search result should be grater than or equal to that of region growing.");
-    CV_CheckGE(pts_size, max(seeds.rows, seeds.cols),
-            "The number of seed should be less than or equal to the number of points in the point cloud.");
     CV_CheckEQ(pts_size, knn_idx.rows,
             "The number of points in the KNN search result should be equal to that in the point cloud.");
     CV_CheckEQ(pts_size, max(normals.rows, normals.cols),
             "The number of points in the normals should be equal to that in the point cloud.");
-    CV_CheckEQ(pts_size, max(curvatures.rows, curvatures.cols),
-            "The number of points in the curvatures should be equal to that in the point cloud.");
+    if (has_curvatures)
+        CV_CheckEQ(pts_size, max(curvatures.rows, curvatures.cols),
+                "The number of points in the curvatures should be equal to that in the point cloud.");
+    if (has_seeds)
+        CV_CheckGE(pts_size, max(seeds.rows, seeds.cols),
+                "The number of seed should be less than or equal to the number of points in the point cloud.");
 
-    if (k == 0) k = knn_idx.cols;
-
-    // Set labels to zero
-    Mat _labels = Mat::zeros(pts_size, 1, CV_32S);
-    // If no seed point is set, curvature sorting is used by default
-    if (seeds.empty()) sortIdx(curvatures, seeds, SORT_EVERY_COLUMN + SORT_ASCENDING);
+    std::vector<int> natural_order_seeds;
+    if (!has_seeds && !has_curvatures)
+    {
+        // If the user does not set the seeds and curvatures, use the natural order of the points
+        natural_order_seeds = std::vector<int>(pts_size);
+        std::iota(natural_order_seeds.begin(), natural_order_seeds.end(), 0);
+        seeds = Mat(natural_order_seeds);
+    }
+    else if (!has_seeds && has_curvatures)
+    {
+        // If the user sets the curvatures without setting the seeds, seeds will be sorted in
+        // ascending order of curvatures
+        sortIdx(curvatures, seeds, SORT_EVERY_COLUMN + SORT_ASCENDING);
+    }
 
     const int *seeds_ptr = (int *) seeds.data;
     const float *curvatures_ptr = (float *) curvatures.data;
 
+    int seeds_num = max(seeds.rows, seeds.cols);
     int flag = 1;
-    for (int i = 0; i < pts_size; i++)
+    double cos_smoothness_thr = std::cos(smoothness_thr);
+    double cos_smoothness_thr_square = cos_smoothness_thr * cos_smoothness_thr;
+    // Initialize labels to zero
+    Mat _labels = Mat::zeros(pts_size, 1, CV_32S);
+    for (int i = 0; i < seeds_num; i++)
     {
-        int *labels_ptr = (int *) _labels.data;
+        int *_labels_ptr = (int *) _labels.data;
         int cur_seed = seeds_ptr[i];
         int region_size = 1;
 
         // If the number of regions is satisfied then stop running
         if (flag > region_num) break;
         // If current seed has been grown then grow the next one
-        if (labels_ptr[cur_seed] != 0) continue;
+        if (_labels_ptr[cur_seed] != 0) continue;
         // Filter out seeds with curvature greater than the threshold
-        if (curvatures_ptr[cur_seed] > curvature_thr) break;
+        if (has_curvatures && curvatures_ptr[cur_seed] > curvature_thr) break;
 
         Mat base_normal;
         if (!smooth_mode) base_normal = normals.row(cur_seed);
@@ -62,7 +101,6 @@ RegionGrowing3DImpl::segment(OutputArray labels)
 
         std::queue<int> grow_list;
         grow_list.push(cur_seed);
-
         while (!grow_list.empty())
         {
             int cur_idx = grow_list.front();
@@ -70,21 +108,21 @@ RegionGrowing3DImpl::segment(OutputArray labels)
             if (smooth_mode) base_normal = normals.row(cur_idx);
 
             const int *pt_knn_ptr = (int *) knn_idx.row(cur_idx).data;
-            for (int j = 0; j < k; j++)
+            // Start from index 1 because the first one of knn_idx is itself
+            for (int j = 1; j < k; j++)
             {
                 int cur_neighbor_idx = pt_knn_ptr[j];
                 // If current point has been grown then grow the next one
                 if (labels_tmp_ptr[cur_neighbor_idx] != 0) continue;
                 // Filter out points with curvature greater than the threshold
-                if (curvatures_ptr[cur_neighbor_idx] > curvature_thr) continue;
+                if (has_curvatures && curvatures_ptr[cur_neighbor_idx] > curvature_thr) continue;
 
                 Mat cur_normal = normals.row(cur_neighbor_idx);
-                float n12 = (float) base_normal.dot(cur_normal);
-                float n1m = (float) base_normal.dot(base_normal);
-                float n2m = (float) cur_normal.dot(cur_normal);
-                float cos_smoothness_thr = std::cos(smoothness_thr);
+                double n12 = base_normal.dot(cur_normal);
+                double n1m = base_normal.dot(base_normal);
+                double n2m = cur_normal.dot(cur_normal);
                 // If the smoothness threshold is satisfied, this neighbor will be pushed to the growth list
-                if (n12 * n12 / (n1m * n2m) > cos_smoothness_thr * cos_smoothness_thr)
+                if (n12 * n12 / (n1m * n2m) > cos_smoothness_thr_square)
                 {
                     labels_tmp_ptr[cur_neighbor_idx] = flag;
                     grow_list.push(cur_neighbor_idx);

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -6,19 +6,12 @@
 
 #include "../precomp.hpp"
 #include "region_growing_3d.hpp"
-#include "opencv2/3d/ptcloud.hpp"
 
 #include <queue>
 #include <numeric>
 
 namespace cv {
 //    namespace _3d {
-
-// Compare the size of two regions in descending order
-bool compareRegionSize(const std::vector<int> &r1, const std::vector<int> &r2)
-{
-    return r1.size() > r2.size();
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////  RegionGrowing3DImpl  //////////////////////////////////////
@@ -79,7 +72,7 @@ RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray label
     std::vector<bool> has_grown(pts_size, false);
     // Store the indexes of the points in each region
     std::vector<std::vector<int>> regions_idx;
-    for (int i = 0; i < seeds_num; i++)
+    for (int i = 0; i < seeds_num; ++i)
     {
         int cur_seed = seeds_ptr[i];
 
@@ -118,7 +111,7 @@ RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray label
                                                                 : max_neighbor_num;
             const int *nn_idx_ptr_base = (int *) nn_idx[cur_idx].data;
             // Start from index 1 because the first one of knn_idx is itself
-            for (int j = 1; j < bound; j++)
+            for (int j = 1; j < bound; ++j)
             {
                 int cur_nei_idx = nn_idx_ptr_base[j];
                 // If the index is less than 0,
@@ -146,12 +139,13 @@ RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray label
             }
         }
 
-        if (min_size <= region.size() && region.size() <= max_size)
+        int region_size = (int) region.size();
+        if (min_size <= region_size && region_size <= max_size)
         {
             regions_idx.emplace_back(Mat(region));
             flag++;
         }
-        else if (region.size() > max_size)
+        else if (region_size > max_size)
         {
             break;
         }
@@ -159,6 +153,12 @@ RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray label
 
     if (need_sort)
     {
+        // Compare the size of two regions in descending order
+        auto compareRegionSize = [](const std::vector<int> &r1,
+                const std::vector<int> &r2) -> bool
+        {
+            return r1.size() > r2.size();
+        };
         sort(regions_idx.begin(), regions_idx.end(), compareRegionSize);
     }
 
@@ -166,7 +166,7 @@ RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray label
     _regions_idx.resize(regions_idx.size());
     Mat labels = Mat::zeros(pts_size, 1, CV_32S);
     int *labels_ptr = (int *) labels.data;
-    for (int i = 0; i < regions_idx.size(); ++i)
+    for (int i = 0; i < (int) regions_idx.size(); ++i)
     {
         Mat(1, (int) regions_idx[i].size(), CV_32S, regions_idx[i].data()).copyTo(_regions_idx[i]);
         for (int j: regions_idx[i])

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -152,7 +152,7 @@ RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArr
                 double n1m = base_normal.dot(base_normal);
                 double n2m = cur_normal.dot(cur_normal);
                 // If the smoothness threshold is satisfied, this neighbor will be pushed to the growth list
-                if (n12 * n12 / (n1m * n2m) > cos_smoothness_thr_square)
+                if (n12 * n12 / (n1m * n2m) >= cos_smoothness_thr_square)
                 {
                     labels_tmp_ptr[cur_neighbor_idx] = flag;
                     grow_list.push(cur_neighbor_idx);

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -92,27 +92,21 @@ RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArr
         int cur_seed = seeds_ptr[i];
         int region_size = 1;
 
-        // If the number of regions is satisfied then stop running
-        if (flag > region_num)
+        // 1. If the number of regions is satisfied then stop running.
+        // 2. Filter out seeds with curvature greater than the threshold.
+        //    If no seed points have been set, it will use seeds sorted in ascending order of curvatures.
+        //    When the curvature doesn't satisfy the threshold, the seed points that follow will not satisfy the threshold either.
+        if (flag > region_num ||
+            (!has_seeds && has_curvatures && curvatures_ptr[cur_seed] > curvature_thr))
         {
             break;
         }
-        // If current seed has been grown then grow the next one
-        if (_labels_ptr[cur_seed] != 0)
+        // 1. If current seed has been grown then grow the next one.
+        // 2. Filter out seeds with curvature greater than the threshold.
+        if (_labels_ptr[cur_seed] != 0 ||
+            (has_seeds && has_curvatures && curvatures_ptr[cur_seed] > curvature_thr))
         {
             continue;
-        }
-        // Filter out seeds with curvature greater than the threshold.
-        if (has_seeds && has_curvatures && curvatures_ptr[cur_seed] > curvature_thr)
-        {
-            continue;
-        }
-        // Filter out seeds with curvature greater than the threshold
-        // If no seed points have been set, it will use seeds sorted in ascending order of curvatures.
-        // When the curvature doesn't satisfy the threshold, the seed points that follow will not satisfy the threshold either.
-        if (!has_seeds && has_curvatures && curvatures_ptr[cur_seed] > curvature_thr)
-        {
-            break;
         }
 
         Mat base_normal;

--- a/modules/3d/src/ptcloud/region_growing_3d.cpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.cpp
@@ -14,30 +14,25 @@
 namespace cv {
 //    namespace _3d {
 
+// Compare the size of two regions in descending order
+bool compareRegionSize(const std::vector<int> &r1, const std::vector<int> &r2)
+{
+    return r1.size() > r2.size();
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////  RegionGrowing3DImpl  //////////////////////////////////////
 
 int
-RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArray normals_,
-        InputArray knn_idx_)
+RegionGrowing3DImpl::segment(OutputArrayOfArrays regions_idx_, OutputArray labels_,
+        InputArray input_pts_, InputArray normals_, InputArrayOfArrays nn_idx_)
 {
-    Mat ori_pts, normals, knn_idx;
+    Mat ori_pts, normals;
     getPointsMatFromInputArray(input_pts_, ori_pts, 0);
     getPointsMatFromInputArray(normals_, normals, 0);
-    if (knn_idx_.rows() < knn_idx_.cols())
-    {
-        // Convert layout of data in memory space to NxK
-        transpose(knn_idx_.getMat(), knn_idx);
-    }
-    else
-    {
-        knn_idx = knn_idx_.getMat();
-    }
 
-    if (k == 0)
-    {
-        k = knn_idx.cols;
-    }
+    std::vector<Mat> nn_idx;
+    nn_idx_.getMatVector(nn_idx);
 
     int pts_size = ori_pts.rows;
     bool has_curvatures = !curvatures.empty();
@@ -45,52 +40,48 @@ RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArr
 
     CV_CheckGE(max_size, min_size,
             "The maximum size should be grater than or equal to the minimum size.");
-    CV_CheckGE(knn_idx.cols, k,
-            "The number of neighbors of KNN search result should be grater than or equal to that of region growing.");
-    CV_CheckEQ(pts_size, knn_idx.rows,
-            "The number of points in the KNN search result should be equal to that in the point cloud.");
-    CV_CheckEQ(pts_size, max(normals.rows, normals.cols),
+    CV_CheckEQ(pts_size, (int) nn_idx.size(),
+            "The point number of NN search result should be equal to the size of the point cloud.");
+    CV_CheckEQ(pts_size, normals.rows,
             "The number of points in the normals should be equal to that in the point cloud.");
     if (has_curvatures)
     {
-        CV_CheckEQ(pts_size, max(curvatures.rows, curvatures.cols),
+        CV_CheckEQ(pts_size, curvatures.cols,
                 "The number of points in the curvatures should be equal to that in the point cloud.");
     }
     if (has_seeds)
     {
-        CV_CheckGE(pts_size, max(seeds.rows, seeds.cols),
+        CV_CheckGE(pts_size, seeds.cols,
                 "The number of seed should be less than or equal to the number of points in the point cloud.");
     }
 
-    std::vector<int> natural_order_seeds;
     if (!has_seeds && !has_curvatures)
     {
         // If the user does not set the seeds and curvatures, use the natural order of the points
-        natural_order_seeds = std::vector<int>(pts_size);
-        std::iota(natural_order_seeds.begin(), natural_order_seeds.end(), 0);
-        seeds = Mat(natural_order_seeds);
+        std::vector<int> *natural_order_seeds = new std::vector<int>(pts_size);
+        std::iota(natural_order_seeds->begin(), natural_order_seeds->end(), 0);
+        seeds = Mat(*natural_order_seeds);
     }
     else if (!has_seeds && has_curvatures)
     {
         // If the user sets the curvatures without setting the seeds, seeds will be sorted in
         // ascending order of curvatures
-        sortIdx(curvatures, seeds, SORT_EVERY_COLUMN + SORT_ASCENDING);
+        sortIdx(curvatures, seeds, SORT_EVERY_ROW + SORT_ASCENDING);
     }
 
     const int *seeds_ptr = (int *) seeds.data;
     const float *curvatures_ptr = (float *) curvatures.data;
 
-    int seeds_num = max(seeds.rows, seeds.cols);
-    int flag = 1;
+    int seeds_num = seeds.cols, flag = 1;
     double cos_smoothness_thr = std::cos(smoothness_thr);
     double cos_smoothness_thr_square = cos_smoothness_thr * cos_smoothness_thr;
-    // Initialize labels to zero
-    Mat _labels = Mat::zeros(pts_size, 1, CV_32S);
+    // Used to determine if the point can be grown
+    std::vector<bool> has_grown(pts_size, false);
+    // Store the indexes of the points in each region
+    std::vector<std::vector<int>> regions_idx;
     for (int i = 0; i < seeds_num; i++)
     {
-        int *_labels_ptr = (int *) _labels.data;
         int cur_seed = seeds_ptr[i];
-        int region_size = 1;
 
         // 1. If the number of regions is satisfied then stop running.
         // 2. Filter out seeds with curvature greater than the threshold.
@@ -103,78 +94,88 @@ RegionGrowing3DImpl::segment(OutputArray labels, InputArray input_pts_, InputArr
         }
         // 1. If current seed has been grown then grow the next one.
         // 2. Filter out seeds with curvature greater than the threshold.
-        if (_labels_ptr[cur_seed] != 0 ||
+        if (has_grown[cur_seed] ||
             (has_seeds && has_curvatures && curvatures_ptr[cur_seed] > curvature_thr))
         {
             continue;
         }
 
         Mat base_normal;
-        if (!smooth_mode)
-        {
-            base_normal = normals.row(cur_seed);
-        }
+        if (!smooth_mode) base_normal = normals.row(cur_seed);
 
-        Mat labels_tmp;
-        _labels.copyTo(labels_tmp);
-        int *labels_tmp_ptr = (int *) labels_tmp.data;
-        labels_tmp_ptr[cur_seed] = flag;
-
+        has_grown[cur_seed] = true;
+        std::vector<int> region = {cur_seed};
         std::queue<int> grow_list;
         grow_list.push(cur_seed);
         while (!grow_list.empty())
         {
             int cur_idx = grow_list.front();
             grow_list.pop();
-            if (smooth_mode)
-            {
-                base_normal = normals.row(cur_idx);
-            }
+            if (smooth_mode) base_normal = normals.row(cur_idx);
 
-            const int *pt_knn_ptr = (int *) knn_idx.row(cur_idx).data;
+            // The maximum size that may be used for this row
+            int bound = max_neighbor_num > nn_idx[cur_idx].cols ? nn_idx[cur_idx].cols
+                                                                : max_neighbor_num;
+            const int *nn_idx_ptr_base = (int *) nn_idx[cur_idx].data;
             // Start from index 1 because the first one of knn_idx is itself
-            for (int j = 1; j < k; j++)
+            for (int j = 1; j < bound; j++)
             {
-                int cur_neighbor_idx = pt_knn_ptr[j];
-                // If current point has been grown then grow the next one
-                if (labels_tmp_ptr[cur_neighbor_idx] != 0)
-                {
-                    continue;
-                }
-                // Filter out points with curvature greater than the threshold
-                if (has_curvatures && curvatures_ptr[cur_neighbor_idx] > curvature_thr)
+                int cur_nei_idx = nn_idx_ptr_base[j];
+                // If the index is less than 0,
+                // the nn_idx of this row will no longer have any information.
+                if (cur_nei_idx < 0) break;
+                // 1. If current point has been grown then grow the next one
+                // 2. Filter out points with curvature greater than the threshold
+                if (has_grown[cur_nei_idx] ||
+                    (has_curvatures && curvatures_ptr[cur_nei_idx] > curvature_thr))
                 {
                     continue;
                 }
 
-                Mat cur_normal = normals.row(cur_neighbor_idx);
+                Mat cur_normal = normals.row(cur_nei_idx);
                 double n12 = base_normal.dot(cur_normal);
                 double n1m = base_normal.dot(base_normal);
                 double n2m = cur_normal.dot(cur_normal);
                 // If the smoothness threshold is satisfied, this neighbor will be pushed to the growth list
                 if (n12 * n12 / (n1m * n2m) >= cos_smoothness_thr_square)
                 {
-                    labels_tmp_ptr[cur_neighbor_idx] = flag;
-                    grow_list.push(cur_neighbor_idx);
-                    region_size++;
+                    has_grown[cur_nei_idx] = true;
+                    region.emplace_back(cur_nei_idx);
+                    grow_list.push(cur_nei_idx);
                 }
-            }
-            // Check if the current region size are less than the maximum size
-            if (region_size > max_size)
-            {
-                break;
             }
         }
 
-        // Check if the current region size are within the range
-        if (min_size <= region_size && region_size <= max_size)
+        if (min_size <= region.size() && region.size() <= max_size)
         {
-            swap(_labels, labels_tmp);
+            regions_idx.emplace_back(Mat(region));
             flag++;
+        }
+        else if (region.size() > max_size)
+        {
+            break;
         }
     }
 
-    _labels.copyTo(labels);
+    if (need_sort)
+    {
+        sort(regions_idx.begin(), regions_idx.end(), compareRegionSize);
+    }
+
+    std::vector<std::vector<int>> &_regions_idx = *(std::vector<std::vector<int>> *) regions_idx_.getObj();
+    _regions_idx.resize(regions_idx.size());
+    Mat labels = Mat::zeros(pts_size, 1, CV_32S);
+    int *labels_ptr = (int *) labels.data;
+    for (int i = 0; i < regions_idx.size(); ++i)
+    {
+        Mat(1, (int) regions_idx[i].size(), CV_32S, regions_idx[i].data()).copyTo(_regions_idx[i]);
+        for (int j: regions_idx[i])
+        {
+            labels_ptr[j] = i + 1;
+        }
+    }
+    labels.copyTo(labels_);
+
     return flag - 1;
 }
 

--- a/modules/3d/src/ptcloud/region_growing_3d.hpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.hpp
@@ -12,139 +12,142 @@
 
 namespace cv {
 
-//! @addtogroup _3d
-//! @{
-
 class RegionGrowing3DImpl : public RegionGrowing3D
 {
 private:
-    //! The
+    //! Threshold of the angle between normals, the value is in radian.
     double smoothness_thr;
 
+    //! Threshold of curvature.
     double curvature_thr;
 
+    //! The number of neighbors including itself.
     int k;
 
+    //! The minimum size of region.
     int min_size;
 
+    //! The maximum size of region
     int max_size;
 
+    //! Whether to use the smoothness mode.
     bool smooth_mode;
 
+    //! The maximum number of regions you want.
     int region_num;
 
+    //! The curvature of each point.
     Mat curvatures;
 
+    //! Seed points.
     Mat seeds;
 
 public:
-
+    //! No-argument constructor using default configuration.
     RegionGrowing3DImpl()
-            : smoothness_thr(0.5235987756 /* 30*π/180 */ ), curvature_thr(0.05), k(0), min_size(1),
+            : smoothness_thr(0.5235987756 /* 30*PI/180 */ ), curvature_thr(0.05), k(0), min_size(1),
               max_size(INT_MAX), smooth_mode(true), region_num(INT_MAX)
     {
-
     }
-
-    ~RegionGrowing3DImpl() override = default;
 
     int segment(OutputArray labels, InputArray input_pts, InputArray normals, InputArray knn_idx) override;
 
     //-------------------------- Getter and Setter -----------------------
-    //! Set
-    void setMinSize(int min_size_) override{
+
+    void setMinSize(int min_size_) override
+    {
         CV_CheckGE(min_size_, 1, "The minimum size of segments should be grater than 0.");
         min_size = min_size_;
     }
 
-    //! Get
-    int getMinSize() const override{
+    int getMinSize() const override
+    {
         return min_size;
     }
 
-    //! Set
-    void setMaxSize(int max_size_) override{
+    void setMaxSize(int max_size_) override
+    {
         CV_CheckGE(max_size_, 1, "The maximum size of segments should be grater than 0.");
         max_size = max_size_;
     }
 
-    //! Get
-    int getMaxSize() const override{
+    int getMaxSize() const override
+    {
         return max_size;
     }
 
-    //! Set
-    void setSmoothModeFlag(bool smooth_mode_) override{
+    void setSmoothModeFlag(bool smooth_mode_) override
+    {
         smooth_mode = smooth_mode_;
     }
 
-    //! Get
-    bool getSmoothModeFlag() const override{
+    bool getSmoothModeFlag() const override
+    {
         return smooth_mode;
     }
 
-    //! Set
-    void setSmoothnessThreshold(double smoothness_thr_) override{
+    void setSmoothnessThreshold(double smoothness_thr_) override
+    {
         CV_CheckGE(smoothness_thr_, 0.0, "The smoothness threshold angle should be greater than or equal to 0 degrees.");
-        CV_CheckLT(smoothness_thr_, 1.5707963268 /* 90*π/180 */, "The smoothness threshold angle should be less than 90 degrees.");
+        CV_CheckLT(smoothness_thr_, 1.5707963268 /* 90*PI/180 */, "The smoothness threshold angle should be less than 90 degrees.");
         smoothness_thr = smoothness_thr_;
     }
 
-    //! Get
-    double getSmoothnessThreshold() const override{
+    double getSmoothnessThreshold() const override
+    {
         return smoothness_thr;
     }
 
-    //! Set
-    void setCurvatureThreshold(double curvature_thr_) override{
+    void setCurvatureThreshold(double curvature_thr_) override
+    {
         CV_CheckGE(curvature_thr_, 0.0, "The curvature threshold should be greater than or equal to 0.");
         curvature_thr = curvature_thr_;
     }
 
-    //! Get
-    double getCurvatureThreshold() const override{
+    double getCurvatureThreshold() const override
+    {
         return curvature_thr;
     }
 
-    //! Set
-    void setNumberOfNeighbors(int k_) override{
+    void setNumberOfNeighbors(int k_) override
+    {
         CV_CheckGE(k_, 2, "The number of neighbors should be grater than 1.");
         k = k_;
     }
 
-    //! Get
-    int getNumberOfNeighbors() const override{
+    int getNumberOfNeighbors() const override
+    {
         return k;
     }
 
-    //! Set
-    void setNumberOfRegions(int region_num_) override{
+    void setNumberOfRegions(int region_num_) override
+    {
         CV_CheckGE(region_num_, 1, "The number of region should be grater than 0.");
         region_num = region_num_;
     }
 
-    //! Get
-    int getNumberOfRegions() const override{
+    int getNumberOfRegions() const override
+    {
         return region_num;
     }
 
-    //! Set
-    void setSeeds(InputArray seeds_) override{
+    void setSeeds(InputArray seeds_) override
+    {
         seeds = seeds_.getMat();
     }
 
-    //! Get
-    void getSeeds(OutputArray seeds_) const override{
+    void getSeeds(OutputArray seeds_) const override
+    {
         seeds.copyTo(seeds_);
     }
 
-    //! Set
-    void setCurvatures(InputArray curvatures_) override{
+    void setCurvatures(InputArray curvatures_) override
+    {
         curvatures = abs(curvatures_.getMat());
     }
 
-    //! Get
-    void getCurvatures(OutputArray curvatures_) const override{
+    void getCurvatures(OutputArray curvatures_) const override
+    {
         curvatures.copyTo(curvatures_);
     }
 
@@ -155,8 +158,6 @@ Ptr<RegionGrowing3D> RegionGrowing3D::create()
     return makePtr<RegionGrowing3DImpl>();
 }
 
-//! @} _3d
 } //end namespace cv
-
 
 #endif //OPENCV_REGION_ROWING_3D_HPP

--- a/modules/3d/src/ptcloud/region_growing_3d.hpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.hpp
@@ -1,3 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+
 #ifndef OPENCV_REGION_ROWING_3D_HPP
 #define OPENCV_REGION_ROWING_3D_HPP
 
@@ -12,34 +18,29 @@ namespace cv {
 class RegionGrowing3DImpl : public RegionGrowing3D
 {
 private:
+    //! The
+    double smoothness_thr;
+
+    double curvature_thr;
+
+    int k;
+
     int min_size;
 
     int max_size;
 
     bool smooth_mode;
 
-    float smoothness_thr;
-
-    float curvature_thr;
-
-    int k;
-
     int region_num;
-
-    Mat input_pts;
-
-    Mat knn_idx;
-
-    Mat seeds;
-
-    Mat normals;
 
     Mat curvatures;
 
+    Mat seeds;
+
 public:
 
-    RegionGrowing3DImpl(float smoothness_thr_, float curvature_thr_)
-            : smoothness_thr(smoothness_thr_), curvature_thr(curvature_thr_), k(0), min_size(1),
+    RegionGrowing3DImpl()
+            : smoothness_thr(0.5235987756 /* 30*π/180 */ ), curvature_thr(0.05), k(0), min_size(1),
               max_size(INT_MAX), smooth_mode(true), region_num(INT_MAX)
     {
 
@@ -47,7 +48,7 @@ public:
 
     ~RegionGrowing3DImpl() override = default;
 
-    int segment(OutputArray labels) override;
+    int segment(OutputArray labels, InputArray input_pts, InputArray normals, InputArray knn_idx) override;
 
     //-------------------------- Getter and Setter -----------------------
     //! Set
@@ -83,25 +84,25 @@ public:
     }
 
     //! Set
-    void setSmoothnessThreshold(float smoothness_thr_) override{
-        CV_CheckGE(smoothness_thr_, 0.f, "The smoothness threshold angle should be greater than or equal to 0 degrees.");
-        CV_CheckLT(smoothness_thr_, 3.1415927f / 2, "The smoothness threshold angle should be less than 90 degrees.");
+    void setSmoothnessThreshold(double smoothness_thr_) override{
+        CV_CheckGE(smoothness_thr_, 0.0, "The smoothness threshold angle should be greater than or equal to 0 degrees.");
+        CV_CheckLT(smoothness_thr_, 1.5707963268 /* 90*π/180 */, "The smoothness threshold angle should be less than 90 degrees.");
         smoothness_thr = smoothness_thr_;
     }
 
     //! Get
-    float getSmoothnessThreshold() const override{
+    double getSmoothnessThreshold() const override{
         return smoothness_thr;
     }
 
     //! Set
-    void setCurvatureThreshold(float curvature_thr_) override{
-        CV_CheckGE(curvature_thr_, 0.f, "The curvature threshold should be greater than or equal to 0.");
+    void setCurvatureThreshold(double curvature_thr_) override{
+        CV_CheckGE(curvature_thr_, 0.0, "The curvature threshold should be greater than or equal to 0.");
         curvature_thr = curvature_thr_;
     }
 
     //! Get
-    float getCurvatureThreshold() const override{
+    double getCurvatureThreshold() const override{
         return curvature_thr;
     }
 
@@ -128,39 +129,30 @@ public:
     }
 
     //! Set
-    void setPtcloud(InputArray input_pts_) override{
-        getPointsMatFromInputArray(input_pts_, input_pts, 0);
-    }
-
-    //! Set
-    void setKnnIdx(InputArray knn_idx_) override{
-        if(knn_idx_.rows() < knn_idx_.cols()){
-            transpose(knn_idx_.getMat(), knn_idx);
-        }else{
-            knn_idx = knn_idx_.getMat();
-        }
-    }
-
-    //! Set
     void setSeeds(InputArray seeds_) override{
         seeds = seeds_.getMat();
     }
 
-    //! Set
-    void setNormals(InputArray normals_) override{
-        getPointsMatFromInputArray(normals_, normals, 0);
+    //! Get
+    void getSeeds(OutputArray seeds_) const override{
+        seeds.copyTo(seeds_);
     }
 
     //! Set
     void setCurvatures(InputArray curvatures_) override{
-        curvatures = curvatures_.getMat();
+        curvatures = abs(curvatures_.getMat());
+    }
+
+    //! Get
+    void getCurvatures(OutputArray curvatures_) const override{
+        curvatures.copyTo(curvatures_);
     }
 
 };
 
-Ptr<RegionGrowing3D> RegionGrowing3D::create(float smoothness_thr_, float curvature_thr_)
+Ptr<RegionGrowing3D> RegionGrowing3D::create()
 {
-    return makePtr<RegionGrowing3DImpl>(smoothness_thr_, curvature_thr_);
+    return makePtr<RegionGrowing3DImpl>();
 }
 
 //! @} _3d

--- a/modules/3d/src/ptcloud/region_growing_3d.hpp
+++ b/modules/3d/src/ptcloud/region_growing_3d.hpp
@@ -1,0 +1,170 @@
+#ifndef OPENCV_REGION_ROWING_3D_HPP
+#define OPENCV_REGION_ROWING_3D_HPP
+
+#include "opencv2/3d/ptcloud.hpp"
+#include "ptcloud_utils.hpp"
+
+namespace cv {
+
+//! @addtogroup _3d
+//! @{
+
+class RegionGrowing3DImpl : public RegionGrowing3D
+{
+private:
+    int min_size;
+
+    int max_size;
+
+    bool smooth_mode;
+
+    float smoothness_thr;
+
+    float curvature_thr;
+
+    int k;
+
+    int region_num;
+
+    Mat input_pts;
+
+    Mat knn_idx;
+
+    Mat seeds;
+
+    Mat normals;
+
+    Mat curvatures;
+
+public:
+
+    RegionGrowing3DImpl(float smoothness_thr_, float curvature_thr_)
+            : smoothness_thr(smoothness_thr_), curvature_thr(curvature_thr_), k(0), min_size(1),
+              max_size(INT_MAX), smooth_mode(true), region_num(INT_MAX)
+    {
+
+    }
+
+    ~RegionGrowing3DImpl() override = default;
+
+    int segment(OutputArray labels) override;
+
+    //-------------------------- Getter and Setter -----------------------
+    //! Set
+    void setMinSize(int min_size_) override{
+        CV_CheckGE(min_size_, 1, "The minimum size of segments should be grater than 0.");
+        min_size = min_size_;
+    }
+
+    //! Get
+    int getMinSize() const override{
+        return min_size;
+    }
+
+    //! Set
+    void setMaxSize(int max_size_) override{
+        CV_CheckGE(max_size_, 1, "The maximum size of segments should be grater than 0.");
+        max_size = max_size_;
+    }
+
+    //! Get
+    int getMaxSize() const override{
+        return max_size;
+    }
+
+    //! Set
+    void setSmoothModeFlag(bool smooth_mode_) override{
+        smooth_mode = smooth_mode_;
+    }
+
+    //! Get
+    bool getSmoothModeFlag() const override{
+        return smooth_mode;
+    }
+
+    //! Set
+    void setSmoothnessThreshold(float smoothness_thr_) override{
+        CV_CheckGE(smoothness_thr_, 0.f, "The smoothness threshold angle should be greater than or equal to 0 degrees.");
+        CV_CheckLT(smoothness_thr_, 3.1415927f / 2, "The smoothness threshold angle should be less than 90 degrees.");
+        smoothness_thr = smoothness_thr_;
+    }
+
+    //! Get
+    float getSmoothnessThreshold() const override{
+        return smoothness_thr;
+    }
+
+    //! Set
+    void setCurvatureThreshold(float curvature_thr_) override{
+        CV_CheckGE(curvature_thr_, 0.f, "The curvature threshold should be greater than or equal to 0.");
+        curvature_thr = curvature_thr_;
+    }
+
+    //! Get
+    float getCurvatureThreshold() const override{
+        return curvature_thr;
+    }
+
+    //! Set
+    void setNumberOfNeighbors(int k_) override{
+        CV_CheckGE(k_, 2, "The number of neighbors should be grater than 1.");
+        k = k_;
+    }
+
+    //! Get
+    int getNumberOfNeighbors() const override{
+        return k;
+    }
+
+    //! Set
+    void setNumberOfRegions(int region_num_) override{
+        CV_CheckGE(region_num_, 1, "The number of region should be grater than 0.");
+        region_num = region_num_;
+    }
+
+    //! Get
+    int getNumberOfRegions() const override{
+        return region_num;
+    }
+
+    //! Set
+    void setPtcloud(InputArray input_pts_) override{
+        getPointsMatFromInputArray(input_pts_, input_pts, 0);
+    }
+
+    //! Set
+    void setKnnIdx(InputArray knn_idx_) override{
+        if(knn_idx_.rows() < knn_idx_.cols()){
+            transpose(knn_idx_.getMat(), knn_idx);
+        }else{
+            knn_idx = knn_idx_.getMat();
+        }
+    }
+
+    //! Set
+    void setSeeds(InputArray seeds_) override{
+        seeds = seeds_.getMat();
+    }
+
+    //! Set
+    void setNormals(InputArray normals_) override{
+        getPointsMatFromInputArray(normals_, normals, 0);
+    }
+
+    //! Set
+    void setCurvatures(InputArray curvatures_) override{
+        curvatures = curvatures_.getMat();
+    }
+
+};
+
+Ptr<RegionGrowing3D> RegionGrowing3D::create(float smoothness_thr_, float curvature_thr_)
+{
+    return makePtr<RegionGrowing3DImpl>(smoothness_thr_, curvature_thr_);
+}
+
+//! @} _3d
+} //end namespace cv
+
+
+#endif //OPENCV_REGION_ROWING_3D_HPP

--- a/modules/3d/test/test_normal_estimation.cpp
+++ b/modules/3d/test/test_normal_estimation.cpp
@@ -6,6 +6,7 @@
 
 #include "test_precomp.hpp"
 #include "test_ptcloud_utils.hpp"
+#include "opencv2/flann.hpp"
 
 namespace opencv_test { namespace {
 

--- a/modules/3d/test/test_normal_estimation.cpp
+++ b/modules/3d/test/test_normal_estimation.cpp
@@ -30,7 +30,7 @@ TEST(NormalEstimationTest, PlaneNormalEstimation)
     normalEstimate(normals, curvatures, plane_pts, knn_idx, k);
 
     float theta_thr = 1.f; // degree of angle between normal of plane and normal of point
-    float curvature_thr = 0.0001f; // threshold for curvature and actual curvature of the point
+    float curvature_thr = 0.01f; // threshold for curvature and actual curvature of the point
     float actual_curvature = 0.f;
 
     Point3f n1(model[0], model[1], model[2]);

--- a/modules/3d/test/test_normal_estimation.cpp
+++ b/modules/3d/test/test_normal_estimation.cpp
@@ -12,7 +12,7 @@ namespace opencv_test { namespace {
 TEST(NormalEstimationTest, PlaneNormalEstimation)
 {
     // generate a plane for test
-    vector<Point3f> plane_pts;
+    Mat plane_pts;
     vector<float> model({1, 2, 3, 4});
     float thr = 0.f;
     int num = 1000;
@@ -20,16 +20,17 @@ TEST(NormalEstimationTest, PlaneNormalEstimation)
     generatePlane(plane_pts, model, thr, num, limit);
 
     // get knn search result
-    Mat knn_idx;
     int k = 10;
-    getKNNSearchResultsByKDTree(knn_idx, noArray(), plane_pts, k);
-
+    Mat knn_idx(num, k, CV_32S);
+    // build kdtree
+    flann::Index tree(plane_pts, flann::KDTreeIndexParams());
+    tree.knnSearch(plane_pts, knn_idx, noArray(), k);
     // estimate normal and curvature
     vector<Point3f> normals;
     vector<float> curvatures;
     normalEstimate(normals, curvatures, plane_pts, knn_idx, k);
 
-    float theta_thr = 1.f; // degree of angle between normal of plane and normal of point
+    float theta_thr = 1.f; // threshold for degree of angle between normal of plane and normal of point
     float curvature_thr = 0.01f; // threshold for curvature and actual curvature of the point
     float actual_curvature = 0.f;
 
@@ -44,58 +45,8 @@ TEST(NormalEstimationTest, PlaneNormalEstimation)
         float cos_theta = n12 / sqrt(n1m * n2m);
         // accuracy problems caused by float numbers, need to be fixed
         cos_theta = cos_theta > 1 ? 1 : cos_theta;
-        cos_theta = cos_theta < 0 ? 0 : cos_theta;
-        float theta = acos(cos_theta);
-
-        total_theta += theta;
-        total_diff_curvature += abs(curvatures[i] - actual_curvature);
-    }
-
-    float avg_theta = total_theta / (float) num;
-    ASSERT_LE(avg_theta, theta_thr);
-
-    float avg_diff_curvature = total_diff_curvature / (float) num;
-    ASSERT_LE(avg_diff_curvature, curvature_thr);
-}
-
-TEST(NormalEstimationTest, SphereNormalEstimation)
-{
-    // generate a sphere for test
-    vector<Point3f> sphere_pts;
-    vector<float> model({0, 0, 0, 1});
-    float thr = 0.f;
-    int num = 1000;
-    vector<float> limit({-1, 1, -1, 1, -1, 1});
-    generateSphere(sphere_pts, model, thr, num, limit);
-
-    // get knn search result
-    Mat knn_idx;
-    int k = 10;
-    getKNNSearchResultsByKDTree(knn_idx, noArray(), sphere_pts, k, nullptr);
-
-    // estimate normal and curvature
-    vector<Point3f> normals;
-    vector<float> curvatures;
-    normalEstimate(normals, curvatures, sphere_pts, knn_idx, k);
-
-    float theta_thr = 1.f; // degree of angle between normal of plane and normal of point
-    float curvature_thr = 0.01f; // threshold for curvature and actual curvature of the point
-    float actual_curvature = 0.f;
-
-    float total_theta = 0.f;
-    float total_diff_curvature = 0.f;
-    for (int i = 0; i < num; ++i)
-    {
-        Point3f n1(sphere_pts[i]);
-        Point3f n2 = normals[i];
-        float n12 = n1.dot(n2);
-        float n1m = n1.dot(n1);
-        float n2m = n2.dot(n2);
-        float cos_theta = n12 / sqrt(n1m * n2m);
-        // accuracy problems caused by float numbers, need to be fixed
-        cos_theta = cos_theta > 1 ? 1 : cos_theta;
-        cos_theta = cos_theta < 0 ? 0 : cos_theta;
-        float theta = acos(cos_theta);
+        cos_theta = cos_theta < -1 ? -1 : cos_theta;
+        float theta = acos(abs(cos_theta));
 
         total_theta += theta;
         total_diff_curvature += abs(curvatures[i] - actual_curvature);

--- a/modules/3d/test/test_normal_estimation.cpp
+++ b/modules/3d/test/test_normal_estimation.cpp
@@ -22,42 +22,47 @@ TEST(NormalEstimationTest, PlaneNormalEstimation)
     // get knn search result
     Mat knn_idx;
     int k = 10;
-    auto *search_params = new flann::SearchParams(128);
-    getKNNSearchResultsByKDTree(knn_idx, noArray(), plane_pts, k, nullptr, search_params);
+    getKNNSearchResultsByKDTree(knn_idx, noArray(), plane_pts, k);
 
     // estimate normal and curvature
     vector<Point3f> normals;
     vector<float> curvatures;
     normalEstimate(normals, curvatures, plane_pts, knn_idx, k);
 
-    // check each normal
+    float theta_thr = 1.f; // degree of angle between normal of plane and normal of point
+    float curvature_thr = 0.0001f; // threshold for curvature and actual curvature of the point
+    float actual_curvature = 0.f;
+
     Point3f n1(model[0], model[1], model[2]);
-    n1 *= 10; // expand the number to avoid too small numbers
-    float theta = 1.f; // degree of angle between normal of plane and normal of point
-    float cos_theta = cos(theta * 3.1415926f / 180.f);
-    for (Point3f n2: normals)
+    float n1m = n1.dot(n1);
+    float total_theta = 0.f;
+    float total_diff_curvature = 0.f;
+    for (int i = 0; i < num; ++i)
     {
-        n2 *= 10; // expand the number to avoid too small numbers
-        float n12 = n1.dot(n2);
-        float n1m = n1.dot(n1);
-        float n2m = n2.dot(n2);
-        ASSERT_GE(n12 * n12 / (n1m * n2m), cos_theta * cos_theta);
+        float n12 = n1.dot(normals[i]);
+        float n2m = normals[i].dot(normals[i]);
+        float cos_theta = n12 / sqrt(n1m * n2m);
+        // accuracy problems caused by float numbers, need to be fixed
+        cos_theta = cos_theta > 1 ? 1 : cos_theta;
+        cos_theta = cos_theta < 0 ? 0 : cos_theta;
+        float theta = acos(cos_theta);
+
+        total_theta += theta;
+        total_diff_curvature += abs(curvatures[i] - actual_curvature);
     }
 
-    // check each curvature
-    float actual_curvature = 0.f;
-    float curvature_thr = 0.0001f; // threshold for curvature and actual curvature of the point
-    for (float cur: curvatures)
-    {
-        ASSERT_LE(abs(cur - actual_curvature), curvature_thr);
-    }
+    float avg_theta = total_theta / (float) num;
+    ASSERT_LE(avg_theta, theta_thr);
+
+    float avg_diff_curvature = total_diff_curvature / (float) num;
+    ASSERT_LE(avg_diff_curvature, curvature_thr);
 }
 
 TEST(NormalEstimationTest, SphereNormalEstimation)
 {
     // generate a sphere for test
     vector<Point3f> sphere_pts;
-    vector<float> model({0, 0, 0, 10});
+    vector<float> model({0, 0, 0, 1});
     float thr = 0.f;
     int num = 1000;
     vector<float> limit({-1, 1, -1, 1, -1, 1});
@@ -66,36 +71,41 @@ TEST(NormalEstimationTest, SphereNormalEstimation)
     // get knn search result
     Mat knn_idx;
     int k = 10;
-    auto *search_params = new flann::SearchParams(128);
-    getKNNSearchResultsByKDTree(knn_idx, noArray(), sphere_pts, k, nullptr, search_params);
+    getKNNSearchResultsByKDTree(knn_idx, noArray(), sphere_pts, k, nullptr);
 
     // estimate normal and curvature
     vector<Point3f> normals;
     vector<float> curvatures;
     normalEstimate(normals, curvatures, sphere_pts, knn_idx, k);
 
-    // check each normal
-    float theta = 1; // degree of angle between normal of plane and normal of point
-    float cos_theta = cos(theta * 3.1415926f / 180.f);
+    float theta_thr = 1.f; // degree of angle between normal of plane and normal of point
+    float curvature_thr = 0.01f; // threshold for curvature and actual curvature of the point
+    float actual_curvature = 0.f;
+
+    float total_theta = 0.f;
+    float total_diff_curvature = 0.f;
     for (int i = 0; i < num; ++i)
     {
         Point3f n1(sphere_pts[i]);
-        n1 *= 10; // expand the number to avoid too small numbers
         Point3f n2 = normals[i];
-        n2 *= 10; // expand the number to avoid too small numbers
         float n12 = n1.dot(n2);
         float n1m = n1.dot(n1);
         float n2m = n2.dot(n2);
-        ASSERT_GE(n12 * n12 / (n1m * n2m), cos_theta * cos_theta);
+        float cos_theta = n12 / sqrt(n1m * n2m);
+        // accuracy problems caused by float numbers, need to be fixed
+        cos_theta = cos_theta > 1 ? 1 : cos_theta;
+        cos_theta = cos_theta < 0 ? 0 : cos_theta;
+        float theta = acos(cos_theta);
+
+        total_theta += theta;
+        total_diff_curvature += abs(curvatures[i] - actual_curvature);
     }
 
-    // check each curvature
-    float actual_curvature = 0.f;
-    float curvature_thr = 0.01f; // threshold for curvature and actual curvature of the point
-    for (float cur: curvatures)
-    {
-        ASSERT_LE(abs(cur - actual_curvature), curvature_thr);
-    }
+    float avg_theta = total_theta / (float) num;
+    ASSERT_LE(avg_theta, theta_thr);
+
+    float avg_diff_curvature = total_diff_curvature / (float) num;
+    ASSERT_LE(avg_diff_curvature, curvature_thr);
 }
 
 } // namespace

--- a/modules/3d/test/test_normal_estimation.cpp
+++ b/modules/3d/test/test_normal_estimation.cpp
@@ -1,0 +1,96 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+
+#include "test_precomp.hpp"
+#include "test_ptcloud_utils.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(NormalEstimationTest, PlaneNormalEstimation)
+{
+    // generate a plane for test
+    vector<Point3f> plane_pts;
+    vector<float> model({1, 2, 3, 4});
+    float thr = 0.f;
+    int num = 1000;
+    vector<float> limit({5, 55, 5, 55, 0, 0});
+    generatePlane(plane_pts, model, thr, num, limit);
+
+    // get knn search result
+    Mat knn_idx;
+    int k = 10;
+    getKNNSearchResultsByKDTree(knn_idx, noArray(), plane_pts, k);
+
+    // estimate normal and curvature
+    vector<Point3f> normals;
+    vector<float> curvatures;
+    normalEstimate(normals, curvatures, plane_pts, knn_idx, k);
+
+    // check each normal
+    Point3f plane_norm(model[0], model[1], model[2]);
+    float theta = 1.f; // degree of angle between normal of plane and normal of point
+    float cos_theta = cos(theta);
+    for (Point3f norm: normals)
+    {
+        float n12 = norm.dot(plane_norm);
+        float n1m = norm.dot(norm);
+        float n2m = plane_norm.dot(plane_norm);
+        ASSERT_GE(n12 * n12 / (n1m * n2m), cos_theta * cos_theta);
+    }
+
+    // check each curvature
+    float actual_curvature = 0;
+    float curvature_thr = 0.0001; // threshold for curvature and actual curvature of the point
+    for (float cur: curvatures)
+    {
+        ASSERT_LE(abs(cur - actual_curvature), curvature_thr);
+    }
+}
+
+TEST(NormalEstimationTest, SphereNormalEstimation)
+{
+    // generate a sphere for test
+    vector<Point3f> sphere_pts;
+    vector<float> model({0, 0, 0, 10});
+    float thr = 0.f;
+    int num = 1000;
+    vector<float> limit({-1, 1, -1, 1, -1, 1});
+    generateSphere(sphere_pts, model, thr, num, limit);
+
+    // get knn search result
+    Mat knn_idx;
+    int k = 10;
+    getKNNSearchResultsByKDTree(knn_idx, noArray(), sphere_pts, k);
+
+    // estimate normal and curvature
+    vector<Point3f> normals;
+    vector<float> curvatures;
+    normalEstimate(normals, curvatures, sphere_pts, knn_idx, k);
+
+    // check each normal
+    float theta = 1; // degree of angle between normal of plane and normal of point
+    float cos_theta = cos(theta);
+    for (int i = 0; i < num; ++i)
+    {
+        Point3f norm = normals[i];
+        Point3f actual_norm(sphere_pts[i]);
+        float n12 = norm.dot(actual_norm);
+        float n1m = norm.dot(norm);
+        float n2m = actual_norm.dot(actual_norm);
+        ASSERT_GE(n12 * n12 / (n1m * n2m), cos_theta * cos_theta);
+    }
+
+    // check each curvature
+    float actual_curvature = 0;
+    float curvature_thr = 0.01; // threshold for curvature and actual curvature of the point
+    for (float cur: curvatures)
+    {
+        ASSERT_LE(abs(cur - actual_curvature), curvature_thr);
+    }
+}
+
+} // namespace
+} // opencv_test

--- a/modules/3d/test/test_ptcloud_utils.cpp
+++ b/modules/3d/test/test_ptcloud_utils.cpp
@@ -1,0 +1,109 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2021, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+
+#include "test_ptcloud_utils.hpp"
+
+namespace opencv_test {
+
+void generatePlane(OutputArray plane_pts, const vector<float> &model, float thr, int num,
+        const vector<float> &limit)
+{
+    if (plane_pts.channels() == 3 && plane_pts.isVector())
+    {
+        // std::vector<cv::Point3f>
+        plane_pts.create(1, num, CV_32FC3);
+    }
+    else
+    {
+        // cv::Mat
+        plane_pts.create(num, 3, CV_32F);
+    }
+
+    cv::RNG rng(0);
+    auto *plane_pts_ptr = (float *) plane_pts.getMat().data;
+
+    // Part of the points are generated for the specific model
+    // The other part of the points are used to increase the thickness of the plane
+    int std_num = (int) (num / 2);
+    // Difference of maximum d between two parallel planes
+    float d_thr = thr * sqrt(model[0] * model[0] + model[1] * model[1] + model[2] * model[2]);
+
+    for (int i = 0; i < num; i++)
+    {
+        // Let d change then generate thickness
+        float d = i < std_num ? model[3] : rng.uniform(model[3] - d_thr, model[3] + d_thr);
+        float x, y, z;
+        // c is 0 means the plane is vertical
+        if (model[2] == 0)
+        {
+            z = rng.uniform(limit[4], limit[5]);
+            if (model[0] == 0)
+            {
+                x = rng.uniform(limit[0], limit[1]);
+                y = -d / model[1];
+            }
+            else if (model[1] == 0)
+            {
+                x = -d / model[0];
+                y = rng.uniform(limit[2], limit[3]);
+            }
+            else
+            {
+                x = rng.uniform(limit[0], limit[1]);
+                y = -(model[0] * x + d) / model[1];
+            }
+        }
+            // c is not 0
+        else
+        {
+            x = rng.uniform(limit[0], limit[1]);
+            y = rng.uniform(limit[2], limit[3]);
+            z = -(model[0] * x + model[1] * y + d) / model[2];
+        }
+
+        plane_pts_ptr[3 * i] = x;
+        plane_pts_ptr[3 * i + 1] = y;
+        plane_pts_ptr[3 * i + 2] = z;
+    }
+}
+
+void generateSphere(OutputArray sphere_pts, const vector<float> &model, float thr, int num,
+        const vector<float> &limit)
+{
+    if (sphere_pts.channels() == 3 && sphere_pts.isVector())
+    {
+        // std::vector<cv::Point3f>
+        sphere_pts.create(1, num, CV_32FC3);
+    }
+    else
+    {
+        // cv::Mat
+        sphere_pts.create(num, 3, CV_32F);
+    }
+    cv::RNG rng(0);
+    auto *sphere_pts_ptr = (float *) sphere_pts.getMat().data;
+
+    // Part of the points are generated for the specific model
+    // The other part of the points are used to increase the thickness of the sphere
+    int sphere_num = (int) (num / 1.5);
+    for (int i = 0; i < num; i++)
+    {
+        // Let r change then generate thickness
+        float r = i < sphere_num ? model[3] : rng.uniform(model[3] - thr, model[3] + thr);
+        // Generate a random vector and normalize it.
+        Vec3f vec(rng.uniform(limit[0], limit[1]), rng.uniform(limit[2], limit[3]),
+                rng.uniform(limit[4], limit[5]));
+        float l = sqrt(vec.dot(vec));
+        // Normalizes it to have a magnitude of r
+        vec /= l / r;
+
+        sphere_pts_ptr[3 * i] = model[0] + vec[0];
+        sphere_pts_ptr[3 * i + 1] = model[1] + vec[1];
+        sphere_pts_ptr[3 * i + 2] = model[2] + vec[2];
+    }
+}
+
+} // opencv_test

--- a/modules/3d/test/test_ptcloud_utils.hpp
+++ b/modules/3d/test/test_ptcloud_utils.hpp
@@ -2,14 +2,14 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+// Copyright (C) 2021, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
 
 #ifndef OPENCV_TEST_PTCLOUD_UTILS_HPP
 #define OPENCV_TEST_PTCLOUD_UTILS_HPP
 
 #include "test_precomp.hpp"
 
-namespace opencv_test { namespace {
+namespace opencv_test {
 
 /**
  * @brief Generate a specific plane with random points.
@@ -23,66 +23,7 @@ namespace opencv_test { namespace {
  *
  */
 void generatePlane(OutputArray plane_pts, const vector<float> &model, float thr, int num,
-        const vector<float> &limit)
-{
-    if (plane_pts.channels() == 3 && plane_pts.isVector())
-    {
-        // std::vector<cv::Point3f>
-        plane_pts.create(1, num, CV_32FC3);
-    }
-    else
-    {
-        // cv::Mat
-        plane_pts.create(num, 3, CV_32F);
-    }
-
-    cv::RNG rng(0);
-    auto *plane_pts_ptr = (float *) plane_pts.getMat().data;
-
-    // Part of the points are generated for the specific model
-    // The other part of the points are used to increase the thickness of the plane
-    int std_num = (int) (num / 2);
-    // Difference of maximum d between two parallel planes
-    float d_thr = thr * sqrt(model[0] * model[0] + model[1] * model[1] + model[2] * model[2]);
-
-    for (int i = 0; i < num; i++)
-    {
-        // Let d change then generate thickness
-        float d = i < std_num ? model[3] : rng.uniform(model[3] - d_thr, model[3] + d_thr);
-        float x, y, z;
-        // c is 0 means the plane is vertical
-        if (model[2] == 0)
-        {
-            z = rng.uniform(limit[4], limit[5]);
-            if (model[0] == 0)
-            {
-                x = rng.uniform(limit[0], limit[1]);
-                y = -d / model[1];
-            }
-            else if (model[1] == 0)
-            {
-                x = -d / model[0];
-                y = rng.uniform(limit[2], limit[3]);
-            }
-            else
-            {
-                x = rng.uniform(limit[0], limit[1]);
-                y = -(model[0] * x + d) / model[1];
-            }
-        }
-            // c is not 0
-        else
-        {
-            x = rng.uniform(limit[0], limit[1]);
-            y = rng.uniform(limit[2], limit[3]);
-            z = -(model[0] * x + model[1] * y + d) / model[2];
-        }
-
-        plane_pts_ptr[3 * i] = x;
-        plane_pts_ptr[3 * i + 1] = y;
-        plane_pts_ptr[3 * i + 2] = z;
-    }
-}
+        const vector<float> &limit);
 
 /**
  * @brief Generate a specific sphere with random points.
@@ -96,41 +37,7 @@ void generatePlane(OutputArray plane_pts, const vector<float> &model, float thr,
  *
  */
 void generateSphere(OutputArray sphere_pts, const vector<float> &model, float thr, int num,
-        const vector<float> &limit)
-{
-    if (sphere_pts.channels() == 3 && sphere_pts.isVector())
-    {
-        // std::vector<cv::Point3f>
-        sphere_pts.create(1, num, CV_32FC3);
-    }
-    else
-    {
-        // cv::Mat
-        sphere_pts.create(num, 3, CV_32F);
-    }
-    cv::RNG rng(0);
-    auto *sphere_pts_ptr = (float *) sphere_pts.getMat().data;
+        const vector<float> &limit);
 
-    // Part of the points are generated for the specific model
-    // The other part of the points are used to increase the thickness of the sphere
-    int sphere_num = (int) (num / 1.5);
-    for (int i = 0; i < num; i++)
-    {
-        // Let r change then generate thickness
-        float r = i < sphere_num ? model[3] : rng.uniform(model[3] - thr, model[3] + thr);
-        // Generate a random vector and normalize it.
-        Vec3f vec(rng.uniform(limit[0], limit[1]), rng.uniform(limit[2], limit[3]),
-                rng.uniform(limit[4], limit[5]));
-        float l = sqrt(vec.dot(vec));
-        // Normalizes it to have a magnitude of r
-        vec /= l / r;
-
-        sphere_pts_ptr[3 * i] = model[0] + vec[0];
-        sphere_pts_ptr[3 * i + 1] = model[1] + vec[1];
-        sphere_pts_ptr[3 * i + 2] = model[2] + vec[2];
-    }
-}
-
-} // namespace
 } // opencv_test
 #endif //OPENCV_TEST_PTCLOUD_UTILS_HPP

--- a/modules/3d/test/test_ptcloud_utils.hpp
+++ b/modules/3d/test/test_ptcloud_utils.hpp
@@ -1,0 +1,136 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2022, Wanli Zhong <zhongwl2018@mail.sustech.edu.cn>
+
+#ifndef OPENCV_TEST_PTCLOUD_UTILS_HPP
+#define OPENCV_TEST_PTCLOUD_UTILS_HPP
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+/**
+ * @brief Generate a specific plane with random points.
+ *
+ * @param[out] plane_pts Point cloud of plane, only support vector<Point3f> or Mat with Nx3 layout
+ *                       in memory.
+ * @param model Plane coefficient [a,b,c,d] means ax+by+cz+d=0.
+ * @param thr Generate the maximum distance from the point to the plane.
+ * @param num The number of points.
+ * @param limit The range of xyz coordinates of the generated plane.
+ *
+ */
+void generatePlane(OutputArray plane_pts, const vector<float> &model, float thr, int num,
+        const vector<float> &limit)
+{
+    if (plane_pts.channels() == 3 && plane_pts.isVector())
+    {
+        // std::vector<cv::Point3f>
+        plane_pts.create(1, num, CV_32FC3);
+    }
+    else
+    {
+        // cv::Mat
+        plane_pts.create(num, 3, CV_32F);
+    }
+
+    cv::RNG rng(0);
+    auto *plane_pts_ptr = (float *) plane_pts.getMat().data;
+
+    // Part of the points are generated for the specific model
+    // The other part of the points are used to increase the thickness of the plane
+    int std_num = (int) (num / 2);
+    // Difference of maximum d between two parallel planes
+    float d_thr = thr * sqrt(model[0] * model[0] + model[1] * model[1] + model[2] * model[2]);
+
+    for (int i = 0; i < num; i++)
+    {
+        // Let d change then generate thickness
+        float d = i < std_num ? model[3] : rng.uniform(model[3] - d_thr, model[3] + d_thr);
+        float x, y, z;
+        // c is 0 means the plane is vertical
+        if (model[2] == 0)
+        {
+            z = rng.uniform(limit[4], limit[5]);
+            if (model[0] == 0)
+            {
+                x = rng.uniform(limit[0], limit[1]);
+                y = -d / model[1];
+            }
+            else if (model[1] == 0)
+            {
+                x = -d / model[0];
+                y = rng.uniform(limit[2], limit[3]);
+            }
+            else
+            {
+                x = rng.uniform(limit[0], limit[1]);
+                y = -(model[0] * x + d) / model[1];
+            }
+        }
+            // c is not 0
+        else
+        {
+            x = rng.uniform(limit[0], limit[1]);
+            y = rng.uniform(limit[2], limit[3]);
+            z = -(model[0] * x + model[1] * y + d) / model[2];
+        }
+
+        plane_pts_ptr[3 * i] = x;
+        plane_pts_ptr[3 * i + 1] = y;
+        plane_pts_ptr[3 * i + 2] = z;
+    }
+}
+
+/**
+ * @brief Generate a specific sphere with random points.
+ *
+ * @param[out] sphere_pts Point cloud of plane, only support vector<Point3f> or Mat with Nx3 layout
+ *                       in memory.
+ * @param model Plane coefficient [a,b,c,d] means x^2+y^2+z^2=r^2.
+ * @param thr Generate the maximum distance from the point to the surface of sphere.
+ * @param num The number of points.
+ * @param limit The range of vector to make the generated sphere incomplete.
+ *
+ */
+void generateSphere(OutputArray sphere_pts, const vector<float> &model, float thr, int num,
+        const vector<float> &limit)
+{
+    if (sphere_pts.channels() == 3 && sphere_pts.isVector())
+    {
+        // std::vector<cv::Point3f>
+        sphere_pts.create(1, num, CV_32FC3);
+    }
+    else
+    {
+        // cv::Mat
+        sphere_pts.create(num, 3, CV_32F);
+    }
+    cv::RNG rng(0);
+    auto *sphere_pts_ptr = (float *) sphere_pts.getMat().data;
+
+    // Part of the points are generated for the specific model
+    // The other part of the points are used to increase the thickness of the sphere
+    int sphere_num = (int) (num / 1.5);
+    for (int i = 0; i < num; i++)
+    {
+        // Let r change then generate thickness
+        float r = i < sphere_num ? model[3] : rng.uniform(model[3] - thr, model[3] + thr);
+        // Generate a random vector and normalize it.
+        Vec3f vec(rng.uniform(limit[0], limit[1]), rng.uniform(limit[2], limit[3]),
+                rng.uniform(limit[4], limit[5]));
+        float l = sqrt(vec.dot(vec));
+        // Normalizes it to have a magnitude of r
+        vec /= l / r;
+
+        sphere_pts_ptr[3 * i] = model[0] + vec[0];
+        sphere_pts_ptr[3 * i + 1] = model[1] + vec[1];
+        sphere_pts_ptr[3 * i + 2] = model[2] + vec[2];
+    }
+}
+
+} // namespace
+} // opencv_test
+#endif //OPENCV_TEST_PTCLOUD_UTILS_HPP


### PR DESCRIPTION
This PR is aimed at adding point cloud normal estimation and region growing algorithms.

Since there are many methods of KNN search, and both normal  estimation and region growing use the results of KNN search, I plan to use the following structure:
![image](https://user-images.githubusercontent.com/49567307/165672103-e2cd1c43-2a7b-4976-9758-30c150f7a414.png)

To summarize the main work of this PR.
1. Added a method called `normalEstimate()` to calculate the normal and curvature of each point in the point cloud.
2. Added a class called `RegionGrowing3D` to configure and implement region growing algorithm for point cloud.

TODO:
- [x] Complete the core part of the algorithm
- [x] Improve and modify the code according to the suggestions
- [x] Complete documentation
- [x] Add GTest for algorithm

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
