### PR TITLE
Fix #22767: Ensure that the buttons are spaced to the size of the toolbar window, which is always visible.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -2253,7 +2253,7 @@ icvCreateTrackbar( const char* trackbar_name, const char* window_name,
         tbis.cbSize = sizeof(tbis);
         tbis.dwMask = TBIF_SIZE;
 
-        GetClientRect(window->hwnd, &rect);
+        GetClientRect(window->toolbar.toolbar, &rect);
         tbis.cx = (unsigned short)(rect.right - rect.left);
 
         SendMessage(window->toolbar.toolbar, TB_SETBUTTONINFO,
@@ -2271,7 +2271,7 @@ icvCreateTrackbar( const char* trackbar_name, const char* window_name,
         trackbar->parent = window;
         trackbar->pos = 0;
         trackbar->data = 0;
-        trackbar->id = bcount;
+        trackbar->id = tbs.idCommand;
         trackbar->next = window->toolbar.first;
         trackbar->name = (char*)(trackbar + 1);
         memcpy( trackbar->name, trackbar_name, len + 1 );


### PR DESCRIPTION
This fixes some of the problems -- when toolbars are created in one go, and some go outside the window bounds (when main client are becomes nothing), they will get sized correctly.

However, with `WINDOW_NORMAL`, some wonkiness still remains and blank buttons tend to appear once in a while (this might be due to the spacers).

Ideally, the trackbars should automatically resize to fit the width of the main window, when said window is resized (either manually when in `NORMAL` mode, or by code). This might however break some existing code that relies on current behaviour to place multiple trackbars on single row. Any opinions?