### PR TITLE
Use `std::chrono::steady_clock` in `getTickCount`

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -301,14 +301,7 @@ DECLARE_CV_CPUID_X86
   #endif
 #endif
 
-
-#if ((__cplusplus >= 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1800))
-  #define HAVE_CXX11 1
-#else
-  #define HAVE_CXX11 0
-#endif
-
-#if HAVE_CXX11
+#if defined CV_CXX11
   #include <chrono>
 #endif
 
@@ -850,7 +843,7 @@ bool useOptimized(void)
 
 int64 getTickCount(void)
 {
-#if HAVE_CXX11
+#if defined CV_CXX11
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     return (int64)now.time_since_epoch().count();
 #elif defined _WIN32 || defined WINCE
@@ -872,7 +865,7 @@ int64 getTickCount(void)
 
 double getTickFrequency(void)
 {
-#if HAVE_CXX11
+#if defined CV_CXX11
     using clock_period_t = std::chrono::steady_clock::duration::period;
     double clock_freq = clock_period_t::den / clock_period_t::num;
     return clock_freq;


### PR DESCRIPTION
This PR enables the use of `std::chrono::steady_clock` on supported compilers as a source to retrieve the current tick count and clock frequency in a cross-platform way.

Resolves #6902.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
