### PR TITLE
DNN: ARMv7 compatible fastConv

### DIFF
--- a/modules/dnn/src/layers/fast_convolution/fast_convolution.hpp
+++ b/modules/dnn/src/layers/fast_convolution/fast_convolution.hpp
@@ -9,7 +9,7 @@
 
 #ifndef FAST_CONV_PRAM
 #define FAST_CONV_PRAM
-#if CV_NEON && __aarch64__  // 32 registers.
+#if CV_NEON && CV_NEON_AARCH64  // 32 registers.
 #define FAST_CONV_MR 4
 #define FAST_CONV_NR 28
 enum { FAST_VEC_NLANES=4 };

--- a/modules/dnn/src/layers/fast_convolution/winograd_3x3s1_f63.cpp
+++ b/modules/dnn/src/layers/fast_convolution/winograd_3x3s1_f63.cpp
@@ -1215,17 +1215,17 @@ int runWinograd63(InputArray _input, OutputArray _output, const Ptr<FastConv2d>&
                             r17 = vmlaq_lane_f32(r17, r08, q02, 0);
                             r18 = vmlaq_lane_f32(r18, r08, q04, 0);
                             r19 = vmlaq_lane_f32(r19, r08, q06, 0);
-                            
+
                             r16 = vmlaq_lane_f32(r16, r09, q00, 1);
                             r17 = vmlaq_lane_f32(r17, r09, q02, 1);
                             r18 = vmlaq_lane_f32(r18, r09, q04, 1);
                             r19 = vmlaq_lane_f32(r19, r09, q06, 1);
-                            
+
                             r16 = vmlaq_lane_f32(r16, r10, q01, 0);
                             r17 = vmlaq_lane_f32(r17, r10, q03, 0);
                             r18 = vmlaq_lane_f32(r18, r10, q05, 0);
                             r19 = vmlaq_lane_f32(r19, r10, q07, 0);
-                            
+
                             r16 = vmlaq_lane_f32(r16, r11, q01, 1);
                             r17 = vmlaq_lane_f32(r17, r11, q03, 1);
                             r18 = vmlaq_lane_f32(r18, r11, q05, 1);


### PR DESCRIPTION
This PR is compatible `fastConv` and `winogradConv` with ARMv7.
The previous #21910 PR only supported AARCH64 or ARMv8. And it has [bugs on ARMv7](https://github.com/opencv/opencv/pull/21910#issuecomment-1172772375)
 as @asenyaev reported. 

closes #22188

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
