### PR TITLE
[GSoC]bugfix: errors raised when cv::Vec used as default arguments

### DIFF
--- a/modules/python/src2/cv2_convert.hpp
+++ b/modules/python/src2/cv2_convert.hpp
@@ -62,6 +62,9 @@ PyObject* pyopencv_from(const T& src) { return PyOpenCV_Converter<T>::from(src);
 template<typename _Tp, int m, int n>
 bool pyopencv_to(PyObject* o, cv::Matx<_Tp, m, n>& mx, const ArgInfo& info)
 {
+    if(!o || o == Py_None)
+        return true
+
     cv::Mat tmp;
     if (!pyopencv_to(o, tmp, info)) {
         return false;

--- a/modules/python/src2/cv2_convert.hpp
+++ b/modules/python/src2/cv2_convert.hpp
@@ -62,8 +62,8 @@ PyObject* pyopencv_from(const T& src) { return PyOpenCV_Converter<T>::from(src);
 template<typename _Tp, int m, int n>
 bool pyopencv_to(PyObject* o, cv::Matx<_Tp, m, n>& mx, const ArgInfo& info)
 {
-    if(!o || o == Py_None)
-        return true
+    if (!o || o == Py_None)
+        return true;
 
     cv::Mat tmp;
     if (!pyopencv_to(o, tmp, info)) {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description
This bug happens when try to generate python-bindings for a function which takes `cv::Vec` as default arguments.
For example, I designed a function randomCrop which takes `padding` of dtype `cv::Vec4i` as default argument:
```c++
randomCrop(InputArray src, OutputArray dst, const Size& sz, const Vec4i& padding=Vec4i() , bool pad_if_need=false, int fill=0, int padding_mode=BORDER_CONSTANT);
```
When I trying to generate python-binding for this function, nothing wrong happens.
But when the user use this function in python environment, and they treat `padding` as default argument so they don't pass value for this argument. They may call this function like this:
```python
# padding is default argument, it should be Vec4i() if we don't pass any value for it
randomCrop(img, np.array([100, 100]))
```
Then wired thing happens, the python generator calls `pyopencv_to` on line 63 of `cv2_convert.hpp`, trying to convert the python object into `Vec4i`. But this function `pyopencv_to` omit the case when this argument has default value and user passes no value for it. In this case, the function trying to copy a None object `tmp` to the target `mx`, which will raise error in the `copyTo` procedure.

By adding judgement of whether the receieved python object is None and if so, simply return true and assign mx to the default value will resolve this problem. This problem happens when the user trying to call any function which takes type `cv::Vec` as default argument and the user don't specify value for it.

