### PR TITLE
core: remove unnecessary pointer cleanup in BufferArea

### DIFF
--- a/modules/core/src/buffer_area.cpp
+++ b/modules/core/src/buffer_area.cpp
@@ -29,8 +29,7 @@ public:
     }
     void cleanup() const
     {
-        CV_Assert(ptr && *ptr);
-        *ptr = 0;
+        CV_DbgAssert(ptr);
         if (raw_mem)
             fastFree(raw_mem);
     }

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -403,9 +403,6 @@ TEST_P(BufferArea, basic)
             EXPECT_EQ((double)0, dbl_ptr[i]);
         }
     }
-    EXPECT_TRUE(int_ptr == NULL);
-    EXPECT_TRUE(uchar_ptr == NULL);
-    EXPECT_TRUE(dbl_ptr == NULL);
 }
 
 TEST_P(BufferArea, align)
@@ -441,10 +438,6 @@ TEST_P(BufferArea, align)
                     << " (element size: " << sizeof(T) << ")";
             }
         }
-    }
-    for (size_t i = 0; i < CNT; ++i)
-    {
-        EXPECT_TRUE(buffers[i] == NULL);
     }
 }
 


### PR DESCRIPTION
resolves #22291

In some cases original pointers can go out of scope. We didn't really need to zero them.

I decided to leave `DbgAssert` for `ptr`, because it can _theoretically_ help to debug some issues.