### PR TITLE
Replace all instances of CUDA texture references with texture objects

### DIFF
--- a/modules/core/include/opencv2/core/cuda/common.hpp
+++ b/modules/core/include/opencv2/core/cuda/common.hpp
@@ -98,6 +98,12 @@ namespace cv { namespace cuda
             return (total + grain - 1) / grain;
         }
 
+#if (CUDART_VERSION >= 12000)
+        template<class T> inline void bindTexture(const textureReference* tex, const PtrStepSz<T>& img) { CV_Error(cv::Error::GpuNotSupported, "Function removed in CUDA SDK 12"); }
+        template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {
+            CV_Error(cv::Error::GpuNotSupported, "Function removed in CUDA SDK 12"); }
+#else
+        //TODO: remove from OpenCV 5.x
         template<class T> inline void bindTexture(const textureReference* tex, const PtrStepSz<T>& img)
         {
             cudaChannelFormatDesc desc = cudaCreateChannelDesc<T>();
@@ -118,6 +124,7 @@ namespace cv { namespace cuda
             cudaSafeCall( cudaCreateTextureObject(tex, &resDesc, &texDesc, NULL) );
         }
     }
+#endif
 }}
 
 //! @endcond


### PR DESCRIPTION
See https://github.com/opencv/opencv_contrib/pull/3378 and https://github.com/opencv/opencv_contrib/issues/3390.  

CUDA texture references have now been completley removed in the latest SDK (CUDA 12.0).

If https://github.com/opencv/opencv_contrib/pull/3378 is merged this code block which is causing builds to fail against CUDA 12.0 (https://github.com/opencv/opencv_contrib/issues/3390) will become redundant.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
