### PR TITLE
Pragma to ignore -Waggressive-loop-optimizations on Linux ARM64

### DIFF
--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -829,10 +829,14 @@ else // CV_8U
         v_pack_store(dst + k, __pack01);
     }
 #endif
+// avoid warning "iteration 7 invokes undefined behavior" on Linux ARM64
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
     for( ; k < len; k++ )
     {
         dst[k] = saturate_cast<uchar>(rawDst[k]*nrm2);
     }
+#pragma GCC diagnostic pop
 }
 #else
     float* dst = dstMat.ptr<float>(row);


### PR DESCRIPTION
This PR fixes the warning during the compilation on Linux ARM64:
```
[1013/2494] Building CXX object modules/features2d/CMakeFiles/opencv_features2d.dir/src/sift.dispatch.cpp.o
In file included from /opencv/modules/features2d/src/sift.dispatch.cpp:76:
/opencv/modules/features2d/src/sift.simd.hpp: In function 'void cv::cpu_baseline::calcSIFTDescriptor(const cv::Mat&, cv::Point2f, float, float, int, int, cv::Mat&, int)':
/opencv/modules/features2d/src/sift.simd.hpp:832:5: warning: iteration 7 invokes undefined behavior [-Waggressive-loop-optimizations]
  832 |     for( ; k < len; k++ )
      |     ^~~
/opencv/modules/features2d/src/sift.simd.hpp:832:14: note: within this loop
  832 |     for( ; k < len; k++ )
      |            ~~^~~~~
```
Link to a pipeline: https://github.com/opencv/ci-gha-workflow/runs/7237266858?check_suite_focus=true#step:16:1405

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
