### PR TITLE
GHA: fix git merge

### DIFF
--- a/.github/workflows/PR-3.4-W10.yaml
+++ b/.github/workflows/PR-3.4-W10.yaml
@@ -44,7 +44,7 @@ jobs:
         OPENCV_EXTRA_FORK=$(git ls-remote --heads "git@github.com:/${{ env.PR_AUTHOR }}/opencv_extra" "${{ env.SOURCE_BRANCH_NAME }}") || true
         if [[ ! -z "$OPENCV_EXTRA_FORK" ]]; then
           echo "Merge opencv_extra with ${{ env.SOURCE_BRANCH_NAME }} branch"
-          cd opencv_extra
+          cd ${{ github.workspace }}\opencv_extra
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
           git pull -v "git@github.com:${{ env.PR_AUTHOR }}/opencv_extra" "${{ env.SOURCE_BRANCH_NAME }}"
@@ -159,7 +159,7 @@ jobs:
         OPENCV_CONTRIB_FORK=$(git ls-remote --heads "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}") || true
         if [[ ! -z "$OPENCV_CONTRIB_FORK" ]]; then
           echo "Merge opencv_contrib with ${{ env.SOURCE_BRANCH_NAME }} branch"
-          cd /opencv_contrib
+          cd ${{ github.workspace }}\opencv_contrib
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
           git pull -v "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}"


### PR DESCRIPTION
Fix failures: https://github.com/opencv/opencv/actions/runs/2323871325

```
Merge opencv_contrib with merge-3.4 branch
c:\GA-opencv-2\_work\_temp\dd6fe827-c75b-47da-be22-d254322f5dba.sh: line 4: cd: /opencv_contrib: No such file or directory
```