### PR TITLE
imgproc: fixup leftovers of int->int64_t conversion

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1040,7 +1040,7 @@ EllipseEx( Mat& img, Point2l center, Size2l axes,
 *                                Polygons filling                                        *
 \****************************************************************************************/
 
-static inline void ICV_HLINE_X(uchar* ptr, int xl, int xr, const uchar* color, int pix_size)
+static inline void ICV_HLINE_X(uchar* ptr, int64_t xl, int64_t xr, const uchar* color, int pix_size)
 {
     uchar* hline_min_ptr = (uchar*)(ptr) + (xl)*(pix_size);
     uchar* hline_end_ptr = (uchar*)(ptr) + (xr+1)*(pix_size);
@@ -1065,7 +1065,7 @@ static inline void ICV_HLINE_X(uchar* ptr, int xl, int xr, const uchar* color, i
 }
 //end ICV_HLINE_X()
 
-static inline void ICV_HLINE(uchar* ptr, int xl, int xr, const void* color, int pix_size)
+static inline void ICV_HLINE(uchar* ptr, int64_t xl, int64_t xr, const void* color, int pix_size)
 {
   ICV_HLINE_X(ptr, xl, xr, reinterpret_cast<const uchar*>(color), pix_size);
 }


### PR DESCRIPTION
fixup #22153 

/cc @vpisarev @vrabaud 


> C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1491): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1492): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1507): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1508): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1531): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1546): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1569): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]
C:\build\3_4-win64-vc14\opencv\modules\imgproc\src\drawing.cpp(1584): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [C:\build\3_4-win64-vc14\build\modules\imgproc\opencv_imgproc.vcxproj]

```
force_builders=Win64
```