### PR TITLE
objdetect: Fix sampling QR code image

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2380,13 +2380,10 @@ bool QRDecode::samplingForVersion()
     const int delta_cols = cvRound((postIntermediate.cols * 1.0) / version_size);
 
     vector<double> listFrequencyElem;
-    for (int i = 0; i < version_size; i++)
+    for (int i = 0, r = 0; i < version_size; i++, r+= delta_rows)
     {
-        const int r = cvRound(static_cast<double>(postIntermediate.rows) * i / version_size);
-
-        for (int j = 0; j < version_size; j++)
+        for (int j = 0, c = 0; j < version_size; j++, c+= delta_cols)
         {
-            const int c = cvRound(static_cast<double>(postIntermediate.cols) * j / version_size);
             Mat tile = postIntermediate(
                            Range(r, min(r + delta_rows, postIntermediate.rows)),
                            Range(c, min(c + delta_cols, postIntermediate.cols)));

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2380,10 +2380,13 @@ bool QRDecode::samplingForVersion()
     const int delta_cols = cvRound((postIntermediate.cols * 1.0) / version_size);
 
     vector<double> listFrequencyElem;
-    for (int r = 0; r < postIntermediate.rows; r += delta_rows)
+    for (int i = 0; i < version_size; i++)
     {
-        for (int c = 0; c < postIntermediate.cols; c += delta_cols)
+        const int r = cvRound(static_cast<double>(postIntermediate.rows) * i / version_size);
+
+        for (int j = 0; j < version_size; j++)
         {
+            const int c = cvRound(static_cast<double>(postIntermediate.cols) * j / version_size);
             Mat tile = postIntermediate(
                            Range(r, min(r + delta_rows, postIntermediate.rows)),
                            Range(c, min(c + delta_cols, postIntermediate.cols)));

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -669,6 +669,33 @@ TEST(Objdetect_QRCode_detect, detect_regression_20882)
 #endif
 }
 
+// for https://github.com/opencv/opencv/issues/21929
+TEST(Objdetect_QRCode_decode, decode_regression_21929)
+{
+    const cv::String expect_msg = "OpenCV";
+    Mat qrimg;
+    QRCodeEncoder::Params params;
+    params.version = 8; // 49x49
+    Ptr<QRCodeEncoder> qrcode_enc = cv::QRCodeEncoder::create(params);;
+    qrcode_enc->encode(expect_msg, qrimg);
+
+    Mat src;
+    cv::resize( qrimg, src, Size(200,200), 1.0, 1.0, INTER_NEAREST );
+
+    QRCodeDetector qrcode;
+    std::vector<Point> corners;
+    Mat straight_barcode;
+
+    EXPECT_TRUE(qrcode.detect(src, corners));
+    EXPECT_TRUE(!corners.empty());
+#ifdef HAVE_QUIRC
+    cv::String decoded_msg;
+    EXPECT_NO_THROW(decoded_msg = qrcode.decode(src, corners, straight_barcode));
+    ASSERT_FALSE(straight_barcode.empty()) << "Can't decode qrimage.";
+    EXPECT_EQ(expect_msg, decoded_msg);
+#endif
+}
+
 TEST(Objdetect_QRCode_basic, not_found_qrcode)
 {
     std::vector<Point> corners;


### PR DESCRIPTION
Fix #21929 

This patch replaces the delta_rows skip loop with a simpler version_size loop. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
