### PR TITLE
Fix CUDA 12.0 build errors

### DIFF
--- a/modules/core/include/opencv2/core/cuda/common.hpp
+++ b/modules/core/include/opencv2/core/cuda/common.hpp
@@ -99,7 +99,6 @@ namespace cv { namespace cuda
         }
 
 #if (CUDART_VERSION >= 12000)
-        template<class T> inline void bindTexture(const textureReference* tex, const PtrStepSz<T>& img) { CV_Error(cv::Error::GpuNotSupported, "Function removed in CUDA SDK 12"); }
         template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {
             CV_Error(cv::Error::GpuNotSupported, "Function removed in CUDA SDK 12"); }
 #else
@@ -123,8 +122,8 @@ namespace cv { namespace cuda
 
             cudaSafeCall( cudaCreateTextureObject(tex, &resDesc, &texDesc, NULL) );
         }
-    }
 #endif
+    }
 }}
 
 //! @endcond


### PR DESCRIPTION
Fix build errors reported in https://github.com/opencv/opencv/issues/23034

Confirmed builds with  CUDA 12.0, CuDNN 8.7.0.84, Nvidia Video Codec SDK 12.0 on both

- Windows 11 22H2: Visual Studio 2022 (17.43)

- Ubuntu 20.04 LTS (WSL): g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
buildworker:Custom=linux-1
build_image:Custom=ubuntu-cuda:16.04
```