### PR TITLE
Suppress warnings in carotene on macOS ARM64 for 3.4 branch

### DIFF
--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -27,6 +27,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
     endif()
 endif()
 
+if(APPLE AND CV_CLANG AND WITH_NEON)
+    ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-unused-function -Wno-c++11-extensions)
+endif()
+
 add_library(carotene_objs OBJECT EXCLUDE_FROM_ALL
   ${carotene_headers}
   ${carotene_sources}

--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 if(APPLE AND CV_CLANG AND WITH_NEON)
-    ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-unused-function -Wno-c++11-extensions)
+    ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-unused-function)
 endif()
 
 add_library(carotene_objs OBJECT EXCLUDE_FROM_ALL

--- a/3rdparty/carotene/src/add_weighted.cpp
+++ b/3rdparty/carotene/src/add_weighted.cpp
@@ -109,9 +109,9 @@ template <> struct wAdd<s32>
         vgamma = vdupq_n_f32(_gamma + 0.5);
     }
 
-    void operator() (const typename VecTraits<s32>::vec128 & v_src0,
-                     const typename VecTraits<s32>::vec128 & v_src1,
-                     typename VecTraits<s32>::vec128 & v_dst) const
+    void operator() (const VecTraits<s32>::vec128 & v_src0,
+                     const VecTraits<s32>::vec128 & v_src1,
+                     VecTraits<s32>::vec128 & v_dst) const
     {
         float32x4_t vs1 = vcvtq_f32_s32(v_src0);
         float32x4_t vs2 = vcvtq_f32_s32(v_src1);
@@ -121,9 +121,9 @@ template <> struct wAdd<s32>
         v_dst = vcvtq_s32_f32(vs1);
     }
 
-    void operator() (const typename VecTraits<s32>::vec64 & v_src0,
-                     const typename VecTraits<s32>::vec64 & v_src1,
-                     typename VecTraits<s32>::vec64 & v_dst) const
+    void operator() (const VecTraits<s32>::vec64 & v_src0,
+                     const VecTraits<s32>::vec64 & v_src1,
+                     VecTraits<s32>::vec64 & v_dst) const
     {
         float32x2_t vs1 = vcvt_f32_s32(v_src0);
         float32x2_t vs2 = vcvt_f32_s32(v_src1);
@@ -153,9 +153,9 @@ template <> struct wAdd<u32>
         vgamma = vdupq_n_f32(_gamma + 0.5);
     }
 
-    void operator() (const typename VecTraits<u32>::vec128 & v_src0,
-                     const typename VecTraits<u32>::vec128 & v_src1,
-                     typename VecTraits<u32>::vec128 & v_dst) const
+    void operator() (const VecTraits<u32>::vec128 & v_src0,
+                     const VecTraits<u32>::vec128 & v_src1,
+                     VecTraits<u32>::vec128 & v_dst) const
     {
         float32x4_t vs1 = vcvtq_f32_u32(v_src0);
         float32x4_t vs2 = vcvtq_f32_u32(v_src1);
@@ -165,9 +165,9 @@ template <> struct wAdd<u32>
         v_dst = vcvtq_u32_f32(vs1);
     }
 
-    void operator() (const typename VecTraits<u32>::vec64 & v_src0,
-                     const typename VecTraits<u32>::vec64 & v_src1,
-                     typename VecTraits<u32>::vec64 & v_dst) const
+    void operator() (const VecTraits<u32>::vec64 & v_src0,
+                     const VecTraits<u32>::vec64 & v_src1,
+                     VecTraits<u32>::vec64 & v_dst) const
     {
         float32x2_t vs1 = vcvt_f32_u32(v_src0);
         float32x2_t vs2 = vcvt_f32_u32(v_src1);
@@ -197,17 +197,17 @@ template <> struct wAdd<f32>
         vgamma = vdupq_n_f32(_gamma + 0.5);
     }
 
-    void operator() (const typename VecTraits<f32>::vec128 & v_src0,
-                     const typename VecTraits<f32>::vec128 & v_src1,
-                     typename VecTraits<f32>::vec128 & v_dst) const
+    void operator() (const VecTraits<f32>::vec128 & v_src0,
+                     const VecTraits<f32>::vec128 & v_src1,
+                     VecTraits<f32>::vec128 & v_dst) const
     {
         float32x4_t vs1 = vmlaq_f32(vgamma, v_src0, valpha);
         v_dst = vmlaq_f32(vs1, v_src1, vbeta);
     }
 
-    void operator() (const typename VecTraits<f32>::vec64 & v_src0,
-                     const typename VecTraits<f32>::vec64 & v_src1,
-                     typename VecTraits<f32>::vec64 & v_dst) const
+    void operator() (const VecTraits<f32>::vec64 & v_src0,
+                     const VecTraits<f32>::vec64 & v_src1,
+                     VecTraits<f32>::vec64 & v_dst) const
     {
         float32x2_t vs1 = vmla_f32(vget_low(vgamma), v_src0, vget_low(valpha));
         v_dst = vmla_f32(vs1, v_src1, vget_low(vbeta));


### PR DESCRIPTION
This PR suppress warnings in 3rdparty carotene. Examples ([link](https://github.com/opencv/ci-gha-workflow/runs/7948765106?check_suite_focus=true#step:12:474)):
```
[459/1823] Building CXX object 3rdparty/carotene/hal/carotene/CMakeFiles/carotene_objs.dir/src/add_weighted.cpp.o
/Users/opencv-cn/GHA-OCV-3/_work/ci-gha-workflow/ci-gha-workflow/opencv/3rdparty/carotene/src/add_weighted.cpp:112:28: warning: 'typename' occurs outside of a template [-Wc++11-extensions]
    void operator() (const typename VecTraits<s32>::vec128 & v_src0,
                           ^~~~~~~~~
...

[473/1823] Building CXX object 3rdparty/carotene/hal/carotene/CMakeFiles/carotene_objs.dir/src/div.cpp.o
/Users/opencv-cn/GHA-OCV-3/_work/ci-gha-workflow/ci-gha-workflow/opencv/3rdparty/carotene/src/div.cpp:93:19: warning: unused function 'divSaturate<__attribute__((neon_vector_type(2))) unsigned int>' [-Wunused-function]
inline uint32x2_t divSaturate<uint32x2_t>(const uint32x2_t &v1, const uint32x2_t &v2, const float scale)

...

[489/1823] Building CXX object 3rdparty/carotene/hal/carotene/CMakeFiles/carotene_objs.dir/src/mul.cpp.o
/Users/opencv-cn/GHA-OCV-3/_work/ci-gha-workflow/ci-gha-workflow/opencv/3rdparty/carotene/src/mul.cpp:932:18: warning: unused function 'mulSaturate<__attribute__((neon_vector_type(2))) int>' [-Wunused-function]
inline int32x2_t mulSaturate<int32x2_t>(const int32x2_t &v1, const int32x2_t &v2, const float scale)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
