### PR TITLE
Detect RISC-V compiler from PATH environment variable

### DIFF
--- a/platforms/linux/riscv64-gcc.toolchain.cmake
+++ b/platforms/linux/riscv64-gcc.toolchain.cmake
@@ -1,11 +1,20 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR riscv64)
 
-set(RISCV_GCC_INSTALL_ROOT /opt/RISCV CACHE PATH "Path to GCC for RISC-V cross compiler installation directory")
-set(CMAKE_SYSROOT ${RISCV_GCC_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
+if(NOT DEFINED CMAKE_C_COMPILER)
+  find_program(CMAKE_C_COMPILER NAMES riscv64-unknown-linux-gnu-gcc
+                                PATHS /opt/RISCV/bin ENV PATH)
+endif()
 
-set(CMAKE_C_COMPILER ${RISCV_GCC_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER ${RISCV_GCC_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-g++)
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  find_program(CMAKE_CXX_COMPILER NAMES riscv64-unknown-linux-gnu-g++
+                                  PATHS /opt/RISCV/bin ENV PATH)
+endif()
+
+get_filename_component(RISCV_GCC_INSTALL_ROOT ${CMAKE_C_COMPILER} DIRECTORY)
+get_filename_component(RISCV_GCC_INSTALL_ROOT ${RISCV_GCC_INSTALL_ROOT} DIRECTORY)
+
+set(CMAKE_SYSROOT ${RISCV_GCC_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
 
 # Don't run the linker on compiler check
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

from https://github.com/riscv-collab/riscv-gnu-toolchain, default install path is `/opt/riscv` and they recommend add it to the PATH variable.
