### PR TITLE
pre: OpenCV 3.4.18 (version++)

### DIFF
--- a/doc/tutorials/introduction/cross_referencing/tutorial_cross_referencing.markdown
+++ b/doc/tutorials/introduction/cross_referencing/tutorial_cross_referencing.markdown
@@ -39,14 +39,14 @@ Open your Doxyfile using your favorite text editor and search for the key
 `TAGFILES`. Change it as follows:
 
 @code
-TAGFILES = ./docs/doxygen-tags/opencv.tag=http://docs.opencv.org/3.4.17
+TAGFILES = ./docs/doxygen-tags/opencv.tag=http://docs.opencv.org/3.4.18
 @endcode
 
 If you had other definitions already, you can append the line using a `\`:
 
 @code
 TAGFILES = ./docs/doxygen-tags/libstdc++.tag=https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen \
-           ./docs/doxygen-tags/opencv.tag=http://docs.opencv.org/3.4.17
+           ./docs/doxygen-tags/opencv.tag=http://docs.opencv.org/3.4.18
 @endcode
 
 Doxygen can now use the information from the tag file to link to the OpenCV

--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -7,8 +7,8 @@
 
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
-#define CV_VERSION_REVISION 17
-#define CV_VERSION_STATUS   "-dev"
+#define CV_VERSION_REVISION 18
+#define CV_VERSION_STATUS   "-pre"
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -47,9 +47,9 @@
 #include "opencv2/core/async.hpp"
 
 #if !defined CV_DOXYGEN && !defined CV_STATIC_ANALYSIS && !defined CV_DNN_DONT_ADD_EXPERIMENTAL_NS
-#define CV__DNN_EXPERIMENTAL_NS_BEGIN namespace experimental_dnn_34_v24 {
+#define CV__DNN_EXPERIMENTAL_NS_BEGIN namespace experimental_dnn_34_v25 {
 #define CV__DNN_EXPERIMENTAL_NS_END }
-namespace cv { namespace dnn { namespace experimental_dnn_34_v24 { } using namespace experimental_dnn_34_v24; }}
+namespace cv { namespace dnn { namespace experimental_dnn_34_v25 { } using namespace experimental_dnn_34_v25; }}
 #else
 #define CV__DNN_EXPERIMENTAL_NS_BEGIN
 #define CV__DNN_EXPERIMENTAL_NS_END

--- a/modules/python/package/setup.py
+++ b/modules/python/package/setup.py
@@ -9,7 +9,7 @@ def main():
     os.chdir(SCRIPT_DIR)
 
     package_name = 'opencv'
-    package_version = os.environ.get('OPENCV_VERSION', '3.4.17')  # TODO
+    package_version = os.environ.get('OPENCV_VERSION', '3.4.18')  # TODO
 
     long_description = 'Open Source Computer Vision Library Python bindings'  # TODO
 

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -269,7 +269,7 @@ class Builder:
         # Add extra data
         apkxmldest = check_dir(os.path.join(apkdest, "res", "xml"), create=True)
         apklibdest = check_dir(os.path.join(apkdest, "libs", abi.name), create=True)
-        for ver, d in self.extra_packs + [("3.4.17", os.path.join(self.libdest, "lib"))]:
+        for ver, d in self.extra_packs + [("3.4.18", os.path.join(self.libdest, "lib"))]:
             r = ET.Element("library", attrib={"version": ver})
             log.info("Adding libraries from %s", d)
 

--- a/platforms/android/service/readme.txt
+++ b/platforms/android/service/readme.txt
@@ -12,7 +12,7 @@ manually using adb tool:
 
     adb install <path-to-OpenCV-sdk>/apk/OpenCV_<version>_Manager_<app_version>_<platform>.apk
 
-Example: OpenCV_3.4.17-dev_Manager_3.49_armeabi-v7a.apk
+Example: OpenCV_3.4.18-dev_Manager_3.49_armeabi-v7a.apk
 
 Use the list of platforms below to determine proper OpenCV Manager package for your device:
 

--- a/platforms/maven/opencv-it/pom.xml
+++ b/platforms/maven/opencv-it/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opencv</groupId>
         <artifactId>opencv-parent</artifactId>
-        <version>3.4.17</version>
+        <version>3.4.18</version>
     </parent>
     <groupId>org.opencv</groupId>
     <artifactId>opencv-it</artifactId>

--- a/platforms/maven/opencv/pom.xml
+++ b/platforms/maven/opencv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opencv</groupId>
         <artifactId>opencv-parent</artifactId>
-        <version>3.4.17</version>
+        <version>3.4.18</version>
     </parent>
     <groupId>org.opencv</groupId>
     <artifactId>opencv</artifactId>

--- a/platforms/maven/pom.xml
+++ b/platforms/maven/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opencv</groupId>
     <artifactId>opencv-parent</artifactId>
-    <version>3.4.17</version>
+    <version>3.4.18</version>
     <packaging>pom</packaging>
     <name>OpenCV Parent POM</name>
     <licenses>


### PR DESCRIPTION
- [x] update version.js on docs.opencv.org

previous PR with version bump: #21280
