### PR TITLE
release png,jpeg resources in destructor

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -260,9 +260,6 @@ bool  JpegDecoder::readHeader()
         }
     }
 
-    if( !result )
-        close();
-
     return result;
 }
 
@@ -512,7 +509,6 @@ bool  JpegDecoder::readData( Mat& img )
         }
     }
 
-    close();
     return result;
 }
 

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -214,9 +214,6 @@ bool  PngDecoder::readHeader()
         }
     }
 
-    if( !result )
-        close();
-
     return result;
 }
 
@@ -304,7 +301,6 @@ bool  PngDecoder::readData( Mat& img )
         }
     }
 
-    close();
     return result;
 }
 


### PR DESCRIPTION
Releasing resources should be done in the destructor. The user might call this method more than once.

```cpp
auto res = decoder.readData(mat);
...
res = decoder.readData(mat);
```

This is not efficient but it is possible. In this case, behavior is undefined because of the `close()` call. 