### PR TITLE
Fix in obsensor for VS 14

### DIFF
--- a/modules/videoio/src/cap_obsensor/obsensor_stream_channel_msmf.cpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_stream_channel_msmf.cpp
@@ -195,7 +195,7 @@ std::vector<UvcDeviceInfo> MFContext::queryUvcDeviceInfoList()
         std::string uid, guid;
         if (!parseUvcDeviceSymbolicLink(symbolicLink, vid, pid, mi, uid, guid))
             continue;
-        uvcDevList.emplace_back(UvcDeviceInfo({ symbolicLink, name, uid, vid, pid, mi }));
+        uvcDevList.emplace_back(UvcDeviceInfo{ symbolicLink, name, uid, vid, pid, mi });
         CV_LOG_INFO(NULL, "UVC device found: name=" << name << ", vid=" << vid << ", pid=" << pid << ", mi=" << mi << ", uid=" << uid << ", guid=" << guid);
     }
     return uvcDevList;

--- a/modules/videoio/src/cap_obsensor/obsensor_stream_channel_v4l2.cpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_stream_channel_v4l2.cpp
@@ -101,7 +101,7 @@ std::vector<UvcDeviceInfo> V4L2Context::queryUvcDeviceInfoList()
         cv::utils::fs::glob(videosDir, "*", videos, false, true);
         for (const auto& video : videos)
         {
-            UvcDeviceInfo uvcDev;
+            UvcDeviceInfo uvcDev{};
             cv::String videoName = video.substr(video.find_last_of("/") + 1);
             char buf[PATH_MAX];
             if (realpath(video.c_str(), buf) == nullptr || cv::String(buf).find("virtual") != std::string::npos)

--- a/modules/videoio/src/cap_obsensor/obsensor_uvc_stream_channel.hpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_uvc_stream_channel.hpp
@@ -33,12 +33,12 @@ namespace obsensor {
 
 struct UvcDeviceInfo
 {
-    std::string id = ""; // uvc sub-device id
-    std::string name = "";
-    std::string uid = ""; // parent usb device id
-    uint16_t vid = 0;
-    uint16_t pid = 0;
-    uint16_t mi = 0; // uvc interface index
+    std::string id; // uvc sub-device id
+    std::string name;
+    std::string uid; // parent usb device id
+    uint16_t vid;
+    uint16_t pid;
+    uint16_t mi; // uvc interface index
 };
 
 enum StreamState


### PR DESCRIPTION
This PR fixes a build on Windows using Visual Studio 14 (it works with VS 16 somehow).

Relates to https://github.com/opencv/opencv/pull/22196

Pipelines before changes:
- [VS-16](https://github.com/asenyaev/ci-gha-workflow/runs/7642171973?check_suite_focus=true) :heavy_check_mark: 
- [VS-14](https://github.com/asenyaev/ci-gha-workflow/runs/7642171912?check_suite_focus=true#step:9:1202) :heavy_multiplication_x: 

Pipelines after changes:
- [VS-16](https://github.com/asenyaev/ci-gha-workflow/runs/7648667221?check_suite_focus=true) :heavy_check_mark: 
- [VS-14](https://github.com/asenyaev/ci-gha-workflow/runs/7648667116?check_suite_focus=true) :heavy_check_mark: 

Thanks @rogday for the help!

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
