### PR TITLE
VideoCapture FFMpeg RTSP low fps fixes

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -203,6 +203,7 @@ enum VideoCaptureProperties {
        CAP_PROP_LRF_HAS_KEY_FRAME = 67, //!< FFmpeg back-end only - Indicates whether the Last Raw Frame (LRF), output from VideoCapture::read() when VideoCapture is initialized with VideoCapture::open(CAP_FFMPEG, {CAP_PROP_FORMAT, -1}) or VideoCapture::set(CAP_PROP_FORMAT,-1) is called before the first call to VideoCapture::read(), contains encoded data for a key frame.
        CAP_PROP_CODEC_EXTRADATA_INDEX = 68, //!< Positive index indicates that returning extra data is supported by the video back end.  This can be retrieved as cap.retrieve(data, <returned index>).  E.g. When reading from a h264 encoded RTSP stream, the FFmpeg backend could return the SPS and/or PPS if available (if sent in reply to a DESCRIBE request), from calls to cap.retrieve(data, <returned index>).
        CAP_PROP_FRAME_TYPE = 69, //!< (read-only) FFmpeg back-end only - Frame type ascii code (73 = 'I', 80 = 'P', 66 = 'B' or 63 = '?' if unknown) of the most recently read frame.
+       CAP_PROP_N_THREADS = 70, //!< (**open-only**) Set the maximum number of threads to use. Use 0 to use as many threads as CPU cores (applicable for FFmpeg back-end only).
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -617,7 +617,6 @@ struct CvCapture_FFMPEG
     int hw_device;
     int use_opencl;
     int extraDataIdx;
-    int nThreads;
 };
 
 void CvCapture_FFMPEG::init()
@@ -663,7 +662,6 @@ void CvCapture_FFMPEG::init()
     hw_device = -1;
     use_opencl = 0;
     extraDataIdx = 1;
-    nThreads = 0;
 }
 
 
@@ -990,7 +988,7 @@ inline void fill_codec_context(AVCodecContext * enc, AVDictionary * dict)
 //  avcodec_thread_init(enc, get_number_of_cpus());
 //#else
     const int nCpus = get_number_of_cpus();
-    enc->thread_count = enc->thread_count ? min(enc->thread_count, nCpus) : nCpus;
+    enc->thread_count = enc->thread_count ? enc->thread_count: nCpus;
 //#endif
 
     AVDictionaryEntry* avdiscard_entry = av_dict_get(dict, "avdiscard", NULL, 0);
@@ -1027,6 +1025,7 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
 
     unsigned i;
     bool valid = false;
+    int nThreads = 0;
 
     close();
 
@@ -1770,7 +1769,7 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         //ic->start_time_realtime is in microseconds
         return ((double)ic->start_time_realtime);
     case CAP_PROP_N_THREADS:
-        return static_cast<double>(nThreads);
+        return static_cast<double>(context->thread_count);
     default:
         break;
     }


### PR DESCRIPTION
When using `VideoCapture` with the FFMpeg backend to stream from an RTSP source at a low frame rate on a machine with a large number of CPU cores, `VideoCapture::read/grab` can fail due to the interrupt timer exceeding `timeout_after_ms`.  To try and fix this, this PR adds the `CAP_PROP_N_THREADS` which can be set on open to reduce the number of threads in this case.  This is related to https://github.com/opencv/opencv/issues/20002 but I cannot tell if it fixes the issue as I am unable to re-create it on a machine with reading from a file with only 20 CPU cores.

In addition to this `VideoCapture::open` can get stuck and therefore interupted on the call to `err = avformat_find_stream_info(ic, NULL);` when streaming from an RTSP source at a low frame rate regardless of the number of CPU cores.  The call to `open` still succeeds and the frame can be read but because the flag `interrupt_metadata.timeout` has been set in `open` the call to `grab/read` fails.  To fix this the `interrupt_metadata.timeout` flag is reset on entry to `grab/read`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
