### PR TITLE
Documentation Fix: Python and Java switched in Explanation

### DIFF
--- a/doc/tutorials/imgproc/imgtrans/hough_circle/hough_circle.markdown
+++ b/doc/tutorials/imgproc/imgtrans/hough_circle/hough_circle.markdown
@@ -74,11 +74,11 @@ The image we used can be found [here](https://raw.githubusercontent.com/opencv/o
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py load
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java load
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java load
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py load
 @end_toggle
 
 ####  Convert it to grayscale:
@@ -88,11 +88,11 @@ The image we used can be found [here](https://raw.githubusercontent.com/opencv/o
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py convert_to_gray
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java convert_to_gray
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java convert_to_gray
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py convert_to_gray
 @end_toggle
 
 #### Apply a Median blur to reduce noise and avoid false circle detection:
@@ -102,11 +102,11 @@ The image we used can be found [here](https://raw.githubusercontent.com/opencv/o
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py reduce_noise
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java reduce_noise
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java reduce_noise
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py reduce_noise
 @end_toggle
 
 #### Proceed to apply Hough Circle Transform:
@@ -116,11 +116,11 @@ The image we used can be found [here](https://raw.githubusercontent.com/opencv/o
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py houghcircles
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java houghcircles
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java houghcircles
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py houghcircles
 @end_toggle
 
 -   with the arguments:
@@ -144,11 +144,11 @@ The image we used can be found [here](https://raw.githubusercontent.com/opencv/o
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py draw
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java draw
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java draw
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py draw
 @end_toggle
 
 You can see that we will draw the circle(s) on red and the center(s) with a small green dot
@@ -160,11 +160,11 @@ You can see that we will draw the circle(s) on red and the center(s) with a smal
 @end_toggle
 
 @add_toggle_java
-@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py display
+@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java display
 @end_toggle
 
 @add_toggle_python
-@snippet samples/java/tutorial_code/ImgTrans/HoughCircle/HoughCircles.java display
+@snippet samples/python/tutorial_code/ImgTrans/HoughCircle/hough_circle.py display
 @end_toggle
 
 Result


### PR DESCRIPTION
On this page: https://docs.opencv.org/4.5.5/d4/d70/tutorial_hough_circle.html, in the _Explanation_ section, the snippets for Python and Java are switched.

This bug exists in the documentation for versions 3.3.1 up to 5.0.0-pre

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
