### PR TITLE
Do not fail tests in Yolo v7 model was not found

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2395,7 +2395,7 @@ TEST_P(Test_ONNX_layers, CumSum)
 //  4. 1D mat dimension issue with the output of range operator
 TEST_P(Test_ONNX_layers, YOLOv7)
 {
-    std::string weightPath = _tf("models/yolov7_not_simplified.onnx");
+    std::string weightPath = _tf("models/yolov7_not_simplified.onnx", false);
     std::string imgPath = _tf("../dog_orig_size.png");
 
     Size targetSize{640, 640};


### PR DESCRIPTION
It's a part of extended DNN test suite and should not fail without downloaded models.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
