### PR TITLE
Update op_conv.cpp

### DIFF
--- a/modules/dnn/src/vkcom/src/op_conv.cpp
+++ b/modules/dnn/src/vkcom/src/op_conv.cpp
@@ -124,13 +124,19 @@ bool OpConv::forward(std::vector<Tensor>& ins,
                      std::vector<Tensor>& blobs,
                      std::vector<Tensor>& outs)
 {
-    std::vector<int> shape = {1};
+    std::vector<int> shape = blobs[0].getShape();
     Tensor bias(0, shape);
 
     if (has_bias_)
     {
         assert(blobs.size() == 2);
         bias = blobs[1];
+    }
+    else
+    {
+        void *p = bias.map();
+        memset(p, 0, bias.size());
+        bias.unMap();
     }
 
     return forward(ins[0], blobs[0], bias, outs[0]);


### PR DESCRIPTION
Leave bias tensor uninitialized causes issues in parallel convolution kernel "conv48" which always uses bias as input.
This change proposes to pass a zero tensor if no bias is used for to latter buffer binding, no matter if kernel uses or not for safety.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
