### PR TITLE
Fix nvcc compile errors when built against CUDA SDK < 11.2

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -427,7 +427,7 @@ if(CUDA_FOUND)
       set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler -fno-finite-math-only)
     endif()
 
-    if(WIN32)
+    if(CUDA_VERSION VERSION_GREATER_EQUAL 11.2 AND WIN32)
       set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcudafe --display_error_number --diag-suppress 1394,1388)
     endif()
 


### PR DESCRIPTION
Fix https://github.com/opencv/opencv/issues/23010.

The ability to disable nvcc warnings wasn't introduced until CUDA 11.2 (https://docs.nvidia.com/cuda/archive/11.2.0/cuda-toolkit-release-notes/index.html)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
