### PR TITLE
Fixed the example in py_calib3d/py_calibration

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
+++ b/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
@@ -127,7 +127,7 @@ for fname in images:
         objpoints.append(objp)
 
         corners2 = cv.cornerSubPix(gray,corners, (11,11), (-1,-1), criteria)
-        imgpoints.append(corners)
+        imgpoints.append(corners2)
 
         # Draw and display the corners
         cv.drawChessboardCorners(img, (7,6), corners2, ret)


### PR DESCRIPTION
FIXED THE EXAMPLE UNDER HEADING Arrays to store object points and image points from all the images IN  py_calib3d/py_calibration

FOLLOWING CHANGES HAVE BEEN DONE:

corners2 = cv.cornerSubPix(gray,corners, (11,11), (-1,-1), criteria)
    imgpoints.append(corners) 
has been changed to 
    corners2 = cv.cornerSubPix(gray,corners, (11,11), (-1,-1), criteria)
    imgpoints.append(corners2) ##corrected line
