### PR TITLE
Modify randomSampling in point cloud

### DIFF
--- a/modules/3d/src/ptcloud/sampling.cpp
+++ b/modules/3d/src/ptcloud/sampling.cpp
@@ -163,7 +163,7 @@ randomSampling(OutputArray sampled_pts, InputArray input_pts, const int sampled_
     for (int i = 0; i < ori_pts_size; ++i) pts_idxs[i] = i;
     randShuffle(pts_idxs, 1, rng);
 
-    int channels = input_pts.channels();
+    int channels = sampled_pts.channels();
     if (channels == 3 && sampled_pts.isVector())
     {
         // std::vector<cv::Point3f>


### PR DESCRIPTION
Fix a bug: the output format should be determined by the channel of the `sampled_pts`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
