### PR TITLE
log a debug message if a capture backend is generally available but isn't capabable of a capture mode

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -188,11 +188,22 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
             else
             {
                 CV_CAPTURE_LOG_DEBUG(NULL,
-                                     cv::format("VIDEOIO(%s): backend is not available "
+                                    cv::format("VIDEOIO(%s): backend is not available "
                                                 "(plugin is missing, or can't be loaded due "
                                                 "dependencies or it is not compatible)",
-                                                 info.name));
+                                                info.name));
             }
+        }
+    }
+
+    if(apiPreference != CAP_ANY)
+    {
+        bool found = cv::videoio_registry::isBackendBuiltIn(static_cast<VideoCaptureAPIs>(apiPreference));
+        if (found)
+        {
+            CV_LOG_WARNING(NULL, cv::format("VIDEOIO(%s): backend is generally available "
+                                            "but can't be used to capture by name",
+                                            cv::videoio_registry::getBackendName(static_cast<VideoCaptureAPIs>(apiPreference)).c_str()));
         }
     }
 
@@ -302,11 +313,22 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
             else
             {
                 CV_CAPTURE_LOG_DEBUG(NULL,
-                                     cv::format("VIDEOIO(%s): backend is not available "
+                                    cv::format("VIDEOIO(%s): backend is not available "
                                                 "(plugin is missing, or can't be loaded due "
                                                 "dependencies or it is not compatible)",
-                                                 info.name));
+                                                info.name));
             }
+        }
+    }
+
+    if(apiPreference != CAP_ANY)
+    {
+        bool found = cv::videoio_registry::isBackendBuiltIn(static_cast<VideoCaptureAPIs>(apiPreference));
+        if (found)
+        {
+            CV_LOG_WARNING(NULL, cv::format("VIDEOIO(%s): backend is generally available "
+                                            "but can't be used to capture by index",
+                                            cv::videoio_registry::getBackendName(static_cast<VideoCaptureAPIs>(apiPreference)).c_str()));
         }
     }
 


### PR DESCRIPTION
The pertaining issue: https://github.com/opencv/opencv/issues/22699

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
