### PR TITLE
Use argument value for 'mat' in call to format for vector_mat and vec…

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -571,8 +571,8 @@ class CppHeaderParser(object):
                     arg_type, arg_name, modlist, argno = self.parse_arg(a, argno)
                     if self.wrap_mode:
                         # TODO: Vectors should contain UMat, but this is not very easy to support and not very needed
-                        vector_mat = "vector_{}".format("Mat")
-                        vector_mat_template = "vector<{}>".format("Mat")
+                        vector_mat = "vector_{}".format(mat)
+                        vector_mat_template = "vector<{}>".format(mat)
 
                         if arg_type == "InputArray":
                             arg_type = mat


### PR DESCRIPTION
…tor_mat_template

The hard-coded string value "Mat" was used in the two format strings for vector_mat and vector_mat_template, preventing UMat arguments to functions that have these types from working correctly. Notably, #12231 references this issue.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
