### PR TITLE
DNN: Add New API blobFromImageParam

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -115,11 +115,12 @@ CV__DNN_INLINE_NS_BEGIN
     enum DataLayout
     {
         DNN_LAYOUT_UNKNOWN = 0,
-        DNN_LAYOUT_ND = 1,
-        DNN_LAYOUT_NCHW = 2,      //!< OpenCV and ONNX data layout.
-        DNN_LAYOUT_NHWC = 3,      //!< Tensorflow-like data layout.
-        DNN_LAYOUT_NDHWC = 4,      //!< Tensorflow-like data layout.
-        DNN_LAYOUT_PLANAR = 5,      //!< 2-dimensional outputs (matmul, flatten, reshape to 2d)
+        DNN_LAYOUT_ND = 1,        //!< OpenCV data layout for 2D data.
+        DNN_LAYOUT_NCHW = 2,      //!< OpenCV data layout for 4D data.
+        DNN_LAYOUT_NCDHW = 3,      //!< OpenCV data layout for 5D data.
+        DNN_LAYOUT_NHWC = 4,      //!< Tensorflow-like data layout for 4D data.
+        DNN_LAYOUT_NDHWC = 5,      //!< Tensorflow-like data layout for 5D data.
+        DNN_LAYOUT_PLANAR = 6,     //!< Tensorflow-like data layout, it should only be used at tf or tflite model parsing.
     };
 
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -108,6 +108,20 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_TARGET_NPU,
     };
 
+    /**
+     * @brief Enum of data layout for model inference.
+     * @see Image2BlobParams
+     */
+    enum DataLayout
+    {
+        DNN_LAYOUT_UNKNOWN = 0,
+        DNN_LAYOUT_ND = 1,
+        DNN_LAYOUT_NCHW = 2,      //!< OpenCV and ONNX data layout.
+        DNN_LAYOUT_NHWC = 3,      //!< Tensorflow-like data layout.
+        DNN_LAYOUT_NDHWC = 4,      //!< Tensorflow-like data layout.
+        DNN_LAYOUT_PLANAR = 5,      //!< 2-dimensional outputs (matmul, flatten, reshape to 2d)
+    };
+
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();
     CV_EXPORTS_W std::vector<Target> getAvailableTargets(dnn::Backend be);
 
@@ -1109,10 +1123,10 @@ CV__DNN_INLINE_NS_BEGIN
     /** @brief Creates 4-dimensional blob from image. Optionally resizes and crops @p image from center,
      *  subtract @p mean values, scales values by @p scalefactor, swap Blue and Red channels.
      *  @param image input image (with 1-, 3- or 4-channels).
+     *  @param scalefactor multiplier for @p images values.
      *  @param size spatial size for output image
      *  @param mean scalar with mean values which are subtracted from channels. Values are intended
      *  to be in (mean-R, mean-G, mean-B) order if @p image has BGR ordering and @p swapRB is true.
-     *  @param scalefactor multiplier for @p image values.
      *  @param swapRB flag which indicates that swap first and last channels
      *  in 3-channel image is necessary.
      *  @param crop flag which indicates whether image will be cropped after resize or not
@@ -1121,6 +1135,9 @@ CV__DNN_INLINE_NS_BEGIN
      *  dimension in @p size and another one is equal or larger. Then, crop from the center is performed.
      *  If @p crop is false, direct resize without cropping and preserving aspect ratio is performed.
      *  @returns 4-dimensional Mat with NCHW dimensions order.
+     *
+     * @note
+     * The order and usage of `scalefactor` and `mean` are (input - mean) * scalefactor.
      */
     CV_EXPORTS_W Mat blobFromImage(InputArray image, double scalefactor=1.0, const Size& size = Size(),
                                    const Scalar& mean = Scalar(), bool swapRB=false, bool crop=false,
@@ -1151,6 +1168,9 @@ CV__DNN_INLINE_NS_BEGIN
      *  dimension in @p size and another one is equal or larger. Then, crop from the center is performed.
      *  If @p crop is false, direct resize without cropping and preserving aspect ratio is performed.
      *  @returns 4-dimensional Mat with NCHW dimensions order.
+     *
+     * @note
+     * The order and usage of `scalefactor` and `mean` are (input - mean) * scalefactor.
      */
     CV_EXPORTS_W Mat blobFromImages(InputArrayOfArrays images, double scalefactor=1.0,
                                     Size size = Size(), const Scalar& mean = Scalar(), bool swapRB=false, bool crop=false,
@@ -1164,6 +1184,74 @@ CV__DNN_INLINE_NS_BEGIN
                                    double scalefactor=1.0, Size size = Size(),
                                    const Scalar& mean = Scalar(), bool swapRB=false, bool crop=false,
                                    int ddepth=CV_32F);
+
+    /**
+     * @brief Enum of image processing mode.
+     * To facilitate the specialization pre-processing requirements of the dnn model.
+     * For example, the `letter box` often used in the Yolo series of models.
+     * @see Image2BlobParams
+     */
+    enum ImagePaddingMode
+    {
+        DNN_PMODE_NULL = 0,        // !< Default. Resize to required input size without extra processing.
+        DNN_PMODE_CROP_CENTER = 1, // !< Image will be cropped after resize.
+        DNN_PMODE_LETTERBOX = 2,   // !< Resize image to the desired size while preserving the aspect ratio of original image.
+    };
+
+    /** @brief Processing params of image to blob.
+     *
+     * It includes all possible image processing operations and corresponding parameters.
+     *
+     * @see blobFromImageWithParams
+     *
+     * @note
+     * The order and usage of `scalefactor` and `mean` are (input - mean) * scalefactor.
+     * The order and usage of `scalefactor`, `size`, `mean`, `swapRB`, and `ddepth` are consistent
+     * with the function of @ref blobFromImage.
+    */
+    struct CV_EXPORTS_W_SIMPLE Image2BlobParams
+    {
+        CV_WRAP Image2BlobParams();
+        CV_WRAP Image2BlobParams(const Scalar& scalefactor, const Size& size = Size(), const Scalar& mean = Scalar(),
+                            bool swapRB = false, int ddepth = CV_32F, DataLayout datalayout = DNN_LAYOUT_NCHW,
+                            ImagePaddingMode mode = DNN_PMODE_NULL);
+
+        CV_PROP_RW Scalar scalefactor; //!< scalefactor multiplier for input image values.
+        CV_PROP_RW Size size;    //!< Spatial size for output image.
+        CV_PROP_RW Scalar mean;  //!< Scalar with mean values which are subtracted from channels.
+        CV_PROP_RW bool swapRB;  //!< Flag which indicates that swap first and last channels
+        CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
+        CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
+        CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
+    };
+
+    /** @brief Creates 4-dimensional blob from image with given params.
+     *
+     *  @details This function is an extension of @ref blobFromImage to meet more image preprocess needs.
+     *  Given input image and preprocessing parameters, and function outputs the blob.
+     *
+     *  @param image input image (all with 1-, 3- or 4-channels).
+     *  @param param struct of Image2BlobParams, contains all parameters needed by processing of image to blob.
+     *  @return 4-dimensional Mat.
+     */
+    CV_EXPORTS_W Mat blobFromImageWithParams(InputArray image, const Image2BlobParams& param = Image2BlobParams());
+
+    /** @overload */
+    CV_EXPORTS_W void blobFromImageWithParams(InputArray image, OutputArray blob, const Image2BlobParams& param = Image2BlobParams());
+
+    /** @brief Creates 4-dimensional blob from series of images with given params.
+     *
+     *  @details This function is an extension of @ref blobFromImages to meet more image preprocess needs.
+     *  Given input image and preprocessing parameters, and function outputs the blob.
+     *
+     *  @param images input image (all with 1-, 3- or 4-channels).
+     *  @param param struct of Image2BlobParams, contains all parameters needed by processing of image to blob.
+     *  @returns 4-dimensional Mat.
+     */
+    CV_EXPORTS_W Mat blobFromImagesWithParams(InputArrayOfArrays images, const Image2BlobParams& param = Image2BlobParams());
+
+    /** @overload */
+    CV_EXPORTS_W void blobFromImagesWithParams(InputArrayOfArrays images, OutputArray blob, const Image2BlobParams& param = Image2BlobParams());
 
     /** @brief Parse a 4D blob and output the images it contains as 2D arrays through a simpler data structure
      *  (std::vector<cv::Mat>).

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -119,7 +119,7 @@ class dnn_test(NewOpenCVTests):
             inp = np.random.standard_normal([1, 2, 10, 11]).astype(np.float32)
             net.setInput(inp)
             net.forward()
-        except BaseException as e:
+        except BaseException:
             return False
         return True
 
@@ -153,6 +153,41 @@ class dnn_test(NewOpenCVTests):
         target = target.transpose(2, 0, 1).reshape(1, 3, height, width)  # to NCHW
         normAssert(self, blob, target)
 
+    def test_blobFromImageWithParams(self):
+        np.random.seed(324)
+
+        width = 6
+        height = 7
+        stddev = np.array([0.2, 0.3, 0.4])
+        scalefactor = 1.0/127.5 * stddev
+        mean = (10, 20, 30)
+
+        # Test arguments names.
+        img = np.random.randint(0, 255, [4, 5, 3]).astype(np.uint8)
+
+        param = cv.dnn.Image2BlobParams()
+        param.scalefactor = scalefactor
+        param.size = (6, 7)
+        param.mean = mean
+        param.swapRB=True
+        param.datalayout = cv.dnn.DNN_LAYOUT_NHWC
+
+        blob = cv.dnn.blobFromImageWithParams(img, param)
+        blob_args = cv.dnn.blobFromImageWithParams(img, cv.dnn.Image2BlobParams(scalefactor=scalefactor, size=(6, 7), mean=mean,
+                                                                      swapRB=True, datalayout=cv.dnn.DNN_LAYOUT_NHWC))
+        normAssert(self, blob, blob_args)
+
+        target2 = cv.resize(img, (width, height), interpolation=cv.INTER_LINEAR).astype(np.float32)
+        target2 = target2[:,:,[2, 1, 0]]  # BGR2RGB
+        target2[:,:,0] -= mean[0]
+        target2[:,:,1] -= mean[1]
+        target2[:,:,2] -= mean[2]
+
+        target2[:,:,0] *= scalefactor[0]
+        target2[:,:,1] *= scalefactor[1]
+        target2[:,:,2] *= scalefactor[2]
+        target2 = target2.reshape(1, height, width, 3)  # to NHWC
+        normAssert(self, blob, target2)
 
     def test_model(self):
         img_path = self.find_dnn_file("dnn/street.png")

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -11,8 +11,17 @@ namespace cv {
 namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
+Image2BlobParams::Image2BlobParams():scalefactor(1.0), size(Size()), mean(Scalar()), swapRB(false), ddepth(CV_32F),
+                           datalayout(DNN_LAYOUT_NCHW), paddingmode(DNN_PMODE_NULL)
+{}
 
-Mat blobFromImage(InputArray image, double scalefactor, const Size& size,
+Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
+                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_):
+        scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
+        datalayout(datalayout_), paddingmode(mode_)
+{}
+
+Mat blobFromImage(InputArray image, const double scalefactor, const Size& size,
         const Scalar& mean, bool swapRB, bool crop, int ddepth)
 {
     CV_TRACE_FUNCTION();
@@ -42,16 +51,63 @@ void blobFromImages(InputArrayOfArrays images_, OutputArray blob_, double scalef
         Size size, const Scalar& mean_, bool swapRB, bool crop, int ddepth)
 {
     CV_TRACE_FUNCTION();
-    CV_CheckType(ddepth, ddepth == CV_32F || ddepth == CV_8U, "Blob depth should be CV_32F or CV_8U");
-    if (ddepth == CV_8U)
-    {
-        CV_CheckEQ(scalefactor, 1.0, "Scaling is not supported for CV_8U blob depth");
-        CV_Assert(mean_ == Scalar() && "Mean subtraction is not supported for CV_8U blob depth");
-    }
+    Image2BlobParams param(scalefactor, size, mean_, swapRB, ddepth);
+    if (crop)
+        param.paddingmode = DNN_PMODE_CROP_CENTER;
+    blobFromImagesWithParams(images_, blob_, param);
+}
 
+Mat blobFromImageWithParams(InputArray image, const Image2BlobParams& param)
+{
+    CV_TRACE_FUNCTION();
+    Mat blob;
+    blobFromImageWithParams(image, blob, param);
+    return blob;
+}
+
+void blobFromImageWithParams(InputArray image, OutputArray blob, const Image2BlobParams& param)
+{
+    CV_TRACE_FUNCTION();
+    std::vector<Mat> images(1, image.getMat());
+    blobFromImagesWithParams(images, blob, param);
+}
+
+Mat blobFromImagesWithParams(InputArrayOfArrays images, const Image2BlobParams& param)
+{
+    CV_TRACE_FUNCTION();
+    Mat blob;
+    blobFromImagesWithParams(images, blob, param);
+    return blob;
+}
+
+void blobFromImagesWithParams(InputArrayOfArrays images_, OutputArray blob_, const Image2BlobParams& param)
+{
+    CV_TRACE_FUNCTION();
+    CV_CheckType(param.ddepth, param.ddepth == CV_32F || param.ddepth == CV_8U,
+                 "Blob depth should be CV_32F or CV_8U");
+
+    Size size = param.size;
     std::vector<Mat> images;
     images_.getMatVector(images);
     CV_Assert(!images.empty());
+
+    int nch = images[0].channels();
+    Scalar scalefactor = param.scalefactor;
+
+    // Because 0 is meaningless in scalefactor.
+    // If the scalefactor is (x, 0, 0, 0), we convert it to (x, x, x, x).
+    if (scalefactor[1] == 0 && scalefactor[2] == 0 && scalefactor[3] == 0)
+    {
+        CV_Assert(scalefactor[0] != 0 && "Scalefactor of 0 is meaningless.");
+        scalefactor = Scalar::all(scalefactor[0]);
+    }
+
+    if (param.ddepth == CV_8U)
+    {
+        CV_Assert(scalefactor == Scalar::all(1.0) && "Scaling is not supported for CV_8U blob depth");
+        CV_Assert(param.mean == Scalar() && "Mean subtraction is not supported for CV_8U blob depth");
+    }
+
     for (size_t i = 0; i < images.size(); i++)
     {
         Size imgSize = images[i].size();
@@ -59,73 +115,122 @@ void blobFromImages(InputArrayOfArrays images_, OutputArray blob_, double scalef
             size = imgSize;
         if (size != imgSize)
         {
-            if (crop)
+            if (param.paddingmode == DNN_PMODE_CROP_CENTER)
             {
                 float resizeFactor = std::max(size.width / (float)imgSize.width,
-                        size.height / (float)imgSize.height);
+                                              size.height / (float)imgSize.height);
                 resize(images[i], images[i], Size(), resizeFactor, resizeFactor, INTER_LINEAR);
                 Rect crop(Point(0.5 * (images[i].cols - size.width),
-                                  0.5 * (images[i].rows - size.height)),
-                        size);
+                                0.5 * (images[i].rows - size.height)),
+                          size);
                 images[i] = images[i](crop);
             }
             else
-                resize(images[i], images[i], size, 0, 0, INTER_LINEAR);
+            {
+                if (param.paddingmode == DNN_PMODE_LETTERBOX)
+                {
+                    float resizeFactor = std::min(size.width / (float)imgSize.width,
+                                                  size.height / (float)imgSize.height);
+                    int rh = int(imgSize.height * resizeFactor);
+                    int rw = int(imgSize.width * resizeFactor);
+                    resize(images[i], images[i], Size(rw, rh), INTER_LINEAR);
+
+                    int top = (size.height - rh)/2;
+                    int bottom = size.height - top - rh;
+                    int left = (size.width - rw)/2;
+                    int right = size.width - left - rw;
+                    copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT);
+                }
+                else
+                    resize(images[i], images[i], size, 0, 0, INTER_LINEAR);
+            }
         }
-        if (images[i].depth() == CV_8U && ddepth == CV_32F)
-            images[i].convertTo(images[i], CV_32F);
-        Scalar mean = mean_;
-        if (swapRB)
+
+        Scalar mean = param.mean;
+        if (param.swapRB)
+        {
             std::swap(mean[0], mean[2]);
+            std::swap(scalefactor[0], scalefactor[2]);
+        }
+
+        if (images[i].depth() == CV_8U && param.ddepth == CV_32F)
+            images[i].convertTo(images[i], CV_32F);
 
         images[i] -= mean;
-        images[i] *= scalefactor;
+        multiply(images[i], scalefactor, images[i]);
     }
 
     size_t nimages = images.size();
     Mat image0 = images[0];
-    int nch = image0.channels();
     CV_Assert(image0.dims == 2);
-    if (nch == 3 || nch == 4)
-    {
-        int sz[] = { (int)nimages, nch, image0.rows, image0.cols };
-        blob_.create(4, sz, ddepth);
-        Mat blob = blob_.getMat();
-        Mat ch[4];
 
+    if (param.datalayout == DNN_LAYOUT_NCHW)
+    {
+        if (nch == 3 || nch == 4)
+        {
+            int sz[] = { (int)nimages, nch, image0.rows, image0.cols };
+            blob_.create(4, sz, param.ddepth);
+            Mat blob = blob_.getMat();
+            Mat ch[4];
+
+            for (size_t i = 0; i < nimages; i++)
+            {
+                const Mat& image = images[i];
+                CV_Assert(image.depth() == blob_.depth());
+                nch = image.channels();
+                CV_Assert(image.dims == 2 && (nch == 3 || nch == 4));
+                CV_Assert(image.size() == image0.size());
+
+                for (int j = 0; j < nch; j++)
+                    ch[j] = Mat(image.rows, image.cols, param.ddepth, blob.ptr((int)i, j));
+                if (param.swapRB)
+                    std::swap(ch[0], ch[2]);
+                split(image, ch);
+            }
+        }
+        else
+        {
+            CV_Assert(nch == 1);
+            int sz[] = { (int)nimages, 1, image0.rows, image0.cols };
+            blob_.create(4, sz, param.ddepth);
+            Mat blob = blob_.getMat();
+
+            for (size_t i = 0; i < nimages; i++)
+            {
+                const Mat& image = images[i];
+                CV_Assert(image.depth() == blob_.depth());
+                nch = image.channels();
+                CV_Assert(image.dims == 2 && (nch == 1));
+                CV_Assert(image.size() == image0.size());
+
+                image.copyTo(Mat(image.rows, image.cols, param.ddepth, blob.ptr((int)i, 0)));
+            }
+        }
+    }
+    else if (param.datalayout == DNN_LAYOUT_NHWC)
+    {
+        int sz[] = { (int)nimages, image0.rows, image0.cols, nch};
+        blob_.create(4, sz, param.ddepth);
+        Mat blob = blob_.getMat();
+        int subMatType = CV_MAKETYPE(param.ddepth, nch);
         for (size_t i = 0; i < nimages; i++)
         {
             const Mat& image = images[i];
             CV_Assert(image.depth() == blob_.depth());
-            nch = image.channels();
-            CV_Assert(image.dims == 2 && (nch == 3 || nch == 4));
+            CV_Assert(image.channels() == image0.channels());
             CV_Assert(image.size() == image0.size());
-
-            for (int j = 0; j < nch; j++)
-                ch[j] = Mat(image.rows, image.cols, ddepth, blob.ptr((int)i, j));
-            if (swapRB)
-                std::swap(ch[0], ch[2]);
-            split(image, ch);
+            if (param.swapRB)
+            {
+                Mat tmpRB;
+                cvtColor(image, tmpRB, COLOR_BGR2RGB);
+                tmpRB.copyTo(Mat(tmpRB.rows, tmpRB.cols, subMatType, blob.ptr((int)i, 0)));
+            }
+            else
+                image.copyTo(Mat(image.rows, image.cols, subMatType, blob.ptr((int)i, 0)));
         }
     }
     else
-    {
-        CV_Assert(nch == 1);
-        int sz[] = { (int)nimages, 1, image0.rows, image0.cols };
-        blob_.create(4, sz, ddepth);
-        Mat blob = blob_.getMat();
-
-        for (size_t i = 0; i < nimages; i++)
-        {
-            const Mat& image = images[i];
-            CV_Assert(image.depth() == blob_.depth());
-            nch = image.channels();
-            CV_Assert(image.dims == 2 && (nch == 1));
-            CV_Assert(image.size() == image0.size());
-
-            image.copyTo(Mat(image.rows, image.cols, ddepth, blob.ptr((int)i, 0)));
-        }
-    }
+        CV_Error(Error::StsUnsupportedFormat, "Unsupported data layout in blobFromImagesWithParams function.");
 }
 
 void imagesFromBlob(const cv::Mat& blob_, OutputArrayOfArrays images_)

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
-Image2BlobParams::Image2BlobParams():scalefactor(1.0), size(Size()), mean(Scalar()), swapRB(false), ddepth(CV_32F),
+Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size()), mean(Scalar()), swapRB(false), ddepth(CV_32F),
                            datalayout(DNN_LAYOUT_NCHW), paddingmode(DNN_PMODE_NULL)
 {}
 
@@ -51,7 +51,7 @@ void blobFromImages(InputArrayOfArrays images_, OutputArray blob_, double scalef
         Size size, const Scalar& mean_, bool swapRB, bool crop, int ddepth)
 {
     CV_TRACE_FUNCTION();
-    Image2BlobParams param(scalefactor, size, mean_, swapRB, ddepth);
+    Image2BlobParams param(Scalar::all(scalefactor), size, mean_, swapRB, ddepth);
     if (crop)
         param.paddingmode = DNN_PMODE_CROP_CENTER;
     blobFromImagesWithParams(images_, blob_, param);
@@ -93,14 +93,6 @@ void blobFromImagesWithParams(InputArrayOfArrays images_, OutputArray blob_, con
 
     int nch = images[0].channels();
     Scalar scalefactor = param.scalefactor;
-
-    // Because 0 is meaningless in scalefactor.
-    // If the scalefactor is (x, 0, 0, 0), we convert it to (x, x, x, x).
-    if (scalefactor[1] == 0 && scalefactor[2] == 0 && scalefactor[3] == 0)
-    {
-        CV_Assert(scalefactor[0] != 0 && "Scalefactor of 0 is meaningless.");
-        scalefactor = Scalar::all(scalefactor[0]);
-    }
 
     if (param.ddepth == CV_8U)
     {


### PR DESCRIPTION
The purpose of this PR:

1. Add new API `blobFromImageParam` to extend `blobFromImage` API. It can support the different datalayout (NCHW or NHWC), and letter_box.
2. ~~`blobFromImage` can output `CV_16F`~~

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
