### PR TITLE
android: add android:exported="true"

### DIFF
--- a/samples/android/15-puzzle/gradle/AndroidManifest.xml
+++ b/samples/android/15-puzzle/gradle/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name">
 
         <activity
+            android:exported="true"
             android:name=".Puzzle15Activity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"

--- a/samples/android/camera-calibration/gradle/AndroidManifest.xml
+++ b/samples/android/camera-calibration/gradle/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:icon="@drawable/icon">
 
-        <activity android:name="CameraCalibrationActivity"
+        <activity
+                  android:exported="true"
+                  android:name="CameraCalibrationActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/color-blob-detection/gradle/AndroidManifest.xml
+++ b/samples/android/color-blob-detection/gradle/AndroidManifest.xml
@@ -8,7 +8,9 @@
         android:icon="@drawable/icon"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
 
-        <activity android:name="ColorBlobDetectionActivity"
+        <activity
+                  android:exported="true"
+                  android:name="ColorBlobDetectionActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/face-detection/gradle/AndroidManifest.xml
+++ b/samples/android/face-detection/gradle/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:icon="@drawable/icon">
 
-        <activity android:name="FdActivity"
+        <activity
+                  android:exported="true"
+                  android:name="FdActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/image-manipulations/gradle/AndroidManifest.xml
+++ b/samples/android/image-manipulations/gradle/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:icon="@drawable/icon">
 
-        <activity android:name="ImageManipulationsActivity"
+        <activity
+                  android:exported="true"
+                  android:name="ImageManipulationsActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/mobilenet-objdetect/gradle/AndroidManifest.xml
+++ b/samples/android/mobilenet-objdetect/gradle/AndroidManifest.xml
@@ -10,8 +10,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.NoActionBar">  <!--Full screen mode-->
-        <activity android:name=".MainActivity"
-            android:screenOrientation="landscape">  <!--Screen orientation-->
+        <activity
+                  android:exported="true"
+                  android:name=".MainActivity"
+                  android:screenOrientation="landscape">  <!--Screen orientation-->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/samples/android/tutorial-1-camerapreview/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-1-camerapreview/gradle/AndroidManifest.xml
@@ -8,7 +8,9 @@
         android:icon="@drawable/icon"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
 
-        <activity android:name="Tutorial1Activity"
+        <activity
+                  android:exported="true"
+                  android:name="Tutorial1Activity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:icon="@drawable/icon">
 
-        <activity android:name="Tutorial2Activity"
+        <activity
+                  android:exported="true"
+                  android:name="Tutorial2Activity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:icon="@drawable/icon">
 
-        <activity android:name="Tutorial3Activity"
+        <activity
+                  android:exported="true"
+                  android:name="Tutorial3Activity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:configChanges="keyboardHidden|orientation">

--- a/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon">
         <activity
+            android:exported="true"
             android:name=".Tutorial4Activity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"


### PR DESCRIPTION
Required for Android 12+ builds.

Error message:

> Manifest merger failed : android:exported needs to be explicitly specified for element <activity#org.opencv.samples.puzzle15.Puzzle15Activity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.

<cut/>

Note:
- `CRLF => LF` is massively changed in `samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml`

```
force_builders_only=Android armeabi-v7a,Android pack
```