### PR TITLE
DNN-TF: let StridedSlice layer support const input

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1706,6 +1706,19 @@ void TFImporter::parseStridedSlice(tensorflow::GraphDef& net, const tensorflow::
     layerParams.set("begin", DictValue::arrayInt((int*)begins.data, begins.total()));
     layerParams.set("end", DictValue::arrayInt((int*)ends.data, ends.total()));
 
+    Pin inp = parsePin(layer.input(0));
+    if (value_id.find(inp.name) != value_id.end())
+    {
+        // The input is constant.
+        LayerParams lp;
+        lp.name = inp.name;
+        lp.type = "Const";
+        lp.blobs.push_back(getTensorContent(getConstBlob(layer, value_id, 0)));
+
+        int constInpId = dstNet.addLayer(lp.name, lp.type, lp);
+        layer_id[lp.name] = constInpId;
+    }
+
     int id = dstNet.addLayer(name, "Slice", layerParams);
     layer_id[name] = id;
 


### PR DESCRIPTION
This PR try to fix #22597.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
