### PR TITLE
add mask for the template image in findTransformECC

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -336,14 +336,14 @@ computeECC, estimateAffine2D, estimateAffinePartial2D, findHomography
 CV_EXPORTS_W double findTransformECC( InputArray templateImage, InputArray inputImage,
                                       InputOutputArray warpMatrix, int motionType,
                                       TermCriteria criteria,
-                                      InputArray inputMask, int gaussFiltSize);
+                                      InputArray inputMask, int gaussFiltSize, InputArray templateMask = noArray() );
 
 /** @overload */
 CV_EXPORTS_W
 double findTransformECC(InputArray templateImage, InputArray inputImage,
     InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),
-    InputArray inputMask = noArray());
+    InputArray inputMask = noArray(),  InputArray templateMask = noArray());
 
 /** @example samples/cpp/kalman.cpp
 An example using the standard Kalman filter


### PR DESCRIPTION
two modifications

-  I added a mask for the template image in findTransformECC
- "update warping matrix" is passed at the beginning of the optimization loop. I found it improve the convergence in case of un-initialized warpMatrix.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
