### PR TITLE
Fix objectness is not assigned in dnn::region_layer

### DIFF
--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -317,6 +317,7 @@ public:
                                 dstData[box_index + 1] = (y + y_tmp) / rows;
                                 dstData[box_index + 2] = (srcData[box_index + 2]) * (srcData[box_index + 2]) * 4 * biasData[2 * a] / wNorm;
                                 dstData[box_index + 3] = (srcData[box_index + 3]) * (srcData[box_index + 3]) * 4 * biasData[2 * a + 1] / hNorm;
+                                dstData[box_index + 4] = srcData[p_index];
 
                                 scale = srcData[p_index];
                                 if (classfix == -1 && scale < thresh)


### PR DESCRIPTION
Fix objectness (dstData[index + 4]) is not assigned if new_coords == 1.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
