### PR TITLE
Fix issue 22837: No more blank buttons on toolbar after resizing the window.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1943,7 +1943,6 @@ static LRESULT CALLBACK HGToolbarProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
 
             if(window->toolbar.rows != rows)
             {
-                SendMessage(window->toolbar.toolbar, TB_BUTTONCOUNT, 0, 0);
                 CvTrackbar* trackbar = window->toolbar.first;
 
                 for( ; trackbar != 0; trackbar = trackbar->next )

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1939,25 +1939,19 @@ static LRESULT CALLBACK HGToolbarProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
     case WM_NCCALCSIZE:
         {
             LRESULT ret = CallWindowProc(window->toolbar.toolBarProc, hwnd, uMsg, wParam, lParam);
-            int rows = (int)SendMessage(hwnd, TB_GETROWS, 0, 0);
+            CvTrackbar* trackbar = window->toolbar.first;
 
-            if(window->toolbar.rows != rows)
-            {
-                CvTrackbar* trackbar = window->toolbar.first;
-
-                for( ; trackbar != 0; trackbar = trackbar->next )
-                {
-                    RECT rect = { 0 };
-                    SendMessage(window->toolbar.toolbar, TB_GETITEMRECT,
-                               (WPARAM)trackbar->id, (LPARAM)&rect);
-                    MoveWindow(trackbar->hwnd, rect.left + HG_BUDDY_WIDTH, rect.top,
-                               rect.right - rect.left - HG_BUDDY_WIDTH,
-                               rect.bottom - rect.top, FALSE);
-                    MoveWindow(trackbar->buddy, rect.left, rect.top,
-                               HG_BUDDY_WIDTH, rect.bottom - rect.top, FALSE);
-                }
-                window->toolbar.rows = rows;
+            for (; trackbar != 0; trackbar = trackbar->next) {
+                RECT rect = { 0 };
+                SendMessage(window->toolbar.toolbar, TB_GETITEMRECT,
+                    (WPARAM)trackbar->id, (LPARAM)&rect);
+                MoveWindow(trackbar->hwnd, rect.left + HG_BUDDY_WIDTH, rect.top,
+                    rect.right - rect.left - HG_BUDDY_WIDTH,
+                    rect.bottom - rect.top, FALSE);
+                MoveWindow(trackbar->buddy, rect.left, rect.top,
+                    HG_BUDDY_WIDTH, rect.bottom - rect.top, FALSE);
             }
+            window->toolbar.rows = static_cast<int>(SendMessage(hwnd, TB_GETROWS, 0, 0));
             return ret;
         }
     }


### PR DESCRIPTION
Slightly related to #22806, since I've mentioned there

> However, with WINDOW_NORMAL, some wonkiness still remains and blank buttons tend to appear once in a while

This fixes that "wonkiness". Details are in the bug report, including a screenshot with the patch applied.