### PR TITLE
G-API: API for configuring model output precision for IE backend

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -88,6 +88,15 @@ struct ParamDesc {
 
     cv::optional<cv::gapi::wip::onevpl::Device> vpl_preproc_device;
     cv::optional<cv::gapi::wip::onevpl::Context> vpl_preproc_ctx;
+
+    using precision_t = int;
+    using precision_map_t = std::unordered_map<std::string, int>;
+    // NB: cv::util::monostate is default value that means precision wasn't specified.
+    using precision_variant_t = cv::util::variant<cv::util::monostate,
+                                                  precision_t,
+                                                  precision_map_t>;
+    precision_variant_t output_precision;
+
 };
 } // namespace detail
 
@@ -132,6 +141,7 @@ public:
               , {}
               , {}
               , {}
+              , {}
               , {}} {
     };
 
@@ -153,6 +163,7 @@ public:
               , {}
               , {}
               , 1u
+              , {}
               , {}
               , {}
               , {}
@@ -351,6 +362,29 @@ public:
         return *this;
     }
 
+    /** @brief Specifies the output precision for model.
+
+    The function is used to set an output precision for model.
+
+    @param precision Precision in OpenCV format.
+    @return reference to this parameter structure.
+    */
+    Params<Net>& cfgOutputPrecision(detail::ParamDesc::precision_t precision) {
+        desc.output_precision = precision;
+        return *this;
+    }
+
+    /** @overload
+
+    @param precision_map Map of pairs: name of corresponding output layer and its precision
+    @return reference to this parameter structure.
+    */
+    Params<Net>&
+    cfgOutputPrecision(detail::ParamDesc::precision_map_t precision_map) {
+        desc.output_precision = precision_map;
+        return *this;
+    }
+
     // BEGIN(G-API's network parametrization API)
     GBackend      backend()    const { return cv::gapi::ie::backend();  }
     std::string   tag()        const { return Net::tag(); }
@@ -385,7 +419,7 @@ public:
            const std::string &device)
         : desc{ model, weights, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Load, true, {}, {}, {}, 1u,
-                {}, {}, {}, {}},
+                {}, {}, {}, {}, {}},
           m_tag(tag) {
     };
 
@@ -403,7 +437,7 @@ public:
            const std::string &device)
         : desc{ model, {}, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u,
-                {}, {}, {}, {}},
+                {}, {}, {}, {}, {}},
           m_tag(tag) {
     };
 
@@ -473,6 +507,19 @@ public:
     /** @see ie::Params::cfgBatchSize */
     Params& cfgBatchSize(const size_t size) {
         desc.batch_size = cv::util::make_optional(size);
+        return *this;
+    }
+
+    /** @see ie::Params::cfgOutputPrecision */
+    Params& cfgOutputPrecision(detail::ParamDesc::precision_t precision) {
+        desc.output_precision = precision;
+        return *this;
+    }
+
+    /** @overload */
+    Params&
+    cfgOutputPrecision(detail::ParamDesc::precision_map_t precision_map) {
+        desc.output_precision = precision_map;
         return *this;
     }
 

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -89,13 +89,17 @@ struct ParamDesc {
     cv::optional<cv::gapi::wip::onevpl::Device> vpl_preproc_device;
     cv::optional<cv::gapi::wip::onevpl::Context> vpl_preproc_ctx;
 
-    using precision_t = int;
-    using precision_map_t = std::unordered_map<std::string, int>;
-    // NB: cv::util::monostate is default value that means precision wasn't specified.
-    using precision_variant_t = cv::util::variant<cv::util::monostate,
-                                                  precision_t,
-                                                  precision_map_t>;
-    precision_variant_t output_precision;
+    using PrecisionT = int;
+    using PrecisionMapT = std::unordered_map<std::string, PrecisionT>;
+    // NB: This parameter can contain:
+    // 1. cv::util::monostate - Don't specify precision, but use default from IR/Blob.
+    // 2. PrecisionT (CV_8U, CV_32F, ...) - Specifies precision for all output layers.
+    // 3. PrecisionMapT ({{"layer0", CV_32F}, {"layer1", CV_16F}} - Specifies precision for certain output layer.
+    // cv::util::monostate is default value that means precision wasn't specified.
+    using PrecisionVariantT = cv::util::variant<cv::util::monostate,
+                                                PrecisionT,
+                                                PrecisionMapT>;
+    PrecisionVariantT output_precision;
 
 };
 } // namespace detail
@@ -366,21 +370,23 @@ public:
 
     The function is used to set an output precision for model.
 
-    @param precision Precision in OpenCV format.
+    @param precision Precision in OpenCV format (CV_8U, CV_32F, ...)
+    will be applied to all output layers.
     @return reference to this parameter structure.
     */
-    Params<Net>& cfgOutputPrecision(detail::ParamDesc::precision_t precision) {
+    Params<Net>& cfgOutputPrecision(detail::ParamDesc::PrecisionT precision) {
         desc.output_precision = precision;
         return *this;
     }
 
     /** @overload
 
-    @param precision_map Map of pairs: name of corresponding output layer and its precision
+    @param precision_map Map of pairs: name of corresponding output layer
+    and its precision in OpenCV format (CV_8U, CV_32F, ...)
     @return reference to this parameter structure.
     */
     Params<Net>&
-    cfgOutputPrecision(detail::ParamDesc::precision_map_t precision_map) {
+    cfgOutputPrecision(detail::ParamDesc::PrecisionMapT precision_map) {
         desc.output_precision = precision_map;
         return *this;
     }
@@ -511,14 +517,14 @@ public:
     }
 
     /** @see ie::Params::cfgOutputPrecision */
-    Params& cfgOutputPrecision(detail::ParamDesc::precision_t precision) {
+    Params& cfgOutputPrecision(detail::ParamDesc::PrecisionT precision) {
         desc.output_precision = precision;
         return *this;
     }
 
     /** @overload */
     Params&
-    cfgOutputPrecision(detail::ParamDesc::precision_map_t precision_map) {
+    cfgOutputPrecision(detail::ParamDesc::PrecisionMapT precision_map) {
         desc.output_precision = precision_map;
         return *this;
     }

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -210,6 +210,12 @@ InferParams read<InferParams>(const cv::FileNode& fn) {
     params.input_layers  = readList<std::string>(fn, "input_layers", name);
     params.output_layers = readList<std::string>(fn, "output_layers", name);
     params.config        = readMap<std::string>(fn["config"]);
+
+    auto out_prec_str = readOpt<std::string>(fn["output_precision"]);
+    if (out_prec_str.has_value()) {
+        params.out_precision =
+            cv::optional<int>(strToPrecision(out_prec_str.value()));
+    }
     return params;
 }
 

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -258,6 +258,7 @@ struct InferParams {
     std::vector<std::string> input_layers;
     std::vector<std::string> output_layers;
     std::map<std::string, std::string> config;
+    cv::util::optional<int> out_precision;
 };
 
 class PipelineBuilder {
@@ -362,6 +363,9 @@ void PipelineBuilder::addInfer(const CallParams&  call_params,
     }
 
     pp->pluginConfig(infer_params.config);
+    if (infer_params.out_precision) {
+        pp->cfgOutputPrecision(infer_params.out_precision.value());
+    }
     m_state->networks += cv::gapi::networks(*pp);
 
     addCall(call_params,

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -197,6 +197,16 @@ inline IE::Blob::Ptr wrapIE(const cv::MediaFrame::View& view,
 
 template<class MatType>
 inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
+    const auto& desc = blob->getTensorDesc();
+    const auto ie_type = toCV(desc.getPrecision());
+    if (ie_type != mat.type()) {
+        std::stringstream ss;
+        ss << "Failed while copying blob from IE to OCV: "
+           << "Blobs have different data types.\n"
+           << "IE type: " << ie_type << "\n"
+           << "OCV type: " << mat.type() << std::endl;
+        throw std::logic_error(ss.str());
+    }
     switch (blob->getTensorDesc().getPrecision()) {
 #define HANDLE(E,T)                                                 \
         case IE::Precision::E: std::copy_n(blob->buffer().as<T*>(), \
@@ -364,6 +374,13 @@ struct IEUnit {
         } else {
             cv::util::throw_error(std::logic_error("Unsupported ParamDesc::Kind"));
         }
+
+        if (params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import &&
+            !cv::util::holds_alternative<cv::util::monostate>(params.output_precision)) {
+            cv::util::throw_error(
+                    std::logic_error("Setting output precision isn't supported for imported network"));
+        }
+
 
         using namespace cv::gapi::wip::onevpl;
         if (params.vpl_preproc_device.has_value() && params.vpl_preproc_ctx.has_value()) {
@@ -1122,6 +1139,32 @@ static IE::PreProcessInfo configurePreProcInfo(const IE::InputInfo::CPtr& ii,
     return info;
 }
 
+using namespace cv::gapi::ie::detail;
+static void configureOutputPrecision(const IE::OutputsDataMap             &outputs_info,
+                                     const ParamDesc::precision_variant_t &output_precision) {
+    switch (output_precision.index()) {
+        case ParamDesc::precision_variant_t::index_of<ParamDesc::precision_t>(): {
+            auto precision = toIE(cv::util::get<ParamDesc::precision_t>(output_precision));
+            for (auto it : outputs_info) {
+                it.second->setPrecision(precision);
+            }
+            break;
+        }
+        case ParamDesc::precision_variant_t::index_of<ParamDesc::precision_map_t>(): {
+            const auto& precision_map =
+                cv::util::get<ParamDesc::precision_map_t>(output_precision);
+            for (auto it : precision_map) {
+                outputs_info.at(it.first)->setPrecision(toIE(it.second));
+            }
+            break;
+        }
+        case ParamDesc::precision_variant_t::index_of<cv::util::monostate>(): {
+            // Do nothing;
+            break;
+        }
+    }
+}
+
 // NB: This is a callback used by async infer
 // to post outputs blobs (cv::GMat's).
 static void PostOutputs(InferenceEngine::InferRequest &request,
@@ -1241,7 +1284,7 @@ struct Infer: public cv::detail::KernelTag {
         GAPI_Assert(uu.params.input_names.size() == in_metas.size()
                     && "Known input layers count doesn't match input meta count");
 
-        // NB: Configuring input precision and network reshape must be done
+        // NB: Configuring input/output precision and network reshape must be done
         // only in the loadNetwork case.
         using namespace cv::gapi::ie::detail;
         if (uu.params.kind == ParamDesc::Kind::Load) {
@@ -1275,6 +1318,7 @@ struct Infer: public cv::detail::KernelTag {
             if (!input_reshape_table.empty()) {
                 const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
             }
+            configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
         } else {
             GAPI_Assert(uu.params.kind == ParamDesc::Kind::Import);
             auto inputs = uu.this_network.GetInputsInfo();
@@ -1393,6 +1437,7 @@ struct InferROI: public cv::detail::KernelTag {
                 const_cast<IEUnit::InputFramesDesc &>(uu.net_input_params)
                             .set_param(input_name, ii->getTensorDesc());
             }
+            configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
         } else {
             GAPI_Assert(uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import);
             auto inputs = uu.this_network.GetInputsInfo();
@@ -1513,6 +1558,7 @@ struct InferList: public cv::detail::KernelTag {
             if (!input_reshape_table.empty()) {
                 const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
             }
+            configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
         } else {
             GAPI_Assert(uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import);
             std::size_t idx = 1u;
@@ -1667,6 +1713,7 @@ struct InferList2: public cv::detail::KernelTag {
                     if (!input_reshape_table.empty()) {
                         const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
                     }
+                    configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
                 } else {
                     GAPI_Assert(uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import);
                     auto inputs = uu.this_network.GetInputsInfo();


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Overview
This `cfgOutputPrecision` handle is partially introduced/discussed there: https://github.com/opencv/opencv/issues/22522 
