### PR TITLE
build: eliminate uninitialized warnings from GCC12

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -50,6 +50,12 @@
 #include <stdlib.h>
 #include "opencv2/core/cvdef.h"
 
+#if defined(__GNUC__) && __GNUC__ == 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #define OPENCV_HAL_ADD(a, b) ((a) + (b))
 #define OPENCV_HAL_AND(a, b) ((a) & (b))
 #define OPENCV_HAL_NOP(a) (a)
@@ -694,5 +700,9 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 } // cv::
 
 //! @endcond
+
+#if defined(__GNUC__) && __GNUC__ == 12
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/modules/imgproc/src/sumpixels.avx512_skx.hpp
+++ b/modules/imgproc/src/sumpixels.avx512_skx.hpp
@@ -6,6 +6,12 @@
 
 #include "opencv2/core/hal/intrin.hpp"
 
+#if defined(__GNUC__) && __GNUC__ == 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace cv { namespace hal {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
@@ -465,3 +471,7 @@ void calculate_integral_avx512(const uchar *src,   size_t _srcstep,
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 }} // end namespace cv::hal
+
+#if defined(__GNUC__) && __GNUC__ == 12
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Warnings looks like:

```
In function ‘__m512i _mm512_cvtepi16_epi32(__m256i)’,
    inlined from ‘void cv::hal_AVX512_SKX::v_expand(const v_int16x32&, v_int32x16&, v_int32x16&)’ at /home/alalek/projects/opencv/dev/modules/core/include/opencv2/core/hal/intrin_avx512.hpp:2028:1,
    inlined from ‘bool cv::hal::opt_AVX512_SKX::{anonymous}::Integral_SIMD<unsigned char, double, double>::operator()(const uchar*, size_t, double*, size_t, double*, size_t, double*, size_t, int, int, int) const’ at /home/alalek/projects/opencv/dev/modules/imgproc/src/sumpixels.simd.hpp:854:29:
/usr/lib/gcc/x86_64-redhat-linux/12/include/avx512fintrin.h:2243:52: warning: ‘__Y’ may be used uninitialized [-Wmaybe-uninitialized]
 2243 |   return (__m512i) __builtin_ia32_pmovsxwd512_mask ((__v16hi) __A,
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
 2244 |                                                     (__v16si)
      |                                                     ~~~~~~~~~
 2245 |                                                     _mm512_undefined_epi32 (),
      |                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
 2246 |                                                     (__mmask16) -1);
      |                                                     ~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-redhat-linux/12/include/avx512fintrin.h: In function ‘bool cv::hal::opt_AVX512_SKX::{anonymous}::Integral_SIMD<unsigned char, double, double>::operator()(const uchar*, size_t, double*, size_t, double*, size_t, double*, size_t, int, int, int) const’:
/usr/lib/gcc/x86_64-redhat-linux/12/include/avx512fintrin.h:206:11: note: ‘__Y’ was declared here
  206 |   __m512i __Y = __Y;
      |           ^~~

```

In general we should not have any warnings from system headers at all.

Probably problem is related to this GCC 12.1 bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562