### PR TITLE
 Update homography tutorial with a small exercise

### DIFF
--- a/doc/tutorials/features2d/homography/homography.markdown
+++ b/doc/tutorials/features2d/homography/homography.markdown
@@ -416,6 +416,12 @@ The homography matrices are similar. If we compare the image 1 warped using both
 
 Visually, it is hard to distinguish a difference between the result image from the homography computed from the camera displacement and the one estimated with @ref cv::findHomography function.
 
+#### Exercise
+
+This demo shows you how to compute the homography transformation from two camera poses. Try to perform the same operations, but by computing N inter homography this time. Instead of computing one homography to directly warp the source image to the desired camera viewpoint, perform N warping operations to the see the different transformations operating.
+
+You should get something similar to this video:
+
 ### Demo 4: Decompose the homography matrix {#tutorial_homography_Demo4}
 
 OpenCV 3 contains the function @ref cv::decomposeHomographyMat which allows to decompose the homography matrix to a set of rotations, translations and plane normals.


### PR DESCRIPTION
An idea I had.
Propose a small exercise to show the different homography transformations operating step-by-step. This should allow the user to learn, exercise the following topics:
- homogeneous transformations,
- rotation interpolation (and maybe SLERP, LERP, ... if using quaternion?),
- homography transformation from camera displacement

---

There is a dedicated YouTube channel for OpenCV tutorials: https://www.youtube.com/user/OpenCVTutorials
Would be great if you could add the following video on this channel:

https://user-images.githubusercontent.com/8229425/174500387-36882645-06ee-4aac-b0e4-3f3111e9d3be.mp4

Title of the video:

> OpenCV homography tutorial - Demo 3: Homography from the camera displacement

And with the following description:

> This video illustrates the following OpenCV homography tutorial: https://docs.opencv.org/4.x/d9/dab/tutorial_homography.html (here for OpenCV 4 version, select the appropriate OpenCV version you are using). 
> Left video shows the source image warped using the homography transformation computed from different camera displacements. Right video shows the "image error" between the final desired camera viewpoint and the currently warped image using the homography computed at the current step.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
