### PR TITLE
OpenEXR encoder: add capability to set the DWA compression level

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -97,6 +97,7 @@ enum ImwriteFlags {
        IMWRITE_PXM_BINARY          = 32, //!< For PPM, PGM, or PBM, it can be a binary format flag, 0 or 1. Default value is 1.
        IMWRITE_EXR_TYPE            = (3 << 4) + 0, /* 48 */ //!< override EXR storage type (FLOAT (FP32) is default)
        IMWRITE_EXR_COMPRESSION     = (3 << 4) + 1, /* 49 */ //!< override EXR compression type (ZIP_COMPRESSION = 3 is default)
+       IMWRITE_EXR_DWA_COMPRESSION_LEVEL = (3 << 4) + 2, /* 50 */ //!< override EXR DWA compression level (45 is default)
        IMWRITE_WEBP_QUALITY        = 64, //!< For WEBP, it can be a quality from 1 to 100 (the higher is the better). By default (without any parameter) and for quality above 100 the lossless compression is used.
        IMWRITE_PAM_TUPLETYPE       = 128,//!< For PAM, sets the TUPLETYPE field to the corresponding string value that is defined for the format
        IMWRITE_TIFF_RESUNIT        = 256,//!< For TIFF, use to specify which DPI resolution unit to set; see libtiff documentation for valid values

--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -693,12 +693,10 @@ bool  ExrEncoder::write( const Mat& img, const std::vector<int>& params )
         }
         if (params[i] == IMWRITE_EXR_DWA_COMPRESSION_LEVEL)
         {
-#if defined(OPENEXR_VERSION_MAJOR) && OPENEXR_VERSION_MAJOR >= 3
+#if OPENEXR_VERSION_MAJOR >= 3
             header.dwaCompressionLevel() = params[i + 1];
-#elif defined(OPENEXR_VERSION_MAJOR)
-            throw std::runtime_error("Setting `IMWRITE_EXR_DWA_COMPRESSION_LEVEL` not supported in OpenEXR version " + std::to_string(OPENEXR_VERSION_MAJOR) + " (version 3 is required)");
 #else
-            throw std::runtime_error("Setting `IMWRITE_EXR_DWA_COMPRESSION_LEVEL` not supported when `OPENEXR_VERSION_MAJOR` is not defined");
+            CV_LOG_ONCE_WARNING(NULL, "Setting `IMWRITE_EXR_DWA_COMPRESSION_LEVEL` not supported in OpenEXR version " + std::to_string(OPENEXR_VERSION_MAJOR) + " (version 3 is required)");
 #endif
         }
     }

--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -691,6 +691,10 @@ bool  ExrEncoder::write( const Mat& img, const std::vector<int>& params )
                 CV_Error(Error::StsBadArg, "IMWRITE_EXR_COMPRESSION is invalid or not supported");
             }
         }
+        if (params[i] == IMWRITE_EXR_DWA_COMPRESSION_LEVEL)
+        {
+            header.dwaCompressionLevel() = params[i + 1];
+        }
     }
 
     if( channels == 3 || channels == 4 )

--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -693,7 +693,13 @@ bool  ExrEncoder::write( const Mat& img, const std::vector<int>& params )
         }
         if (params[i] == IMWRITE_EXR_DWA_COMPRESSION_LEVEL)
         {
+#if defined(OPENEXR_VERSION_MAJOR) && OPENEXR_VERSION_MAJOR >= 3
             header.dwaCompressionLevel() = params[i + 1];
+#elif defined(OPENEXR_VERSION_MAJOR)
+            throw std::runtime_error("Setting `IMWRITE_EXR_DWA_COMPRESSION_LEVEL` not supported in OpenEXR version " + std::to_string(OPENEXR_VERSION_MAJOR) + " (version 3 is required)");
+#else
+            throw std::runtime_error("Setting `IMWRITE_EXR_DWA_COMPRESSION_LEVEL` not supported when `OPENEXR_VERSION_MAJOR` is not defined");
+#endif
         }
     }
 


### PR DESCRIPTION
extracted from #21324

(cherry picked from commit aa276ece66265dcf07af5f840933377d2106c871)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
