### PR TITLE
Fix Xcode version matching

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -41,7 +41,7 @@ def execute(cmd, cwd = None):
         raise Exception("Child returned:", retcode)
 
 def getXCodeMajor():
-    ret = check_output(["xcodebuild", "-version"])
+    ret = check_output(["xcodebuild", "-version"]).decode("utf-8")
     m = re.match(r'Xcode\s+(\d+)\..*', ret, flags=re.IGNORECASE)
     if m:
         return int(m.group(1))


### PR DESCRIPTION
I've faced an issue building iOS framework on macOS. This issue happened on different devices with different python versions. It happens only with 3.4 branch.

The output:
```
============================================================
ERROR: cannot use a string pattern on a bytes-like object
============================================================
Traceback (most recent call last):
  File "/Users/user/test/opencv/platforms/ios/build_framework.py", line 120, in build
    self._build(outdir)
  File "/Users/user/test/opencv/platforms/ios/build_framework.py", line 88, in _build
    xcode_ver = getXCodeMajor()
  File "/Users/user/test/opencv/platforms/ios/build_framework.py", line 45, in getXCodeMajor
    m = re.match(r'Xcode\s+(\d+)\..*', ret, flags=re.IGNORECASE)
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.9/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
