### PR TITLE
dnn: eliminate GCC12 warning in total() call

### DIFF
--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -160,18 +160,45 @@ static inline MatShape shape(int a0, int a1=-1, int a2=-1, int a3=-1)
 
 static inline int total(const MatShape& shape, int start = -1, int end = -1)
 {
-    if (start == -1) start = 0;
-    if (end == -1) end = (int)shape.size();
-
     if (shape.empty())
         return 0;
 
+    int dims = (int)shape.size();
+
+    if (start == -1) start = 0;
+    if (end == -1) end = dims;
+
+    CV_CheckLE(0, start, "");
+    CV_CheckLE(start, end, "");
+    CV_CheckLE(end, dims, "");
+
     int elems = 1;
-    CV_Assert(start <= (int)shape.size() && end <= (int)shape.size() &&
-              start <= end);
-    for(int i = start; i < end; i++)
+    for (int i = start; i < end; i++)
     {
         elems *= shape[i];
+    }
+    return elems;
+}
+
+// TODO: rename to countDimsElements()
+static inline int total(const Mat& mat, int start = -1, int end = -1)
+{
+    if (mat.empty())
+        return 0;
+
+    int dims = mat.dims;
+
+    if (start == -1) start = 0;
+    if (end == -1) end = dims;
+
+    CV_CheckLE(0, start, "");
+    CV_CheckLE(start, end, "");
+    CV_CheckLE(end, dims, "");
+
+    int elems = 1;
+    for (int i = start; i < end; i++)
+    {
+        elems *= mat.size[i];
     }
     return elems;
 }

--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -208,8 +208,8 @@ public:
         const float* inpData = inp0.ptr<float>();
         float* outData = outputs[0].ptr<float>();
 
-        size_t num = total(shape(inp0.size), 0, startAxis);
-        size_t numPlanes = total(shape(inp0.size), startAxis, endAxis + 1);
+        size_t num = total(inp0, 0, startAxis);
+        size_t numPlanes = total(inp0, startAxis, endAxis + 1);
         CV_Assert(num * numPlanes != 0);
         size_t planeSize = inp0.total() / (num * numPlanes);
         for (size_t n = 0; n < num; ++n)


### PR DESCRIPTION
Make GCC 12 happy:

```
In file included from /usr/include/c++/12/x86_64-redhat-linux/bits/c++allocator.h:33,
                 from /usr/include/c++/12/bits/allocator.h:46,
                 from /usr/include/c++/12/string:41,
                 from /home/alalek/projects/opencv/dev/modules/core/include/opencv2/core/cvstd.hpp:56,
                 from /home/alalek/projects/opencv/dev/modules/core/include/opencv2/core/base.hpp:58,
                 from /home/alalek/projects/opencv/dev/modules/core/include/opencv2/core.hpp:53,
                 from /home/alalek/projects/opencv/dev/modules/dnn/src/layers/../precomp.hpp:42,
                 from /home/alalek/projects/opencv/dev/modules/dnn/src/layers/normalize_bbox_layer.cpp:43:
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /usr/include/c++/12/bits/alloc_traits.h:496:23,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:387:19,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:366:15,
    inlined from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:733:7,
    inlined from ‘virtual void cv::dnn::NormalizeBBoxLayerImpl::forward(cv::InputArrayOfArrays, cv::OutputArrayOfArrays, cv::OutputArrayOfArrays)’ at /home/alalek/projects/opencv/dev/modules/dnn/src/layers/normalize_bbox_layer.cpp:219:39:
/usr/include/c++/12/bits/new_allocator.h:158:33: warning: ‘void operator delete(void*)’ called on pointer ‘<unknown>’ with nonzero offset [1, 9223372036854775804] [-Wfree-nonheap-object]
  158 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = int]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_CharT> >::allocate(allocator_type&, size_type) [with _Tp = int]’ at /usr/include/c++/12/bits/alloc_traits.h:464:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:378:33,
    inlined from ‘std::vector<_Tp, _Alloc>::pointer std::vector<_Tp, _Alloc>::_M_allocate_and_copy(size_type, _ForwardIterator, _ForwardIterator) [with _ForwardIterator = const int*; _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:1614:40,
    inlined from ‘void std::vector<_Tp, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const int*; _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/vector.tcc:318:40,
    inlined from ‘void std::vector<_Tp, _Alloc>::_M_assign_dispatch(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = const int*; _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:1737:17,
    inlined from ‘void std::vector<_Tp, _Alloc>::assign(_InputIterator, _InputIterator) [with _InputIterator = const int*; <template-parameter-2-2> = void; _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/12/bits/stl_vector.h:824:22,
    inlined from ‘cv::dnn::dnn4_v20220524::MatShape cv::dnn::dnn4_v20220524::shape(const int*, int)’ at /home/alalek/projects/opencv/dev/modules/dnn/include/opencv2/dnn/shape_utils.hpp:122:17,
    inlined from ‘cv::dnn::dnn4_v20220524::MatShape cv::dnn::dnn4_v20220524::shape(const cv::MatSize&)’ at /home/alalek/projects/opencv/dev/modules/dnn/include/opencv2/dnn/shape_utils.hpp:133:33,
    inlined from ‘virtual void cv::dnn::NormalizeBBoxLayerImpl::forward(cv::InputArrayOfArrays, cv::OutputArrayOfArrays, cv::OutputArrayOfArrays)’ at /home/alalek/projects/opencv/dev/modules/dnn/src/layers/normalize_bbox_layer.cpp:219:39:
/usr/include/c++/12/bits/new_allocator.h:137:55: note: returned from ‘void* operator new(std::size_t)’
  137 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```