### PR TITLE
Addition of the destroyWindow function invocation in the display image example and update of related documentation

### DIFF
--- a/doc/tutorials/introduction/display_image/display_image.markdown
+++ b/doc/tutorials/introduction/display_image/display_image.markdown
@@ -112,7 +112,7 @@ The first argument is the title of the window and the second argument is the @re
 Because we want our window to be displayed until the user presses a key (otherwise the program would
 end far too quickly), we use the @ref cv::waitKey function whose only parameter is just how long
 should it wait for a user input (measured in milliseconds). Zero means to wait forever.
-The return value is the key that was pressed.
+The return value is the key that was pressed. The function cv::waitKey is followed by the function cv::destroyWindow which accepts as a parameter a string representing the name of a window to be closed.
 
 @add_toggle_cpp
 @snippet cpp/tutorial_code/introduction/display_image/display_image.cpp imshow

--- a/samples/python/tutorial_code/introduction/display_image/display_image.py
+++ b/samples/python/tutorial_code/introduction/display_image/display_image.py
@@ -13,6 +13,9 @@ if img is None:
 cv.imshow("Display window", img)
 k = cv.waitKey(0)
 ## [imshow]
+## [closewindow]
+cv.destroyWindow("Display window")
+## [closewindow]
 ## [imsave]
 if k == ord("s"):
     cv.imwrite("starry_night.png", img)


### PR DESCRIPTION
The aim of this pull request is to make the display image guide less misleading. The invocation of the destroyWindow function has been introduced to match the behaviour described in this part of the guide:

> Because we want our window to be displayed until the user presses a key (otherwise the program would end far too quickly) ...

The pull request follows what is stated in this issue: #22261 