### PR TITLE
[GSOC 2022] Better DB model support based on old API

### DIFF
--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -1364,6 +1364,12 @@ struct TextDetectionModel_DB_Impl : public TextDetectionModel_Impl
         CV_Assert(outs.size() == 1);
         Mat binary = outs[0];
 
+        //Support ppdetect
+        int dim=binary.dims;
+        if(dim==3){
+            binary=binary.reshape(0,binary.size[1]);
+        }
+
         // Threshold
         Mat bitmap;
         threshold(binary, bitmap, binaryThreshold, 255, THRESH_BINARY);


### PR DESCRIPTION
Because the output size of ppdetect(https://github.com/opencv/opencv_zoo/pull/66) is 1x1x-1x-1 but DB api is 1x-1x-1.I modify 'modules/dnn/src/model.cpp' as below.Still working on writing more tests
```
 //Support ppdetect
        int dim=binary.dims;
        if(dim==3){
            binary=binary.reshape(0,binary.size[1]);
        }

```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x]  I agree to contribute to the project under Apache 2 License.
- [x]  To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x]  The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x]  The feature is well documented and sample code can be built with the project CMake
