### PR TITLE
riscv: use /opt/riscv path in toolchain

### DIFF
--- a/platforms/linux/riscv64-clang.toolchain.cmake
+++ b/platforms/linux/riscv64-clang.toolchain.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR riscv64)
 
 set(RISCV_CLANG_BUILD_ROOT /opt/rvv-llvm CACHE PATH "Path to CLANG for RISC-V cross compiler build directory")
-set(RISCV_GCC_INSTALL_ROOT /opt/RISCV CACHE PATH "Path to GCC for RISC-V cross compiler installation directory")
+set(RISCV_GCC_INSTALL_ROOT /opt/riscv CACHE PATH "Path to GCC for RISC-V cross compiler installation directory")
 set(CMAKE_SYSROOT ${RISCV_GCC_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
 
 set(CLANG_TARGET_TRIPLE riscv64-unknown-linux-gnu)

--- a/platforms/linux/riscv64-gcc.toolchain.cmake
+++ b/platforms/linux/riscv64-gcc.toolchain.cmake
@@ -3,12 +3,12 @@ set(CMAKE_SYSTEM_PROCESSOR riscv64)
 
 if(NOT DEFINED CMAKE_C_COMPILER)
   find_program(CMAKE_C_COMPILER NAMES riscv64-unknown-linux-gnu-gcc
-                                PATHS /opt/RISCV/bin ENV PATH)
+                                PATHS /opt/riscv/bin ENV PATH)
 endif()
 
 if(NOT DEFINED CMAKE_CXX_COMPILER)
   find_program(CMAKE_CXX_COMPILER NAMES riscv64-unknown-linux-gnu-g++
-                                  PATHS /opt/RISCV/bin ENV PATH)
+                                  PATHS /opt/riscv/bin ENV PATH)
 endif()
 
 get_filename_component(RISCV_GCC_INSTALL_ROOT ${CMAKE_C_COMPILER} DIRECTORY)


### PR DESCRIPTION
- uppercase paths should be avoided
- align with defaults from https://github.com/riscv-collab/riscv-gnu-toolchain

relates #18228

/cc @dkurt (#22547)