### PR TITLE
clarify automatic memory management

### DIFF
--- a/modules/core/doc/intro.markdown
+++ b/modules/core/doc/intro.markdown
@@ -62,16 +62,13 @@ this case, use explicit namespace specifiers to resolve the name conflicts:
 
 ### Automatic Memory Management
 
-OpenCV handles all the memory automatically.
-
-First of all, std::vector, cv::Mat, and other data structures used by the functions and methods have
-destructors that deallocate the underlying memory buffers when needed. This means that the
-destructors do not always deallocate the buffers as in case of Mat. They take into account possible
-data sharing. A destructor decrements the reference counter associated with the matrix data buffer.
-The buffer is deallocated if and only if the reference counter reaches zero, that is, when no other
-structures refer to the same buffer. Similarly, when a Mat instance is copied, no actual data is
-really copied. Instead, the reference counter is incremented to memorize that there is another owner
-of the same data. There is also the cv::Mat::clone method that creates a full copy of the matrix data.
+OpenCV manages memory automatically. Destructors for data structures such as std::vector and cv::Mat
+do not always deallocate their underlying memory buffers because they take into account possible data
+sharing. A destructor decrements the reference counter associated with the matrix data buffer.
+The buffer is deallocated if and only if the reference counter reaches zero, which is when no other
+structures refer to the shared buffer. Similarly, when a cv::Mat instance is copied, no actual data is
+copied. Instead, the reference counter is incremented to record that there is another owner
+of the same data. If needed, the cv::Mat::clone method creates a full copy of the underlying data.
 See the example below:
 ```.cpp
     // create a big 8Mb matrix


### PR DESCRIPTION
### Overview

Attempts to improve clarity of memory management section in the intro page. Hopefully rephrases the existing information without adding or removing anything.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
