### PR TITLE
changed names of permutations if Reshpe is in NHWC

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1097,6 +1097,9 @@ void TFImporter::parseReshape(tensorflow::GraphDef& net, const tensorflow::NodeD
             std::swap(*newShape.ptr<int32_t>(0, 1), *newShape.ptr<int32_t>(0, 2));
             hasSwap = true;
         }
+
+        bool changedType{false};
+
         if (inpLayout == DATA_LAYOUT_NHWC)
         {
             if (newShapeSize >= 2 || newShape.at<int>(1) == 1)
@@ -1110,23 +1113,28 @@ void TFImporter::parseReshape(tensorflow::GraphDef& net, const tensorflow::NodeD
                 else
                 {
                     inpLayout = DATA_LAYOUT_NHWC;
+                    changedType = newShapeSize == 4 && !hasSwap;
                 }
             }
         }
         layerParams.set("dim", DictValue::arrayInt<int*>(newShape.ptr<int>(), newShapeSize));
 
-        int id = dstNet.addLayer(name, "Reshape", layerParams);
-        layer_id[name] = id;
+        std::string setName = changedType ? name + "/realReshape" : name;
+
+        int id = dstNet.addLayer(setName, "Reshape", layerParams);
+        layer_id[setName] = id;
 
         // one input only
         connect(layer_id, dstNet, inpId, id, 0);
-        inpId = Pin(name);
+        inpId = Pin(setName);
 
         if ((inpLayout == DATA_LAYOUT_NHWC || inpLayout == DATA_LAYOUT_UNKNOWN || inpLayout == DATA_LAYOUT_PLANAR) &&
             newShapeSize == 4 && !hasSwap)
         {
             int order[] = {0, 3, 1, 2};  // Transform back to OpenCV's NCHW.
-            addPermuteLayer(order, name + "/nchw", inpId);
+
+            setName = changedType ? name : name + "/nchw";
+            addPermuteLayer(order, setName, inpId);
             inpLayout = DATA_LAYOUT_NCHW;
         }
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -337,6 +337,12 @@ TEST_P(Test_TensorFlow_layers, eltwise_mul_vec)
     runTensorFlowNet("eltwise_mul_vec");
 }
 
+TEST_P(Test_TensorFlow_layers, tf_reshape_nhwc)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    runTensorFlowNet("tf_reshape_nhwc");
+}
 
 TEST_P(Test_TensorFlow_layers, channel_broadcast)
 {


### PR DESCRIPTION
Fixes #21290 
opencv_extra: https://github.com/opencv/opencv_extra/pull/1004

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Original issue:
https://github.com/opencv/opencv/issues/21290

Found out, why my tf models wasn't supported by latest version of OpenCV. The problem was, that in graph layers with their id's were looking like:
0: input
1: reshape
2: conv

But while building graph in OpenCV it was looking like:
0: input
1: reshape//nhwc
2: reshape
3: reshape/nchw
4: conv

The problem is while getting memory shapes and connecting nodes with each other, the algorithm is connecting them by names, so the chain of layers ids was not: 0 -> 1 -> 2 -> 3 -> 4, but 0 -> 1 -> 2 -> 4.
There's 2 ways of solving this issue:

1. Place the original name as the latest in this permutation chain, which may be not 100% correct, but it fixes bug.
2. Change the input layer name on conv layer(see above in example). But there's no interface for such a fix.