### PR TITLE
DNN: Reduce Layer (add dynamic batch and ReduceSum support) 

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -334,7 +334,8 @@ CV__DNN_INLINE_NS_BEGIN
     {
     public:
         int reduceType;
-        std::vector<size_t> reduceDims;
+        // reduceDims contains the dimensions that need to be reduced, targetDims is the target output dimension.
+        std::vector<size_t> reduceDims, targetDims;
         static Ptr<ReduceLayer> create(const LayerParams& params);
     };
 

--- a/modules/dnn/src/int8layers/reduce_layer.cpp
+++ b/modules/dnn/src/int8layers/reduce_layer.cpp
@@ -38,6 +38,15 @@ public:
         {
             reduceDims[i] = tempDims.get<int>(i);
         }
+
+        CV_Assert(params.has("target_dims"));
+        tempDims = params.get("target_dims");
+        n = tempDims.size();
+        targetDims.resize(n);
+        for (i = 0; i < n; i++)
+        {
+            targetDims[i] = tempDims.get<int>(i);
+        }
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
@@ -161,18 +170,30 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size() > 0);
-        CV_Assert(reduceDims.size() != 0 && inputs[0].size() >= reduceDims.size());
+        CV_Assert( reduceDims.size() !=0 && targetDims.size() != 0 && inputs[0].size() >= reduceDims.size());
 
-        std::vector<int> outShape;
+        // outShapeTmp can save the right number of `total(outShapeTmp)`. And the outShape is used as the final output shape.
+        std::vector<int> outShapeTmp, outShape;
+        outShape.assign(targetDims.begin(), targetDims.end());
         if (inputs[0].size() == reduceDims.size())
-            outShape.push_back(1);
+            outShapeTmp.push_back(1);
         else
         {
             for (int i = 0; i < inputs[0].size() - reduceDims.size(); i++)
             {
-                outShape.push_back(inputs[0][i]);
+                outShapeTmp.push_back(inputs[0][i]);
             }
         }
+
+        // Support dynamic shape of Batch size.
+        // Note that: when there are multiple dynamic inputs, we will give an error.
+        if (total(outShape) != total(outShapeTmp))
+        {
+            if (outShape[0] != outShapeTmp[0])
+                outShape[0] = outShapeTmp[0];
+        }
+
+        CV_Assert(total(outShape) == total(outShapeTmp));
         outputs.assign(1, outShape);
 
         return false;

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1303,7 +1303,7 @@ void ONNXImporter::parseReduce(LayerParams& layerParams, const opencv_onnx::Node
     layerParams.set("dim", DictValue::arrayInt(&targetShape[0], targetShape.size()));
 
     // Set batchsize dim as dynamic to be compatible with batch size >= 2.
-    if (targetShape[0] == 1 && targetShape.size() > 1)
+    if (targetShape.size() > 1)
     {
         std::vector<int> dynamicAxes = {0};  // The index of batchsize dim is 0.
         std::vector<int> inputIndices = {0};

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -411,7 +411,6 @@ TEST_P(Test_ONNX_layers, ReduceMean)
 TEST_P(Test_ONNX_layers, ReduceSum)
 {
     testONNXModels("reduce_sum");
-    testONNXModels("reduce_sum_axis");
     testONNXModels("reduce_sum_axis_dynamic_batch");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -411,6 +411,8 @@ TEST_P(Test_ONNX_layers, ReduceMean)
 TEST_P(Test_ONNX_layers, ReduceSum)
 {
     testONNXModels("reduce_sum");
+    testONNXModels("reduce_sum_axis");
+    testONNXModels("reduce_sum_axis_dynamic_batch");
 }
 
 TEST_P(Test_ONNX_layers, ReduceMax)


### PR DESCRIPTION
Related ReduceSum issue #22195 
Related Dynamic Batch of Reduce Layer issue #22086
In this PR, we supported two input of `ReduceSum layer` and dynamic batch size in `Reduce Layer` of `ONNX_importer.cpp`.

[Regression test](https://github.com/opencv/opencv_extra/pull/987).

The [pervious PR](https://github.com/opencv/opencv/pull/22140) on Dynamic Batch of Reduce Layer has been closed.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
