### PR TITLE
Doc fix for LMSolver

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -619,7 +619,7 @@ public:
 
          @param param the current vector of parameters
          @param err output vector of errors: err_i = actual_f_i - ideal_f_i
-         @param J output Jacobian: J_ij = d(err_i)/d(param_j)
+         @param J output Jacobian: J_ij = d(ideal_f_i)/d(param_j)
 
          when J=noArray(), it means that it does not need to be computed.
          Dimensionality of error vector and param vector can be different.


### PR DESCRIPTION
Fixes #22563

It was incorrectly stated that Jacobian should be calculated for error function (which is always L2).
In fact it should be calculated for data function.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
