### PR TITLE
Fix the bug in pyrDown when src_width is even and swidth/2+1=dwidth

### DIFF
--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -882,8 +882,9 @@ void PyrDownInvoker<CastOp>::operator()(const Range& range) const
                 const int* tabR = *_tabR;
                 for (int x_ = 0; x < dsize.width; x++, x_++)
                 {
-                    row[x] = src[tabR[x_+cn*2]]*6 + (src[tabR[x_+cn]] + src[tabR[x_+cn*3]])*4 +
-                        src[tabR[x_]] + src[tabR[x_+cn*4]];
+                    int cn_off = (x_ / cn) * cn;
+                    row[x] = src[tabR[x_+cn_off+cn*2]]*6 + (src[tabR[x_+cn_off+cn]] + src[tabR[x_+cn_off+cn*3]])*4 +
+                        src[tabR[x_+cn_off]] + src[tabR[x_+cn_off+cn*4]];
                 }
             } while (0);
         }

--- a/modules/imgproc/test/test_pyramid.cpp
+++ b/modules/imgproc/test/test_pyramid.cpp
@@ -16,4 +16,33 @@ TEST(Imgproc_PyrUp, pyrUp_regression_22184)
     ASSERT_GT(cvRound(min_val), 0);
 }
 
+TEST(Imgproc_PyrDown, pyrDown_regression)
+{
+    Mat src(16, 16,CV_16UC3,Scalar(0,0,0));
+    {
+        int swidth = src.cols;
+        int sheight = src.rows;
+        int cn = src.channels();
+        int count = 0;
+        for (int y = 0; y < sheight; y++)
+        {
+            ushort *src_c = src.ptr<ushort>(y);
+            for (int x = 0; x < swidth * cn; x++)
+            {
+                src_c[x] = (count++) % 10;
+            }
+        }
+    }
+    Mat dst(src.cols / 2 + 1, src.rows / 2 + 1, CV_16UC3, Scalar(0,0,0));
+    pyrDown(src, dst, Size(dst.cols, dst.rows));
+
+    {
+        int cn = dst.channels();
+        ushort *dst_c = dst.ptr<ushort>(dst.rows - 1);
+        ASSERT_EQ(dst_c[(dst.cols - 1) * cn], 5);
+        ASSERT_EQ(dst_c[(dst.cols - 1) * cn + 1], 5);
+        ASSERT_EQ(dst_c[(dst.cols - 1) * cn + 2], 5);
+    }
+}
+
 }}  // namespace


### PR DESCRIPTION
There is a bug to deal the right border in the case of src_width is even and swidth/2+1=dwidth.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
