### PR TITLE
[G-API] Pipeline modeling tool - support local infer node config

### DIFF
--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -193,7 +193,7 @@ CallParams read<CallParams>(const cv::FileNode& fn) {
 template <typename V>
 std::map<std::string, V> readMap(const cv::FileNode& fn) {
     std::map<std::string, V> map;
-    for (auto&& item : fn) {
+    for (auto item : fn) {
         map.emplace(item.name(), read<V>(item));
     }
     return map;

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -190,6 +190,15 @@ CallParams read<CallParams>(const cv::FileNode& fn) {
     return CallParams{std::move(name), static_cast<size_t>(call_every_nth)};
 }
 
+template <typename V>
+std::map<std::string, V> readMap(const cv::FileNode& fn) {
+    std::map<std::string, V> map;
+    for (auto item : fn) {
+        map.emplace(item.name(), read<V>(item));
+    }
+    return map;
+}
+
 template <>
 InferParams read<InferParams>(const cv::FileNode& fn) {
     auto name =
@@ -200,7 +209,7 @@ InferParams read<InferParams>(const cv::FileNode& fn) {
     params.device        = check_and_read<std::string>(fn, "device", name);
     params.input_layers  = readList<std::string>(fn, "input_layers", name);
     params.output_layers = readList<std::string>(fn, "output_layers", name);
-
+    params.config        = readMap<std::string>(fn["config"]);
     return params;
 }
 
@@ -309,13 +318,13 @@ int main(int argc, char* argv[]) {
                                       cv::FileStorage::MEMORY);
         }
 
-        std::map<std::string, std::string> config;
+        std::map<std::string, std::string> gconfig;
         if (!load_config.empty()) {
-            loadConfig(load_config, config);
+            loadConfig(load_config, gconfig);
         }
         // NB: Takes priority over config from file
         if (!cached_dir.empty()) {
-            config =
+            gconfig =
                 std::map<std::string, std::string>{{"CACHE_DIR", cached_dir}};
         }
 
@@ -371,7 +380,10 @@ int main(int argc, char* argv[]) {
                     builder.addDummy(call_params, read<DummyParams>(node_fn));
                 } else if (node_type == "Infer") {
                     auto infer_params = read<InferParams>(node_fn);
-                    infer_params.config = config;
+                    RETHROW_WITH_MSG_IF_FAILED(
+                            utils::intersectMapWith(infer_params.config, gconfig),
+                            "Failed to combine global and local configs for Infer node: "
+                            + call_params.name);
                     builder.addInfer(call_params, infer_params);
                 } else {
                     throw std::logic_error("Unsupported node type: " + node_type);

--- a/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
@@ -93,21 +93,12 @@ typename duration_t::rep timestamp() {
     return duration_cast<duration_t>(now.time_since_epoch()).count();
 }
 
-#define RETHROW_WITH_MSG_IF_FAILED(expr, msg)      \
-    try {                                          \
-        expr;                                      \
-    } catch (const std::exception& e) {            \
-        std::stringstream ss;                      \
-        ss << msg << "\n caused by: " << e.what(); \
-        throw std::logic_error(ss.str());          \
-    }                                              \
-
 template <typename K, typename V>
-void intersectMapWith(std::map<K, V>& target, const std::map<K, V>& second) {
+void mergeMapWith(std::map<K, V>& target, const std::map<K, V>& second) {
     for (auto&& item : second) {
         auto it = target.find(item.first);
         if (it != target.end()) {
-            throw std::logic_error("Met already existing key: " + item.first);
+            throw std::logic_error("Error: key: " + it->first + " is already in target map");
         }
         target.insert(item);
     }

--- a/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENCV_GAPI_PIPELINE_MODELING_TOOL_UTILS_HPP
 #define OPENCV_GAPI_PIPELINE_MODELING_TOOL_UTILS_HPP
 
+#include <map>
+
 #include <opencv2/core.hpp>
 
 #if defined(_WIN32)
@@ -89,6 +91,26 @@ typename duration_t::rep timestamp() {
     using namespace std::chrono;
     auto now = high_resolution_clock::now();
     return duration_cast<duration_t>(now.time_since_epoch()).count();
+}
+
+#define RETHROW_WITH_MSG_IF_FAILED(expr, msg)      \
+    try {                                          \
+        expr;                                      \
+    } catch (const std::exception& e) {            \
+        std::stringstream ss;                      \
+        ss << msg << "\n caused by: " << e.what(); \
+        throw std::logic_error(ss.str());          \
+    }                                              \
+
+template <typename K, typename V>
+void intersectMapWith(std::map<K, V>& target, const std::map<K, V>& second) {
+    for (auto&& item : second) {
+        auto it = target.find(item.first);
+        if (it != target.end()) {
+            throw std::logic_error("Met already existing key: " + item.first);
+        }
+        target.insert(item);
+    }
 }
 
 } // namespace utils


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Overview
The motivation of this PR is the following:
1. Some NN models might require individual `config`
2. Specifying `config` in `.yml` config file once is more convenient if it isn't supposed to be changed according user scenario.

The logic is following: 
- User can specify configuration parameters for every `Infer` node locally via `.yml` config file. 
- `local` config might be combined with `global` (in case it's specified via `--load_config`) until they have key conflicts.
- In case "key conflict" app reports the problem and crash.


```
build_image:Custom=centos:7
buildworker:Custom=linux-1
```