### PR TITLE
Draft: Cancel old jobs for the same PR if new changes happened

### DIFF
--- a/.github/workflows/PR-3.4.yaml
+++ b/.github/workflows/PR-3.4.yaml
@@ -2,6 +2,7 @@ name: PR:3.4
 
 on:
   pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
     branches:
       - 3.4
 

--- a/.github/workflows/PR-3.4.yaml
+++ b/.github/workflows/PR-3.4.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - 3.4
 
+concurrency:
+  group: ${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   Ubuntu2004-ARM64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-3.4-ARM64.yaml@main


### PR DESCRIPTION
This PR re-trigger jobs if a label was updated and cancel old jobs for the same PR if new changes happened.

The example how it can be cancelled already in this PR: https://github.com/opencv/opencv/actions/runs/3291502065

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
