### PR TITLE
Fix global variable assignment in JS test suite

### DIFF
--- a/modules/js/test/test_imgproc.js
+++ b/modules/js/test/test_imgproc.js
@@ -948,7 +948,7 @@ QUnit.test('test_filter', function(assert) {
 
         cv.rotate(src, dst, cv.ROTATE_90_CLOCKWISE);
 
-        size = dst.size();
+        let size = dst.size();
         assert.equal(size.height, 2, "ROTATE_HEIGHT");
         assert.equal(size.width, 3, "ROTATE_WIGTH");
 


### PR DESCRIPTION
In test_imgproc.js, the test_filter suite's last test assigns a variable to `size` without declaring it with `let`, polluting the global scope. This PR adds `let` to the statement, so that the variable is scoped to the test block.

Before:
![image](https://user-images.githubusercontent.com/21111572/167940978-cd77fa37-c8e1-4bf0-86e7-fc9c2ee343c9.png)

After:
![image](https://user-images.githubusercontent.com/21111572/167941013-546d3ab9-47ff-4837-ad99-6790c6ef059f.png)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builder=Custom
build_image:Custom=javascript
buildworker:Custom=linux-f1
```