### PR TITLE
Backported fix for fisheye aspect ratio

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -611,7 +611,7 @@ void cv::fisheye::estimateNewCameraMatrixForUndistortRectify(InputArray K, Input
                                                 : K.getMat().at<double>(0,0)/K.getMat().at<double>(1,1);
 
     // convert to identity ratio
-    cn[0] *= aspect_ratio;
+    cn[1] *= aspect_ratio;
     for(size_t i = 0; i < points.total(); ++i)
         pptr[i][1] *= aspect_ratio;
 


### PR DESCRIPTION
Backport of #22604 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
