### PR TITLE
Fix compilation error on CentOS 7 (gcc 4.8)

### DIFF
--- a/modules/videoio/src/cap_obsensor/obsensor_stream_channel_v4l2.cpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_stream_channel_v4l2.cpp
@@ -153,7 +153,8 @@ std::vector<UvcDeviceInfo> V4L2Context::queryUvcDeviceInfoList()
                 }
                 std::istringstream(modalias.substr(5, 4)) >> std::hex >> uvcDev.vid;
                 std::istringstream(modalias.substr(10, 4)) >> std::hex >> uvcDev.pid;
-                std::getline(std::ifstream(video + "/device/interface"), uvcDev.name);
+                std::ifstream iface(video + "/device/interface");
+                std::getline(iface, uvcDev.name);
                 std::ifstream(video + "/device/bInterfaceNumber") >> uvcDev.mi;
                 uvcDevMap.insert({ interfaceRealPath, uvcDev });
             }


### PR DESCRIPTION
libstdc++ that comes with gcc 4.8 doesn't
define `getline(basic_istream<char>&&, std::string&)`
even if it's part of the c++11 standard.
However we can still use the following:
`getline(basic_istream<char>&, std::string&)`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
