### PR TITLE
support construct submatrix from numpy array

### DIFF
--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -232,6 +232,25 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
     }
     m.allocator = &g_numpyAllocator;
 
+    // Whether oarr is an ROI
+    PyObject *obase = PyArray_BASE(oarr);
+    if (obase)
+    {
+        PyArray_Chunk chunk;
+        int res = PyArray_BufferConverter(obase, &chunk);
+        if (res == NPY_SUCCEED)
+        {
+            uchar *start = (uchar *)chunk.ptr;
+            uchar *end = start + chunk.len;
+            if (start < m.datastart || end > m.dataend)
+            {
+                m.datastart = start;
+                m.datalimit = m.dataend = end;
+                m.flags |= Mat::SUBMATRIX_FLAG;
+            }
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Some APIs behave differently when operating on a small mat, or an ROI of a large mat. For example `cv::filter2D`. However, python cannot construct a Mat with ROI. This patch enables python to invoke these behaviors that rely on ROI.

```python
cv2.filter2D(img[y1:y2, x1:x2], -1, kernel)
```

This may change the behavior of some old code. But I think the new behavior is more suitable and matches the expectation of C++ programmers.

I think this is a "Small feature", so the base branch is 4.x.

Not sure whether or where I should add some docs about this?

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
