### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2022.09

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/4.x_20220524
-# Binaries were created for OpenCV: d6e9616256b46bd59be0a93d397f6ab958d39cd2
-ocv_update(FFMPEG_BINARIES_COMMIT "65ec04d4573dcdfa4531f0b9e67f35d8ffff873e")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "5573e2262ad1298e603122b7759fc2f6")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "5f9e2b2e04c15f080f40e844de80c867")
+# Binaries branch name: ffmpeg/4.x_20220912
+# Binaries were created for OpenCV: 4154bd06677c30475e2545cbee05906dd9a367cb
+ocv_update(FFMPEG_BINARIES_COMMIT "524023e38e27649d4f5ce97d57ceb8864c838fb6")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "88f87420899e07151b682a76e30d3e01")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "81b1e1e9fd2a10f4ec7b239c743240fe")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -413,10 +413,6 @@ TEST_P(ffmpeg_get_fourcc, check_short_codecs)
     if (!cap.isOpened())
         throw SkipTestException("Video stream is not supported");
     const double fourcc = cap.get(CAP_PROP_FOURCC);
-#ifdef _WIN32  // handle old FFmpeg backend
-    if(!fourcc && fileName == "../cv/tracking/faceocc2/data/faceocc2.webm")
-        throw SkipTestException("Feature not yet supported by Windows FFmpeg shared library!");
-#endif
     ASSERT_EQ(fourcc_string, fourccToString((int)fourcc));
 }
 
@@ -443,10 +439,8 @@ TEST(videoio, mp4_orientation_meta_auto)
     EXPECT_NO_THROW(cap.open(video_file, CAP_FFMPEG));
     ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << CAP_FFMPEG << std::endl;
 
-#ifndef _WIN32 // TODO: FFmpeg wrapper update
     // related issue: https://github.com/opencv/opencv/issues/22088
     EXPECT_EQ(90, cap.get(CAP_PROP_ORIENTATION_META));
-#endif
 
     cap.set(CAP_PROP_ORIENTATION_AUTO, true);
     if (cap.get(CAP_PROP_ORIENTATION_AUTO) == 0)
@@ -521,10 +515,6 @@ TEST(videoio_ffmpeg, ffmpeg_check_extra_data)
     EXPECT_NO_THROW(cap.open(video_file, CAP_FFMPEG));
     ASSERT_TRUE(cap.isOpened()) << "Can't open the video";
     const int codecExtradataIdx = (int)cap.get(CAP_PROP_CODEC_EXTRADATA_INDEX);
-#ifdef _WIN32  // handle old FFmpeg backend
-    if (codecExtradataIdx <= 0)
-        throw SkipTestException("Codec extra data is not supported by backend or video stream");
-#endif
     Mat data;
     ASSERT_TRUE(cap.retrieve(data, codecExtradataIdx));
     EXPECT_EQ(CV_8UC1, data.type()) << "CV_8UC1 != " << typeToString(data.type());

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -771,8 +771,8 @@ static const VideoCaptureAccelerationInput hw_filename[] = {
         { "sample_322x242_15frames.yuv420p.libxvid.mp4", 28.0 },
         { "sample_322x242_15frames.yuv420p.mjpeg.mp4", 20.0 },
         { "sample_322x242_15frames.yuv420p.mpeg2video.mp4", 24.0 },  // GSTREAMER on Ubuntu 18.04
-        { "sample_322x242_15frames.yuv420p.libx264.mp4", 24.0 },  // GSTREAMER on Ubuntu 18.04
-        { "sample_322x242_15frames.yuv420p.libx265.mp4", 30.0 },
+        { "sample_322x242_15frames.yuv420p.libx264.mp4", 23.0 },  // D3D11 on GHA/Windows, GSTREAMER on Ubuntu 18.04
+        { "sample_322x242_15frames.yuv420p.libx265.mp4", 23.0 },  // D3D11 on GHA/Windows
         { "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4", 30.0 },
         { "sample_322x242_15frames.yuv420p.libaom-av1.mp4", 30.0 }
 };


### PR DESCRIPTION
**Merge with 3rdparty**: https://github.com/opencv/opencv_3rdparty/pull/73

- FFmpeg 4.4.2
- added AV1 support through aom 3.4.0: https://aomedia.googlesource.com/aom/+/refs/tags/v3.4.0

resolves #11389

previous update: https://github.com/opencv/opencv/pull/22034

```
force_builders=Win64,Win32
```