### PR TITLE
(4.x) build warnings

### DIFF
--- a/modules/calib3d/perf/perf_undistort.cpp
+++ b/modules/calib3d/perf/perf_undistort.cpp
@@ -27,31 +27,27 @@ PERF_TEST(Undistort, DISABLED_InitInverseRectificationMap)
     SANITY_CHECK_NOTHING();
 }
 
-using PerfIntType = perf::TestBaseWithParam<std::tuple<int>>;
-PERF_TEST_P(PerfIntType, fisheye_undistortPoints,
-                                            (testing::Values(1e2, 1e3, 1e4)))
+PERF_TEST(Undistort, fisheye_undistortPoints_100k_10iter)
 {
-    const cv::Size imageSize(1280, 800);
+    const int pointsNumber = 100000;
+    const Size imageSize(1280, 800);
 
     /* Set camera matrix */
-    const cv::Matx33d K(558.478087865323,  0, 620.458515360843,
+    const Matx33d K(558.478087865323,  0, 620.458515360843,
                          0, 560.506767351568, 381.939424848348,
                          0,               0,                1);
 
     /* Set distortion coefficients */
-    Mat D(1, 4, CV_64F);
-    theRNG().fill(D, RNG::UNIFORM, -1.e-5, 1.e-5);
-
-    int pointsNumber = std::get<0>(GetParam());
+    const Matx14d D(2.81e-06, 1.31e-06, -4.42e-06, -1.25e-06);
 
     /* Create two-channel points matrix */
-    cv::Mat xy[2] = {};
+    Mat xy[2] = {};
     xy[0].create(pointsNumber, 1, CV_64F);
-    theRNG().fill(xy[0], cv::RNG::UNIFORM, 0, imageSize.width); // x
+    theRNG().fill(xy[0], RNG::UNIFORM, 0, imageSize.width); // x
     xy[1].create(pointsNumber, 1, CV_64F);
-    theRNG().fill(xy[1], cv::RNG::UNIFORM, 0, imageSize.height); // y
+    theRNG().fill(xy[1], RNG::UNIFORM, 0, imageSize.height); // y
 
-    cv::Mat points;
+    Mat points;
     merge(xy, 2, points);
 
     /* Set fixed iteration number to check only c++ code, not algo convergence */

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -375,7 +375,7 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
     size_t n = distorted.total();
     int sdepth = distorted.depth();
 
-    const bool isEps = criteria.type & TermCriteria::EPS;
+    const bool isEps = (criteria.type & TermCriteria::EPS) != 0;
 
     /* Define max count for solver iterations */
     int maxCount = std::numeric_limits<int>::max();

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -131,20 +131,20 @@ TEST_F(fisheyeTest, distortUndistortPoints)
 
     /* Test with random D set */
     for (size_t i = 0; i < 10; ++i) {
-        cv::Mat D(1, 4, CV_64F);
-        theRNG().fill(D, cv::RNG::UNIFORM, -0.00001, 0.00001);
+        cv::Mat distortion(1, 4, CV_64F);
+        theRNG().fill(distortion, cv::RNG::UNIFORM, -0.00001, 0.00001);
 
         /* Distort -> Undistort */
         cv::Mat distortedPoints;
-        cv::fisheye::distortPoints(points0, distortedPoints, K, D);
+        cv::fisheye::distortPoints(points0, distortedPoints, K, distortion);
         cv::Mat undistortedPoints;
-        cv::fisheye::undistortPoints(distortedPoints, undistortedPoints, K, D);
+        cv::fisheye::undistortPoints(distortedPoints, undistortedPoints, K, distortion);
 
         EXPECT_MAT_NEAR(points0, undistortedPoints, 1e-8);
 
         /* Undistort -> Distort */
-        cv::fisheye::undistortPoints(points0, undistortedPoints, K, D);
-        cv::fisheye::distortPoints(undistortedPoints, distortedPoints, K, D);
+        cv::fisheye::undistortPoints(points0, undistortedPoints, K, distortion);
+        cv::fisheye::distortPoints(undistortedPoints, distortedPoints, K, distortion);
 
         EXPECT_MAT_NEAR(points0, distortedPoints, 1e-8);
     }


### PR DESCRIPTION
Messages:

- MSVS 2015: `modules\calib3d\src\fisheye.cpp(378): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)`
- MSVS 2015+: `warning C4244: 'initializing': conversion from 'const double' to 'int', possible loss of data (compiling source file modules\calib3d\perf\perf_undistort.cpp`