### PR TITLE
G-API Expose all core operations to python

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -635,7 +635,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 */
 GAPI_EXPORTS_W GMat addC(const GMat& src1, const GScalar& c, int ddepth = -1);
 //! @overload
-GAPI_EXPORTS GMat addC(const GScalar& c, const GMat& src1, int ddepth = -1);
+GAPI_EXPORTS_W GMat addC(const GScalar& c, const GMat& src1, int ddepth = -1);
 
 /** @brief Calculates the per-element difference between two matrices.
 
@@ -660,7 +660,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix.
 @sa  add, addC
   */
-GAPI_EXPORTS GMat sub(const GMat& src1, const GMat& src2, int ddepth = -1);
+GAPI_EXPORTS_W GMat sub(const GMat& src1, const GMat& src2, int ddepth = -1);
 
 /** @brief Calculates the per-element difference between matrix and given scalar.
 
@@ -679,7 +679,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix.
 @sa  add, addC, subRC
   */
-GAPI_EXPORTS GMat subC(const GMat& src, const GScalar& c, int ddepth = -1);
+GAPI_EXPORTS_W GMat subC(const GMat& src, const GScalar& c, int ddepth = -1);
 
 /** @brief Calculates the per-element difference between given scalar and the matrix.
 
@@ -698,7 +698,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix.
 @sa  add, addC, subC
   */
-GAPI_EXPORTS GMat subRC(const GScalar& c, const GMat& src, int ddepth = -1);
+GAPI_EXPORTS_W GMat subRC(const GScalar& c, const GMat& src, int ddepth = -1);
 
 /** @brief Calculates the per-element scaled product of two matrices.
 
@@ -719,7 +719,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix.
 @sa add, sub, div, addWeighted
 */
-GAPI_EXPORTS GMat mul(const GMat& src1, const GMat& src2, double scale = 1.0, int ddepth = -1);
+GAPI_EXPORTS_W GMat mul(const GMat& src1, const GMat& src2, double scale = 1.0, int ddepth = -1);
 
 /** @brief Multiplies matrix by scalar.
 
@@ -737,11 +737,11 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix. If -1, the depth of output matrix will be the same as input matrix depth.
 @sa add, sub, div, addWeighted
 */
-GAPI_EXPORTS GMat mulC(const GMat& src, double multiplier, int ddepth = -1);
+GAPI_EXPORTS_W GMat mulC(const GMat& src, double multiplier, int ddepth = -1);
 //! @overload
-GAPI_EXPORTS GMat mulC(const GMat& src, const GScalar& multiplier, int ddepth = -1);   // FIXME: merge with mulc
+GAPI_EXPORTS_W GMat mulC(const GMat& src, const GScalar& multiplier, int ddepth = -1);   // FIXME: merge with mulc
 //! @overload
-GAPI_EXPORTS GMat mulC(const GScalar& multiplier, const GMat& src, int ddepth = -1);   // FIXME: merge with mulc
+GAPI_EXPORTS_W GMat mulC(const GScalar& multiplier, const GMat& src, int ddepth = -1);   // FIXME: merge with mulc
 
 /** @brief Performs per-element division of two matrices.
 
@@ -764,7 +764,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix; you can only pass -1 when src1.depth() == src2.depth().
 @sa  mul, add, sub
 */
-GAPI_EXPORTS GMat div(const GMat& src1, const GMat& src2, double scale, int ddepth = -1);
+GAPI_EXPORTS_W GMat div(const GMat& src1, const GMat& src2, double scale, int ddepth = -1);
 
 /** @brief Divides matrix by scalar.
 
@@ -785,7 +785,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param scale scale factor.
 @sa add, sub, div, addWeighted
 */
-GAPI_EXPORTS GMat divC(const GMat& src, const GScalar& divisor, double scale, int ddepth = -1);
+GAPI_EXPORTS_W GMat divC(const GMat& src, const GScalar& divisor, double scale, int ddepth = -1);
 
 /** @brief Divides scalar by matrix.
 
@@ -806,7 +806,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param scale scale factor
 @sa add, sub, div, addWeighted
 */
-GAPI_EXPORTS GMat divRC(const GScalar& divident, const GMat& src, double scale, int ddepth = -1);
+GAPI_EXPORTS_W GMat divRC(const GScalar& divident, const GMat& src, double scale, int ddepth = -1);
 
 /** @brief Applies a mask to a matrix.
 
@@ -819,7 +819,7 @@ Supported src matrix data types are @ref CV_8UC1, @ref CV_16SC1, @ref CV_16UC1. 
 @param src input matrix.
 @param mask input mask matrix.
 */
-GAPI_EXPORTS GMat mask(const GMat& src, const GMat& mask);
+GAPI_EXPORTS_W GMat mask(const GMat& src, const GMat& mask);
 
 /** @brief Calculates an average (mean) of matrix elements.
 
@@ -854,8 +854,8 @@ Both output must have the same size and depth as input matrices.
 degrees, otherwise, they are measured in radians.
 @sa cartToPolar, exp, log, pow, sqrt
 */
-GAPI_EXPORTS std::tuple<GMat, GMat> polarToCart(const GMat& magnitude, const GMat& angle,
-                                              bool angleInDegrees = false);
+GAPI_EXPORTS_W std::tuple<GMat, GMat> polarToCart(const GMat& magnitude, const GMat& angle,
+                                                  bool angleInDegrees = false);
 
 /** @brief Calculates the magnitude and angle of 2D vectors.
 
@@ -878,8 +878,8 @@ x; the angles are measured in radians (from 0 to 2\*Pi) or in degrees (0 to 360 
 in radians (which is by default), or in degrees.
 @sa polarToCart
 */
-GAPI_EXPORTS std::tuple<GMat, GMat> cartToPolar(const GMat& x, const GMat& y,
-                                              bool angleInDegrees = false);
+GAPI_EXPORTS_W std::tuple<GMat, GMat> cartToPolar(const GMat& x, const GMat& y,
+                                                  bool angleInDegrees = false);
 
 /** @brief Calculates the rotation angle of 2D vectors.
 
@@ -896,7 +896,7 @@ same size and the same type as x.
 degrees, otherwise, they are measured in radians.
 @return array of vector angles; it has the same size and same type as x.
 */
-GAPI_EXPORTS GMat phase(const GMat& x, const GMat &y, bool angleInDegrees = false);
+GAPI_EXPORTS_W GMat phase(const GMat& x, const GMat &y, bool angleInDegrees = false);
 
 /** @brief Calculates a square root of array elements.
 
@@ -907,7 +907,7 @@ std::sqrt .
 @param src input floating-point array.
 @return output array of the same size and type as src.
 */
-GAPI_EXPORTS GMat sqrt(const GMat &src);
+GAPI_EXPORTS_W GMat sqrt(const GMat &src);
 
 //! @} gapi_math
 //!
@@ -934,11 +934,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_16UC1, @ref CV_16SC1
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpLE, cmpGE, cmpLT
 */
-GAPI_EXPORTS GMat cmpGT(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpGT(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpGTScalar"
 */
-GAPI_EXPORTS GMat cmpGT(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpGT(const GMat& src1, const GScalar& src2);
 
 /** @brief Performs the per-element comparison of two matrices checking if elements from first matrix are less than elements in second.
 
@@ -960,11 +960,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpLE, cmpGE, cmpGT
 */
-GAPI_EXPORTS GMat cmpLT(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpLT(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpLTScalar"
 */
-GAPI_EXPORTS GMat cmpLT(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpLT(const GMat& src1, const GScalar& src2);
 
 /** @brief Performs the per-element comparison of two matrices checking if elements from first matrix are greater or equal compare to elements in second.
 
@@ -986,11 +986,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpLE, cmpGT, cmpLT
 */
-GAPI_EXPORTS GMat cmpGE(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpGE(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpLGEcalar"
 */
-GAPI_EXPORTS GMat cmpGE(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpGE(const GMat& src1, const GScalar& src2);
 
 /** @brief Performs the per-element comparison of two matrices checking if elements from first matrix are less or equal compare to elements in second.
 
@@ -1012,11 +1012,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpGT, cmpGE, cmpLT
 */
-GAPI_EXPORTS GMat cmpLE(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpLE(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpLEScalar"
 */
-GAPI_EXPORTS GMat cmpLE(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpLE(const GMat& src1, const GScalar& src2);
 
 /** @brief Performs the per-element comparison of two matrices checking if elements from first matrix are equal to elements in second.
 
@@ -1038,11 +1038,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpNE
 */
-GAPI_EXPORTS GMat cmpEQ(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpEQ(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpEQScalar"
 */
-GAPI_EXPORTS GMat cmpEQ(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpEQ(const GMat& src1, const GScalar& src2);
 
 /** @brief Performs the per-element comparison of two matrices checking if elements from first matrix are not equal to elements in second.
 
@@ -1064,11 +1064,11 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix/scalar of the same depth as first input matrix.
 @sa min, max, threshold, cmpEQ
 */
-GAPI_EXPORTS GMat cmpNE(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat cmpNE(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.compare.cmpNEScalar"
 */
-GAPI_EXPORTS GMat cmpNE(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat cmpNE(const GMat& src1, const GScalar& src2);
 
 /** @brief computes bitwise conjunction of the two matrixes (src1 & src2)
 Calculates the per-element bit-wise logical conjunction of two matrices of the same size.
@@ -1086,13 +1086,13 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src1 first input matrix.
 @param src2 second input matrix.
 */
-GAPI_EXPORTS GMat bitwise_and(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat bitwise_and(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.bitwise_andS"
 @param src1 first input matrix.
 @param src2 scalar, which will be per-lemenetly conjuncted with elements of src1.
 */
-GAPI_EXPORTS GMat bitwise_and(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat bitwise_and(const GMat& src1, const GScalar& src2);
 
 /** @brief computes bitwise disjunction of the two matrixes (src1 | src2)
 Calculates the per-element bit-wise logical disjunction of two matrices of the same size.
@@ -1110,13 +1110,13 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src1 first input matrix.
 @param src2 second input matrix.
 */
-GAPI_EXPORTS GMat bitwise_or(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat bitwise_or(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.bitwise_orS"
 @param src1 first input matrix.
 @param src2 scalar, which will be per-lemenetly disjuncted with elements of src1.
 */
-GAPI_EXPORTS GMat bitwise_or(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat bitwise_or(const GMat& src1, const GScalar& src2);
 
 
 /** @brief computes bitwise logical "exclusive or" of the two matrixes (src1 ^ src2)
@@ -1135,13 +1135,13 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src1 first input matrix.
 @param src2 second input matrix.
 */
-GAPI_EXPORTS GMat bitwise_xor(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat bitwise_xor(const GMat& src1, const GMat& src2);
 /** @overload
 @note Function textual ID is "org.opencv.core.pixelwise.bitwise_xorS"
 @param src1 first input matrix.
 @param src2 scalar, for which per-lemenet "logical or" operation on elements of src1 will be performed.
 */
-GAPI_EXPORTS GMat bitwise_xor(const GMat& src1, const GScalar& src2);
+GAPI_EXPORTS_W GMat bitwise_xor(const GMat& src1, const GScalar& src2);
 
 
 /** @brief Inverts every bit of an array.
@@ -1162,7 +1162,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 
 @param src input matrix.
 */
-GAPI_EXPORTS GMat bitwise_not(const GMat& src);
+GAPI_EXPORTS_W GMat bitwise_not(const GMat& src);
 
 /** @brief Select values from either first or second of input matrices by given mask.
 The function set to the output matrix either the value from the first input matrix if corresponding value of mask matrix is 255,
@@ -1178,7 +1178,7 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix.
 @param mask mask input matrix.
 */
-GAPI_EXPORTS GMat select(const GMat& src1, const GMat& src2, const GMat& mask);
+GAPI_EXPORTS_W GMat select(const GMat& src1, const GMat& src2, const GMat& mask);
 
 //! @} gapi_pixelwise
 
@@ -1200,7 +1200,7 @@ Supported input matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1,
 @param src2 second input matrix of the same size and depth as src1.
 @sa max, cmpEQ, cmpLT, cmpLE
 */
-GAPI_EXPORTS GMat min(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat min(const GMat& src1, const GMat& src2);
 
 /** @brief Calculates per-element maximum of two matrices.
 
@@ -1217,7 +1217,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src2 second input matrix of the same size and depth as src1.
 @sa min, compare, cmpEQ, cmpGT, cmpGE
 */
-GAPI_EXPORTS GMat max(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat max(const GMat& src1, const GMat& src2);
 
 /** @brief Calculates the per-element absolute difference between two matrices.
 
@@ -1234,7 +1234,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src2 second input matrix.
 @sa abs
 */
-GAPI_EXPORTS GMat absDiff(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat absDiff(const GMat& src1, const GMat& src2);
 
 /** @brief Calculates absolute value of matrix elements.
 
@@ -1251,7 +1251,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param c scalar to be subtracted.
 @sa min, max
 */
-GAPI_EXPORTS GMat absDiffC(const GMat& src, const GScalar& c);
+GAPI_EXPORTS_W GMat absDiffC(const GMat& src, const GScalar& c);
 
 /** @brief Calculates sum of all matrix elements.
 
@@ -1263,7 +1263,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src input matrix.
 @sa countNonZero, mean, min, max
 */
-GAPI_EXPORTS GScalar sum(const GMat& src);
+GAPI_EXPORTS_W GScalar sum(const GMat& src);
 
 /** @brief Counts non-zero array elements.
 
@@ -1276,7 +1276,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_16UC1, @ref CV_16SC1, @ref
 @param src input single-channel matrix.
 @sa  mean, min, max
 */
-GAPI_EXPORTS GOpaque<int> countNonZero(const GMat& src);
+GAPI_EXPORTS_W GOpaque<int> countNonZero(const GMat& src);
 
 /** @brief Calculates the weighted sum of two matrices.
 
@@ -1299,7 +1299,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param ddepth optional depth of the output matrix.
 @sa  add, sub
 */
-GAPI_EXPORTS GMat addWeighted(const GMat& src1, double alpha, const GMat& src2, double beta, double gamma, int ddepth = -1);
+GAPI_EXPORTS_W GMat addWeighted(const GMat& src1, double alpha, const GMat& src2, double beta, double gamma, int ddepth = -1);
 
 /** @brief Calculates the  absolute L1 norm of a matrix.
 
@@ -1322,7 +1322,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src input matrix.
 @sa normL2, normInf
 */
-GAPI_EXPORTS GScalar normL1(const GMat& src);
+GAPI_EXPORTS_W GScalar normL1(const GMat& src);
 
 /** @brief Calculates the absolute L2 norm of a matrix.
 
@@ -1344,7 +1344,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src input matrix.
 @sa normL1, normInf
 */
-GAPI_EXPORTS GScalar normL2(const GMat& src);
+GAPI_EXPORTS_W GScalar normL2(const GMat& src);
 
 /** @brief Calculates the absolute infinite norm of a matrix.
 
@@ -1367,7 +1367,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src input matrix.
 @sa normL1, normL2
 */
-GAPI_EXPORTS GScalar normInf(const GMat& src);
+GAPI_EXPORTS_W GScalar normInf(const GMat& src);
 
 /** @brief Calculates the integral of an image.
 
@@ -1387,7 +1387,7 @@ The function return integral image as \f$(W+1)\times (H+1)\f$ , 32-bit integer o
 CV_64F.
 @param sqdepth desired depth of the integral image of squared pixel values, CV_32F or CV_64F.
  */
-GAPI_EXPORTS std::tuple<GMat, GMat> integral(const GMat& src, int sdepth = -1, int sqdepth = -1);
+GAPI_EXPORTS_W std::tuple<GMat, GMat> integral(const GMat& src, int sdepth = -1, int sqdepth = -1);
 
 /** @brief Applies a fixed-level threshold to each matrix element.
 
@@ -1416,7 +1416,7 @@ types.
 
 @sa min, max, cmpGT, cmpLE, cmpGE, cmpLT
  */
-GAPI_EXPORTS GMat threshold(const GMat& src, const GScalar& thresh, const GScalar& maxval, int type);
+GAPI_EXPORTS_W GMat threshold(const GMat& src, const GScalar& thresh, const GScalar& maxval, int type);
 /** @overload
 This function applicable for all threshold types except CV_THRESH_OTSU and CV_THRESH_TRIANGLE
 @note Function textual ID is "org.opencv.core.matrixop.thresholdOT"
@@ -1438,7 +1438,7 @@ Input and output matrices must be CV_8UC1.
 
 @sa threshold
  */
-GAPI_EXPORTS GMat inRange(const GMat& src, const GScalar& threshLow, const GScalar& threshUp);
+GAPI_EXPORTS_W GMat inRange(const GMat& src, const GScalar& threshLow, const GScalar& threshUp);
 
 //! @} gapi_matrixop
 
@@ -1462,7 +1462,7 @@ The function split4 does the reverse operation.
 @param src4 fourth input @ref CV_8UC1 matrix to be merged.
 @sa merge3, split4, split3
 */
-GAPI_EXPORTS GMat merge4(const GMat& src1, const GMat& src2, const GMat& src3, const GMat& src4);
+GAPI_EXPORTS_W GMat merge4(const GMat& src1, const GMat& src2, const GMat& src3, const GMat& src4);
 
 /** @brief Creates one 3-channel matrix out of 3 single-channel ones.
 
@@ -1481,7 +1481,7 @@ The function split3 does the reverse operation.
 @param src3 third input @ref CV_8UC1 matrix to be merged.
 @sa merge4, split4, split3
 */
-GAPI_EXPORTS GMat merge3(const GMat& src1, const GMat& src2, const GMat& src3);
+GAPI_EXPORTS_W GMat merge3(const GMat& src1, const GMat& src2, const GMat& src3);
 
 /** @brief Divides a 4-channel matrix into 4 single-channel matrices.
 
@@ -1498,7 +1498,7 @@ The function merge4 does the reverse operation.
 @param src input @ref CV_8UC4 matrix.
 @sa split3, merge3, merge4
 */
-GAPI_EXPORTS std::tuple<GMat, GMat, GMat,GMat> split4(const GMat& src);
+GAPI_EXPORTS_W std::tuple<GMat, GMat, GMat,GMat> split4(const GMat& src);
 
 /** @brief Divides a 3-channel matrix into 3 single-channel matrices.
 
@@ -1548,9 +1548,9 @@ borderMode=BORDER_TRANSPARENT, it means that the pixels in the destination image
 corresponds to the "outliers" in the source image are not modified by the function.
 @param borderValue Value used in case of a constant border. By default, it is 0.
  */
-GAPI_EXPORTS GMat remap(const GMat& src, const Mat& map1, const Mat& map2,
-                      int interpolation, int borderMode = BORDER_CONSTANT,
-                      const Scalar& borderValue = Scalar());
+GAPI_EXPORTS_W GMat remap(const GMat& src, const Mat& map1, const Mat& map2,
+                          int interpolation, int borderMode = BORDER_CONSTANT,
+                          const Scalar& borderValue = Scalar());
 
 /** @brief Flips a 2D matrix around vertical, horizontal, or both axes.
 
@@ -1587,7 +1587,7 @@ flipping around y-axis. Negative value (for example, -1) means flipping
 around both axes.
 @sa remap
 */
-GAPI_EXPORTS GMat flip(const GMat& src, int flipCode);
+GAPI_EXPORTS_W GMat flip(const GMat& src, int flipCode);
 
 /** @brief Crops a 2D matrix.
 
@@ -1601,7 +1601,7 @@ Output matrix must be of the same depth as input one, size is specified by given
 @param rect a rect to crop a matrix to
 @sa resize
 */
-GAPI_EXPORTS GMat crop(const GMat& src, const Rect& rect);
+GAPI_EXPORTS_W GMat crop(const GMat& src, const Rect& rect);
 
 /** @brief Applies horizontal concatenation to given matrices.
 
@@ -1629,7 +1629,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src2 second input matrix to be considered for horizontal concatenation.
 @sa concatVert
 */
-GAPI_EXPORTS GMat concatHor(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat concatHor(const GMat& src1, const GMat& src2);
 
 /** @overload
 The function horizontally concatenates given number of GMat matrices (with the same number of columns).
@@ -1637,7 +1637,7 @@ Output matrix must the same number of columns and depth as the input matrices, a
 
 @param v vector of input matrices to be concatenated horizontally.
 */
-GAPI_EXPORTS GMat concatHor(const std::vector<GMat> &v);
+GAPI_EXPORTS_W GMat concatHor(const std::vector<GMat> &v);
 
 /** @brief Applies vertical concatenation to given matrices.
 
@@ -1669,7 +1669,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @param src2 second input matrix to be considered for vertical concatenation.
 @sa concatHor
 */
-GAPI_EXPORTS GMat concatVert(const GMat& src1, const GMat& src2);
+GAPI_EXPORTS_W GMat concatVert(const GMat& src1, const GMat& src2);
 
 /** @overload
 The function vertically concatenates given number of GMat matrices (with the same number of columns).
@@ -1677,7 +1677,7 @@ Output matrix must the same number of columns and depth as the input matrices, a
 
 @param v vector of input matrices to be concatenated vertically.
 */
-GAPI_EXPORTS GMat concatVert(const std::vector<GMat> &v);
+GAPI_EXPORTS_W GMat concatVert(const std::vector<GMat> &v);
 
 
 /** @brief Performs a look-up table transform of a matrix.
@@ -1696,7 +1696,7 @@ Output is a matrix of the same size and number of channels as src, and the same 
 either have a single channel (in this case the same table is used for all channels) or the same
 number of channels as in the input matrix.
 */
-GAPI_EXPORTS GMat LUT(const GMat& src, const Mat& lut);
+GAPI_EXPORTS_W GMat LUT(const GMat& src, const Mat& lut);
 
 /** @brief Converts a matrix to another data depth with optional scaling.
 
@@ -1713,7 +1713,7 @@ same as the input has; if rdepth is negative, the output matrix will have the sa
 @param alpha optional scale factor.
 @param beta optional delta added to the scaled values.
  */
-GAPI_EXPORTS GMat convertTo(const GMat& src, int rdepth, double alpha=1, double beta=0);
+GAPI_EXPORTS_W GMat convertTo(const GMat& src, int rdepth, double alpha=1, double beta=0);
 
 /** @brief Normalizes the norm or value range of an array.
 
@@ -1735,8 +1735,8 @@ normalization.
 number of channels as src and the depth =ddepth.
 @sa norm, Mat::convertTo
 */
-GAPI_EXPORTS GMat normalize(const GMat& src, double alpha, double beta,
-                            int norm_type, int ddepth = -1);
+GAPI_EXPORTS_W GMat normalize(const GMat& src, double alpha, double beta,
+                              int norm_type, int ddepth = -1);
 
 /** @brief Applies a perspective transformation to an image.
 
@@ -1759,8 +1759,8 @@ optional flag #WARP_INVERSE_MAP, that sets M as the inverse transformation (
 
 @sa  warpAffine, resize, remap, getRectSubPix, perspectiveTransform
  */
-GAPI_EXPORTS GMat warpPerspective(const GMat& src, const Mat& M, const Size& dsize, int flags = cv::INTER_LINEAR,
-                                  int borderMode = cv::BORDER_CONSTANT, const Scalar& borderValue = Scalar());
+GAPI_EXPORTS_W GMat warpPerspective(const GMat& src, const Mat& M, const Size& dsize, int flags = cv::INTER_LINEAR,
+                                    int borderMode = cv::BORDER_CONSTANT, const Scalar& borderValue = Scalar());
 
 /** @brief Applies an affine transformation to an image.
 
@@ -1784,8 +1784,8 @@ borderMode=#BORDER_TRANSPARENT isn't supported
 
 @sa  warpPerspective, resize, remap, getRectSubPix, transform
  */
-GAPI_EXPORTS GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, int flags = cv::INTER_LINEAR,
-                             int borderMode = cv::BORDER_CONSTANT, const Scalar& borderValue = Scalar());
+GAPI_EXPORTS_W GMat warpAffine(const GMat& src, const Mat& M, const Size& dsize, int flags = cv::INTER_LINEAR,
+                               int borderMode = cv::BORDER_CONSTANT, const Scalar& borderValue = Scalar());
 //! @} gapi_transform
 
 /** @brief Finds centers of clusters and groups input samples around the clusters.
@@ -1834,7 +1834,7 @@ compactness value are returned by the function.
  - Integer array that stores the cluster indices for every sample.
  - Array of the cluster centers.
 */
-GAPI_EXPORTS std::tuple<GOpaque<double>,GMat,GMat>
+GAPI_EXPORTS_W std::tuple<GOpaque<double>,GMat,GMat>
 kmeans(const GMat& data, const int K, const GMat& bestLabels,
        const TermCriteria& criteria, const int attempts, const KmeansFlags flags);
 
@@ -1857,7 +1857,7 @@ kmeans(const GArray<Point2f>& data, const int K, const GArray<int>& bestLabels,
 /** @overload
 @note Function textual ID is "org.opencv.core.kmeans3D"
  */
-GAPI_EXPORTS std::tuple<GOpaque<double>,GArray<int>,GArray<Point3f>>
+GAPI_EXPORTS_W std::tuple<GOpaque<double>,GArray<int>,GArray<Point3f>>
 kmeans(const GArray<Point3f>& data, const int K, const GArray<int>& bestLabels,
        const TermCriteria& criteria, const int attempts, const KmeansFlags flags);
 
@@ -1873,7 +1873,7 @@ The function transposes the matrix:
 
 @param src input array.
 */
-GAPI_EXPORTS GMat transpose(const GMat& src);
+GAPI_EXPORTS_W GMat transpose(const GMat& src);
 
 
 namespace streaming {
@@ -1903,7 +1903,7 @@ GAPI_EXPORTS_W GOpaque<Size> size(const GOpaque<Rect>& r);
 @param src Input frame
 @return Size (frame dimensions).
 */
-GAPI_EXPORTS GOpaque<Size> size(const GFrame& src);
+GAPI_EXPORTS_W GOpaque<Size> size(const GFrame& src);
 } //namespace streaming
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -51,6 +51,7 @@ namespace detail
         CV_STRING,     // std::string user G-API data
         CV_POINT,      // cv::Point user G-API data
         CV_POINT2F,    // cv::Point2f user G-API data
+        CV_POINT3F,    // cv::Point3f user G-API data
         CV_SIZE,       // cv::Size user G-API data
         CV_RECT,       // cv::Rect user G-API data
         CV_SCALAR,     // cv::Scalar user G-API data
@@ -72,16 +73,17 @@ namespace detail
     template<> struct GOpaqueTraits<cv::Scalar>  { static constexpr const OpaqueKind kind = OpaqueKind::CV_SCALAR; };
     template<> struct GOpaqueTraits<cv::Point>   { static constexpr const OpaqueKind kind = OpaqueKind::CV_POINT; };
     template<> struct GOpaqueTraits<cv::Point2f> { static constexpr const OpaqueKind kind = OpaqueKind::CV_POINT2F; };
+    template<> struct GOpaqueTraits<cv::Point3f> { static constexpr const OpaqueKind kind = OpaqueKind::CV_POINT3F; };
     template<> struct GOpaqueTraits<cv::Mat>     { static constexpr const OpaqueKind kind = OpaqueKind::CV_MAT; };
     template<> struct GOpaqueTraits<cv::Rect>    { static constexpr const OpaqueKind kind = OpaqueKind::CV_RECT; };
     template<> struct GOpaqueTraits<cv::GMat>    { static constexpr const OpaqueKind kind = OpaqueKind::CV_MAT; };
     template<> struct GOpaqueTraits<cv::gapi::wip::draw::Prim>
                                                  { static constexpr const OpaqueKind kind = OpaqueKind::CV_DRAW_PRIM; };
     using GOpaqueTraitsArrayTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Scalar, cv::Point, cv::Point2f,
-                                               cv::Mat, cv::Rect, cv::gapi::wip::draw::Prim>;
+                                               cv::Point3f, cv::Mat, cv::Rect, cv::gapi::wip::draw::Prim>;
     // GOpaque is not supporting cv::Mat and cv::Scalar since there are GScalar and GMat types
-    using GOpaqueTraitsOpaqueTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Point, cv::Point2f, cv::Rect,
-                                                cv::gapi::wip::draw::Prim>;
+    using GOpaqueTraitsOpaqueTypes = std::tuple<int, double, float, uint64_t, bool, std::string, cv::Size, cv::Point, cv::Point2f, cv::Point3f,
+                                                cv::Rect, cv::gapi::wip::draw::Prim>;
 } // namespace detail
 
 // This definition is here because it is reused by both public(?) and internal

--- a/modules/gapi/include/opencv2/gapi/gscalar.hpp
+++ b/modules/gapi/include/opencv2/gapi/gscalar.hpp
@@ -67,6 +67,7 @@ public:
      *
      * @param s a cv::Scalar value to associate with this GScalar object.
      */
+    GAPI_WRAP
     explicit GScalar(const cv::Scalar& s);
 
     /**

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -654,8 +654,8 @@ center.
 @param borderValue border value in case of constant border type
 @sa  boxFilter, bilateralFilter, GaussianBlur, medianBlur
  */
-GAPI_EXPORTS GMat blur(const GMat& src, const Size& ksize, const Point& anchor = Point(-1,-1),
-                       int borderType = BORDER_DEFAULT, const Scalar& borderValue = Scalar(0));
+GAPI_EXPORTS_W GMat blur(const GMat& src, const Size& ksize, const Point& anchor = Point(-1,-1),
+                         int borderType = BORDER_DEFAULT, const Scalar& borderValue = Scalar(0));
 
 
 //GAPI_EXPORTS_W void blur( InputArray src, OutputArray dst,

--- a/modules/gapi/include/opencv2/gapi/s11n.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n.hpp
@@ -229,6 +229,9 @@ GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Point &pt);
 GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Point2f &pt);
 GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Point2f &pt);
 
+GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Point3f &pt);
+GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Point3f &pt);
+
 GAPI_EXPORTS IOStream& operator<< (IOStream& os, const cv::Size &sz);
 GAPI_EXPORTS IIStream& operator>> (IIStream& is,       cv::Size &sz);
 

--- a/modules/gapi/misc/python/package/gapi/__init__.py
+++ b/modules/gapi/misc/python/package/gapi/__init__.py
@@ -76,6 +76,10 @@ class GOpaque():
         def __new__(self):
             return cv.GOpaqueT(cv.gapi.CV_POINT2F)
 
+    class Point3f():
+        def __new__(self):
+            return cv.GOpaqueT(cv.gapi.CV_POINT3F)
+
     class Size():
         def __new__(self):
             return cv.GOpaqueT(cv.gapi.CV_SIZE)
@@ -127,6 +131,10 @@ class GArray():
         def __new__(self):
             return cv.GArrayT(cv.gapi.CV_POINT2F)
 
+    class Point3f():
+        def __new__(self):
+            return cv.GArrayT(cv.gapi.CV_POINT3F)
+
     class Size():
         def __new__(self):
             return cv.GArrayT(cv.gapi.CV_SIZE)
@@ -167,6 +175,7 @@ def op(op_id, in_types, out_types):
             cv.GArray.String:  cv.gapi.CV_STRING,
             cv.GArray.Point:   cv.gapi.CV_POINT,
             cv.GArray.Point2f: cv.gapi.CV_POINT2F,
+            cv.GArray.Point3f: cv.gapi.CV_POINT3F,
             cv.GArray.Size:    cv.gapi.CV_SIZE,
             cv.GArray.Rect:    cv.gapi.CV_RECT,
             cv.GArray.Scalar:  cv.gapi.CV_SCALAR,
@@ -186,6 +195,7 @@ def op(op_id, in_types, out_types):
             cv.GOpaque.String:  cv.gapi.CV_STRING,
             cv.GOpaque.Point:   cv.gapi.CV_POINT,
             cv.GOpaque.Point2f: cv.gapi.CV_POINT2F,
+            cv.GOpaque.Point3f: cv.gapi.CV_POINT3F,
             cv.GOpaque.Size:    cv.gapi.CV_SIZE,
             cv.GOpaque.Rect:    cv.gapi.CV_RECT,
             cv.GOpaque.Prim:    cv.gapi.CV_DRAW_PRIM,
@@ -200,6 +210,7 @@ def op(op_id, in_types, out_types):
         cv.gapi.CV_STRING:    'cv.gapi.CV_STRING' ,
         cv.gapi.CV_POINT:     'cv.gapi.CV_POINT' ,
         cv.gapi.CV_POINT2F:   'cv.gapi.CV_POINT2F' ,
+        cv.gapi.CV_POINT3F:   'cv.gapi.CV_POINT3F' ,
         cv.gapi.CV_SIZE:      'cv.gapi.CV_SIZE',
         cv.gapi.CV_RECT:      'cv.gapi.CV_RECT',
         cv.gapi.CV_SCALAR:    'cv.gapi.CV_SCALAR',

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -19,6 +19,7 @@ using gapi_wip_IStreamSource_Ptr    = cv::Ptr<cv::gapi::wip::IStreamSource>;
 using detail_ExtractArgsCallback    = cv::detail::ExtractArgsCallback;
 using detail_ExtractMetaCallback    = cv::detail::ExtractMetaCallback;
 using vector_GNetParam              = std::vector<cv::gapi::GNetParam>;
+using vector_GMat                   = std::vector<cv::GMat>;
 using gapi_streaming_queue_capacity = cv::gapi::streaming::queue_capacity;
 using GStreamerSource_OutputType    = cv::gapi::wip::GStreamerSource::OutputType;
 
@@ -41,6 +42,7 @@ using GArray_float   = cv::GArray<double>;
 using GArray_string  = cv::GArray<std::string>;
 using GArray_Point2i = cv::GArray<cv::Point>;
 using GArray_Point2f = cv::GArray<cv::Point2f>;
+using GArray_Point3f = cv::GArray<cv::Point3f>;
 using GArray_Size    = cv::GArray<cv::Size>;
 using GArray_Rect    = cv::GArray<cv::Rect>;
 using GArray_Scalar  = cv::GArray<cv::Scalar>;
@@ -238,6 +240,7 @@ PyObject* pyopencv_from(const cv::GArg& value)
         HANDLE_CASE(STRING,    std::string);
         HANDLE_CASE(POINT,     cv::Point);
         HANDLE_CASE(POINT2F,   cv::Point2f);
+        HANDLE_CASE(POINT3F,   cv::Point3f);
         HANDLE_CASE(SIZE,      cv::Size);
         HANDLE_CASE(RECT,      cv::Rect);
         HANDLE_CASE(SCALAR,    cv::Scalar);
@@ -295,6 +298,7 @@ PyObject* pyopencv_from(const cv::detail::OpaqueRef& o)
         case cv::detail::OpaqueKind::CV_STRING    : return pyopencv_from(o.rref<std::string>());
         case cv::detail::OpaqueKind::CV_POINT     : return pyopencv_from(o.rref<cv::Point>());
         case cv::detail::OpaqueKind::CV_POINT2F   : return pyopencv_from(o.rref<cv::Point2f>());
+        case cv::detail::OpaqueKind::CV_POINT3F   : return pyopencv_from(o.rref<cv::Point3f>());
         case cv::detail::OpaqueKind::CV_SIZE      : return pyopencv_from(o.rref<cv::Size>());
         case cv::detail::OpaqueKind::CV_RECT      : return pyopencv_from(o.rref<cv::Rect>());
         case cv::detail::OpaqueKind::CV_UNKNOWN   : return pyopencv_from(o.rref<cv::GArg>());
@@ -321,6 +325,7 @@ PyObject* pyopencv_from(const cv::detail::VectorRef& v)
         case cv::detail::OpaqueKind::CV_STRING    : return pyopencv_from_generic_vec(v.rref<std::string>());
         case cv::detail::OpaqueKind::CV_POINT     : return pyopencv_from_generic_vec(v.rref<cv::Point>());
         case cv::detail::OpaqueKind::CV_POINT2F   : return pyopencv_from_generic_vec(v.rref<cv::Point2f>());
+        case cv::detail::OpaqueKind::CV_POINT3F   : return pyopencv_from_generic_vec(v.rref<cv::Point3f>());
         case cv::detail::OpaqueKind::CV_SIZE      : return pyopencv_from_generic_vec(v.rref<cv::Size>());
         case cv::detail::OpaqueKind::CV_RECT      : return pyopencv_from_generic_vec(v.rref<cv::Rect>());
         case cv::detail::OpaqueKind::CV_SCALAR    : return pyopencv_from_generic_vec(v.rref<cv::Scalar>());
@@ -491,6 +496,7 @@ static cv::detail::OpaqueRef extract_opaque_ref(PyObject* from, cv::detail::Opaq
         HANDLE_CASE(STRING,  std::string);
         HANDLE_CASE(POINT,   cv::Point);
         HANDLE_CASE(POINT2F, cv::Point2f);
+        HANDLE_CASE(POINT3F, cv::Point3f);
         HANDLE_CASE(SIZE,    cv::Size);
         HANDLE_CASE(RECT,    cv::Rect);
         HANDLE_CASE(UNKNOWN, cv::GArg);
@@ -523,6 +529,7 @@ static cv::detail::VectorRef extract_vector_ref(PyObject* from, cv::detail::Opaq
         HANDLE_CASE(STRING,    std::string);
         HANDLE_CASE(POINT,     cv::Point);
         HANDLE_CASE(POINT2F,   cv::Point2f);
+        HANDLE_CASE(POINT3F,   cv::Point3f);
         HANDLE_CASE(SIZE,      cv::Size);
         HANDLE_CASE(RECT,      cv::Rect);
         HANDLE_CASE(SCALAR,    cv::Scalar);

--- a/modules/gapi/misc/python/python_bridge.hpp
+++ b/modules/gapi/misc/python/python_bridge.hpp
@@ -36,6 +36,7 @@ WRAP_ARGS(float       , cv::gapi::ArgType::CV_FLOAT,     G)  \
 WRAP_ARGS(std::string , cv::gapi::ArgType::CV_STRING,    G)  \
 WRAP_ARGS(cv::Point   , cv::gapi::ArgType::CV_POINT,     G)  \
 WRAP_ARGS(cv::Point2f , cv::gapi::ArgType::CV_POINT2F,   G)  \
+WRAP_ARGS(cv::Point3f , cv::gapi::ArgType::CV_POINT3F,   G)  \
 WRAP_ARGS(cv::Size    , cv::gapi::ArgType::CV_SIZE,      G)  \
 WRAP_ARGS(cv::Rect    , cv::gapi::ArgType::CV_RECT,      G)  \
 WRAP_ARGS(cv::Scalar  , cv::gapi::ArgType::CV_SCALAR,    G)  \
@@ -53,6 +54,7 @@ WRAP_ARGS(float       , cv::gapi::ArgType::CV_FLOAT,   G)  \
 WRAP_ARGS(std::string , cv::gapi::ArgType::CV_STRING,  G)  \
 WRAP_ARGS(cv::Point   , cv::gapi::ArgType::CV_POINT,   G)  \
 WRAP_ARGS(cv::Point2f , cv::gapi::ArgType::CV_POINT2F, G)  \
+WRAP_ARGS(cv::Point3f , cv::gapi::ArgType::CV_POINT3F, G)  \
 WRAP_ARGS(cv::Size    , cv::gapi::ArgType::CV_SIZE,    G)  \
 WRAP_ARGS(cv::GArg    , cv::gapi::ArgType::CV_ANY,     G)  \
 WRAP_ARGS(cv::Rect    , cv::gapi::ArgType::CV_RECT,    G2) \
@@ -70,6 +72,7 @@ enum ArgType {
     CV_STRING,
     CV_POINT,
     CV_POINT2F,
+    CV_POINT3F,
     CV_SIZE,
     CV_RECT,
     CV_SCALAR,

--- a/modules/gapi/misc/python/test/test_gapi_types.py
+++ b/modules/gapi/misc/python/test/test_gapi_types.py
@@ -18,7 +18,7 @@ try:
 
         def test_garray_type(self):
             types = [cv.gapi.CV_BOOL  , cv.gapi.CV_INT   , cv.gapi.CV_DOUBLE , cv.gapi.CV_FLOAT,
-                     cv.gapi.CV_STRING, cv.gapi.CV_POINT , cv.gapi.CV_POINT2F, cv.gapi.POINT3f ,
+                     cv.gapi.CV_STRING, cv.gapi.CV_POINT , cv.gapi.CV_POINT2F, cv.gapi.CV_POINT3F ,
                      cv.gapi.CV_SIZE  , cv.gapi.CV_RECT  , cv.gapi.CV_SCALAR , cv.gapi.CV_MAT  ,
                      cv.gapi.CV_GMAT]
 

--- a/modules/gapi/misc/python/test/test_gapi_types.py
+++ b/modules/gapi/misc/python/test/test_gapi_types.py
@@ -18,8 +18,9 @@ try:
 
         def test_garray_type(self):
             types = [cv.gapi.CV_BOOL  , cv.gapi.CV_INT   , cv.gapi.CV_DOUBLE , cv.gapi.CV_FLOAT,
-                     cv.gapi.CV_STRING, cv.gapi.CV_POINT , cv.gapi.CV_POINT2F, cv.gapi.CV_SIZE ,
-                     cv.gapi.CV_RECT  , cv.gapi.CV_SCALAR, cv.gapi.CV_MAT    , cv.gapi.CV_GMAT]
+                     cv.gapi.CV_STRING, cv.gapi.CV_POINT , cv.gapi.CV_POINT2F, cv.gapi.POINT3f ,
+                     cv.gapi.CV_SIZE  , cv.gapi.CV_RECT  , cv.gapi.CV_SCALAR , cv.gapi.CV_MAT  ,
+                     cv.gapi.CV_GMAT]
 
             for t in types:
                 g_array = cv.GArrayT(t)
@@ -27,9 +28,9 @@ try:
 
 
         def test_gopaque_type(self):
-            types = [cv.gapi.CV_BOOL  , cv.gapi.CV_INT   , cv.gapi.CV_DOUBLE , cv.gapi.CV_FLOAT,
-                     cv.gapi.CV_STRING, cv.gapi.CV_POINT , cv.gapi.CV_POINT2F, cv.gapi.CV_SIZE ,
-                     cv.gapi.CV_RECT]
+            types = [cv.gapi.CV_BOOL  , cv.gapi.CV_INT  , cv.gapi.CV_DOUBLE , cv.gapi.CV_FLOAT  ,
+                     cv.gapi.CV_STRING, cv.gapi.CV_POINT, cv.gapi.CV_POINT2F, cv.gapi.CV_POINT3F,
+                     cv.gapi.CV_SIZE  , cv.gapi.CV_RECT]
 
             for t in types:
                 g_opaque = cv.GOpaqueT(t)

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -176,6 +176,13 @@ IIStream& operator>> (IIStream& is, cv::Point2f& pt) {
     return is >> pt.x >> pt.y;
 }
 
+IOStream& operator<< (IOStream& os, const cv::Point3f &pt) {
+    return os << pt.x << pt.y << pt.z;
+}
+IIStream& operator>> (IIStream& is, cv::Point3f& pt) {
+    return is >> pt.x >> pt.y >> pt.z;
+}
+
 IOStream& operator<< (IOStream& os, const cv::Size &sz) {
     return os << sz.width << sz.height;
 }
@@ -584,6 +591,7 @@ IIStream& operator>> (IIStream& is, cv::GArg &arg) {
             HANDLE_CASE(STRING  , std::string);
             HANDLE_CASE(POINT   , cv::Point);
             HANDLE_CASE(POINT2F , cv::Point2f);
+            HANDLE_CASE(POINT3F , cv::Point3f);
             HANDLE_CASE(SIZE    , cv::Size);
             HANDLE_CASE(RECT    , cv::Rect);
             HANDLE_CASE(SCALAR  , cv::Scalar);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Motivation
Python bindings are available since a long time, but only a few operations (`operation::on(...)` wrappers) were exposed.
There was a great plan to implement feature in python parser that could automatically detect `G-API` operation (via `GAPI_TYPED_KERNEL` macro or so) and expose it into python, but this functionality is more about giving an opportunity to user to implement python `kernels` for already existing in G-API operations. 

This PR is going to expose just `operation::on` wrappers to python in order to give user everything that is available from c++, because now, for developers who don't build from source and change the code only available a small amount of functionality.
Since a lot of developers use `opencv` from `pip` let's expose it once and forever.

Great example of G-API usage: https://github.com/xiong-jie-y/g_api_examples

TODO list:
- [x] Expose `core`
- [ ] Expose `imgproc`
- [ ] Expose `video` 
- [ ] Expose `stereo` 
- [ ] Other stuff (e.g constant initialization for `G-Type`'s & some compiler args) 


