### PR TITLE
fix number of squares calculation

### DIFF
--- a/modules/calib3d/src/checkchessboard.cpp
+++ b/modules/calib3d/src/checkchessboard.cpp
@@ -141,8 +141,8 @@ static bool checkQuads(vector<pair<float, int> > & quads, const cv::Size & size)
             // check the number of black and white squares
             std::vector<int> counts;
             countClasses(quads, i, j, counts);
-            const int black_count = cvRound(ceil(size.width/2.0)*ceil(size.height/2.0));
-            const int white_count = cvRound(floor(size.width/2.0)*floor(size.height/2.0));
+            const int black_count = cvRound(ceil((size.width + 1.0) * (size.height + 1.0) / 2.0));
+            const int white_count = cvRound(floor((size.width - 1.0) * (size.height - 1.0) / 2.0));
             if(counts[0] < black_count*0.75 ||
                counts[1] < white_count*0.75)
             {


### PR DESCRIPTION
The size parameters describes the number of crossing in the chessboard.

The algorithm calculates the number of black and white squares that can
be found in the image given the size parameter. Assuming that a
chessboard has no outer black border (see https://github.com/opencv/opencv/blob/4.x/doc/pattern.png), the previous implementation for calculating the black and white count might be incorrect? The outer white squares cannot be found since they are a part of the white background.

New implementation results in a higher ``black_count`` and ``white_count`` since we are taking all the squares into account in ``checkQuads``. The factor of ``0.75`` in following if condition has not been changed thus resulting in a stricter condition. Not sure if this is reasonable?  

Comparison:
| size (width, height) | black_count (old) | white_count (old) | black_count (new) | white_count (new) |
|----------------------|-------------------|-------------------|-------------------|-------------------|
| (8,6)                | 12                | 12                | 32                | 17                |
| (9,6)                | 15                | 12                | 35                | 20                |
| (2,2)                | 1                 | 1                 | 5                 | 0                 |



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
