### PR TITLE
Fix bug in ObjC/Swift Quicklook function

### DIFF
--- a/modules/imgcodecs/misc/objc/ios/Mat+QuickLook.mm
+++ b/modules/imgcodecs/misc/objc/ios/Mat+QuickLook.mm
@@ -62,7 +62,7 @@ typedef UIFont* (*FontGetter)();
 }
 
 - (id)debugQuickLookObject {
-    if ([self dims] == 2 && [self rows] <= 10 && [self cols] <= 10) {
+    if ([self dims] == 2 && [self rows] <= 10 && [self cols] <= 10 && [self channels] == 1) {
         FontGetter fontGetters[] = { getCMU, getBodoni72, getAnySerif, getSystemFont };
         UIFont* font = nil;
         for (int fontGetterIndex = 0; font==nil && fontGetterIndex < (sizeof(fontGetters)) / (sizeof(fontGetters[0])); fontGetterIndex++) {

--- a/modules/imgcodecs/misc/objc/macosx/Mat+QuickLook.mm
+++ b/modules/imgcodecs/misc/objc/macosx/Mat+QuickLook.mm
@@ -58,7 +58,7 @@ typedef NSFont* (*FontGetter)();
 
 - (id)debugQuickLookObject {
     // for smallish Mat objects display as a matrix
-    if ([self dims] == 2 && [self rows] <= 10 && [self cols] <= 10) {
+    if ([self dims] == 2 && [self rows] <= 10 && [self cols] <= 10 && [self channels] == 1) {
         FontGetter fontGetters[] = { getCMU, getBodoni72, getAnySerif, getSystemFont };
         NSFont* font = nil;
         for (int fontGetterIndex = 0; font==nil && fontGetterIndex < (sizeof(fontGetters)) / (sizeof(fontGetters[0])); fontGetterIndex++) {


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

Bugfix (Objc Bindings):
For a Mat with 10 or less rows and 10 or less columns and more than one channel - Quicklook fails like this:
<img width="597" alt="スクリーンショット 2022-07-31 20 58 30" src="https://user-images.githubusercontent.com/5875290/182049833-bef243ad-8740-42b5-8bfe-6c00d9716a65.png">

This PR fixes the problem by adding a check that the number of channels is 1 before trying to draw a matrix style Quicklook

