### PR TITLE
correct an issue of trackbar on macOS

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -1201,7 +1201,7 @@ static NSSize constrainAspectRatio(NSSize base, NSSize constraint) {
     (void)notification;
     int pos = [slider intValue];
     NSString *temp = [self initialName];
-    NSString *text = [NSString stringWithFormat:@"%@ %d", temp, *value];
+    NSString *text = [NSString stringWithFormat:@"%@ %d", temp, pos];
     [name setStringValue: text];
     if(value)
         *value = pos;


### PR DESCRIPTION
Python binding is passing NULL as (int*)value.
sliderChanged crash when trying to dereference value

A user reported this issue to me on IRC and opened an issue in opencv-python
https://github.com/opencv/opencv-python/issues/691

I have a solution for the issue but I do not know which OpenCV branch I should target

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
