### PR TITLE
Obtain the angle of the relative object captured by the 3D scene camera

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
@@ -238,6 +238,10 @@ CV_EXPORTS void integral(int depth, int sdepth, int sqdepth,
                          uchar* sqsum, size_t sqsumstep,
                          uchar* tilted, size_t tstep,
                          int width, int height, int cn);
+    
+CV_EXPORTS double getlen(InputArray Point1, InputArray Point2);
+
+CV_EXPORTS void getangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB);
 
 //! @}
 

--- a/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
@@ -241,7 +241,8 @@ CV_EXPORTS void integral(int depth, int sdepth, int sqdepth,
     
 CV_EXPORTS double getlen(InputArray Point1, InputArray Point2);
 
-CV_EXPORTS void getangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB);
+// Get camera angle
+CV_EXPORTS void findfilmangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB);
 
 //! @}
 

--- a/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
@@ -242,7 +242,7 @@ CV_EXPORTS void integral(int depth, int sdepth, int sqdepth,
 CV_EXPORTS double getlen(InputArray Point1, InputArray Point2);
 
 // Get camera angle
-CV_EXPORTS void findfilmangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB);
+CV_EXPORTS void findcamangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB);
 
 //! @}
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2676,7 +2676,7 @@ double hal::getlen(InputArray Point1, InputArray Point2)
     return std::sqrt(pow(p1.x - p2.x, 2) + pow(p1.y - p2.y, 2));
 }
 
-void getangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB)
+void findcamangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB)
 {
     double ratio = h/w;
     double ab = getlen(Point1, Point2);

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2665,6 +2665,36 @@ static bool ipp_warpAffine( InputArray _src, OutputArray _dst, int interpolation
 
 namespace hal {
 
+const double rad =  0.01745;
+
+double hal::getlen(InputArray Point1, InputArray Point2)
+{
+    Mat point1 = Point1.getMat(), point2 = Point2.getMat();
+    Point2f p1 = point1.at<Point2f>(0, 0);
+    Point2f p2 = point2.at<Point2f>(0, 0);
+
+    return std::sqrt(pow(p1.x - p2.x, 2) + pow(p1.y - p2.y, 2));
+}
+
+void getangle(InputArray Point1, InputArray Point2, InputArray Point3, InputArray Point4, double w, double h, double& angleA, double& angleB)
+{
+    double ratio = h/w;
+    double ab = getlen(Point1, Point2);
+    double bc = getlen(Point2, Point3);
+    double ad = getlen(Point1, Point4);
+
+    double sinA = ratio * bc / ab;
+
+    double sinA_1 = ratio * ad / ab;
+
+    double A = asin(sinA);
+    double A_1 = asin(sinA_1);
+
+    angleA = A / rad;
+    angleB = A_1 / rad;
+
+}
+   
 void warpAffine(int src_type,
                 const uchar * src_data, size_t src_step, int src_width, int src_height,
                 uchar * dst_data, size_t dst_step, int dst_width, int dst_height,


### PR DESCRIPTION
First，Opencv source code has warpAffine and warpPerspective，It has made great contributions to image transformation in two-dimensional scenes.  I want to pull a function for base on 3D scene.

Second, This function returns two angle values between the two angles between the shooting surface and the actual object surface, which play a great role in positioning the shooting angle.

Third, Give an example of usage，The shape of a cuboid and the external parameters of the camera are known, and the image of the cuboid can be obtained according to these two angles. On the contrary, the external parameters of the camera can also be deduced if the image is known.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
