### PR TITLE
imgproc: optimise local cost computation in IntelligentScissorsMB::buildMap

### DIFF
--- a/modules/imgproc/src/intelligent_scissors.cpp
+++ b/modules/imgproc/src/intelligent_scissors.cpp
@@ -40,7 +40,7 @@ static const int neighbors_encode[8] = {
 };
 
 #define ACOS_TABLE_SIZE 64
-// acos_table[x + ACOS_TABLE_SIZE] = acos(x / ACOS_TABLE_SIZE) / CV_PI (see local_cost)
+// acos_table[x + ACOS_TABLE_SIZE] = acos(x / ACOS_TABLE_SIZE) / CV_PI (see add_local_cost)
 //    x = [ -ACOS_TABLE_SIZE .. ACOS_TABLE_SIZE ]
 float* getAcosTable()
 {
@@ -495,55 +495,76 @@ struct IntelligentScissorsMB::Impl
 
     // details: see section 3.1 of the article
     const float* acos_table = getAcosTable();
-    float local_cost(const Point& p, const Point& q) const
+    const float sqrt2_inv = 0.7071067811865475f; // 1.0 / sqrt(2)
+
+    /** @brief Adds local_cost(p, q) to cost_p.
+     *
+     * local_cost(p, q) is computed as
+          weight_non_edge_compute * non_edge_feature.at<uchar>(q) +
+          weight_gradient_direction * fD +
+          weight_gradient_magnitude * fG
+     *
+     * @param p point p (input)
+     * @param q point q (input)
+     * @param cost_p cost for p (input/output)
+     * @param cost_q cost for q (input)
+     *
+     * @return The boolean result of the (cost_p < cost_q) comparison.
+     *
+     * @note The computed output cost_p can be partial if (cost_p < cost_q) is false.
+     */
+    bool add_local_cost(const Point& p, const Point& q, float& cost_p, const float cost_q) const
     {
-        const bool isDiag = (p.x != q.x) && (p.y != q.y);
-
-        float fG = gradient_magnitude.at<float>(q);
-
-        const Point2f diff((float)(q.x - p.x), (float)(q.y - p.y));
-
-        const Point2f Ip = gradient_direction(p);
-        const Point2f Iq = gradient_direction(q);
-
-        const Point2f Dp(Ip.y, -Ip.x);  // D(p) - 90 degrees clockwise
-        const Point2f Dq(Iq.y, -Iq.x);  // D(q) - 90 degrees clockwise
-
-        float dp = Dp.dot(diff);  // dp(p, q)
-        float dq = Dq.dot(diff);  // dq(p, q)
-        if (dp < 0)
+        if ((cost_p += weight_non_edge_compute * non_edge_feature.at<uchar>(q)) < cost_q)
         {
-            dp = -dp;  // ensure dp >= 0
-            dq = -dq;
-        }
+            const bool isDiag = (p.x != q.x) && (p.y != q.y);
 
-        const float sqrt2_inv = 0.7071067811865475f; // 1.0 / sqrt(2)
-        if (isDiag)
-        {
-            dp *= sqrt2_inv;  // normalize length of (q - p)
-            dq *= sqrt2_inv;  // normalize length of (q - p)
-        }
-        else
-        {
-            fG *= sqrt2_inv;
-        }
+            float fG = gradient_magnitude.at<float>(q);
+            if (!isDiag)
+            {
+                fG *= sqrt2_inv;
+            }
+
+            if ((cost_p += weight_gradient_magnitude * fG) < cost_q)
+            {
+
+                const Point2f diff((float)(q.x - p.x), (float)(q.y - p.y));
+
+                const Point2f Ip = gradient_direction(p);
+                const Point2f Iq = gradient_direction(q);
+
+                const Point2f Dp(Ip.y, -Ip.x);  // D(p) - 90 degrees clockwise
+                const Point2f Dq(Iq.y, -Iq.x);  // D(q) - 90 degrees clockwise
+
+                float dp = Dp.dot(diff);  // dp(p, q)
+                float dq = Dq.dot(diff);  // dq(p, q)
+                if (dp < 0)
+                {
+                    dp = -dp;  // ensure dp >= 0
+                    dq = -dq;
+                }
+
+                if (isDiag)
+                {
+                    dp *= sqrt2_inv;  // normalize length of (q - p)
+                    dq *= sqrt2_inv;  // normalize length of (q - p)
+                }
 
 #if 1
-        int dp_i = cvFloor(dp * ACOS_TABLE_SIZE);  // dp is in range 0..1
-        dp_i = std::min(ACOS_TABLE_SIZE, std::max(0, dp_i));
-        int dq_i = cvFloor(dq * ACOS_TABLE_SIZE);  // dq is in range -1..1
-        dq_i = std::min(ACOS_TABLE_SIZE, std::max(-ACOS_TABLE_SIZE, dq_i));
-        const float fD = acos_table[dp_i + ACOS_TABLE_SIZE] + acos_table[dq_i + ACOS_TABLE_SIZE];
+                int dp_i = cvFloor(dp * ACOS_TABLE_SIZE);  // dp is in range 0..1
+                dp_i = std::min(ACOS_TABLE_SIZE, std::max(0, dp_i));
+                int dq_i = cvFloor(dq * ACOS_TABLE_SIZE);  // dq is in range -1..1
+                dq_i = std::min(ACOS_TABLE_SIZE, std::max(-ACOS_TABLE_SIZE, dq_i));
+                const float fD = acos_table[dp_i + ACOS_TABLE_SIZE] + acos_table[dq_i + ACOS_TABLE_SIZE];
 #else
-        const float CV_PI_inv = static_cast<float>(1.0 / CV_PI);
-        const float fD = (acosf(dp) + acosf(dq)) * CV_PI_inv;  // TODO optimize acos calls (through tables)
+                const float CV_PI_inv = static_cast<float>(1.0 / CV_PI);
+                const float fD = (acosf(dp) + acosf(dq)) * CV_PI_inv;  // TODO optimize acos calls (through tables)
 #endif
 
-        float cost =
-            weight_non_edge_compute * non_edge_feature.at<uchar>(q) +
-            weight_gradient_direction * fD +
-            weight_gradient_magnitude * fG;
-        return cost;
+                cost_p += weight_gradient_direction * fD;
+            }
+        }
+        return cost_p < cost_q;
     }
 
     struct Pix
@@ -625,8 +646,8 @@ struct IntelligentScissorsMB::Impl
                 CV_DbgCheckLE(cost_q, cost_r, "INTERNAL ERROR: sorted queue is corrupted");
 #endif
 
-                float cost = cost_q + local_cost(q, r);  // TODO(opt): compute partially until cost < cost_r
-                if (cost < cost_r)
+                float cost = cost_q;
+                if (add_local_cost(q, r, cost, cost_r))
                 {
 #if 0  // avoid compiler warning
                     if (cost_r != FLT_MAX)


### PR DESCRIPTION
When reading the code I noticed a `TODO(opt)` comment, this pull request is for that.

https://github.com/opencv/opencv/blob/4.5.5/modules/imgproc/src/intelligent_scissors.cpp#L628

```
float cost = cost_q + local_cost(q, r);  // TODO(opt): compute partially until cost < cost_r
```

### Notes

* https://github.com/opencv/opencv/pull/21941 and this pull request change the same non-test files. However, the changes themselves don't overlap i.e. there should be no merge conflicts.

* Based on https://github.com/opencv/opencv/wiki/Branches#which-branch-should-i-target-my-pr this pull request here could be for 3.4 instead of 4.x branch. However, it is for 4.x since 3.4 doesn't have the intelligent scissors code.

### Test run snippet

```
$ export OPENCV_TEST_DATA_PATH=../opencv_extra/testdata

$./bin/opencv_perf_imgproc --gtest_filter="TestIntelligentScissorsMB*" 
...
[ RUN      ] TestIntelligentScissorsMB_buildMap_setComputeFullLocalCost.buildMap_setComputeFullLocalCost/0, where GetParam() = false
...
[ PERFSTAT ]    (samples=10   mean=5459.27   median=5452.70   min=5410.39   stddev=34.39 (0.6%))
[       OK ] TestIntelligentScissorsMB_buildMap_setComputeFullLocalCost.buildMap_setComputeFullLocalCost/0 (54604 ms)
[ RUN      ] TestIntelligentScissorsMB_buildMap_setComputeFullLocalCost.buildMap_setComputeFullLocalCost/1, where GetParam() = true
...
[ PERFSTAT ]    (samples=10   mean=5635.78   median=5634.03   min=5621.81   stddev=9.53 (0.2%))
[       OK ] TestIntelligentScissorsMB_buildMap_setComputeFullLocalCost.buildMap_setComputeFullLocalCost/1 (56360 ms)
...
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
