### PR TITLE
ocl_minMaxIdx to call minmaxloc.cl for OpenCL 1.2+ only

### DIFF
--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -973,6 +973,12 @@ bool ocl_minMaxIdx( InputArray _src, double* minVal, double* maxVal, int* minLoc
         return false;
 #endif
 
+    if (dev.deviceVersionMajor() == 1 && dev.deviceVersionMinor() < 2)
+    {
+        // 'static' storage class specifier used by "minmaxloc" is available from OpenCL 1.2+ only
+        return false;
+    }
+
     bool doubleSupport = dev.doubleFPConfig() > 0, haveMask = !_mask.empty(),
         haveSrc2 = _src2.kind() != _InputArray::NONE;
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type),

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1491,10 +1491,8 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     CV_Assert( (cn == 1 && (_mask.empty() || _mask.type() == CV_8U)) ||
         (cn > 1 && _mask.empty() && !minIdx && !maxIdx) );
 
-#if defined(CL_VERSION_1_2)
     CV_OCL_RUN(OCL_PERFORMANCE_CHECK(_src.isUMat()) && _src.dims() <= 2  && (_mask.empty() || _src.size() == _mask.size()),
                ocl_minMaxIdx(_src, minVal, maxVal, minIdx, maxIdx, _mask))
-#endif
 
     Mat src = _src.getMat(), mask = _mask.getMat();
 

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1491,8 +1491,10 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     CV_Assert( (cn == 1 && (_mask.empty() || _mask.type() == CV_8U)) ||
         (cn > 1 && _mask.empty() && !minIdx && !maxIdx) );
 
+#if defined(CL_VERSION_1_2)
     CV_OCL_RUN(OCL_PERFORMANCE_CHECK(_src.isUMat()) && _src.dims() <= 2  && (_mask.empty() || _src.size() == _mask.size()),
                ocl_minMaxIdx(_src, minVal, maxVal, minIdx, maxIdx, _mask))
+#endif
 
     Mat src = _src.getMat(), mask = _mask.getMat();
 


### PR DESCRIPTION
naive change for the #22860 issue (but untested since I don't have OpenCL 1.1 here)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
