### PR TITLE
Fixed  time value obtained on some frames at the end of the video #22141

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1510,10 +1510,6 @@ bool CvCapture_FFMPEG::grabFrame()
         ret = got_picture ? 0 : -1;
 #endif
         if (ret >= 0) {
-            //picture_pts = picture->best_effort_timestamp;
-            if( picture_pts == AV_NOPTS_VALUE_ )
-                picture_pts = picture->CV_FFMPEG_PTS_FIELD != AV_NOPTS_VALUE_ && picture->CV_FFMPEG_PTS_FIELD != 0 ? picture->CV_FFMPEG_PTS_FIELD : picture->pkt_dts;
-
             valid = true;
         } else if (ret == AVERROR(EAGAIN)) {
             continue;
@@ -1526,8 +1522,11 @@ bool CvCapture_FFMPEG::grabFrame()
         }
     }
 
-    if (valid)
+    if (valid) {
+        if( picture_pts == AV_NOPTS_VALUE_ )
+            picture_pts = picture->CV_FFMPEG_PTS_FIELD != AV_NOPTS_VALUE_ && picture->CV_FFMPEG_PTS_FIELD != 0 ? picture->CV_FFMPEG_PTS_FIELD : picture->pkt_dts;
         frame_number++;
+    }
 
     if (!rawMode && valid && first_frame_number < 0)
         first_frame_number = dts_to_frame_number(picture_pts);

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -215,8 +215,28 @@ public:
             throw SkipTestException(cv::String("Backend ") +  cv::videoio_registry::getBackendName(apiPref) +
                     cv::String(" can't open the video: ")  + video_file);
 
+        int frame_count = (int)cap.get(CAP_PROP_FRAME_COUNT);
+
+        // HACK: Video consists of 125 frames, but cv::VideoCapture with FFmpeg reports only 122 frames for mpg video.
+        // mpg file reports 5.08 sec * 24 fps => property returns 122 frames,but actual number of frames returned is 125
+        // HACK: CAP_PROP_FRAME_COUNT is not supported for vmw + MSMF. Just force check for all 125 frames
+        if (ext == "mpg")
+            EXPECT_GT(frame_count, 121);
+        else if ((ext == "wmv") && (apiPref == CAP_MSMF))
+            frame_count = 125;
+        else
+            EXPECT_EQ(frame_count, 125);
         Mat img;
-        for(int i = 0; i < 10; i++)
+
+#ifdef _WIN32  // handle old FFmpeg wrapper on Windows till rebuild
+        frame_count = 10;
+#else
+        // HACK: FFmpeg reports picture_pts = AV_NOPTS_VALUE_ for the last frame for AVI container by some reason
+        if ((ext == "avi") && (apiPref == CAP_FFMPEG))
+            frame_count--;
+#endif
+
+        for (int i = 0; i < frame_count; i++)
         {
             double timestamp = 0;
             ASSERT_NO_THROW(cap >> img);


### PR DESCRIPTION
resolves #22141

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x ] I agree to contribute to the project under Apache 2 License.
- [ x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ x ] The PR is proposed to the proper branch
- [ x ] There is a reference to the original bug report and related work
- [  ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ x ] The feature is well documented and sample code can be built with the project CMake
