### PR TITLE
Disabled compiling warnings in case of symbols in cmake for 3.4

### DIFF
--- a/3rdparty/openexr/CMakeLists.txt
+++ b/3rdparty/openexr/CMakeLists.txt
@@ -123,6 +123,7 @@ ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4334) # vs2005 Win64
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4244) # vs2008
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4267) # vs2008 Win64
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4456) # vs2015
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4819) # vs2019 Win64
 
 if(MSVC AND CV_ICC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qrestrict")

--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -426,6 +426,7 @@ if(MSVC)
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4275) # non dll-interface class 'std::exception' used as base for dll-interface class 'cv::Exception'
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4512) # Assignment operator could not be generated
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4589) # Constructor of abstract class 'cv::ORB' ignores initializer for virtual base class 'cv::Algorithm'
+    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4819) # Symbols like delta or epsilon cannot be represented
   endif()
 
   if(CV_ICC AND NOT ENABLE_NOISY_WARNINGS)

--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -488,8 +488,16 @@ public:
     //! Allocates a new GpuMat of given size and type.
     GpuMat getBuffer(int rows, int cols, int type);
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     //! Allocates a new GpuMat of given size and type.
     GpuMat getBuffer(Size size, int type) { return getBuffer(size.height, size.width, type); }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
     //! Returns the allocator associated with the stream.
     Ptr<GpuMat::Allocator> getAllocator() const { return allocator_; }

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -75,6 +75,11 @@ GpuMat::GpuMat(Size size_, int type_, Allocator* allocator_)
         create(size_.height, size_.width, type_);
 }
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 GpuMat::GpuMat(int rows_, int cols_, int type_, Scalar s_, Allocator* allocator_)
     : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), allocator(allocator_)
@@ -96,6 +101,9 @@ GpuMat::GpuMat(Size size_, int type_, Scalar s_, Allocator* allocator_)
         setTo(s_);
     }
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 inline
 GpuMat::GpuMat(const GpuMat& m)
@@ -158,11 +166,19 @@ GpuMat GpuMat::clone() const
     return m;
 }
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 void GpuMat::copyTo(OutputArray dst, InputArray mask) const
 {
     copyTo(dst, mask, Stream::Null());
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 inline
 GpuMat& GpuMat::setTo(Scalar s)
@@ -176,6 +192,11 @@ GpuMat& GpuMat::setTo(Scalar s, InputArray mask)
     return setTo(s, mask, Stream::Null());
 }
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 void GpuMat::convertTo(OutputArray dst, int rtype) const
 {
@@ -187,6 +208,9 @@ void GpuMat::convertTo(OutputArray dst, int rtype, double alpha, double beta) co
 {
     convertTo(dst, rtype, alpha, beta, Stream::Null());
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 inline
 void GpuMat::convertTo(OutputArray dst, int rtype, double alpha, Stream& stream) const
@@ -554,6 +578,11 @@ Event::Event(const Ptr<Impl>& impl)
 // Initialization & Info
 //===================================================================================
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 bool TargetArchs::has(int major, int minor)
 {
@@ -571,6 +600,9 @@ DeviceInfo::DeviceInfo()
 {
     device_id_ = getDevice();
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 inline
 DeviceInfo::DeviceInfo(int device_id)
@@ -579,6 +611,11 @@ DeviceInfo::DeviceInfo(int device_id)
     device_id_ = device_id;
 }
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 int DeviceInfo::deviceID() const
 {
@@ -607,6 +644,9 @@ bool DeviceInfo::supports(FeatureSet feature_set) const
     int version = majorVersion() * 10 + minorVersion();
     return version >= feature_set;
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 
 }} // namespace cv { namespace cuda {

--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -681,11 +681,19 @@ Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp 
     for(int i = 16; i < channels; i++) val[i] = _Tp(0);
 }
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>::Matx(const _Tp* values)
 {
     for( int i = 0; i < channels; i++ ) val[i] = values[i];
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 #ifdef CV_CXX11
 template<typename _Tp, int m, int n> inline

--- a/modules/core/include/opencv2/core/opengl.hpp
+++ b/modules/core/include/opencv2/core/opengl.hpp
@@ -703,10 +703,18 @@ cv::ogl::Texture2D::Format cv::ogl::Texture2D::format() const
 
 ///////
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
 inline
 cv::ogl::Arrays::Arrays() : size_(0)
 {
 }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
 inline
 int cv::ogl::Arrays::size() const

--- a/modules/core/include/opencv2/core/utils/filesystem.private.hpp
+++ b/modules/core/include/opencv2/core/utils/filesystem.private.hpp
@@ -36,7 +36,7 @@ namespace cv { namespace utils { namespace fs {
  * Provides interprocess synchronization mechanism.
  * Platform dependent.
  *
- * Supports multiple readers / single writer access pattern (RW / readers–writer / shared-exclusive lock).
+ * Supports multiple readers / single writer access pattern (RW / readers-writer / shared-exclusive lock).
  *
  * File must exist.
  * File can't be re-used (for example, I/O operations via std::fstream is not safe)

--- a/modules/features2d/src/affine_feature.cpp
+++ b/modules/features2d/src/affine_feature.cpp
@@ -41,7 +41,7 @@
 
 /*
  Guoshen Yu, Jean-Michel Morel, ASIFT: An Algorithm for Fully Affine
- Invariant Comparison,  Image Processing On Line, 1 (2011), pp. 11–38.
+ Invariant Comparison,  Image Processing On Line, 1 (2011), pp. 11-38.
  https://doi.org/10.5201/ipol.2011.my-asift
  */
 

--- a/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
@@ -472,6 +472,11 @@ class CV_EXPORTS PlaneWarperGpu : public PlaneWarper
 public:
     PlaneWarperGpu(float scale = 1.f) : PlaneWarper(scale) {}
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     Rect buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap) CV_OVERRIDE
     {
         Rect result = buildMaps(src_size, K, R, d_xmap_, d_ymap_);
@@ -505,6 +510,9 @@ public:
         d_dst_.download(dst);
         return result;
     }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
     Rect buildMaps(Size src_size, InputArray K, InputArray R, cuda::GpuMat & xmap, cuda::GpuMat & ymap);
 
@@ -526,6 +534,11 @@ class CV_EXPORTS SphericalWarperGpu : public SphericalWarper
 public:
     SphericalWarperGpu(float scale) : SphericalWarper(scale) {}
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     Rect buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap) CV_OVERRIDE
     {
         Rect result = buildMaps(src_size, K, R, d_xmap_, d_ymap_);
@@ -542,6 +555,9 @@ public:
         d_dst_.download(dst);
         return result;
     }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
     Rect buildMaps(Size src_size, InputArray K, InputArray R, cuda::GpuMat & xmap, cuda::GpuMat & ymap);
 
@@ -558,6 +574,11 @@ class CV_EXPORTS CylindricalWarperGpu : public CylindricalWarper
 public:
     CylindricalWarperGpu(float scale) : CylindricalWarper(scale) {}
 
+// WARNING: unreachable code using Ninja
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     Rect buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap) CV_OVERRIDE
     {
         Rect result = buildMaps(src_size, K, R, d_xmap_, d_ymap_);
@@ -574,6 +595,9 @@ public:
         d_dst_.download(dst);
         return result;
     }
+#if defined _MSC_VER && _MSC_VER >= 1920
+#pragma warning(pop)
+#endif
 
     Rect buildMaps(Size src_size, InputArray K, InputArray R, cuda::GpuMat & xmap, cuda::GpuMat & ymap);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Win64
build_image:Custom Win=msvs2019
```