### PR TITLE
G-API(test): reduce used amount of memory

### DIFF
--- a/modules/gapi/test/rmat/rmat_view_tests.cpp
+++ b/modules/gapi/test/rmat/rmat_view_tests.cpp
@@ -132,7 +132,7 @@ TEST_P(RMatViewNDTest, StepFromView) {
 
 INSTANTIATE_TEST_CASE_P(Test, RMatViewNDTest,
                         Combine(Values(CV_8U, CV_32F), // depth
-                                Values(1,2,3,4,7)));   // ndims
+                                Values(1,2,3,4,5)));   // ndims
 
 struct RMatViewNDTestNegative : public TestWithParam<
     std::tuple<int /*depth*/, int /*chan*/, int /*ndims*/>>{};
@@ -153,7 +153,7 @@ TEST_P(RMatViewNDTestNegative, DefaultStep) {
 INSTANTIATE_TEST_CASE_P(Test, RMatViewNDTestNegative,
                         Combine(Values(CV_8U, CV_32F), // depth
                                 Values(1,2,3,4),       // chan
-                                Values(2,4,7)));       // ndims
+                                Values(2,4,5)));       // ndims
 
 TEST_P(RMatViewTest, NonDefaultStepInput) {
     auto type = GetParam();


### PR DESCRIPTION
Fixes [Win32 failure](http://pullrequest.opencv.org/buildbot/builders/master-win32-vc16/builds/100001) due to allocation of 1.5Gb.

```
[ RUN      ] Test/RMatViewNDTest.StepFromView/9, where GetParam() = (5, 7)
unknown file: error: C++ exception with description "bad allocation" thrown in the test body.
[  FAILED  ] Test/RMatViewNDTest.StepFromView/9, where GetParam() = (5, 7) (0 ms)
```

Max memory usage is reduced up to 4x.

- [x] [Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_windows32/builds/100020)

```
force_builders=Win32
```