### PR TITLE
G-API: Add synchronous execution for IE backend

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -52,6 +52,8 @@ enum class TraitAs: int
 
 using IEConfig = std::map<std::string, std::string>;
 
+enum InferMode {Sync, Async};
+
 namespace detail {
 struct ParamDesc {
     std::string model_path;
@@ -89,7 +91,6 @@ struct ParamDesc {
     cv::optional<cv::gapi::wip::onevpl::Device> vpl_preproc_device;
     cv::optional<cv::gapi::wip::onevpl::Context> vpl_preproc_ctx;
 
-    enum InferMode {Sync, Async};
     InferMode mode;
 };
 } // namespace detail
@@ -136,7 +137,7 @@ public:
               , {}
               , {}
               , {}
-              , detail::ParamDesc::InferMode::Async} {
+              , InferMode::Async} {
     };
 
     /** @overload
@@ -161,7 +162,7 @@ public:
               , {}
               , {}
               , {}
-              , detail::ParamDesc::InferMode::Async} {
+              , InferMode::Async} {
     };
 
     /** @brief Specifies sequence of network input layers names for inference.
@@ -367,7 +368,7 @@ public:
     @param mode Inference mode which will be used.
     @return reference to this parameter structure.
     */
-    Params<Net>& cfgInferMode(detail::ParamDesc::InferMode mode) {
+    Params<Net>& cfgInferMode(InferMode mode) {
         desc.mode = mode;
         return *this;
     }
@@ -407,7 +408,7 @@ public:
         : desc{ model, weights, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Load, true, {}, {}, {}, 1u,
                 {}, {}, {}, {},
-                detail::ParamDesc::InferMode::Async },
+                InferMode::Async },
           m_tag(tag) {
     };
 
@@ -426,7 +427,7 @@ public:
         : desc{ model, {}, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u,
                 {}, {}, {}, {},
-                detail::ParamDesc::InferMode::Async },
+                InferMode::Async },
           m_tag(tag) {
     };
 
@@ -500,7 +501,7 @@ public:
     }
 
     /** @see ie::Params::cfgInferAPI */
-    Params& cfgInferMode(detail::ParamDesc::InferMode mode) {
+    Params& cfgInferMode(InferMode mode) {
         desc.mode = mode;
         return *this;
     }

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -88,6 +88,9 @@ struct ParamDesc {
 
     cv::optional<cv::gapi::wip::onevpl::Device> vpl_preproc_device;
     cv::optional<cv::gapi::wip::onevpl::Context> vpl_preproc_ctx;
+
+    enum InferMode {Sync, Async};
+    InferMode mode;
 };
 } // namespace detail
 
@@ -132,7 +135,8 @@ public:
               , {}
               , {}
               , {}
-              , {}} {
+              , {}
+              , detail::ParamDesc::InferMode::Async} {
     };
 
     /** @overload
@@ -156,7 +160,8 @@ public:
               , {}
               , {}
               , {}
-              , {}} {
+              , {}
+              , detail::ParamDesc::InferMode::Async} {
     };
 
     /** @brief Specifies sequence of network input layers names for inference.
@@ -351,6 +356,22 @@ public:
         return *this;
     }
 
+    /** @brief Specifies which api will be used to run inference.
+
+    The function is used to specify mode for OpenVINO inference.
+    OpenVINO has two options to run inference:
+    1. Asynchronous (using StartAsync: https://docs.openvino.ai/latest/classInferenceEngine_1_1InferRequest.html#doxid-class-inference-engine-1-1-infer-request-1a405293e8423d82a5b45f642a3bef0d24)
+    2. Synchronous (using Infer: https://docs.openvino.ai/latest/classInferenceEngine_1_1InferRequest.html#doxid-class-inference-engine-1-1-infer-request-1a3391ce30894abde730523e9ca9371ce8)
+    By default asynchronous mode is used.
+
+    @param mode Inference mode which will be used.
+    @return reference to this parameter structure.
+    */
+    Params<Net>& cfgInferMode(detail::ParamDesc::InferMode mode) {
+        desc.mode = mode;
+        return *this;
+    }
+
     // BEGIN(G-API's network parametrization API)
     GBackend      backend()    const { return cv::gapi::ie::backend();  }
     std::string   tag()        const { return Net::tag(); }
@@ -385,7 +406,8 @@ public:
            const std::string &device)
         : desc{ model, weights, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Load, true, {}, {}, {}, 1u,
-                {}, {}, {}, {}},
+                {}, {}, {}, {},
+                detail::ParamDesc::InferMode::Async },
           m_tag(tag) {
     };
 
@@ -403,7 +425,8 @@ public:
            const std::string &device)
         : desc{ model, {}, device, {}, {}, {}, 0u, 0u,
                 detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u,
-                {}, {}, {}, {}},
+                {}, {}, {}, {},
+                detail::ParamDesc::InferMode::Async },
           m_tag(tag) {
     };
 
@@ -473,6 +496,12 @@ public:
     /** @see ie::Params::cfgBatchSize */
     Params& cfgBatchSize(const size_t size) {
         desc.batch_size = cv::util::make_optional(size);
+        return *this;
+    }
+
+    /** @see ie::Params::cfgInferAPI */
+    Params& cfgInferMode(detail::ParamDesc::InferMode mode) {
+        desc.mode = mode;
         return *this;
     }
 

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -175,6 +175,17 @@ static PLMode strToPLMode(const std::string& mode_str) {
     }
 }
 
+static cv::gapi::ie::InferMode strToInferMode(const std::string& infer_mode) {
+    if (infer_mode == "async") {
+        return cv::gapi::ie::InferMode::Async;
+    } else if (infer_mode == "sync") {
+        return cv::gapi::ie::InferMode::Sync;
+    } else {
+        throw std::logic_error("Unsupported Infer mode: " + infer_mode +
+                "\nPlease chose between: async and sync");
+    }
+}
+
 template <>
 CallParams read<CallParams>(const cv::FileNode& fn) {
     auto name =
@@ -282,7 +293,8 @@ int main(int argc, char* argv[]) {
         "{ drop_frames | false     | Drop frames if they come earlier than pipeline is completed. }"
         "{ exec_list   |           | A comma-separated list of pipelines that"
                                    " will be executed. Spaces around commas"
-                                   " are prohibited. }";
+                                   " are prohibited. }"
+        "{ infer_mode  | async     | OpenVINO inference mode (async/sync). }";
 
         cv::CommandLineParser cmd(argc, argv, keys);
         if (cmd.has("help")) {
@@ -298,6 +310,7 @@ int main(int argc, char* argv[]) {
         const auto qc          = cmd.get<int>("qc");
         const auto app_mode    = strToAppMode(cmd.get<std::string>("app_mode"));
         const auto exec_str    = cmd.get<std::string>("exec_list");
+        const auto infer_mode  = strToInferMode(cmd.get<std::string>("infer_mode"));
         const auto drop_frames = cmd.get<bool>("drop_frames");
 
         cv::FileStorage fs;
@@ -388,6 +401,7 @@ int main(int argc, char* argv[]) {
                            << call_params.name << std::endl << e.what();
                         throw std::logic_error(ss.str());
                     }
+                    infer_params.mode = infer_mode;
                     builder.addInfer(call_params, infer_params);
                 } else {
                     throw std::logic_error("Unsupported node type: " + node_type);

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -258,6 +258,7 @@ struct InferParams {
     std::vector<std::string> input_layers;
     std::vector<std::string> output_layers;
     std::map<std::string, std::string> config;
+    cv::gapi::ie::InferMode mode;
 };
 
 class PipelineBuilder {
@@ -362,6 +363,7 @@ void PipelineBuilder::addInfer(const CallParams&  call_params,
     }
 
     pp->pluginConfig(infer_params.config);
+    pp->cfgInferMode(infer_params.mode);
     m_state->networks += cv::gapi::networks(*pp);
 
     addCall(call_params,

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -918,13 +918,13 @@ public:
 
 private:
     void setup();
-    void release(const int id);
+    void release(const size_t id);
 
     QueueClass<size_t>               m_idle_ids;
     std::vector<IInferExecutor::Ptr> m_requests;
 };
 
-void cv::gimpl::ie::RequestPool::release(const int id) {
+void cv::gimpl::ie::RequestPool::release(const size_t id) {
     m_idle_ids.push(id);
 }
 
@@ -932,7 +932,7 @@ void cv::gimpl::ie::RequestPool::release(const int id) {
 cv::gimpl::ie::RequestPool::RequestPool(std::vector<InferenceEngine::InferRequest>&& requests) {
     for (size_t i = 0; i < requests.size(); ++i) {
         m_requests.emplace_back(
-                std::make_shared<AsyncInferExecutor>(std::move(requests[0]),
+                std::make_shared<AsyncInferExecutor>(std::move(requests[i]),
                                                      std::bind(&RequestPool::release, this, i)));
     }
     setup();

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -376,10 +376,10 @@ struct IEUnit {
             GAPI_LOG_INFO(nullptr, "VPP preproc created successfuly");
         }
 
-        if (params.mode == cv::gapi::ie::detail::ParamDesc::InferMode::Sync &&
+        if (params.mode == cv::gapi::ie::InferMode::Sync &&
             params.nireq != 1u) {
             throw std::logic_error(
-                    "Failed: ParamDesc::InferMode::Sync works only with nireq equal to 1.");
+                    "Failed: cv::gapi::ie::InferMode::Sync works only with nireq equal to 1.");
         }
     }
 
@@ -917,7 +917,7 @@ void AsyncInferExecutor::callback(IInferExecutor::Task task,
 class cv::gimpl::ie::RequestPool {
 public:
 
-    explicit RequestPool(cv::gapi::ie::detail::ParamDesc::InferMode   mode,
+    explicit RequestPool(cv::gapi::ie::InferMode                      mode,
                          std::vector<InferenceEngine::InferRequest>&& requests);
 
     IInferExecutor::Ptr getIdleRequest();
@@ -936,21 +936,21 @@ void cv::gimpl::ie::RequestPool::release(const size_t id) {
 }
 
 // RequestPool implementation //////////////////////////////////////////////
-cv::gimpl::ie::RequestPool::RequestPool(cv::gapi::ie::detail::ParamDesc::InferMode   mode,
+cv::gimpl::ie::RequestPool::RequestPool(cv::gapi::ie::InferMode                      mode,
                                         std::vector<InferenceEngine::InferRequest>&& requests) {
     for (size_t i = 0; i < requests.size(); ++i) {
         IInferExecutor::Ptr iexec = nullptr;
         switch (mode) {
-            case cv::gapi::ie::detail::ParamDesc::InferMode::Async:
+            case cv::gapi::ie::InferMode::Async:
                 iexec = std::make_shared<AsyncInferExecutor>(std::move(requests[i]),
                                                              std::bind(&RequestPool::release, this, i));
                 break;
-            case cv::gapi::ie::detail::ParamDesc::InferMode::Sync:
+            case cv::gapi::ie::InferMode::Sync:
                 iexec = std::make_shared<SyncInferExecutor>(std::move(requests[i]),
                                                              std::bind(&RequestPool::release, this, i));
                 break;
             default:
-                GAPI_Assert(false && "Unsupported ParamDesc::InferMode");
+                GAPI_Assert(false && "Unsupported cv::gapi::ie::InferMode");
         }
         m_requests.emplace_back(std::move(iexec));
     }

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -2956,6 +2956,77 @@ TEST(TestAgeGender, ThrowBlobAndInputPrecisionMismatchStreaming)
     }
 }
 
+struct AgeGenderInferTest: public ::testing::Test {
+    cv::Mat m_in_mat;
+    cv::Mat m_gapi_age;
+    cv::Mat m_gapi_gender;
+
+    cv::gimpl::ie::wrap::Plugin     m_plugin;
+    IE::CNNNetwork                  m_net;
+    cv::gapi::ie::detail::ParamDesc m_params;
+
+    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
+    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+
+    void SetUp() {
+        initDLDTDataPath();
+        m_params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
+        m_params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
+        m_params.device_id = "CPU";
+
+        m_plugin = cv::gimpl::ie::wrap::getPlugin(m_params);
+        m_net    = cv::gimpl::ie::wrap::readNetwork(m_params);
+        setNetParameters(m_net);
+
+        m_in_mat = cv::Mat(cv::Size(320, 240), CV_8UC3);
+        cv::randu(m_in_mat, 0, 255);
+    }
+
+    cv::GComputation buildGraph() {
+        cv::GMat in, age, gender;
+        std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
+        return cv::GComputation(cv::GIn(in), cv::GOut(age, gender));
+    }
+
+    void validate() {
+        IE::Blob::Ptr ie_age, ie_gender;
+        {
+            auto this_network  = cv::gimpl::ie::wrap::loadNetwork(m_plugin, m_net, m_params);
+            auto infer_request = this_network.CreateInferRequest();
+            infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(m_in_mat));
+            infer_request.Infer();
+            ie_age    = infer_request.GetBlob("age_conv3");
+            ie_gender = infer_request.GetBlob("prob");
+        }
+        // Validate with IE itself (avoid DNN module dependency here)
+        normAssert(cv::gapi::ie::util::to_ocv(ie_age),    m_gapi_age,    "Test age output"   );
+        normAssert(cv::gapi::ie::util::to_ocv(ie_gender), m_gapi_gender, "Test gender output");
+    }
+};
+
+TEST_F(AgeGenderInferTest, SyncExecution) {
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        m_params.model_path, m_params.weights_path, m_params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .cfgInferMode(cv::gapi::ie::InferMode::Sync);
+
+    buildGraph().apply(cv::gin(m_in_mat), cv::gout(m_gapi_age, m_gapi_gender),
+                       cv::compile_args(cv::gapi::networks(pp)));
+
+    validate();
+}
+
+TEST_F(AgeGenderInferTest, ThrowSyncWithNireqNotEqualToOne) {
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        m_params.model_path, m_params.weights_path, m_params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .cfgInferMode(cv::gapi::ie::InferMode::Sync)
+     .cfgNumRequests(4u);
+
+    EXPECT_ANY_THROW(buildGraph().apply(cv::gin(m_in_mat), cv::gout(m_gapi_age, m_gapi_gender),
+                                        cv::compile_args(cv::gapi::networks(pp))));
+}
+
 } // namespace opencv_test
 
 #endif //  HAVE_INF_ENGINE

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -3027,109 +3027,32 @@ TEST_F(AgeGenderInferTest, ThrowSyncWithNireqNotEqualToOne) {
                                         cv::compile_args(cv::gapi::networks(pp))));
 }
 
-TEST(TestAgeGenderIE, ChangeOutputPrecision)
-{
-    initDLDTDataPath();
-
-    cv::gapi::ie::detail::ParamDesc params;
-    params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
-    params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
-    params.device_id = "CPU";
-
-    cv::Mat in_mat(cv::Size(320, 240), CV_8UC3);
-    cv::randu(in_mat, 0, 255);
-
-    cv::Mat gapi_age, gapi_gender;
-
-    // Load & run IE network
-    IE::Blob::Ptr ie_age, ie_gender;
-    {
-        auto plugin        = cv::gimpl::ie::wrap::getPlugin(params);
-        auto net           = cv::gimpl::ie::wrap::readNetwork(params);
-        setNetParameters(net);
-        for (auto it : net.getOutputsInfo()) {
-            it.second->setPrecision(IE::Precision::U8);
-        }
-        auto this_network  = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
-        auto infer_request = this_network.CreateInferRequest();
-        infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(in_mat));
-        infer_request.Infer();
-        ie_age    = infer_request.GetBlob("age_conv3");
-        ie_gender = infer_request.GetBlob("prob");
-    }
-
-    // Configure & run G-API
-    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
-    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
-
-    cv::GMat in;
-    cv::GMat age, gender;
-    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
-    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
-
+TEST_F(AgeGenderInferTest, ChangeOutputPrecision) {
     auto pp = cv::gapi::ie::Params<AgeGender> {
-        params.model_path, params.weights_path, params.device_id
+        m_params.model_path, m_params.weights_path, m_params.device_id
     }.cfgOutputLayers({ "age_conv3", "prob" })
      .cfgOutputPrecision(CV_8U);
-    comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
-               cv::compile_args(cv::gapi::networks(pp)));
 
-    // Validate with IE itself (avoid DNN module dependency here)
-    normAssert(cv::gapi::ie::util::to_ocv(ie_age),    gapi_age,    "Test age output"   );
-    normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
-}
-
-TEST(TestAgeGenderIE, ChangeSpecificOutputPrecison)
-{
-    initDLDTDataPath();
-
-    cv::gapi::ie::detail::ParamDesc params;
-    params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
-    params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
-    params.device_id = "CPU";
-
-    cv::Mat in_mat(cv::Size(320, 240), CV_8UC3);
-    cv::randu(in_mat, 0, 255);
-
-    cv::Mat gapi_age, gapi_gender;
-
-    // Load & run IE network
-    IE::Blob::Ptr ie_age, ie_gender;
-    {
-        auto plugin = cv::gimpl::ie::wrap::getPlugin(params);
-        auto net    = cv::gimpl::ie::wrap::readNetwork(params);
-        setNetParameters(net);
-
-        // NB: Specify precision only for "prob" output.
-        net.getOutputsInfo().at("prob")->setPrecision(IE::Precision::U8);
-
-        auto this_network  = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
-        auto infer_request = this_network.CreateInferRequest();
-        infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(in_mat));
-        infer_request.Infer();
-        ie_age    = infer_request.GetBlob("age_conv3");
-        ie_gender = infer_request.GetBlob("prob");
+    for (auto it : m_net.getOutputsInfo()) {
+        it.second->setPrecision(IE::Precision::U8);
     }
 
-    // Configure & run G-API
-    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
-    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+    buildGraph().apply(cv::gin(m_in_mat), cv::gout(m_gapi_age, m_gapi_gender),
+                       cv::compile_args(cv::gapi::networks(pp)));
+    validate();
+}
 
-    cv::GMat in;
-    cv::GMat age, gender;
-    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
-    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
-
+TEST_F(AgeGenderInferTest, ChangeSpecificOutputPrecison) {
     auto pp = cv::gapi::ie::Params<AgeGender> {
-        params.model_path, params.weights_path, params.device_id
+        m_params.model_path, m_params.weights_path, m_params.device_id
     }.cfgOutputLayers({ "age_conv3", "prob" })
      .cfgOutputPrecision({{"prob", CV_8U}});
-    comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
-               cv::compile_args(cv::gapi::networks(pp)));
 
-    // Validate with IE itself (avoid DNN module dependency here)
-    normAssert(cv::gapi::ie::util::to_ocv(ie_age),    gapi_age,    "Test age output"   );
-    normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
+    m_net.getOutputsInfo().at("prob")->setPrecision(IE::Precision::U8);
+
+    buildGraph().apply(cv::gin(m_in_mat), cv::gout(m_gapi_age, m_gapi_gender),
+                       cv::compile_args(cv::gapi::networks(pp)));
+    validate();
 }
 
 } // namespace opencv_test


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


# Overview
The implementation is straight forward: replace `IE::InferRequest` to `IInferExecutor` which encapsulates how execution should be started (`Infer()`/`StartAsync`). Every kind of `IInferExecutor` must notify `RequestPool` when execution finishes by using by using callback that was passed while instantiation (see `m_notify()`) it helps `RequestPool` to understand which requests are working and which are idle.


