### PR TITLE
Reset cuda runtime error code to cudasuccess on runtime failure.

### DIFF
--- a/modules/core/include/opencv2/core/cuda/common.hpp
+++ b/modules/core/include/opencv2/core/cuda/common.hpp
@@ -65,8 +65,10 @@
 namespace cv { namespace cuda {
     static inline void checkCudaError(cudaError_t err, const char* file, const int line, const char* func)
     {
-        if (cudaSuccess != err)
+        if (cudaSuccess != err) {
+            cudaGetLastError(); // reset the last stored error to cudaSuccess
             cv::error(cv::Error::GpuApiCallError, cudaGetErrorString(err), func, file, line);
+        }
     }
 }}
 


### PR DESCRIPTION
Fix for https://github.com/opencv/opencv_contrib/issues/3361.

When a cuda runtime/driver function returns an error code which generates an OpenCV exception that code is not cleared so any subsequent calls to `cudaGetLastError();` will return it.  This means any future functions which call `cudaSafeCall(cudaGetLastError())` or similar macros can throw an exception from this error as described in https://github.com/opencv/opencv_contrib/issues/3361.

As OpenCV does not expose a method for clearing this error it seems reasonable that it would be the responsibility of the OpenCV lib to automatically clear it when it throws and exception.  If this is valid fix, it should probably also be applied to the [macro ](https://github.com/opencv/opencv_contrib/blob/c4027ab7f912a3053175477d41b1a62d0078bc5f/modules/cudev/include/opencv2/cudev/common.hpp#L72)in the contrib repo aswell. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
