### PR TITLE
Increasing tolerance for Preproc4lpiTest set on ARM

### DIFF
--- a/modules/gapi/test/gapi_fluid_resize_test.cpp
+++ b/modules/gapi/test/gapi_fluid_resize_test.cpp
@@ -829,7 +829,11 @@ TEST_P(Preproc4lpiTest, Test)
     cv::cvtColor(in_mat, rgb_mat, cv::COLOR_YUV2RGB_NV12);
     cv::resize(rgb_mat, out_mat_ocv, out_sz, 0, 0, interp);
 
+#if defined(__arm__) || defined(__aarch64__)
+    EXPECT_GE(2, cvtest::norm(out_mat(roi), out_mat_ocv(roi), NORM_INF));
+#else
     EXPECT_EQ(0, cvtest::norm(out_mat(roi), out_mat_ocv(roi), NORM_INF));
+#endif
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, Preproc4lpiTest,


### PR DESCRIPTION
The Resize gives calculation deviation on ARM. So the Resize test tolerance should be increased up to 2.
Fix for issue:
https://github.com/opencv/opencv/issues/19122

<cut/>


```
Xforce_builders=Linux AVX2,Linux32,Win32,Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2021.3.0:20.04
build_image:Custom Win=openvino-2021.4.1
build_image:Custom Mac=openvino-2021.2.0

buildworker:Custom Win=windows-3

test_modules:Custom=gapi,python2,python3,java
test_modules:Custom Win=gapi,python2,python3,java
test_modules:Custom Mac=gapi,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

CPU_BASELINE:Custom Win=AVX512_SKX
CPU_BASELINE:Custom=SSE4_2
```