### PR TITLE
Fixing how stdDev in calibration is calculated

### DIFF
--- a/modules/calib/src/calibration.cpp
+++ b/modules/calib/src/calibration.cpp
@@ -404,6 +404,12 @@ static double calibrateCameraInternal( const Mat& objectPoints,
         mask[nparams - 1] = 0;
     }
 
+    int nparams_nz = countNonZero(mask);
+
+    if (nparams_nz > 2 * total)
+        CV_Error_(Error::StsBadArg,
+                  ("There should be less vars to optimize (having %d) than the number of residuals (%d = 2 per point)", nparams_nz, 2 * total));
+
     // 2. initialize extrinsic parameters
     for(int i = 0, pos = 0; i < nimages; i++ )
     {
@@ -572,7 +578,6 @@ static double calibrateCameraInternal( const Mat& objectPoints,
 
     if (!stdDevs.empty())
     {
-        int nparams_nz = countNonZero(mask);
         JtJN.create(nparams_nz, nparams_nz, CV_64F);
 
         subMatrix(JtJ, JtJN, mask, mask);

--- a/modules/calib/src/calibration.cpp
+++ b/modules/calib/src/calibration.cpp
@@ -406,7 +406,7 @@ static double calibrateCameraInternal( const Mat& objectPoints,
 
     int nparams_nz = countNonZero(mask);
 
-    if (nparams_nz > 2 * total)
+    if (nparams_nz >= 2 * total)
         CV_Error_(Error::StsBadArg,
                   ("There should be less vars to optimize (having %d) than the number of residuals (%d = 2 per point)", nparams_nz, 2 * total));
 
@@ -587,19 +587,13 @@ static double calibrateCameraInternal( const Mat& objectPoints,
         // an explanation of that denominator correction can be found here:
         // R. Hartley, A. Zisserman, Multiple View Geometry in Computer Vision, 2004, section 5.1.3, page 134
         // see the discussion for more details: https://github.com/opencv/opencv/pull/22992
-        int nErrors = 2 * total - nparams_nz;
-        if (nErrors > 0)
-        {
-            double sigma2 = norm(allErrors, NORM_L2SQR) / nErrors;
+        double sigma2 = norm(allErrors, NORM_L2SQR) / (2 * total - nparams_nz);
         int j = 0;
         for ( int s = 0; s < nparams; s++ )
+        {
+            stdDevs.at<double>(s) = mask[s] ? std::sqrt(JtJinv.at<double>(j, j) * sigma2) : 0.0;
             if( mask[s] )
-            {
-                stdDevs.at<double>(s) = std::sqrt(JtJinv.at<double>(j,j) * sigma2);
                 j++;
-            }
-            else
-                stdDevs.at<double>(s) = 0.;
         }
     }
 


### PR DESCRIPTION
Fixes #19803 

This PR should fix the standard deviation calculation for calibration procedure.

### TODOs:
- [x] Agree on the root cause of the problem
- [x] (Needs discussion) `total` should contain 2x the number of object points (one per each coordinate)
- [x] Forbid calibration calculation when a number of variables is less than a total number of residuals
- [x] Forbid stddev calculation when a number of variables is greater than or equal to a total number of residuals
- [x] Fix backport to 4.x
- [x] Make backport for 3.x

**EDIT:** the previous stddev calculation motivation is considered to be wrong, we need that denominator correction to make our estimates unbiased. An explanation of it can be found in [MVG].
Also, Cramer-Rao bound has nothing to do with it.

<details><summary>Previous incorrect explanation</summary>

_The stddevs estimation is based on [Cramer-Rao bound](https://en.wikipedia.org/wiki/Cram%C3%A9r%E2%80%93Rao_bound). While it's not said about the variance of samples,  the original code (Camera Calibration Toolbox by Jean-Yves Bouguet) and other available implementations calculate sigma2 based on all object points regardless how many are of them or how many parameters are to optimize._

</details>

I invite anyone to discuss that and verify that, especially those who've participated in the original issue discussion:
@Seneral @sanketc001 @lamm45 @alalek

I also invite @vpisarev and @ivashmak because of their experience in calibration.

* **MVG:** _R. Hartley, A. Zisserman, Multiple View Geometry in Computer Vision, 2004, section 5.1.3, page 134_

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
