### PR TITLE
DNN: let MatMul can work when both two inputs are const

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -961,6 +961,8 @@ TEST_P(Test_ONNX_layers, MatMul_init)
     testONNXModels("matmul_2d_init");
     testONNXModels("matmul_3d_init");
     testONNXModels("matmul_4d_init");
+
+    testONNXModels("matmul_init_2");
 }
 
 TEST_P(Test_ONNX_layers, MatMulAdd)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/1021

This PR is try to solve the `MatMul` node problem of https://github.com/opencv/opencv/issues/22859

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
