### PR TITLE
risc-v: fix RVV backend on clang with undefined CV_RVV_SCALABLE

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv.hpp
@@ -2646,14 +2646,14 @@ inline v_##_Tpvec v_interleave_quads(const v_##_Tpvec& vec) \
     v_store(ptrvec, vec); \
     for (int i = 0; i < v_##_Tpvec::nlanes/8; i++) \
     { \
-        ptr[8*i  ] = ptrvec[4*i  ]; \
-        ptr[8*i+1] = ptrvec[4*i+4]; \
-        ptr[8*i+2] = ptrvec[4*i+1]; \
-        ptr[8*i+3] = ptrvec[4*i+5]; \
-        ptr[8*i+4] = ptrvec[4*i+2]; \
-        ptr[8*i+5] = ptrvec[4*i+6]; \
-        ptr[8*i+6] = ptrvec[4*i+3]; \
-        ptr[8*i+7] = ptrvec[4*i+7]; \
+        ptr[8*i  ] = ptrvec[8*i  ]; \
+        ptr[8*i+1] = ptrvec[8*i+4]; \
+        ptr[8*i+2] = ptrvec[8*i+1]; \
+        ptr[8*i+3] = ptrvec[8*i+5]; \
+        ptr[8*i+4] = ptrvec[8*i+2]; \
+        ptr[8*i+5] = ptrvec[8*i+6]; \
+        ptr[8*i+6] = ptrvec[8*i+3]; \
+        ptr[8*i+7] = ptrvec[8*i+7]; \
     } \
     return v_load(ptr); \
 }
@@ -2753,7 +2753,7 @@ inline int v_signmask(const _Tpvec& a) \
 { \
     uint8_t ans[16] = {0};\
     vsm(ans, vmslt(a, 0, vl), vl);\
-    return reinterpret_cast<int*>(ans)[0];\
+    return reinterpret_cast<int*>(ans)[0] & ((1 << (vl)) - 1);\
 }
 
 OPENCV_HAL_IMPL_RVV_SIGNMASK_OP(v_int8x16, 8, 16)
@@ -2810,7 +2810,7 @@ OPENCV_HAL_IMPL_RVV_SCAN_FORWOARD_OP(v_float64x2, double, f64)
 #ifndef __clang__
 inline v_int8x16 v_pack_triplets(const v_int8x16& vec)
 {
-    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFFFF0E0D0C0A};
+    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFF0F0E0D0C0A};
     return v_int8x16((vint8m1_t)vrgather_vv_u8m1((vuint8m1_t)vint8m1_t(vec), (vuint8m1_t)vle64_v_u64m1(ptr, 2), 16));
 }
 inline v_uint8x16 v_pack_triplets(const v_uint8x16& vec)
@@ -2820,7 +2820,7 @@ inline v_uint8x16 v_pack_triplets(const v_uint8x16& vec)
 
 inline v_int16x8 v_pack_triplets(const v_int16x8& vec)
 {
-    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFFFF0E0D0C0A};
+    uint64 ptr[2] = {0x0908050403020100, 0xFFFF0F0E0D0C0B0A};
     return v_int16x8((vint16m1_t)vrgather_vv_u8m1((vuint8m1_t)vint16m1_t(vec), (vuint8m1_t)vle64_v_u64m1(ptr, 2), 16));
 }
 inline v_uint16x8 v_pack_triplets(const v_uint16x8& vec)
@@ -2836,7 +2836,7 @@ inline v_float32x4 v_pack_triplets(const v_float32x4& vec) { return vec; }
 
 inline v_int8x16 v_pack_triplets(const v_int8x16& vec)
 {
-    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFFFF0E0D0C0A};
+    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFF0F0E0D0C0A};
     return v_int8x16(vreinterpret_i8m1(vrgather_vv_u8m1(v_reinterpret_as_u8(vec), vreinterpret_u8m1(vle64_v_u64m1(ptr, 2)), 16)));
 }
 inline v_uint8x16 v_pack_triplets(const v_uint8x16& vec)
@@ -2846,7 +2846,7 @@ inline v_uint8x16 v_pack_triplets(const v_uint8x16& vec)
 
 inline v_int16x8 v_pack_triplets(const v_int16x8& vec)
 {
-    uint64 ptr[2] = {0x0908060504020100, 0xFFFFFFFF0E0D0C0A};
+    uint64 ptr[2] = {0x0908050403020100, 0xFFFF0F0E0D0C0B0A};
     return v_int16x8(v_reinterpret_as_s16(v_uint8x16(vrgather_vv_u8m1(v_reinterpret_as_u8(vec), vreinterpret_u8m1(vle64_v_u64m1(ptr, 2)), 16))));
 }
 inline v_uint16x8 v_pack_triplets(const v_uint16x8& vec)


### PR DESCRIPTION
- v_interleave_quads
- v_pack_triplets
- v_signmask

relates #18228

<cut/>

Resolved test failures:

<details>

```
[ RUN      ] hal_intrin128.uint8x16_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_uint8()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:523: Failure
Expected equality of these values:
  resQ[8*i]
    Which is: '\x5' (5)
  dataA[8*i ]
    Which is: '\t' (9)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:524: Failure
Expected equality of these values:
  resQ[8*i + 1]
    Which is: '\t' (9)
  dataA[8*i+4]
    Which is: '\r' (13, 0xD)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:525: Failure
Expected equality of these values:
  resQ[8*i + 2]
    Which is: '\x6' (6)
  dataA[8*i+1]
    Which is: '\n' (10, 0xA)
With diff:
@@ -1,1 +1,2 @@
-'\x6' (6)
+'
+' (10, 0xA)

Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:526: Failure
Expected equality of these values:
  resQ[8*i + 3]
    Which is: '\n' (10, 0xA)
  dataA[8*i+5]
    Which is: '\xE' (14)
With diff:
@@ -1,2 +1,1 @@
-'
-' (10, 0xA)
+'\xE' (14)

Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:527: Failure
Expected equality of these values:
  resQ[8*i + 4]
    Which is: '\a' (7)
  dataA[8*i+2]
    Which is: '\v' (11, 0xB)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:528: Failure
Expected equality of these values:
  resQ[8*i + 5]
    Which is: '\v' (11, 0xB)
  dataA[8*i+6]
    Which is: '\xF' (15)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:529: Failure
Expected equality of these values:
  resQ[8*i + 6]
    Which is: '\b' (8)
  dataA[8*i+3]
    Which is: '\f' (12, 0xC)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:530: Failure
Expected equality of these values:
  resQ[8*i + 7]
    Which is: '\f' (12, 0xC)
  dataA[8*i+7]
    Which is: '\x10' (16)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
[  FAILED  ] hal_intrin128.uint8x16_BASELINE (23 ms)
[ RUN      ] hal_intrin128.int8x16_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_int8()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:523: Failure
Expected equality of these values:
  resQ[8*i]
    Which is: '\x5' (5)
  dataA[8*i ]
    Which is: '\t' (9)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:524: Failure
Expected equality of these values:
  resQ[8*i + 1]
    Which is: '\t' (9)
  dataA[8*i+4]
    Which is: '\r' (13, 0xD)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:525: Failure
Expected equality of these values:
  resQ[8*i + 2]
    Which is: '\x6' (6)
  dataA[8*i+1]
    Which is: '\n' (10, 0xA)
With diff:
@@ -1,1 +1,2 @@
-'\x6' (6)
+'
+' (10, 0xA)

Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:526: Failure
Expected equality of these values:
  resQ[8*i + 3]
    Which is: '\n' (10, 0xA)
  dataA[8*i+5]
    Which is: '\xE' (14)
With diff:
@@ -1,2 +1,1 @@
-'
-' (10, 0xA)
+'\xE' (14)

Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:527: Failure
Expected equality of these values:
  resQ[8*i + 4]
    Which is: '\a' (7)
  dataA[8*i+2]
    Which is: '\v' (11, 0xB)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:528: Failure
Expected equality of these values:
  resQ[8*i + 5]
    Which is: '\v' (11, 0xB)
  dataA[8*i+6]
    Which is: '\xF' (15)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:529: Failure
Expected equality of these values:
  resQ[8*i + 6]
    Which is: '\b' (8)
  dataA[8*i+3]
    Which is: '\f' (12, 0xC)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:530: Failure
Expected equality of these values:
  resQ[8*i + 7]
    Which is: '\f' (12, 0xC)
  dataA[8*i+7]
    Which is: '\x10' (16)
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:522: i=1
[  FAILED  ] hal_intrin128.int8x16_BASELINE (11 ms)
[ RUN      ] hal_intrin128.uint16x8_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_uint16()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1177: Failure
Expected equality of these values:
  dataA[4*i+1]
    Which is: 2
  res[3*i+1]
    Which is: 770
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=0
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1178: Failure
Expected equality of these values:
  dataA[4*i+2]
    Which is: 3
  res[3*i+2]
    Which is: 1024
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=0
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1177: Failure
Expected equality of these values:
  dataA[4*i+1]
    Which is: 6
  res[3*i+1]
    Which is: 1798
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1178: Failure
Expected equality of these values:
  dataA[4*i+2]
    Which is: 7
  res[3*i+2]
    Which is: 2048
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=1
[  FAILED  ] hal_intrin128.uint16x8_BASELINE (15 ms)
[ RUN      ] hal_intrin128.int16x8_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_int16()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1177: Failure
Expected equality of these values:
  dataA[4*i+1]
    Which is: 2
  res[3*i+1]
    Which is: 770
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=0
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1178: Failure
Expected equality of these values:
  dataA[4*i+2]
    Which is: 3
  res[3*i+2]
    Which is: 1024
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=0
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1177: Failure
Expected equality of these values:
  dataA[4*i+1]
    Which is: 6
  res[3*i+1]
    Which is: 1798
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=1
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1178: Failure
Expected equality of these values:
  dataA[4*i+2]
    Which is: 7
  res[3*i+2]
    Which is: 2048
Google Test trace:
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1175: i=1
[  FAILED  ] hal_intrin128.int16x8_BASELINE (9 ms)
[ RUN      ] hal_intrin128.int32x4_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_int32()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1103: Failure
Expected equality of these values:
  2
  v_signmask(a)
    Which is: 242
[  FAILED  ] hal_intrin128.int32x4_BASELINE (12 ms)
[ RUN      ] hal_intrin128.uint32x4_BASELINE
SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_uint32()
/home/alalek/projects/opencv/dev/modules/core/test/test_intrin_utils.hpp:1103: Failure
Expected equality of these values:
  2
  v_signmask(a)
    Which is: 242
[  FAILED  ] hal_intrin128.uint32x4_BASELINE (7 ms)
```

</details>

CMake options:

> cmake -GNinja <opencv_src> -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=<opencv_src>/platforms/linux/riscv64-clang.toolchain.cmake -DRISCV_CLANG_BUILD_ROOT=<sc-ide_dir>/llvm -DRISCV_GCC_INSTALL_ROOT=<sc-ide_dir>/riscv-gcc -DBUILD_WITH_DEBUG_INFO=ON -DCPU_BASELINE=RVV -DRISCV_RVV_SCALABLE=OFF

QEMU: v7.0.0

RISCV builds:
- [before](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100098)
- [after](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100099)