### PR TITLE
[GSoC] Fix compilation errors and warnings when using MSVC on Windows.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -714,7 +714,7 @@ namespace CV__SIMD_NAMESPACE {
         return a - b; \
     } \
     template<typename... Args> \
-    inline _Tpvec v_add(_Tpvec f1, _Tpvec f2, Args... vf) { \
+    inline _Tpvec v_add(const _Tpvec& f1, const _Tpvec& f2, const Args&... vf) { \
         return v_add(f1 + f2, vf...); \
     }
 
@@ -765,7 +765,7 @@ namespace CV__SIMD_NAMESPACE {
         return a * b; \
     } \
     template<typename... Args> \
-    inline _Tpvec v_mul(_Tpvec f1, _Tpvec f2, Args... vf) { \
+    inline _Tpvec v_mul(const _Tpvec& f1, const _Tpvec& f2, const Args&... vf) { \
         return v_mul(f1 * f2, vf...); \
     }
     OPENCV_HAL_WRAP_BIN_OP_MUL(v_uint8)
@@ -820,7 +820,7 @@ namespace CV__SIMD_NAMESPACE {
 
     //////////// get0 ////////////
     #define OPENCV_HAL_WRAP_GRT0_INT(_Tpvec, _Tp) \
-    inline _Tp v_get0(v_##_Tpvec v) \
+    inline _Tp v_get0(const v_##_Tpvec& v) \
     { \
         return v.get0(); \
     }
@@ -839,7 +839,7 @@ namespace CV__SIMD_NAMESPACE {
     #endif
 
     #define OPENCV_HAL_WRAP_EXTRACT(_Tpvec, _Tp, vl) \
-    inline _Tp v_extract_highest(_Tpvec v) \
+    inline _Tp v_extract_highest(const _Tpvec& v) \
     { \
         return v_extract_n<vl-1>(v); \
     }
@@ -858,7 +858,7 @@ namespace CV__SIMD_NAMESPACE {
     #endif
 
     #define OPENCV_HAL_WRAP_BROADCAST(_Tpvec) \
-    inline _Tpvec v_broadcast_highest(_Tpvec v) \
+    inline _Tpvec v_broadcast_highest(const _Tpvec& v) \
     { \
         return v_broadcast_element<VTraits<_Tpvec>::nlanes-1>(v); \
     }
@@ -868,7 +868,7 @@ namespace CV__SIMD_NAMESPACE {
     OPENCV_HAL_WRAP_BROADCAST(v_float32)
 
 
-#endif //CV_SIMD
+#endif //!CV_SIMD_SCALABLE
 
 //! @cond IGNORED
 

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -123,7 +123,7 @@ struct VTraits<v_float64>
 
 //////////// get0 ////////////
 #define OPENCV_HAL_IMPL_RVV_GRT0_INT(_Tpvec, _Tp) \
-inline _Tp v_get0(v_##_Tpvec v) \
+inline _Tp v_get0(const v_##_Tpvec& v) \
 { \
     return vmv_x(v); \
 }
@@ -137,12 +137,12 @@ OPENCV_HAL_IMPL_RVV_GRT0_INT(int32, int)
 OPENCV_HAL_IMPL_RVV_GRT0_INT(uint64, uint64)
 OPENCV_HAL_IMPL_RVV_GRT0_INT(int64, int64)
 
-inline float v_get0(v_float32 v) \
+inline float v_get0(const v_float32& v) \
 { \
     return vfmv_f(v); \
 }
 #if CV_SIMD_SCALABLE_64F
-inline double v_get0(v_float64 v) \
+inline double v_get0(const v_float64& v) \
 { \
     return vfmv_f(v); \
 }

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -1004,7 +1004,7 @@ template<typename R> struct TheTest
     TheTest & test_reduce()
     {
         Data<R> dataA;
-        LaneType min = VTraits<R>::vlanes(), max = 0;
+        LaneType min = (LaneType)VTraits<R>::vlanes(), max = 0;
         int sum = 0;
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
         {
@@ -1016,9 +1016,9 @@ template<typename R> struct TheTest
         EXPECT_EQ((LaneType)min, (LaneType)v_reduce_min(a));
         EXPECT_EQ((LaneType)max, (LaneType)v_reduce_max(a));
         EXPECT_EQ((int)(sum), (int)v_reduce_sum(a));
-        dataA[0] += VTraits<R>::vlanes();
+        dataA[0] += (LaneType)VTraits<R>::vlanes();
         R an = dataA;
-        min = VTraits<R>::vlanes();
+        min = (LaneType)VTraits<R>::vlanes();
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
         {
             min = std::min<LaneType>(min, dataA[i]);
@@ -1029,7 +1029,7 @@ template<typename R> struct TheTest
 
     TheTest & test_reduce_sad()
     {
-        Data<R> dataA, dataB(VTraits<R>::vlanes()/2);
+        Data<R> dataA, dataB((LaneType)VTraits<R>::vlanes() /2);
         R a = dataA;
         R b = dataB;
         uint sum = 0;


### PR DESCRIPTION
Related PR: #22278  

According to the build issues on [Win64](https://pullrequest.opencv.org/buildbot/builders/precommit_windows64/builds/100064/steps/compile%20release/logs/warnings%20%28210%29) and [Win32](https://pullrequest.opencv.org/buildbot/builders/precommit_windows32/builds/100053/steps/compile%20release/logs/stdio), I have already modify the code. But since I do not have a device with Windows and MVCS 15, please let the build bot compile the code for further verification.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Win64,win32,Custom Win
build_image:Custom Win=msvs2019
```