### PR TITLE
cmake: VERSION_GREATER_EQUAL is not supported in CMake 3.5.1

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -427,7 +427,7 @@ if(CUDA_FOUND)
       set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler -fno-finite-math-only)
     endif()
 
-    if(CUDA_VERSION VERSION_GREATER_EQUAL 11.2 AND WIN32)
+    if(WIN32 AND NOT (CUDA_VERSION VERSION_LESS "11.2"))
       set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcudafe --display_error_number --diag-suppress 1394,1388)
     endif()
 

--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -59,7 +59,7 @@ ocv_module_include_directories()
 #message(STATUS "${OPENCV_MODULE_${the_module}_SOURCES}")
 ocv_create_module(${link_deps})
 
-if(";${OPENCV_MODULES_BUILD};" MATCHES ";opencv_viz;" AND OPENCV_MODULE_opencv_viz_IS_PART_OF_WORLD AND VTK_VERSION VERSION_GREATER_EQUAL "8.90.0")
+if(";${OPENCV_MODULES_BUILD};" MATCHES ";opencv_viz;" AND OPENCV_MODULE_opencv_viz_IS_PART_OF_WORLD AND NOT (VTK_VERSION VERSION_LESS "8.90.0"))
   vtk_module_autoinit(TARGETS opencv_world MODULES ${VTK_LIBRARIES})
 endif()
 


### PR DESCRIPTION

```
buildworker:Custom=linux-1
build_image:Custom=ubuntu-cuda:16.04
```