### PR TITLE
imgproc: fix two typos (imput, magnutude)

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/segmentation.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/segmentation.hpp
@@ -92,7 +92,7 @@ public:
     CV_WRAP
     IntelligentScissorsMB& applyImage(InputArray image);
 
-    /** @brief Specify custom features of imput image
+    /** @brief Specify custom features of input image
      *
      * Customized advanced variant of applyImage() call.
      *

--- a/modules/imgproc/src/intelligent_scissors.cpp
+++ b/modules/imgproc/src/intelligent_scissors.cpp
@@ -429,13 +429,13 @@ struct IntelligentScissorsMB::Impl
         gradient_direction.create(src_size);
         for (int y = 0; y < src_size.height; y++)
         {
-            const float* magnutude_row = image_magnitude_.ptr<float>(y);
+            const float* magnitude_row = image_magnitude_.ptr<float>(y);
             const float* Ix_row = Ix_.ptr<float>(y);
             const float* Iy_row = Iy_.ptr<float>(y);
             Point2f* gradient_direction_row = gradient_direction.ptr<Point2f>(y);
             for (int x = 0; x < src_size.width; x++)
             {
-                const float m = magnutude_row[x];
+                const float m = magnitude_row[x];
                 if (m > FLT_EPSILON)
                 {
                     float m_inv = 1.0f / m;


### PR DESCRIPTION
(Noting that based on https://github.com/opencv/opencv/wiki/Branches#which-branch-should-i-target-my-pr this pull request here could be for 3.4 instead of 4.x branch. However, it is for 4.x since 3.4 doesn't have the typos.)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
