### PR TITLE
cmake: ocv_check_modules: ignore -latomic and -lstdc++

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -866,7 +866,10 @@ macro(ocv_check_modules define)
       foreach(flag ${${define}_LDFLAGS})
         if(flag MATCHES "^-L(.*)")
           list(APPEND _libs_paths ${CMAKE_MATCH_1})
-        elseif(IS_ABSOLUTE "${flag}")
+        elseif(IS_ABSOLUTE "${flag}"
+            OR flag STREQUAL "-lstdc++"
+            OR flag STREQUAL "-latomic"
+        )
           list(APPEND _libs "${flag}")
         elseif(flag MATCHES "^-l(.*)")
           set(_lib "${CMAKE_MATCH_1}")


### PR DESCRIPTION
- [x] [Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100068) ([issue](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100067))

```
buildworker:Custom=linux-4
build_image:Custom=ffmpeg-master
```