### PR TITLE
Fix self converTo.

### DIFF
--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -176,16 +176,16 @@ public:
 
         parallel_for_(Range(0, static_cast<int>(images.size())), [&](const Range& range) {
             for(int i = range.start; i < range.end; i++) {
-                Mat& img = images[i];
-                Mat gray, contrast, saturation, wellexp;
+                Mat img, gray, contrast, saturation, wellexp;
                 std::vector<Mat> splitted(channels);
 
-                img.convertTo(img, CV_32F, 1.0f/255.0f);
+                images[i].convertTo(img, CV_32F, 1.0f/255.0f);
                 if(channels == 3) {
                     cvtColor(img, gray, COLOR_RGB2GRAY);
                 } else {
                     img.copyTo(gray);
                 }
+                images[i] = img;
                 split(img, splitted);
 
                 Laplacian(gray, contrast, CV_32F);


### PR DESCRIPTION
We still need images[i] = img because it is used below in buildPyramid.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work