### PR TITLE
Fix for using sampleIdx to limit training data

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -904,7 +904,7 @@ public:
             if( s )
             {
                 j = s[i];
-                CV_Assert( 0 <= j && j < nsamples );
+                CV_Assert( 0 <= j && j < ((layout == ROW_SAMPLE) ? samples.rows : samples.cols) );
             }
             values[i] = src[j*sstep];
             if( values[i] == MISSED_VAL )


### PR DESCRIPTION
When using a sampleIdx Mat to limit the training samples to train on the current code will fail with an assert since it is checking that the index is < the length of the samples to train on instead of the available samples.
