### PR TITLE
updated cvRound(), cvFloor() and cvCeil(), cvIsInf(), cvIsNan implementations

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -128,12 +128,8 @@
     #define CV_INLINE_ISNAN_FLT(value) CV_INLINE_ISNAN_DBL(value)
   #endif
 
-  #if !defined(OPENCV_USE_FASTMATH_BUILTINS) \
-    && ( \
-        defined(__x86_64__) || defined(__i686__) \
-        || defined(__arm__) \
-        || defined(__PPC64__) \
-    )
+  #if !defined(OPENCV_USE_FASTMATH_BUILTINS) && \
+      (defined __GNUC__ || defined __clang__ || defined _MSC_VER)
     /* Let builtin C math functions when available. Dedicated hardware is available to
        round and convert FP values. */
     #define OPENCV_USE_FASTMATH_BUILTINS 1
@@ -201,9 +197,7 @@ cvRound( double value )
 {
 #if defined CV_INLINE_ROUND_DBL
     CV_INLINE_ROUND_DBL(value);
-#elif ((defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__ \
-    && defined __SSE2__ && !defined __APPLE__) || CV_SSE2) \
-    && !defined(__CUDACC__)
+#elif (defined _MSC_VER && defined _M_X64) && !defined(__CUDACC__)
     __m128d t = _mm_set_sd( value );
     return _mm_cvtsd_si32(t);
 #elif defined _MSC_VER && defined _M_IX86
@@ -214,12 +208,11 @@ cvRound( double value )
         fistp t;
     }
     return t;
-#elif defined CV_ICC || defined __GNUC__
-    return (int)(lrint(value));
+#elif defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+      defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_lrint(value);
 #else
-    /* it's ok if round does not comply with IEEE754 standard;
-       the tests should allow +/-1 difference when the tested functions use round */
-    return (int)(value + (value >= 0 ? 0.5 : -0.5));
+    return (int)lrint(value);
 #endif
 }
 
@@ -233,11 +226,9 @@ cvRound( double value )
  */
 CV_INLINE int cvFloor( double value )
 {
-#if (defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS) \
-    && ( \
-        defined(__PPC64__) \
-    )
-    return __builtin_floor(value);
+#if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+    defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_floor(value);
 #else
     int i = (int)value;
     return i - (i > value);
@@ -253,11 +244,9 @@ CV_INLINE int cvFloor( double value )
  */
 CV_INLINE int cvCeil( double value )
 {
-#if (defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS) \
-    && ( \
-        defined(__PPC64__) \
-    )
-    return __builtin_ceil(value);
+#if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+    defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_ceil(value);
 #else
     int i = (int)value;
     return i + (i < value);
@@ -312,9 +301,7 @@ CV_INLINE int cvRound(float value)
 {
 #if defined CV_INLINE_ROUND_FLT
     CV_INLINE_ROUND_FLT(value);
-#elif ((defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__ \
-    && defined __SSE2__ && !defined __APPLE__) || CV_SSE2) \
-    && !defined(__CUDACC__)
+#elif (defined _MSC_VER && defined _M_X64) && !defined(__CUDACC__)
     __m128 t = _mm_set_ss( value );
     return _mm_cvtss_si32(t);
 #elif defined _MSC_VER && defined _M_IX86
@@ -325,12 +312,11 @@ CV_INLINE int cvRound(float value)
         fistp t;
     }
     return t;
-#elif defined CV_ICC || defined __GNUC__
-    return (int)(lrintf(value));
+#elif defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+      defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_lrintf(value);
 #else
-    /* it's ok if round does not comply with IEEE754 standard;
-     the tests should allow +/-1 difference when the tested functions use round */
-    return (int)(value + (value >= 0 ? 0.5f : -0.5f));
+    return (int)lrintf(value);
 #endif
 }
 
@@ -343,11 +329,9 @@ CV_INLINE int cvRound( int value )
 /** @overload */
 CV_INLINE int cvFloor( float value )
 {
-#if (defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS) \
-    && ( \
-        defined(__PPC64__) \
-    )
-    return __builtin_floorf(value);
+#if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+    defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_floorf(value);
 #else
     int i = (int)value;
     return i - (i > value);
@@ -363,11 +347,9 @@ CV_INLINE int cvFloor( int value )
 /** @overload */
 CV_INLINE int cvCeil( float value )
 {
-#if (defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS) \
-    && ( \
-        defined(__PPC64__) \
-    )
-    return __builtin_ceilf(value);
+#if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
+    defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
+    return (int)__builtin_ceilf(value);
 #else
     int i = (int)value;
     return i + (i < value);


### PR DESCRIPTION
* removed the old branch with non-standard rounding completely
* enable the use of GCC/clang `__builtin_*()` functions more broadly; now it's not limited to x86, x64, arm and PPC64 archs. Actually, before this patch some of `__builtin_*()` have been used only inside PPC64 branch. Now they are used everywhere. We assume that GCC/clang provide the necessary intrinsics on all target platforms.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-f1
```