### PR TITLE
android: add configuration for NDK 25 and Android API 32 (12L)

### DIFF
--- a/platforms/android/ndk-25.config.py
+++ b/platforms/android/ndk-25.config.py
@@ -1,0 +1,19 @@
+# Docs: https://developer.android.com/ndk/guides/cmake#android_native_api_level
+ANDROID_NATIVE_API_LEVEL = int(os.environ.get('ANDROID_NATIVE_API_LEVEL', 32))
+cmake_common_vars = {
+    # Docs: https://source.android.com/docs/setup/about/build-numbers
+    # Docs: https://developer.android.com/studio/publish/versioning
+    'ANDROID_COMPILE_SDK_VERSION': os.environ.get('ANDROID_COMPILE_SDK_VERSION', 32),
+    'ANDROID_TARGET_SDK_VERSION': os.environ.get('ANDROID_TARGET_SDK_VERSION', 32),
+    'ANDROID_MIN_SDK_VERSION': os.environ.get('ANDROID_MIN_SDK_VERSION', ANDROID_NATIVE_API_LEVEL),
+    # Docs: https://developer.android.com/studio/releases/gradle-plugin
+    'ANDROID_GRADLE_PLUGIN_VERSION': '7.3.1',
+    'GRADLE_VERSION': '7.5.1',
+    'KOTLIN_PLUGIN_VERSION': '1.5.20',
+}
+ABIs = [
+    ABI("2", "armeabi-v7a", None, ndk_api_level=ANDROID_NATIVE_API_LEVEL, cmake_vars=cmake_common_vars),
+    ABI("3", "arm64-v8a",   None, ndk_api_level=ANDROID_NATIVE_API_LEVEL, cmake_vars=cmake_common_vars),
+    ABI("5", "x86_64",      None, ndk_api_level=ANDROID_NATIVE_API_LEVEL, cmake_vars=cmake_common_vars),
+    ABI("4", "x86",         None, ndk_api_level=ANDROID_NATIVE_API_LEVEL, cmake_vars=cmake_common_vars),
+]


### PR DESCRIPTION
This PR provides modern Android build configuration.

Usage example with NDK 25b:

<cut/>

```.bash
export ANDROID_NDK="/opt/android/android-sdk.studio/ndk/25.1.8937393"
export ANDROID_SDK="/opt/android/android-sdk.studio"
export ANDROID_SDK_ROOT="/opt/android/android-sdk.studio"
#export ANDROID_NATIVE_API_LEVEL=28
python3 ${OPENCV_SRC_DIR}/platforms/android/build_sdk.py --config ndk-25.config.py --use_android_buildtools
```

Note:
- `--use_android_buildtools` is recommended to use `cmake&ninja` tools from Android SDK instead of system packages (`cmake` package should be pre-installed through [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager)).
- `ANDROID_NATIVE_API_LEVEL` is optional (default=32), use 28 for Android 9 ([versions list](https://source.android.com/docs/setup/about/build-numbers))

---

List of preinstalled packages:

```
$ /opt/android/android-sdk.studio/cmdline-tools/latest/bin/sdkmanager --list_installed --include_obsolete
Installed packages:=====================] 100% Fetch remote repository...       
  Path                                           | Version      | Description                             | Location                                      
  -------                                        | -------      | -------                                 | -------                                       
  build-tools;33.0.0                             | 33.0.0       | Android SDK Build-Tools 33              | build-tools/33.0.0                            
  cmake;3.22.1                                   | 3.22.1       | CMake 3.22.1                            | cmake/3.22.1                                  
  cmdline-tools;latest                           | 7.0          | Android SDK Command-line Tools (latest) | cmdline-tools/latest                          
  ndk;25.1.8937393                               | 25.1.8937393 | NDK (Side by side) 25.1.8937393         | ndk/25.1.8937393                              
  patcher;v4                                     | 1            | SDK Patch Applier v4                    | patcher/v4                                    
  platform-tools                                 | 33.0.3       | Android SDK Platform-Tools              | platform-tools                                
  platforms;android-32                           | 1            | Android SDK Platform 32                 | platforms/android-32                          
  platforms;android-33                           | 2            | Android SDK Platform 33                 | platforms/android-33                          
  sources;android-32                             | 1            | Sources for Android 32                  | sources/android-32                            
  sources;android-33                             | 1            | Sources for Android 33                  | sources/android-33                            

Installed Obsolete Packages:
  Path    | Version | Description       | Location
  ------- | ------- | -------           | ------- 
  tools   | 26.1.1  | Android SDK Tools | tools
```