### PR TITLE
Fixed an issue with a recursion of cv2 in python

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -40,7 +40,7 @@ def bootstrap():
     BINARIES_PATHS = []
 
     g_vars = globals()
-    l_vars = locals()
+    l_vars = locals().copy()
 
     if sys.version_info[:2] < (3, 0):
         from . load_config_py2 import exec_file_wrapper


### PR DESCRIPTION
This PR fixes an issue https://github.com/opencv/opencv-python/issues/689 as @impact27 suggested.

Python docs said ([link](https://docs.python.org/3/library/functions.html#locals)): 
> The contents of this dictionary should not be modified; changes may not affect the values of local and free variables used by the interpreter.

### Actual behavior

`ImportError: ERROR: recursion is detected during loading of "cv2" binary extensions.`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
