### PR TITLE
opencv_contrib branch check on Windows

### DIFF
--- a/.github/workflows/PR-3.4-W10.yaml
+++ b/.github/workflows/PR-3.4-W10.yaml
@@ -42,8 +42,8 @@ jobs:
     - name: Merge opencv_extra with ${{ env.SOURCE_BRANCH_NAME }} branch
       shell: bash
       run: |
-        RET=$(git ls-remote --heads "git@github.com:${{ env.PR_AUTHOR }}/opencv_extra" "${{ env.SOURCE_BRANCH_NAME }}") || true
-        if [[ ! -z "$RET" ]]; then
+        OPENCV_EXTRA_FORK=$(git ls-remote --heads "git@github.com:/${{ env.PR_AUTHOR }}/opencv_extra" "${{ env.SOURCE_BRANCH_NAME }}") || true
+        if [[ ! -z "$OPENCV_EXTRA_FORK" ]]; then
           echo "Merge opencv_extra with ${{ env.SOURCE_BRANCH_NAME }} branch"
           cd opencv_extra
           git config user.email "opencv.ci"
@@ -154,6 +154,19 @@ jobs:
         git pull -v "git@github.com:${{ env.PR_AUTHOR_FORK }}" "${{ env.SOURCE_BRANCH_NAME }}"
     - name: Fetch opencv_contrib
       run: cd ${{ github.workspace }} && git clone --single-branch --branch ${{ env.TARGET_BRANCH_NAME }} --reference ${{ env.GIT_CACHE }}\opencv_contrib.git --depth 1 git@github.com:opencv/opencv_contrib.git
+    - name: Merge opencv_contrib with ${{ env.SOURCE_BRANCH_NAME }} branch
+      shell: bash
+      run: |
+        OPENCV_CONTRIB_FORK=$(git ls-remote --heads "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}") || true
+        if [[ ! -z "$OPENCV_CONTRIB_FORK" ]]; then
+          echo "Merge opencv_contrib with ${{ env.SOURCE_BRANCH_NAME }} branch"
+          cd /opencv_contrib
+          git config user.email "opencv.ci"
+          git config user.name "opencv.ci"
+          git pull -v "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}"
+        else
+          echo "No merge since ${{ env.PR_AUTHOR }}/opencv_contrib does not have branch ${{ env.SOURCE_BRANCH_NAME }}"
+        fi
     - name: Configure OpenCV Contrib
       run: |
         mkdir ${{ github.workspace }}\opencv-contrib-build && cd ${{ github.workspace }}\opencv-contrib-build


### PR DESCRIPTION
This PR adds a check for the same branch in opencv_contrib fork of PR owner for 3.4 branch on Windows.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
