### PR TITLE
dnn: updated YOLOv4-tiny model and tests

### DIFF
--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -251,7 +251,7 @@ PERF_TEST_P_(DNNTestNetwork, YOLOv4_tiny)
     cvtColor(sample, sample, COLOR_BGR2RGB);
     Mat inp;
     sample.convertTo(inp, CV_32FC3, 1.0f / 255, 0);
-    processNet("dnn/yolov4-tiny.weights", "dnn/yolov4-tiny.cfg", "", inp);
+    processNet("dnn/yolov4-tiny-2020-12.weights", "dnn/yolov4-tiny-2020-12.cfg", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, EAST_text_detection)

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -562,12 +562,12 @@ TEST_P(Test_Darknet_nets_async, Accuracy)
             l1 = 0.001;
             lInf = 0.005;
         }
-        if (INF_ENGINE_VER_MAJOR_EQ(2021040000) && targetId == DNN_TARGET_OPENCL_FP16 && prefix == "yolov4-tiny")  // FIXIT: 4.x only, 3.4 branch works well
+        if (INF_ENGINE_VER_MAJOR_EQ(2021040000) && targetId == DNN_TARGET_OPENCL_FP16 && prefix == "yolov4-tiny-2020-12")  // FIXIT: 4.x only, 3.4 branch works well
         {
             l1 = 0.001;
             lInf = 0.005;
         }
-        if (INF_ENGINE_VER_MAJOR_EQ(2022010000) && targetId == DNN_TARGET_OPENCL_FP16 && prefix == "yolov4-tiny")  // FIXIT: 4.x only, 3.4 branch works well
+        if (INF_ENGINE_VER_MAJOR_EQ(2022010000) && targetId == DNN_TARGET_OPENCL_FP16 && prefix == "yolov4-tiny-2020-12")  // FIXIT: 4.x only, 3.4 branch works well
         {
             l1 = 0.001;
             lInf = 0.005;
@@ -594,7 +594,7 @@ TEST_P(Test_Darknet_nets_async, Accuracy)
 }
 
 INSTANTIATE_TEST_CASE_P(/**/, Test_Darknet_nets_async, Combine(
-    Values("yolo-voc", "tiny-yolo-voc", "yolov3", "yolov4", "yolov4-tiny"),
+    Values("yolo-voc", "tiny-yolo-voc", "yolov3", "yolov4", "yolov4-tiny-2020-12"),
     dnnBackendsAndTargets()
 ));
 
@@ -827,25 +827,26 @@ TEST_P(Test_Darknet_nets, YOLOv4_tiny)
 
     const double confThreshold = 0.5;
     // batchId, classId, confidence, left, top, right, bottom
-    const int N0 = 2;
+    const int N0 = 3;
     const int N1 = 3;
     static const float ref_[/* (N0 + N1) * 7 */] = {
-0, 7, 0.85935f, 0.593484f, 0.141211f, 0.920356f, 0.291593f,
-0, 16, 0.795188f, 0.169207f, 0.386886f, 0.423753f, 0.933004f,
+0, 16, 0.889883f, 0.177204f, 0.356279f, 0.417204f, 0.937517f,
+0, 7, 0.816615f, 0.604293f, 0.137345f, 0.918016f, 0.295708f,
+0, 1, 0.595912f, 0.0940107f, 0.178122f, 0.750619f, 0.829336f,
 
-1, 2, 0.996832f, 0.653802f, 0.464573f, 0.815193f, 0.653292f,
-1, 2, 0.963325f, 0.451151f, 0.458915f, 0.496255f, 0.52241f,
-1, 0, 0.926244f, 0.194851f, 0.361743f, 0.260277f, 0.632364f,
+1, 2, 0.998224f, 0.652883f, 0.463477f, 0.813952f, 0.657163f,
+1, 2, 0.967396f, 0.4539f, 0.466368f, 0.497716f, 0.520299f,
+1, 0, 0.807866f, 0.205039f, 0.361842f, 0.260984f, 0.643621f,
     };
     Mat ref(N0 + N1, 7, CV_32FC1, (void*)ref_);
 
-    double scoreDiff = 0.01f;
+    double scoreDiff = 0.012f;
     double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.15 : 0.01f;
     if (target == DNN_TARGET_CUDA_FP16)
         iouDiff = 0.02;
 
-    std::string config_file = "yolov4-tiny.cfg";
-    std::string weights_file = "yolov4-tiny.weights";
+    std::string config_file = "yolov4-tiny-2020-12.cfg";
+    std::string weights_file = "yolov4-tiny-2020-12.weights";
 
 #if defined(INF_ENGINE_RELEASE)
     if (target == DNN_TARGET_MYRIAD)  // bad accuracy

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -1320,19 +1320,19 @@ TEST_P(Test_Int8_nets, YOLOv4_tiny)
     const int N0 = 2;
     const int N1 = 3;
     static const float ref_[/* (N0 + N1) * 7 */] = {
-0, 7, 0.85935f, 0.593484f, 0.141211f, 0.920356f, 0.291593f,
-0, 16, 0.795188f, 0.169207f, 0.386886f, 0.423753f, 0.933004f,
+0, 16, 0.912199f, 0.169926f, 0.350896f, 0.422704f, 0.941837f,
+0, 7, 0.845388f, 0.617568f, 0.13961f, 0.9008f, 0.29315f,
 
-1, 2, 0.996832f, 0.653802f, 0.464573f, 0.815193f, 0.653292f,
-1, 2, 0.963325f, 0.451151f, 0.458915f, 0.496255f, 0.52241f,
-1, 0, 0.926244f, 0.194851f, 0.361743f, 0.260277f, 0.632364f,
+1, 2, 0.997789f, 0.657455f, 0.459714f, 0.809122f, 0.656829f,
+1, 2, 0.924423f, 0.442872f, 0.470127f, 0.49816f, 0.516516f,
+1, 0, 0.728307f, 0.202607f, 0.369828f, 0.259445f, 0.613846f,
     };
     Mat ref(N0 + N1, 7, CV_32FC1, (void*)ref_);
 
-    std::string config_file = "yolov4-tiny.cfg";
-    std::string weights_file = "yolov4-tiny.weights";
+    std::string config_file = "yolov4-tiny-2020-12.cfg";
+    std::string weights_file = "yolov4-tiny-2020-12.weights";
     double scoreDiff = 0.12;
-    double iouDiff = target == DNN_TARGET_OPENCL_FP16 ? 0.2 : 0.082;
+    double iouDiff = target == DNN_TARGET_OPENCL_FP16 ? 0.2 : 0.118;
 
     {
         SCOPED_TRACE("batch size 1");
@@ -1340,7 +1340,7 @@ TEST_P(Test_Int8_nets, YOLOv4_tiny)
 
         {
             SCOPED_TRACE("Per-tensor quantize");
-            testDarknetModel(config_file, weights_file, ref.rowRange(0, N0), scoreDiff, 0.16, 0.7, 0.4, false);
+            testDarknetModel(config_file, weights_file, ref.rowRange(0, N0), scoreDiff, 0.224, 0.7, 0.4, false);
         }
     }
 


### PR DESCRIPTION
Merge with opencv/opencv_extra#1026

- All tests now use `yolov4-tiny-2022-12` instead of `yolov4-tiny`
- I had to update test reference data, because results were different, I didn't check how previous bounding boxes look like, but updated boxes looks well:

First image:
![img0-2](https://user-images.githubusercontent.com/3304494/208907622-145a0e40-85a4-42e7-a725-dc373cef986c.jpg)

Second image:
![img1-2](https://user-images.githubusercontent.com/3304494/208907634-6580866e-80a7-4df1-9f44-3f87f0582e80.jpg)
