### PR TITLE
dynamically linked libs on mobile

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -160,6 +160,7 @@ class Builder:
         self.no_samples_build = True if config.no_samples_build else False
         self.opencl = True if config.opencl else False
         self.no_kotlin = True if config.no_kotlin else False
+        self.shared = True if config.shared else False
 
     def get_cmake(self):
         if not self.config.use_android_buildtools and check_executable(['cmake', '--version']):
@@ -244,6 +245,9 @@ class Builder:
 
         if self.no_kotlin:
             cmake_vars['BUILD_KOTLIN_EXTENSIONS'] = "OFF"
+
+        if self.shared:
+            cmake_vars['BUILD_SHARED_LIBS'] = "ON"
 
         if self.config.modules_list is not None:
             cmd.append("-DBUILD_LIST='%s'" % self.config.modules_list)
@@ -365,6 +369,7 @@ if __name__ == "__main__":
     parser.add_argument('--no_samples_build', action="store_true", help="Do not build samples (speeds up build)")
     parser.add_argument('--opencl', action="store_true", help="Enable OpenCL support")
     parser.add_argument('--no_kotlin', action="store_true", help="Disable Kotlin extensions")
+    parser.add_argument('--shared', action="store_true", help="Build shared libraries")
     args = parser.parse_args()
 
     log.basicConfig(format='%(message)s', level=log.DEBUG)

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -379,6 +379,13 @@ class Builder:
                 "-framework", "CoreImage", "-framework", "CoreMedia", "-framework", "QuartzCore",
                 "-framework", "Accelerate", "-framework", "OpenCL",
             ]
+        elif target_platform == "iphoneos" or target_platform == "iphonesimulator":
+            framework_options = [
+                "-iframework", "%s/System/iOSSupport/System/Library/Frameworks" % sdk_dir,
+                "-framework", "AVFoundation", "-framework", "CoreGraphics",
+                "-framework", "CoreImage", "-framework", "CoreMedia", "-framework", "QuartzCore",
+                "-framework", "Accelerate", "-framework", "UIKit", "-framework", "CoreVideo",
+            ]
         execute([
             "clang++",
             "-Xlinker", "-rpath",


### PR DESCRIPTION
This PR enables building dynamically linked opencv libs using python build scripts. Shared object for Android and framework for iOS. 
On Android building SO was already possible before this PR, now it is exposed in build_sdk.py as a command line parameter.
On iOS the option was already available as a command line argument, but was doing nothing for iOS simulator or device build. This PR enables that build providing it with the required dependencies.

### Pull Request Readiness Checklist
- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
