### PR TITLE
obj-c: de-duplicate values of nested enums

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -789,6 +789,9 @@ class ObjectiveCWrapperGenerator(object):
                 logging.info('class not found: %s', constinfo)
                 constinfo.name = constinfo.classname + '_' + constinfo.name
                 constinfo.classname = ''
+            elif constinfo.enumType and constinfo.classpath:
+                constinfo.name = constinfo.classname + '_' + constinfo.name
+                logging.info('use outer class prefix: %s', constinfo)
 
             ci = self.getClass(constinfo.classname)
             duplicate = ci.getConst(constinfo.name)

--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -774,6 +774,8 @@ class ObjectiveCWrapperGenerator(object):
         logging.info('ok: class %s, name: %s, base: %s', classinfo, name, classinfo.base)
         return classinfo
 
+    const_rename_map = dict()
+
     def add_const(self, decl, scope=None, enumType=None): # [ "const cname", val, [], [] ]
         constinfo = ConstInfo(decl, namespaces=self.namespaces, enumType=enumType)
         if constinfo.isIgnored():
@@ -790,7 +792,11 @@ class ObjectiveCWrapperGenerator(object):
                 constinfo.name = constinfo.classname + '_' + constinfo.name
                 constinfo.classname = ''
             elif constinfo.enumType and constinfo.classpath:
-                constinfo.name = constinfo.classname + '_' + constinfo.name
+                new_name = constinfo.classname + '_' + constinfo.name
+                self.const_rename_map[constinfo.name] = new_name
+                constinfo.name = new_name
+                if constinfo.value in self.const_rename_map:
+                    constinfo.value = self.const_rename_map[constinfo.value]
                 logging.info('use outer class prefix: %s', constinfo)
 
             ci = self.getClass(constinfo.classname)


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/3398

- prefix with outer class name

resolves #22206
resolves https://github.com/opencv/opencv_contrib/issues/3302
relates #17165

TODO:
- [x] fix build with updated names

<cut/>

```.diff
./modules/objc_bindings_generator/osx/gen/objc/xfeatures2d/BEBLID.h
@@ -18,8 +18,8 @@
 
 // C++: enum BeblidSize (cv.xfeatures2d.BEBLID.BeblidSize)
 typedef NS_ENUM(int, BeblidSize) {
-    SIZE_512_BITS = 100,
-    SIZE_256_BITS = 101
+    BEBLID_SIZE_512_BITS = 100,
+    BEBLID_SIZE_256_BITS = 101
 };


./modules/objc_bindings_generator/osx/gen/objc/xfeatures2d/TEBLID.h
@@ -18,8 +18,8 @@
 
 // C++: enum TeblidSize (cv.xfeatures2d.TEBLID.TeblidSize)
 typedef NS_ENUM(int, TeblidSize) {
-    SIZE_256_BITS = 102,
-    SIZE_512_BITS = 103
+    TEBLID_SIZE_256_BITS = 102,
+    TEBLID_SIZE_512_BITS = 103
 };
```

Other classes are affected too. E.g.

```.diff
 // C++: enum PointDistribution (cv.xfeatures2d.PCTSignatures.PointDistribution)
 typedef NS_ENUM(int, PointDistribution) {
-    UNIFORM = 0,
-    REGULAR = 1,
-    NORMAL = 2
+    PCTSignatures_UNIFORM = 0,
+    PCTSignatures_REGULAR = 1,
+    PCTSignatures_NORMAL = 2
 };
```

Also some values already have prefix:

```
// C++: enum FormatType (cv.Formatter.FormatType)
typedef NS_ENUM(int, FormatType) {
    Formatter_FMT_DEFAULT = 0,
    Formatter_FMT_MATLAB = 1,
    Formatter_FMT_CSV = 2,
    Formatter_FMT_PYTHON = 3,
    Formatter_FMT_NUMPY = 4,
    Formatter_FMT_C = 5
};
```