### PR TITLE
valgrind: suppress FFV1 16 bit issue in avcodec-57

### DIFF
--- a/platforms/scripts/valgrind_3rdparty.supp
+++ b/platforms/scripts/valgrind_3rdparty.supp
@@ -215,3 +215,16 @@
    fun:start_thread
    fun:clone
 }
+
+{
+   avcodec57-ffv1-16bit-ubuntu18
+   Memcheck:Cond
+   ...
+   obj:/usr/lib/x86_64-linux-gnu/libavcodec.so.57.107.100
+   fun:avcodec_default_execute
+   obj:/usr/lib/x86_64-linux-gnu/libavcodec.so.57.107.100
+   fun:avcodec_encode_video2
+   obj:/usr/lib/x86_64-linux-gnu/libavcodec.so.57.107.100
+   fun:avcodec_send_frame
+   ...
+}


### PR DESCRIPTION
resolves #22991

Issue is not reproducible with newer FFmpeg version, hence suppressing. Tested with system package from Ubuntu 22.04 (probably 4.4.2):
```
--     FFMPEG:                      YES
--       avcodec:                   YES (58.134.100)
--       avformat:                  YES (58.76.100)
--       avutil:                    YES (56.70.100)
--       swscale:                   YES (5.9.100)
--       avresample:                NO
```
Note: suppressing only libavcodec 57

- [ ] TODO: check several FFmpeg versions before and after problematic