### PR TITLE
DNN: Make MatMul layer support 3D or 4D operation with const input

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -956,6 +956,13 @@ TEST_P(Test_ONNX_layers, MatMul)
     testONNXModels("matmul_4d");
 }
 
+TEST_P(Test_ONNX_layers, MatMul_init)
+{
+    testONNXModels("matmul_2d_init");
+    testONNXModels("matmul_3d_init");
+    testONNXModels("matmul_4d_init");
+}
+
 TEST_P(Test_ONNX_layers, MatMulAdd)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/1015

This PR is a temporary solution to fix #22713.

When 3D or 4D `MatMul` with a const input, it will create a virtual layer to ensure it can be run correctly. Later I will create a new PR to optimize the parsing of `MatMul` so that 3D or 4D operations can also use SIMD and multi-thread acceleration like 2D `MatMul`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
