### PR TITLE
LevMarq log level warning fix

### DIFF
--- a/modules/3d/src/levmarq.cpp
+++ b/modules/3d/src/levmarq.cpp
@@ -343,17 +343,29 @@ LevMarq::Report detail::LevMarqBase::optimize()
     CV_LOG_DEBUG(NULL, "Finished: " << (found ? "" : "not ") << "found");
     std::string fr = "Finish reason: ";
     if (settings.checkMinGradient && smallGradient)
+    {
         CV_LOG_DEBUG(NULL, fr + "gradient max val dropped below threshold");
+    }
     if (settings.checkStepNorm && smallStep)
+    {
         CV_LOG_DEBUG(NULL, fr + "step size dropped below threshold");
+    }
     if (settings.checkRelEnergyChange && smallEnergyDelta)
+    {
         CV_LOG_DEBUG(NULL, fr + "relative energy change between iterations dropped below threshold");
+    }
     if (smallEnergy)
+    {
         CV_LOG_DEBUG(NULL, fr + "energy dropped below threshold");
+    }
     if (tooLong)
+    {
         CV_LOG_DEBUG(NULL, fr + "max number of iterations reached");
+    }
     if (bigLambda)
+    {
         CV_LOG_DEBUG(NULL, fr + "lambda has grown above the threshold, the trust region is too small");
+    }
 
     return LevMarq::Report(found, iter, oldEnergy);
 }


### PR DESCRIPTION
Fixes compilation warning caused by #22413 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
