### PR TITLE
Dump the values of OPENCV_FFMPEG_CAPTURE_OPTIONS and OPENCV_FFMPEG_WRITER_OPTIONS to debug log

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1116,6 +1116,7 @@ bool CvCapture_FFMPEG::open(const char* _filename, const VideoCaptureParameters&
     }
     else
     {
+        CV_LOG_DEBUG(NULL, "VIDEOIO/FFMPEG: using capture options from environment: " << options);
 #if LIBAVUTIL_BUILD >= (LIBAVUTIL_VERSION_MICRO >= 100 ? CALC_FFMPEG_VERSION(52, 17, 100) : CALC_FFMPEG_VERSION(52, 7, 0))
         av_dict_parse_string(&dict, options, ";", "|", 0);
 #else
@@ -2911,7 +2912,9 @@ bool CvVideoWriter_FFMPEG::open( const char * filename, int fourcc,
     AVDictionary *dict = NULL;
 #if !defined(NO_GETENV) && (LIBAVUTIL_VERSION_MAJOR >= 53)
     char* options = getenv("OPENCV_FFMPEG_WRITER_OPTIONS");
-    if (options) {
+    if (options)
+    {
+        CV_LOG_DEBUG(NULL, "VIDEOIO/FFMPEG: using writer options from environment: " << options);
         av_dict_parse_string(&dict, options, ";", "|", 0);
     }
 #endif


### PR DESCRIPTION
The pertaining issue: https://github.com/opencv/opencv/issues/22701

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
