### PR TITLE
Linux ARM64 rename ubuntu version on 5.x

### DIFF
--- a/.github/workflows/PR-5.x.yaml
+++ b/.github/workflows/PR-5.x.yaml
@@ -6,7 +6,7 @@ on:
       - 5.x
 
 jobs:
-  Ubuntu1804-ARM64:
+  Ubuntu2004-ARM64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-5.x-ARM64.yaml@main
 
   Ubuntu2004-x64:


### PR DESCRIPTION
Renaming in case of ubuntu 20.04 is in use ([dockerfile](https://github.com/opencv-infrastructure/opencv-gha-dockerfile/blob/main/ubuntu-github-actions-arm64--20.04/Dockerfile#L4)).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
