### PR TITLE
fix typo: Gausssian to Gaussian

### DIFF
--- a/doc/js_tutorials/js_imgproc/js_gradients/js_gradients.markdown
+++ b/doc/js_tutorials/js_imgproc/js_gradients/js_gradients.markdown
@@ -15,7 +15,7 @@ We will see each one of them.
 
 ### 1. Sobel and Scharr Derivatives
 
-Sobel operators is a joint Gausssian smoothing plus differentiation operation, so it is more
+Sobel operators is a joint Gaussian smoothing plus differentiation operation, so it is more
 resistant to noise. You can specify the direction of derivatives to be taken, vertical or horizontal
 (by the arguments, yorder and xorder respectively). You can also specify the size of kernel by the
 argument ksize. If ksize = -1, a 3x3 Scharr filter is used which gives better results than 3x3 Sobel

--- a/doc/py_tutorials/py_imgproc/py_gradients/py_gradients.markdown
+++ b/doc/py_tutorials/py_imgproc/py_gradients/py_gradients.markdown
@@ -17,7 +17,7 @@ We will see each one of them.
 
 ### 1. Sobel and Scharr Derivatives
 
-Sobel operators is a joint Gausssian smoothing plus differentiation operation, so it is more
+Sobel operators is a joint Gaussian smoothing plus differentiation operation, so it is more
 resistant to noise. You can specify the direction of derivatives to be taken, vertical or horizontal
 (by the arguments, yorder and xorder respectively). You can also specify the size of kernel by the
 argument ksize. If ksize = -1, a 3x3 Scharr filter is used which gives better results than 3x3 Sobel

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -47,7 +47,7 @@
 //International Conference Pattern Recognition, UK, August, 2004
 //http://www.zoranz.net/Publications/zivkovic2004ICPR.pdf
 //The code is very fast and performs also shadow detection.
-//Number of Gausssian components is adapted per pixel.
+//Number of Gaussian components is adapted per pixel.
 //
 // and
 //
@@ -97,7 +97,7 @@ namespace cv
  http://www.zoranz.net/Publications/zivkovic2004ICPR.pdf
 
  Advantages:
- -fast - number of Gausssian components is constantly adapted per pixel.
+ -fast - number of Gaussian components is constantly adapted per pixel.
  -performs also shadow detection (see bgfg_segm_test.cpp example)
 
 */


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


There is `Gaussian` used in API names and documentations. To keep the same, I change `Gausssian` (3 s) to `Gaussian` (2 s). Correct me if I am wrong.