### PR TITLE
Integer underflow fix for morphologyEx in Carotene (arm).

### DIFF
--- a/3rdparty/carotene/hal/tegra_hal.hpp
+++ b/3rdparty/carotene/hal/tegra_hal.hpp
@@ -1296,13 +1296,13 @@ struct MorphCtx
     CAROTENE_NS::BORDER_MODE border;
     uchar borderValues[4];
 };
-inline int TEGRA_MORPHINIT(cvhalFilter2D **context, int operation, int src_type, int dst_type, int, int,
+inline int TEGRA_MORPHINIT(cvhalFilter2D **context, int operation, int src_type, int dst_type, int width, int height,
                            int kernel_type, uchar *kernel_data, size_t kernel_step, int kernel_width, int kernel_height, int anchor_x, int anchor_y,
                            int borderType, const double borderValue[4], int iterations, bool allowSubmatrix, bool allowInplace)
 {
     if(!context || !kernel_data || src_type != dst_type ||
        CV_MAT_DEPTH(src_type) != CV_8U || src_type < 0 || (src_type >> CV_CN_SHIFT) > 3 ||
-
+       width < kernel_width || height < kernel_height ||
        allowSubmatrix || allowInplace || iterations != 1 ||
        !CAROTENE_NS::isSupportedConfiguration())
         return CV_HAL_ERROR_NOT_IMPLEMENTED;

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2366,5 +2366,18 @@ TEST(Imgproc_GaussianBlur, regression_11303)
     EXPECT_LE(cv::norm(src, dst, NORM_L2), 1e-3);
 }
 
+TEST(Imgproc, morphologyEx_small_input_22893)
+{
+    char input_data[] = {1, 2, 3, 4};
+    char gold_data[] = {2, 3, 4, 4};
+    cv::Mat img(1, 4, CV_8UC1, input_data);
+    cv::Mat gold(1, 4, CV_8UC1, gold_data);
+
+    cv::Mat kernel = getStructuringElement(cv::MORPH_RECT, cv::Size(4,4));
+    cv::Mat result;
+    morphologyEx(img, result, cv::MORPH_DILATE, kernel);
+
+    ASSERT_EQ(0, cvtest::norm(result, gold, NORM_INF));
+}
 
 }} // namespace


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/22893

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
