### PR TITLE
Changing data_layout for pack in tf_importer

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2541,6 +2541,8 @@ void TFImporter::parsePack(tensorflow::GraphDef& net, const tensorflow::NodeDef&
     if (dim != 0)
         CV_Error(Error::StsNotImplemented, "Unsupported mode of pack operation.");
 
+    data_layouts[name] = DATA_LAYOUT_UNKNOWN;
+
     CV_Assert(hasLayerAttr(layer, "N"));
     int num = (int)getLayerAttr(layer, "N").i();
     CV_CheckEQ(num_inputs, num, "");


### PR DESCRIPTION
Fixes #22221.

In this case, the `pack` operator stacks three 4-dimensional tensors into a 5-dimensional tensor. However, the data layout of the output of the `pack` operator is still recognized as 4-dimensional (`DATA_LAYOUT_NHWC`) in tf_importer, which will lead to some problems like #22221 . Changing the data layout to `DATA_LAYOUT_UNKNOWN` fixes the problem.

For testing, I doubt whether we should put the model in opencv_extra since it is ~432MB.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
