### PR TITLE
videoio(test): reduce number of test threads

### DIFF
--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -144,7 +144,7 @@ const videoio_read_params_t videoio_read_params[] =
 };
 
 INSTANTIATE_TEST_CASE_P(/**/, videoio_read, testing::Combine(testing::ValuesIn(videoio_read_params),
-                                                             testing::Values(0, 1, 2, 2000),
+                                                             testing::Values(0, 1, 2, 50),
                                                              testing::Values(true, false)));
 
 //==========================================================================


### PR DESCRIPTION
relates #22248

Avoid reaching of valgrind default limitations:

```
[ RUN      ] videoio_read.threads/6, where GetParam() = (("video/big_buck_bunny.h264", 125, false), 2000, true)
Use --max-threads=INT to specify a larger number of threads
and rerun valgrind

valgrind: the 'impossible' happened:
   Max number of threads is too low
```