### PR TITLE
Aspect ratio fix for fisheye camera matrix estimation

### DIFF
--- a/modules/calib3d/misc/java/test/Calib3dTest.java
+++ b/modules/calib3d/misc/java/test/Calib3dTest.java
@@ -835,10 +835,10 @@ public class Calib3dTest extends OpenCVTestCase {
         D.put(2,0,-0.021509225493198905);
         D.put(3,0,0.0043378096628297145);
 
-        K_new_truth.put(0,0, 387.4809086880343);
-        K_new_truth.put(0,2, 1036.669802754649);
-        K_new_truth.put(1,1, 373.6375700303157);
-        K_new_truth.put(1,2, 538.8373261247601);
+        K_new_truth.put(0,0, 387.5118215642316);
+        K_new_truth.put(0,2, 1033.936556777084);
+        K_new_truth.put(1,1, 373.6673784974842);
+        K_new_truth.put(1,2, 538.794152656429);
 
         Calib3d.fisheye_estimateNewCameraMatrixForUndistortRectify(K,D,new Size(1920,1080),
                     new Mat().eye(3, 3, CvType.CV_64F), K_new, 0.0, new Size(1920,1080));

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -403,7 +403,7 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
 
         if (!isEps || fabs(theta_d) > criteria.epsilon)
         {
-            // compensate distortion iteratively
+            // compensate distortion iteratively using Newton method
 
             for (int j = 0; j < maxCount; j++)
             {
@@ -611,7 +611,7 @@ void cv::fisheye::estimateNewCameraMatrixForUndistortRectify(InputArray K, Input
                                                 : K.getMat().at<double>(0,0)/K.getMat().at<double>(1,1);
 
     // convert to identity ratio
-    cn[0] *= aspect_ratio;
+    cn[1] *= aspect_ratio;
     for(size_t i = 0; i < points.total(); ++i)
         pptr[i][1] *= aspect_ratio;
 


### PR DESCRIPTION
Fixes #22537

Connected PR in extra: [#1028@extra](https://github.com/opencv/opencv_extra/pull/1028)

### TODOs:
- [x] Make backport for 3.x

### Changes
* A bug looks like a typo, fixed
* Do not write correct image file to test data, read it instead
* Do not write anything without `--test_debug` flag
* Java test fixed too & enabled (no reason why it was turned off)

### Notes
Unfortunately, we (me and the issue author) have no idea on how to reproduce the bug: fisheye cameras with significantly non-square pixels are not that popular, fixed new values instead.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
