### PR TITLE
Opencv.js: on imread add willReadFrequently to getContext

### DIFF
--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -55,7 +55,7 @@ Module['imread'] = function(imageSource) {
         canvas = document.createElement('canvas');
         canvas.width = img.width;
         canvas.height = img.height;
-        ctx = canvas.getContext('2d');
+        ctx = canvas.getContext('2d', { willReadFrequently: true });
         ctx.drawImage(img, 0, 0, img.width, img.height);
     } else if (img instanceof HTMLCanvasElement) {
         canvas = img;


### PR DESCRIPTION
On **opencv.js**, `cv.imread` on a canvas element first gets the 2d context by `getContext('2d')`.
This produces the warning on Chrome (and other webkit browsers):
```
Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true.
See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
```
The link: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
The correct syntax: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#syntax
The compatibility: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#browser_compatibility

In this PR i added the `willReadFrequently` attribute and checked on Chrome (compatible), Safari (not compatible) and other browsers.
On compatible browsers the warning is avoided and `imread` should work faster.
On non-compatible browsers the change has no effect and `imread` works as before.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
