### PR TITLE
fix JpegEncoder::write

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -602,9 +602,9 @@ bool JpegEncoder::write( const Mat& img, const std::vector<int>& params )
     JpegErrorMgr jerr;
     JpegDestination dest;
 
-    jpeg_create_compress(&cinfo);
     cinfo.err = jpeg_std_error(&jerr.pub);
     jerr.pub.error_exit = error_exit;
+    jpeg_create_compress(&cinfo);
 
     if( !m_buf )
     {


### PR DESCRIPTION
Hello, I encountered [this kind of crash](https://github.com/opencv/opencv/issues/19635) on Windows and I think I've got the solution.

[`3rdparty/libjpeg-turbo/src/jpeglib.h`](https://github.com/opencv/opencv/blob/c8228e5789510ec26378eceb17311dd7bddf0b33/3rdparty/libjpeg-turbo/src/jpeglib.h#L898):
```
* NB: you must set up the error-manager BEFORE calling jpeg_create_xxx.
```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch *(upd)*
- [x] There is a reference to the original bug report and related work
- [ ] ~~There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.~~
- [ ] ~~The feature is well documented and sample code can be built with the project CMake~~
