### PR TITLE
DNN: load fp16 ONNX model as fp32

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -18,17 +18,6 @@ CV__DNN_INLINE_NS_BEGIN
 
 extern bool DNN_DIAGNOSTICS_RUN;
 
-static int isLittleEndianCPU()
-{
-    int x = 7;
-    char *ptr = (char *)&x;
-
-    if(ptr[0] == 0)
-        return 0;
-    else
-        return 1;
-}
-
 // This wrapper can behave differently for fake input nodes and real graph nodes.
 class ONNXNodeWrapper : public ImportNodeWrapper
 {
@@ -787,7 +776,10 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
         // Link: https://github.com/onnx/onnx/issues/4460#issuecomment-1224373746
         if (!tensor_proto.int32_data().empty())
         {
-            const int offset = isLittleEndianCPU() ? 0 : 1;
+            int offset = 0;
+#ifdef WORDS_BIGENDIAN
+            offset = 1;
+#endif
             const ::google::protobuf::RepeatedField<int32_t> field = tensor_proto.int32_data();
 
             AutoBuffer<float16_t, 16> aligned_val;

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -18,6 +18,17 @@ CV__DNN_INLINE_NS_BEGIN
 
 extern bool DNN_DIAGNOSTICS_RUN;
 
+static int isLittleEndianCPU()
+{
+    int x = 7;
+    char *ptr = (char *)&x;
+
+    if(ptr[0] == 0)
+        return 0;
+    else
+        return 1;
+}
+
 // This wrapper can behave differently for fake input nodes and real graph nodes.
 class ONNXNodeWrapper : public ImportNodeWrapper
 {
@@ -767,11 +778,64 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
             Mat(sizes, CV_32FC1, val).copyTo(blob);
         }
     }
+    else if (datatype == opencv_onnx::TensorProto_DataType_FLOAT16)
+    {
+        // FIXME, for now, we only load FP16 Tensor as FP32 Mat, full support for FP16 is required in the future.
+        CV_LOG_ONCE_WARNING(NULL, "DNN: load FP16 model as FP32 model, and it takes twice the FP16 RAM requirement.");
+
+        // ONNX saves float 16 data in two format: int32 and raw_data.
+        // Link: https://github.com/onnx/onnx/issues/4460#issuecomment-1224373746
+        if (!tensor_proto.int32_data().empty())
+        {
+            const int offset = isLittleEndianCPU() ? 0 : 1;
+            const ::google::protobuf::RepeatedField<int32_t> field = tensor_proto.int32_data();
+
+            AutoBuffer<float16_t, 16> aligned_val;
+            size_t sz = tensor_proto.int32_data().size();
+            aligned_val.allocate(sz);
+            float16_t* bufPtr = aligned_val.data();
+
+            float16_t *fp16Ptr = (float16_t *)field.data();
+            for (int i = 0; i < sz; i++)
+            {
+                bufPtr[i] = fp16Ptr[i*2 + offset];
+            }
+            Mat(sizes, CV_16FC1, bufPtr).convertTo(blob, CV_32FC1);
+        }
+        else
+        {
+            char* val = const_cast<char*>(tensor_proto.raw_data().c_str());
+#if CV_STRONG_ALIGNMENT
+            // Aligned pointer is required.
+            AutoBuffer<float16_t, 16> aligned_val;
+            if (!isAligned<sizeof(float16_t)>(val))
+            {
+                size_t sz = tensor_proto.raw_data().size();
+                aligned_val.allocate(divUp(sz, sizeof(float16_t)));
+                memcpy(aligned_val.data(), val, sz);
+                val = (char*)aligned_val.data();
+            }
+#endif
+            Mat(sizes, CV_16FC1, val).convertTo(blob, CV_32FC1);
+        }
+    }
     else if (datatype == opencv_onnx::TensorProto_DataType_DOUBLE)
     {
         const ::google::protobuf::RepeatedField<double> field = tensor_proto.double_data();
         CV_Assert(!field.empty());
-        Mat(sizes, CV_64FC1, (void*)field.data()).convertTo(blob, CV_32FC1);
+        char* val = (char *)field.data();
+#if CV_STRONG_ALIGNMENT
+        // Aligned pointer is required.
+        AutoBuffer<double, 16> aligned_val;
+        if (!isAligned<sizeof(double)>(val))
+        {
+            size_t sz = tensor_proto.raw_data().size();
+            aligned_val.allocate(divUp(sz, sizeof(double)));
+            memcpy(aligned_val.data(), val, sz);
+            val = (char*)aligned_val.data();
+        }
+#endif
+        Mat(sizes, CV_64FC1, val).convertTo(blob, CV_32FC1);
     }
     else if (datatype == opencv_onnx::TensorProto_DataType_INT32)
     {

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2098,6 +2098,11 @@ TEST_P(Test_ONNX_nets, MobileNet_v2)
     testONNXModels("mobilenetv2", pb, default_l1, default_lInf, true);
 }
 
+TEST_P(Test_ONNX_nets, MobileNet_v2_FP16)
+{
+    testONNXModels("mobilenetv2_fp16", npy, default_l1, default_lInf, true);
+}
+
 TEST_P(Test_ONNX_nets, LResNet100E_IR)
 {
     applyTestTag(


### PR DESCRIPTION
[Related extra data](https://github.com/opencv/opencv_extra/pull/993)
[Download link](https://github.com/zihaomu/zihaomu/files/9393786/mobilenetv2_fp16_v7.tar.gz)

The FP16 model is half the size of the FP32 model, which will be edge device friendly.
Currently, OpenCV `ONNX_importer` cannot load FP16 models correctly and DNN also doesn't have full FP16 backend support.
So, my idea is that in the first step we make OpenCV DNN load FP16 ONNX model as FP32 model, and every layer will be computed as FP32.

Here is a [FP16 text recognition model(CRNN)](https://github.com/opencv/opencv_zoo/pull/79) which was converted by my GSoC student Yiyao @Charles-258, and we found it even has better accuracy performance than the original FP32 model.
And I have tested these FP16 CRNN models in the existing High-Level API, `testTextRecognitionModel`, and it works well. Maybe we can use this to replace the original FP32 model.

### How to convert ONNX fP32 model to FP16 model?
```py
from onnx import load_model, save_model
from onnxmltools.utils import float16_converter

dir = "MODEL_DIR_PATH"
onnx_model = load_model(os.path.join(dir, "resnet50v1.onnx"))
trans_model = float16_converter.convert_float_to_float16(onnx_model, keep_io_types=False)
save_model(trans_model, os.path.join(dir, "resnet50v1_FP16.onnx"))

```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
