### PR TITLE
improve code style and Doc of stackblur

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1620,14 +1620,15 @@ CV_EXPORTS_W void blur( InputArray src, OutputArray dst,
                         Size ksize, Point anchor = Point(-1,-1),
                         int borderType = BORDER_DEFAULT );
 
-/** @brief Blurs an image using the StackBlur.
-The function applies and StackBlur to an image.
-StackBlur can generate similar results as Gaussian blur, and the time does not increase as the kernel size increases.
+/** @brief Blurs an image using the stackBlur.
+
+The function applies and stackBlur to an image.
+stackBlur can generate similar results as Gaussian blur, and the time consumption does not increase with the increase of kernel size.
 It creates a kind of moving stack of colors whilst scanning through the image. Thereby it just has to add one new block of color to the right side
 of the stack and remove the leftmost color. The remaining colors on the topmost layer of the stack are either added on or reduced by one,
-depending on if they are on the right or on the left side of the stack.
-Described here: http://underdestruction.com/2004/02/25/stackblur-2004.
-Stack Blur Algorithm by Mario Klingemann <mario@quasimondo.com>
+depending on if they are on the right or on the left side of the stack. The only supported borderType is BORDER_REPLICATE.
+Original paper was proposed by Mario Klingemann, which can be found http://underdestruction.com/2004/02/25/stackblur-2004.
+
 @param src input image. The number of channels can be arbitrary, but the depth should be one of
 CV_8U, CV_16U, CV_16S or CV_32F.
 @param dst output image of the same size and type as src.

--- a/modules/imgproc/src/stackblur.cpp
+++ b/modules/imgproc/src/stackblur.cpp
@@ -461,8 +461,6 @@ public:
 
     ~ParallelStackBlurRow() {}
 
-    ParallelStackBlurRow& operator=(const ParallelStackBlurRow &) { return *this; }
-
     /*
      * The idea is as follows:
      * The stack can be understood as a sliding window of length kernel size.
@@ -1084,8 +1082,6 @@ public:
 
     ~ParallelStackBlurColumn() {}
 
-    ParallelStackBlurColumn& operator=(const ParallelStackBlurColumn &) { return *this; }
-
     virtual void operator ()(const Range& range) const CV_OVERRIDE
     {
         if (radius == 0)
@@ -1146,7 +1142,8 @@ public:
             if (stackStart >= kernelSize) stackStart -= kernelSize;
 
             int sp1 = sp + 1;
-            sp1 &= -(sp1 < kernelSize);
+            if (sp1 >= kernelSize)
+                sp1 = 0;
 
             if (yp < hm)
             {
@@ -1176,7 +1173,8 @@ public:
 
             dstPtr += widthElem;
             ++sp;
-            if (sp >= kernelSize) sp = 0;
+            if (sp >= kernelSize)
+                sp = 0;
         }
     }
 
@@ -1255,7 +1253,7 @@ void stackBlur(InputArray _src, OutputArray _dst, Size ksize)
             parallel_for_(Range(0, widthElem), ParallelStackBlurColumn<float, float>(dst, dst, radiusH), numOfThreads);
     }
     else
-        CV_Error_( CV_StsNotImplemented,
+        CV_Error(Error::StsNotImplemented,
                    ("Unsupported input format in StackBlur, the supported formats are: CV_8U, CV_16U, CV_16S and CV_32F."));
 }
 } //namespace

--- a/modules/imgproc/test/test_stackblur.cpp
+++ b/modules/imgproc/test/test_stackblur.cpp
@@ -125,7 +125,8 @@ void _stackblurRef(const Mat& src, Mat& dst, Size ksize)
             }
 
             int sp1 = sp + 1;
-            sp1 &= -(sp1 < stackLenW);
+            if (sp1 >= stackLenW)
+                sp1 = 0;
 
             for(int ci = 0; ci < CN; ci++)
             {
@@ -143,7 +144,8 @@ void _stackblurRef(const Mat& src, Mat& dst, Size ksize)
             }
 
             ++sp;
-            if (sp >= stackLenW) sp = 0;
+            if (sp >= stackLenW)
+                sp = 0;
         }
     }
 
@@ -239,7 +241,7 @@ void stackBlurRef(const Mat& img, Mat& dst, Size ksize)
     else if (img.depth() == CV_32F)
         _stackblurRef<float>(img, dst, ksize);
     else
-        CV_Error_( CV_StsNotImplemented,
+        CV_Error(Error::StsNotImplemented,
                    ("Unsupported Mat type in stackBlurRef, "
                     "the supported formats are: CV_8U, CV_16U, CV_16S and CV_32F."));
 }


### PR DESCRIPTION
Related comments: https://github.com/opencv/opencv/pull/20379#discussion_r1007458906

Purpose of this PR:
1. Remove the C-style implementation
2. Improve API documentation of `stackBlur`.
3. Remove inappropriate optimizations.
4. Remove never used code.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
