### PR TITLE
select correct MediaType in MSMF backend.

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -347,6 +347,12 @@ struct MediaType
         }
         return false;
     }
+    bool VideoIsAvailable() const
+    {
+        return ((subType == MFVideoFormat_RGB32) ||
+            (subType == MFVideoFormat_RGB24) ||
+            (subType == MFVideoFormat_YUY2));
+    }
 };
 
 void printFormat(std::ostream& out, const GUID& fmt)
@@ -627,7 +633,7 @@ public:
         {
             if (i->second.majorType == MFMediaType_Video)
             {
-                if (best.second.isEmpty() || i->second.VideoIsBetterThan(best.second, newType))
+                if (best.second.isEmpty() || (i->second.VideoIsBetterThan(best.second, newType) && i->second.VideoIsAvailable()))
                 {
                     best = *i;
                 }


### PR DESCRIPTION
There may be more than one streams in some camera device (for example RealSense D405)
some streaming setting may be not regular visualable image.
But, in MSMF backend, by default, regular visualable image is require.

This patch will skip some streaming base on the format.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
