### PR TITLE
change subpixel coordinates of chessboard corners

### DIFF
--- a/modules/calib/src/calibinit.cpp
+++ b/modules/calib/src/calibinit.cpp
@@ -677,6 +677,10 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
         }
         cornerSubPix(img, out_corners, Size(2, 2), Size(-1,-1),
                          TermCriteria(TermCriteria::EPS + TermCriteria::MAX_ITER, 15, 0.1));
+        for(auto& c: out_corners)
+        {
+            c = c + Point2f(0.5, 0.5);
+        }
     }
 
     Mat(out_corners).copyTo(corners_);

--- a/modules/calib/src/chessboard.cpp
+++ b/modules/calib/src/chessboard.cpp
@@ -3917,6 +3917,10 @@ bool cv::findChessboardCornersSB(InputArray image_, Size pattern_size,
     }
     std::vector<cv::Point2f> points;
     KeyPoint::convert(corners,points);
+    for(auto& c: points)
+    {
+        c = c + Point2f(0.5, 0.5);
+    }
     Mat(points).copyTo(corners_);
 
     // export meta data


### PR DESCRIPTION
`findChessBoardCorners` and `findChessBoardCornersSB` assume that the
top left corner of the top left pixel has the coordinates (-0.5, -0.5).
This is uncommen in rendering and does not conform with `projectPoints`.
This commit changes the returned corner coordinates such, that they can
be directly used to calculate a pose with solvePnP and render with that.

For further analysis, see #22288 .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
