### PR TITLE
Allow src=float, dst=double combination for filter2D

### DIFF
--- a/modules/imgproc/src/filter.simd.hpp
+++ b/modules/imgproc/src/filter.simd.hpp
@@ -3288,6 +3288,9 @@ Ptr<BaseFilter> getLinearFilter(
     if( sdepth == CV_32F && ddepth == CV_32F )
         return makePtr<Filter2D<float, Cast<float, float>, FilterVec_32f> >
             (kernel, anchor, delta, Cast<float, float>(), FilterVec_32f(kernel, 0, delta));
+    if( sdepth == CV_32F && ddepth == CV_64F )
+        return makePtr<Filter2D<float,
+            Cast<double, double>, FilterNoVec> >(kernel, anchor, delta);
     if( sdepth == CV_64F && ddepth == CV_64F )
         return makePtr<Filter2D<double,
             Cast<double, double>, FilterNoVec> >(kernel, anchor, delta);

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2366,5 +2366,35 @@ TEST(Imgproc_GaussianBlur, regression_11303)
     EXPECT_LE(cv::norm(src, dst, NORM_L2), 1e-3);
 }
 
+TEST(Imgproc_filter2D, float_double_regression_22242)
+{
+    cv::Mat1f input_float(5, 5);
+    input_float(0, 0) = 17;   input_float(0, 1) = 24;   input_float(0, 2) = 1;    input_float(0, 3) = 8;    input_float(0, 4) = 15;
+    input_float(1, 0) = 23;   input_float(1, 1) = 5;    input_float(1, 2) = 7;    input_float(1, 3) = 14;   input_float(1, 4) = 16;
+    input_float(2, 0) = 4;    input_float(2, 1) = 6;    input_float(2, 2) = 13;   input_float(2, 3) = 20;   input_float(2, 4) = 22;
+    input_float(3, 0) = 10;   input_float(3, 1) = 12;   input_float(3, 2) = 19;   input_float(3, 3) = 21;   input_float(3, 4) = 3;
+    input_float(4, 0) = 11;   input_float(4, 1) = 18;   input_float(4, 2) = 25;   input_float(4, 3) = 2;    input_float(4, 4) = 9;
+
+    cv::Mat1d input_double(5, 5);
+    input_double(0, 0) = 17;   input_double(0, 1) = 24;   input_double(0, 2) = 1;    input_double(0, 3) = 8;    input_double(0, 4) = 15;
+    input_double(1, 0) = 23;   input_double(1, 1) = 5;    input_double(1, 2) = 7;    input_double(1, 3) = 14;   input_double(1, 4) = 16;
+    input_double(2, 0) = 4;    input_double(2, 1) = 6;    input_double(2, 2) = 13;   input_double(2, 3) = 20;   input_double(2, 4) = 22;
+    input_double(3, 0) = 10;   input_double(3, 1) = 12;   input_double(3, 2) = 19;   input_double(3, 3) = 21;   input_double(3, 4) = 3;
+    input_double(4, 0) = 11;   input_double(4, 1) = 18;   input_double(4, 2) = 25;   input_double(4, 3) = 2;    input_double(4, 4) = 9;
+
+    cv::Mat1d kernel(3, 3);
+    kernel(0, 0) = 0;   kernel(0, 1) = 1;   kernel(0, 2) = 0;
+    kernel(1, 0) = 1;   kernel(1, 1) = -4;  kernel(1, 2) = 1;
+    kernel(2, 0) = 0;   kernel(2, 1) = 1;   kernel(2, 2) = 0;
+
+    cv::Mat1d output_from_float(5, 5);
+    cv::filter2D(input_float, output_from_float, output_from_float.depth(), kernel, cv::Point(-1, -1), 0, cv::BORDER_CONSTANT);
+
+    cv::Mat1d output_from_double(5, 5);
+    cv::filter2D(input_double, output_from_double, output_from_double.depth(), kernel, cv::Point(-1, -1), 0, cv::BORDER_CONSTANT);
+
+    EXPECT_LE(cv::norm(output_from_float, output_from_double, NORM_L2), 1e-9);
+}
+
 
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Try to fix https://github.com/opencv/opencv/issues/22242

Reading the [doc](https://docs.opencv.org/4.5.5/d4/d86/group__imgproc__filter.html#details), I also understand that `CV_32F` / `CV_64F` combination should be allowed.