### PR TITLE
Extend USAC coverage.

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -3246,6 +3246,150 @@ CV_EXPORTS_W cv::Mat estimateAffinePartial2D(InputArray from, InputArray to, Out
                                   size_t maxIters = 2000, double confidence = 0.99,
                                   size_t refineIters = 10);
 
+
+/** @brief Computes an optimal limited \f$SE(2)\f$ transformation with 3 degrees of freedom between
+two 2D point sets.
+
+@param from First input 2D point set containing \f$(X,Y)\f$.
+@param to Second input 2D point set containing \f$(x,y)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffinePartial2D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$SE(2)\f$ transformation (3 degrees of freedom) matrix \f$2 \times 3\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$SE(2)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation and rotation.
+@sa estimateAffine2D
+*/
+CV_EXPORTS_W cv::Mat estimateSE2(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$Sim(2)\f$ transformation with 3 degrees of freedom between
+two 2D point sets.
+
+@param from First input 2D point set containing \f$(X,Y)\f$.
+@param to Second input 2D point set containing \f$(x,y)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffinePartial2D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$Sim(2)\f$ transformation (4 degrees of freedom) matrix \f$2 \times 3\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$Sim(2)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation, rotation, and uniform scaling.
+@sa estimateAffine2D
+*/
+CV_EXPORTS_W cv::Mat estimateSIM2(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$SE(3)\f$ transformation with 4 degrees of freedom between
+two 3D point sets.
+
+@param from First input 3D point set containing \f$(X,Y,Z)\f$.
+@param to Second input 3D point set containing \f$(x,y,z)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffine3D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$SE(3)\f$ transformation (4 degrees of freedom) matrix \f$3 \times 4\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$SE(3)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation and rotation.
+@sa estimateAffine3D
+*/
+CV_EXPORTS_W cv::Mat estimateSE3(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$Sim(3)\f$ transformation with 4 degrees of freedom between
+two 3D point sets.
+
+@param from First input 3D point set containing \f$(X,Y,Z)\f$.
+@param to Second input 3D point set containing \f$(x,y,z)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffine3D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$Sim(3)\f$ transformation (5 degrees of freedom) matrix \f$3 \times 4\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$Sim(3)\f$ transformation with 5 degrees of freedom limited to
+combinations of translation, rotation, and uniform scaling.
+@sa estimateAffine3D
+*/CV_EXPORTS_W cv::Mat estimateSIM3(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
 /** @example samples/cpp/tutorial_code/features2D/Homography/decompose_homography.cpp
 An example program with homography decomposition.
 


### PR DESCRIPTION
## Problem
Nice feature based on [USAC](https://docs.opencv.org/4.x/d1/df1/md__build_master-contrib_docs-lin64_opencv_doc_tutorials_calib3d_usac.html):  RANSAC-based universal framework has been introduced for the following functions.
+ [`findHomography`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L488)
+ [`findFundamentalMat`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L505)
+ [`findEssentialMat`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L522)
+ [`solvePnPRansac`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L539)
+ [`estimateAffine2D`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L565)

However, the following functions do not support and only support legacy methods (`RANSAC` and `LMEDS`).
+ [`estimateAffinePartial2D`](https://docs.opencv.org/4.5.4/d9/d0c/group__calib3d.html#gad767faff73e9cbd8b9d92b955b50062d)
+ [`estimateAffine3D`](https://docs.opencv.org/4.5.4/d9/d0c/group__calib3d.html#gac12d1f05b3bb951288e7250713ce98f0)

Meanwhile, these functions provided to estimate a constrained geometric transformations consists of rotation, translation, and scaling with appropriate options. 

## Proposal
I really needed to estimate for the transformation in the class of Rigid/Similarity transform in 2D and 3D, denoted as $\mathit{SE}(d), \mathit{SIM}(d)$, where $d=2,3$.
In order to clarify the class of the transformation of the output, I propose to add the functions of `estimateSE2(...)`, `estimateSE3(...)`, `estimateSIM2(...)`, `estimateSIM3(...)` as alternative for `estimateAffinePartial2D` and `estimateAffine3D`. These functions takes arguments compatible with the existing functions such as `estimateAffine2D`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
