### PR TITLE
Add confidence threshold to camera adjuster

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -368,7 +368,7 @@ def main():
         cam.R = cam.R.astype(np.float32)
 
     adjuster = BA_COST_CHOICES[args.ba]()
-    adjuster.setConfThresh(1)
+    adjuster.setConfThresh(conf_thresh)
     refine_mask = np.zeros((3, 3), np.uint8)
     if ba_refine_mask[0] == 'x':
         refine_mask[0, 0] = 1


### PR DESCRIPTION
if this is not done, adjusting will fail if there are some low confidence matches which are included by the user by lowering the conf_thresh parameter. 

see https://github.com/lukasalexanderweber/stitching/pull/19