### PR TITLE
Rename shadow variable in fisheye test

### DIFF
--- a/modules/calib/test/test_fisheye.cpp
+++ b/modules/calib/test/test_fisheye.cpp
@@ -131,20 +131,20 @@ TEST_F(fisheyeTest, distortUndistortPoints)
 
     /* Test with random D set */
     for (size_t i = 0; i < 10; ++i) {
-        cv::Mat D(1, 4, CV_64F);
-        theRNG().fill(D, cv::RNG::UNIFORM, -0.00001, 0.00001);
+        cv::Mat DE(1, 4, CV_64F);
+        theRNG().fill(DE, cv::RNG::UNIFORM, -0.00001, 0.00001);
 
         /* Distort -> Undistort */
         cv::Mat distortedPoints;
-        cv::fisheye::distortPoints(points0, distortedPoints, K, D);
+        cv::fisheye::distortPoints(points0, distortedPoints, K, DE);
         cv::Mat undistortedPoints;
-        cv::fisheye::undistortPoints(distortedPoints, undistortedPoints, K, D);
+        cv::fisheye::undistortPoints(distortedPoints, undistortedPoints, K, DE);
 
         EXPECT_MAT_NEAR(points0, undistortedPoints, 1e-8);
 
         /* Undistort -> Distort */
-        cv::fisheye::undistortPoints(points0, undistortedPoints, K, D);
-        cv::fisheye::distortPoints(undistortedPoints, distortedPoints, K, D);
+        cv::fisheye::undistortPoints(points0, undistortedPoints, K, DE);
+        cv::fisheye::distortPoints(undistortedPoints, distortedPoints, K, DE);
 
         EXPECT_MAT_NEAR(points0, distortedPoints, 1e-8);
     }


### PR DESCRIPTION
This PR fixes a warning of a shadow variable during the build.

The log:
```
[1920/3209] Building CXX object modules/calib/CMakeFiles/opencv_test_calib.dir/test/test_fisheye.cpp.o
/home/ci/opencv/modules/calib/test/test_fisheye.cpp: In member function 'virtual void opencv_test::{anonymous}::fisheyeTest_distortUndistortPoints_Test::Body()':
/home/ci/opencv/modules/calib/test/test_fisheye.cpp:134:18: warning: declaration of 'D' shadows a member of 'opencv_test::{anonymous}::fisheyeTest_distortUndistortPoints_Test' [-Wshadow]
  134 |         cv::Mat D(1, 4, CV_64F);
      |                  ^
/home/ci/opencv/modules/calib/test/test_fisheye.cpp:55:28: note: shadowed declaration is here
   55 |     const static cv::Vec4d D;
      |       
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
