### PR TITLE
use INTER_LINEAR instead of INTER_LINEAR_EXACT for resize in HOG to actually use OpenCL

### DIFF
--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -1865,7 +1865,7 @@ static bool ocl_detectMultiScale(InputArray _img, std::vector<Rect> &found_locat
         }
         else
         {
-            resize(_img, image_scale, effect_size, 0, 0, INTER_LINEAR_EXACT);
+            resize(_img, image_scale, effect_size, 0, 0, INTER_LINEAR);
             if(!ocl_detect(image_scale, locations, hit_threshold, win_stride, oclSvmDetector, blockSize, cellSize, nbins,
                 blockStride, winSize, gammaCorrection, L2HysThreshold, sigma, free_coef, signedGradient))
                 return false;


### PR DESCRIPTION
Pertaining Issue: https://github.com/opencv/opencv/issues/22772

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
