### PR TITLE
videoio(test): update PSNR check for H264/265

### DIFF
--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -55,7 +55,11 @@ TEST_P(videoio_ffmpeg, write_big)
     remove(filename.c_str());
 }
 
+#if defined(OPENCV_32BIT_CONFIGURATION)
+static const Size bigSize(1920, 1080);
+#else
 static const Size bigSize(4096, 4096);
+#endif
 
 const FourCC_Ext_Size entries[] =
 {

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -793,8 +793,8 @@ static const VideoCaptureAccelerationInput hw_filename[] = {
         { "sample_322x242_15frames.yuv420p.libxvid.mp4", 28.0 },
         { "sample_322x242_15frames.yuv420p.mjpeg.mp4", 20.0 },
         { "sample_322x242_15frames.yuv420p.mpeg2video.mp4", 24.0 },  // GSTREAMER on Ubuntu 18.04
-        { "sample_322x242_15frames.yuv420p.libx264.mp4", 23.0 },  // D3D11 on GHA/Windows, GSTREAMER on Ubuntu 18.04
-        { "sample_322x242_15frames.yuv420p.libx265.mp4", 23.0 },  // D3D11 on GHA/Windows
+        { "sample_322x242_15frames.yuv420p.libx264.mp4", 20.0 },  // 20 - D3D11 (i7-11800H), 23 - D3D11 on GHA/Windows, GSTREAMER on Ubuntu 18.04
+        { "sample_322x242_15frames.yuv420p.libx265.mp4", 20.0 },  // 20 - D3D11 (i7-11800H), 23 - D3D11 on GHA/Windows
         { "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4", 30.0 },
         { "sample_322x242_15frames.yuv420p.libaom-av1.mp4", 30.0 }
 };


### PR DESCRIPTION
Nightly build: http://pullrequest.opencv.org/buildbot/builders/master-win64-vc16/builds/100005 (sporadic on i7-11800H)

<cut/>

```
[ RUN      ] videoio/videocapture_acceleration.read/74, where GetParam() = (sample_322x242_15frames.yuv420p.libx264.mp4, FFMPEG, ANY, false)
VideoCapture FFMPEG:D3D11
VideoCapture with acceleration = D3D11  @ FFMPEG     on sample_322x242_15frames.yuv420p.libx264.mp4 with PSNR-original = 20.7884
C:\build\master-win64-vc16\opencv\modules\videoio\test\test_video_io.cpp(789): error: Expected: (min_psnr_original) >= (psnr_threshold), actual: 20.7884 vs 23
[  FAILED  ] videoio/videocapture_acceleration.read/74, where GetParam() = (sample_322x242_15frames.yuv420p.libx264.mp4, FFMPEG, ANY, false) (61 ms)

[ RUN      ] videoio/videocapture_acceleration.read/78, where GetParam() = (sample_322x242_15frames.yuv420p.libx264.mp4, FFMPEG, D3D11, false)
[ERROR:0@87.262] global /build/opencv/modules/videoio/src/cap_ffmpeg_impl.hpp (1272) open VIDEOIO/FFMPEG: Failed to initialize VideoCapture
VideoCapture FFMPEG:D3D11
VideoCapture with acceleration = D3D11  @ FFMPEG     on sample_322x242_15frames.yuv420p.libx264.mp4 with PSNR-original = 20.7884
C:\build\master-win64-vc16\opencv\modules\videoio\test\test_video_io.cpp(789): error: Expected: (min_psnr_original) >= (psnr_threshold), actual: 20.7884 vs 23
[  FAILED  ] videoio/videocapture_acceleration.read/78, where GetParam() = (sample_322x242_15frames.yuv420p.libx264.mp4, FFMPEG, D3D11, false) (56 ms)

 RUN      ] videoio/videocapture_acceleration.read/98, where GetParam() = (sample_322x242_15frames.yuv420p.libx265.mp4, FFMPEG, ANY, false)
VideoCapture FFMPEG:D3D11
VideoCapture with acceleration = D3D11  @ FFMPEG     on sample_322x242_15frames.yuv420p.libx265.mp4 with PSNR-original = 20.78
C:\build\master-win64-vc16\opencv\modules\videoio\test\test_video_io.cpp(789): error: Expected: (min_psnr_original) >= (psnr_threshold), actual: 20.78 vs 23
[  FAILED  ] videoio/videocapture_acceleration.read/98, where GetParam() = (sample_322x242_15frames.yuv420p.libx265.mp4, FFMPEG, ANY, false) (73 ms)

[ RUN      ] videoio/videocapture_acceleration.read/102, where GetParam() = (sample_322x242_15frames.yuv420p.libx265.mp4, FFMPEG, D3D11, false)
[ERROR:0@87.711] global /build/opencv/modules/videoio/src/cap_ffmpeg_impl.hpp (1272) open VIDEOIO/FFMPEG: Failed to initialize VideoCapture
VideoCapture FFMPEG:D3D11
VideoCapture with acceleration = D3D11  @ FFMPEG     on sample_322x242_15frames.yuv420p.libx265.mp4 with PSNR-original = 20.78
C:\build\master-win64-vc16\opencv\modules\videoio\test\test_video_io.cpp(789): error: Expected: (min_psnr_original) >= (psnr_threshold), actual: 20.78 vs 23
[  FAILED  ] videoio/videocapture_acceleration.read/102, where GetParam() = (sample_322x242_15frames.yuv420p.libx265.mp4, FFMPEG, D3D11, false) (74 ms)
```

4096x4096 encoding issue in FFmpeg big_size tests on Win32:

```
[OPENCV:FFMPEG:24] Cannot allocate worst case packet size, the encoding could fail
[OPENCV:FFMPEG:16] Failed to allocate packet of size 2147483551
[ERROR:0@0.054] global /build/opencv/modules/videoio/src/cap_ffmpeg_impl.hpp (2277) icv_av_write_frame_FFMPEG Error sending frame to encoder (avcodec_send_frame)
```

```
force_builders=Win64,Win64 OpenCL,Win32,Custom Win
Xtest_modules=videoio
```