### PR TITLE
G-API: replace GAPI_Assert() with 'false' and '0' to GAPI_Error()

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -41,6 +41,9 @@ if(MSVC)
     # and IE deprecated code warning C4996
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4503 /wd4996)
   endif()
+  if(MSVC_VERSION LESS 1920)  # MSVS 2015/2017
+    ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4702)  # 'unreachable code'
+  endif()
 endif()
 
 file(GLOB gapi_ext_hdrs

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -8,9 +8,9 @@
 #ifndef OPENCV_GAPI_GCPUKERNEL_HPP
 #define OPENCV_GAPI_GCPUKERNEL_HPP
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4702)  // "Unreachable code"
-// on postprocess(...) call inside OCVCallHelper
+#if defined _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702)  // "Unreachable code" on postprocess(...) call inside OCVCallHelper
 #endif
 
 #include <functional>
@@ -534,5 +534,9 @@ gapi::cpu::GOCVFunctor gapi::cpu::ocv_kernel(const Callable& c)
 //! @endcond
 
 } // namespace cv
+
+#if defined _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // OPENCV_GAPI_GCPUKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -248,11 +248,11 @@ struct scratch_helper<false, Impl, Ins...>
                           const cv::GArgs     &,
                           gapi::fluid::Buffer &)
     {
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
     static void help_reset(gapi::fluid::Buffer &)
     {
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 };
 

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -177,7 +177,7 @@ namespace detail
             {
                 util::get<rw_own_t>(m_ref).clear();
             }
-            else GAPI_Assert(false); // shouldn't be called in *EXT modes
+            else GAPI_Error("InternalError"); // shouldn't be called in *EXT modes
         }
 
         // Obtain a WRITE reference to underlying object

--- a/modules/gapi/include/opencv2/gapi/gopaque.hpp
+++ b/modules/gapi/include/opencv2/gapi/gopaque.hpp
@@ -171,7 +171,7 @@ namespace detail
             {
                 util::get<rw_own_t>(m_ref) = {};
             }
-            else GAPI_Assert(false); // shouldn't be called in *EXT modes
+            else GAPI_Error("InternalError"); // shouldn't be called in *EXT modes
         }
 
         // Obtain a WRITE reference to underlying object

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -397,7 +397,7 @@ void inline unpackBlobs(const cv::GInferInputs::Map& blobs,
                 kinds.emplace_back(cv::detail::OpaqueKind::CV_UNKNOWN);
                 break;
             default:
-                GAPI_Assert(false);
+                GAPI_Error("InternalError");
         }
     }
 }
@@ -629,7 +629,7 @@ infer2(const std::string& tag,
                 kinds.emplace_back(cv::detail::OpaqueKind::CV_RECT);
                 break;
             default:
-                GAPI_Assert(false);
+                GAPI_Error("InternalError");
         }
     }
 

--- a/modules/gapi/include/opencv2/gapi/media.hpp
+++ b/modules/gapi/include/opencv2/gapi/media.hpp
@@ -242,11 +242,11 @@ public:
     // The default implementation does nothing
     virtual cv::util::any blobParams() const;
     virtual void serialize(cv::gapi::s11n::IOStream&) {
-        GAPI_Assert(false && "Generic serialize method of MediaFrame::IAdapter does nothing by default. "
+        GAPI_Error("Generic serialize method of MediaFrame::IAdapter does nothing by default. "
                              "Please, implement it in derived class to properly serialize the object.");
     }
     virtual void deserialize(cv::gapi::s11n::IIStream&) {
-        GAPI_Assert(false && "Generic deserialize method of MediaFrame::IAdapter does nothing by default. "
+        GAPI_Error("Generic deserialize method of MediaFrame::IAdapter does nothing by default. "
                              "Please, implement it in derived class to properly deserialize the object.");
     }
 };

--- a/modules/gapi/include/opencv2/gapi/own/assert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/assert.hpp
@@ -25,6 +25,8 @@
 #  define GAPI_DbgAssert(expr) GAPI_DbgAssertNoOp(expr)
 #endif
 
+#define GAPI_Error(msg) CV_Error(cv::Error::StsError, msg)
+
 #else
 #include <stdexcept>
 #include <sstream>
@@ -48,6 +50,10 @@ namespace detail
 #else
 #  define GAPI_DbgAssert(expr) GAPI_Assert(expr)
 #endif
+
+#define GAPI_Error(msg) { \
+    ::detail::assert_abort(msg, __LINE__, __FILE__, __func__); \
+}
 
 #endif // GAPI_STANDALONE
 

--- a/modules/gapi/include/opencv2/gapi/rmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/rmat.hpp
@@ -112,11 +112,11 @@ public:
         // is transferred to the device when the view is destroyed
         virtual View access(Access) = 0;
         virtual void serialize(cv::gapi::s11n::IOStream&) {
-            GAPI_Assert(false && "Generic serialize method of RMat::IAdapter does nothing by default. "
+            GAPI_Error("Generic serialize method of RMat::IAdapter does nothing by default. "
                                  "Please, implement it in derived class to properly serialize the object.");
         }
         virtual void deserialize(cv::gapi::s11n::IIStream&) {
-            GAPI_Assert(false && "Generic deserialize method of RMat::IAdapter does nothing by default. "
+            GAPI_Error("Generic deserialize method of RMat::IAdapter does nothing by default. "
                                  "Please, implement it in derived class to properly deserialize the object.");
         }
     };

--- a/modules/gapi/include/opencv2/gapi/s11n.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n.hpp
@@ -335,7 +335,7 @@ IIStream& operator>> (IIStream& is, std::vector<T> &ts) {
 namespace detail {
 template<typename V>
 IOStream& put_v(IOStream&, const V&, std::size_t) {
-    GAPI_Assert(false && "variant>>: requested index is invalid");
+    GAPI_Error("variant>>: requested index is invalid");
 };
 
 template<typename V, typename X, typename... Xs>
@@ -347,7 +347,7 @@ IOStream& put_v(IOStream& os, const V& v, std::size_t x) {
 
 template<typename V>
 IIStream& get_v(IIStream&, V&, std::size_t, std::size_t) {
-    GAPI_Assert(false && "variant<<: requested index is invalid");
+    GAPI_Error("variant<<: requested index is invalid");
 }
 
 template<typename V, typename X, typename... Xs>
@@ -423,7 +423,7 @@ static GRunArg exec(cv::gapi::s11n::IIStream& is) {
 template<typename RA>
 struct deserialize_arg_with_adapter<RA, void> {
 static GRunArg exec(cv::gapi::s11n::IIStream&) {
-    GAPI_Assert(false && "No suitable adapter class found during RMat/MediaFrame deserialization. "
+    GAPI_Error("No suitable adapter class found during RMat/MediaFrame deserialization. "
                          "Please, make sure you've passed them in cv::gapi::deserialize() template");
     return GRunArg{};
 }

--- a/modules/gapi/include/opencv2/gapi/s11n.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n.hpp
@@ -17,7 +17,8 @@
 #include <opencv2/gapi/util/util.hpp>
 
 // FIXME: caused by deserialize_runarg
-#if (defined _WIN32 || defined _WIN64) && defined _MSC_VER
+#if defined _MSC_VER
+#pragma warning(push)
 #pragma warning(disable: 4702)
 #endif
 
@@ -504,5 +505,9 @@ cv::GRunArgs getRunArgsWithAdapters(const std::vector<char> &bytes) {
 
 } // namespace gapi
 } // namespace cv
+
+#if defined _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // OPENCV_GAPI_S11N_HPP

--- a/modules/gapi/include/opencv2/gapi/s11n/base.hpp
+++ b/modules/gapi/include/opencv2/gapi/s11n/base.hpp
@@ -52,7 +52,7 @@ struct S11N: public NotImplemented {
      * properly overload the function to use it.
      */
     static void serialize(IOStream &, const T &) {
-        GAPI_Assert(false && "No serialization routine is provided!");
+        GAPI_Error("No serialization routine is provided!");
     }
     /**
      * @brief This function allows user to deserialize their custom type.
@@ -61,7 +61,7 @@ struct S11N: public NotImplemented {
      * properly overload the function to use it.
      */
     static T deserialize(IIStream &) {
-        GAPI_Assert(false && "No deserialization routine is provided!");
+        GAPI_Error("No deserialization routine is provided!");
     }
 };
 

--- a/modules/gapi/include/opencv2/gapi/stereo.hpp
+++ b/modules/gapi/include/opencv2/gapi/stereo.hpp
@@ -62,7 +62,7 @@ G_TYPED_KERNEL(GStereo, <GMat(GMat, GMat, const StereoOutputFormat)>, "org.openc
             case StereoOutputFormat::DISPARITY_FIXED16_12_4:
                 return left.withDepth(CV_16SC1);
             default:
-                GAPI_Assert(false && "Unknown output format!");
+                GAPI_Error("Unknown output format!");
         }
     }
 };

--- a/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
@@ -67,7 +67,7 @@ protected:
         cv::Mat tmp;
         if (!cap.read(tmp))
         {
-            GAPI_Assert(false && "Couldn't grab the very first frame");
+            GAPI_Error("Couldn't grab the very first frame");
         }
         // NOTE: Some decode/media VideoCapture backends continue
         // owning the video buffer under cv::Mat so in order to

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -738,7 +738,7 @@ static cv::GRunArgs run_py_kernel(cv::detail::PyObjectHolder kernel,
         else
         {
             // Seems to be impossible case.
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
         }
     }
     catch (...)

--- a/modules/gapi/misc/python/python_bridge.hpp
+++ b/modules/gapi/misc/python/python_bridge.hpp
@@ -22,7 +22,7 @@
     switch(type) { \
         LIST_G(HC, HC)  \
         default: \
-            GAPI_Assert(false && "Unsupported type"); \
+            GAPI_Error("Unsupported type"); \
     }
 
 using cv::gapi::wip::draw::Prim;
@@ -157,7 +157,7 @@ public:
         SWITCH(m_arg.index(), GOPAQUE_TYPE_LIST_G, HC)
 #undef HC
 
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
     }
 
     GAPI_WRAP gapi::ArgType type() { return m_type; }
@@ -195,7 +195,7 @@ public:
         SWITCH(m_arg.index(), GARRAY_TYPE_LIST_G, HC)
 #undef HC
 
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 
     GAPI_WRAP gapi::ArgType type() { return m_type; }

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -35,7 +35,7 @@ cv::gapi::GBackend::Priv::compile(const ade::Graph&,
                                   const std::vector<ade::NodeHandle> &) const
 {
     // ...and this method is here for the same reason!
-    GAPI_Assert(false);
+    GAPI_Error("InternalError");
     return {};
 }
 
@@ -391,7 +391,7 @@ void unbind(Mag& mag, const RcDesc &rc)
         break;
 
     default:
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 }
 

--- a/modules/gapi/src/api/gframe.cpp
+++ b/modules/gapi/src/api/gframe.cpp
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &d) {
     case MediaFormat::BGR:  os << "BGR"; break;
     case MediaFormat::NV12: os << "NV12"; break;
     case MediaFormat::GRAY: os << "GRAY"; break;
-    default: GAPI_Assert(false && "Invalid media format");
+    default: GAPI_Error("Invalid media format");
     }
     os << ' ' << d.size << ']';
     return os;

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -313,7 +313,7 @@ std::ostream& operator<<(std::ostream& os, const cv::GMetaArg &arg)
         break;
 
     default:
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 
     return os;

--- a/modules/gapi/src/api/s11n.cpp
+++ b/modules/gapi/src/api/s11n.cpp
@@ -98,7 +98,7 @@ cv::GRunArgsP cv::gapi::bind(cv::GRunArgs &out_args)
             outputs.emplace_back(&(cv::util::get<cv::MediaFrame>(res_obj)));
             break;
         default:
-            GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
+            GAPI_Error("This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
         }
     }
@@ -114,7 +114,7 @@ cv::GRunArg cv::gapi::bind(cv::GRunArgP &out)
     {
 #if !defined(GAPI_STANDALONE)
     case T::index_of<cv::UMat*>() :
-        GAPI_Assert(false && "Please implement this!");
+        GAPI_Error("Please implement this!");
         break;
 #endif
 
@@ -138,7 +138,7 @@ cv::GRunArg cv::gapi::bind(cv::GRunArgP &out)
 
     default:
         // ...maybe our types were extended
-        GAPI_Assert(false && "This value type is UNKNOWN!");
+        GAPI_Error("This value type is UNKNOWN!");
         break;
     }
     return cv::GRunArg();

--- a/modules/gapi/src/backends/common/gcompoundkernel.cpp
+++ b/modules/gapi/src/backends/common/gcompoundkernel.cpp
@@ -37,7 +37,7 @@ cv::detail::GCompoundContext::GCompoundContext(const cv::GArgs& in_args)
                     // do nothing - as handled in a special way, see gcompoundkernel.hpp for details
                     // same applies to GMatP
                     break;
-                default: GAPI_Assert(false);
+                default: GAPI_Error("InternalError");
             }
         }
     }

--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -290,7 +290,7 @@ IOStream& operator<< (IOStream& os, const cv::Mat &m) {
     case CV_32S: write_mat_data< int32_t>(os, m); break;
     case CV_32F: write_mat_data<   float>(os, m); break;
     case CV_64F: write_mat_data<  double>(os, m); break;
-    default: GAPI_Assert(false && "Unsupported Mat depth");
+    default: GAPI_Error("Unsupported Mat depth");
     }
     return os;
 }
@@ -306,7 +306,7 @@ IIStream& operator>> (IIStream& is, cv::Mat& m) {
     case CV_32S: read_mat_data< int32_t>(is, m); break;
     case CV_32F: read_mat_data<   float>(is, m); break;
     case CV_64F: read_mat_data<  double>(is, m); break;
-    default: GAPI_Assert(false && "Unsupported Mat depth");
+    default: GAPI_Error("Unsupported Mat depth");
     }
     return is;
 }
@@ -319,10 +319,10 @@ IIStream& operator>> (IIStream& is,       cv::gapi::wip::draw::Text &t) {
 }
 
 IOStream& operator<< (IOStream&, const cv::gapi::wip::draw::FText &) {
-    GAPI_Assert(false && "Serialization: Unsupported << for FText");
+    GAPI_Error("Serialization: Unsupported << for FText");
 }
 IIStream& operator>> (IIStream&,       cv::gapi::wip::draw::FText &) {
-    GAPI_Assert(false && "Serialization: Unsupported >> for FText");
+    GAPI_Error("Serialization: Unsupported >> for FText");
 }
 
 IOStream& operator<< (IOStream& os, const cv::gapi::wip::draw::Circle &c) {
@@ -398,19 +398,19 @@ IIStream& operator>> (IIStream& is,       cv::GArrayDesc &) {return is;}
 #if !defined(GAPI_STANDALONE)
 IOStream& operator<< (IOStream& os, const cv::UMat &)
 {
-    GAPI_Assert(false && "Serialization: Unsupported << for UMat");
+    GAPI_Error("Serialization: Unsupported << for UMat");
     return os;
 }
 IIStream& operator >> (IIStream& is, cv::UMat &)
 {
-    GAPI_Assert(false && "Serialization: Unsupported >> for UMat");
+    GAPI_Error("Serialization: Unsupported >> for UMat");
     return is;
 }
 #endif // !defined(GAPI_STANDALONE)
 
 IOStream& operator<< (IOStream& os, const cv::gapi::wip::IStreamSource::Ptr &)
 {
-    GAPI_Assert(false && "Serialization: Unsupported << for IStreamSource::Ptr");
+    GAPI_Error("Serialization: Unsupported << for IStreamSource::Ptr");
     return os;
 }
 IIStream& operator >> (IIStream& is, cv::gapi::wip::IStreamSource::Ptr &)
@@ -429,7 +429,7 @@ struct putToStream<Ref, std::tuple<>>
 {
     static void put(IOStream&, const Ref &)
     {
-        GAPI_Assert(false && "Unsupported type for GArray/GOpaque serialization");
+        GAPI_Error("Unsupported type for GArray/GOpaque serialization");
     }
 };
 
@@ -454,7 +454,7 @@ struct getFromStream<Ref, std::tuple<>>
 {
     static void get(IIStream&, Ref &, cv::detail::OpaqueKind)
     {
-        GAPI_Assert(false && "Unsupported type for GArray/GOpaque deserialization");
+        GAPI_Error("Unsupported type for GArray/GOpaque deserialization");
     }
 };
 
@@ -560,7 +560,7 @@ IOStream& operator<< (IOStream& os, const cv::GArg &arg) {
         case cv::detail::OpaqueKind::CV_RECT:    os << arg.get<cv::Rect>();     break;
         case cv::detail::OpaqueKind::CV_SCALAR:  os << arg.get<cv::Scalar>();   break;
         case cv::detail::OpaqueKind::CV_MAT:     os << arg.get<cv::Mat>();      break;
-        default: GAPI_Assert(false && "GArg: Unsupported (unknown?) opaque value type");
+        default: GAPI_Error("GArg: Unsupported (unknown?) opaque value type");
         }
     }
     return os;
@@ -597,7 +597,7 @@ IIStream& operator>> (IIStream& is, cv::GArg &arg) {
             HANDLE_CASE(SCALAR  , cv::Scalar);
             HANDLE_CASE(MAT     , cv::Mat);
 #undef HANDLE_CASE
-        default: GAPI_Assert(false && "GArg: Unsupported (unknown?) opaque value type");
+        default: GAPI_Error("GArg: Unsupported (unknown?) opaque value type");
         }
     }
     return is;
@@ -665,7 +665,7 @@ struct initCtor<Ref, std::tuple<>>
 {
     static void init(cv::gimpl::Data&)
     {
-        GAPI_Assert(false && "Unsupported type for GArray/GOpaque deserialization");
+        GAPI_Error("Unsupported type for GArray/GOpaque deserialization");
     }
 };
 

--- a/modules/gapi/src/backends/common/serialization.hpp
+++ b/modules/gapi/src/backends/common/serialization.hpp
@@ -18,7 +18,8 @@
 #include "opencv2/gapi/render/render_types.hpp"
 #include "opencv2/gapi/s11n.hpp" // basic interfaces
 
-#if (defined _WIN32 || defined _WIN64) && defined _MSC_VER
+#if defined _MSC_VER
+#pragma warning(push)
 #pragma warning(disable: 4702)
 #endif
 
@@ -231,5 +232,9 @@ GAPI_EXPORTS std::vector<std::string> vector_of_strings_deserialize(IIStream& is
 } // namespace s11n
 } // namespace gapi
 } // namespace cv
+
+#if defined _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // OPENCV_GAPI_COMMON_SERIALIZATION_HPP

--- a/modules/gapi/src/backends/cpu/gcpustereo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpustereo.cpp
@@ -63,9 +63,9 @@ GAPI_OCV_KERNEL_ST(GCPUStereo, cv::gapi::calib3d::GStereo, StereoSetup)
                 stereoSetup.stereoBM->compute(left, right, out_mat);
                 break;
             case cv::gapi::StereoOutputFormat::DISPARITY_FIXED16_11_5:
-                GAPI_Assert(false && "This case may be supported in future.");
+                GAPI_Error("This case may be supported in future.");
             default:
-                GAPI_Assert(false && "Unknown output format!");
+                GAPI_Error("Unknown output format!");
         }
     }
 };

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -313,7 +313,7 @@ static int maxLineConsumption(const cv::GFluidKernel::Kind kind, int window, int
         }
     } break;
     case cv::GFluidKernel::Kind::YUV420toRGB: return inPort == 0 ? 2 : 1; break;
-    default: GAPI_Assert(false); return 0;
+    default: GAPI_Error("InternalError"); return 0;
     }
 }
 
@@ -325,7 +325,7 @@ static int borderSize(const cv::GFluidKernel::Kind kind, int window)
     // Resize never reads from border pixels
     case cv::GFluidKernel::Kind::Resize: return 0; break;
     case cv::GFluidKernel::Kind::YUV420toRGB: return 0; break;
-    default: GAPI_Assert(false); return 0;
+    default: GAPI_Error("InternalError"); return 0;
     }
 }
 
@@ -685,7 +685,7 @@ void cv::gimpl::GFluidExecutable::initBufferRois(std::vector<int>& readStarts,
                         case 0: roi = produced; break;
                         case 1:
                         case 2: roi = cv::Rect{ produced.x/2, produced.y/2, produced.width/2, produced.height/2 }; break;
-                        default: GAPI_Assert(false);
+                        default: GAPI_Error("InternalError");
                         }
                         return roi;
                     };
@@ -699,7 +699,7 @@ void cv::gimpl::GFluidExecutable::initBufferRois(std::vector<int>& readStarts,
                     case GFluidKernel::Kind::Filter:      resized = produced; break;
                     case GFluidKernel::Kind::Resize:      resized = adjResizeRoi(produced, in_meta.size, meta.size); break;
                     case GFluidKernel::Kind::YUV420toRGB: resized = adj420Roi(produced, m_gm.metadata(in_edge).get<Input>().port); break;
-                    default: GAPI_Assert(false);
+                    default: GAPI_Error("InternalError");
                     }
 
                     // All below transformations affect roi of the writer, preserve read start position here
@@ -814,7 +814,7 @@ cv::gimpl::FluidGraphInputData cv::gimpl::fluidExtractInputDataFromGraph(const a
             last_agent++;
             break;
         }
-        default: GAPI_Assert(false);
+        default: GAPI_Error("InternalError");
         }
     }
 
@@ -844,7 +844,7 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph                  
             case GFluidKernel::Kind::Filter:      agent_ptr.reset(new FluidFilterAgent(g, agent_data.nh));      break;
             case GFluidKernel::Kind::Resize:      agent_ptr.reset(new FluidResizeAgent(g, agent_data.nh));      break;
             case GFluidKernel::Kind::YUV420toRGB: agent_ptr.reset(new Fluid420toRGBAgent(g, agent_data.nh));    break;
-            default: GAPI_Assert(false);
+            default: GAPI_Error("InternalError");
         }
         std::tie(agent_ptr->in_buffer_ids, agent_ptr->out_buffer_ids) = std::tie(agent_data.in_buffer_ids, agent_data.out_buffer_ids);
         return agent_ptr;
@@ -1388,7 +1388,7 @@ cv::gimpl::GParallelFluidExecutable::GParallelFluidExecutable(const ade::Graph  
 void cv::gimpl::GParallelFluidExecutable::reshape(ade::Graph&, const GCompileArgs& )
 {
     //TODO: implement ?
-    GAPI_Assert(false && "Not Implemented;");
+    GAPI_Error("Not Implemented;");
 }
 
 void cv::gimpl::GParallelFluidExecutable::run(std::vector<InObj>  &&input_objs,
@@ -1474,7 +1474,7 @@ void GFluidBackendImpl::addMetaSensitiveBackendPasses(ade::ExecutionEngineSetupC
             case NodeKind::EMIT:
             case NodeKind::SINK:
                 break; // do nothing for Streaming nodes
-            default: GAPI_Assert(false);
+            default: GAPI_Error("InternalError");
             } // switch
         } // for (gim.nodes())
     });

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -90,7 +90,7 @@ void fillBorderConstant(int borderSize, cv::Scalar borderValue, cv::Mat& mat)
         case CV_16S: return &fillConstBorderRow< int16_t>; break;
         case CV_16U: return &fillConstBorderRow<uint16_t>; break;
         case CV_32F: return &fillConstBorderRow< float  >; break;
-        default: GAPI_Assert(false); return &fillConstBorderRow<uint8_t>;
+        default: GAPI_Error("InternalError"); return &fillConstBorderRow<uint8_t>;
         }
     };
 
@@ -231,7 +231,7 @@ void fluid::BufferStorageWithBorder::init(int dtype, int border_size, Border bor
     case cv::BORDER_REFLECT_101:
         m_borderHandler.reset(new BorderHandlerT<cv::BORDER_REFLECT_101>(border_size, dtype)); break;
     default:
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 }
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -114,7 +114,7 @@ inline IE::Precision toIE(int depth) {
     case CV_32S: return IE::Precision::I32;
     case CV_32F: return IE::Precision::FP32;
     case CV_16F: return IE::Precision::FP16;
-    default:     GAPI_Assert(false && "IE. Unsupported data type");
+    default:     GAPI_Error("IE. Unsupported data type");
     }
     return IE::Precision::UNSPECIFIED;
 }
@@ -125,7 +125,7 @@ inline int toCV(IE::Precision prec) {
     case IE::Precision::I32:  return CV_32S;
     case IE::Precision::I64:  return CV_32S;
     case IE::Precision::FP16: return CV_16F;
-    default:     GAPI_Assert(false && "IE. Unsupported data type");
+    default:     GAPI_Error("IE. Unsupported data type");
     }
     return -1;
 }
@@ -167,7 +167,7 @@ inline IE::Blob::Ptr wrapIE(const cv::Mat &mat, cv::gapi::ie::TraitAs hint) {
         HANDLE(32S, int);
         HANDLE(16F, int16_t);
 #undef HANDLE
-    default: GAPI_Assert(false && "IE. Unsupported data type");
+    default: GAPI_Error("IE. Unsupported data type");
     }
     return IE::Blob::Ptr{};
 }
@@ -190,9 +190,9 @@ inline IE::Blob::Ptr wrapIE(const cv::MediaFrame::View& view,
             return wrapIE(gray, cv::gapi::ie::TraitAs::IMAGE);
         }
         default:
-            GAPI_Assert(false && "Unsupported media format for IE backend");
+            GAPI_Error("Unsupported media format for IE backend");
     }
-    GAPI_Assert(false);
+    GAPI_Error("InternalError");
 }
 
 template<class MatType>
@@ -225,7 +225,7 @@ inline void copyFromIE(const IE::Blob::Ptr &blob, MatType &mat) {
                                            mat.total());
             break;
         }
-    default: GAPI_Assert(false && "IE. Unsupported data type");
+    default: GAPI_Error("IE. Unsupported data type");
     }
 }
 
@@ -439,7 +439,7 @@ void IEUnit::InputFramesDesc::set_param(const input_name_type &input,
     if (layout != InferenceEngine::NHWC && layout != InferenceEngine::NCHW) {
         GAPI_LOG_WARNING(nullptr, "Unsupported layout for VPP preproc: " << layout <<
                                   ", input name: " << input);
-        GAPI_Assert(false && "Unsupported layout for VPP preproc");
+        GAPI_Error("Unsupported layout for VPP preproc");
     }
     GAPI_Assert(inDims.size() == 4u);
     ret.size.width = static_cast<int>(inDims[3]);
@@ -754,7 +754,7 @@ inline IE::Blob::Ptr extractBlob(IECallContext& ctx,
 
                 NV12ParamType* blob_params = cv::util::any_cast<NV12ParamType>(&any_blob_params);
                 if (blob_params == nullptr) {
-                    GAPI_Assert(false && "Incorrect type of blobParams:"
+                    GAPI_Error("Incorrect type of blobParams:"
                                          "expected std::pair<ParamType, ParamType>,"
                                          "with ParamType std::pair<InferenceEngine::TensorDesc,"
                                          "InferenceEngine::ParamMap >>");
@@ -782,7 +782,7 @@ inline IE::Blob::Ptr extractBlob(IECallContext& ctx,
         default:
             GAPI_Assert("Unsupported input shape for IE backend");
     }
-    GAPI_Assert(false);
+    GAPI_Error("InternalError");
 }
 
 
@@ -967,7 +967,7 @@ cv::gimpl::ie::RequestPool::RequestPool(cv::gapi::ie::InferMode                 
                                                              std::bind(&RequestPool::release, this, i));
                 break;
             default:
-                GAPI_Assert(false && "Unsupported cv::gapi::ie::InferMode");
+                GAPI_Error("Unsupported cv::gapi::ie::InferMode");
         }
         m_requests.emplace_back(std::move(iexec));
     }
@@ -1144,7 +1144,7 @@ static void configureInputReshapeByImage(const IE::InputInfo::Ptr& ii,
     auto input_dims = ii->getTensorDesc().getDims();
     const auto size = input_dims.size();
     if (size <= 1) {
-        GAPI_Assert(false && "Unsupported number of dimensions for reshape by image");
+        GAPI_Error("Unsupported number of dimensions for reshape by image");
     }
     input_dims.at(size - 2) = static_cast<size_t>(image_sz.height);
     input_dims.at(size - 1) = static_cast<size_t>(image_sz.width);
@@ -1173,7 +1173,7 @@ static void configureInputInfo(const IE::InputInfo::Ptr& ii, const cv::GMetaArg 
                     // NB: Do nothing
                     break;
                 default:
-                    GAPI_Assert(false && "Unsupported media format for IE backend");
+                    GAPI_Error("Unsupported media format for IE backend");
             }
             ii->setPrecision(toIE(CV_8U));
             break;

--- a/modules/gapi/src/backends/ie/giebackend.hpp
+++ b/modules/gapi/src/backends/ie/giebackend.hpp
@@ -62,12 +62,12 @@ public:
 
     virtual inline bool canReshape() const override { return false; }
     virtual inline void reshape(ade::Graph&, const GCompileArgs&) override {
-        GAPI_Assert(false); // Not implemented yet
+        GAPI_Error("InternalError"); // Not implemented yet
     }
 
     virtual void run(std::vector<InObj>  &&,
                      std::vector<OutObj> &&) override {
-        GAPI_Assert(false && "Not implemented");
+        GAPI_Error("Not implemented");
     }
 
     virtual void run(GIslandExecutable::IInput  &in,

--- a/modules/gapi/src/backends/oak/goakbackend.cpp
+++ b/modules/gapi/src/backends/oak/goakbackend.cpp
@@ -1119,13 +1119,10 @@ namespace oak {
 
 cv::gapi::GKernelPackage kernels() {
     GAPI_Error("Built without OAK support");
-    return {};
 }
 
 cv::gapi::GBackend backend() {
     GAPI_Error("Built without OAK support");
-    static cv::gapi::GBackend this_backend(nullptr);
-    return this_backend;
 }
 
 } // namespace oak

--- a/modules/gapi/src/backends/oak/goakbackend.cpp
+++ b/modules/gapi/src/backends/oak/goakbackend.cpp
@@ -39,7 +39,7 @@ class GOAKExecutable final: public GIslandExecutable {
     friend class OAKKernelParams;
     virtual void run(std::vector<InObj>&&,
                      std::vector<OutObj>&&) override {
-        GAPI_Assert(false && "Not implemented");
+        GAPI_Error("Not implemented");
     }
 
     virtual void run(GIslandExecutable::IInput &in,
@@ -121,7 +121,7 @@ public:
     // FIXME: could it reshape?
     virtual bool canReshape() const override { return false; }
     virtual void reshape(ade::Graph&, const GCompileArgs&) override {
-        GAPI_Assert(false && "GOAKExecutable::reshape() is not supported");
+        GAPI_Error("GOAKExecutable::reshape() is not supported");
     }
 
     virtual void handleNewStream() override;
@@ -391,7 +391,7 @@ void cv::gimpl::GOAKExecutable::linkCopy(ade::NodeHandle handle) {
     for (const auto& copy_next_op : copy_out.front().get()->outNodes()) {
         const auto& op = m_gm.metadata(copy_next_op).get<Op>();
         if (op.k.name == "org.opencv.oak.copy") {
-            GAPI_Assert(false && "Back-to-back Copy operations are not supported in graph");
+            GAPI_Error("Back-to-back Copy operations are not supported in graph");
         }
     }
 
@@ -701,14 +701,14 @@ cv::gimpl::GOAKExecutable::GOAKExecutable(const ade::Graph& g,
                                     [](ExtractTypeHelper::InputPtr ptr) {
                             return ptr == nullptr;
                         })) {
-                        GAPI_Assert(false && "DAI input are not set");
+                        GAPI_Error("DAI input are not set");
                     }
 
                     if (std::any_of(node_info.outputs.cbegin(), node_info.outputs.cend(),
                                     [](ExtractTypeHelper::OutputPtr ptr) {
                             return ptr == nullptr;
                         })) {
-                        GAPI_Assert(false && "DAI outputs are not set");
+                        GAPI_Error("DAI outputs are not set");
                     }
                 }
             }
@@ -907,7 +907,7 @@ void cv::gimpl::GOAKExecutable::run(GIslandExecutable::IInput  &in,
         }
         // FIXME: Add support for remaining types
         default:
-            GAPI_Assert(false && "Unsupported type in OAK backend");
+            GAPI_Error("Unsupported type in OAK backend");
         }
 
         out.meta(out_arg, meta);
@@ -1080,7 +1080,7 @@ class GOAKBackendImpl final : public cv::gapi::GBackend::Priv {
         // NB: how could we have non-OAK source in streaming mode, then OAK backend in
         //     streaming mode but without camera input?
         if (!gm.metadata().contains<cv::gimpl::Streaming>()) {
-            GAPI_Assert(false && "OAK backend only supports Streaming mode for now");
+            GAPI_Error("OAK backend only supports Streaming mode for now");
         }
         return EPtr{new cv::gimpl::GOAKExecutable(graph, args, nodes, ins_data, outs_data)};
     }
@@ -1118,12 +1118,12 @@ namespace gapi {
 namespace oak {
 
 cv::gapi::GKernelPackage kernels() {
-    GAPI_Assert(false && "Built without OAK support");
+    GAPI_Error("Built without OAK support");
     return {};
 }
 
 cv::gapi::GBackend backend() {
-    GAPI_Assert(false && "Built without OAK support");
+    GAPI_Error("Built without OAK support");
     static cv::gapi::GBackend this_backend(nullptr);
     return this_backend;
 }

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -171,7 +171,7 @@ inline int toCV(ONNXTensorElementDataType prec) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: return CV_32F;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32: return CV_32S;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: return CV_32S;
-    default: GAPI_Assert(false && "ONNX. Unsupported data type");
+    default: GAPI_Error("ONNX. Unsupported data type");
     }
     return -1;
 }
@@ -207,7 +207,7 @@ inline void copyFromONNX(Ort::Value &v, cv::Mat& mat) {
                                            mat.total());
             break;
         }
-    default: GAPI_Assert(false && "ONNX. Unsupported data type");
+    default: GAPI_Error("ONNX. Unsupported data type");
     }
 }
 
@@ -233,7 +233,7 @@ inline void preprocess(const cv::Mat& src,
                             "32F tensor dimensions should match with all non-dynamic NN input dimensions");
             }
         } else {
-            GAPI_Assert(false && "32F tensor size should match with NN input");
+            GAPI_Error("32F tensor size should match with NN input");
         }
 
         dst = src;
@@ -338,7 +338,7 @@ void preprocess(const cv::MediaFrame::View& view,
             break;
         }
         default:
-            GAPI_Assert(false && "Unsupported media format for ONNX backend");
+            GAPI_Error("Unsupported media format for ONNX backend");
     }
 }
 
@@ -367,7 +367,7 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
         return createTensor<int32_t>(memory_info, tensor_params, data);
     default:
-        GAPI_Assert(false && "ONNX. Unsupported data type");
+        GAPI_Error("ONNX. Unsupported data type");
     }
     return Ort::Value{nullptr};
 }
@@ -858,7 +858,7 @@ static void checkInputMeta(const cv::GMetaArg mm) {
                 case cv::MediaFormat::NV12: break;
                 case cv::MediaFormat::BGR:  break;
                 default:
-                    GAPI_Assert(false && "Unsupported media format for ONNX backend");
+                    GAPI_Error("Unsupported media format for ONNX backend");
             } break;
         } break;
         default:
@@ -1101,7 +1101,7 @@ struct InferList2: public cv::detail::KernelTag {
                     const auto &vec = this_vec.rref<cv::Mat>();
                     uu.oc->setInput(in_idx, vec[list_idx]);
                 } else {
-                    GAPI_Assert(false && "Only Rect and Mat types are supported for infer list 2!");
+                    GAPI_Error("Only Rect and Mat types are supported for infer list 2!");
                 }
                 // }}} (Prepare input)
             } // }}} (For every input of the net)

--- a/modules/gapi/src/backends/onnx/gonnxbackend.hpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.hpp
@@ -43,7 +43,7 @@ public:
 
     virtual inline bool canReshape() const override { return false; }
     virtual inline void reshape(ade::Graph&, const GCompileArgs&) override {
-        GAPI_Assert(false); // Not implemented yet
+        GAPI_Error("InternalError"); // Not implemented yet
     }
 
     virtual void run(std::vector<InObj>  &&input_objs,

--- a/modules/gapi/src/backends/python/gpythonbackend.cpp
+++ b/modules/gapi/src/backends/python/gpythonbackend.cpp
@@ -150,7 +150,7 @@ static void writeBack(cv::GRunArg& arg, cv::GRunArgP& out)
             break;
         }
         default:
-            GAPI_Assert(false && "Unsupported output type");
+            GAPI_Error("Unsupported output type");
     }
 }
 

--- a/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
+++ b/modules/gapi/src/backends/streaming/gstreamingbackend.cpp
@@ -42,7 +42,7 @@ class GStreamingIntrinExecutable final: public cv::gimpl::GIslandExecutable
 {
     virtual void run(std::vector<InObj>  &&,
                      std::vector<OutObj> &&) override {
-        GAPI_Assert(false && "Not implemented");
+        GAPI_Error("Not implemented");
     }
 
     virtual void run(GIslandExecutable::IInput &in,
@@ -188,7 +188,7 @@ void Copy::Actor::run(cv::gimpl::GIslandExecutable::IInput  &in,
         break;
     // FIXME: Add support for remaining types
     default:
-        GAPI_Assert(false && "Copy: unsupported data type");
+        GAPI_Error("Copy: unsupported data type");
     }
     out.meta(out_arg, in_arg.meta);
     out.post(std::move(out_arg));

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -338,7 +338,7 @@ void cv::gimpl::GCompiler::validateInputMeta()
             return util::holds_alternative<cv::GOpaqueDesc>(meta);
 
         default:
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
         }
         return false; // should never happen
     };
@@ -485,7 +485,7 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::produceStreamingCompiled(GPtr &&pg)
         // Otherwise, set it up with executor object only
         compiled.priv().setup(std::move(pE));
     }
-    else GAPI_Assert(false && "Impossible happened -- please report a bug");
+    else GAPI_Error("Impossible happened -- please report a bug");
     return compiled;
 }
 

--- a/modules/gapi/src/compiler/gislandmodel.cpp
+++ b/modules/gapi/src/compiler/gislandmodel.cpp
@@ -120,7 +120,7 @@ ade::NodeHandle GIsland::producer(const ade::Graph &g,
     }
     // Consistency: A GIsland requested for producer() of slot_nh should
     // always had the appropriate GModel node handle in its m_out_ops vector.
-    GAPI_Assert(false && "Broken GIslandModel ?.");
+    GAPI_Error("Broken GIslandModel ?.");
 }
 
 std::string GIsland::name() const
@@ -164,7 +164,7 @@ void GIslandModel::generateInitial(GIslandModel::Graph &g,
         {
         case NodeType::OP:   all_operations.insert(src_nh);                break;
         case NodeType::DATA: data_to_slot[src_nh] = mkSlotNode(g, src_nh); break;
-        default: GAPI_Assert(false); break;
+        default: GAPI_Error("InternalError"); break;
         }
     } // for (src_g.nodes)
 

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -122,7 +122,7 @@ public:
     virtual bool canReshape() const = 0;
     virtual void reshape(ade::Graph& g, const GCompileArgs& args) = 0;
     virtual bool allocatesOutputs() const { return false; }
-    virtual cv::RMat allocate(const cv::GMatDesc&) const { GAPI_Assert(false && "should never be called"); }
+    virtual cv::RMat allocate(const cv::GMatDesc&) const { GAPI_Error("should never be called"); }
 
     // This method is called when the GStreamingCompiled gets a new
     // input source to process. Normally this method is called once

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -162,7 +162,7 @@ cv::gimpl::Unrolled cv::gimpl::unrollExpr(const GProtoArgs &ins,
 
         default:
             // Unsupported node shape
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
             break;
         }
     }

--- a/modules/gapi/src/compiler/passes/dump_dot.cpp
+++ b/modules/gapi/src/compiler/passes/dump_dot.cpp
@@ -149,7 +149,7 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
             }
         }
         break;
-        default: GAPI_Assert(false);
+        default: GAPI_Error("InternalError");
         }
     }
 
@@ -209,7 +209,7 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
             }
             break;
         default:
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
             break;
         }
     }

--- a/modules/gapi/src/compiler/passes/intrin.cpp
+++ b/modules/gapi/src/compiler/passes/intrin.cpp
@@ -128,7 +128,7 @@ void traceUp(cv::gimpl::GModel::Graph &g,
         // this recursive process (e.g. via some other output or branch in the
         // subgraph)
         if (g.metadata(nh).get<DesyncPath>().index != desync_id) {
-            GAPI_Assert(false && "Desynchronization can't be nested!");
+            GAPI_Error("Desynchronization can't be nested!");
         }
         return; // This object belongs to the desync path - exit early.
     }

--- a/modules/gapi/src/compiler/passes/pattern_matching.cpp
+++ b/modules/gapi/src/compiler/passes/pattern_matching.cpp
@@ -371,7 +371,7 @@ cv::gimpl::findMatches(const cv::gimpl::GModel::Graph& patternGraph,
                                                   testNodeMeta,
                                                   isAlreadyVisited);
                         default:
-                            GAPI_Assert(false && "Unsupported Node type!");
+                            GAPI_Error("Unsupported Node type!");
                         }
 
                         return false;

--- a/modules/gapi/src/compiler/passes/pattern_matching.cpp
+++ b/modules/gapi/src/compiler/passes/pattern_matching.cpp
@@ -371,10 +371,9 @@ cv::gimpl::findMatches(const cv::gimpl::GModel::Graph& patternGraph,
                                                   testNodeMeta,
                                                   isAlreadyVisited);
                         default:
-                            GAPI_Error("Unsupported Node type!");
+                            break;
                         }
-
-                        return false;
+                        GAPI_Error("Unsupported Node type!");
                     });
 
                     if (testIt == testOutputNodesLabeled.end()) {

--- a/modules/gapi/src/compiler/transactions.hpp
+++ b/modules/gapi/src/compiler/transactions.hpp
@@ -117,7 +117,7 @@ struct ChangeT
             {
             case Direction::In:  eh = g.link(m_sibling, m_node); break;
             case Direction::Out: eh = g.link(m_node, m_sibling); break;
-            default: GAPI_Assert(false);
+            default: GAPI_Error("InternalError");
             }
             GAPI_Assert(eh != nullptr);
             m_meta.copyTo(g, eh);

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -75,7 +75,7 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
             break;
 
         default:
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
             break;
         } // switch(kind)
     } // for(gim nodes)
@@ -248,7 +248,7 @@ void cv::gimpl::GExecutor::initResource(const ade::NodeHandle & nh, const ade::N
         break;
     }
     default:
-        GAPI_Assert(false);
+        GAPI_Error("InternalError");
     }
 }
 

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -157,7 +157,7 @@ void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
             *cv::util::get<cv::MediaFrame*>(out_obj) = std::move(cv::util::get<cv::MediaFrame>(res_obj));
             break;
         default:
-            GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
+            GAPI_Error("This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
         }
     }
@@ -227,7 +227,7 @@ void sync_data(cv::gimpl::stream::Result &r, cv::GOptRunArgsP &outputs)
         } break;
         default:
             // ...maybe because of STANDALONE mode.
-            GAPI_Assert(false && "This value type is not supported!");
+            GAPI_Error("This value type is not supported!");
             break;
         }
     }
@@ -446,7 +446,7 @@ cv::gimpl::StreamMsg QueueReader::getInputVector(std::vector<Q*> &in_queues,
               break;
           }
           default:
-              GAPI_Assert(false && "Unsupported cmd type in getInputVector()");
+              GAPI_Error("Unsupported cmd type in getInputVector()");
        }
     } // for(in_queues)
 
@@ -920,7 +920,7 @@ class StreamingOutput final: public cv::gimpl::GIslandExecutable::IOutput
                     m_stops_sent++;
                     break;
                 default:
-                    GAPI_Assert(false && "Unreachable code");
+                    GAPI_Error("Unreachable code");
             }
 
             for (auto &&q : m_out_queues[out_idx])
@@ -1115,7 +1115,7 @@ void collectorThread(std::vector<Q*>   in_queues,
                 out_queue.push(Cmd{cv::util::get<cv::gimpl::Exception>(result)});
                 break;
             default:
-                GAPI_Assert(false && "Unreachable code");
+                GAPI_Error("Unreachable code");
         }
     }
 }
@@ -1479,7 +1479,7 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
             }
             break;
         default:
-            GAPI_Assert(false);
+            GAPI_Error("InternalError");
             break;
         } // switch(kind)
     } // for(gim nodes)
@@ -1820,9 +1820,9 @@ bool cv::gimpl::GStreamingExecutor::pull(cv::GRunArgsP &&outs)
             return true;
         }
         default:
-            GAPI_Assert(false && "Unsupported cmd type in pull");
+            GAPI_Error("Unsupported cmd type in pull");
     }
-    GAPI_Assert(false && "Unreachable code");
+    GAPI_Error("Unreachable code");
 }
 
 bool cv::gimpl::GStreamingExecutor::pull(cv::GOptRunArgsP &&outs)
@@ -1853,7 +1853,7 @@ bool cv::gimpl::GStreamingExecutor::pull(cv::GOptRunArgsP &&outs)
             return true;
         }
     }
-    GAPI_Assert(false && "Unreachable code");
+    GAPI_Error("Unreachable code");
 }
 
 cv::gimpl::GAbstractStreamingExecutor::PyPullResult cv::gimpl::GStreamingExecutor::pull()

--- a/modules/gapi/src/streaming/gstreamer/gstreamer_media_adapter.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamer_media_adapter.cpp
@@ -40,7 +40,7 @@ GStreamerMediaAdapter::GStreamerMediaAdapter(const cv::GFrameDesc& frameDesc,
                 break;
             }
             default: {
-                GAPI_Assert(false && "Non NV12 or GRAY Media format is not expected here");
+                GAPI_Error("Non NV12 or GRAY Media format is not expected here");
                 break;
             }
         }
@@ -59,7 +59,7 @@ GStreamerMediaAdapter::GStreamerMediaAdapter(const cv::GFrameDesc& frameDesc,
                 break;
             }
             default: {
-                GAPI_Assert(false && "Non NV12 or GRAY Media format is not expected here");
+                GAPI_Error("Non NV12 or GRAY Media format is not expected here");
                 break;
             }
         }
@@ -160,7 +160,7 @@ cv::MediaFrame::View GStreamerMediaAdapter::access(cv::MediaFrame::Access access
             break;
         }
         default: {
-            GAPI_Assert(false && "Non NV12 or GRAY Media format is not expected here");
+            GAPI_Error("Non NV12 or GRAY Media format is not expected here");
             break;
         }
     }
@@ -171,7 +171,7 @@ cv::MediaFrame::View GStreamerMediaAdapter::access(cv::MediaFrame::Access access
 }
 
 cv::util::any GStreamerMediaAdapter::blobParams() const {
-    GAPI_Assert(false && "No implementation for GStreamerMediaAdapter::blobParams()");
+    GAPI_Error("No implementation for GStreamerMediaAdapter::blobParams()");
 }
 
 } // namespace gst

--- a/modules/gapi/src/streaming/gstreamer/gstreamerenv.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamerenv.cpp
@@ -69,12 +69,12 @@ GStreamerEnv::~GStreamerEnv()
 
 const GStreamerEnv& GStreamerEnv::init()
 {
-    GAPI_Assert(false && "Built without GStreamer support!");
+    GAPI_Error("Built without GStreamer support!");
 }
 
 GStreamerEnv::GStreamerEnv()
 {
-    GAPI_Assert(false && "Built without GStreamer support!");
+    GAPI_Error("Built without GStreamer support!");
 }
 
 GStreamerEnv::~GStreamerEnv()

--- a/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamerpipeline.cpp
@@ -73,7 +73,7 @@ GStreamerPipeline::Priv::~Priv() { }
 
 GStreamerPipeline::Priv::Priv(const std::string&)
 {
-    GAPI_Assert(false && "Built without GStreamer support!");
+    GAPI_Error("Built without GStreamer support!");
 }
 
 IStreamSource::Ptr GStreamerPipeline::Priv::getStreamingSource(const std::string&,

--- a/modules/gapi/src/streaming/gstreamer/gstreamersource.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamersource.cpp
@@ -205,7 +205,7 @@ void GStreamerSource::Priv::prepareVideoMeta()
                         break;
                     }
                     default: {
-                        GAPI_Assert(false && "Unsupported GStreamerSource FRAME type.");
+                        GAPI_Error("Unsupported GStreamerSource FRAME type.");
                     }
                 }
                 break;
@@ -317,7 +317,7 @@ bool GStreamerSource::Priv::retrieveFrame(cv::Mat& data)
                 break;
             }
             default: {
-                GAPI_Assert(false && "retrieveFrame - unsupported GStreamerSource FRAME type.");
+                GAPI_Error("retrieveFrame - unsupported GStreamerSource FRAME type.");
             }
         }
     }
@@ -354,13 +354,13 @@ GStreamerSource::Priv::~Priv() { }
 
 GStreamerSource::Priv::Priv(const std::string&, const GStreamerSource::OutputType)
 {
-    GAPI_Assert(false && "Built without GStreamer support!");
+    GAPI_Error("Built without GStreamer support!");
 }
 
 GStreamerSource::Priv::Priv(std::shared_ptr<GStreamerPipelineFacade>, const std::string&,
                             const GStreamerSource::OutputType)
 {
-    GAPI_Assert(false && "Built without GStreamer support!");
+    GAPI_Error("Built without GStreamer support!");
 }
 
 bool GStreamerSource::Priv::pull(cv::gapi::wip::Data&)

--- a/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_cpu.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_cpu.cpp
@@ -65,7 +65,7 @@ static surface_ptr_t create_surface_RGB4_(mfxFrameInfo frameInfo,
                                   ", offset: " << out_buf_ptr_offset <<
                                   ", W: " << surfW <<
                                   ", H: " << surfH);
-        GAPI_Assert(false && "Invalid offset");
+        GAPI_Error("Invalid offset");
     }
 
     std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
@@ -98,7 +98,7 @@ static surface_ptr_t create_surface_other_(mfxFrameInfo frameInfo,
                                   ", offset: " << out_buf_ptr_offset <<
                                   ", W: " << surfW <<
                                   ", H: " << surfH);
-        GAPI_Assert(false && "Invalid offset");
+        GAPI_Error("Invalid offset");
     }
 
     std::unique_ptr<mfxFrameSurface1> handle(new mfxFrameSurface1);
@@ -209,7 +209,7 @@ VPLCPUAccelerationPolicy::create_surface_pool(size_t pool_size, size_t surface_s
     if (!pool_table.emplace(preallocated_pool_memory_ptr, std::move(pool)).second) {
         GAPI_LOG_WARNING(nullptr, "Cannot insert pool, table size: " + std::to_string(pool_table.size()) <<
                                   ", key: " << preallocated_pool_memory_ptr << " exists");
-        GAPI_Assert(false && "Cannot create pool in VPLCPUAccelerationPolicy");
+        GAPI_Error("Cannot create pool in VPLCPUAccelerationPolicy");
     }
 
     return preallocated_pool_memory_ptr;
@@ -248,7 +248,7 @@ VPLCPUAccelerationPolicy::surface_weak_ptr_t VPLCPUAccelerationPolicy::get_free_
     if (pool_it == pool_table.end()) {
         GAPI_LOG_WARNING(nullptr, "key is not found, table size: " <<
                                   pool_table.size());
-        GAPI_Assert(false && "Invalid surface key requested in VPLCPUAccelerationPolicy");
+        GAPI_Error("Invalid surface key requested in VPLCPUAccelerationPolicy");
     }
 
     pool_t& requested_pool = pool_it->second;

--- a/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_dx11.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_dx11.cpp
@@ -152,7 +152,7 @@ VPLDX11AccelerationPolicy::surface_weak_ptr_t VPLDX11AccelerationPolicy::get_fre
 }
 
 size_t VPLDX11AccelerationPolicy::get_free_surface_count(pool_key_t) const {
-    GAPI_Assert(false && "get_free_surface_count() is not implemented");
+    GAPI_Error("get_free_surface_count() is not implemented");
 }
 
 size_t VPLDX11AccelerationPolicy::get_surface_count(pool_key_t key) const {
@@ -448,39 +448,39 @@ namespace wip {
 namespace onevpl {
 VPLDX11AccelerationPolicy::VPLDX11AccelerationPolicy(device_selector_ptr_t selector) :
     VPLAccelerationPolicy(selector) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 VPLDX11AccelerationPolicy::~VPLDX11AccelerationPolicy() = default;
 
 void VPLDX11AccelerationPolicy::init(session_t ) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 void VPLDX11AccelerationPolicy::deinit(session_t) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 VPLDX11AccelerationPolicy::pool_key_t VPLDX11AccelerationPolicy::create_surface_pool(const mfxFrameAllocRequest&,
                                                                                      mfxFrameInfo&) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 VPLDX11AccelerationPolicy::surface_weak_ptr_t VPLDX11AccelerationPolicy::get_free_surface(pool_key_t) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 size_t VPLDX11AccelerationPolicy::get_free_surface_count(pool_key_t) const {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 size_t VPLDX11AccelerationPolicy::get_surface_count(pool_key_t) const {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 
 cv::MediaFrame::AdapterPtr VPLDX11AccelerationPolicy::create_frame_adapter(pool_key_t,
                                                                           const FrameConstructorArgs &) {
-    GAPI_Assert(false && "VPLDX11AccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLDX11AccelerationPolicy unavailable in current configuration");
 }
 } // namespace onevpl
 } // namespace wip

--- a/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_va_api.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/accel_policy_va_api.cpp
@@ -39,13 +39,13 @@ VPLVAAPIAccelerationPolicy::VPLVAAPIAccelerationPolicy(device_selector_ptr_t sel
 
     va_handle = reinterpret_cast<VADisplay>(devices.begin()->second.get_ptr());
 #else  // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 #endif // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
 }
 #else // __linux__
 VPLVAAPIAccelerationPolicy::VPLVAAPIAccelerationPolicy(device_selector_ptr_t selector) :
     VPLAccelerationPolicy(selector) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 #endif // __linux__
 
@@ -102,33 +102,33 @@ cv::MediaFrame::AdapterPtr VPLVAAPIAccelerationPolicy::create_frame_adapter(pool
 VPLVAAPIAccelerationPolicy::~VPLVAAPIAccelerationPolicy() = default;
 
 void VPLVAAPIAccelerationPolicy::init(session_t ) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 void VPLVAAPIAccelerationPolicy::deinit(session_t) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 VPLVAAPIAccelerationPolicy::pool_key_t VPLVAAPIAccelerationPolicy::create_surface_pool(const mfxFrameAllocRequest&,
                                                                                      mfxFrameInfo&) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 VPLVAAPIAccelerationPolicy::surface_weak_ptr_t VPLVAAPIAccelerationPolicy::get_free_surface(pool_key_t) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 size_t VPLVAAPIAccelerationPolicy::get_free_surface_count(pool_key_t) const {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 size_t VPLVAAPIAccelerationPolicy::get_surface_count(pool_key_t) const {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 
 cv::MediaFrame::AdapterPtr VPLVAAPIAccelerationPolicy::create_frame_adapter(pool_key_t,
                                                                           const FrameConstructorArgs &) {
-    GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current configuration");
+    GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current configuration");
 }
 #endif // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
 } // namespace onevpl

--- a/modules/gapi/src/streaming/onevpl/accelerators/dx11_alloc_resource.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/dx11_alloc_resource.cpp
@@ -46,7 +46,7 @@ size_t LockAdapter::read_lock(mfxMemId mid, mfxFrameData &data) {
     // adapter will throw error if VPL frame allocator fails
     if (sts != MFX_ERR_NONE) {
         impl->unlock_shared();
-        GAPI_Assert(false && "Cannot lock frame on READ using VPL allocator");
+        GAPI_Error("Cannot lock frame on READ using VPL allocator");
     }
 
     return prev_lock_count;
@@ -76,7 +76,7 @@ void LockAdapter::write_lock(mfxMemId mid, mfxFrameData &data) {
     // adapter will throw error if VPL frame allocator fails
     if (sts != MFX_ERR_NONE) {
         impl->unlock();
-        GAPI_Assert(false && "Cannot lock frame on WRITE using VPL allocator");
+        GAPI_Error("Cannot lock frame on WRITE using VPL allocator");
     }
 }
 
@@ -199,13 +199,13 @@ void DX11AllocationItem::on_first_in_impl(mfxFrameData *ptr) {
         err = shared_device_context->Map(get_staging_texture_ptr(), 0, mapType, mapFlags, &lockedRect);
         if (S_OK != err && DXGI_ERROR_WAS_STILL_DRAWING != err) {
             GAPI_LOG_WARNING(nullptr, "Cannot Map staging texture in device context, error: " << std::to_string(HRESULT_CODE(err)));
-            GAPI_Assert(false && "Cannot Map staging texture in device context");
+            GAPI_Error("Cannot Map staging texture in device context");
         }
     } while (DXGI_ERROR_WAS_STILL_DRAWING == err);
 
     if (FAILED(err)) {
         GAPI_LOG_WARNING(nullptr, "Cannot lock frame");
-        GAPI_Assert(false && "Cannot lock frame");
+        GAPI_Error("Cannot lock frame");
         return ;
     }
 

--- a/modules/gapi/src/streaming/onevpl/accelerators/surface/dx11_frame_adapter.cpp
+++ b/modules/gapi/src/streaming/onevpl/accelerators/surface/dx11_frame_adapter.cpp
@@ -125,7 +125,7 @@ mfxHDLPair VPLMediaFrameDX11Adapter::getHandle() const {
 }
 
 cv::util::any VPLMediaFrameDX11Adapter::blobParams() const {
-    /*GAPI_Assert(false && "VPLMediaFrameDX11Adapter::blobParams() is not fully integrated"
+    /*GAPI_Error("VPLMediaFrameDX11Adapter::blobParams() is not fully integrated"
                          "in OpenVINO InferenceEngine and would be temporary disable.");*/
 #ifdef HAVE_INF_ENGINE
     mfxHDLPair handle = getHandle();
@@ -162,16 +162,16 @@ cv::util::any VPLMediaFrameDX11Adapter::blobParams() const {
     return std::make_pair(std::make_pair(y_tdesc, y_params),
                           std::make_pair(uv_tdesc, uv_params));
 #else
-    GAPI_Assert(false && "VPLMediaFrameDX11Adapter::blobParams() is not implemented");
+    GAPI_Error("VPLMediaFrameDX11Adapter::blobParams() is not implemented");
 #endif // HAVE_INF_ENGINE
 }
 
 void VPLMediaFrameDX11Adapter::serialize(cv::gapi::s11n::IOStream&) {
-    GAPI_Assert(false && "VPLMediaFrameDX11Adapter::serialize() is not implemented");
+    GAPI_Error("VPLMediaFrameDX11Adapter::serialize() is not implemented");
 }
 
 void VPLMediaFrameDX11Adapter::deserialize(cv::gapi::s11n::IIStream&) {
-    GAPI_Assert(false && "VPLMediaFrameDX11Adapter::deserialize() is not implemented");
+    GAPI_Error("VPLMediaFrameDX11Adapter::deserialize() is not implemented");
 }
 
 DXGI_FORMAT VPLMediaFrameDX11Adapter::get_dx11_color_format(uint32_t mfx_fourcc) {

--- a/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
@@ -244,10 +244,10 @@ CfgParamDeviceSelector::CfgParamDeviceSelector(const CfgParams& cfg_params) :
             suggested_device = IDeviceSelector::create<Device>(va_handle, "GPU", AccelType::VAAPI);
             suggested_context = IDeviceSelector::create<Context>(nullptr, AccelType::VAAPI);
 #else  // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
-            GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
+            GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
 #endif // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
 #else // #ifdef __linux__
-            GAPI_Assert(false && "MFX_IMPL_VIA_VAAPI is supported on linux only");
+            GAPI_Error("MFX_IMPL_VIA_VAAPI is supported on linux only");
 #endif // #ifdef __linux__
             break;
         }
@@ -335,10 +335,10 @@ CfgParamDeviceSelector::CfgParamDeviceSelector(Device::Ptr device_ptr,
             suggested_device = IDeviceSelector::create<Device>(device_ptr, device_id, AccelType::VAAPI);
             suggested_context = IDeviceSelector::create<Context>(nullptr, AccelType::VAAPI);
 #else  // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
-            GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
+            GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
 #endif // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
 #else // #ifdef __linux__
-            GAPI_Assert(false && "MFX_IMPL_VIA_VAAPI is supported on linux only");
+            GAPI_Error("MFX_IMPL_VIA_VAAPI is supported on linux only");
 #endif // #ifdef __linux__
             break;
         }
@@ -394,10 +394,10 @@ CfgParamDeviceSelector::CfgParamDeviceSelector(const Device &device,
         case AccelType::VAAPI:
 #ifdef __linux__
 #if !defined(HAVE_VA) || !defined(HAVE_VA_INTEL)
-            GAPI_Assert(false && "VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
+            GAPI_Error("VPLVAAPIAccelerationPolicy unavailable in current linux configuration");
 #endif // defined(HAVE_VA) || defined(HAVE_VA_INTEL)
 #else // #ifdef __linux__
-            GAPI_Assert(false && "MFX_IMPL_VIA_VAAPI is supported on linux only");
+            GAPI_Error("MFX_IMPL_VIA_VAAPI is supported on linux only");
 #endif // #ifdef __linux__
             break;
         case AccelType::HOST:

--- a/modules/gapi/src/streaming/onevpl/cfg_params_parser.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_params_parser.cpp
@@ -60,7 +60,7 @@ private:
         return ret;
     }
     mfxVariant create_impl(const std::string&, const std::string&) {
-        GAPI_Assert(false && "Something wrong: you should not create mfxVariant "
+        GAPI_Error("Something wrong: you should not create mfxVariant "
                              "from string directly - native type is lost in this case");
     }
 };
@@ -173,7 +173,7 @@ void extract_optional_param_by_name(const std::string &name,
             [&out_param](int64_t value)   { out_param = cv::util::make_optional(static_cast<size_t>(value));   },
             [&out_param](float_t value)   { out_param = cv::util::make_optional(static_cast<size_t>(value));   },
             [&out_param](double_t value)  { out_param = cv::util::make_optional(static_cast<size_t>(value));   },
-            [&out_param](void*)     { GAPI_Assert(false && "`void*` is unsupported type");  },
+            [&out_param](void*)     { GAPI_Error("`void*` is unsupported type");  },
             [&out_param](const std::string& value) {
                 out_param = cv::util::make_optional(strtoull_or_throw(value.c_str()));
             }),
@@ -189,7 +189,7 @@ unsigned long strtoul_or_throw(const char* str) {
         ((ret == ULONG_MAX) && errno == ERANGE)) {
             // nothing parsed from the string, handle errors or exit
         GAPI_LOG_WARNING(nullptr, "strtoul failed for: " << str);
-        GAPI_Assert(false && "strtoul_or_throw");
+        GAPI_Error("strtoul_or_throw");
     }
     return ret;
 }
@@ -202,7 +202,7 @@ size_t strtoull_or_throw(const char* str) {
         ((ret == ULLONG_MAX) && errno == ERANGE)) {
             // nothing parsed from the string, handle errors or exit
         GAPI_LOG_WARNING(nullptr, "strtoull failed for: " << str);
-        GAPI_Assert(false && "strtoull_or_throw");
+        GAPI_Error("strtoull_or_throw");
     }
     return ret;
 }
@@ -215,7 +215,7 @@ int64_t strtoll_or_throw(const char* str) {
         ((ret == LONG_MAX || ret == LONG_MIN) && errno == ERANGE)) {
             // nothing parsed from the string, handle errors or exit
         GAPI_LOG_WARNING(nullptr, "strtoll failed for: " << str);
-        GAPI_Assert(false && "strtoll_or_throw");
+        GAPI_Error("strtoll_or_throw");
     }
     return ret;
 }

--- a/modules/gapi/src/streaming/onevpl/data_provider_defines.hpp
+++ b/modules/gapi/src/streaming/onevpl/data_provider_defines.hpp
@@ -18,7 +18,7 @@ struct IDataProvider::mfx_bitstream : public mfxBitstream {};
 #else // HAVE_ONEVPL
 struct IDataProvider::mfx_bitstream {
     mfx_bitstream() {
-        GAPI_Assert(false && "Reject to create `mfxBitstream` because library compiled without VPL/MFX support");
+        GAPI_Error("Reject to create `mfxBitstream` because library compiled without VPL/MFX support");
     }
 };
 #endif // HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/demux/async_mfp_demux_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/demux/async_mfp_demux_data_provider.cpp
@@ -745,7 +745,7 @@ bool MFPAsyncDemuxDataProvider::fetch_bitstream_data(std::shared_ptr<mfx_bitstre
             GAPI_LOG_WARNING(nullptr, "[" << this << "] " <<
                                       "cannot find appropriate dmux buffer by key: " <<
                                       static_cast<void*>(out_bitsream->Data));
-            GAPI_Assert(false && "invalid bitstream key");
+            GAPI_Error("invalid bitstream key");
         }
         if (it->second) {
             it->second->Unlock();
@@ -788,20 +788,20 @@ bool MFPAsyncDemuxDataProvider::empty() const {
 #else // _WIN32
 
 MFPAsyncDemuxDataProvider::MFPAsyncDemuxDataProvider(const std::string&) {
-    GAPI_Assert(false && "Unsupported: Microsoft Media Foundation is not available");
+    GAPI_Error("Unsupported: Microsoft Media Foundation is not available");
 }
 IDataProvider::mfx_codec_id_type MFPAsyncDemuxDataProvider::get_mfx_codec_id() const {
-    GAPI_Assert(false && "Unsupported: Microsoft Media Foundation is not available");
+    GAPI_Error("Unsupported: Microsoft Media Foundation is not available");
     return std::numeric_limits<mfx_codec_id_type>::max();
 }
 
 bool MFPAsyncDemuxDataProvider::fetch_bitstream_data(std::shared_ptr<mfx_bitstream> &) {
-    GAPI_Assert(false && "Unsupported: Microsoft Media Foundation is not available");
+    GAPI_Error("Unsupported: Microsoft Media Foundation is not available");
     return false;
 }
 
 bool MFPAsyncDemuxDataProvider::empty() const {
-    GAPI_Assert(false && "Unsupported: Microsoft Media Foundation is not available");
+    GAPI_Error("Unsupported: Microsoft Media Foundation is not available");
     return true;
 }
 #endif // _WIN32

--- a/modules/gapi/src/streaming/onevpl/engine/decode/decode_engine_legacy.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/decode/decode_engine_legacy.cpp
@@ -190,7 +190,7 @@ VPLLegacyDecodeEngine::SessionParam VPLLegacyDecodeEngine::prepare_session_param
         // TODO make proper direction
         mfxDecParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
     } else {
-        GAPI_Assert(false && "unsupported AccelType from device selector");
+        GAPI_Error("unsupported AccelType from device selector");
     }
 
     // try fetch & decode input data

--- a/modules/gapi/src/streaming/onevpl/engine/preproc/preproc_dispatcher.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/preproc/preproc_dispatcher.cpp
@@ -66,7 +66,7 @@ pp_session VPPPreprocDispatcher::initialize_preproc(const pp_params& initial_fra
             return sess;
         }
     }
-    GAPI_Assert(false && "Cannot initialize VPP preproc in dispatcher, no suitable worker");
+    GAPI_Error("Cannot initialize VPP preproc in dispatcher, no suitable worker");
 }
 
 cv::MediaFrame VPPPreprocDispatcher::run_sync(const pp_session &session_handle,
@@ -80,7 +80,7 @@ cv::MediaFrame VPPPreprocDispatcher::run_sync(const pp_session &session_handle,
             return w->run_sync(session_handle, in_frame, opt_roi);
         }
     }
-    GAPI_Assert(false && "Cannot invoke VPP preproc in dispatcher, no suitable worker");
+    GAPI_Error("Cannot invoke VPP preproc in dispatcher, no suitable worker");
 }
 
 #else // HAVE_ONEVPL
@@ -90,13 +90,13 @@ cv::util::optional<pp_params> VPPPreprocDispatcher::is_applicable(const cv::Medi
 
 pp_session VPPPreprocDispatcher::initialize_preproc(const pp_params&,
                                                     const GFrameDesc&) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 cv::MediaFrame VPPPreprocDispatcher::run_sync(const pp_session &,
                                               const cv::MediaFrame&,
                                               const cv::util::optional<cv::Rect> &) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 #endif // HAVE_ONEVPL
 } // namespace onevpl

--- a/modules/gapi/src/streaming/onevpl/engine/preproc/preproc_engine.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/preproc/preproc_engine.cpp
@@ -249,13 +249,13 @@ pp_session VPPPreprocEngine::initialize_preproc(const pp_params& initial_frame_p
     sts = MFXCreateSession(mfx_handle, impl_number, &mfx_vpp_session);
     if (sts != MFX_ERR_NONE) {
         GAPI_LOG_WARNING(nullptr, "Cannot clone VPP session, error: " << mfxstatus_to_string(sts));
-        GAPI_Assert(false && "Cannot continue VPP preprocessing");
+        GAPI_Error("Cannot continue VPP preprocessing");
     }
 
     sts = MFXJoinSession(params.handle, mfx_vpp_session);
     if (sts != MFX_ERR_NONE) {
         GAPI_LOG_WARNING(nullptr, "Cannot join VPP sessions, error: " << mfxstatus_to_string(sts));
-        GAPI_Assert(false && "Cannot continue VPP preprocessing");
+        GAPI_Error("Cannot continue VPP preprocessing");
     }
 
     GAPI_LOG_INFO(nullptr, "[" << mfx_vpp_session << "] starting pool allocation");
@@ -301,7 +301,7 @@ pp_session VPPPreprocEngine::initialize_preproc(const pp_params& initial_frame_p
         }
     } catch (const std::exception&) {
         MFXClose(mfx_vpp_session);
-        GAPI_Assert(false && "Cannot init preproc resources");
+        GAPI_Error("Cannot init preproc resources");
     }
 
     // create engine session after all

--- a/modules/gapi/src/streaming/onevpl/engine/preproc/utils.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/preproc/utils.cpp
@@ -28,7 +28,7 @@ cv::MediaFormat fourcc_to_MediaFormat(int value) {
         default:
             GAPI_LOG_WARNING(nullptr, "Unsupported FourCC format requested: " << value <<
                                      ". Cannot cast to cv::MediaFrame");
-            GAPI_Assert(false && "Unsupported FOURCC");
+            GAPI_Error("Unsupported FOURCC");
 
     }
 }
@@ -44,7 +44,7 @@ int MediaFormat_to_fourcc(cv::MediaFormat value) {
             GAPI_LOG_WARNING(nullptr, "Unsupported cv::MediaFormat format requested: " <<
                                       static_cast<typename std::underlying_type<cv::MediaFormat>::type>(value) <<
                                      ". Cannot cast to FourCC");
-            GAPI_Assert(false && "Unsupported cv::MediaFormat");
+            GAPI_Error("Unsupported cv::MediaFormat");
     }
 }
 int MediaFormat_to_chroma(cv::MediaFormat value) {
@@ -58,7 +58,7 @@ int MediaFormat_to_chroma(cv::MediaFormat value) {
             GAPI_LOG_WARNING(nullptr, "Unsupported cv::MediaFormat format requested: " <<
                                       static_cast<typename std::underlying_type<cv::MediaFormat>::type>(value) <<
                                      ". Cannot cast to ChromaFormateIdc");
-            GAPI_Assert(false && "Unsupported cv::MediaFormat");
+            GAPI_Error("Unsupported cv::MediaFormat");
     }
 }
 

--- a/modules/gapi/src/streaming/onevpl/engine/preproc_engine_interface.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/preproc_engine_interface.cpp
@@ -30,7 +30,7 @@ namespace wip {
 template<typename SpecificPreprocEngine, typename ...PreprocEngineArgs >
 std::unique_ptr<SpecificPreprocEngine>
 IPreprocEngine::create_preproc_engine_impl(const PreprocEngineArgs& ...) {
-    GAPI_Assert(false && "Unsupported ");
+    GAPI_Error("Unsupported ");
 }
 
 template <>
@@ -91,7 +91,7 @@ IPreprocEngine::create_preproc_engine_impl(const onevpl::Device &device,
     }
     if (!pp_is_created) {
         GAPI_LOG_WARNING(nullptr, "Cannot create VPP preprocessing engine: configuration unsupported");
-        GAPI_Assert(false && "VPP preproc unsupported");
+        GAPI_Error("VPP preproc unsupported");
     }
 #endif // HAVE_ONEVPL
     return dispatcher;

--- a/modules/gapi/src/streaming/onevpl/engine/transcode/transcode_engine_legacy.cpp
+++ b/modules/gapi/src/streaming/onevpl/engine/transcode/transcode_engine_legacy.cpp
@@ -404,7 +404,7 @@ void VPLLegacyTranscodeEngine::validate_vpp_param(const mfxVideoParam& mfxVPPPar
                                   " must be less or equal to \"" <<
                                   CfgParam::vpp_in_width_name() << "\": " <<
                                   mfxVPPParams.vpp.In.Width);
-        GAPI_Assert(false && "Invalid VPP params combination: Width & Crop");
+        GAPI_Error("Invalid VPP params combination: Width & Crop");
     }
 
     if (mfxVPPParams.vpp.In.Height < mfxVPPParams.vpp.In.CropH + mfxVPPParams.vpp.In.CropY) {
@@ -416,7 +416,7 @@ void VPLLegacyTranscodeEngine::validate_vpp_param(const mfxVideoParam& mfxVPPPar
                                   " must be less or equal to \"" <<
                                   CfgParam::vpp_in_height_name() << "\": " <<
                                   mfxVPPParams.vpp.In.Height);
-        GAPI_Assert(false && "Invalid VPP params combination: Height & Crop");
+        GAPI_Error("Invalid VPP params combination: Height & Crop");
     }
 
     if (mfxVPPParams.vpp.Out.Width < mfxVPPParams.vpp.Out.CropW + mfxVPPParams.vpp.Out.CropX) {
@@ -428,7 +428,7 @@ void VPLLegacyTranscodeEngine::validate_vpp_param(const mfxVideoParam& mfxVPPPar
                                   " must be less or equal to \"" <<
                                   CfgParam::vpp_out_width_name() << "\": " <<
                                   mfxVPPParams.vpp.Out.Width);
-        GAPI_Assert(false && "Invalid VPP params combination: Width & Crop");
+        GAPI_Error("Invalid VPP params combination: Width & Crop");
     }
 
     if (mfxVPPParams.vpp.Out.Height < mfxVPPParams.vpp.Out.CropH + mfxVPPParams.vpp.Out.CropY) {
@@ -440,7 +440,7 @@ void VPLLegacyTranscodeEngine::validate_vpp_param(const mfxVideoParam& mfxVPPPar
                                   " must be less or equal to \"" <<
                                   CfgParam::vpp_out_height_name() << "\": " <<
                                   mfxVPPParams.vpp.Out.Height);
-        GAPI_Assert(false && "Invalid VPP params combination: Height & Crop");
+        GAPI_Error("Invalid VPP params combination: Height & Crop");
     }
 
     GAPI_LOG_INFO(nullptr, "Finished VPP param validation");

--- a/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
@@ -127,25 +127,25 @@ FileDataProvider::FileDataProvider(const std::string&,
     source_handle(nullptr, &fclose),
     codec(std::numeric_limits<mfx_codec_id_type>::max()),
     bitstream_data_size(bitstream_data_size_value) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 FileDataProvider::~FileDataProvider() = default;
 
 IDataProvider::mfx_codec_id_type FileDataProvider::get_mfx_codec_id() const {
     cv::util::suppress_unused_warning(codec);
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
     return codec;
 }
 
 bool FileDataProvider::fetch_bitstream_data(std::shared_ptr<mfx_bitstream> &) {
     cv::util::suppress_unused_warning(bitstream_data_size);
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
     return false;
 }
 
 bool FileDataProvider::empty() const {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
     return true;
 }
 #endif // HAVE_ONEVPL

--- a/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
+++ b/modules/gapi/src/streaming/onevpl/file_data_provider.cpp
@@ -135,18 +135,15 @@ FileDataProvider::~FileDataProvider() = default;
 IDataProvider::mfx_codec_id_type FileDataProvider::get_mfx_codec_id() const {
     cv::util::suppress_unused_warning(codec);
     GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
-    return codec;
 }
 
 bool FileDataProvider::fetch_bitstream_data(std::shared_ptr<mfx_bitstream> &) {
     cv::util::suppress_unused_warning(bitstream_data_size);
     GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
-    return false;
 }
 
 bool FileDataProvider::empty() const {
     GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
-    return true;
 }
 #endif // HAVE_ONEVPL
 } // namespace onevpl

--- a/modules/gapi/src/streaming/onevpl/source.cpp
+++ b/modules/gapi/src/streaming/onevpl/source.cpp
@@ -73,33 +73,33 @@ GSource::GSource(std::shared_ptr<IDataProvider> source,
 
 #else
 GSource::GSource(const std::string&, const CfgParams&) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(const std::string&, const CfgParams&, const std::string&,
                  void*, void*) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(const std::string&, const CfgParams&, const Device &, const Context &) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(const std::string&, const CfgParams&, std::shared_ptr<IDeviceSelector>) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(std::shared_ptr<IDataProvider>, const CfgParams&) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(std::shared_ptr<IDataProvider>, const CfgParams&,
                  const std::string&, void*, void*) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 
 GSource::GSource(std::shared_ptr<IDataProvider>, const CfgParams&, std::shared_ptr<IDeviceSelector>) {
-    GAPI_Assert(false && "Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
+    GAPI_Error("Unsupported: G-API compiled without `WITH_GAPI_ONEVPL=ON`");
 }
 #endif
 

--- a/modules/gapi/src/streaming/onevpl/source_priv.cpp
+++ b/modules/gapi/src/streaming/onevpl/source_priv.cpp
@@ -109,7 +109,7 @@ GSource::Priv::Priv(std::shared_ptr<IDataProvider> provider,
             GAPI_LOG_WARNING(nullptr, "MFXSetConfigFilterProperty failed, error: " <<
                                       mfxstatus_to_string(sts) <<
                                       " - for \"" << cfg_param_it->get_name() << "\"");
-            GAPI_Assert(false && "MFXSetConfigFilterProperty failed");
+            GAPI_Error("MFXSetConfigFilterProperty failed");
         }
 
         mfx_param.Type     = MFX_VARIANT_TYPE_U32;
@@ -123,7 +123,7 @@ GSource::Priv::Priv(std::shared_ptr<IDataProvider> provider,
             GAPI_LOG_WARNING(nullptr, "MFXSetConfigFilterProperty failed, error: " <<
                                       mfxstatus_to_string(sts) <<
                                       " - for \"mfxImplDescription.mfxVPPDescription.filter.FilterFourCC\"");
-            GAPI_Assert(false && "MFXSetConfigFilterProperty failed");
+            GAPI_Error("MFXSetConfigFilterProperty failed");
         }
 
         ++cfg_param_it;
@@ -317,7 +317,7 @@ std::unique_ptr<VPLAccelerationPolicy> GSource::Priv::initializeHWAccel(std::sha
             GAPI_LOG_WARNING(nullptr, "Cannot initialize HW Accel: "
                                       "invalid accelerator type: " <<
                                       std::to_string(accel_mode.Data.U32));
-            GAPI_Assert(false && "Cannot initialize HW Accel");
+            GAPI_Error("Cannot initialize HW Accel");
         }
     }
 

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -41,7 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, mathOp op)
         CASE(SUB);
         CASE(MUL);
         CASE(DIV);
-        default: GAPI_Assert(false && "unknown mathOp value");
+        default: GAPI_Error("unknown mathOp value");
     }
 #undef CASE
     return os;
@@ -57,7 +57,7 @@ inline std::ostream& operator<<(std::ostream& os, bitwiseOp op)
         CASE(OR);
         CASE(XOR);
         CASE(NOT);
-        default: GAPI_Assert(false && "unknown bitwiseOp value");
+        default: GAPI_Error("unknown bitwiseOp value");
     }
 #undef CASE
     return os;

--- a/modules/gapi/test/common/gapi_operators_tests.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests.hpp
@@ -34,7 +34,7 @@ inline std::ostream& operator<<(std::ostream& os, operation op)
         CASE(GTR); CASE(LTR); CASE(GER); CASE(LER); CASE(EQR); CASE(NER);
         CASE(AND);  CASE(OR);  CASE(XOR);
         CASE(ANDR); CASE(ORR); CASE(XORR);
-        default: GAPI_Assert(false && "unknown operation value");
+        default: GAPI_Error("unknown operation value");
     }
 #undef CASE
     return os;
@@ -187,7 +187,7 @@ struct g_api_ocv_pair_mat_scalar {
             CASE(GTR); CASE(LTR); CASE(GER); CASE(LER); CASE(EQR); CASE(NER);
             CASE(AND);  CASE(OR);  CASE(XOR);
             CASE(ANDR); CASE(ORR); CASE(XORR);
-            default: GAPI_Assert(false && "unknown operation value");
+            default: GAPI_Error("unknown operation value");
         }
     }
 #undef CASE
@@ -214,7 +214,7 @@ struct g_api_ocv_pair_mat_mat {
             CASE(ADD);  CASE(SUB);  CASE(DIV);
             CASE(GT); CASE(LT); CASE(GE); CASE(LE); CASE(EQ); CASE(NE);
             CASE(AND); CASE(OR); CASE(XOR);
-            default: GAPI_Assert(false && "unknown operation value");
+            default: GAPI_Error("unknown operation value");
         }
     }
 #undef CASE

--- a/modules/gapi/test/common/gapi_stereo_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_stereo_tests_inl.hpp
@@ -25,7 +25,7 @@ TEST_P(TestGAPIStereo, DisparityDepthTest)
         case format::DEPTH_FLOAT16: dtype = CV_16FC1; break;
         case format::DEPTH_FLOAT32: dtype = CV_32FC1; break;
         case format::DISPARITY_FIXED16_12_4: dtype = CV_16SC1; break;
-        default: GAPI_Assert(false && "Unsupported format in test");
+        default: GAPI_Error("Unsupported format in test");
     }
     initOutMats(sz, dtype);
 
@@ -61,7 +61,7 @@ TEST_P(TestGAPIStereo, DisparityDepthTest)
         case format::DISPARITY_FIXED16_12_4:
             break;
         default:
-            GAPI_Assert(false && "Unsupported format in test");
+            GAPI_Error("Unsupported format in test");
     }
 
     EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -373,7 +373,7 @@ public:
             initMatByPointsVectorRandU<Pt<cv::float16_t>>(sz_in);
             break;
         default:
-            GAPI_Assert(false && "Unsupported depth");
+            GAPI_Error("Unsupported depth");
             break;
         }
     }
@@ -1065,7 +1065,7 @@ inline std::ostream& operator<<(std::ostream& os, CmpTypes op)
         CASE(CMP_LT);
         CASE(CMP_LE);
         CASE(CMP_NE);
-        default: GAPI_Assert(false && "unknown CmpTypes value");
+        default: GAPI_Error("unknown CmpTypes value");
     }
 #undef CASE
     return os;
@@ -1084,7 +1084,7 @@ inline std::ostream& operator<<(std::ostream& os, NormTypes op)
         CASE(NORM_HAMMING2);
         CASE(NORM_RELATIVE);
         CASE(NORM_MINMAX);
-        default: GAPI_Assert(false && "unknown NormTypes value");
+        default: GAPI_Error("unknown NormTypes value");
     }
 #undef CASE
     return os;
@@ -1100,7 +1100,7 @@ inline std::ostream& operator<<(std::ostream& os, RetrievalModes op)
         CASE(RETR_CCOMP);
         CASE(RETR_TREE);
         CASE(RETR_FLOODFILL);
-        default: GAPI_Assert(false && "unknown RetrievalModes value");
+        default: GAPI_Error("unknown RetrievalModes value");
     }
 #undef CASE
     return os;
@@ -1115,7 +1115,7 @@ inline std::ostream& operator<<(std::ostream& os, ContourApproximationModes op)
         CASE(CHAIN_APPROX_SIMPLE);
         CASE(CHAIN_APPROX_TC89_L1);
         CASE(CHAIN_APPROX_TC89_KCOS);
-        default: GAPI_Assert(false && "unknown ContourApproximationModes value");
+        default: GAPI_Error("unknown ContourApproximationModes value");
     }
 #undef CASE
     return os;
@@ -1134,7 +1134,7 @@ inline std::ostream& operator<<(std::ostream& os, MorphTypes op)
         CASE(MORPH_TOPHAT);
         CASE(MORPH_BLACKHAT);
         CASE(MORPH_HITMISS);
-        default: GAPI_Assert(false && "unknown MorphTypes value");
+        default: GAPI_Error("unknown MorphTypes value");
     }
 #undef CASE
     return os;
@@ -1153,7 +1153,7 @@ inline std::ostream& operator<<(std::ostream& os, DistanceTypes op)
         CASE(DIST_FAIR);
         CASE(DIST_WELSCH);
         CASE(DIST_HUBER);
-        default: GAPI_Assert(false && "unknown DistanceTypes value");
+        default: GAPI_Error("unknown DistanceTypes value");
     }
 #undef CASE
     return os;
@@ -1176,7 +1176,7 @@ inline std::ostream& operator<<(std::ostream& os, KmeansFlags op)
     case KmeansFlags::KMEANS_PP_CENTERS | KmeansFlags::KMEANS_USE_INITIAL_LABELS:
         os << "KMEANS_PP_CENTERS | KMEANS_USE_INITIAL_LABELS";
         break;
-    default: GAPI_Assert(false && "unknown KmeansFlags value");
+    default: GAPI_Error("unknown KmeansFlags value");
     }
     return os;
 }

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -435,7 +435,7 @@ inline cv::GComputation runOCVnGAPIBuildOptFlowPyramid(TestFunctional&,
                                                        BuildOpticalFlowPyramidTestOutput&,
                                                        BuildOpticalFlowPyramidTestOutput&)
 {
-    GAPI_Assert(0 && "This function shouldn't be called without opencv_video");
+    GAPI_Error("This function shouldn't be called without opencv_video");
 }
 
 inline cv::GComputation runOCVnGAPIOptFlowLK(TestFunctional&,
@@ -444,7 +444,7 @@ inline cv::GComputation runOCVnGAPIOptFlowLK(TestFunctional&,
                                              OptFlowLKTestOutput&,
                                              OptFlowLKTestOutput&)
 {
-    GAPI_Assert(0 && "This function shouldn't be called without opencv_video");
+    GAPI_Error("This function shouldn't be called without opencv_video");
 }
 
 inline cv::GComputation runOCVnGAPIOptFlowLKForPyr(TestFunctional&,
@@ -454,7 +454,7 @@ inline cv::GComputation runOCVnGAPIOptFlowLKForPyr(TestFunctional&,
                                                    OptFlowLKTestOutput&,
                                                    OptFlowLKTestOutput&)
 {
-    GAPI_Assert(0 && "This function shouldn't be called without opencv_video");
+    GAPI_Error("This function shouldn't be called without opencv_video");
 }
 
 inline GComputation runOCVnGAPIOptFlowPipeline(TestFunctional&,
@@ -463,7 +463,7 @@ inline GComputation runOCVnGAPIOptFlowPipeline(TestFunctional&,
                                                OptFlowLKTestOutput&,
                                                std::vector<Point2f>&)
 {
-    GAPI_Assert(0 && "This function shouldn't be called without opencv_video");
+    GAPI_Error("This function shouldn't be called without opencv_video");
 }
 
 #endif // HAVE_OPENCV_VIDEO
@@ -481,7 +481,7 @@ inline std::ostream& operator<<(std::ostream& os, const BackgroundSubtractorType
     {
         CASE(TYPE_BS_MOG2);
         CASE(TYPE_BS_KNN);
-        default: GAPI_Assert(false && "unknown BackgroundSubtractor type");
+        default: GAPI_Error("unknown BackgroundSubtractor type");
     }
 #undef CASE
     return os;

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -114,7 +114,7 @@ inline int toCV(ONNXTensorElementDataType prec) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: return CV_32F;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32: return CV_32S;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: return CV_32S;
-    default: GAPI_Assert(false && "Unsupported data type");
+    default: GAPI_Error("Unsupported data type");
     }
     return -1;
 }
@@ -142,7 +142,7 @@ void copyFromONNX(Ort::Value &v, cv::Mat& mat) {
                    [](int64_t el) { return static_cast<int>(el); });
             break;
         }
-    default: GAPI_Assert(false && "ONNX. Unsupported data type");
+    default: GAPI_Error("ONNX. Unsupported data type");
     }
 }
 

--- a/modules/gapi/test/s11n/gapi_s11n_tests.cpp
+++ b/modules/gapi/test/s11n/gapi_s11n_tests.cpp
@@ -554,7 +554,7 @@ TEST_F(S11N_Basic, Test_RunArgs_MatScalar) {
             EXPECT_EQ(scalar, out_scalar);
         } break;
         default:
-            GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
+            GAPI_Error("This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
         }
         i++;
@@ -587,7 +587,7 @@ TEST_F(S11N_Basic, Test_Bind_RunArgs_MatScalar) {
             EXPECT_EQ(out_scalar->val[2], scalar.val[2]);
         } break;
         default:
-            GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
+            GAPI_Error("This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
         }
     }

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -49,7 +49,7 @@ std::ostream& operator<< (std::ostream &os, const KernelPackage &e)
         _C(OCL);
         _C(OCL_FLUID);
 #undef _C
-    default: GAPI_Assert(false);
+    default: GAPI_Error("InternalError");
     }
     return os;
 }
@@ -298,7 +298,7 @@ void checkPullOverload(const cv::Mat& ref,
             out_mat = *opt_mat;
             break;
         }
-        default: GAPI_Assert(false && "Incorrect type of Args");
+        default: GAPI_Error("Incorrect type of Args");
     }
 
     EXPECT_EQ(0., cv::norm(ref, out_mat, cv::NORM_INF));
@@ -2420,7 +2420,7 @@ TEST(GAPI_Streaming, TestPythonAPI)
     switch (args.index()) {
         case RunArgs::index_of<cv::GRunArgs>():
             out_args = util::get<cv::GRunArgs>(args); break;
-        default: GAPI_Assert(false && "Incorrect type of return value");
+        default: GAPI_Error("Incorrect type of return value");
     }
 
     ASSERT_EQ(1u, out_args.size());


### PR DESCRIPTION
to eliminate build warnings about unreachable control flow (GCC 12)

relates #21496

Update rules:

```
echo "Patch: $1"
sed -i "s/GAPI_Assert(false)/GAPI_Error(\"InternalError\")/g" $1
sed -i "s/GAPI_Assert(false && \"/GAPI_Error(\"/g" $1
sed -i "s/GAPI_Assert(0 && \"/GAPI_Error(\"/g" $1
```

TODO:
- [x] resolve new MSVC build warnings


```
force_builders=Win64,Win64 OpenCL,Win32,Custom Win
Xtest_modules=none

Xbuild_gapi_standalone:Linux x64=ade-0.1.2a
Xbuild_gapi_standalone:Win64=ade-0.1.2a

build_image:Custom=ubuntu:22.04
buildworker:Custom=linux-4
```