### PR TITLE
DNN: make MatMul support 3D or 4D with broadcast

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
@@ -23,9 +23,14 @@ namespace cv { namespace dnn { namespace cuda4dnn {
     public:
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
-        MatMulOp(csl::Stream stream_, csl::cublas::Handle handle)
+        MatMulOp(csl::Stream stream_, csl::cublas::Handle handle, const Mat& constInp)
             : stream(std::move(stream_)), cublasHandle(std::move(handle))
         {
+            if (!constInp.empty())
+            {
+                constTensor = csl::makeTensorHeader<T>(constInp);
+                csl::copyMatToTensor<T>(constInp, constTensor, stream);
+            }
         }
 
         void forward(
@@ -33,13 +38,20 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             const std::vector<cv::Ptr<BackendWrapper>>& outputs,
             csl::Workspace& workspace) override
         {
-            CV_Assert(inputs.size() == 2 && outputs.size() == 1);
+            CV_Assert((inputs.size() == 2 && constTensor.empty() ||
+                       inputs.size() == 1 && !constTensor.empty()) && outputs.size() == 1);
 
             auto input1_wrapper = inputs[0].dynamicCast<wrapper_type>();
             auto input1 = input1_wrapper->getView();
 
-            auto input2_wrapper = inputs[1].dynamicCast<wrapper_type>();
-            auto input2 = input2_wrapper->getView();
+            csl::TensorView<T> input2;
+            if (constTensor.empty())
+            {
+                auto input2_wrapper = inputs[1].dynamicCast<wrapper_type>();
+                input2 = input2_wrapper->getView();
+            }
+            else
+                input2 = csl::TensorView<T>(constTensor);
 
             auto output_wrapper = outputs[0].dynamicCast<wrapper_type>();
             auto output = output_wrapper->getSpan();
@@ -59,9 +71,18 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             auto m = input1.get_axis_size(-2);
             auto n = input1.get_axis_size(-1);
-            auto k = input2.get_axis_size(-1);
             auto b = input1.size() / m / n;
-            CV_Assert(input2.get_axis_size(-2) == n);
+            int k;
+            if (constTensor.empty())
+            {
+                k = input2.get_axis_size(-1);
+                CV_Assert(input2.get_axis_size(-2) == n);
+            }
+            else
+            {
+                k = input2.get_axis_size(-2);
+                CV_Assert(input2.get_axis_size(-1) == n);
+            }
             CV_Assert(output.get_axis_size(-2) == m);
             CV_Assert(output.get_axis_size(-1) == k);
 
@@ -70,24 +91,28 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                 CV_Assert(b == 1);
                 CV_Assert(get_effective_rank(input1) <= 2);
                 CV_Assert(get_effective_rank(input2) <= 2);
-                csl::tensor_ops::gemm<T>(cublasHandle, 0.0, output, 1.0, false, input1, false, input2);
+                csl::tensor_ops::gemm<T>(cublasHandle, 0.0, output, 1.0, false, input1, !constTensor.empty(), input2);
             }
             else
             {
                 CV_Assert(rank >= 3);
                 input1.reshape(b, m, n);
-                input2.reshape(b, n, k);
+                if (constTensor.empty())
+                    input2.reshape(b, n, k);
+                else
+                    input2.reshape(b, k, n);
                 output.reshape(b, m, k);
                 input1.squeeze_to(3);
                 input2.squeeze_to(3);
                 output.squeeze_to(3);
-                csl::tensor_ops::gemmStridedBatched<T>(cublasHandle, 0.0, output, 1.0, false, input1, false, input2);
+                csl::tensor_ops::gemmStridedBatched<T>(cublasHandle, 0.0, output, 1.0, false, input1, !constTensor.empty(), input2);
             }
         }
 
     private:
         csl::Stream stream;
         csl::cublas::Handle cublasHandle;
+        csl::Tensor<T> constTensor;
     };
 
 }}} /* namespace cv::dnn::cuda4dnn */

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -921,6 +921,7 @@ TEST_P(Test_ONNX_layers, MatMul_init)
     testONNXModels("matmul_4d_init");
 
     testONNXModels("matmul_init_2");
+    testONNXModels("matmul_init_bcast");
 }
 
 TEST_P(Test_ONNX_layers, MatMulAdd)


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/1018

This PR follows the https://github.com/opencv/opencv/pull/22775

The main purpose of this PR is making `MatMul` support the broadcast that the second input has less dimention than the first one.  And let the operation support SIMD and multi-thread. Beacuse it doesn't support 1D Mat, only support MatMul like 
```
2x3x4 mul 4x5 -> 2x3x5
2x3x4x5 mul 3x5x6 -> 2x3x4x6
```
- **2 const inputs:** create a virtual layer for the first input
- **1 const input with CPU (whether or not using broadcast):** use the SIMD and multi-thread flow which for `InnerProduct`
- **1 const input with CUDA:** broadcast inputs will fallback to CPU. Inputs with the same shape will use the cuda. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
