### PR TITLE
DNN: add another two Mish activation to onnx_graph_simplifier

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -531,6 +531,38 @@ public:
     }
 };
 
+class MishSubgraph2 : public Subgraph
+{
+public:
+    MishSubgraph2()
+    {
+        int input = addNodeToMatch("");
+        int exp = addNodeToMatch("Exp", input);
+        int addVal = addNodeToMatch("");
+        int add = addNodeToMatch("Add", addVal, exp);
+        int log = addNodeToMatch("Log", add);
+        int tanh = addNodeToMatch("Tanh", log);
+        addNodeToMatch("Mul", input, tanh);
+        setFusedNode("Mish", input);
+    }
+};
+
+class MishSubgraph3 : public Subgraph
+{
+public:
+    MishSubgraph3()
+    {
+        int input = addNodeToMatch("");
+        int exp = addNodeToMatch("Exp", input);
+        int addVal = addNodeToMatch("");
+        int add = addNodeToMatch("Add", exp, addVal);
+        int log = addNodeToMatch("Log", add);
+        int tanh = addNodeToMatch("Tanh", log);
+        addNodeToMatch("Mul", input, tanh);
+        setFusedNode("Mish", input);
+    }
+};
+
 class MulCastSubgraph : public Subgraph
 {
 public:
@@ -735,6 +767,8 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<BatchNormalizationSubgraph2>());
     subgraphs.push_back(makePtr<ExpandSubgraph>());
     subgraphs.push_back(makePtr<MishSubgraph>());
+    subgraphs.push_back(makePtr<MishSubgraph2>());
+    subgraphs.push_back(makePtr<MishSubgraph3>());
     subgraphs.push_back(makePtr<NormalizeSubgraph4>());
     subgraphs.push_back(makePtr<NormalizeSubgraph5>());
 

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -531,35 +531,32 @@ public:
     }
 };
 
-class MishSubgraph2 : public Subgraph
+// softplus(x) = log(exp(x) + 1)
+class SoftplusSubgraph: public Subgraph
 {
 public:
-    MishSubgraph2()
+    SoftplusSubgraph()
     {
         int input = addNodeToMatch("");
         int exp = addNodeToMatch("Exp", input);
         int addVal = addNodeToMatch("");
         int add = addNodeToMatch("Add", addVal, exp);
-        int log = addNodeToMatch("Log", add);
-        int tanh = addNodeToMatch("Tanh", log);
-        addNodeToMatch("Mul", input, tanh);
-        setFusedNode("Mish", input);
+        addNodeToMatch("Log", add);
+        setFusedNode("Softplus", input);
     }
 };
 
-class MishSubgraph3 : public Subgraph
+class SoftplusSubgraph2: public Subgraph
 {
 public:
-    MishSubgraph3()
+    SoftplusSubgraph2()
     {
         int input = addNodeToMatch("");
         int exp = addNodeToMatch("Exp", input);
         int addVal = addNodeToMatch("");
         int add = addNodeToMatch("Add", exp, addVal);
-        int log = addNodeToMatch("Log", add);
-        int tanh = addNodeToMatch("Tanh", log);
-        addNodeToMatch("Mul", input, tanh);
-        setFusedNode("Mish", input);
+        addNodeToMatch("Log", add);
+        setFusedNode("Softplus", input);
     }
 };
 
@@ -766,9 +763,9 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<BatchNormalizationSubgraph1>());
     subgraphs.push_back(makePtr<BatchNormalizationSubgraph2>());
     subgraphs.push_back(makePtr<ExpandSubgraph>());
+    subgraphs.push_back(makePtr<SoftplusSubgraph>());
+    subgraphs.push_back(makePtr<SoftplusSubgraph2>());
     subgraphs.push_back(makePtr<MishSubgraph>());
-    subgraphs.push_back(makePtr<MishSubgraph2>());
-    subgraphs.push_back(makePtr<MishSubgraph3>());
     subgraphs.push_back(makePtr<NormalizeSubgraph4>());
     subgraphs.push_back(makePtr<NormalizeSubgraph5>());
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1325,6 +1325,7 @@ TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
 TEST_P(Test_ONNX_layers, Mish)
 {
     testONNXModels("mish");
+    testONNXModels("mish_no_softplus");
 }
 
 TEST_P(Test_ONNX_layers, CalculatePads)


### PR DESCRIPTION
## Speed test on YoloV4

| Test in YoloV4 with M1 chip |  |  |
| --------------------------- | -- | -- |
|                             | Befor Patch optimize | With Patch optimize |
| Time                        | 364 ms | **304 ms (17% faster)**  |

The Mish layer can be generated by two different implementations:
```py
# PyTorch code 1: (We have supported in OpenCV.)
x * (torch.tanh(F.softplus(x)))

# PyTorch code 2: (Proposed: We do not support.)
x * (torch.tanh(torch.log(torch.exp(x) + 1)))
```

In order to make [YoloV4](https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/yolov4) run faster on OpenCV, Mish's graph fusion optimization is essential.

For now, the original [YoloV4 in ONNX's model_zoo](https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/yolov4) cannot be loaded correctly by OpenCV, because original YoloV4 has very complicated struct and the input is dynamic shape.

So I convert it to a suitable format by following python code:
```py
import onnx
import onnxsim
import numpy as np

input_model = "yolov4.onnx"
output_model = "yolov4_sim.onnx"
onnx_model = onnx.load(input_model)
input_shape = np.array([1, 416, 416, 3])
input = dict()
input["input_1:0"] = input_shape
out = onnxsim.simplify(onnx_model, dynamic_input_shape=False, input_shapes=input)
onnx.save(out[0], output_model)
```
And the converted model can be found at this [google drive](https://drive.google.com/file/d/1WBZO-YCqYTO73j8w_soMPD3ljp8fAD_-/view?usp=sharing).

[Test case in OpenCV_extra](https://github.com/opencv/opencv_extra/pull/990).


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
