### PR TITLE
videoio(test): test skip due to non-updated FFmpeg wrapper

### DIFF
--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -584,6 +584,11 @@ TEST_P(videoio_ffmpeg_16bit, basic)
     const double time_sec = 1;
     const int numFrames = static_cast<int>(fps * time_sec);
 
+#ifdef _WIN32 // TODO: FFmpeg wrapper update
+    if (isSupported)
+        throw SkipTestException("FFmpeg wrapper update is required");
+#endif
+
     {
         VideoWriter writer;
         writer.open(filename, CAP_FFMPEG, fourcc, fps, sz,


### PR DESCRIPTION
relates #22894

Fail messages on Windows:
```
[ RUN      ] videoio_ffmpeg_16bit.basic/0, where GetParam() = ("FFV1", "avi", false, true)
[ INFO:0@44.452] global /build/opencv/modules/videoio/src/cap_interface.hpp (188) warnUnusedParameters VIDEOIO: unused parameter: [5]=2 / 0x0000000000000002
C:\build\precommit_windows64\4.x\opencv\modules\videoio\test\test_ffmpeg.cpp(595): error: Expected equality of these values:
  isSupported
    Which is: true
  writer.isOpened()
    Which is: false
[  FAILED  ] videoio_ffmpeg_16bit.basic/0, where GetParam() = ("FFV1", "avi", false, true) (0 ms)
[ RUN      ] videoio_ffmpeg_16bit.basic/1, where GetParam() = ("FFV1", "mkv", false, true)
[ INFO:0@44.453] global /build/opencv/modules/videoio/src/cap_interface.hpp (188) warnUnusedParameters VIDEOIO: unused parameter: [5]=2 / 0x0000000000000002
C:\build\precommit_windows64\4.x\opencv\modules\videoio\test\test_ffmpeg.cpp(595): error: Expected equality of these values:
  isSupported
    Which is: true
  writer.isOpened()
    Which is: false
[  FAILED  ] videoio_ffmpeg_16bit.basic/1, where GetParam() = ("FFV1", "mkv", false, true) (1 ms)
```