### PR TITLE
Save Frames option for interactive calibration tool

### DIFF
--- a/apps/interactive-calibration/calibCommon.hpp
+++ b/apps/interactive-calibration/calibCommon.hpp
@@ -45,6 +45,8 @@ namespace calib
         double totalAvgErr;
         cv::Size imageSize;
 
+        std::vector<cv::Mat> allFrames;
+
         std::vector<std::vector<cv::Point2f> > imagePoints;
         std::vector< std::vector<cv::Point3f> > objectPoints;
 
@@ -91,6 +93,7 @@ namespace calib
         cv::Size cameraResolution;
         int maxFramesNum;
         int minFramesNum;
+        bool saveFrames;
 
         captureParameters()
         {
@@ -100,6 +103,7 @@ namespace calib
             minFramesNum = 10;
             fps = 30;
             cameraResolution = cv::Size(IMAGE_MAX_WIDTH, IMAGE_MAX_HEIGHT);
+            saveFrames = false;
         }
     };
 

--- a/apps/interactive-calibration/calibController.cpp
+++ b/apps/interactive-calibration/calibController.cpp
@@ -10,6 +10,7 @@
 
 #include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 double calib::calibController::estimateCoverageQuality()
 {
@@ -212,6 +213,9 @@ void calib::calibDataController::filterFrames()
         }
         showOverlayMessage(cv::format("Frame %zu is worst", worstElemIndex + 1));
 
+        if(mCalibData->allFrames.size())
+            mCalibData->allFrames.erase(mCalibData->allFrames.begin() + worstElemIndex);
+
         if(mCalibData->imagePoints.size()) {
             mCalibData->imagePoints.erase(mCalibData->imagePoints.begin() + worstElemIndex);
             mCalibData->objectPoints.erase(mCalibData->objectPoints.begin() + worstElemIndex);
@@ -239,6 +243,11 @@ void calib::calibDataController::setParametersFileName(const std::string &name)
 
 void calib::calibDataController::deleteLastFrame()
 {
+    if(!mCalibData->allFrames.empty())
+    {
+        mCalibData->allFrames.pop_back();
+    }
+
     if( !mCalibData->imagePoints.empty()) {
         mCalibData->imagePoints.pop_back();
         mCalibData->objectPoints.pop_back();
@@ -269,6 +278,7 @@ void calib::calibDataController::rememberCurrentParameters()
 
 void calib::calibDataController::deleteAllData()
 {
+    mCalibData->allFrames.clear();
     mCalibData->imagePoints.clear();
     mCalibData->objectPoints.clear();
     mCalibData->allCharucoCorners.clear();
@@ -280,6 +290,10 @@ void calib::calibDataController::deleteAllData()
 
 bool calib::calibDataController::saveCurrentCameraParameters() const
 {
+
+    for(size_t i = 0; i < mCalibData->allFrames.size(); i++)
+        cv::imwrite(cv::format("calibration_%zu.png", i), mCalibData->allFrames[i]);
+
     bool success = false;
     if(mCalibData->cameraMatrix.total()) {
             cv::FileStorage parametersWriter(mParamsFileName, cv::FileStorage::WRITE);

--- a/apps/interactive-calibration/frameProcessor.cpp
+++ b/apps/interactive-calibration/frameProcessor.cpp
@@ -266,6 +266,7 @@ CalibProcessor::CalibProcessor(cv::Ptr<calibrationData> data, captureParameters 
                                    static_cast<float>(mCalibData->imageSize.width * mCalibData->imageSize.width)) / 20.0;
     mSquareSize = capParams.squareSize;
     mTemplDist = capParams.templDst;
+    mSaveFrames = capParams.saveFrames;
 
     switch(mBoardType)
     {
@@ -291,9 +292,13 @@ CalibProcessor::CalibProcessor(cv::Ptr<calibrationData> data, captureParameters 
 cv::Mat CalibProcessor::processFrame(const cv::Mat &frame)
 {
     cv::Mat frameCopy;
+    cv::Mat frameCopyToSave;
     frame.copyTo(frameCopy);
     bool isTemplateFound = false;
     mCurrentImagePoints.clear();
+
+    if(mSaveFrames)
+        frame.copyTo(frameCopyToSave);
 
     switch(mBoardType)
     {
@@ -322,6 +327,10 @@ cv::Mat CalibProcessor::processFrame(const cv::Mat &frame)
                                                                                         mCalibData->allCharucoCorners.size()));
                 if(!showOverlayMessage(displayMessage))
                     showCaptureMessage(frame, displayMessage);
+
+                if(mSaveFrames)
+                    mCalibData->allFrames.push_back(frameCopyToSave);
+
                 mCapuredFrames++;
             }
             else {

--- a/apps/interactive-calibration/frameProcessor.hpp
+++ b/apps/interactive-calibration/frameProcessor.hpp
@@ -50,6 +50,7 @@ protected:
     double mMaxTemplateOffset;
     float mSquareSize;
     float mTemplDist;
+    bool mSaveFrames;
 
     bool detectAndParseChessboard(const cv::Mat& frame);
     bool detectAndParseChAruco(const cv::Mat& frame);

--- a/apps/interactive-calibration/main.cpp
+++ b/apps/interactive-calibration/main.cpp
@@ -40,6 +40,7 @@ const std::string keys  =
         "{vis      | grid    | Captured boards visualisation (grid, window)}"
         "{d        | 0.8     | Min delay between captures}"
         "{pf       | defaultConfig.xml| Advanced application parameters}"
+        "{save_frames | false   | Save frames that contribute to final calibration}"
         "{help     |         | Print help}";
 
 bool calib::showOverlayMessage(const std::string& message)

--- a/apps/interactive-calibration/parametersController.cpp
+++ b/apps/interactive-calibration/parametersController.cpp
@@ -89,6 +89,7 @@ bool calib::parametersController::loadFromParser(cv::CommandLineParser &parser)
     mCapParams.captureDelay = parser.get<float>("d");
     mCapParams.squareSize = parser.get<float>("sz");
     mCapParams.templDst = parser.get<float>("dst");
+    mCapParams.saveFrames = parser.has("save_frames");
 
     if(!checkAssertion(mCapParams.squareSize > 0, "Distance between corners or circles must be positive"))
         return false;


### PR DESCRIPTION
The option to save all frames that contribute to final calibration result.
Useful for dataset collection and further offline tuning.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
