### PR TITLE
Switch to new OpenVINO API after 2022.1 release

### DIFF
--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -1123,6 +1123,7 @@ std::cout << 7 << std::endl;
 
 std::cout << 7.5 << std::endl;
         std::vector<ov::Tensor> inputs, outputs;
+        int i = 0;
         for (const auto& it : netExec.inputs())
         {
 //             std::cout <<  << std::endl;
@@ -1132,15 +1133,14 @@ std::cout << 7.5 << std::endl;
             CV_Assert(blobIt != allBlobs.end());
 
             std::cout << name << std::endl;
-            inputs.push_back(blobIt->second);
             // reqWrapper->req.set_tensor(name, blobIt->second);            
             // inpBlobs[name] = isAsync ? copyBlob(blobIt->second) : blobIt->second;
+            reqWrapper->req.set_input_tensor(i++, blobIt->second);
         }
-        reqWrapper->req.set_input_tensors(inputs);
 std::cout << 8 << std::endl;
 
 std::cout << 5 << std::endl;
-        int i = 0;
+        i = 0;
         for (const auto& it : netExec.outputs())
         {
             for (const auto& it : allBlobs) {

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -76,253 +76,253 @@ ngraphWrappers(const std::vector<Ptr<BackendWrapper> >& ptrs)
     return wrappers;
 }
 
-class NgraphCustomOp: public ngraph::op::Op {
-public:
-    const ngraph::NodeTypeInfo& get_type_info() const override
-    {
-        static constexpr ngraph::NodeTypeInfo type_info{kOpenCVLayersType, static_cast<uint64_t>(0)};
-        return type_info;
-    }
+// class NgraphCustomOp: public ngraph::op::Op {
+// public:
+//     const ngraph::NodeTypeInfo& get_type_info() const override
+//     {
+//         static constexpr ngraph::NodeTypeInfo type_info{kOpenCVLayersType, static_cast<uint64_t>(0)};
+//         return type_info;
+//     }
 
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_3)
-    NgraphCustomOp(const ngraph::OutputVector& inputs,
-#else
-    NgraphCustomOp(const ngraph::NodeVector& inputs,
-#endif
-                   const std::map<std::string, InferenceEngine::Parameter>& params = {}):
-        Op(inputs), params(params)
-    {
-        constructor_validate_and_infer_types();
-    }
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_3)
+//     NgraphCustomOp(const ngraph::OutputVector& inputs,
+// #else
+//     NgraphCustomOp(const ngraph::NodeVector& inputs,
+// #endif
+//                    const std::map<std::string, InferenceEngine::Parameter>& params = {}):
+//         Op(inputs), params(params)
+//     {
+//         constructor_validate_and_infer_types();
+//     }
 
-    ~NgraphCustomOp()
-    {
-        // nothing
-    }
+//     ~NgraphCustomOp()
+//     {
+//         // nothing
+//     }
 
-    void validate_and_infer_types() override
-    {
-        std::vector<std::vector<size_t> > shapes;
-        strToShapes(params["outputs"], shapes);
-        set_output_size(shapes.size());
-        for (size_t i = 0; i < shapes.size(); ++i)
-        {
-            ngraph::Shape output_shape(shapes[i]);
-            set_output_type(i, get_input_element_type(0), output_shape);
-        }
-    }
+//     void validate_and_infer_types() override
+//     {
+//         std::vector<std::vector<size_t> > shapes;
+//         strToShapes(params["outputs"], shapes);
+//         set_output_size(shapes.size());
+//         for (size_t i = 0; i < shapes.size(); ++i)
+//         {
+//             ngraph::Shape output_shape(shapes[i]);
+//             set_output_type(i, get_input_element_type(0), output_shape);
+//         }
+//     }
 
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_4)
-    std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override
-    {
-        return std::make_shared<NgraphCustomOp>(new_args, params);
-    }
-#else
-    std::shared_ptr<ngraph::Node> copy_with_new_args(const ngraph::NodeVector& new_args) const override
-    {
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_3)
-        return std::make_shared<NgraphCustomOp>(ngraph::as_output_vector(new_args), params);
-#else
-        return std::make_shared<NgraphCustomOp>(new_args, params);
-#endif
-    }
-#endif
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_4)
+//     std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override
+//     {
+//         return std::make_shared<NgraphCustomOp>(new_args, params);
+//     }
+// #else
+//     std::shared_ptr<ngraph::Node> copy_with_new_args(const ngraph::NodeVector& new_args) const override
+//     {
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_3)
+//         return std::make_shared<NgraphCustomOp>(ngraph::as_output_vector(new_args), params);
+// #else
+//         return std::make_shared<NgraphCustomOp>(new_args, params);
+// #endif
+//     }
+// #endif
 
-    bool visit_attributes(ngraph::AttributeVisitor& visitor) override
-    {
-        for (auto& attr : params)
-        {
-            if (attr.second.is<std::string>())
-                visitor.on_attribute(attr.first, attr.second.as<std::string>());
-        }
-        return true;
-    }
+//     bool visit_attributes(ngraph::AttributeVisitor& visitor) override
+//     {
+//         for (auto& attr : params)
+//         {
+//             if (attr.second.is<std::string>())
+//                 visitor.on_attribute(attr.first, attr.second.as<std::string>());
+//         }
+//         return true;
+//     }
 
-    std::map<std::string, InferenceEngine::Parameter> params;
-};
-
-
-class InfEngineNgraphCustomLayer : public InferenceEngine::ILayerExecImpl
-{
-public:
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
-    explicit InfEngineNgraphCustomLayer(const std::shared_ptr<ngraph::Node>& _node)
-    {
-        node = std::dynamic_pointer_cast<NgraphCustomOp>(_node);
-        CV_Assert(node);
-        std::string implStr = node->params["impl"];
-        std::istringstream iss(implStr);
-#else
-    explicit InfEngineNgraphCustomLayer(const InferenceEngine::CNNLayer& layer) : cnnLayer(layer)
-    {
-        std::istringstream iss(layer.GetParamAsString("impl"));
-#endif
-        size_t ptr;
-        iss >> ptr;
-        cvLayer = (Layer*)ptr;
-
-        std::vector<std::vector<size_t> > shapes;
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
-        strToShapes(node->params["internals"], shapes);
-#else
-        strToShapes(layer.GetParamAsString("internals"), shapes);
-#endif
-        internals.resize(shapes.size());
-        for (int i = 0; i < shapes.size(); ++i)
-            internals[i].create(std::vector<int>(shapes[i].begin(), shapes[i].end()), CV_32F);
-    }
-
-    ~InfEngineNgraphCustomLayer()
-    {
-        // nothing
-    }
-
-    virtual InferenceEngine::StatusCode execute(std::vector<InferenceEngine::Blob::Ptr>& inputs,
-                                                std::vector<InferenceEngine::Blob::Ptr>& outputs,
-                                                InferenceEngine::ResponseDesc *resp) noexcept
-    {
-        std::vector<Mat> inpMats, outMats;
-        infEngineBlobsToMats(inputs, inpMats);
-        infEngineBlobsToMats(outputs, outMats);
-
-        try
-        {
-            cvLayer->forward(inpMats, outMats, internals);
-            return InferenceEngine::StatusCode::OK;
-        }
-        catch (...)
-        {
-            return InferenceEngine::StatusCode::GENERAL_ERROR;
-        }
-    }
-
-    virtual InferenceEngine::StatusCode
-    getSupportedConfigurations(std::vector<InferenceEngine::LayerConfig>& conf,
-                               InferenceEngine::ResponseDesc* resp) noexcept
-    {
-        std::vector<InferenceEngine::DataConfig> inDataConfig;
-        std::vector<InferenceEngine::DataConfig> outDataConfig;
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
-        InferenceEngine::SizeVector order;
-        for (int i = 0; i < node->get_input_size(); ++i)
-        {
-            InferenceEngine::DataConfig conf;
-            auto shape = node->input_value(i).get_shape();
-            order.resize(shape.size());
-            std::iota(order.begin(), order.end(), 0);
-            conf.desc = InferenceEngine::TensorDesc(InferenceEngine::Precision::FP32, shape, {shape, order});
-            inDataConfig.push_back(conf);
-        }
-
-        for (int i = 0; i < node->get_output_size(); ++i)
-        {
-            InferenceEngine::DataConfig conf;
-            auto shape = node->output(i).get_shape();
-            order.resize(shape.size());
-            std::iota(order.begin(), order.end(), 0);
-            conf.desc = InferenceEngine::TensorDesc(InferenceEngine::Precision::FP32, shape, {shape, order});
-            outDataConfig.push_back(conf);
-        }
-#else
-        for (auto& it : cnnLayer.insData)
-        {
-            InferenceEngine::DataConfig conf;
-            conf.desc = it.lock()->getTensorDesc();
-            inDataConfig.push_back(conf);
-        }
-
-        for (auto& it : cnnLayer.outData)
-        {
-            InferenceEngine::DataConfig conf;
-            conf.desc = it->getTensorDesc();
-            outDataConfig.push_back(conf);
-        }
-#endif
-
-        InferenceEngine::LayerConfig layerConfig;
-        layerConfig.inConfs = inDataConfig;
-        layerConfig.outConfs = outDataConfig;
-
-        conf.push_back(layerConfig);
-        return InferenceEngine::StatusCode::OK;
-    }
-
-    InferenceEngine::StatusCode init(InferenceEngine::LayerConfig& config,
-                                     InferenceEngine::ResponseDesc *resp) noexcept
-    {
-        return InferenceEngine::StatusCode::OK;
-    }
-
-private:
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
-    std::shared_ptr<NgraphCustomOp> node;
-#else
-    InferenceEngine::CNNLayer cnnLayer;
-#endif
-    dnn::Layer* cvLayer;
-    std::vector<Mat> internals;
-};
-
-#if INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2020_2)
-class InfEngineNgraphCustomLayerFactory : public InferenceEngine::ILayerImplFactory {
-public:
-    explicit InfEngineNgraphCustomLayerFactory(const InferenceEngine::CNNLayer* layer) : cnnLayer(*layer)
-    {
-        // nothing
-    }
-
-    InferenceEngine::StatusCode
-    getImplementations(std::vector<InferenceEngine::ILayerImpl::Ptr>& impls,
-                       InferenceEngine::ResponseDesc* resp) noexcept override
-    {
-        impls.push_back(std::make_shared<InfEngineNgraphCustomLayer>(cnnLayer));
-        return InferenceEngine::StatusCode::OK;
-    }
-
-private:
-    InferenceEngine::CNNLayer cnnLayer;
-};
-#endif
+//     std::map<std::string, InferenceEngine::Parameter> params;
+// };
 
 
-class InfEngineNgraphExtension : public InferenceEngine::IExtension
-{
-public:
-    void Unload() noexcept override {}
-    void Release() noexcept override { delete this; }
-    void GetVersion(const InferenceEngine::Version*&) const noexcept override {}
+// class InfEngineNgraphCustomLayer : public InferenceEngine::ILayerExecImpl
+// {
+// public:
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
+//     explicit InfEngineNgraphCustomLayer(const std::shared_ptr<ngraph::Node>& _node)
+//     {
+//         node = std::dynamic_pointer_cast<NgraphCustomOp>(_node);
+//         CV_Assert(node);
+//         std::string implStr = node->params["impl"];
+//         std::istringstream iss(implStr);
+// #else
+//     explicit InfEngineNgraphCustomLayer(const InferenceEngine::CNNLayer& layer) : cnnLayer(layer)
+//     {
+//         std::istringstream iss(layer.GetParamAsString("impl"));
+// #endif
+//         size_t ptr;
+//         iss >> ptr;
+//         cvLayer = (Layer*)ptr;
 
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
-    std::vector<std::string> getImplTypes(const std::shared_ptr<ngraph::Node>& node) override {
-        return {"CPU"};
-    }
+//         std::vector<std::vector<size_t> > shapes;
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
+//         strToShapes(node->params["internals"], shapes);
+// #else
+//         strToShapes(layer.GetParamAsString("internals"), shapes);
+// #endif
+//         internals.resize(shapes.size());
+//         for (int i = 0; i < shapes.size(); ++i)
+//             internals[i].create(std::vector<int>(shapes[i].begin(), shapes[i].end()), CV_32F);
+//     }
 
-    InferenceEngine::ILayerImpl::Ptr getImplementation(const std::shared_ptr<ngraph::Node>& node, const std::string& implType) override {
-        if (std::dynamic_pointer_cast<NgraphCustomOp>(node) && implType == "CPU") {
-            return std::make_shared<InfEngineNgraphCustomLayer>(node);
-        }
-        return nullptr;
-    }
-#else
-    virtual void SetLogCallback(InferenceEngine::IErrorListener&) noexcept {}
+//     ~InfEngineNgraphCustomLayer()
+//     {
+//         // nothing
+//     }
 
-    virtual InferenceEngine::StatusCode getPrimitiveTypes(char**&, unsigned int&,
-                                                          InferenceEngine::ResponseDesc*) noexcept
-    {
-        return InferenceEngine::StatusCode::OK;
-    }
+//     virtual InferenceEngine::StatusCode execute(std::vector<InferenceEngine::Blob::Ptr>& inputs,
+//                                                 std::vector<InferenceEngine::Blob::Ptr>& outputs,
+//                                                 InferenceEngine::ResponseDesc *resp) noexcept
+//     {
+//         std::vector<Mat> inpMats, outMats;
+//         infEngineBlobsToMats(inputs, inpMats);
+//         infEngineBlobsToMats(outputs, outMats);
 
-    InferenceEngine::StatusCode getFactoryFor(InferenceEngine::ILayerImplFactory*& factory,
-                                              const InferenceEngine::CNNLayer* cnnLayer,
-                                              InferenceEngine::ResponseDesc* resp) noexcept
-    {
-        if (cnnLayer->type != kOpenCVLayersType)
-            return InferenceEngine::StatusCode::NOT_IMPLEMENTED;
-        factory = new InfEngineNgraphCustomLayerFactory(cnnLayer);
-        return InferenceEngine::StatusCode::OK;
-    }
-#endif
-};
+//         try
+//         {
+//             cvLayer->forward(inpMats, outMats, internals);
+//             return InferenceEngine::StatusCode::OK;
+//         }
+//         catch (...)
+//         {
+//             return InferenceEngine::StatusCode::GENERAL_ERROR;
+//         }
+//     }
+
+//     virtual InferenceEngine::StatusCode
+//     getSupportedConfigurations(std::vector<InferenceEngine::LayerConfig>& conf,
+//                                InferenceEngine::ResponseDesc* resp) noexcept
+//     {
+//         std::vector<InferenceEngine::DataConfig> inDataConfig;
+//         std::vector<InferenceEngine::DataConfig> outDataConfig;
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
+//         InferenceEngine::SizeVector order;
+//         for (int i = 0; i < node->get_input_size(); ++i)
+//         {
+//             InferenceEngine::DataConfig conf;
+//             auto shape = node->input_value(i).get_shape();
+//             order.resize(shape.size());
+//             std::iota(order.begin(), order.end(), 0);
+//             conf.desc = InferenceEngine::TensorDesc(InferenceEngine::Precision::FP32, shape, {shape, order});
+//             inDataConfig.push_back(conf);
+//         }
+
+//         for (int i = 0; i < node->get_output_size(); ++i)
+//         {
+//             InferenceEngine::DataConfig conf;
+//             auto shape = node->output(i).get_shape();
+//             order.resize(shape.size());
+//             std::iota(order.begin(), order.end(), 0);
+//             conf.desc = InferenceEngine::TensorDesc(InferenceEngine::Precision::FP32, shape, {shape, order});
+//             outDataConfig.push_back(conf);
+//         }
+// #else
+//         for (auto& it : cnnLayer.insData)
+//         {
+//             InferenceEngine::DataConfig conf;
+//             conf.desc = it.lock()->getTensorDesc();
+//             inDataConfig.push_back(conf);
+//         }
+
+//         for (auto& it : cnnLayer.outData)
+//         {
+//             InferenceEngine::DataConfig conf;
+//             conf.desc = it->getTensorDesc();
+//             outDataConfig.push_back(conf);
+//         }
+// #endif
+
+//         InferenceEngine::LayerConfig layerConfig;
+//         layerConfig.inConfs = inDataConfig;
+//         layerConfig.outConfs = outDataConfig;
+
+//         conf.push_back(layerConfig);
+//         return InferenceEngine::StatusCode::OK;
+//     }
+
+//     InferenceEngine::StatusCode init(InferenceEngine::LayerConfig& config,
+//                                      InferenceEngine::ResponseDesc *resp) noexcept
+//     {
+//         return InferenceEngine::StatusCode::OK;
+//     }
+
+// private:
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
+//     std::shared_ptr<NgraphCustomOp> node;
+// #else
+//     InferenceEngine::CNNLayer cnnLayer;
+// #endif
+//     dnn::Layer* cvLayer;
+//     std::vector<Mat> internals;
+// };
+
+// #if INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2020_2)
+// class InfEngineNgraphCustomLayerFactory : public InferenceEngine::ILayerImplFactory {
+// public:
+//     explicit InfEngineNgraphCustomLayerFactory(const InferenceEngine::CNNLayer* layer) : cnnLayer(*layer)
+//     {
+//         // nothing
+//     }
+
+//     InferenceEngine::StatusCode
+//     getImplementations(std::vector<InferenceEngine::ILayerImpl::Ptr>& impls,
+//                        InferenceEngine::ResponseDesc* resp) noexcept override
+//     {
+//         impls.push_back(std::make_shared<InfEngineNgraphCustomLayer>(cnnLayer));
+//         return InferenceEngine::StatusCode::OK;
+//     }
+
+// private:
+//     InferenceEngine::CNNLayer cnnLayer;
+// };
+// #endif
+
+
+// class InfEngineNgraphExtension : public InferenceEngine::IExtension
+// {
+// public:
+//     void Unload() noexcept override {}
+//     void Release() noexcept override { delete this; }
+//     void GetVersion(const InferenceEngine::Version*&) const noexcept override {}
+
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_2)
+//     std::vector<std::string> getImplTypes(const std::shared_ptr<ngraph::Node>& node) override {
+//         return {"CPU"};
+//     }
+
+//     InferenceEngine::ILayerImpl::Ptr getImplementation(const std::shared_ptr<ngraph::Node>& node, const std::string& implType) override {
+//         if (std::dynamic_pointer_cast<NgraphCustomOp>(node) && implType == "CPU") {
+//             // return std::make_shared<InfEngineNgraphCustomLayer>(node);
+//         }
+//         return nullptr;
+//     }
+// #else
+//     virtual void SetLogCallback(InferenceEngine::IErrorListener&) noexcept {}
+
+//     virtual InferenceEngine::StatusCode getPrimitiveTypes(char**&, unsigned int&,
+//                                                           InferenceEngine::ResponseDesc*) noexcept
+//     {
+//         return InferenceEngine::StatusCode::OK;
+//     }
+
+//     InferenceEngine::StatusCode getFactoryFor(InferenceEngine::ILayerImplFactory*& factory,
+//                                               const InferenceEngine::CNNLayer* cnnLayer,
+//                                               InferenceEngine::ResponseDesc* resp) noexcept
+//     {
+//         if (cnnLayer->type != kOpenCVLayersType)
+//             return InferenceEngine::StatusCode::NOT_IMPLEMENTED;
+//         factory = new InfEngineNgraphCustomLayerFactory(cnnLayer);
+//         return InferenceEngine::StatusCode::OK;
+//     }
+// #endif
+// };
 
 
 
@@ -340,11 +340,11 @@ InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& n
     std::ostringstream oss;
     oss << (size_t)cvLayer.get();
 
-    std::map<std::string, InferenceEngine::Parameter> params = {
-        {"impl", oss.str()},
-        {"outputs", shapesToStr(outputs)},
-        {"internals", shapesToStr(internals)}
-    };
+    // std::map<std::string, InferenceEngine::Parameter> params = {
+    //     {"impl", oss.str()},
+    //     {"outputs", shapesToStr(outputs)},
+    //     {"internals", shapesToStr(internals)}
+    // };
 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2020_3)
     ngraph::OutputVector inp_nodes;
@@ -353,7 +353,7 @@ InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& n
 #endif
     for (const auto& node : nodes)
         inp_nodes.emplace_back(node.dynamicCast<InfEngineNgraphNode>()->node);
-    node = std::make_shared<NgraphCustomOp>(inp_nodes, params);
+    // node = std::make_shared<NgraphCustomOp>(inp_nodes, params);
 
     CV_Assert(!cvLayer->name.empty());
     setName(cvLayer->name);
@@ -536,26 +536,26 @@ void InfEngineNgraphNet::init(Target targetId)
         }
         cnn = InferenceEngine::CNNNetwork(ngraph_function);
 
-        if (DNN_IE_SERIALIZE)
-        {
-#ifndef OPENCV_DNN_DISABLE_NETWORK_AUTO_DUMP
-            std::string dumpFileNameBase = netImpl_.getDumpFileNameBase();
-            try
-            {
-                cnn.serialize(dumpFileNameBase + "_ngraph.xml", dumpFileNameBase + "_ngraph.bin");
-            }
-            catch (const std::exception& e)
-            {
-                std::ofstream out((dumpFileNameBase + "_ngraph.error").c_str(), std::ios::out);
-                out << "Exception: " << e.what() << std::endl;
-            }
-            catch (...)
-            {
-                std::ofstream out((dumpFileNameBase + "_ngraph.error").c_str(), std::ios::out);
-                out << "Can't dump: unknown exception" << std::endl;
-            }
-#endif
-        }
+//         if (DNN_IE_SERIALIZE)
+//         {
+// #ifndef OPENCV_DNN_DISABLE_NETWORK_AUTO_DUMP
+//             std::string dumpFileNameBase = netImpl_.getDumpFileNameBase();
+//             try
+//             {
+//                 cnn.serialize(dumpFileNameBase + "_ngraph.xml", dumpFileNameBase + "_ngraph.bin");
+//             }
+//             catch (const std::exception& e)
+//             {
+//                 std::ofstream out((dumpFileNameBase + "_ngraph.error").c_str(), std::ios::out);
+//                 out << "Exception: " << e.what() << std::endl;
+//             }
+//             catch (...)
+//             {
+//                 std::ofstream out((dumpFileNameBase + "_ngraph.error").c_str(), std::ios::out);
+//                 out << "Can't dump: unknown exception" << std::endl;
+//             }
+// #endif
+//         }
     }
 
     switch (targetId)
@@ -588,27 +588,28 @@ void InfEngineNgraphNet::init(Target targetId)
                 auto iter = requestedOutputs.find(name);
                 if (iter != requestedOutputs.end()) {
                     requestedOutputs.erase(iter);
-                    cnn.addOutput(name);
+                    std::cout << "add putput" << name << std::endl;
+                    // cnn.addOutput(name);
                 }
             }
         }
     }
+std::cout << "ahaha" << std::endl;
+    // for (const auto& it : cnn.getInputsInfo())
+    // {
+    //     const std::string& name = it.first;
+    //     auto blobIt = allBlobs.find(name);
+    //     CV_Assert(blobIt != allBlobs.end());
+    //     it.second->setPrecision(blobIt->second->getTensorDesc().getPrecision());
+    // }
 
-    for (const auto& it : cnn.getInputsInfo())
-    {
-        const std::string& name = it.first;
-        auto blobIt = allBlobs.find(name);
-        CV_Assert(blobIt != allBlobs.end());
-        it.second->setPrecision(blobIt->second->getTensorDesc().getPrecision());
-    }
-
-    for (const auto& it : cnn.getOutputsInfo())
-    {
-        const std::string& name = it.first;
-        auto blobIt = allBlobs.find(name);
-        CV_Assert(blobIt != allBlobs.end());
-        it.second->setPrecision(blobIt->second->getTensorDesc().getPrecision());  // Should be always FP32
-    }
+    // for (const auto& it : cnn.getOutputsInfo())
+    // {
+    //     const std::string& name = it.first;
+    //     auto blobIt = allBlobs.find(name);
+    //     CV_Assert(blobIt != allBlobs.end());
+    //     it.second->setPrecision(blobIt->second->getTensorDesc().getPrecision());  // Should be always FP32
+    // }
 
     initPlugin(cnn);
 }
@@ -657,22 +658,22 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
             bool found = false;
             for (size_t i = 0; i != candidates.size(); ++i)
             {
-                const std::string& libName = candidates[i];
-                try
-                {
-                    InferenceEngine::IExtensionPtr extension =
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
-                        std::make_shared<InferenceEngine::Extension>(libName);
-#else
-                        InferenceEngine::make_so_pointer<InferenceEngine::IExtension>(libName);
-#endif
+                // const std::string& libName = candidates[i];
+//                 try
+//                 {
+//                     InferenceEngine::IExtensionPtr extension =
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
+//                         std::make_shared<InferenceEngine::Extension>(libName);
+// #else
+//                         InferenceEngine::make_so_pointer<InferenceEngine::IExtension>(libName);
+// #endif
 
-                    ie.AddExtension(extension, "CPU");
-                    CV_LOG_INFO(NULL, "DNN-IE: Loaded extension plugin: " << libName);
-                    found = true;
-                    break;
-                }
-                catch(...) {}
+//                     // ie.AddExtension(extension, "CPU");
+//                     CV_LOG_INFO(NULL, "DNN-IE: Loaded extension plugin: " << libName);
+//                     found = true;
+//                     break;
+//                 }
+//                 catch(...) {}
             }
             if (!found && !candidates.empty())
             {
@@ -682,7 +683,7 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
             // OpenCV fallbacks as extensions.
             try
             {
-                ie.AddExtension(std::make_shared<InfEngineNgraphExtension>(), "CPU");
+                // ie.AddExtension(std::make_shared<InfEngineNgraphExtension>(), "CPU");
             }
             catch(const std::exception& e)
             {
@@ -691,9 +692,9 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 #ifndef _WIN32
             // Limit the number of CPU threads.
             if (device_name == "CPU")
-                ie.SetConfig({{
-                    InferenceEngine::PluginConfigParams::KEY_CPU_THREADS_NUM, format("%d", getNumThreads()),
-                }}, device_name);
+                // ie.SetConfig({{
+                //     InferenceEngine::PluginConfigParams::KEY_CPU_THREADS_NUM, format("%d", getNumThreads()),
+                // }}, device_name);
 #endif
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_2)
             if (device_name.find("GPU") == 0)
@@ -706,9 +707,9 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
                 if (!cache_path.empty() && cache_path != "disabled")
                 {
                     CV_LOG_INFO(NULL, "OpenCV/nGraph: using GPU kernels cache: " << cache_path);
-                    ie.SetConfig({{
-                        InferenceEngine::PluginConfigParams::KEY_CACHE_DIR, cache_path,
-                    }}, device_name);
+                    // ie.SetConfig({{
+                    //     InferenceEngine::PluginConfigParams::KEY_CACHE_DIR, cache_path,
+                    // }}, device_name);
                 }
             }
 #endif
@@ -716,9 +717,9 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
         std::map<std::string, std::string> config;
         if (device_name == "MYRIAD" || device_name == "HDDL") {
 #if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
-            config.emplace("MYRIAD_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+            // config.emplace("MYRIAD_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
 #else
-            config.emplace("VPU_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+            // config.emplace("VPU_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
 #endif
         }
 
@@ -739,7 +740,7 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 
         std::string ieDevice = isHetero ? ("HETERO:" + device_name + ",CPU") : device_name;
         CV_LOG_INFO(NULL, "DNN/IE: Calling LoadNetwork(device=" << ieDevice << ")...");
-        netExec = ie.LoadNetwork(net, ieDevice, config);
+        netExec = ie.LoadNetwork(net, ieDevice);
     }
     catch (const std::exception& ex)
     {
@@ -757,28 +758,38 @@ bool NgraphBackendLayer::getMemoryShapes(const std::vector<MatShape> &inputs,
                                             std::vector<MatShape> &outputs,
                                             std::vector<MatShape> &internals) const
 {
-    InferenceEngine::ICNNNetwork::InputShapes inShapes = t_net.getInputShapes();
-    InferenceEngine::ICNNNetwork::InputShapes::iterator itr;
-    bool equal_flag = true;
-    size_t i = 0;
-    for (itr = inShapes.begin(); itr != inShapes.end(); ++itr)
-    {
-        InferenceEngine::SizeVector currentInShape(inputs[i].begin(), inputs[i].end());
-        if (itr->second != currentInShape)
-        {
-            itr->second = currentInShape;
-            equal_flag = false;
-        }
-        i++;
-    }
+    // InferenceEngine::ICNNNetwork::InputShapes inShapes = t_net.getInputShapes();
+    // InferenceEngine::ICNNNetwork::InputShapes::iterator itr;
+    // bool equal_flag = true;
+    // size_t i = 0;
+    // for (itr = inShapes.begin(); itr != inShapes.end(); ++itr)
+    // {
+    //     InferenceEngine::SizeVector currentInShape(inputs[i].begin(), inputs[i].end());
+    //     if (itr->second != currentInShape)
+    //     {
+    //         itr->second = currentInShape;
+    //         equal_flag = false;
+    //     }
+    //     i++;
+    // }
 
-    if (!equal_flag)
-    {
-        InferenceEngine::CNNNetwork curr_t_net(t_net);
-        curr_t_net.reshape(inShapes);
+    // if (!equal_flag)
+    // {
+    //     InferenceEngine::CNNNetwork curr_t_net(t_net);
+    //     curr_t_net.reshape(inShapes);
+    // }
+    for (const auto& it : t_net.getFunction()->outputs()) {
+        // std::cout << "name - " << std::endl;
+        // std::cout << it.get_node()->get_friendly_name() << std::endl;
+        // std::cout << it.get_any_name() << std::endl;
+        if (it.get_any_name() == name) {
+            auto dims = it.get_shape();
+            outputs.push_back(MatShape(dims.begin(), dims.end()));
+            return false;
+        }
     }
-    std::vector<size_t> dims = t_net.getOutputsInfo()[name]->getDims();
-    outputs.push_back(MatShape(dims.begin(), dims.end()));
+    if (outputs.empty())
+        CV_Error(Error::StsError, "Cannot find output with name " + name);
     return false;
 }
 
@@ -796,71 +807,94 @@ void NgraphBackendLayer::forward(InputArrayOfArrays inputs, OutputArrayOfArrays 
 }
 
 
-static InferenceEngine::Layout estimateLayout(int dims)
-{
-    if (dims == 4)
-        return InferenceEngine::Layout::NCHW;
-    else if (dims == 3)
-        return InferenceEngine::Layout::CHW;
-    else if (dims == 2)
-        return InferenceEngine::Layout::NC;
-    else if (dims == 1)
-        return InferenceEngine::Layout::C;
-    else if (dims == 5)
-        return InferenceEngine::Layout::NCDHW;
-    else
-        return InferenceEngine::Layout::ANY;
-}
-static inline
-InferenceEngine::Layout estimateLayout(size_t dims)
-{
-    return estimateLayout((int)dims);
-}
+// static InferenceEngine::Layout estimateLayout(int dims)
+// {
+//     if (dims == 4)
+//         return InferenceEngine::Layout::NCHW;
+//     else if (dims == 3)
+//         return InferenceEngine::Layout::CHW;
+//     else if (dims == 2)
+//         return InferenceEngine::Layout::NC;
+//     else if (dims == 1)
+//         return InferenceEngine::Layout::C;
+//     else if (dims == 5)
+//         return InferenceEngine::Layout::NCDHW;
+//     else
+//         return InferenceEngine::Layout::ANY;
+// }
+// static inline
+// InferenceEngine::Layout estimateLayout(size_t dims)
+// {
+//     return estimateLayout((int)dims);
+// }
 
-static inline
-InferenceEngine::Layout estimateLayout(const Mat& m)
-{
-    return estimateLayout(m.dims);
-}
+// static inline
+// InferenceEngine::Layout estimateLayout(const Mat& m)
+// {
+//     return estimateLayout(m.dims);
+// }
 
-static InferenceEngine::DataPtr wrapToInfEngineDataNode(const Mat& m, const std::string& name = "")
-{
+// static InferenceEngine::DataPtr wrapToInfEngineDataNode(const Mat& m, const std::string& name = "")
+// {
+//     std::vector<size_t> shape = getShape<size_t>(m);
+//     if (m.type() == CV_32F)
+//         return InferenceEngine::DataPtr(new InferenceEngine::Data(name,
+//                {InferenceEngine::Precision::FP32, shape, estimateLayout(m)}));
+//     else if (m.type() == CV_8U)
+//         return InferenceEngine::DataPtr(new InferenceEngine::Data(name,
+//                {InferenceEngine::Precision::U8, shape, estimateLayout(m)}));
+//     else
+//         CV_Error(Error::StsNotImplemented, format("Unsupported data type %s", typeToString(m.type()).c_str()));
+// }
+
+// InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, const std::vector<size_t>& shape,
+//                                                InferenceEngine::Layout layout)
+// {
+//     if (m.type() == CV_32F)
+//         return InferenceEngine::make_shared_blob<float>(
+//                {InferenceEngine::Precision::FP32, shape, layout}, (float*)m.data);
+//     else if (m.type() == CV_8U)
+//         return InferenceEngine::make_shared_blob<uint8_t>(
+//                {InferenceEngine::Precision::U8, shape, layout}, (uint8_t*)m.data);
+//     else
+//         CV_Error(Error::StsNotImplemented, format("Unsupported data type %s", typeToString(m.type()).c_str()));
+// }
+
+// InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, InferenceEngine::Layout layout)
+// {
+//     std::vector<size_t> shape = getShape<size_t>(m);
+//     return wrapToNgraphBlob(m, shape, layout);
+// }
+
+// InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, const std::vector<size_t>& shape,
+//                                                InferenceEngine::Layout layout)
+// {
+//     if (m.type() == CV_32F)
+//         return InferenceEngine::make_shared_blob<float>(
+//                {InferenceEngine::Precision::FP32, shape, layout}, (float*)m.data);
+//     else if (m.type() == CV_8U)
+//         return InferenceEngine::make_shared_blob<uint8_t>(
+//                {InferenceEngine::Precision::U8, shape, layout}, (uint8_t*)m.data);
+//     else
+//         CV_Error(Error::StsNotImplemented, format("Unsupported data type %s", typeToString(m.type()).c_str()));
+// }
+
+ov::Tensor wrapToTensor(const Mat& m) {
+    std::cout << "wrapToTensor " << (void*)m.data << std::endl;
     std::vector<size_t> shape = getShape<size_t>(m);
     if (m.type() == CV_32F)
-        return InferenceEngine::DataPtr(new InferenceEngine::Data(name,
-               {InferenceEngine::Precision::FP32, shape, estimateLayout(m)}));
+        return ov::Tensor(ov::element::f32, shape, m.data);
     else if (m.type() == CV_8U)
-        return InferenceEngine::DataPtr(new InferenceEngine::Data(name,
-               {InferenceEngine::Precision::U8, shape, estimateLayout(m)}));
+        return ov::Tensor(ov::element::u8, shape, m.data);
     else
         CV_Error(Error::StsNotImplemented, format("Unsupported data type %s", typeToString(m.type()).c_str()));
-}
-
-InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, const std::vector<size_t>& shape,
-                                               InferenceEngine::Layout layout)
-{
-    if (m.type() == CV_32F)
-        return InferenceEngine::make_shared_blob<float>(
-               {InferenceEngine::Precision::FP32, shape, layout}, (float*)m.data);
-    else if (m.type() == CV_8U)
-        return InferenceEngine::make_shared_blob<uint8_t>(
-               {InferenceEngine::Precision::U8, shape, layout}, (uint8_t*)m.data);
-    else
-        CV_Error(Error::StsNotImplemented, format("Unsupported data type %s", typeToString(m.type()).c_str()));
-}
-
-InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, InferenceEngine::Layout layout)
-{
-    std::vector<size_t> shape = getShape<size_t>(m);
-    return wrapToNgraphBlob(m, shape, layout);
 }
 
 NgraphBackendWrapper::NgraphBackendWrapper(int targetId, const cv::Mat& m)
     : BackendWrapper(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH, targetId)
     , host((Mat*)&m)
 {
-    dataPtr = wrapToInfEngineDataNode(m);
-    blob = wrapToNgraphBlob(m, estimateLayout(m));
+    blob = wrapToTensor(m);
 }
 
 NgraphBackendWrapper::NgraphBackendWrapper(Ptr<BackendWrapper> wrapper)
@@ -868,8 +902,7 @@ NgraphBackendWrapper::NgraphBackendWrapper(Ptr<BackendWrapper> wrapper)
 {
     Ptr<NgraphBackendWrapper> ieWrapper = wrapper.dynamicCast<NgraphBackendWrapper>();
     CV_Assert(!ieWrapper.empty());
-    InferenceEngine::DataPtr srcData = ieWrapper->dataPtr;
-    dataPtr = InferenceEngine::DataPtr(new InferenceEngine::Data(srcData->getName(), srcData->getTensorDesc()));
+    name = ieWrapper->name;
     blob = ieWrapper->blob;
 }
 
@@ -895,111 +928,111 @@ void NgraphBackendWrapper::setHostDirty()
     //CV_Error(Error::StsNotImplemented, "");
 }
 
-InferenceEngine::Blob::Ptr copyBlob(const InferenceEngine::Blob::Ptr& blob)
-{
-    InferenceEngine::Blob::Ptr copy;
-    auto description = blob->getTensorDesc();
-    InferenceEngine::Precision precision = description.getPrecision();
-    if (precision == InferenceEngine::Precision::FP32)
-    {
-        copy = InferenceEngine::make_shared_blob<float>(description);
-    }
-    else if (precision == InferenceEngine::Precision::U8)
-    {
-        copy = InferenceEngine::make_shared_blob<uint8_t>(description);
-    }
-    else
-    {
-        std::ostringstream msg;
-        msg << precision;
-        CV_Error_(Error::StsNotImplemented, ("Unsupported blob precision: %s", msg.str().c_str()));
-    }
-    copy->allocate();
-    return copy;
-}
+// InferenceEngine::Blob::Ptr copyBlob(const InferenceEngine::Blob::Ptr& blob)
+// {
+//     InferenceEngine::Blob::Ptr copy;
+//     auto description = blob->getTensorDesc();
+//     InferenceEngine::Precision precision = description.getPrecision();
+//     if (precision == InferenceEngine::Precision::FP32)
+//     {
+//         copy = InferenceEngine::make_shared_blob<float>(description);
+//     }
+//     else if (precision == InferenceEngine::Precision::U8)
+//     {
+//         copy = InferenceEngine::make_shared_blob<uint8_t>(description);
+//     }
+//     else
+//     {
+//         std::ostringstream msg;
+//         msg << precision;
+//         CV_Error_(Error::StsNotImplemented, ("Unsupported blob precision: %s", msg.str().c_str()));
+//     }
+//     copy->allocate();
+//     return copy;
+// }
 
-InferenceEngine::DataPtr ngraphDataNode(const Ptr<BackendWrapper>& ptr)
-{
-    CV_Assert(!ptr.empty());
-    Ptr<NgraphBackendWrapper> p = ptr.dynamicCast<NgraphBackendWrapper>();
-    CV_Assert(!p.empty());
-    return p->dataPtr;
-}
+// InferenceEngine::DataPtr ngraphDataNode(const Ptr<BackendWrapper>& ptr)
+// {
+//     CV_Assert(!ptr.empty());
+//     Ptr<NgraphBackendWrapper> p = ptr.dynamicCast<NgraphBackendWrapper>();
+//     CV_Assert(!p.empty());
+//     return p->dataPtr;
+// }
 
-static
-InferenceEngine::Blob::Ptr reallocateBlob(Mat &m, const InferenceEngine::TensorDesc& description)
-{
-    auto dims = description.getDims();
-    auto layout = estimateLayout(dims.size());
-    MatShape matShape(dims.begin(), dims.end());
-    if (description.getPrecision() == InferenceEngine::Precision::FP32)
-    {
-        m.create(matShape, CV_32FC1);
-        return InferenceEngine::make_shared_blob<float>(
-                {description.getPrecision(), dims, layout}, (float*)m.data);
-    }
-    else if (description.getPrecision() == InferenceEngine::Precision::I32)
-    {
-        m.create(matShape, CV_32SC1);
-        return InferenceEngine::make_shared_blob<int>(
-                {description.getPrecision(), dims, layout}, (int*)m.data);
-    }
-    else if (description.getPrecision() == InferenceEngine::Precision::U8)
-    {
-        m.create(matShape, CV_8UC1);
-        return InferenceEngine::make_shared_blob<uchar>(
-                {description.getPrecision(), dims, layout}, (uchar*)m.data);
-    }
-    std::ostringstream msg;
-    msg << "Unsupported IE precision: " << description.getPrecision();
-    CV_Error(Error::StsNotImplemented, msg.str());
-}
+// static
+// InferenceEngine::Blob::Ptr reallocateBlob(Mat &m, const InferenceEngine::TensorDesc& description)
+// {
+//     auto dims = description.getDims();
+//     auto layout = estimateLayout(dims.size());
+//     MatShape matShape(dims.begin(), dims.end());
+//     if (description.getPrecision() == InferenceEngine::Precision::FP32)
+//     {
+//         m.create(matShape, CV_32FC1);
+//         return InferenceEngine::make_shared_blob<float>(
+//                 {description.getPrecision(), dims, layout}, (float*)m.data);
+//     }
+//     else if (description.getPrecision() == InferenceEngine::Precision::I32)
+//     {
+//         m.create(matShape, CV_32SC1);
+//         return InferenceEngine::make_shared_blob<int>(
+//                 {description.getPrecision(), dims, layout}, (int*)m.data);
+//     }
+//     else if (description.getPrecision() == InferenceEngine::Precision::U8)
+//     {
+//         m.create(matShape, CV_8UC1);
+//         return InferenceEngine::make_shared_blob<uchar>(
+//                 {description.getPrecision(), dims, layout}, (uchar*)m.data);
+//     }
+//     std::ostringstream msg;
+//     msg << "Unsupported IE precision: " << description.getPrecision();
+//     CV_Error(Error::StsNotImplemented, msg.str());
+// }
 
-InferenceEngine::DataPtr ngraphDataOutputNode(
-        const Ptr<BackendWrapper>& ptr,
-        const InferenceEngine::TensorDesc& description,
-        const std::string name)
-{
-    CV_Assert(!ptr.empty());
-    Ptr<NgraphBackendWrapper> p = ptr.dynamicCast<NgraphBackendWrapper>();
-    CV_Assert(!p.empty());
-    NgraphBackendWrapper& w = *p;
-    const InferenceEngine::TensorDesc& blobDesc = w.blob.get()->getTensorDesc();
-    auto dims = description.getDims();
-    bool reallocate = false;
-    if (blobDesc.getPrecision() != description.getPrecision())
-    {
-        reallocate = true;
-        CV_LOG_WARNING(NULL, "Reallocate output '" << name << "' blob due to wrong precision: " << blobDesc.getPrecision() << " => " << description.getPrecision() << "  ndims=" << dims.size());
-    }
-    if (dims.size() != blobDesc.getDims().size())
-    {
-        reallocate = true;
-        CV_LOG_WARNING(NULL, "Reallocate output '" << name << "' blob due to wrong dims: " << blobDesc.getDims().size() << " => " << dims.size());
-    }
-    if (reallocate)
-    {
-        auto layout = estimateLayout(dims.size());
-        w.dataPtr = InferenceEngine::DataPtr(new InferenceEngine::Data(name,
-               {description.getPrecision(), dims, layout}));
-        w.blob = reallocateBlob(*w.host, description);
-    }
-    return w.dataPtr;
-}
+// InferenceEngine::DataPtr ngraphDataOutputNode(
+//         const Ptr<BackendWrapper>& ptr,
+//         const InferenceEngine::TensorDesc& description,
+//         const std::string name)
+// {
+//     CV_Assert(!ptr.empty());
+//     Ptr<NgraphBackendWrapper> p = ptr.dynamicCast<NgraphBackendWrapper>();
+//     CV_Assert(!p.empty());
+//     NgraphBackendWrapper& w = *p;
+//     const InferenceEngine::TensorDesc& blobDesc = w.blob.get()->getTensorDesc();
+//     auto dims = description.getDims();
+//     bool reallocate = false;
+//     if (blobDesc.getPrecision() != description.getPrecision())
+//     {
+//         reallocate = true;
+//         CV_LOG_WARNING(NULL, "Reallocate output '" << name << "' blob due to wrong precision: " << blobDesc.getPrecision() << " => " << description.getPrecision() << "  ndims=" << dims.size());
+//     }
+//     if (dims.size() != blobDesc.getDims().size())
+//     {
+//         reallocate = true;
+//         CV_LOG_WARNING(NULL, "Reallocate output '" << name << "' blob due to wrong dims: " << blobDesc.getDims().size() << " => " << dims.size());
+//     }
+//     if (reallocate)
+//     {
+//         auto layout = estimateLayout(dims.size());
+//         w.dataPtr = InferenceEngine::DataPtr(new InferenceEngine::Data(name,
+//                {description.getPrecision(), dims, layout}));
+//         w.blob = reallocateBlob(*w.host, description);
+//     }
+//     return w.dataPtr;
+// }
 
 
 void InfEngineNgraphNet::reset()
 {
     allBlobs.clear();
-    infRequests.clear();
-    isInit = false;
+    // infRequests.clear();
+    // isInit = false;
 
-    outputsDesc.clear();
-    for (const auto& it : cnn.getOutputsInfo())
-    {
-        const std::string& name = it.first;
-        outputsDesc.insert({name, it.second->getTensorDesc()});
-    }
+    // outputsDesc.clear();
+    // for (const auto& it : cnn.getOutputsInfo())
+    // {
+    //     const std::string& name = it.first;
+    //     outputsDesc.insert({name, it.second->getTensorDesc()});
+    // }
 }
 
 void InfEngineNgraphNet::addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs)
@@ -1007,7 +1040,7 @@ void InfEngineNgraphNet::addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& p
     auto wrappers = ngraphWrappers(ptrs);
     for (const auto& wrapper : wrappers)
     {
-        std::string name = wrapper->dataPtr->getName();
+        std::string name = wrapper->name;
         name = name.empty() ? kDefaultInpLayerName : name;
         allBlobs.insert({name, wrapper->blob});
     }
@@ -1022,26 +1055,26 @@ void InfEngineNgraphNet::NgraphReqWrapper::makePromises(const std::vector<Ptr<Ba
     for (int i = 0; i < outs.size(); ++i)
     {
         outs[i]->futureMat = outProms[i].getArrayResult();
-        outsNames[i] = outs[i]->dataPtr->getName();
+        outsNames[i] = outs[i]->name;
     }
 }
 
-Mat ngraphBlobToMat(const InferenceEngine::Blob::Ptr& blob)
-{
-    std::vector<size_t> dims = blob->getTensorDesc().getDims();
-    std::vector<int> size(dims.begin(), dims.end());
-    auto precision = blob->getTensorDesc().getPrecision();
+// Mat ngraphBlobToMat(const InferenceEngine::Blob::Ptr& blob)
+// {
+//     std::vector<size_t> dims = blob->getTensorDesc().getDims();
+//     std::vector<int> size(dims.begin(), dims.end());
+//     auto precision = blob->getTensorDesc().getPrecision();
 
-    int type = -1;
-    switch (precision)
-    {
-        case InferenceEngine::Precision::FP32: type = CV_32F; break;
-        case InferenceEngine::Precision::U8: type = CV_8U; break;
-        default:
-            CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
-    }
-    return Mat(size, type, (void*)blob->buffer());
-}
+//     int type = -1;
+//     switch (precision)
+//     {
+//         case InferenceEngine::Precision::FP32: type = CV_32F; break;
+//         case InferenceEngine::Precision::U8: type = CV_8U; break;
+//         default:
+//             CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
+//     }
+//     return Mat(size, type, (void*)blob->buffer());
+// }
 
 void InfEngineNgraphNet::forward(const std::vector<Ptr<BackendWrapper> >& outBlobsWrappers, bool isAsync)
 {
@@ -1062,7 +1095,7 @@ void InfEngineNgraphNet::forward(const std::vector<Ptr<BackendWrapper> >& outBlo
         reqWrapper = Ptr<NgraphReqWrapper>(new NgraphReqWrapper());
         try
         {
-            reqWrapper->req = netExec.CreateInferRequest();
+            reqWrapper->req = netExec.create_infer_request();
         }
         catch (const std::exception& ex)
         {
@@ -1070,6 +1103,30 @@ void InfEngineNgraphNet::forward(const std::vector<Ptr<BackendWrapper> >& outBlo
         }
         infRequests.push_back(reqWrapper);
 
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+        for (const auto& it : cnn.getFunction()->inputs())
+        {
+            const std::string& name = it.get_any_name();
+            auto blobIt = allBlobs.find(name);
+            CV_Assert(blobIt != allBlobs.end());
+
+std::cout << 1 << std::endl;
+            reqWrapper->req.set_tensor(name, blobIt->second);
+std::cout << 2 << std::endl;
+            
+            // inpBlobs[name] = isAsync ? copyBlob(blobIt->second) : blobIt->second;
+        }
+        for (const auto& it : cnn.getFunction()->outputs())
+        {
+            const std::string& name = it.get_any_name();
+            auto blobIt = allBlobs.find(name);
+            CV_Assert(blobIt != allBlobs.end());
+            // outBlobs[name] = isAsync ? copyBlob(blobIt->second) : blobIt->second;
+std::cout << 3 << std::endl;
+            reqWrapper->req.set_tensor(name, blobIt->second);
+std::cout << 4 << std::endl;
+        }
+#else
         InferenceEngine::BlobMap inpBlobs, outBlobs;
         for (const auto& it : cnn.getInputsInfo())
         {
@@ -1087,99 +1144,101 @@ void InfEngineNgraphNet::forward(const std::vector<Ptr<BackendWrapper> >& outBlo
         }
         reqWrapper->req.SetInput(inpBlobs);
         reqWrapper->req.SetOutput(outBlobs);
-
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
-        InferenceEngine::InferRequest infRequest = reqWrapper->req;
-        NgraphReqWrapper* wrapperPtr = reqWrapper.get();
-        CV_Assert(wrapperPtr && "Internal error");
-#else
-        InferenceEngine::IInferRequest::Ptr infRequestPtr = reqWrapper->req;
-        CV_Assert(infRequestPtr);
-        InferenceEngine::IInferRequest& infRequest = *infRequestPtr.get();
-        infRequest.SetUserData(reqWrapper.get(), 0);
 #endif
 
-#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
-        // do NOT capture 'reqWrapper' (smart ptr) in the lambda callback
-        infRequest.SetCompletionCallback<std::function<void(InferenceEngine::InferRequest, InferenceEngine::StatusCode)>>(
-            [wrapperPtr](InferenceEngine::InferRequest /*request*/, InferenceEngine::StatusCode status)
-#else
-        infRequest.SetCompletionCallback(
-            [](InferenceEngine::IInferRequest::Ptr requestPtr, InferenceEngine::StatusCode status)
-#endif
-            {
-                CV_LOG_DEBUG(NULL, "DNN(nGraph): completionCallback(" << (int)status << ")");
-#if !INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
-                CV_Assert(requestPtr);
-                InferenceEngine::IInferRequest& request = *requestPtr.get();
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
+//         InferenceEngine::InferRequest infRequest = reqWrapper->req;
+//         NgraphReqWrapper* wrapperPtr = reqWrapper.get();
+//         CV_Assert(wrapperPtr && "Internal error");
+// #else
+//         InferenceEngine::IInferRequest::Ptr infRequestPtr = reqWrapper->req;
+//         CV_Assert(infRequestPtr);
+//         InferenceEngine::IInferRequest& infRequest = *infRequestPtr.get();
+//         infRequest.SetUserData(reqWrapper.get(), 0);
+// #endif
 
-                NgraphReqWrapper* wrapperPtr;
-                request.GetUserData((void**)&wrapperPtr, 0);
-                CV_Assert(wrapperPtr && "Internal error");
-#endif
-                NgraphReqWrapper& wrapper = *wrapperPtr;
+// #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
+//         // do NOT capture 'reqWrapper' (smart ptr) in the lambda callback
+//         // infRequest.SetCompletionCallback<std::function<void(InferenceEngine::InferRequest, InferenceEngine::StatusCode)>>(
+//             // [wrapperPtr](InferenceEngine::InferRequest /*request*/, InferenceEngine::StatusCode status)
+// #else
+//         infRequest.SetCompletionCallback(
+//             [](InferenceEngine::IInferRequest::Ptr requestPtr, InferenceEngine::StatusCode status)
+// #endif
+//             {
+//                 CV_LOG_DEBUG(NULL, "DNN(nGraph): completionCallback(" << (int)status << ")");
+// #if !INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_4)
+//                 CV_Assert(requestPtr);
+//                 InferenceEngine::IInferRequest& request = *requestPtr.get();
 
-                size_t processedOutputs = 0;
-                try
-                {
-                    for (; processedOutputs < wrapper.outProms.size(); ++processedOutputs)
-                    {
-                        const std::string& name = wrapper.outsNames[processedOutputs];
-                        Mat m = ngraphBlobToMat(wrapper.req.GetBlob(name));
+//                 NgraphReqWrapper* wrapperPtr;
+//                 request.GetUserData((void**)&wrapperPtr, 0);
+//                 CV_Assert(wrapperPtr && "Internal error");
+// #endif
+//                 NgraphReqWrapper& wrapper = *wrapperPtr;
 
-                        try
-                        {
-                            CV_Assert(status == InferenceEngine::StatusCode::OK);
-                            wrapper.outProms[processedOutputs].setValue(m.clone());
-                        }
-                        catch (...)
-                        {
-                            try {
-                                wrapper.outProms[processedOutputs].setException(std::current_exception());
-                            } catch(...) {
-                                CV_LOG_ERROR(NULL, "DNN: Exception occurred during async inference exception propagation");
-                            }
-                        }
-                    }
-                }
-                catch (...)
-                {
-                    std::exception_ptr e = std::current_exception();
-                    for (; processedOutputs < wrapper.outProms.size(); ++processedOutputs)
-                    {
-                        try {
-                            wrapper.outProms[processedOutputs].setException(e);
-                        } catch(...) {
-                            CV_LOG_ERROR(NULL, "DNN: Exception occurred during async inference exception propagation");
-                        }
-                    }
-                }
-                wrapper.isReady = true;
-            }
-        );
+//                 size_t processedOutputs = 0;
+//                 try
+//                 {
+//                     for (; processedOutputs < wrapper.outProms.size(); ++processedOutputs)
+//                     {
+//                         const std::string& name = wrapper.outsNames[processedOutputs];
+//                         // Mat m = ngraphBlobToMat(wrapper.req.GetBlob(name));
+//                         Mat m;
+
+//                         try
+//                         {
+//                             CV_Assert(status == InferenceEngine::StatusCode::OK);
+//                             wrapper.outProms[processedOutputs].setValue(m.clone());
+//                         }
+//                         catch (...)
+//                         {
+//                             try {
+//                                 wrapper.outProms[processedOutputs].setException(std::current_exception());
+//                             } catch(...) {
+//                                 CV_LOG_ERROR(NULL, "DNN: Exception occurred during async inference exception propagation");
+//                             }
+//                         }
+//                     }
+//                 }
+//                 catch (...)
+//                 {
+//                     std::exception_ptr e = std::current_exception();
+//                     for (; processedOutputs < wrapper.outProms.size(); ++processedOutputs)
+//                     {
+//                         try {
+//                             wrapper.outProms[processedOutputs].setException(e);
+//                         } catch(...) {
+//                             CV_LOG_ERROR(NULL, "DNN: Exception occurred during async inference exception propagation");
+//                         }
+//                     }
+//                 }
+//                 wrapper.isReady = true;
+//             }
+//         );
     }
 
     if (isAsync)
     {
         // Copy actual data to infer request's input blobs.
-        for (const auto& it : cnn.getInputsInfo())
-        {
-            const std::string& name = it.first;
-            auto blobIt = allBlobs.find(name);
-            Mat srcMat = ngraphBlobToMat(blobIt->second);
-            Mat dstMat = ngraphBlobToMat(reqWrapper->req.GetBlob(name));
-            srcMat.copyTo(dstMat);
-        }
+        // for (const auto& it : cnn.getInputsInfo())
+        // {
+        //     const std::string& name = it.first;
+        //     auto blobIt = allBlobs.find(name);
+        //     Mat srcMat = ngraphBlobToMat(blobIt->second);
+        //     Mat dstMat = ngraphBlobToMat(reqWrapper->req.GetBlob(name));
+        //     srcMat.copyTo(dstMat);
+        // }
 
         // Set promises to output blobs wrappers.
         reqWrapper->makePromises(outBlobsWrappers);
 
         reqWrapper->isReady = false;
-        reqWrapper->req.StartAsync();
+        // reqWrapper->req.StartAsync();
     }
     else
     {
-        reqWrapper->req.Infer();
+        reqWrapper->req.infer();
     }
 }
 

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -797,9 +797,9 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
         std::map<std::string, std::string> config;
         if (device_name == "MYRIAD" || device_name == "HDDL") {
 #if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
-            // config.emplace("MYRIAD_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+            config.emplace("MYRIAD_DETECT_NETWORK_BATCH", "NO");
 #else
-            // config.emplace("VPU_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+            config.emplace("VPU_DETECT_NETWORK_BATCH", "NO");
 #endif
         }
 
@@ -820,7 +820,7 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 
         std::string ieDevice = isHetero ? ("HETERO:" + device_name + ",CPU") : device_name;
         CV_LOG_INFO(NULL, "DNN/IE: Calling LoadNetwork(device=" << ieDevice << ")...");
-        netExec = ie.LoadNetwork(net, ieDevice);
+        netExec = ie.LoadNetwork(net, ieDevice, config);
     }
     catch (const std::exception& ex)
     {

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -499,9 +499,13 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
 #ifndef _WIN32
             // Limit the number of CPU threads.
             if (device_name == "CPU")
-                // ie.SetConfig({{
-                //     InferenceEngine::PluginConfigParams::KEY_CPU_THREADS_NUM, format("%d", getNumThreads()),
-                // }}, device_name);
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+                ie.set_property(device_name, ov::inference_num_threads(getNumThreads()));
+#else
+                ie.SetConfig({{
+                    InferenceEngine::PluginConfigParams::KEY_CPU_THREADS_NUM, format("%d", getNumThreads()),
+                }}, device_name);
+#endif // OpenVINO >= 2022.1
 #endif
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2021_2)
             if (device_name.find("GPU") == 0)
@@ -514,9 +518,13 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
                 if (!cache_path.empty() && cache_path != "disabled")
                 {
                     CV_LOG_INFO(NULL, "OpenCV/nGraph: using GPU kernels cache: " << cache_path);
-                    // ie.SetConfig({{
-                    //     InferenceEngine::PluginConfigParams::KEY_CACHE_DIR, cache_path,
-                    // }}, device_name);
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+                    ie.set_property(device_name, ov::cache_dir(cache_path));
+#else
+                    ie.SetConfig({{
+                        InferenceEngine::PluginConfigParams::KEY_CACHE_DIR, cache_path,
+                    }}, device_name);
+#endif // OpenVINO >= 2022.1
                 }
             }
 #endif

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -337,9 +337,9 @@ InfEngineNgraphNode::InfEngineNgraphNode(const std::vector<Ptr<BackendNode> >& n
                                          std::vector<Mat>& outputs, std::vector<Mat>& internals)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH), cvLayer(cvLayer_)
 {
+    CV_Error(Error::StsNotImplemented, "Custom layer");
     std::ostringstream oss;
     oss << (size_t)cvLayer.get();
-
     // std::map<std::string, InferenceEngine::Parameter> params = {
     //     {"impl", oss.str()},
     //     {"outputs", shapesToStr(outputs)},

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -671,8 +671,11 @@ void InfEngineNgraphNet::init(Target targetId)
 
         // A workaround for single dimension output for which OpenCV allocates 2d Mat.
         // For example, face-detection-0105 with Result of shape {200} while output blob is {200, 1}
-        if (it.get_shape() != src.get_shape()) {
-            allBlobs[name] = ov::Tensor(src.get_element_type(), it.get_shape(), src.data());
+        auto outShape = it.get_partial_shape().get_max_shape();
+        if (outShape != src.get_shape()) {
+            size_t sz = std::accumulate(outShape.begin(), outShape.end(), 1, std::multiplies<size_t>());
+            CV_Assert(sz == src.get_size());
+            allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
         ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -655,6 +655,7 @@ void InfEngineNgraphNet::init(Target targetId)
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
     auto model = cnn.getFunction();
     ov::preprocess::PrePostProcessor ppp(model);
+    int i = 0;
     for (const auto& inp : model->inputs()) {  // TODO: not sure why but ngraph_function->inputs() here causes segfault.
         const std::string& name = inp.get_node()->get_friendly_name();
         auto blobIt = allBlobs.find(name);
@@ -662,11 +663,11 @@ void InfEngineNgraphNet::init(Target targetId)
 
         auto srcT = blobIt->second.get_element_type();
         if (srcT != inp.get_node()->get_element_type()) {
-            ppp.input(name).tensor().set_element_type(srcT);
+            ppp.input(i++).tensor().set_element_type(srcT);
         }
     }
 
-    int i = 0;
+    i = 0;
     for (const auto& it : model->outputs())
     {
         const std::string& name = it.get_node()->get_friendly_name();

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -67,8 +67,9 @@ public:
     std::vector<std::vector<std::shared_ptr<ngraph::Node>>> components;
     std::unordered_map<std::string, std::shared_ptr<ngraph::Node>* > all_nodes;
 
-    InferenceEngine::ExecutableNetwork netExec;
-    InferenceEngine::BlobMap allBlobs;
+    // InferenceEngine::ExecutableNetwork netExec;
+    ov::CompiledModel netExec;
+    std::map<std::string, ov::Tensor> allBlobs;
     std::string device_name;
     bool isInit = false;
 
@@ -78,7 +79,7 @@ public:
 
         void makePromises(const std::vector<Ptr<BackendWrapper> >& outs);
 
-        InferenceEngine::InferRequest req;
+        ov::InferRequest req;
         std::vector<cv::AsyncPromise> outProms;
         std::vector<std::string> outsNames;
         bool isReady;
@@ -89,7 +90,7 @@ public:
     bool hasNetOwner;
     std::unordered_map<std::string, Ptr<InfEngineNgraphNode> > requestedOutputs;
 
-    std::map<std::string, InferenceEngine::TensorDesc> outputsDesc;
+    // std::map<std::string, InferenceEngine::TensorDesc> outputsDesc;
 };
 
 class InfEngineNgraphNode : public BackendNode
@@ -123,16 +124,17 @@ public:
     virtual void setHostDirty() CV_OVERRIDE;
 
     Mat* host;
-    InferenceEngine::DataPtr dataPtr;
-    InferenceEngine::Blob::Ptr blob;
+    std::string name;
+    ov::Tensor blob;
+    // InferenceEngine::Blob::Ptr blob;
     AsyncArray futureMat;
 };
 
-InferenceEngine::DataPtr ngraphDataNode(const Ptr<BackendWrapper>& ptr);
-InferenceEngine::DataPtr ngraphDataOutputNode(
-        const Ptr<BackendWrapper>& ptr,
-        const InferenceEngine::TensorDesc& description,
-        const std::string name);
+// InferenceEngine::DataPtr ngraphDataNode(const Ptr<BackendWrapper>& ptr);
+// InferenceEngine::DataPtr ngraphDataOutputNode(
+//         const Ptr<BackendWrapper>& ptr,
+//         const InferenceEngine::TensorDesc& description,
+//         const std::string name);
 
 // This is a fake class to run networks from Model Optimizer. Objects of that
 // class simulate responses of layers are imported by OpenCV and supported by

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -68,7 +68,11 @@ public:
     std::unordered_map<std::string, std::shared_ptr<ngraph::Node>* > all_nodes;
 
     InferenceEngine::ExecutableNetwork netExec;
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
     std::map<std::string, ov::Tensor> allBlobs;
+#else
+    InferenceEngine::BlobMap allBlobs;
+#endif
     std::string device_name;
     bool isInit = false;
 
@@ -88,8 +92,6 @@ public:
     InferenceEngine::CNNNetwork cnn;
     bool hasNetOwner;
     std::unordered_map<std::string, Ptr<InfEngineNgraphNode> > requestedOutputs;
-
-    // std::map<std::string, InferenceEngine::TensorDesc> outputsDesc;
 };
 
 class InfEngineNgraphNode : public BackendNode

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -134,12 +134,6 @@ public:
     AsyncArray futureMat;
 };
 
-// InferenceEngine::DataPtr ngraphDataNode(const Ptr<BackendWrapper>& ptr);
-// InferenceEngine::DataPtr ngraphDataOutputNode(
-//         const Ptr<BackendWrapper>& ptr,
-//         const InferenceEngine::TensorDesc& description,
-//         const std::string name);
-
 // This is a fake class to run networks from Model Optimizer. Objects of that
 // class simulate responses of layers are imported by OpenCV and supported by
 // Inference Engine. The main difference is that they do not perform forward pass.

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -67,8 +67,7 @@ public:
     std::vector<std::vector<std::shared_ptr<ngraph::Node>>> components;
     std::unordered_map<std::string, std::shared_ptr<ngraph::Node>* > all_nodes;
 
-    // InferenceEngine::ExecutableNetwork netExec;
-    ov::CompiledModel netExec;
+    InferenceEngine::ExecutableNetwork netExec;
     std::map<std::string, ov::Tensor> allBlobs;
     std::string device_name;
     bool isInit = false;
@@ -79,7 +78,7 @@ public:
 
         void makePromises(const std::vector<Ptr<BackendWrapper> >& outs);
 
-        ov::InferRequest req;
+        InferenceEngine::InferRequest req;
         std::vector<cv::AsyncPromise> outProms;
         std::vector<std::string> outsNames;
         bool isReady;
@@ -125,8 +124,11 @@ public:
 
     Mat* host;
     std::string name;
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
     ov::Tensor blob;
-    // InferenceEngine::Blob::Ptr blob;
+#else
+    InferenceEngine::Blob::Ptr blob;
+#endif
     AsyncArray futureMat;
 };
 

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -91,7 +91,7 @@ public:
 
     InferenceEngine::CNNNetwork cnn;
     bool hasNetOwner;
-    std::unordered_map<std::string, Ptr<InfEngineNgraphNode> > requestedOutputs;
+    std::unordered_map<std::string, InfEngineNgraphNode*> requestedOutputs;
 };
 
 class InfEngineNgraphNode : public BackendNode

--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -403,6 +403,7 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
+        CV_Error(Error::StsNotImplemented, "Concat layer");
         // InferenceEngine::DataPtr data = ngraphDataNode(inputs[0]);
         // const int numDims = data->getDims().size();
         // const int numDims = 4;

--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -403,46 +403,47 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        InferenceEngine::DataPtr data = ngraphDataNode(inputs[0]);
-        const int numDims = data->getDims().size();
-        const int cAxis = normalize_axis(axis, numDims);
-        std::vector<size_t> maxDims(numDims, 0);
+        // InferenceEngine::DataPtr data = ngraphDataNode(inputs[0]);
+        // const int numDims = data->getDims().size();
+        // const int numDims = 4;
+        // const int cAxis = normalize_axis(axis, numDims);
+        // std::vector<size_t> maxDims(numDims, 0);
 
-        CV_Assert(inputs.size() == nodes.size());
-        ngraph::OutputVector inp_nodes;
-        for (int i = 0; i < nodes.size(); ++i)
-        {
-            inp_nodes.push_back(nodes[i].dynamicCast<InfEngineNgraphNode>()->node);
+        // CV_Assert(inputs.size() == nodes.size());
+        // ngraph::OutputVector inp_nodes;
+        // for (int i = 0; i < nodes.size(); ++i)
+        // {
+        //     inp_nodes.push_back(nodes[i].dynamicCast<InfEngineNgraphNode>()->node);
 
-            std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
-            for (int i = 0; i < numDims; ++i)
-                maxDims[i] = std::max(maxDims[i], inpShape[i]);
-        }
-        for (int i = 0; i < inp_nodes.size(); ++i)
-        {
-            bool needPadding = false;
-            std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
-            std::vector<int64_t> begins(inpShape.size(), 0), ends(inpShape.size(), 0);
-            for (int j = 0; j < inpShape.size(); ++j)
-            {
-                if (j != cAxis && inpShape[j] != maxDims[j])
-                {
-                    needPadding = true;
-                    begins[j] = static_cast<int64_t>((maxDims[j] - inpShape[j]) / 2);
-                    ends[j] = static_cast<int64_t>(maxDims[j] - inpShape[j] - begins[j]);
-                }
-            }
-            if (needPadding)
-            {
-                inp_nodes[i] = std::make_shared<ngraph::op::v1::Pad>(
-                    inp_nodes[i],
-                    std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{begins.size()}, begins.data()),
-                    std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{ends.size()}, ends.data()),
-                    ngraph::op::PadMode::CONSTANT);
-            }
-        }
-        auto concat = std::make_shared<ngraph::op::Concat>(inp_nodes, cAxis);
-        return Ptr<BackendNode>(new InfEngineNgraphNode(concat));
+        //     std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
+        //     for (int i = 0; i < numDims; ++i)
+        //         maxDims[i] = std::max(maxDims[i], inpShape[i]);
+        // }
+        // for (int i = 0; i < inp_nodes.size(); ++i)
+        // {
+        //     bool needPadding = false;
+        //     std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
+        //     std::vector<int64_t> begins(inpShape.size(), 0), ends(inpShape.size(), 0);
+        //     for (int j = 0; j < inpShape.size(); ++j)
+        //     {
+        //         if (j != cAxis && inpShape[j] != maxDims[j])
+        //         {
+        //             needPadding = true;
+        //             begins[j] = static_cast<int64_t>((maxDims[j] - inpShape[j]) / 2);
+        //             ends[j] = static_cast<int64_t>(maxDims[j] - inpShape[j] - begins[j]);
+        //         }
+        //     }
+        //     if (needPadding)
+        //     {
+        //         inp_nodes[i] = std::make_shared<ngraph::op::v1::Pad>(
+        //             inp_nodes[i],
+        //             std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{begins.size()}, begins.data()),
+        //             std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{ends.size()}, ends.data()),
+        //             ngraph::op::PadMode::CONSTANT);
+        //     }
+        // }
+        // auto concat = std::make_shared<ngraph::op::Concat>(inp_nodes, cAxis);
+        // return Ptr<BackendNode>(new InfEngineNgraphNode(concat));
     }
 #endif  // HAVE_DNN_NGRAPH
 

--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -403,48 +403,46 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        CV_Error(Error::StsNotImplemented, "Concat layer");
-        // InferenceEngine::DataPtr data = ngraphDataNode(inputs[0]);
-        // const int numDims = data->getDims().size();
-        // const int numDims = 4;
-        // const int cAxis = normalize_axis(axis, numDims);
-        // std::vector<size_t> maxDims(numDims, 0);
+        const int numDims = nodes[0].dynamicCast<InfEngineNgraphNode>()->node->get_shape().size();
+        const int cAxis = normalize_axis(axis, numDims);
+        std::vector<size_t> maxDims(numDims, 0);
 
-        // CV_Assert(inputs.size() == nodes.size());
-        // ngraph::OutputVector inp_nodes;
-        // for (int i = 0; i < nodes.size(); ++i)
-        // {
-        //     inp_nodes.push_back(nodes[i].dynamicCast<InfEngineNgraphNode>()->node);
+        CV_Assert(inputs.size() == nodes.size());
+        ngraph::OutputVector inp_nodes;
+        for (int i = 0; i < nodes.size(); ++i)
+        {
+            auto inp = nodes[i].dynamicCast<InfEngineNgraphNode>()->node;
+            inp_nodes.push_back(inp);
 
-        //     std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
-        //     for (int i = 0; i < numDims; ++i)
-        //         maxDims[i] = std::max(maxDims[i], inpShape[i]);
-        // }
-        // for (int i = 0; i < inp_nodes.size(); ++i)
-        // {
-        //     bool needPadding = false;
-        //     std::vector<size_t> inpShape = ngraphDataNode(inputs[i])->getDims();
-        //     std::vector<int64_t> begins(inpShape.size(), 0), ends(inpShape.size(), 0);
-        //     for (int j = 0; j < inpShape.size(); ++j)
-        //     {
-        //         if (j != cAxis && inpShape[j] != maxDims[j])
-        //         {
-        //             needPadding = true;
-        //             begins[j] = static_cast<int64_t>((maxDims[j] - inpShape[j]) / 2);
-        //             ends[j] = static_cast<int64_t>(maxDims[j] - inpShape[j] - begins[j]);
-        //         }
-        //     }
-        //     if (needPadding)
-        //     {
-        //         inp_nodes[i] = std::make_shared<ngraph::op::v1::Pad>(
-        //             inp_nodes[i],
-        //             std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{begins.size()}, begins.data()),
-        //             std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{ends.size()}, ends.data()),
-        //             ngraph::op::PadMode::CONSTANT);
-        //     }
-        // }
-        // auto concat = std::make_shared<ngraph::op::Concat>(inp_nodes, cAxis);
-        // return Ptr<BackendNode>(new InfEngineNgraphNode(concat));
+            std::vector<size_t> inpShape = inp->get_shape();
+            for (int i = 0; i < numDims; ++i)
+                maxDims[i] = std::max(maxDims[i], inpShape[i]);
+        }
+        for (int i = 0; i < inp_nodes.size(); ++i)
+        {
+            bool needPadding = false;
+            std::vector<size_t> inpShape = inp_nodes[i].get_shape();
+            std::vector<int64_t> begins(inpShape.size(), 0), ends(inpShape.size(), 0);
+            for (int j = 0; j < inpShape.size(); ++j)
+            {
+                if (j != cAxis && inpShape[j] != maxDims[j])
+                {
+                    needPadding = true;
+                    begins[j] = static_cast<int64_t>((maxDims[j] - inpShape[j]) / 2);
+                    ends[j] = static_cast<int64_t>(maxDims[j] - inpShape[j] - begins[j]);
+                }
+            }
+            if (needPadding)
+            {
+                inp_nodes[i] = std::make_shared<ngraph::op::v1::Pad>(
+                    inp_nodes[i],
+                    std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{begins.size()}, begins.data()),
+                    std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{ends.size()}, ends.data()),
+                    ngraph::op::PadMode::CONSTANT);
+            }
+        }
+        auto concat = std::make_shared<ngraph::op::Concat>(inp_nodes, cAxis);
+        return Ptr<BackendNode>(new InfEngineNgraphNode(concat));
     }
 #endif  // HAVE_DNN_NGRAPH
 

--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -401,6 +401,24 @@ public:
 #else
         ngraph::op::v4::Interpolate::InterpolateAttrs attrs;
 
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+        if (interpolation == "nearest") {
+            attrs.mode = ngraph::op::v4::Interpolate::InterpolateMode::NEAREST;
+            attrs.coordinate_transformation_mode = ngraph::op::v4::Interpolate::CoordinateTransformMode::HALF_PIXEL;
+        } else if (interpolation == "bilinear") {
+            attrs.mode = ngraph::op::v4::Interpolate::InterpolateMode::LINEAR_ONNX;
+            attrs.coordinate_transformation_mode = ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC;
+        } else {
+            CV_Error(Error::StsNotImplemented, format("Unsupported interpolation: %s", interpolation.c_str()));
+        }
+        attrs.shape_calculation_mode = ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES;
+
+        if (alignCorners) {
+            attrs.coordinate_transformation_mode = ngraph::op::v4::Interpolate::CoordinateTransformMode::ALIGN_CORNERS;
+        }
+
+        attrs.nearest_mode = ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_FLOOR;
+#else
         if (interpolation == "nearest") {
             attrs.mode = ngraph::op::v4::Interpolate::InterpolateMode::nearest;
             attrs.coordinate_transformation_mode = ngraph::op::v4::Interpolate::CoordinateTransformMode::half_pixel;
@@ -417,6 +435,7 @@ public:
         }
 
         attrs.nearest_mode = ngraph::op::v4::Interpolate::NearestMode::round_prefer_floor;
+#endif // OpenVINO >= 2022.1
 
         std::vector<int64_t> shape = {outHeight, outWidth};
         auto out_shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{2}, shape.data());

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -831,6 +831,8 @@ Net openvino_readNetwork(
         const uchar* bufferWeightsPtr, size_t bufferWeightsSize
 )
 {
+    CV_Error(Error::StsNotImplemented, "From Model Optimizer buffer");
+
     FPDenormalsIgnoreHintScope fp_denormals_ignore_scope;
 
     // InferenceEngine::Core& ie = getCore("");

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -312,24 +312,6 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
                     ld.inputBlobsWrappers[i].dynamicCast<NgraphBackendWrapper>()->name = netInputLayer->outNames[i];
                 }
             }
-            else
-            {
-                for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
-                {
-                    // auto it = ienet.outputsDesc.find(ld.name);
-                    // if (it != ienet.outputsDesc.end())
-                    // {
-                    //     // const InferenceEngine::TensorDesc& descriptor = it->second;
-                    //     // InferenceEngine::DataPtr dataPtr = ngraphDataOutputNode(ld.outputBlobsWrappers[i], descriptor, ld.name);
-                    //     // dataPtr->setName(ld.name);
-                    // }
-                    // else
-                    // {
-                    //     // InferenceEngine::DataPtr dataPtr = ngraphDataNode(ld.outputBlobsWrappers[i]);
-                    //     // dataPtr->setName(ld.name);
-                    // }
-                }
-            }
             ienet.addBlobs(ld.inputBlobsWrappers);
             ienet.addBlobs(ld.outputBlobsWrappers);
             ld.skip = true;

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -316,7 +316,7 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
             {
                 for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
                 {
-                        std::cout << "here 2" << std::endl;
+                        // std::cout << "here 2" << std::endl;
                     // auto it = ienet.outputsDesc.find(ld.name);
                     // if (it != ienet.outputsDesc.end())
                     // {
@@ -739,7 +739,7 @@ Net NetImplOpenVINO::createNetworkFromModelOptimizer(InferenceEngine::CNNNetwork
 
     std::vector<std::shared_ptr<ngraph::Node>> ngraphOperations = ngraphFunction->get_ops();
 
-    std::cout << 1 << std::endl;
+    // std::cout << 1 << std::endl;
     for (auto& it : ngraphFunction->outputs())
     {
         CV_TRACE_REGION("output");
@@ -794,7 +794,7 @@ Net NetImplOpenVINO::createNetworkFromModelOptimizer(InferenceEngine::CNNNetwork
         for (int i = 0; i < inputsNames.size(); ++i)
             cvNet.connect(0, i, lid, i);
     }
-    std::cout << 2 << std::endl;
+    // std::cout << 2 << std::endl;
 
     CV_TRACE_REGION_NEXT("finalize");
 
@@ -811,7 +811,7 @@ Net openvino_readNetwork(const String& modelPath, const String& binPath)
 
     InferenceEngine::Core& ie = getCore("");
     InferenceEngine::CNNNetwork ieNet;
-    std::cout << modelPath << std::endl;
+    // std::cout << modelPath << std::endl;
     try
     {
         ieNet = ie.ReadNetwork(modelPath, binPath);

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -316,7 +316,6 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
             {
                 for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
                 {
-                        // std::cout << "here 2" << std::endl;
                     // auto it = ienet.outputsDesc.find(ld.name);
                     // if (it != ienet.outputsDesc.end())
                     // {
@@ -739,14 +738,13 @@ Net NetImplOpenVINO::createNetworkFromModelOptimizer(InferenceEngine::CNNNetwork
 
     std::vector<std::shared_ptr<ngraph::Node>> ngraphOperations = ngraphFunction->get_ops();
 
-    // std::cout << 1 << std::endl;
     for (auto& it : ngraphFunction->outputs())
     {
         CV_TRACE_REGION("output");
         // nGraph models end with "Result" layers which have names such as "output/sink_port_0".
         // Their inputs are actual model outputs and we set friendly name to them.
         it.get_node()->set_friendly_name(it.get_any_name());
-        auto outputName = it.get_node()->get_friendly_name();
+        const auto outputName = it.get_node()->get_friendly_name();
 
         LayerParams lp;
         int lid = cvNet.addLayer(outputName, "", lp);
@@ -794,7 +792,6 @@ Net NetImplOpenVINO::createNetworkFromModelOptimizer(InferenceEngine::CNNNetwork
         for (int i = 0; i < inputsNames.size(); ++i)
             cvNet.connect(0, i, lid, i);
     }
-    // std::cout << 2 << std::endl;
 
     CV_TRACE_REGION_NEXT("finalize");
 

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -276,7 +276,7 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
             for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
             {
                 std::string outputName = netInputLayer->outNames.empty() ? ld.name : netInputLayer->outNames[i];
-                outputName = ld.outputBlobsWrappers.size() > 1 ? (outputName + "." + std::to_string(i)) : outputName;
+                outputName = i > 0 ? (outputName + "." + std::to_string(i)) : outputName;
                 ld.outputBlobsWrappers[i].dynamicCast<NgraphBackendWrapper>()->name = outputName;
             }
         }
@@ -284,7 +284,7 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
         {
             for (int i = 0; i < ld.outputBlobsWrappers.size(); ++i)
             {
-                std::string outputName = ld.outputBlobsWrappers.size() > 1 ? (ld.name + "." + std::to_string(i)) : ld.name;
+                std::string outputName = i > 0 ? (ld.name + "." + std::to_string(i)) : ld.name;
                 ld.outputBlobsWrappers[i].dynamicCast<NgraphBackendWrapper>()->name = outputName;
             }
         }
@@ -811,7 +811,6 @@ Net openvino_readNetwork(const String& modelPath, const String& binPath)
 
     InferenceEngine::Core& ie = getCore("");
     InferenceEngine::CNNNetwork ieNet;
-    // std::cout << modelPath << std::endl;
     try
     {
         ieNet = ie.ReadNetwork(modelPath, binPath);

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -492,7 +492,12 @@ void NetImplOpenVINO::initBackend(const std::vector<LayerPin>& blobsToKeep_)
                 CV_LOG_DEBUG(NULL, "DNN/IE: bind output port " << lid << ":" << oid << " (" << ngraph_input_node->get_friendly_name() << ":" << ngraph_input_node->get_type_info().name << ")");
 
                 // Handle parameters from other subnets. Output port is not used in this case
+#if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
                 if ((ngraph::op::is_parameter(ngraph_input_node) || ngraph::op::is_constant(ngraph_input_node)) &&
+#else
+                if ((ngraph_input_node->is_parameter() || ngraph_input_node->is_constant()) &&
+#endif
+
                         ngraph_input_node->get_output_size() == 1)
                 {
                     inputNodes[i] = Ptr<BackendNode>(new InfEngineNgraphNode(ngraph_input_node));

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -90,8 +90,13 @@ CNNNetwork Core::ReadNetwork(const std::string& xmlPath, const std::string& binP
     return read_model(xmlPath, binPath);
 }
 
-ExecutableNetwork Core::LoadNetwork(CNNNetwork net, const std::string& device) {
-    return compile_model(net.getFunction(), device);
+ExecutableNetwork Core::LoadNetwork(CNNNetwork net, const std::string& device,
+                                    const std::map<std::string, std::string>& config) {
+    ov::AnyMap props;
+    for (const auto& it : config) {
+        props.insert(it);
+    }
+    return compile_model(net.getFunction(), device, props);
 }
 
 ExecutableNetwork::ExecutableNetwork() {}

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -20,6 +20,10 @@
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <opencv2/core/utils/logger.hpp>
 
+#if INF_ENGINE_VER_MAJOR_EQ(INF_ENGINE_RELEASE_2022_1)
+#include <ngraph/pass/serialize.hpp>
+#endif
+
 namespace cv { namespace dnn {
 
 #ifdef HAVE_INF_ENGINE

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -20,10 +20,6 @@
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <opencv2/core/utils/logger.hpp>
 
-#if INF_ENGINE_VER_MAJOR_EQ(INF_ENGINE_RELEASE_2022_1)
-#include <ngraph/pass/serialize.hpp>
-#endif
-
 namespace cv { namespace dnn {
 
 #ifdef HAVE_INF_ENGINE

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -39,6 +39,7 @@ cv::String setInferenceEngineBackendType(const cv::String& newBackendType)
 
 CV__DNN_INLINE_NS_END
 
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 Mat infEngineBlobToMat(const ov::Tensor& blob)
 {
     std::vector<size_t> dims = blob.get_shape();
@@ -63,31 +64,35 @@ void infEngineBlobsToMats(const ov::TensorVector& blobs,
     for (int i = 0; i < blobs.size(); ++i)
         mats[i] = infEngineBlobToMat(blobs[i]);
 }
-// Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
-// {
-//     // NOTE: Inference Engine sizes are reversed.
-//     std::vector<size_t> dims = blob->getTensorDesc().getDims();
-//     std::vector<int> size(dims.begin(), dims.end());
-//     auto precision = blob->getTensorDesc().getPrecision();
 
-//     int type = -1;
-//     switch (precision)
-//     {
-//         case InferenceEngine::Precision::FP32: type = CV_32F; break;
-//         case InferenceEngine::Precision::U8: type = CV_8U; break;
-//         default:
-//             CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
-//     }
-//     return Mat(size, type, (void*)blob->buffer());
-// }
+#else
 
-// void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
-//                           std::vector<Mat>& mats)
-// {
-//     mats.resize(blobs.size());
-//     for (int i = 0; i < blobs.size(); ++i)
-//         mats[i] = infEngineBlobToMat(blobs[i]);
-// }
+Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
+{
+    // NOTE: Inference Engine sizes are reversed.
+    std::vector<size_t> dims = blob->getTensorDesc().getDims();
+    std::vector<int> size(dims.begin(), dims.end());
+    auto precision = blob->getTensorDesc().getPrecision();
+
+    int type = -1;
+    switch (precision)
+    {
+        case InferenceEngine::Precision::FP32: type = CV_32F; break;
+        case InferenceEngine::Precision::U8: type = CV_8U; break;
+        default:
+            CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
+    }
+    return Mat(size, type, (void*)blob->buffer());
+}
+
+void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
+                          std::vector<Mat>& mats)
+{
+    mats.resize(blobs.size());
+    for (int i = 0; i < blobs.size(); ++i)
+        mats[i] = infEngineBlobToMat(blobs[i]);
+}
+#endif // OpenVINO >= 2022.1
 
 static bool init_IE_plugins()
 {
@@ -152,9 +157,13 @@ static bool detectArmPlugin_()
     {
         if (i->find("CPU") != std::string::npos)
         {
-            // const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
-            // CV_LOG_INFO(NULL, "CPU plugin: " << name);
-            // return name.find("arm_compute::NEON") != std::string::npos;
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+            const std::string name = ie.get_property(*i, ov::device::full_name);
+#else
+            const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
+#endif
+            CV_LOG_INFO(NULL, "CPU plugin: " << name);
+            return name.find("arm_compute::NEON") != std::string::npos;
         }
     }
     return false;
@@ -172,9 +181,13 @@ static bool detectMyriadX_(const std::string& device)
     {
         if (i->find(device) != std::string::npos)
         {
-            // const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
-            // CV_LOG_INFO(NULL, "Myriad device: " << name);
-            // return name.find("MyriadX") != std::string::npos || name.find("Myriad X") != std::string::npos || name.find("HDDL") != std::string::npos;
+#if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+            const std::string name = ie.get_property(*i, ov::device::full_name);
+#else
+            const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
+#endif
+            CV_LOG_INFO(NULL, "Myriad device: " << name);
+            return name.find("MyriadX") != std::string::npos || name.find("Myriad X") != std::string::npos || name.find("HDDL") != std::string::npos;
         }
     }
     return false;

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -39,7 +39,30 @@ cv::String setInferenceEngineBackendType(const cv::String& newBackendType)
 
 CV__DNN_INLINE_NS_END
 
+Mat infEngineBlobToMat(const ov::Tensor& blob)
+{
+    std::vector<size_t> dims = blob.get_shape();
+    std::vector<int> size(dims.begin(), dims.end());
+    auto precision = blob.get_element_type();
 
+    int type = -1;
+    switch (precision)
+    {
+        case ov::element::f32: type = CV_32F; break;
+        case ov::element::u8: type = CV_8U; break;
+        default:
+            CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
+    }
+    return Mat(size, type, blob.data());
+}
+
+void infEngineBlobsToMats(const ov::TensorVector& blobs,
+                          std::vector<Mat>& mats)
+{
+    mats.resize(blobs.size());
+    for (int i = 0; i < blobs.size(); ++i)
+        mats[i] = infEngineBlobToMat(blobs[i]);
+}
 // Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
 // {
 //     // NOTE: Inference Engine sizes are reversed.

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -58,6 +58,20 @@ void CNNNetwork::reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>&
     model->reshape(shapes);
 }
 
+std::map<std::string, std::vector<size_t> > CNNNetwork::getOutputsInfo() const {
+    std::map<std::string, std::vector<size_t> > res;
+    for (const auto& it : model->outputs()) {
+        const std::string& name = it.get_any_name();
+        // nGraph models end with "Result" layers which have names such as "output/sink_port_0".
+        // Their inputs are actual model outputs and we set friendly name to them.
+        if (it.get_node()->get_friendly_name() != name)
+            it.get_node()->set_friendly_name(name);
+
+        res.insert({name, it.get_shape()});
+    }
+    return res;
+}
+
 std::vector<std::string> Core::GetAvailableDevices() {
     return get_available_devices();
 }

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -40,32 +40,31 @@ cv::String setInferenceEngineBackendType(const cv::String& newBackendType)
 CV__DNN_INLINE_NS_END
 
 
-Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
-{
-    // NOTE: Inference Engine sizes are reversed.
-    std::vector<size_t> dims = blob->getTensorDesc().getDims();
-    std::vector<int> size(dims.begin(), dims.end());
-    auto precision = blob->getTensorDesc().getPrecision();
+// Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
+// {
+//     // NOTE: Inference Engine sizes are reversed.
+//     std::vector<size_t> dims = blob->getTensorDesc().getDims();
+//     std::vector<int> size(dims.begin(), dims.end());
+//     auto precision = blob->getTensorDesc().getPrecision();
 
-    int type = -1;
-    switch (precision)
-    {
-        case InferenceEngine::Precision::FP32: type = CV_32F; break;
-        case InferenceEngine::Precision::U8: type = CV_8U; break;
-        default:
-            CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
-    }
-    return Mat(size, type, (void*)blob->buffer());
-}
+//     int type = -1;
+//     switch (precision)
+//     {
+//         case InferenceEngine::Precision::FP32: type = CV_32F; break;
+//         case InferenceEngine::Precision::U8: type = CV_8U; break;
+//         default:
+//             CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
+//     }
+//     return Mat(size, type, (void*)blob->buffer());
+// }
 
-void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
-                          std::vector<Mat>& mats)
-{
-    mats.resize(blobs.size());
-    for (int i = 0; i < blobs.size(); ++i)
-        mats[i] = infEngineBlobToMat(blobs[i]);
-}
-
+// void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
+//                           std::vector<Mat>& mats)
+// {
+//     mats.resize(blobs.size());
+//     for (int i = 0; i < blobs.size(); ++i)
+//         mats[i] = infEngineBlobToMat(blobs[i]);
+// }
 
 static bool init_IE_plugins()
 {
@@ -130,9 +129,9 @@ static bool detectArmPlugin_()
     {
         if (i->find("CPU") != std::string::npos)
         {
-            const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
-            CV_LOG_INFO(NULL, "CPU plugin: " << name);
-            return name.find("arm_compute::NEON") != std::string::npos;
+            // const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
+            // CV_LOG_INFO(NULL, "CPU plugin: " << name);
+            // return name.find("arm_compute::NEON") != std::string::npos;
         }
     }
     return false;
@@ -150,9 +149,9 @@ static bool detectMyriadX_(const std::string& device)
     {
         if (i->find(device) != std::string::npos)
         {
-            const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
-            CV_LOG_INFO(NULL, "Myriad device: " << name);
-            return name.find("MyriadX") != std::string::npos || name.find("Myriad X") != std::string::npos || name.find("HDDL") != std::string::npos;
+            // const std::string name = ie.GetMetric(*i, METRIC_KEY(FULL_DEVICE_NAME)).as<std::string>();
+            // CV_LOG_INFO(NULL, "Myriad device: " << name);
+            // return name.find("MyriadX") != std::string::npos || name.find("Myriad X") != std::string::npos || name.find("HDDL") != std::string::npos;
         }
     }
     return false;

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -40,6 +40,48 @@ cv::String setInferenceEngineBackendType(const cv::String& newBackendType)
 CV__DNN_INLINE_NS_END
 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
+namespace InferenceEngine {
+
+CNNNetwork::CNNNetwork() {}
+
+CNNNetwork::CNNNetwork(std::shared_ptr<ov::Model> model) : model(model) {}
+
+std::shared_ptr<ov::Model> CNNNetwork::getFunction() const {
+    return model;
+}
+
+void CNNNetwork::serialize(const std::string& xmlPath, const std::string& binPath) {
+    ov::pass::Serialize(xmlPath, binPath).run_on_model(model);
+}
+
+void CNNNetwork::reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes) {
+    model->reshape(shapes);
+}
+
+std::vector<std::string> Core::GetAvailableDevices() {
+    return get_available_devices();
+}
+
+void Core::UnregisterPlugin(const std::string& id) {
+    unload_plugin(id);
+}
+
+CNNNetwork Core::ReadNetwork(const std::string& xmlPath, const std::string& binPath) {
+    return read_model(xmlPath, binPath);
+}
+
+ExecutableNetwork Core::LoadNetwork(CNNNetwork net, const std::string& device) {
+    return compile_model(net.getFunction(), device);
+}
+
+ExecutableNetwork::ExecutableNetwork() {}
+
+ExecutableNetwork::ExecutableNetwork(const ov::CompiledModel& copy) : CompiledModel(copy) {}
+
+ov::InferRequest ExecutableNetwork::CreateInferRequest() { return create_infer_request(); }
+
+}  // namespace InferenceEngine
+
 Mat infEngineBlobToMat(const ov::Tensor& blob)
 {
     std::vector<size_t> dims = blob.get_shape();

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -54,8 +54,14 @@ void CNNNetwork::serialize(const std::string& xmlPath, const std::string& binPat
     ov::pass::Serialize(xmlPath, binPath).run_on_model(model);
 }
 
-void CNNNetwork::reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes) {
-    model->reshape(shapes);
+void CNNNetwork::reshape(const std::map<std::string, std::vector<size_t> >& shapes) {
+    std::map<std::string, ov::PartialShape> partialShapes;
+    for (const auto& it : shapes) {
+        ov::PartialShape shape;
+        shape.insert(shape.begin(), it.second.begin(), it.second.end());
+        partialShapes.insert({it.first, shape});
+    }
+    model->reshape(partialShapes);
 }
 
 std::map<std::string, std::vector<size_t> > CNNNetwork::getOutputsInfo() const {

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -64,19 +64,6 @@ void CNNNetwork::reshape(const std::map<std::string, std::vector<size_t> >& shap
     model->reshape(partialShapes);
 }
 
-std::map<std::string, std::vector<size_t> > CNNNetwork::getOutputsInfo() const {
-    std::map<std::string, std::vector<size_t> > res;
-    for (const auto& it : model->outputs()) {
-        const std::string& name = it.get_any_name();
-        // nGraph models end with "Result" layers which have names such as "output/sink_port_0".
-        // Their inputs are actual model outputs and we set friendly name to them.
-        if (it.get_node()->get_friendly_name() != name)
-            it.get_node()->set_friendly_name(name);
-        res.insert({name, it.get_partial_shape().get_max_shape()});
-    }
-    return res;
-}
-
 std::vector<std::string> Core::GetAvailableDevices() {
     return get_available_devices();
 }

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -72,8 +72,7 @@ std::map<std::string, std::vector<size_t> > CNNNetwork::getOutputsInfo() const {
         // Their inputs are actual model outputs and we set friendly name to them.
         if (it.get_node()->get_friendly_name() != name)
             it.get_node()->set_friendly_name(name);
-
-        res.insert({name, it.get_shape()});
+        res.insert({name, it.get_partial_shape().get_max_shape()});
     }
     return res;
 }

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -46,6 +46,8 @@
 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 #include <openvino/openvino.hpp>
+#else
+#include <inference_engine.hpp>
 #endif
 
 #if defined(__GNUC__) && __GNUC__ >= 5
@@ -116,31 +118,23 @@ private:
     std::shared_ptr<ov::Model> model = nullptr;
 };
 
-class Core {
+class Core : public ov::Core {
 public:
-    Core() {
-    }
-
-    Core(ov::Core& core) : core(core) {}
-
     std::vector<std::string> GetAvailableDevices() {
-        return core.get_available_devices();
+        return get_available_devices();
     }
 
     void UnregisterPlugin(const std::string& id) {
-        core.unload_plugin(id);
+        unload_plugin(id);
     }
 
     CNNNetwork ReadNetwork(const std::string& xmlPath, const std::string& binPath) {
-        return core.read_model(xmlPath, binPath);
+        return read_model(xmlPath, binPath);
     }
 
     ov::CompiledModel LoadNetwork(CNNNetwork net, const std::string& device) {
-        return core.compile_model(net.getFunction(), device);
+        return compile_model(net.getFunction(), device);
     }
-
-private:
-    ov::Core core;
 };
 
 }

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -138,7 +138,8 @@ public:
 
     CNNNetwork ReadNetwork(const std::string& xmlPath, const std::string& binPath);
 
-    ExecutableNetwork LoadNetwork(CNNNetwork net, const std::string& device);
+    ExecutableNetwork LoadNetwork(CNNNetwork net, const std::string& device,
+                                  const std::map<std::string, std::string>& config);
 };
 
 }

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -74,7 +74,7 @@ Backend& getInferenceEngineBackendTypeParam();
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 Mat infEngineBlobToMat(const ov::Tensor& blob);
 
-void infEngineBlobsToMats(const std::vector<ov::Tensor>& blobs,
+void infEngineBlobsToMats(const ov::TensorVector& blobs,
                           std::vector<Mat>& mats);
 #else
 Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob);

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -108,6 +108,10 @@ public:
         return model;
     }
 
+    void serialize(const std::string& xmlPath, const std::string& binPath) {
+        ov::pass::Serialize(xmlPath, binPath).run_on_model(model);
+    }
+
 private:
     std::shared_ptr<ov::Model> model = nullptr;
 };

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -96,49 +96,47 @@ bool isArmComputePlugin();
 
 CV__DNN_INLINE_NS_END
 
-// This is a temporal wrapper for OpenVINO 2.0 API compatibility
+// A series of wrappers for classes from OpenVINO API 2.0.
+// Need just for less conditional compilation inserts.
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 namespace InferenceEngine {
 
 class CNNNetwork {
 public:
-    CNNNetwork() {}
+    CNNNetwork();
 
-    CNNNetwork(std::shared_ptr<ov::Model> model) : model(model) {}
+    CNNNetwork(std::shared_ptr<ov::Model> model);
 
-    std::shared_ptr<ov::Model> getFunction() const {
-        return model;
-    }
+    std::shared_ptr<ov::Model> getFunction() const;
 
-    void serialize(const std::string& xmlPath, const std::string& binPath) {
-        ov::pass::Serialize(xmlPath, binPath).run_on_model(model);
-    }
+    void serialize(const std::string& xmlPath, const std::string& binPath);
 
-    void reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes) {
-        model->reshape(shapes);
-    }
+    void reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes);
 
 private:
     std::shared_ptr<ov::Model> model = nullptr;
 };
 
+typedef ov::InferRequest InferRequest;
+
+class ExecutableNetwork : public ov::CompiledModel {
+public:
+    ExecutableNetwork();
+
+    ExecutableNetwork(const ov::CompiledModel& copy);
+
+    ov::InferRequest CreateInferRequest();
+};
+
 class Core : public ov::Core {
 public:
-    std::vector<std::string> GetAvailableDevices() {
-        return get_available_devices();
-    }
+    std::vector<std::string> GetAvailableDevices();
 
-    void UnregisterPlugin(const std::string& id) {
-        unload_plugin(id);
-    }
+    void UnregisterPlugin(const std::string& id);
 
-    CNNNetwork ReadNetwork(const std::string& xmlPath, const std::string& binPath) {
-        return read_model(xmlPath, binPath);
-    }
+    CNNNetwork ReadNetwork(const std::string& xmlPath, const std::string& binPath);
 
-    ov::CompiledModel LoadNetwork(CNNNetwork net, const std::string& device) {
-        return compile_model(net.getFunction(), device);
-    }
+    ExecutableNetwork LoadNetwork(CNNNetwork net, const std::string& device);
 };
 
 }

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -114,6 +114,10 @@ public:
         ov::pass::Serialize(xmlPath, binPath).run_on_model(model);
     }
 
+    void reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes) {
+        model->reshape(shapes);
+    }
+
 private:
     std::shared_ptr<ov::Model> model = nullptr;
 };

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -46,6 +46,8 @@
 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 #include <openvino/openvino.hpp>
+#include <openvino/pass/serialize.hpp>
+#include <openvino/pass/convert_fp32_to_fp16.hpp>
 #else
 #include <inference_engine.hpp>
 #endif

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -111,7 +111,7 @@ public:
 
     void serialize(const std::string& xmlPath, const std::string& binPath);
 
-    void reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes);
+    void reshape(const std::map<std::string, std::vector<size_t> >& shapes);
 
     std::map<std::string, std::vector<size_t> > getOutputsInfo() const;
 

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -113,6 +113,8 @@ public:
 
     void reshape(const std::map<ov::Output<ov::Node>, ov::PartialShape>& shapes);
 
+    std::map<std::string, std::vector<size_t> > getOutputsInfo() const;
+
 private:
     std::shared_ptr<ov::Model> model = nullptr;
 };

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -115,8 +115,6 @@ public:
 
     void reshape(const std::map<std::string, std::vector<size_t> >& shapes);
 
-    std::map<std::string, std::vector<size_t> > getOutputsInfo() const;
-
 private:
     std::shared_ptr<ov::Model> model = nullptr;
 };

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -531,7 +531,7 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
     if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD)
     {
         l1 = 0.4;
-        lInf = 7.45;
+        lInf = 7.46;
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -725,18 +725,21 @@ TEST_P(Test_Caffe_nets, FasterRCNN_vgg16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
 
+    double scoreDiff = 0.0;
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)
     // Check 'backward_compatible_check || in_out_elements_equal' failed at core/src/op/reshape.cpp:427:
     // While validating node 'v1::Reshape bbox_pred_reshape (bbox_pred[0]:f32{1,84}, Constant_265242[0]:i64{4}) -> (f32{?,?,?,?})' with friendly_name 'bbox_pred_reshape':
     // Requested output shape {1,6300,4,1} is incompatible with input shape {1, 84}
     if (target == DNN_TARGET_MYRIAD)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
+    if (target == DNN_TARGET_OPENCL_FP16)
+        scoreDiff = 0.02;
 #endif
 
     static Mat ref = (Mat_<float>(3, 7) << 0, 2, 0.949398, 99.2454, 210.141, 601.205, 462.849,
                                            0, 7, 0.997022, 481.841, 92.3218, 722.685, 175.953,
                                            0, 12, 0.993028, 133.221, 189.377, 350.994, 563.166);
-    testFaster("faster_rcnn_vgg16.prototxt", "VGG16_faster_rcnn_final.caffemodel", ref);
+    testFaster("faster_rcnn_vgg16.prototxt", "VGG16_faster_rcnn_final.caffemodel", ref, scoreDiff);
 }
 
 TEST_P(Test_Caffe_nets, FasterRCNN_zf)

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -638,6 +638,11 @@ TEST_P(Test_Darknet_nets, YOLOv3)
     double scoreDiff = 8e-5, iouDiff = 3e-4;
     if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD)
     {
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2022010000)
+        if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+            scoreDiff = 0.009;
+        else
+#endif
         scoreDiff = 0.006;
         iouDiff = 0.042;
     }
@@ -771,6 +776,7 @@ TEST_P(Test_Darknet_nets, YOLOv4)
     // accuracy (batch 2)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_OPENCL_FP16)
     {
+        scoreDiff = 0.008f;
         iouDiff = 0.05f;
     }
     // accuracy

--- a/modules/dnn/test/test_ie_models.cpp
+++ b/modules/dnn/test/test_ie_models.cpp
@@ -438,6 +438,9 @@ TEST_P(DNNTestOpenVINO, models)
     {
         auto dstIt = cvOutputsMap.find(srcIt.first);
         CV_Assert(dstIt != cvOutputsMap.end());
+
+        dstIt->second.convertTo(dstIt->second, srcIt.second.type());
+
         double normInf = cvtest::norm(srcIt.second, dstIt->second, cv::NORM_INF);
         EXPECT_LE(normInf, eps) << "output=" << srcIt.first;
     }

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1289,10 +1289,10 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
 
     std::vector<int> outLayers = net.getUnconnectedOutLayers();
     ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
-        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
-    else
-        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
+    // if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
+    // else
+    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
 }
 
 TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1287,12 +1287,12 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
     double lInf = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 1.8e-2 : 1e-4;
     normAssert(outDefault, out, "", l1, lInf);
 
-    // std::vector<int> outLayers = net.getUnconnectedOutLayers();
-    // ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
-    // if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
-    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
-    // else
-    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Add");
+    std::vector<int> outLayers = net.getUnconnectedOutLayers();
+    ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
+    else
+        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
 }
 
 TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1287,12 +1287,12 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
     double lInf = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 1.8e-2 : 1e-4;
     normAssert(outDefault, out, "", l1, lInf);
 
-    std::vector<int> outLayers = net.getUnconnectedOutLayers();
-    ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
-        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
-    else
-        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Add");
+    // std::vector<int> outLayers = net.getUnconnectedOutLayers();
+    // ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
+    // if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
+    // else
+    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Add");
 }
 
 TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1289,10 +1289,6 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
 
     std::vector<int> outLayers = net.getUnconnectedOutLayers();
     ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
-    // if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
-    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
-    // else
-    //     ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
 }
 
 TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1289,6 +1289,10 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
 
     std::vector<int> outLayers = net.getUnconnectedOutLayers();
     ASSERT_EQ(net.getLayer(outLayers[0])->name, "output");
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Convolution");
+    else
+        ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
 }
 
 TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -447,6 +447,10 @@ TEST_P(Test_Model, DetectionOutput)
     {
         if (backend == DNN_BACKEND_OPENCV)
             scoreDiff = 4e-3;
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2022010000)
+        else if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+            scoreDiff = 4e-2;
+#endif
         else
             scoreDiff = 2e-2;
         iouDiff = 1.8e-1;


### PR DESCRIPTION
* Use OpenVINO Runtime API (aka Tensor API or API 2.0) which has been introduces in 2022.1
* Remove `InferenceEngine::DataPtr` completely
* Internal dynamism feature works only with a new API. Actual for Faster-* family models and with layers such as NonZero, Top-k and others. This feature may improve performance.

- [x] Tested with OpenVINO 2022.1 ([CI](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100158))
- [x] Tested with OpenVINO 2021.4 ([CI](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100157))
- [ ] Tested with old OpenVINO (for example, 2020.3) - (**alalek**: older versions are not supported on 4.x branch)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom

Xbuild_image:Custom=ubuntu-openvino-2021.4.2:20.04
build_image:Custom=ubuntu-openvino-2022.1.0:20.04

test_modules:Custom=dnn,python2,python3,java,gapi,video

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

allow_multiple_commits=1
```