### PR TITLE
Add bindings to CUDA photo denoising functions

### DIFF
--- a/modules/photo/include/opencv2/photo/cuda.hpp
+++ b/modules/photo/include/opencv2/photo/cuda.hpp
@@ -65,11 +65,20 @@ BORDER_REPLICATE , BORDER_CONSTANT , BORDER_REFLECT and BORDER_WRAP are supporte
    fastNlMeansDenoising
  */
 CV_EXPORTS void nonLocalMeans(InputArray src, OutputArray dst,
-                              float h,
-                              int search_window = 21,
-                              int block_size = 7,
-                              int borderMode = BORDER_DEFAULT,
-                              Stream& stream = Stream::Null());
+                            float h,
+                            int search_window = 21,
+                            int block_size = 7,
+                            int borderMode = BORDER_DEFAULT,
+                            Stream& stream = Stream::Null());
+CV_WRAP inline void nonLocalMeans(const GpuMat& src, CV_OUT GpuMat& dst,
+                            float h,
+                            int search_window = 21,
+                            int block_size = 7,
+                            int borderMode = BORDER_DEFAULT,
+                            Stream& stream = Stream::Null())
+{
+    nonLocalMeans(InputArray(src), OutputArray(dst), h, search_window, block_size, borderMode, stream);
+};
 
 /** @brief Perform image denoising using Non-local Means Denoising algorithm
 <http://www.ipol.im/pub/algo/bcm_non_local_means_denoising> with several computational
@@ -93,10 +102,18 @@ FastNonLocalMeansDenoising::labMethod.
    fastNlMeansDenoising
  */
 CV_EXPORTS void fastNlMeansDenoising(InputArray src, OutputArray dst,
-                                     float h,
-                                     int search_window = 21,
-                                     int block_size = 7,
-                                     Stream& stream = Stream::Null());
+                                    float h,
+                                    int search_window = 21,
+                                    int block_size = 7,
+                                    Stream& stream = Stream::Null());
+CV_WRAP inline void fastNlMeansDenoising(const GpuMat& src, CV_OUT GpuMat& dst,
+                                    float h,
+                                    int search_window = 21,
+                                    int block_size = 7,
+                                    Stream& stream = Stream::Null())
+{
+    fastNlMeansDenoising(InputArray(src), OutputArray(dst), h, search_window, block_size, stream);
+}
 
 /** @brief Modification of fastNlMeansDenoising function for colored images
 
@@ -124,6 +141,14 @@ CV_EXPORTS void fastNlMeansDenoisingColored(InputArray src, OutputArray dst,
                                             int search_window = 21,
                                             int block_size = 7,
                                             Stream& stream = Stream::Null());
+CV_WRAP inline void fastNlMeansDenoisingColored(const GpuMat& src, CV_OUT GpuMat& dst,
+                                            float h_luminance, float photo_render,
+                                            int search_window = 21,
+                                            int block_size = 7,
+                                            Stream& stream = Stream::Null())
+{
+    fastNlMeansDenoisingColored(InputArray(src), OutputArray(dst), h_luminance, photo_render, search_window, block_size, stream);
+}
 
 //! @} photo
 

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -64,5 +64,10 @@ class cuda_test(NewOpenCVTests):
         self.assertTrue(cuMat.step == 0)
         self.assertTrue(cuMat.size() == (0, 0))
 
+    def test_cuda_denoising(self):
+        self.assertEqual(True, hasattr(cv.cuda, 'fastNlMeansDenoising'))
+        self.assertEqual(True, hasattr(cv.cuda, 'fastNlMeansDenoisingColored'))
+        self.assertEqual(True, hasattr(cv.cuda, 'nonLocalMeans'))
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Python bindings were missing from the CUDA photo denoising functions.  The function signatures have been updated and python test added to verify their existence.

Are these supposed to be in the main repository?

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
