### PR TITLE
3D: Handle cases where the depth of Octree setting is too large

### DIFF
--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2534,6 +2534,7 @@ public:
     /** @brief Insert a point data to a OctreeNode.
     *
     * @param point The point data in Point3f format.
+    * @return Returns whether the insertion is successful.
     */
     bool insertPoint(const Point3f& point);
 

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2535,7 +2535,7 @@ public:
     *
     * @param point The point data in Point3f format.
     */
-    void insertPoint(const Point3f& point);
+    bool insertPoint(const Point3f& point);
 
     /** @brief Read point cloud data and create OctreeNode.
     *

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -182,9 +182,8 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, int _maxDepth)
             cnt++;
         };
     }
-    if(cnt!=0){
-        CV_LOG_WARNING(NULL,"OverAll "<<cnt<<" points has been ignored!");
-    }
+
+    CV_LOG_IF_WARNING(NULL,cnt!=0,"OverAll "<<cnt<<" points has been ignored! The number of point clouds contained in the current octree is "<<pointCloud.size()-cnt);
     return true;
 }
 
@@ -352,11 +351,12 @@ bool deletePointRecurse(Ptr<OctreeNode>& _node)
 bool insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point, int maxDepth)
 {
     OctreeNode& node = *_node;
-    if(node.depth==0 && !node.isPointInBound(point, node.origin, node.size))
+    bool pointInBoundFlag = node.isPointInBound(point, node.origin, node.size);
+    if(node.depth==0 && !pointInBoundFlag)
     {
         CV_Error(Error::StsBadArg, "The point is out of boundary!");
     }
-    else if (!node.isPointInBound(point, node.origin, node.size)){
+    else if (!pointInBoundFlag){
         return false;
     }
 

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -13,7 +13,7 @@ namespace cv{
 static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node);
 
 static bool _isPointInBound(const Point3f& _point, const Point3f& _origin, double _size);
-static void insertPointRecurse( Ptr<OctreeNode>& node,  const Point3f& point, int maxDepth);
+static bool insertPointRecurse( Ptr<OctreeNode>& node,  const Point3f& point, int maxDepth);
 bool deletePointRecurse( Ptr<OctreeNode>& node);
 
 // For Nearest neighbor search.
@@ -128,14 +128,14 @@ Octree::Octree(int _maxDepth) : p(new Impl)
 
 Octree::~Octree(){}
 
-void Octree::insertPoint(const Point3f& point)
+bool Octree::insertPoint(const Point3f& point)
 {
     if(p->rootNode.empty())
     {
         p->rootNode = new OctreeNode( 0, p->size, p->origin, -1);
     }
 
-    insertPointRecurse(p->rootNode, point, p->maxDepth);
+    return insertPointRecurse(p->rootNode, point, p->maxDepth);
 }
 
 
@@ -175,11 +175,15 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, int _maxDepth)
     this->p->size = 2 * halfSize;
 
     // Insert every point in PointCloud data.
+    int cnt=0;
     for(size_t idx = 0; idx < pointCloud.size(); idx++ )
     {
-        insertPoint(pointCloud[idx]);
+        if(!insertPoint(pointCloud[idx])){
+            //CV_LOG_INFO(NULL,"The Point which index is "<<idx<<" has been ignored!");
+            cnt++;
+        };
     }
-
+    CV_LOG_WARNING(NULL,"OverAll "<<cnt<<" points has been ignored!");
     return true;
 }
 
@@ -344,19 +348,22 @@ bool deletePointRecurse(Ptr<OctreeNode>& _node)
     }
 }
 
-void insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point, int maxDepth)
+bool insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point, int maxDepth)
 {
     OctreeNode& node = *_node;
-    if(!node.isPointInBound(point, node.origin, node.size))
+    if(node.depth==0 && !node.isPointInBound(point, node.origin, node.size))
     {
         CV_Error(Error::StsBadArg, "The point is out of boundary!");
+    }
+    else if (!node.isPointInBound(point, node.origin, node.size)){
+        return false;
     }
 
     if(node.depth == maxDepth)
     {
         node.isLeaf = true;
         node.pointList.push_back(point);
-        return;
+        return true;
     }
 
     double childSize = node.size * 0.5;
@@ -377,7 +384,7 @@ void insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point, int maxD
         node.children[childIndex] = new OctreeNode(node.depth + 1, childSize, childOrigin, int(childIndex));
         node.children[childIndex]->parent = _node;
     }
-    insertPointRecurse(node.children[childIndex], point, maxDepth);
+    return insertPointRecurse(node.children[childIndex], point, maxDepth);
 }
 
 // For Nearest neighbor search.

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -179,11 +179,12 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, int _maxDepth)
     for(size_t idx = 0; idx < pointCloud.size(); idx++ )
     {
         if(!insertPoint(pointCloud[idx])){
-            //CV_LOG_INFO(NULL,"The Point which index is "<<idx<<" has been ignored!");
             cnt++;
         };
     }
-    CV_LOG_WARNING(NULL,"OverAll "<<cnt<<" points has been ignored!");
+    if(cnt!=0){
+        CV_LOG_WARNING(NULL,"OverAll "<<cnt<<" points has been ignored!");
+    }
     return true;
 }
 

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -14,7 +14,7 @@ protected:
     void SetUp() override
     {
         pointCloudSize = 1000;
-        maxDepth = 4;
+        maxDepth = 18;
 
         int scale;
         Point3i pmin, pmax;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -14,7 +14,7 @@ protected:
     void SetUp() override
     {
         pointCloudSize = 1000;
-        maxDepth = 18;
+        maxDepth =  18;
 
         int scale;
         Point3i pmin, pmax;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -14,7 +14,7 @@ protected:
     void SetUp() override
     {
         pointCloudSize = 1000;
-        maxDepth =  18;
+        maxDepth = 18;
 
         int scale;
         Point3i pmin, pmax;


### PR DESCRIPTION
This PR is aim at handling cases where the depth setting is too large in 3D module 's octree

**Current Problem**

​	When we build an octree by cloud data, if the `maxDepth` we set is too large, we can not get an octree since a CV_ERROR  was thrown. This is due to precision problems with floating-point number. For example, in `test_octree.cpp`, if we set `maxDepth`=18, this statement will be execute 

`CV_Error(Error::StsBadArg, "The point is out of boundary!");`



**Reason**

​	In the current version, every time the function `insertPointRecurse()` is called to insert a point, it always determines whether the point is in the space first through this statement

`if(!node.isPointInBound(point, node.origin, node.size))`

if true, it will throw a `CV_Error`

​	It decide which subblock the point is in through 

```c++
size_t xIndex = point.x <= node.origin.x + float(childSize) + epsX ? 0 : 1;
size_t yIndex = point.y <= node.origin.y + float(childSize) + epsY ? 0 : 1;
size_t zIndex = point.z <= node.origin.z + float(childSize) + epsZ ? 0 : 1;

size_t childIndex = xIndex + yIndex * 2 + zIndex * 4;
```

​	When the maxDepth is too large, in current function `insertPointRecurse()`, it finds the subblock to which it belongs and call this function recursively. But in next  `insertPointRecurse()`, the value of this statement is true 

`if(!node.isPointInBound(point, node.origin, node.size))`

This is due to precision problems with floating-point number. Just like the photo below.This is a cutaway of a cube, showing one plane, and the other planes as well

![picture](https://user-images.githubusercontent.com/83380147/197227471-da9cdbb4-82ee-4748-ad39-9430a496a426.png)


Since the type of  `node.size`  is double, the subblock's boundary(upper and right) is not the same as current space. If the point is right between the two boundaries which means point is not in the bound of subspace, the program will report an error.



**Possible Solution**

​	When we determines whether the point is in the space, we only need to throw a `CV_Error` if this is the first time `insertPointRecurse()` is called recursively. At other times, if this point is out of bounds, it means that this point is near the boundary of the voxel, and we can discard those points, just notifies the user with a warning when the program is over. The details of solution can be seen in the code.



**Test**

​	I have no idea for this, only the original test( file `test_octree.cpp`) was used. In the original test, if you were able to successfully build the octree, this time also works. If the build didn't succeed before, it can still succeed (with some points dropped). When the number of discarded points is small, all tests in the file are successfully passed (for example, in my computer, when`maxDepth`=18, it will drop 8 points). However, when the number of discarded points is big, it can not pass all tests.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
