### PR TITLE
[WIP] overloaded imread method for reading images only if user-given size is bigger than image size

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -322,6 +322,7 @@ CV_EXPORTS_W bool haveImageReader( const String& filename );
  */
 CV_EXPORTS_W bool haveImageWriter( const String& filename );
 
+CV_EXPORTS_W Mat imreadoptional( const String& filename, Size limitSize, int flags = IMREAD_ANYCOLOR);
 
 //! @} imgcodecs
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -383,7 +383,7 @@ static void ApplyExifOrientation(ExifEntry_t orientationTag, Mat& img)
  *
 */
 static bool
-imread_( const String& filename, int flags, Mat& mat )
+imread_( const String& filename, int flags, Mat& mat, Size limitSize = Size())
 {
     /// Search for the relevant decoder to handle the imagery
     ImageDecoder decoder;
@@ -440,6 +440,10 @@ imread_( const String& filename, int flags, Mat& mat )
 
     // established the required input image size
     Size size = validateInputImageSize(Size(decoder->width(), decoder->height()));
+
+    if(!limitSize.empty() && (limitSize.width * limitSize.height < size.width * size.height)) {
+        return false;
+    }
 
     // grab the decoded type
     int type = decoder->type();
@@ -627,6 +631,15 @@ Mat imread( const String& filename, int flags )
     imread_( filename, flags, img );
 
     /// return a reference to the data
+    return img;
+}
+
+Mat imreadoptional( const String& filename, Size limitSize, int flags) {
+    CV_TRACE_FUNCTION();
+
+    Mat img;
+    imread_(filename, flags, img, limitSize);
+
     return img;
 }
 

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -303,4 +303,12 @@ TEST(Imgcodecs_Image, write_umat)
     EXPECT_EQ(0, remove(dst_name.c_str()));
 }
 
+TEST(ImgCodecs_Image, imreadoptional)
+{
+    const string src_name = TS::ptr()->get_data_path() + "../python/images/baboon.bmp";
+
+    Mat img = imreadoptional(src_name, Size(400,400));
+    ASSERT_TRUE(img.empty());
+}
+
 }} // namespace


### PR DESCRIPTION
This new method allows users to read image data only if the user given limit is bigger than the image size. The image might be 100000 x 100000 pixels, in which case openCV will go ahead and allocate an extremely large buffer to hold this image. This new method gives the user the ability to restrict reading images if the image size is too big for them.

I am aware that the method name is not very appropriate. I wanted to learn what you folks think about this approach? IMO, it's very simple but powerful. Should OpenCV expose Encoder/Decoder API to the user? 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
