### PR TITLE
Make Mat::at only support data types of the same channels as the source.

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -896,6 +896,7 @@ _Tp& Mat::at(int i0, int i1)
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
     return ((_Tp*)(data + step.p[0] * i0))[i1];
@@ -907,6 +908,7 @@ const _Tp& Mat::at(int i0, int i1) const
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
     return ((const _Tp*)(data + step.p[0] * i0))[i1];
@@ -918,6 +920,7 @@ _Tp& Mat::at(Point pt)
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
     return ((_Tp*)(data + step.p[0] * pt.y))[pt.x];
@@ -929,6 +932,7 @@ const _Tp& Mat::at(Point pt) const
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
     return ((const _Tp*)(data + step.p[0] * pt.y))[pt.x];
@@ -939,6 +943,7 @@ _Tp& Mat::at(int i0)
 {
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)i0 < (unsigned)(size.p[0] * size.p[1]));
     CV_DbgAssert(elemSize() == sizeof(_Tp));
     if( isContinuous() || size.p[0] == 1 )
@@ -954,6 +959,7 @@ const _Tp& Mat::at(int i0) const
 {
     CV_DbgAssert(dims <= 2);
     CV_DbgAssert(data);
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     CV_DbgAssert((unsigned)i0 < (unsigned)(size.p[0] * size.p[1]));
     CV_DbgAssert(elemSize() == sizeof(_Tp));
     if( isContinuous() || size.p[0] == 1 )
@@ -968,6 +974,7 @@ template<typename _Tp> inline
 _Tp& Mat::at(int i0, int i1, int i2)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(_Tp*)ptr(i0, i1, i2);
 }
 
@@ -975,6 +982,7 @@ template<typename _Tp> inline
 const _Tp& Mat::at(int i0, int i1, int i2) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(const _Tp*)ptr(i0, i1, i2);
 }
 
@@ -982,6 +990,7 @@ template<typename _Tp> inline
 _Tp& Mat::at(const int* idx)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(_Tp*)ptr(idx);
 }
 
@@ -989,6 +998,7 @@ template<typename _Tp> inline
 const _Tp& Mat::at(const int* idx) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(const _Tp*)ptr(idx);
 }
 
@@ -996,6 +1006,7 @@ template<typename _Tp, int n> inline
 _Tp& Mat::at(const Vec<int, n>& idx)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(_Tp*)ptr(idx.val);
 }
 
@@ -1003,6 +1014,7 @@ template<typename _Tp, int n> inline
 const _Tp& Mat::at(const Vec<int, n>& idx) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
+    CV_DbgAssert((unsigned)DataType<_Tp>::channels == (unsigned)channels());
     return *(const _Tp*)ptr(idx.val);
 }
 

--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -124,7 +124,7 @@ namespace cv
 
 static inline void* cvAlignPtr( const void* ptr, int align = 32 )
 {
-    CV_DbgAssert ( (align & (align-1)) == 0 );
+    CV_DbgAssert( (align & (align-1)) == 0 );
     return (void*)( ((size_t)ptr + align - 1) & ~(size_t)(align-1) );
 }
 

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -116,7 +116,7 @@ namespace cv { namespace gapi { namespace own {
         : MatHeader (std::move(_dims), _type, _data)
         {}
 
-        Mat(Mat const& src, const Rect& roi )
+        Mat(Mat const& src, const Rect& roi)
         : Mat(src)
         {
            rows = roi.height;


### PR DESCRIPTION
Related issue: https://github.com/opencv/opencv/issues/22734

The current Mat::at has no constraints for the data type of different channels as the source. And, it will cause a little confusion in some code practices.

For example:
``` c++
cv::Mat img(rows, cols, CV_64F);
```
The number of channels of `img` is 1, however, the following operations are still correct since the number of channels of `cv::Vec3d` is 3.

``` c++
img.at<cv::Vec3d>(0, 0)[0] = 255.0;
img.at<cv::Vec3d>(0, 0)[1] = 255.0;
img.at<cv::Vec3d>(0, 0)[2] = 255.0;
```

The [] operation in cv::Vec limits the number of channels, but it cannot limit the converted ones in this case.

**I personally feel that the better way is to add some assertions (in the current PR) or warnings that appear during compile time.**

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] The feature is well documented and sample code can be built with the project CMake
