### PR TITLE
apps/opencv_visualisation: configurable video codec

### DIFF
--- a/apps/visualisation/opencv_visualisation.cpp
+++ b/apps/visualisation/opencv_visualisation.cpp
@@ -85,7 +85,7 @@ int main( int argc, const char** argv )
         "{ help h usage ? |      | show this message }"
         "{ image i        |      | (required) path to reference image }"
         "{ model m        |      | (required) path to cascade xml file }"
-        "{ data d         |      | (optional) path to video output folder incl. trailing path separator }"
+        "{ data d         |      | (optional) path to video output folder }"
         "{ ext            | avi  | (optional) output video file extension e.g. avi (default) or mp4 }"
         "{ fourcc         | XVID | (optional) output video file's 4-character codec e.g. XVID (default) or H264 }"
         "{ fps            |   15 | (optional) output video file's frames-per-second rate }"

--- a/apps/visualisation/opencv_visualisation.cpp
+++ b/apps/visualisation/opencv_visualisation.cpp
@@ -85,7 +85,10 @@ int main( int argc, const char** argv )
         "{ help h usage ? |      | show this message }"
         "{ image i        |      | (required) path to reference image }"
         "{ model m        |      | (required) path to cascade xml file }"
-        "{ data d         |      | (optional) path to video output folder }"
+        "{ data d         |      | (optional) path to video output folder incl. trailing path separator }"
+        "{ ext            | avi  | (optional) output video file extension e.g. avi (default) or mp4 }"
+        "{ fourcc         | XVID | (optional) output video file's 4-character codec e.g. XVID (default) or H264 }"
+        "{ fps            |   15 | (optional) output video file's frames-per-second rate }"
     );
     // Read in the input arguments
     if (parser.has("help")){
@@ -96,7 +99,9 @@ int main( int argc, const char** argv )
     string model(parser.get<string>("model"));
     string output_folder(parser.get<string>("data"));
     string image_ref = (parser.get<string>("image"));
-    if (model.empty() || image_ref.empty()){
+    string fourcc = (parser.get<string>("fourcc"));
+    int fps = parser.get<int>("fps");
+    if (model.empty() || image_ref.empty() || fourcc.size()!=4 || fps<1){
         parser.printMessage();
         printLimits();
         return -1;
@@ -166,11 +171,19 @@ int main( int argc, const char** argv )
     // each stage, containing all weak classifiers for that stage.
     bool draw_planes = false;
     stringstream output_video;
-    output_video << output_folder << "model_visualization.avi";
+    output_video << output_folder << "model_visualization." << parser.get<string>("ext");
     VideoWriter result_video;
     if( output_folder.compare("") != 0 ){
         draw_planes = true;
-        result_video.open(output_video.str(), VideoWriter::fourcc('X','V','I','D'), 15, Size(reference_image.cols * resize_factor, reference_image.rows * resize_factor), false);
+        result_video.open(output_video.str(), VideoWriter::fourcc(fourcc[0],fourcc[1],fourcc[2],fourcc[3]), fps, visualization.size(), false);
+        if (!result_video.isOpened()){
+            cerr << "the output video '" << output_video.str() << "' could not be opened."
+                 << " fourcc=" << fourcc
+                 << " fps=" << fps
+                 << " frameSize=" << visualization.size()
+                 << endl;
+            return -1;
+        }
     }
 
     if(haar){


### PR DESCRIPTION
Problem: the `model_visualization.avi` with `XVID` codec did (silently) not work whereas `model_visualization.mp4` with `H264` does work.

Proposed solution: make the video codec configurable (defaulting to existing behaviour) and error-log-and-exit if the output video file could not be opened.

#### Usage example

(The "happy fish" image does not have the 20x20 size of the "profile face" model but it seems nonetheless suitable for smoke test use.)

```
opencv_build/bin/opencv_visualisation \
--image=opencv/samples/data/HappyFish.jpg \
--model=opencv/data/haarcascades/haarcascade_profileface.xml \
--data=temp_data/ \
--ext=mp4 --fourcc=H264 --fps=42
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
