### PR TITLE
Add stateful kernel to python G-API

### DIFF
--- a/modules/gapi/include/opencv2/gapi/python/python.hpp
+++ b/modules/gapi/include/opencv2/gapi/python/python.hpp
@@ -31,17 +31,26 @@ struct GPythonContext
     const cv::GArgs      &ins;
     const cv::GMetaArgs  &in_metas;
     const cv::GTypesInfo &out_info;
+
+    bool m_isStateful;
+
+    GArg m_state;
 };
 
 using Impl = std::function<cv::GRunArgs(const GPythonContext&)>;
+using Setup = std::function<cv::GArg(const GMetaArgs&, const GArgs&)>;
 
 class GAPI_EXPORTS GPythonKernel
 {
 public:
     GPythonKernel() = default;
-    GPythonKernel(Impl run);
+    GPythonKernel(Impl run, Setup setup);
 
     cv::GRunArgs operator()(const GPythonContext& ctx);
+
+    bool m_isStateful = false;
+    Setup m_setup = nullptr;
+
 private:
     Impl m_run;
 };
@@ -51,7 +60,8 @@ class GAPI_EXPORTS GPythonFunctor : public cv::gapi::GFunctor
 public:
     using Meta = cv::GKernel::M;
 
-    GPythonFunctor(const char* id, const Meta &meta, const Impl& impl);
+    GPythonFunctor(const char* id, const Meta& meta, const Impl& impl,
+                   const Setup& setup = nullptr);
 
     GKernelImpl    impl()    const override;
     gapi::GBackend backend() const override;

--- a/modules/gapi/include/opencv2/gapi/python/python.hpp
+++ b/modules/gapi/include/opencv2/gapi/python/python.hpp
@@ -32,9 +32,7 @@ struct GPythonContext
     const cv::GMetaArgs  &in_metas;
     const cv::GTypesInfo &out_info;
 
-    bool m_isStateful;
-
-    GArg m_state;
+    cv::optional<cv::GArg> m_state;
 };
 
 using Impl = std::function<cv::GRunArgs(const GPythonContext&)>;
@@ -46,13 +44,9 @@ public:
     GPythonKernel() = default;
     GPythonKernel(Impl run, Setup setup);
 
-    cv::GRunArgs operator()(const GPythonContext& ctx);
-
-    bool m_isStateful = false;
-    Setup m_setup = nullptr;
-
-private:
-    Impl m_run;
+    Impl  run;
+    Setup setup       = nullptr;
+    bool  is_stateful = false;
 };
 
 class GAPI_EXPORTS GPythonFunctor : public cv::gapi::GFunctor

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -660,7 +660,7 @@ static cv::GRunArgs run_py_kernel(cv::detail::PyObjectHolder kernel,
         // NB: Doesn't increase reference counter (false),
         // because PyObject already have ownership.
         // In case exception decrement reference counter.
-        cv::detail::PyObjectHolder args(PyTuple_New(ins.size()), false);
+        cv::detail::PyObjectHolder args(PyTuple_New(ctx.m_isStateful ? ins.size() + 1: ins.size()), false);
         for (size_t i = 0; i < ins.size(); ++i)
         {
             // NB: If meta is monostate then object isn't associated with G-TYPE.
@@ -690,6 +690,12 @@ static cv::GRunArgs run_py_kernel(cv::detail::PyObjectHolder kernel,
             }
             ++in_idx;
         }
+
+        if (ctx.m_isStateful)
+        {
+            PyTuple_SetItem(args.get(), ins.size(), pyopencv_from(ctx.m_state));
+        }
+
         // NB: Doesn't increase reference counter (false).
         // In case PyObject_CallObject return NULL, do nothing in destructor.
         cv::detail::PyObjectHolder result(
@@ -734,6 +740,80 @@ static cv::GRunArgs run_py_kernel(cv::detail::PyObjectHolder kernel,
     PyGILState_Release(gstate);
 
     return outs;
+}
+
+static cv::GArg setup_py(cv::detail::PyObjectHolder out_meta, const cv::GMetaArgs& meta,
+                         const cv::GArgs& gargs)
+{
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    cv::GArg out;
+
+    try
+    {
+        // NB: Doesn't increase reference counter (false),
+        // because PyObject already have ownership.
+        // In case exception decrement reference counter.
+        cv::detail::PyObjectHolder args(PyTuple_New(meta.size()), false);
+        size_t idx = 0;
+        for (auto&& m : meta)
+        {
+            switch (m.index())
+            {
+                case cv::GMetaArg::index_of<cv::GMatDesc>():
+                    PyTuple_SetItem(args.get(), idx, pyopencv_from(cv::util::get<cv::GMatDesc>(m)));
+                    break;
+                case cv::GMetaArg::index_of<cv::GScalarDesc>():
+                    PyTuple_SetItem(args.get(), idx,
+                                    pyopencv_from(cv::util::get<cv::GScalarDesc>(m)));
+                    break;
+                case cv::GMetaArg::index_of<cv::GArrayDesc>():
+                    PyTuple_SetItem(args.get(), idx,
+                                    pyopencv_from(cv::util::get<cv::GArrayDesc>(m)));
+                    break;
+                case cv::GMetaArg::index_of<cv::GOpaqueDesc>():
+                    PyTuple_SetItem(args.get(), idx,
+                                    pyopencv_from(cv::util::get<cv::GOpaqueDesc>(m)));
+                    break;
+                case cv::GMetaArg::index_of<cv::util::monostate>():
+                    PyTuple_SetItem(args.get(), idx, pyopencv_from(gargs[idx]));
+                    break;
+                case cv::GMetaArg::index_of<cv::GFrameDesc>():
+                    util::throw_error(
+                        std::logic_error("GFrame isn't supported for custom operation"));
+                    break;
+            }
+            ++idx;
+        }
+
+        // PyTuple_SetItem(args.get(), idx, pyopencv_from(gmarg));
+
+        // NB: Doesn't increase reference counter (false).
+        // In case PyObject_CallObject return NULL, do nothing in destructor.
+        cv::detail::PyObjectHolder result(PyObject_CallObject(out_meta.get(), args.get()), false);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_PrintEx(0);
+            PyErr_Clear();
+            throw std::logic_error("Python kernel failed with error!");
+        }
+        // NB: In fact it's impossible situation, because errors were handled above.
+        GAPI_Assert(result.get() && "Python kernel returned NULL!");
+
+        if (!pyopencv_to(result.get(), out, ArgInfo("arg", false)))
+        {
+            util::throw_error(std::logic_error("Unsupported output meta type"));
+        }
+    }
+    catch (...)
+    {
+        PyGILState_Release(gstate);
+        throw;
+    }
+    PyGILState_Release(gstate);
+    return out;
 }
 
 static GMetaArg get_meta_arg(PyObject* obj)
@@ -860,6 +940,10 @@ static PyObject* pyopencv_cv_gapi_kernels(PyObject* , PyObject* py_args, PyObjec
                     "Python kernel should contain run, please use cv.gapi.kernel to define kernel");
             return NULL;
         }
+        PyObject* setup = nullptr;
+        if (PyObject_HasAttrString(user_kernel, "setup")) {
+            setup  = PyObject_GetAttrString(user_kernel, "setup");
+        }
 
         std::string id;
         if (!pyopencv_to(id_obj, id, ArgInfo("id", false)))
@@ -869,10 +953,22 @@ static PyObject* pyopencv_cv_gapi_kernels(PyObject* , PyObject* py_args, PyObjec
         }
 
         using namespace std::placeholders;
-        gapi::python::GPythonFunctor f(id.c_str(),
-                std::bind(run_py_meta  , cv::detail::PyObjectHolder{out_meta}, _1, _2),
-                std::bind(run_py_kernel, cv::detail::PyObjectHolder{run}    , _1));
-        pkg.include(f);
+
+        if (setup)
+        {
+            gapi::python::GPythonFunctor f(
+                id.c_str(), std::bind(run_py_meta, cv::detail::PyObjectHolder{out_meta}, _1, _2),
+                std::bind(run_py_kernel, cv::detail::PyObjectHolder{run}, _1),
+                std::bind(setup_py, cv::detail::PyObjectHolder{setup}, _1, _2));
+            pkg.include(f);
+        }
+        else
+        {
+            gapi::python::GPythonFunctor f(
+                id.c_str(), std::bind(run_py_meta, cv::detail::PyObjectHolder{out_meta}, _1, _2),
+                std::bind(run_py_kernel, cv::detail::PyObjectHolder{run}, _1));
+            pkg.include(f);
+        }
     }
     return pyopencv_from(pkg);
 }

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -432,7 +432,7 @@ try:
             with self.assertRaises(Exception): create_op([cv.GMat, int], [cv.GMat]).on(cv.GMat())
 
 
-        def test_stateful_kernel(self):
+        def test_state_in_class(self):
             @cv.gapi.op('custom.sum', in_types=[cv.GArray.Int], out_types=[cv.GOpaque.Int])
             class GSum:
                 @staticmethod

--- a/modules/gapi/misc/python/test/test_gapi_stateful_kernel.py
+++ b/modules/gapi/misc/python/test/test_gapi_stateful_kernel.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import numpy as np
+import cv2 as cv
+import os
+import sys
+import unittest
+
+from tests_common import NewOpenCVTests
+
+
+try:
+
+    if sys.version_info[:2] < (3, 0):
+        raise unittest.SkipTest('Python 2.x is not supported')
+
+
+    class CounterState:
+        def __init__(self):
+            self.counter = 0
+
+
+    @cv.gapi.op('stateful_counter',
+                in_types=[cv.GOpaque.Int],
+                out_types=[cv.GOpaque.Int])
+    class GStatefulCounter:
+        """Accumulate state counter on every call"""
+
+        @staticmethod
+        def outMeta(desc):
+            return cv.empty_gopaque_desc()
+
+
+    @cv.gapi.kernel(GStatefulCounter)
+    class GStatefulCounterImpl:
+        """Implementation for GStatefulCounter operation."""
+
+        @staticmethod
+        def setup(desc):
+            return CounterState()
+
+        @staticmethod
+        def run(value, state):
+            state.counter += value
+            return state.counter
+
+
+    class gapi_sample_pipelines(NewOpenCVTests):
+        def test_stateful_kernel_single_instance(self):
+            g_in  = cv.GOpaque.Int()
+            g_out = GStatefulCounter.on(g_in)
+            comp  = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out))
+            pkg   = cv.gapi.kernels(GStatefulCounterImpl)
+
+            nums = [i for i in range(10)]
+            acc = 0
+            for v in nums:
+                acc = comp.apply(cv.gin(v), args=cv.gapi.compile_args(pkg))
+
+            self.assertEqual(sum(nums), acc)
+
+
+        def test_stateful_kernel_multiple_instances(self):
+            # NB: Every counter has his own independent state.
+            g_in   = cv.GOpaque.Int()
+            g_out0 = GStatefulCounter.on(g_in)
+            g_out1 = GStatefulCounter.on(g_in)
+            comp   = cv.GComputation(cv.GIn(g_in), cv.GOut(g_out0, g_out1))
+            pkg    = cv.gapi.kernels(GStatefulCounterImpl)
+
+            nums = [i for i in range(10)]
+            acc0 = acc1 = 0
+            for v in nums:
+                acc0, acc1 = comp.apply(cv.gin(v), args=cv.gapi.compile_args(pkg))
+
+            ref = sum(nums)
+            self.assertEqual(ref, acc0)
+            self.assertEqual(ref, acc1)
+
+
+except unittest.SkipTest as e:
+
+    message = str(e)
+
+    class TestSkip(unittest.TestCase):
+        def setUp(self):
+            self.skipTest('Skip tests: ' + message)
+
+        def test_skip():
+            pass
+
+    pass
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/gapi/src/backends/python/gpythonbackend.cpp
+++ b/modules/gapi/src/backends/python/gpythonbackend.cpp
@@ -6,15 +6,19 @@
 
 #include <ade/util/zip_range.hpp> // zip_range, indexed
 
+#include "compiler/gmodel.hpp"
+#include <opencv2/gapi/garg.hpp>
 #include <opencv2/gapi/util/throw.hpp> // throw_error
 #include <opencv2/gapi/python/python.hpp>
 
 #include "api/gbackend_priv.hpp"
 #include "backends/common/gbackend.hpp"
 
-cv::gapi::python::GPythonKernel::GPythonKernel(cv::gapi::python::Impl run)
-    : m_run(run)
+cv::gapi::python::GPythonKernel::GPythonKernel(cv::gapi::python::Impl run,
+                                               cv::gapi::python::Setup setup)
+    : m_run(run), m_setup(setup)
 {
+    m_isStateful = (setup != nullptr);
 }
 
 cv::GRunArgs cv::gapi::python::GPythonKernel::operator()(const cv::gapi::python::GPythonContext& ctx)
@@ -23,9 +27,10 @@ cv::GRunArgs cv::gapi::python::GPythonKernel::operator()(const cv::gapi::python:
 }
 
 cv::gapi::python::GPythonFunctor::GPythonFunctor(const char* id,
-                                                 const cv::gapi::python::GPythonFunctor::Meta &meta,
-                                                 const cv::gapi::python::Impl& impl)
-    : gapi::GFunctor(id), impl_{GPythonKernel{impl}, meta}
+                                                 const cv::gapi::python::GPythonFunctor::Meta& meta,
+                                                 const cv::gapi::python::Impl& impl,
+                                                 const cv::gapi::python::Setup& setup)
+    : gapi::GFunctor(id), impl_{GPythonKernel{impl, setup}, meta}
 {
 }
 
@@ -68,6 +73,7 @@ class GPythonExecutable final: public cv::gimpl::GIslandExecutable
     virtual cv::RMat allocate(const cv::GMatDesc&) const override { return {}; }
 
     virtual bool canReshape() const override { return true; }
+    virtual void handleNewStream() override;
     virtual void reshape(ade::Graph&, const cv::GCompileArgs&) override {
         // Do nothing here
     }
@@ -80,6 +86,7 @@ public:
     cv::gimpl::GModel::ConstGraph m_gm;
     cv::gapi::python::GPythonKernel m_kernel;
     ade::NodeHandle m_op;
+    cv::GArg m_node_state;
 
     cv::GTypesInfo m_out_info;
     cv::GMetaArgs  m_in_metas;
@@ -153,6 +160,15 @@ static void writeBack(cv::GRunArg& arg, cv::GRunArgP& out)
     }
 }
 
+void GPythonExecutable::handleNewStream()
+{
+    if (!m_kernel.m_isStateful)
+        return;
+
+    m_node_state = m_kernel.m_setup(cv::gimpl::GModel::collectInputMeta(m_gm, m_op),
+                                    m_gm.metadata(m_op).get<cv::gimpl::Op>().args);
+}
+
 void GPythonExecutable::run(std::vector<InObj>  &&input_objs,
                             std::vector<OutObj> &&output_objs)
 {
@@ -165,8 +181,15 @@ void GPythonExecutable::run(std::vector<InObj>  &&input_objs,
                          std::back_inserter(inputs),
                          std::bind(&packArg, std::ref(m_res), _1));
 
+    cv::gapi::python::GPythonContext ctx{inputs, m_in_metas, m_out_info, false};
 
-    cv::gapi::python::GPythonContext ctx{inputs, m_in_metas, m_out_info};
+    // For stateful kernel add state to its execution context
+    if (m_kernel.m_isStateful)
+    {
+        ctx.m_state = m_node_state;
+        ctx.m_isStateful = true;
+    }
+
     auto outs = m_kernel(ctx);
 
     for (auto&& it : ade::util::zip(outs, output_objs))
@@ -224,6 +247,12 @@ GPythonExecutable::GPythonExecutable(const ade::Graph& g,
 
     m_op = *it;
     m_kernel = cag.metadata(m_op).get<PythonUnit>().kernel;
+
+    // If kernel is stateful then prepare storage for its state.
+    if (m_kernel.m_isStateful)
+    {
+        m_node_state = cv::GArg{ };
+    }
 
     // Ensure this the only op in the graph
     if (std::any_of(it+1, nodes.end(), is_op))


### PR DESCRIPTION
**Please review both interface design and code.** :slightly_smiling_face: 

### Motivation
Stateful kernel in C++ is really useful to many usecases like tracking.
This PR will enable python G-API users to use stateful kernel and expand the usecases in python G-API.

### Feature Design
[Here](https://github.com/xiong-jie-y/g_api_examples/tree/main/tracking_example) is the example video and the example code of this feature.
The example kernel is like this.
```python
class State:
    def __init__(self, tracker, initial_box):
        self.tracker = tracker
        self.initial_box = initial_box

@cv.gapi.kernel(Tracker)
class TrackerImpl:
    @staticmethod
    def setup(input_image_desc, box):
        tracker = cv.TrackerKCF_create()
        return State(tracker, None)

    @staticmethod
    def run(image, box, state):
        if state.initial_box is None:
            state.tracker.init(image, box)
            state.initial_box = box
            return box
        else:
            ok, bbox = state.tracker.update(image)
            return bbox
```

Basically it create internal state in the `setup` method and pass it to the G-API framework by returning it.
`run` method recieves additional `state` argument and user can handle state with this argument.
It is quite similar to the C++ stateful kernel API `GAPI_OCV_KERNEL_ST` and difference is setup method return state to the framework. This is the interface that I'd like to ask you to review :slightly_smiling_face: 

### How to run the demo code?
1. Build OpenCV as usual.
2. Run `pip install numpy click`
3. Run demo program by the following command.

For video input.
```
python track_video.py --input ${DEVICE_ID}
```

For video file
```
python track_video.py --input ${VIDEO_FILE_PATH}
```

###  TODO
- [ ] Fix interface design
- [ ] Add example PR following this PR.
- [ ] Add unit test for this feature.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work https://github.com/opencv/opencv/pull/17350/files
- [] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
-> No need for performance
- [ ] The feature is well documented and sample code can be built with the project CMake
- > I will work on example code later.
