### PR TITLE
Fix #21894: Wrap constructor to Python to create initialized cuda::BufferPool object

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -689,7 +689,7 @@ class CV_EXPORTS_W BufferPool
 public:
 
     //! Gets the BufferPool for the given stream.
-    explicit BufferPool(Stream& stream);
+    CV_WRAP explicit BufferPool(Stream& stream);
 
     //! Allocates a new GpuMat of given size and type.
     CV_WRAP GpuMat getBuffer(int rows, int cols, int type);

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -45,5 +45,15 @@ class cuda_test(NewOpenCVTests):
         asyncstream = cv.cuda_Stream(1)  # cudaStreamNonBlocking
         self.assertTrue(asyncstream.cudaPtr() != 0)
 
+    def test_cuda_buffer_pool(self):
+        cv.cuda.setBufferPoolUsage(True)
+        cv.cuda.setBufferPoolConfig(cv.cuda.getDevice(), 1024 * 1024 * 64, 2)
+        stream_a = cv.cuda.Stream()
+        pool_a = cv.cuda.BufferPool(stream_a)
+        cuMat = pool_a.getBuffer(1024, 1024, cv.CV_8UC3)
+        cv.cuda.setBufferPoolUsage(False)
+        self.assertEqual(cuMat.size(), (1024, 1024))
+        self.assertEqual(cuMat.type(), cv.CV_8UC3)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
https://github.com/opencv/opencv/issues/21894

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
