### PR TITLE
add cvGetPropVisible_COCOA

### DIFF
--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -114,6 +114,7 @@ double cvGetOpenGlProp_W32(const char* name);
 double cvGetOpenGlProp_GTK(const char* name);
 
 double cvGetPropVisible_W32(const char* name);
+double cvGetPropVisible_COCOA(const char* name);
 
 double cvGetPropTopmost_W32(const char* name);
 double cvGetPropTopmost_COCOA(const char* name);

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -366,6 +366,8 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
             return cvGetPropVisible_QT(name);
         #elif defined(HAVE_WIN32UI)
             return cvGetPropVisible_W32(name);
+        #elif defined(HAVE_COCOA)
+            return cvGetPropVisible_COCOA(name);
         #else
             return -1;
         #endif

--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -740,6 +740,31 @@ void cvSetModeWindow_COCOA( const char* name, double prop_value )
     __END__;
 }
 
+double cvGetPropVisible_COCOA(const char* name)
+{
+    double    result = -1;
+    CVWindow* window = nil;
+
+    CV_FUNCNAME("cvGetPropVisible_COCOA");
+
+    __BEGIN__;
+    if (name == NULL)
+    {
+        CV_ERROR(CV_StsNullPtr, "NULL name string");
+    }
+
+    window = cvGetWindow(name);
+    if (window == NULL)
+    {
+        CV_ERROR(CV_StsNullPtr, "NULL window");
+    }
+
+    result = window.isVisible ? 1 : 0;
+
+    __END__;
+    return result;
+}
+
 double cvGetPropTopmost_COCOA(const char* name)
 {
     double    result = -1;


### PR DESCRIPTION
naive fix for the #22595 issue.

tested 'not visible' behaviour via `cv::waitKey(12345);` and minimising the window during that wait.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
