### PR TITLE
[GSoC 2022] new imread api with named parameters and outputarray

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -82,6 +82,13 @@ enum ImreadModes {
        IMREAD_IGNORE_ORIENTATION   = 128 //!< If set, do not rotate the image according to EXIF's orientation flag.
      };
 
+enum ImreadScaleDenom {
+       IMREAD_SCALE_DENOM_1 = 1,
+       IMREAD_SCALE_DENOM_2 = 2,
+       IMREAD_SCALE_DENOM_4 = 4,
+       IMREAD_SCALE_DENOM_8 = 8
+};
+
 //! Imwrite flags
 enum ImwriteFlags {
        IMWRITE_JPEG_QUALITY        = 1,  //!< For JPEG, it can be a quality from 0 to 100 (the higher is the better). Default value is 95.
@@ -177,11 +184,13 @@ enum ImreadError {
 @param flags
 @param maxPixels
 @param maxSize
+@param scaleDenom
 */
 struct CV_EXPORTS_W_PARAMS ImreadParams {
       CV_PROP_RW int flags = IMREAD_COLOR;
       CV_PROP_RW size_t maxPixels = 0;
       CV_PROP_RW Size maxSize = {};
+      CV_PROP_RW ImreadScaleDenom scaleDenom = IMREAD_SCALE_DENOM_1;
      };
 
 //! @} imgcodecs_flags

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -179,7 +179,7 @@ enum ImreadError {
 @param maxSize
 */
 struct CV_EXPORTS_W_PARAMS ImreadParams {
-      CV_PROP_RW int flags;
+      CV_PROP_RW int flags = IMREAD_COLOR;
       CV_PROP_RW size_t maxPixels = 0;
       CV_PROP_RW Size maxSize = {};
      };

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -160,6 +160,30 @@ enum ImwritePAMFlags {
        IMWRITE_PAM_FORMAT_RGB_ALPHA       = 5
      };
 
+
+enum ImreadError {
+      IMREAD_OK = 0,
+      IMREAD_ERROR_FILE_NOT_FOUND,
+      IMREAD_ERROR_UNRECOGNIZED_FORMAT,
+      IMREAD_ERROR_SIZE_LIMIT_EXCEEDED,
+      IMREAD_ERROR_INVALID_HEADER,
+      IMREAD_ERROR_INVALID_DATA,
+     };
+
+/** @brief Additional parameters for imread2
+
+@anchor ImreadParams
+
+@param flags
+@param maxPixels
+@param maxSize
+*/
+struct CV_EXPORTS_W_PARAMS ImreadParams {
+      CV_PROP_RW int flags;
+      CV_PROP_RW size_t maxPixels = 0;
+      CV_PROP_RW Size maxSize = {};
+     };
+
 //! @} imgcodecs_flags
 
 /** @brief Loads an image from a file.
@@ -214,6 +238,61 @@ Currently, the following file formats are supported:
 @param flags Flag that can take values of cv::ImreadModes
 */
 CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
+
+
+/** @brief Loads an image from a file.
+
+@anchor imread2
+
+The function imread loads an image from the specified file and returns it. If the image cannot be
+read (because of missing file, improper permissions, unsupported or invalid format), the function
+returns an empty matrix ( Mat::data==NULL ).
+
+Currently, the following file formats are supported:
+
+-   Windows bitmaps - \*.bmp, \*.dib (always supported)
+-   JPEG files - \*.jpeg, \*.jpg, \*.jpe (see the *Note* section)
+-   JPEG 2000 files - \*.jp2 (see the *Note* section)
+-   Portable Network Graphics - \*.png (see the *Note* section)
+-   WebP - \*.webp (see the *Note* section)
+-   Portable image format - \*.pbm, \*.pgm, \*.ppm \*.pxm, \*.pnm (always supported)
+-   PFM files - \*.pfm (see the *Note* section)
+-   Sun rasters - \*.sr, \*.ras (always supported)
+-   TIFF files - \*.tiff, \*.tif (see the *Note* section)
+-   OpenEXR Image files - \*.exr (see the *Note* section)
+-   Radiance HDR - \*.hdr, \*.pic (always supported)
+-   Raster and Vector geospatial data supported by GDAL (see the *Note* section)
+
+@note
+-   The function determines the type of an image by the content, not by the file extension.
+-   In the case of color images, the decoded images will have the channels stored in **B G R** order.
+-   When using IMREAD_GRAYSCALE, the codec's internal grayscale conversion will be used, if available.
+    Results may differ to the output of cvtColor()
+-   On Microsoft Windows\* OS and MacOSX\*, the codecs shipped with an OpenCV image (libjpeg,
+    libpng, libtiff, and libjasper) are used by default. So, OpenCV can always read JPEGs, PNGs,
+    and TIFFs. On MacOSX, there is also an option to use native MacOSX image readers. But beware
+    that currently these native image loaders give images with different pixel values because of
+    the color management embedded into MacOSX.
+-   On Linux\*, BSD flavors and other Unix-like open-source operating systems, OpenCV looks for
+    codecs supplied with an OS image. Install the relevant packages (do not forget the development
+    files, for example, "libjpeg-dev", in Debian\* and Ubuntu\*) to get the codec support or turn
+    on the OPENCV_BUILD_3RDPARTY_LIBS flag in CMake.
+-   In the case you set *WITH_GDAL* flag to true in CMake and @ref IMREAD_LOAD_GDAL to load the image,
+    then the [GDAL](http://www.gdal.org) driver will be used in order to decode the image, supporting
+    the following formats: [Raster](http://www.gdal.org/formats_list.html),
+    [Vector](http://www.gdal.org/ogr_formats.html).
+-   If EXIF information is embedded in the image file, the EXIF orientation will be taken into account
+    and thus the image will be rotated accordingly except if the flags @ref IMREAD_IGNORE_ORIENTATION
+    or @ref IMREAD_UNCHANGED are passed.
+-   Use the IMREAD_UNCHANGED flag to keep the floating point values from PFM image.
+-   By default number of pixels must be less than 2^30. Limit can be set using system
+    variable OPENCV_IO_MAX_IMAGE_PIXELS
+
+@param filename Name of file to be loaded.
+@param image OutputArray that image is loaded
+@param params additional parameters to set how image is read
+*/
+CV_EXPORTS_W ImreadError imread2( const std::string& filename, OutputArray image, ImreadParams params);
 
 /** @brief Loads a multi-page image from a file.
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -246,47 +246,10 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
 The function imread loads an image from the specified file and returns it. If the image cannot be
 read (because of missing file, improper permissions, unsupported or invalid format), the function
-returns an empty matrix ( Mat::data==NULL ).
+returns an ImreadError codes and empty OutputArray ( Mat::data==NULL ).
 
 Currently, the following file formats are supported:
-
--   Windows bitmaps - \*.bmp, \*.dib (always supported)
--   JPEG files - \*.jpeg, \*.jpg, \*.jpe (see the *Note* section)
--   JPEG 2000 files - \*.jp2 (see the *Note* section)
--   Portable Network Graphics - \*.png (see the *Note* section)
--   WebP - \*.webp (see the *Note* section)
--   Portable image format - \*.pbm, \*.pgm, \*.ppm \*.pxm, \*.pnm (always supported)
--   PFM files - \*.pfm (see the *Note* section)
--   Sun rasters - \*.sr, \*.ras (always supported)
--   TIFF files - \*.tiff, \*.tif (see the *Note* section)
--   OpenEXR Image files - \*.exr (see the *Note* section)
--   Radiance HDR - \*.hdr, \*.pic (always supported)
--   Raster and Vector geospatial data supported by GDAL (see the *Note* section)
-
-@note
--   The function determines the type of an image by the content, not by the file extension.
--   In the case of color images, the decoded images will have the channels stored in **B G R** order.
--   When using IMREAD_GRAYSCALE, the codec's internal grayscale conversion will be used, if available.
-    Results may differ to the output of cvtColor()
--   On Microsoft Windows\* OS and MacOSX\*, the codecs shipped with an OpenCV image (libjpeg,
-    libpng, libtiff, and libjasper) are used by default. So, OpenCV can always read JPEGs, PNGs,
-    and TIFFs. On MacOSX, there is also an option to use native MacOSX image readers. But beware
-    that currently these native image loaders give images with different pixel values because of
-    the color management embedded into MacOSX.
--   On Linux\*, BSD flavors and other Unix-like open-source operating systems, OpenCV looks for
-    codecs supplied with an OS image. Install the relevant packages (do not forget the development
-    files, for example, "libjpeg-dev", in Debian\* and Ubuntu\*) to get the codec support or turn
-    on the OPENCV_BUILD_3RDPARTY_LIBS flag in CMake.
--   In the case you set *WITH_GDAL* flag to true in CMake and @ref IMREAD_LOAD_GDAL to load the image,
-    then the [GDAL](http://www.gdal.org) driver will be used in order to decode the image, supporting
-    the following formats: [Raster](http://www.gdal.org/formats_list.html),
-    [Vector](http://www.gdal.org/ogr_formats.html).
--   If EXIF information is embedded in the image file, the EXIF orientation will be taken into account
-    and thus the image will be rotated accordingly except if the flags @ref IMREAD_IGNORE_ORIENTATION
-    or @ref IMREAD_UNCHANGED are passed.
--   Use the IMREAD_UNCHANGED flag to keep the floating point values from PFM image.
--   By default number of pixels must be less than 2^30. Limit can be set using system
-    variable OPENCV_IO_MAX_IMAGE_PIXELS
+- @sa imread
 
 @param filename Name of file to be loaded.
 @param image OutputArray that image is loaded

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -168,13 +168,13 @@ enum ImwritePAMFlags {
      };
 
 
-enum ImreadError {
-      IMREAD_OK = 0,
-      IMREAD_ERROR_FILE_NOT_FOUND,
-      IMREAD_ERROR_UNRECOGNIZED_FORMAT,
-      IMREAD_ERROR_SIZE_LIMIT_EXCEEDED,
-      IMREAD_ERROR_INVALID_HEADER,
-      IMREAD_ERROR_INVALID_DATA,
+enum ImreadStatus {
+      IMREAD_OK                         = 0,
+      IMREAD_ERROR_FILE_NOT_FOUND       = 1,
+      IMREAD_ERROR_UNRECOGNIZED_FORMAT  = 2,
+      IMREAD_ERROR_SIZE_LIMIT_EXCEEDED  = 3,
+      IMREAD_ERROR_INVALID_HEADER       = 4,
+      IMREAD_ERROR_INVALID_DATA         = 5
      };
 
 /** @brief Additional parameters for imread2
@@ -255,7 +255,7 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
 The function imread loads an image from the specified file and returns it. If the image cannot be
 read (because of missing file, improper permissions, unsupported or invalid format), the function
-returns an ImreadError codes and empty OutputArray ( Mat::data==NULL ).
+returns an ImreadStatus codes and empty OutputArray ( Mat::data==NULL ).
 
 Currently, the following file formats are supported:
 - @sa imread
@@ -264,7 +264,7 @@ Currently, the following file formats are supported:
 @param image OutputArray that image is loaded
 @param params additional parameters to set how image is read
 */
-CV_EXPORTS_W ImreadError imread2( const std::string& filename, OutputArray image, ImreadParams params);
+CV_EXPORTS_W ImreadStatus imread2( const std::string& filename, OutputArray image, ImreadParams params);
 
 /** @brief Loads a multi-page image from a file.
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -257,7 +257,7 @@ static ImageDecoder findDecoder( const String& filename ) {
     return ImageDecoder();
 }
 
-static ImageDecoder findDecoder( const String& filename, ImreadError& error ) {
+static ImageDecoder findDecoder( const std::string& filename, ImreadError& error ) {
 
     size_t i, maxlen = 0;
 
@@ -280,8 +280,8 @@ static ImageDecoder findDecoder( const String& filename, ImreadError& error ) {
     }
 
     // read the file signature
-    String signature(maxlen, ' ');
-    maxlen = fread( (void*)signature.c_str(), 1, maxlen, f );
+    std::string signature(maxlen, ' ');
+    maxlen = fread( (void*)&signature[0], 1, maxlen, f );
     fclose(f);
     signature = signature.substr(0, maxlen);
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -563,19 +563,8 @@ imread_2( String const& filename, OutputArray image, ImreadParams params)
         return error;
     }
 
-    int scale_denom = 1;
-    if( flags > IMREAD_LOAD_GDAL )
-    {
-        if( flags & IMREAD_REDUCED_GRAYSCALE_2 )
-            scale_denom = 2;
-        else if( flags & IMREAD_REDUCED_GRAYSCALE_4 )
-            scale_denom = 4;
-        else if( flags & IMREAD_REDUCED_GRAYSCALE_8 )
-            scale_denom = 8;
-    }
-
     /// set the scale_denom in the driver
-    decoder->setScale( scale_denom );
+    decoder->setScale( params.scaleDenom );
 
     /// set the filename in the driver
     decoder->setSource( filename );
@@ -648,9 +637,9 @@ imread_2( String const& filename, OutputArray image, ImreadParams params)
         return IMREAD_ERROR_INVALID_DATA;
     }
 
-    if( decoder->setScale( scale_denom ) > 1 ) // if decoder is JpegDecoder then decoder->setScale always returns 1
+    if( decoder->setScale( params.scaleDenom ) > 1 ) // if decoder is JpegDecoder then decoder->setScale always returns 1
     {
-        resize( image_data, image_data, Size( size.width / scale_denom, size.height / scale_denom ), 0, 0, INTER_LINEAR_EXACT);
+        resize( image_data, image_data, Size( size.width / params.scaleDenom, size.height / params.scaleDenom ), 0, 0, INTER_LINEAR_EXACT);
     }
 
     /// optionally rotate the data if EXIF orientation flag says so

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -600,7 +600,7 @@ imread_2( String const& filename, OutputArray image, ImreadParams params)
     // established the required input image size
     Size size = validateInputImageSize(Size(decoder->width(), decoder->height()));
 
-    if(params.maxPixels != 0 && params.maxPixels <= static_cast<size_t>(decoder->width()) * decoder->height())
+    if(params.maxPixels != 0 && params.maxPixels < static_cast<size_t>(decoder->width()) * decoder->height())
     {
         return IMREAD_ERROR_SIZE_LIMIT_EXCEEDED;
     }

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -312,7 +312,7 @@ TEST(ImgCodecs_Imread, read_signature_fail)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_UNRECOGNIZED_FORMAT);
+    EXPECT_EQ(IMREAD_ERROR_UNRECOGNIZED_FORMAT, err);
 }
 
 TEST(ImgCodecs_Imread, read_header_fail)
@@ -324,7 +324,7 @@ TEST(ImgCodecs_Imread, read_header_fail)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_INVALID_HEADER);
+    EXPECT_EQ(IMREAD_ERROR_INVALID_HEADER, err);
     EXPECT_TRUE(m.empty());
 }
 
@@ -337,7 +337,7 @@ TEST(ImgCodecs_Imread, read_data_fail)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_INVALID_DATA);
+    EXPECT_EQ(IMREAD_ERROR_INVALID_DATA, err);
     EXPECT_TRUE(m.empty());
 }
 
@@ -350,7 +350,7 @@ TEST(ImgCodecs_Imread, file_not_found)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_FILE_NOT_FOUND);
+    EXPECT_EQ(IMREAD_ERROR_FILE_NOT_FOUND, err);
     EXPECT_TRUE(m.empty());
 }
 
@@ -364,7 +364,7 @@ TEST(ImgCodecs_Imread, max_pixels_exceeded)
     params.flags = IMREAD_COLOR;
     params.maxPixels = 1920*1080;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_SIZE_LIMIT_EXCEEDED);
+    EXPECT_EQ(IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, err);
     EXPECT_TRUE(m.empty());
 }
 
@@ -378,7 +378,7 @@ TEST(ImgCodecs_Imread, max_size_exceed)
     params.flags = IMREAD_COLOR;
     params.maxSize = {2560, 1599};
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_ERROR_SIZE_LIMIT_EXCEEDED);
+    EXPECT_EQ(IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, err);
     EXPECT_TRUE(m.empty());
 }
 
@@ -391,7 +391,7 @@ TEST(ImgCodecs_Imread, read_success)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     ImreadError err = imread2(filename, m, params);
-    EXPECT_EQ(err, IMREAD_OK);
+    EXPECT_EQ(IMREAD_OK, err);
     EXPECT_FALSE(m.empty());
 }
 

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -311,7 +311,7 @@ TEST(ImgCodecs_Imread, read_signature_fail)
     cv::Mat m;
     ImreadParams params;
     params.flags = IMREAD_COLOR;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_UNRECOGNIZED_FORMAT, err);
 }
 
@@ -323,7 +323,7 @@ TEST(ImgCodecs_Imread, read_header_fail)
     cv::Mat m;
     ImreadParams params;
     params.flags = IMREAD_COLOR;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_INVALID_HEADER, err);
     EXPECT_TRUE(m.empty());
 }
@@ -336,7 +336,7 @@ TEST(ImgCodecs_Imread, read_data_fail)
     cv::Mat m;
     ImreadParams params;
     params.flags = IMREAD_COLOR;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_INVALID_DATA, err);
     EXPECT_TRUE(m.empty());
 }
@@ -349,7 +349,7 @@ TEST(ImgCodecs_Imread, file_not_found)
     cv::Mat m;
     ImreadParams params;
     params.flags = IMREAD_COLOR;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_FILE_NOT_FOUND, err);
     EXPECT_TRUE(m.empty());
 }
@@ -363,7 +363,7 @@ TEST(ImgCodecs_Imread, max_pixels_exceeded)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     params.maxPixels = 1920*1080;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, err);
     EXPECT_TRUE(m.empty());
 }
@@ -377,7 +377,7 @@ TEST(ImgCodecs_Imread, max_size_exceed)
     ImreadParams params;
     params.flags = IMREAD_COLOR;
     params.maxSize = {2560, 1599};
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, err);
     EXPECT_TRUE(m.empty());
 }
@@ -390,7 +390,7 @@ TEST(ImgCodecs_Imread, read_success)
     cv::Mat m;
     ImreadParams params;
     params.flags = IMREAD_COLOR;
-    ImreadError err = imread2(filename, m, params);
+    ImreadStatus err = imread2(filename, m, params);
     EXPECT_EQ(IMREAD_OK, err);
     EXPECT_FALSE(m.empty());
 }

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -303,4 +303,97 @@ TEST(Imgcodecs_Image, write_umat)
     EXPECT_EQ(0, remove(dst_name.c_str()));
 }
 
+TEST(ImgCodecs_Imread, read_signature_fail)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../highgui/pngsuite/xcrn0g04.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_UNRECOGNIZED_FORMAT);
+}
+
+TEST(ImgCodecs_Imread, read_header_fail)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../highgui/pngsuite/xd0n2c08.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_INVALID_HEADER);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(ImgCodecs_Imread, read_data_fail)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../highgui/pngsuite/xcsn0g01.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_INVALID_DATA);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(ImgCodecs_Imread, file_not_found)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../highgui/pngsuite/file_not_found.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_FILE_NOT_FOUND);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(ImgCodecs_Imread, max_pixels_exceeded)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../perf/2560x1600.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    params.maxPixels = 1920*1080;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_SIZE_LIMIT_EXCEEDED);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(ImgCodecs_Imread, max_size_exceed)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../perf/2560x1600.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    params.maxSize = {2560, 1599};
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_ERROR_SIZE_LIMIT_EXCEEDED);
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(ImgCodecs_Imread, read_success)
+{
+    const string root = cvtest::TS::ptr()->get_data_path();
+    const string filename = root + "../cv/shared/baboon.png";
+
+    cv::Mat m;
+    ImreadParams params;
+    params.flags = IMREAD_COLOR;
+    ImreadError err = imread2(filename, m, params);
+    EXPECT_EQ(err, IMREAD_OK);
+    EXPECT_FALSE(m.empty());
+}
+
+
 }} // namespace

--- a/modules/python/test/test_imgcodecs.py
+++ b/modules/python/test/test_imgcodecs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+'''
+Test for imread2
+'''
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class imgcodecs_test(NewOpenCVTests):
+    def test_imread2(self):
+        ret, img = cv.imread2('samples/data/lena.jpg', maxSize = (512, 512))
+        self.assertEqual(0, ret)
+        self.assertTrue(img.size)
+
+        ret, img = cv.imread2('samples/data/lena.jpg', maxSize = (511, 512))
+        self.assertEqual(3, ret)
+        self.assertIsNone(img)
+
+        ret, img = cv.imread2('samples/data/lena.jpg', maxPixels = 512*512)
+        self.assertEqual(0, ret)
+        self.assertIsNotNone(img)
+
+        ret, img = cv.imread2('samples/data/lena.jpg', maxPixels = 512*512 - 1)
+        self.assertEqual(3, ret)
+        self.assertIsNone(img)
+
+        ret, img = cv.imread2('nofile.png')
+        self.assertEqual(1, ret)
+        self.assertIsNone(img)
+
+        ret, img = cv.imread2('samples/data/lena.jpg', flags = 1, maxPixels = 512*512, maxSize = (512,512))
+        self.assertEqual(0, ret)
+        self.assertIsNotNone(img)
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/python/test/test_imgcodecs.py
+++ b/modules/python/test/test_imgcodecs.py
@@ -8,12 +8,13 @@ Test for imread2
 from __future__ import print_function
 
 import cv2 as cv
+import os
 
 from tests_common import NewOpenCVTests
 
 class imgcodecs_test(NewOpenCVTests):
     def test_imread2(self):
-        path = self.find_file('samples/data/lena.jpg')
+        path = self.find_file('python/images/baboon.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
         ret, img = cv.imread2(path, maxSize = (512, 512))
         self.assertEqual(0, ret)
         self.assertTrue(img.size)

--- a/modules/python/test/test_imgcodecs.py
+++ b/modules/python/test/test_imgcodecs.py
@@ -13,19 +13,20 @@ from tests_common import NewOpenCVTests
 
 class imgcodecs_test(NewOpenCVTests):
     def test_imread2(self):
-        ret, img = cv.imread2('samples/data/lena.jpg', maxSize = (512, 512))
+        path = self.find_file('samples/data/lena.jpg')
+        ret, img = cv.imread2(path, maxSize = (512, 512))
         self.assertEqual(0, ret)
         self.assertTrue(img.size)
 
-        ret, img = cv.imread2('samples/data/lena.jpg', maxSize = (511, 512))
+        ret, img = cv.imread2(path, maxSize = (511, 512))
         self.assertEqual(3, ret)
         self.assertIsNone(img)
 
-        ret, img = cv.imread2('samples/data/lena.jpg', maxPixels = 512*512)
+        ret, img = cv.imread2(path, maxPixels = 512*512)
         self.assertEqual(0, ret)
         self.assertIsNotNone(img)
 
-        ret, img = cv.imread2('samples/data/lena.jpg', maxPixels = 512*512 - 1)
+        ret, img = cv.imread2(path, maxPixels = 512*512 - 1)
         self.assertEqual(3, ret)
         self.assertIsNone(img)
 
@@ -33,7 +34,7 @@ class imgcodecs_test(NewOpenCVTests):
         self.assertEqual(1, ret)
         self.assertIsNone(img)
 
-        ret, img = cv.imread2('samples/data/lena.jpg', flags = 1, maxPixels = 512*512, maxSize = (512,512))
+        ret, img = cv.imread2(path, flags = 1, maxPixels = 512*512, maxSize = (512,512))
         self.assertEqual(0, ret)
         self.assertIsNotNone(img)
 

--- a/modules/python/test/test_imgcodecs.py
+++ b/modules/python/test/test_imgcodecs.py
@@ -39,5 +39,10 @@ class imgcodecs_test(NewOpenCVTests):
         self.assertEqual(0, ret)
         self.assertIsNotNone(img)
 
+        ret, img2 = cv.imread2(path, flags = 1, maxPixels = 512*512, maxSize = (512,512), scaleDenom = 2)
+        self.assertEqual(0, ret)
+        self.assertIsNotNone(img2)
+        self.assertEqual(img2.size, img.size / 4)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/python/test/test_imgcodecs.py
+++ b/modules/python/test/test_imgcodecs.py
@@ -16,31 +16,31 @@ class imgcodecs_test(NewOpenCVTests):
     def test_imread2(self):
         path = self.find_file('python/images/baboon.jpg', [os.environ.get('OPENCV_TEST_DATA_PATH')])
         ret, img = cv.imread2(path, maxSize = (512, 512))
-        self.assertEqual(0, ret)
+        self.assertEqual(cv.IMREAD_OK, ret)
         self.assertTrue(img.size)
 
         ret, img = cv.imread2(path, maxSize = (511, 512))
-        self.assertEqual(3, ret)
+        self.assertEqual(cv.IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, ret)
         self.assertIsNone(img)
 
         ret, img = cv.imread2(path, maxPixels = 512*512)
-        self.assertEqual(0, ret)
+        self.assertEqual(cv.IMREAD_OK, ret)
         self.assertIsNotNone(img)
 
         ret, img = cv.imread2(path, maxPixels = 512*512 - 1)
-        self.assertEqual(3, ret)
+        self.assertEqual(cv.IMREAD_ERROR_SIZE_LIMIT_EXCEEDED, ret)
         self.assertIsNone(img)
 
         ret, img = cv.imread2('nofile.png')
-        self.assertEqual(1, ret)
+        self.assertEqual(cv.IMREAD_ERROR_FILE_NOT_FOUND, ret)
         self.assertIsNone(img)
 
-        ret, img = cv.imread2(path, flags = 1, maxPixels = 512*512, maxSize = (512,512))
-        self.assertEqual(0, ret)
+        ret, img = cv.imread2(path, flags = cv.IMREAD_COLOR, maxPixels = 512*512, maxSize = (512,512))
+        self.assertEqual(cv.IMREAD_OK, ret)
         self.assertIsNotNone(img)
 
         ret, img2 = cv.imread2(path, flags = 1, maxPixels = 512*512, maxSize = (512,512), scaleDenom = 2)
-        self.assertEqual(0, ret)
+        self.assertEqual(cv.IMREAD_OK, ret)
         self.assertIsNotNone(img2)
         self.assertEqual(img2.size, img.size / 4)
 


### PR DESCRIPTION
This proposed new imread api based on [named parameters](https://github.com/opencv/opencv/wiki/OE-34.-Named-Parameters).

There are a few things that needs to be discussed. I have not seen `enum class` usage in openCV. Hence i prepared this pull request using plain enum. Imo, enum classes are better to express intention hence should be favor when usable. I propose to use 

```cpp
enum class ImreadError {
      OK = 0,
      FILE_NOT_FOUND,
      UNRECOGNIZED_FORMAT,
      SIZE_LIMIT_EXCEEDED,
      INVALID_HEADER,
      INVALID_DATA,
     };
```

It is more readable without `IMREAD_ERROR_` prefix. And user can safely check error type with `ImreadError::xxxx` without implicit conversion. 

The other thing is i created a new `findDecoder` method. This is kinda duplicate function. I could implement it via

```cpp
static ImageDecoder findDecoder( string const& filename, ImreadError* error = nullptr) {
   ....
   if(error) {
        *error = IMREAD_OK;
   }
}
```

This is fine and works with the existing api, however it adds 2 extra if check. So if user reads thousand of images and does not use the new api, it adds 2 extra if check. I am not sure if this is ok or not.

Other than that, C++20 users can use designated initializers. Aggregate initialization does not permit default member initialization in C++11, this restriction removed at C++14.

In C++11 :
```cpp
struct Test {
    int a;
    int b = 5;
    int c = 6;
};

int main()
{
    int a;
    Test t{a};
}
```

This code sample does not compile, but it compiles with C++14 version

Sample usage :

```py
import cv2

ret,img = cv2.imread2("/home/ocpalo/Desktop/aaa.png", flags = 1)
print(ret) # 0
ret = cv2.imread2("/home/ocpalo/Desktop/aaa.png", maxSize = (100,100))
print(ret) # 3, aaa.png size is 3024x4032
```

```cpp

// after c++20
cv::Mat mat;
auto ret = imread2("filename.png", mat, {.flags = IMREAD_COLOR, .maxSize {1024,1024});

// after c++14
cv::Mat mat2;
auto ret2 = imread2("filename.png", mat2, {IMREAD_COLOR});
```

================================================================================================

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

