### PR TITLE
Fix issue 22015, let Clip layer support 1-3 inputs

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1933,16 +1933,20 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
 {
     layerParams.type = "ReLU6";
     float min_value = -FLT_MAX, max_value = FLT_MAX;
-    if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+    int input_size = node_proto.input_size();
+
+    if(input_size >= 2 && constBlobs.find(node_proto.input(1)) != constBlobs.end())
     {
         min_value = getBlob(node_proto, 1).at<float>(0);
     }
-    if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
+
+    if(input_size >= 3 && constBlobs.find(node_proto.input(2)) != constBlobs.end())
     {
         max_value = getBlob(node_proto, 2).at<float>(0);
     }
-    layerParams.set("min_value", min_value);
-    layerParams.set("max_value", max_value);
+
+    layerParams.set("min_value", layerParams.get<float>("min", min_value));
+    layerParams.set("max_value", layerParams.get<float>("max", max_value));
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1931,10 +1931,18 @@ void ONNXImporter::parseImageScaler(LayerParams& layerParams, const opencv_onnx:
 
 void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
-    CV_CheckEQ(node_proto.input_size(), 1, "");
     layerParams.type = "ReLU6";
-    layerParams.set("min_value", layerParams.get<float>("min", -FLT_MAX));
-    layerParams.set("max_value", layerParams.get<float>("max", FLT_MAX));
+    float min_value = -FLT_MAX, max_value = FLT_MAX;
+    if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+    {
+        min_value = getBlob(node_proto, 1).at<float>(0);
+    }
+    if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
+    {
+        max_value = getBlob(node_proto, 2).at<float>(0);
+    }
+    layerParams.set("min_value", min_value);
+    layerParams.set("max_value", max_value);
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1936,20 +1936,20 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
     int input_size = node_proto.input_size();
     CV_Check(input_size, 1 <= input_size && input_size <= 3, "");
 
-    if(input_size >= 2)
+    if(input_size == 2)
     {
         if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
             min_value = getBlob(node_proto, 1).at<float>(0);
         else
-            CV_Error(Error::StsNotImplemented, "Non-constant min/max values in Clip are not supported");
+            CV_Error(Error::StsNotImplemented, "Non-constant min values in Clip are not supported");
     }
 
-    if(input_size >= 3)
+    if(input_size == 3)
     {
+        if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+            min_value = getBlob(node_proto, 1).at<float>(0);
         if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
             max_value = getBlob(node_proto, 2).at<float>(0);
-        else
-            CV_Error(Error::StsNotImplemented, "Non-constant min/max values in Clip are not supported");
     }
 
     layerParams.set("min_value", layerParams.get<float>("min", min_value));

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1936,7 +1936,7 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
     int input_size = node_proto.input_size();
     CV_Check(input_size, 1 <= input_size && input_size <= 3, "");
 
-    if(input_size == 2)
+    if (input_size >= 2 && !node_proto.input(1).empty())
     {
         if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
             min_value = getBlob(node_proto, 1).at<float>(0);
@@ -1944,12 +1944,12 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
             CV_Error(Error::StsNotImplemented, "Non-constant min values in Clip are not supported");
     }
 
-    if(input_size == 3)
+    if (input_size == 3 && !node_proto.input(2).empty())
     {
-        if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
-            min_value = getBlob(node_proto, 1).at<float>(0);
         if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
             max_value = getBlob(node_proto, 2).at<float>(0);
+        else
+            CV_Error(Error::StsNotImplemented, "Non-constant max values in Clip are not supported");
     }
 
     layerParams.set("min_value", layerParams.get<float>("min", min_value));

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1934,7 +1934,7 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
     layerParams.type = "ReLU6";
     float min_value = -FLT_MAX, max_value = FLT_MAX;
     int input_size = node_proto.input_size();
-    CV_Assert(1 <= input_size && input_size <= 3);
+    CV_Check(input_size, 1 <= input_size && input_size <= 3, "");
 
     if(input_size >= 2)
     {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1934,6 +1934,7 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
     layerParams.type = "ReLU6";
     float min_value = -FLT_MAX, max_value = FLT_MAX;
     int input_size = node_proto.input_size();
+    CV_Assert(1 <= input_size && input_size <= 3);
 
     if(input_size >= 2)
     {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1935,14 +1935,20 @@ void ONNXImporter::parseClip(LayerParams& layerParams, const opencv_onnx::NodePr
     float min_value = -FLT_MAX, max_value = FLT_MAX;
     int input_size = node_proto.input_size();
 
-    if(input_size >= 2 && constBlobs.find(node_proto.input(1)) != constBlobs.end())
+    if(input_size >= 2)
     {
-        min_value = getBlob(node_proto, 1).at<float>(0);
+        if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+            min_value = getBlob(node_proto, 1).at<float>(0);
+        else
+            CV_Error(Error::StsNotImplemented, "Non-constant min/max values in Clip are not supported");
     }
 
-    if(input_size >= 3 && constBlobs.find(node_proto.input(2)) != constBlobs.end())
+    if(input_size >= 3)
     {
-        max_value = getBlob(node_proto, 2).at<float>(0);
+        if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
+            max_value = getBlob(node_proto, 2).at<float>(0);
+        else
+            CV_Error(Error::StsNotImplemented, "Non-constant min/max values in Clip are not supported");
     }
 
     layerParams.set("min_value", layerParams.get<float>("min", min_value));

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -389,9 +389,11 @@ TEST_P(Test_ONNX_layers, Clip)
     testONNXModels("clip", npy);
 }
 
-TEST_P(Test_ONNX_layers, Clip_init_min_max)
+TEST_P(Test_ONNX_layers, Clip_init)
 {
     testONNXModels("clip_init_min_max");
+    testONNXModels("clip_init_min");
+    testONNXModels("clip_init_max");
 }
 
 TEST_P(Test_ONNX_layers, Shape)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -387,6 +387,7 @@ TEST_P(Test_ONNX_layers, PReLU)
 TEST_P(Test_ONNX_layers, Clip)
 {
     testONNXModels("clip", npy);
+    testONNXModels("clip_init_min_max");
 }
 
 TEST_P(Test_ONNX_layers, Shape)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -387,6 +387,10 @@ TEST_P(Test_ONNX_layers, PReLU)
 TEST_P(Test_ONNX_layers, Clip)
 {
     testONNXModels("clip", npy);
+}
+
+TEST_P(Test_ONNX_layers, Clip_init_min_max)
+{
     testONNXModels("clip_init_min_max");
 }
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/980

This PR will fix the issue #22015 

The essence of the issue is that the `Clip layer` is supposed to accept 1-3 inputs, but the implementation here  is based on `ReLU6`, which only supports attributes as parameters.

https://github.com/opencv/opencv/blob/b19683eb41f425ec436193bd90a27f7637b4e8e1/modules/dnn/src/onnx/onnx_importer.cpp#L1935

Solution: When parsing the `Clip layer`, the `min` and `max` obtained from `node_proto.input()`, instead of from `layerParams`, are passed as parameters to the `ReLU6`. This allows the `Clip layer` to support 1-3 inputs.