### PR TITLE
Fix v_signmask for RISC-V Vector

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1618,7 +1618,7 @@ inline int v_signmask(const _Tpvec& a) \
 { \
     uint8_t ans[4] = {0}; \
     vsm(ans, vmslt(a, 0, VTraits<_Tpvec>::vlanes()), VTraits<_Tpvec>::vlanes()); \
-    return *(reinterpret_cast<int*>(ans)); \
+    return *(reinterpret_cast<int*>(ans)) & (((__int128_t)1 << VTraits<_Tpvec>::vlanes()) - 1); \
 } \
 inline int v_scan_forward(const _Tpvec& a) \
 { \

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -1081,6 +1081,7 @@ template<typename R> struct TheTest
         typedef typename VTraits<uint_reg>::lane_type uint_type;
 
         Data<R> dataA, dataB(0), dataC, dataD(1), dataE(2);
+        dataA[0] = std::numeric_limits<int_type>::max();
         dataA[1] *= (LaneType)-1;
         union
         {


### PR DESCRIPTION
The original signmask implementation returned incorrect results in some cases (e.g. new test cases, 242 is returned but 2 is expected).

This is due to [Vector Tail Agnostic](https://github.com/riscv/riscv-v-spec/blob/b6368b3c44d775f8eb01c7ce0ad017db19944aa7/v-spec.adoc#343-vector-tail-agnostic-and-vector-mask-agnostic-vta-and-vma) in RVV, and this patch solves the problem by using "bitwise AND" to mask high bit.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
