### PR TITLE
Extend USAC coverage.

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -3246,6 +3246,150 @@ CV_EXPORTS_W cv::Mat estimateAffinePartial2D(InputArray from, InputArray to, Out
                                   size_t maxIters = 2000, double confidence = 0.99,
                                   size_t refineIters = 10);
 
+
+/** @brief Computes an optimal limited \f$SE(2)\f$ transformation with 3 degrees of freedom between
+two 2D point sets.
+
+@param from First input 2D point set containing \f$(X,Y)\f$.
+@param to Second input 2D point set containing \f$(x,y)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffinePartial2D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$SE(2)\f$ transformation (3 degrees of freedom) matrix \f$2 \times 3\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$SE(2)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation and rotation.
+@sa estimateAffine2D
+*/
+CV_EXPORTS_W cv::Mat estimateSE2(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$Sim(2)\f$ transformation with 3 degrees of freedom between
+two 2D point sets.
+
+@param from First input 2D point set containing \f$(X,Y)\f$.
+@param to Second input 2D point set containing \f$(x,y)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffinePartial2D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$Sim(2)\f$ transformation (4 degrees of freedom) matrix \f$2 \times 3\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$Sim(2)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation, rotation, and uniform scaling.
+@sa estimateAffine2D
+*/
+CV_EXPORTS_W cv::Mat estimateSIM2(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$SE(3)\f$ transformation with 4 degrees of freedom between
+two 3D point sets.
+
+@param from First input 3D point set containing \f$(X,Y,Z)\f$.
+@param to Second input 3D point set containing \f$(x,y,z)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffine3D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$SE(3)\f$ transformation (4 degrees of freedom) matrix \f$3 \times 4\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$SE(3)\f$ transformation with 3 degrees of freedom limited to
+combinations of translation and rotation.
+@sa estimateAffine3D
+*/
+CV_EXPORTS_W cv::Mat estimateSE3(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
+/** @brief Computes an optimal limited \f$Sim(3)\f$ transformation with 4 degrees of freedom between
+two 3D point sets.
+
+@param from First input 3D point set containing \f$(X,Y,Z)\f$.
+@param to Second input 3D point set containing \f$(x,y,z)\f$.
+@param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+@param method Robust method used to compute transformation. The following methods are possible:
+-   @ref USAC_DEFAULT – has standard LO-RANSAC.
+-   @ref USAC_PARALLEL – has LO-RANSAC and RANSACs run in parallel.
+-   @ref USAC_ACCURATE – has GC-RANSAC.
+-   @ref USAC_FAST – has LO-RANSAC with smaller number iterations in local optimization step. Uses RANSAC score to maximize number of inliers and terminate earlier.
+-   @ref USAC_PROSAC – has PROSAC sampling. Note, points must be sorted.
+-   @ref USAC_MAGSAC – has MAGSAC++.
+USAC_DEFAULT is the default method.
+The legacy methods of @ref RANSAC and @ref LMEDS are not supported. Use @sa estimateAffine3D for them.
+@param ransacReprojThreshold Maximum reprojection error in the RANSAC algorithm to consider
+a point as an inlier. Applies only to RANSAC.
+@param maxIters The maximum number of robust method iterations.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+@param refineIters Maximum number of iterations of refining algorithm (Levenberg-Marquardt).
+Passing 0 will disable refining, so the output matrix will be output of robust method.
+
+@return Output \f$Sim(3)\f$ transformation (5 degrees of freedom) matrix \f$3 \times 4\f$ or
+empty matrix if transformation could not be estimated.
+
+The function estimates an optimal \f$Sim(3)\f$ transformation with 5 degrees of freedom limited to
+combinations of translation, rotation, and uniform scaling.
+@sa estimateAffine3D
+*/CV_EXPORTS_W cv::Mat estimateSIM3(InputArray from, InputArray to, OutputArray inliers = noArray(),
+                                  int method = USAC_DEFAULT, double ransacReprojThreshold = 3,
+                                  size_t maxIters = 2000, double confidence = 0.99,
+                                  size_t refineIters = 10);
+
 /** @example samples/cpp/tutorial_code/features2D/Homography/decompose_homography.cpp
 An example program with homography decomposition.
 

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -1182,4 +1182,57 @@ Mat estimateAffinePartial2D(InputArray _from, InputArray _to, OutputArray _inlie
     return H;
 }
 
+
+Mat estimateSE2(InputArray _from, InputArray _to, OutputArray _inliers,
+                     const int method, const double ransacReprojThreshold,
+                     const size_t maxIters, const double confidence,
+                     const size_t refineIters)
+{
+
+    if (method >= USAC_DEFAULT && method <= USAC_MAGSAC)
+        return cv::usac::estimateSE2(_from, _to, _inliers, method,
+            ransacReprojThreshold, (int)maxIters, confidence, (int)refineIters);
+    else
+        CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
+}
+
+Mat estimateSIM2(InputArray _from, InputArray _to, OutputArray _inliers,
+                     const int method, const double ransacReprojThreshold,
+                     const size_t maxIters, const double confidence,
+                     const size_t refineIters)
+{
+
+    if (method >= USAC_DEFAULT && method <= USAC_MAGSAC)
+        return cv::usac::estimateSIM2(_from, _to, _inliers, method,
+            ransacReprojThreshold, (int)maxIters, confidence, (int)refineIters);
+    else
+        CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
+}
+
+Mat estimateSE3(InputArray _from, InputArray _to, OutputArray _inliers,
+                     const int method, const double ransacReprojThreshold,
+                     const size_t maxIters, const double confidence,
+                     const size_t refineIters)
+{
+    if (method >= USAC_DEFAULT && method <= USAC_MAGSAC)
+        return cv::usac::estimateSE3(_from, _to, _inliers, method,
+            ransacReprojThreshold, (int)maxIters, confidence, (int)refineIters);
+    else
+        CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
+}
+
+Mat estimateSIM3(InputArray _from, InputArray _to, OutputArray _inliers,
+                     const int method, const double ransacReprojThreshold,
+                     const size_t maxIters, const double confidence,
+                     const size_t refineIters)
+{
+
+    if (method >= USAC_DEFAULT && method <= USAC_MAGSAC)
+        return cv::usac::estimateSIM3(_from, _to, _inliers, method,
+            ransacReprojThreshold, (int)maxIters, confidence, (int)refineIters);
+    else
+        CV_Error(Error::StsBadArg, "Unknown or unsupported robust estimation method");
+}
+
+
 } // namespace cv

--- a/modules/calib3d/src/usac.hpp
+++ b/modules/calib3d/src/usac.hpp
@@ -6,7 +6,7 @@
 #define OPENCV_USAC_USAC_HPP
 
 namespace cv { namespace usac {
-enum EstimationMethod { Homography, Fundamental, Fundamental8, Essential, Affine, P3P, P6P};
+enum EstimationMethod { Homography, Fundamental, Fundamental8, Essential, Affine, SE2, SE3, SIM2, SIM3, P3P, P6P};
 enum VerificationMethod { NullVerifier, SprtVerifier };
 enum PolishingMethod { NonePolisher, LSQPolisher };
 enum ErrorMetric {DIST_TO_LINE, SAMPSON_ERR, SGD_ERR, SYMM_REPR_ERR, FORW_REPR_ERR, RERPOJ};
@@ -56,6 +56,12 @@ public:
 class ReprojectionErrorAffine : public Error {
 public:
     static Ptr<ReprojectionErrorAffine> create(const Mat &points);
+};
+
+// Reprojection Error for Affine 3D matrix
+class ReprojectionErrorAffine3D : public Error {
+public:
+    static Ptr<ReprojectionErrorAffine3D> create(const Mat &points);
 };
 
 // Normalizing transformation of data points
@@ -125,6 +131,29 @@ public:
     static Ptr<AffineMinimalSolver> create(const Mat &points_);
 };
 
+//-------------------------- SE/SIM -----------------------
+class SE2MinimalSolver : public MinimalSolver {
+public:
+    static Ptr<SE2MinimalSolver> create(const Mat &points_);
+};
+// class PartialNdMinimalSolver : public MinimalSolver {
+// public:
+//     static Ptr<PartialNdMinimalSolver> create(const Mat &points_, const int Nd=2, const bool is_similarity=false);
+// };
+class SIM2MinimalSolver : public MinimalSolver {
+public:
+    static Ptr<SIM2MinimalSolver> create(const Mat &points_);
+};
+class SE3MinimalSolver : public MinimalSolver {
+public:
+    static Ptr<SE3MinimalSolver> create(const Mat &points_);
+};
+class SIM3MinimalSolver : public MinimalSolver {
+public:
+    static Ptr<SIM3MinimalSolver> create(const Mat &points_);
+};
+
+
 //////////////////////////////////////// NON MINIMAL SOLVER ///////////////////////////////////////
 class NonMinimalSolver : public Algorithm {
 public:
@@ -172,6 +201,30 @@ class AffineNonMinimalSolver : public NonMinimalSolver {
 public:
     static Ptr<AffineNonMinimalSolver> create(const Mat &points_);
 };
+
+
+//-------------------------- SE/SIM -----------------------
+class SE2NonMinimalSolver : public NonMinimalSolver {
+public:
+    static Ptr<SE2NonMinimalSolver> create(const Mat &points_);
+};
+// class PartialNdNonMinimalSolver : public NonMinimalSolver {
+// public:
+//     static Ptr<PartialNdNonMinimalSolver> create(const Mat &points_, const int Nd=2, const bool is_similarity=false);
+// };
+class SIM2NonMinimalSolver : public NonMinimalSolver {
+public:
+    static Ptr<SIM2NonMinimalSolver> create(const Mat &points_);
+};
+class SE3NonMinimalSolver : public NonMinimalSolver {
+public:
+    static Ptr<SE3NonMinimalSolver> create(const Mat &points_);
+};
+class SIM3NonMinimalSolver : public NonMinimalSolver {
+public:
+    static Ptr<SIM3NonMinimalSolver> create(const Mat &points_);
+};
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////// SCORE ///////////////////////////////////////////
@@ -804,6 +857,22 @@ Mat findEssentialMat( InputArray points1, InputArray points2,
                       double threshold, OutputArray mask);
 
 Mat estimateAffine2D(InputArray from, InputArray to, OutputArray inliers,
+     int method, double ransacReprojThreshold, int maxIters,
+     double confidence, int refineIters);
+
+Mat estimateSE2(InputArray from, InputArray to, OutputArray inliers,
+     int method, double ransacReprojThreshold, int maxIters,
+     double confidence, int refineIters);
+
+Mat estimateSIM2(InputArray from, InputArray to, OutputArray inliers,
+     int method, double ransacReprojThreshold, int maxIters,
+     double confidence, int refineIters);
+
+Mat estimateSE3(InputArray from, InputArray to, OutputArray inliers,
+     int method, double ransacReprojThreshold, int maxIters,
+     double confidence, int refineIters);
+
+Mat estimateSIM3(InputArray from, InputArray to, OutputArray inliers,
      int method, double ransacReprojThreshold, int maxIters,
      double confidence, int refineIters);
 

--- a/modules/calib3d/src/usac/estimator.cpp
+++ b/modules/calib3d/src/usac/estimator.cpp
@@ -590,6 +590,66 @@ ReprojectionErrorAffine::create(const Mat &points) {
     return makePtr<ReprojectionDistanceAffineImpl>(points);
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Computes forward reprojection error for affine 3D transformation.
+class ReprojectionDistanceAffine3DImpl : public ReprojectionErrorAffine3D {
+private:
+    /*
+     * m11 m12 m13 m14
+     * m21 m22 m23 m24
+     * m31 m32 m33 m34
+     * 0   0   0   1
+     */
+    const Mat * points_mat;
+    const float * const points;
+    float m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34;
+    std::vector<float> errors;
+public:
+    explicit ReprojectionDistanceAffine3DImpl (const Mat &points_)
+        : points_mat(&points_), points ((float *) points_.data)
+        , m11(0), m12(0), m13(0), m14(0)
+        , m21(0), m22(0), m23(0), m24(0)
+        , m31(0), m32(0), m33(0), m34(0)
+        , errors(points_.rows)
+    {
+        CV_DbgAssert(points);
+    }
+
+    inline void setModelParameters(const Mat& model) override
+    {
+        CV_Assert(!model.empty());
+        CV_CheckTypeEQ(model.depth(), CV_64F, "");
+
+        const auto * const m = (double *) model.data;
+        m11 = (float)m[0]; m12 = (float)m[1]; m13 = (float)m[2];  m14 = (float)m[3];
+        m21 = (float)m[4]; m22 = (float)m[5]; m23 = (float)m[6];  m24 = (float)m[7];
+        m31 = (float)m[8]; m32 = (float)m[9]; m33 = (float)m[10]; m34 = (float)m[11];
+    }
+    inline float getError (int point_idx) const override {
+        const int smpl = 6*point_idx;
+        const float x1=points[smpl], y1=points[smpl+1], z1=points[smpl+2], x2=points[smpl+3], y2=points[smpl+4], z2=points[smpl+5];
+        const float dx2 = x2 - (m11 * x1 + m12 * y1 + m13 * z1 + m14), dy2 = y2 - (m21 * x1 + m22 * y1 + m23 * z1 + m24), dz2 = z2 - (m31 * x1 + m32 * y1 + m33 * z1 + m34);
+        return dx2 * dx2 + dy2 * dy2 + dz2 * dz2;
+    }
+    const std::vector<float> &getErrors (const Mat &model) override {
+        setModelParameters(model);
+        for (int point_idx = 0; point_idx < points_mat->rows; point_idx++) {
+            const int smpl = 6*point_idx;
+            const float x1=points[smpl], y1=points[smpl+1], z1=points[smpl+2], x2=points[smpl+3], y2=points[smpl+4], z2=points[smpl+5];
+            const float dx2 = x2 - (m11 * x1 + m12 * y1 + m13 * z1 + m14), dy2 = y2 - (m21 * x1 + m22 * y1 + m23 * z1 + m24), dz2 = z2 - (m31 * x1 + m32 * y1 + m33 * z1 + m34);
+            errors[point_idx] = dx2 * dx2 + dy2 * dy2 + dz2 * dz2;
+        }
+        return errors;
+    }
+    Ptr<Error> clone () const override {
+        return makePtr<ReprojectionDistanceAffineImpl>(*points_mat);
+    }
+};
+Ptr<ReprojectionErrorAffine3D>
+ReprojectionErrorAffine3D::create(const Mat &points) {
+    return makePtr<ReprojectionDistanceAffine3DImpl>(points);
+}
+
 ////////////////////////////////////// NORMALIZING TRANSFORMATION /////////////////////////
 class NormTransformImpl : public NormTransform {
 private:


### PR DESCRIPTION
Add `estimateSE2(...)`, `estimateSE3(...)`, `estimateSIM2(...)`, `estimateSIM3(...)` for estimating an geometric transformation with rotation and translation (with scaling for SIM) using USAC: as alternative for `estimateAffinePartial2D` and `estimateAffine3D`.

## Problem
Nice feature based on [USAC](https://docs.opencv.org/4.x/d1/df1/md__build_master-contrib_docs-lin64_opencv_doc_tutorials_calib3d_usac.html):  RANSAC-based universal framework has been introduced for the following functions.
+ [`findHomography`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L488)
+ [`findFundamentalMat`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L505)
+ [`findEssentialMat`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L522)
+ [`solvePnPRansac`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L539)
+ [`estimateAffine2D`](https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/ransac_solvers.cpp#L565)

However, the following functions are not supported and only support legacy methods (`RANSAC` and `LMEDS`).
+ [`estimateAffinePartial2D`](https://docs.opencv.org/4.5.4/d9/d0c/group__calib3d.html#gad767faff73e9cbd8b9d92b955b50062d)
+ [`estimateAffine3D`](https://docs.opencv.org/4.5.4/d9/d0c/group__calib3d.html#gac12d1f05b3bb951288e7250713ce98f0)

Meanwhile, these functions provided to estimate a constrained geometric transformations consists of rotation, translation, and scaling with appropriate options. 

## Proposal
I really needed to estimate for the transformation in the class of Rigid/Similarity transform in 2D and 3D, denoted as $\mathit{SE}(d), \mathit{SIM}(d)$, where $d=2,3$.
In order to clarify the class of the transformation of the output, I propose to add the functions of `estimateSE2(...)`, `estimateSE3(...)`, `estimateSIM2(...)`, `estimateSIM3(...)` as alternative for `estimateAffinePartial2D` and `estimateAffine3D`. These functions takes arguments compatible with the existing functions such as `estimateAffine2D`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
