### PR TITLE
core: support CV_Check*() macros with 'bool' parameters

### DIFF
--- a/modules/core/include/opencv2/core/check.hpp
+++ b/modules/core/include/opencv2/core/check.hpp
@@ -65,6 +65,7 @@ struct CheckContext {
     static const cv::detail::CheckContext CV__CHECK_LOCATION_VARNAME(id) = \
             { CV__CHECK_FUNCTION, CV__CHECK_FILENAME, __LINE__, testOp, "" message, "" p1_str, "" p2_str }
 
+CV_EXPORTS void CV_NORETURN check_failed_auto(const bool v1, const bool v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const size_t v1, const size_t v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const float v1, const float v2, const CheckContext& ctx);
@@ -73,6 +74,9 @@ CV_EXPORTS void CV_NORETURN check_failed_auto(const Size_<int> v1, const Size_<i
 CV_EXPORTS void CV_NORETURN check_failed_MatDepth(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatType(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatChannels(const int v1, const int v2, const CheckContext& ctx);
+
+CV_EXPORTS void CV_NORETURN check_failed_true(const bool v, const CheckContext& ctx);
+CV_EXPORTS void CV_NORETURN check_failed_false(const bool v, const CheckContext& ctx);
 
 CV_EXPORTS void CV_NORETURN check_failed_auto(const int v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const size_t v, const CheckContext& ctx);
@@ -133,6 +137,12 @@ CV_EXPORTS void CV_NORETURN check_failed_MatChannels(const int v, const CheckCon
 
 /// Example: v == A || v == B
 #define CV_Check(v, test_expr, msg)  CV__CHECK_CUSTOM_TEST(_, auto, v, (test_expr), #v, #test_expr, msg)
+
+/// Example: v == true
+#define CV_CheckTrue(v, msg)  CV__CHECK_CUSTOM_TEST(_, true, v, v, #v, "", msg)
+
+/// Example: v == false
+#define CV_CheckFalse(v, msg)  CV__CHECK_CUSTOM_TEST(_, false, v, (!(v)), #v, "", msg)
 
 /// Some complex conditions: CV_Check(src2, src2.empty() || (src2.type() == src1.type() && src2.size() == src1.size()), "src2 should have same size/type as src1")
 // TODO define pretty-printers

--- a/modules/core/src/check.cpp
+++ b/modules/core/src/check.cpp
@@ -97,6 +97,10 @@ void check_failed_MatChannels(const int v1, const int v2, const CheckContext& ct
 {
     check_failed_auto_<int>(v1, v2, ctx);
 }
+void check_failed_auto(const bool v1, const bool v2, const CheckContext& ctx)
+{
+    check_failed_auto_<bool>(v1, v2, ctx);
+}
 void check_failed_auto(const int v1, const int v2, const CheckContext& ctx)
 {
     check_failed_auto_<int>(v1, v2, ctx);
@@ -150,6 +154,22 @@ void check_failed_MatType(const int v, const CheckContext& ctx)
 void check_failed_MatChannels(const int v, const CheckContext& ctx)
 {
     check_failed_auto_<int>(v, ctx);
+}
+void check_failed_true(const bool v, const CheckContext& ctx)
+{
+    CV_UNUSED(v);
+    std::stringstream ss;
+    ss  << ctx.message << ":" << std::endl
+        << "    '" << ctx.p1_str << "' must be 'true'";
+    cv::errorNoReturn(cv::Error::StsError, ss.str(), ctx.func, ctx.file, ctx.line);
+}
+void check_failed_false(const bool v, const CheckContext& ctx)
+{
+    CV_UNUSED(v);
+    std::stringstream ss;
+    ss  << ctx.message << ":" << std::endl
+        << "    '" << ctx.p1_str << "' must be 'false'";
+    cv::errorNoReturn(cv::Error::StsError, ss.str(), ctx.func, ctx.file, ctx.line);
 }
 void check_failed_auto(const int v, const CheckContext& ctx)
 {

--- a/modules/imgcodecs/src/grfmt_webp.cpp
+++ b/modules/imgcodecs/src/grfmt_webp.cpp
@@ -126,7 +126,7 @@ bool WebPDecoder::readHeader()
     WebPBitstreamFeatures features;
     if (VP8_STATUS_OK == WebPGetFeatures(header, sizeof(header), &features))
     {
-        CV_CheckEQ(features.has_animation, false, "WebP backend does not support animated webp images");
+        CV_CheckEQ(features.has_animation, 0, "WebP backend does not support animated webp images");
 
         m_width  = features.width;
         m_height = features.height;


### PR DESCRIPTION
Added support for:
- `CV_Check{EQ,NE}(bool, bool, msg)`  (LT,GE,etc variants doesn't makes sense with `bool` and should not be used)
- `CV_CheckTrue(bool_expr_must_be_true, msg)`
- `CV_CheckFalse(bool_expr_must_be_false, msg)`

Also eliminates related build warning: http://pullrequest.opencv.org/buildbot/builders/precommit_linux32/builds/100058

```
force_builders=Linux32
build_image:Custom Win=msvs2019
```