### PR TITLE
dnn: add layer normalization for vision transformers

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1085,6 +1085,16 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<TileLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS LayerNormLayer : public Layer
+    {
+    public:
+        bool hasBias;
+        int axis;
+        float epsilon;
+
+        static Ptr<LayerNormLayer> create(const LayerParams& params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -494,9 +494,9 @@ struct Layer_LayerNormExpanded : public TestBaseWithParam<tuple<Backend, Target>
         randu(b, 0.f, 1.f);
 
         // sub graph structure:
-        //   -> ReduceMean ->     -> Pow -> ReduceMean -> Add(epsilon) -> Sqrt ->
-        // x                  Sub                                                 Div -> Mul(scale) -> Add(bias)
-        //   --------------->     ---------------------------------------------->
+        //   -> ReduceMean ->     -> Pow(2) -> ReduceMean -> Add(epsilon) -> Sqrt ->
+        // x                  Sub                                                    Div -> Mul(scale) -> Add(bias)
+        //   --------------->     ------------------------------------------------->
 
         Net net;
 

--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -618,7 +618,7 @@ struct Layer_LayerNormExpanded : public TestBaseWithParam<tuple<Backend, Target>
     int W = 768;
 };
 
-PERF_TEST_P_(Layer_LayerNormExpanded, LayerNormExpanded)
+PERF_TEST_P_(Layer_LayerNormExpanded, DISABLED_LayerNormExpanded)
 {
     test_layer({N, H ,W});
 }

--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -417,6 +417,212 @@ PERF_TEST_P_(Layer_ScatterND, DISABLED_ScatterND_add)
     test_layer({N, C, H , W}, "add");
 }
 
+struct Layer_LayerNorm : public TestBaseWithParam<tuple<Backend, Target> >
+{
+    void test_layer(const std::vector<int>& x_shape)
+    {
+        int backendId = get<0>(GetParam());
+        int targetId = get<1>(GetParam());
+
+        Mat x(x_shape, CV_32FC1);
+        Mat scale(x_shape.back(), 1, CV_32FC1);
+        Mat b(x_shape.back(), 1, CV_32FC1);
+
+        randu(x, 0.f, 1.f);
+        randu(scale, 0.f, 1.f);
+        randu(b, 0.f, 1.f);
+
+
+        Net net;
+        LayerParams lp;
+        lp.type = "LayerNormalization";
+        lp.name = "testLayer";
+        lp.set("axis", 2);
+        lp.set("hasBias", true);
+        int id = net.addLayerToPrev(lp.name, lp.type, lp);
+        net.connect(0, 0, id, 0);
+        net.connect(0, 1, id, 1);
+        net.connect(0, 2, id, 2);
+
+        // warmup
+        {
+            std::vector<String> inpNames(3);
+            inpNames[0] = "x";
+            inpNames[1] = "scale";
+            inpNames[2] = "b";
+            net.setInputsNames(inpNames);
+            net.setInput(x, inpNames[0]);
+            net.setInput(scale, inpNames[1]);
+            net.setInput(b, inpNames[2]);
+
+            net.setPreferableBackend(backendId);
+            net.setPreferableTarget(targetId);
+            Mat out = net.forward();
+        }
+
+        TEST_CYCLE()
+        {
+            Mat res = net.forward();
+        }
+
+        SANITY_CHECK_NOTHING();
+    }
+
+    int N = 1;
+    int H = 50;
+    int W = 768;
+};
+
+PERF_TEST_P_(Layer_LayerNorm, LayerNorm)
+{
+    test_layer({N, H ,W});
+}
+
+struct Layer_LayerNormExpanded : public TestBaseWithParam<tuple<Backend, Target> >
+{
+    void test_layer(const std::vector<int>& x_shape)
+    {
+        int backendId = get<0>(GetParam());
+        int targetId = get<1>(GetParam());
+
+        Mat x(x_shape, CV_32FC1);
+        Mat scale(1, x_shape.back(), CV_32FC1); // transpose to pass shape check
+        Mat b(1, x_shape.back(), CV_32FC1);     // transpose to pass shape check
+
+        randu(x, 0.f, 1.f);
+        randu(scale, 0.f, 1.f);
+        randu(b, 0.f, 1.f);
+
+        // sub graph structure:
+        //   -> ReduceMean ->     -> Pow -> ReduceMean -> Add(epsilon) -> Sqrt ->
+        // x                  Sub                                                 Div -> Mul(scale) -> Add(bias)
+        //   --------------->     ---------------------------------------------->
+
+        Net net;
+
+        LayerParams lp_rm;
+        lp_rm.type = "Reduce";
+        lp_rm.name = "reducemean1";
+        lp_rm.set("reduce", "AVE");
+        std::vector<int> deleteDims(1, x_shape.back());
+        lp_rm.set("deleted_dims", DictValue::arrayInt(&deleteDims[0], deleteDims.size()));
+        std::vector<int> targetDims(x_shape.begin(), x_shape.end());
+        targetDims[x_shape.size() - 1] = 1;
+        lp_rm.set("target_dims", DictValue::arrayInt(&targetDims[0], targetDims.size()));
+        int id_rm = net.addLayerToPrev(lp_rm.name, lp_rm.type, lp_rm);
+        net.connect(0, 0, id_rm, 0);
+
+        LayerParams lp_sub;
+        lp_sub.type = "NaryEltwise";
+        lp_sub.name = "sub1";
+        lp_sub.set("operation", "sub");
+        int id_sub = net.addLayer(lp_sub.name, lp_sub.type, lp_sub);
+        net.connect(0, 0, id_sub, 0);
+        net.connect(id_rm, 0, id_sub, 1);
+
+        Mat pow_const(1, 1, CV_32FC1);
+        pow_const.at<float>(0) = 2.f;
+        LayerParams lp_pow_const;
+        lp_pow_const.type = "Const";
+        lp_pow_const.name = "const1";
+        lp_pow_const.blobs.push_back(pow_const);
+        int id_pow_const = net.addLayer(lp_pow_const.name, lp_pow_const.type, lp_pow_const);
+        LayerParams lp_pow;
+        lp_pow.type = "NaryEltwise";
+        lp_pow.name = "pow1";
+        lp_pow.set("operation", "pow");
+        int id_pow = net.addLayer(lp_pow.name, lp_pow.type, lp_pow);
+        net.connect(id_sub, 0, id_pow, 0);
+        net.connect(id_pow_const, 0, id_pow, 1);
+
+        LayerParams lp_rm1;
+        lp_rm1.type = "Reduce";
+        lp_rm1.name = "reducemean2";
+        lp_rm1.set("reduce", "AVE");
+        lp_rm1.set("deleted_dims", DictValue::arrayInt(&deleteDims[0], deleteDims.size()));
+        lp_rm1.set("target_dims", DictValue::arrayInt(&targetDims[0], targetDims.size()));
+        int id_rm1 = net.addLayer(lp_rm1.name, lp_rm1.type, lp_rm1);
+        net.connect(id_pow, 0, id_rm1, 0);
+
+        Mat add_const(1, 1, CV_32F);
+        add_const.at<float>(0) = 1e-5;
+        LayerParams lp_add_const;
+        lp_add_const.type = "Const";
+        lp_add_const.name = "const2";
+        lp_add_const.blobs.push_back(add_const);
+        int id_add_const = net.addLayer(lp_add_const.name, lp_add_const.type, lp_add_const);
+        LayerParams lp_add;
+        lp_add.type = "NaryEltwise";
+        lp_add.name = "add1";
+        lp_add.set("operation", "add");
+        int id_add = net.addLayer(lp_add.name, lp_add.type, lp_add);
+        net.connect(id_rm1, 0, id_add, 0);
+        net.connect(id_add_const, 0, id_add, 1);
+
+        LayerParams lp_sqrt;
+        lp_sqrt.type = "Sqrt";
+        lp_sqrt.name = "sqrt1";
+        int id_sqrt = net.addLayer(lp_sqrt.name, lp_sqrt.type, lp_sqrt);
+        net.connect(id_add, 0, id_sqrt, 0);
+
+        LayerParams lp_div;
+        lp_div.type = "NaryEltwise";
+        lp_div.name = "div1";
+        lp_div.set("operation", "div");
+        int id_div = net.addLayer(lp_div.name, lp_div.type, lp_div);
+        net.connect(id_sub, 0, id_div, 0);
+        net.connect(id_sqrt, 0, id_div, 1);
+
+        LayerParams lp_mul;
+        lp_mul.type = "NaryEltwise";
+        lp_mul.name = "mul1";
+        lp_mul.set("operation", "mul");
+        int id_mul = net.addLayer(lp_mul.name, lp_mul.type, lp_mul);
+        net.connect(id_div, 0, id_mul, 0);
+        net.connect(0, 1, id_mul, 1);
+
+        LayerParams lp_add1;
+        lp_add1.type = "NaryEltwise";
+        lp_add1.name = "add2";
+        lp_add1.set("operation", "add");
+        int id_add1 = net.addLayer(lp_add1.name, lp_add1.type, lp_add1);
+        net.connect(id_mul, 0, id_add1, 0);
+        net.connect(0, 2, id_add1, 1);
+
+        // warmup
+        {
+            std::vector<String> inpNames(3);
+            inpNames[0] = "x";
+            inpNames[1] = "scale";
+            inpNames[2] = "b";
+            net.setInputsNames(inpNames);
+            net.setInput(x, inpNames[0]);
+            net.setInput(scale, inpNames[1]);
+            net.setInput(b, inpNames[2]);
+
+            net.setPreferableBackend(backendId);
+            net.setPreferableTarget(targetId);
+            Mat out = net.forward();
+        }
+
+        TEST_CYCLE()
+        {
+            Mat res = net.forward();
+        }
+
+        SANITY_CHECK_NOTHING();
+    }
+
+    int N = 1;
+    int H = 50;
+    int W = 768;
+};
+
+PERF_TEST_P_(Layer_LayerNormExpanded, LayerNormExpanded)
+{
+    test_layer({N, H ,W});
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Layer_Slice, dnnBackendsAndTargets(false, false));
 INSTANTIATE_TEST_CASE_P(/**/, Layer_NaryEltwise, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 #ifdef HAVE_CUDA
@@ -424,5 +630,7 @@ INSTANTIATE_TEST_CASE_P(CUDA, Layer_NaryEltwise, testing::Values(std::make_tuple
 #endif
 INSTANTIATE_TEST_CASE_P(/**/, Layer_Scatter, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 INSTANTIATE_TEST_CASE_P(/**/, Layer_ScatterND, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
+INSTANTIATE_TEST_CASE_P(/**/, Layer_LayerNorm, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
+INSTANTIATE_TEST_CASE_P(/**/, Layer_LayerNormExpanded, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 
 } // namespace

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -154,6 +154,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Arg,            ArgLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reciprocal,     ReciprocalLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Gather,         GatherLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(LayerNormalization, LayerNormLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Crop,           CropLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Eltwise,        EltwiseLayer);

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -118,7 +118,7 @@ public:
             if (hasBias) {
                 biasData = (const float *)bias->data;
             }
-            
+
             for (int ofs = stripeStart; ofs < stripeEnd; ++ofs)
             {
                 const float* first = srcData + ofs * normSize;

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -105,6 +105,7 @@ public:
             LayerNormInvoker p(src, scale, b, dst, axis, epsilon);
 
             double nstripes = ((size_t)p.total * p.normSize) * (1 / 1024.0);
+            // double nstripes = ((size_t)p.total) * (1 / 1024.0);
             parallel_for_(Range(0, p.total), p, nstripes);
         }
 

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -1,0 +1,160 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+
+namespace cv { namespace dnn {
+
+class LayerNormLayerImpl CV_FINAL : public LayerNormLayer
+{
+public:
+    LayerNormLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+
+        // standard attr
+        axis = params.get<int>("axis", 0);
+        epsilon = params.get<float>("epsilon", 1e-5);
+
+        // opencv attr
+        hasBias = params.get<bool>("hasBias", false);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                                 const int requiredOutputs,
+                                 std::vector<MatShape> &outputs,
+                                 std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        // check shapes of weight and bias if existed
+        // inputs >= 2 (X and Weight are requested, bias is optional)
+        CV_CheckGE(inputs.size(), 2ull, "LayerNorm: require at least two inputs (x, weight)");
+        CV_CheckLE(inputs.size(), 3ull, "LayerNorm: have at most three inputs (x, weight, bias)");
+
+        auto x_shape = inputs[0];
+        int x_ndims = static_cast<int>(x_shape.size());
+
+        auto w_shape = inputs[1];
+        // if axis == last_dim, scale and b are both 1d tensor (represented as 2d mat nx1)
+        int w_ndims = static_cast<int>(w_shape.size());
+        w_ndims = (axis == x_ndims - 1 && w_ndims == 2) ? w_ndims - 1 : w_ndims;
+        CV_CheckEQ(x_ndims - axis, w_ndims, "LayerNorm: shape of weight does not match with given axis and shape of input");
+        for (int i = 0; i < w_ndims; ++i)
+            CV_CheckEQ(x_shape[axis+i], w_shape[i], "LayerNorm: weight dimensions does not match with input dimensions");
+        if (hasBias)
+        {
+            auto b_shape = inputs[2];
+            CV_CheckEQ(w_shape.size(), b_shape.size(), "LayerNorm: shape of weight does not match with shape of bias");
+            for (size_t i = 0; i < w_shape.size(); ++i)
+                CV_CheckEQ(w_shape[i], b_shape[i], "LayerNorm: bias dimensions does not match with weight dimensions");
+        }
+
+        // only one output is needed; Mean & InvStdDev are not needed
+        // in inference and should beomitted in onnx importer
+        outputs.assign(1, inputs[0]);
+        return false;
+    }
+
+    class LayerNormInvoker : public ParallelLoopBody
+    {
+    public:
+        const Mat* src, *scale, *bias;
+        Mat *dst;
+
+        float epsilon;
+        int nstripes;
+
+        int total;
+        int stripeSize;
+        int normSize;
+
+        LayerNormInvoker() : src(0), scale(0), bias(0), dst(0), epsilon(0.f), nstripes(0), total(0), stripeSize(0), normSize(0) { }
+
+        static void run(const Mat* src, const Mat* scale, const Mat* b, Mat* dst, int axis, float epsilon, int nstripes)
+        {
+            CV_Assert_N( src->isContinuous(), dst->isContinuous(), src->type() == CV_32F, src->type() == dst->type());
+
+            LayerNormInvoker p;
+
+            p.src = src;
+            p.scale = scale;
+            p.bias = b;
+            p.dst = dst;
+
+            p.epsilon = epsilon;
+            p.nstripes = nstripes;
+
+            auto dstShape = shape(*dst);
+            p.total = std::accumulate(dstShape.begin(), dstShape.begin() + axis, 1, std::multiplies<int>());
+            p.stripeSize = (p.total + nstripes - 1) / nstripes;
+            p.normSize = std::accumulate(dstShape.begin() + axis, dstShape.end(), 1, std::multiplies<int>());
+
+            parallel_for_(Range(0, nstripes), p, nstripes);
+        }
+
+        void operator()(const Range& r) const CV_OVERRIDE
+        {
+            int stripeStart = r.start * stripeSize;
+            int stripeEnd = std::min(r.end * stripeSize, total);
+
+            float *dstData = (float *)dst->data;
+            const float *srcData = (const float *)src->data;
+            const float *scaleData = (const float *)scale->data;
+            const float *biasData = nullptr;
+            if (bias != nullptr)
+                biasData = (const float *)bias->data;
+
+            for (int ofs = stripeStart; ofs < stripeEnd; ++ofs)
+            {
+                const float* first = srcData + ofs * normSize;
+                float* dst_first = dstData + ofs * normSize;
+
+                float mean = 0;
+                float mean_square = 0;
+                for (int h = 0; h < normSize; ++h) {
+                    mean += first[h];
+                    mean_square += first[h] * first[h];
+                }
+                mean /= normSize;
+                mean_square = std::sqrt(mean_square / normSize - mean * mean + epsilon);
+                for (int h = 0; h < normSize; ++h) {
+                    if (biasData == nullptr) {
+                        dst_first[h] = (first[h] - mean) / mean_square * scaleData[h];
+                    } else {
+                        dst_first[h] = (first[h] - mean) / mean_square * scaleData[h] + biasData[h];
+                    }
+                }
+            }
+        }
+    };
+
+    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+        const int nstripes = getNumThreads();
+
+        if (hasBias)
+        {
+            LayerNormInvoker::run(&inputs[0], &inputs[1], &inputs[2], &outputs[0], axis, epsilon, nstripes);
+        }
+        else
+        {
+            LayerNormInvoker::run(&inputs[0], &inputs[1], nullptr, &outputs[0], axis, epsilon, nstripes);
+        }
+    }
+};
+
+Ptr<LayerNormLayer> LayerNormLayer::create(const LayerParams& params)
+{
+    return makePtr<LayerNormLayerImpl>(params);
+}
+
+}} // cv::dnn

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -78,7 +78,10 @@ public:
 
         static void run(const Mat* src, const Mat* scale, const Mat* b, Mat* dst, int axis, float epsilon, int nstripes)
         {
-            CV_Assert_N( src->isContinuous(), dst->isContinuous(), src->type() == CV_32F, src->type() == dst->type());
+            CV_Assert(src->isContinuous());
+            CV_Assert(dst->isContinuous());
+            CV_CheckType(src->type(), CV_32F, "DNN/LayerNorm: only support float32");
+            CV_Assert(src->type() == dst->type());
 
             LayerNormInvoker p;
 
@@ -136,6 +139,15 @@ public:
 
     void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
     {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        if (inputs_arr.depth() == CV_16S)
+        {
+            forward_fallback(inputs_arr, outputs_arr, internals_arr);
+            return;
+        }
+
         std::vector<Mat> inputs, outputs;
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2421,6 +2421,7 @@ TEST_P(Test_ONNX_layers, LayerNorm)
 TEST_P(Test_ONNX_layers, LayerNormExpanded)
 {
     testONNXModels("layer_norm_expanded");
+    testONNXModels("layer_norm_expanded_with_initializers");
 }
 
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2394,6 +2394,35 @@ TEST_P(Test_ONNX_layers, Tile)
     testONNXModels("tile", pb);
 }
 
+TEST_P(Test_ONNX_layers, LayerNorm)
+{
+    testONNXModels("test_layer_normalization_2d_axis0", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_2d_axis1", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_2d_axis_negative_1", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_2d_axis_negative_2", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis0_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis1_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis2_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis_negative_1_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis_negative_2_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_3d_axis_negative_3_epsilon", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis0", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis1", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis2", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis3", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis_negative_1", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis_negative_2", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis_negative_3", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_4d_axis_negative_4", pb, 0, 0, false, true, 3);
+    testONNXModels("test_layer_normalization_default_axis", pb, 0, 0, false, true, 3);
+}
+
+// for testing graph simplification
+// TEST_P(Test_ONNX_layers, LayerNormExpanded)
+// {
+//     testONNXModels("layer_norm_expanded");
+// }
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
 }} // namespace

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2418,10 +2418,10 @@ TEST_P(Test_ONNX_layers, LayerNorm)
 }
 
 // for testing graph simplification
-// TEST_P(Test_ONNX_layers, LayerNormExpanded)
-// {
-//     testONNXModels("layer_norm_expanded");
-// }
+TEST_P(Test_ONNX_layers, LayerNormExpanded)
+{
+    testONNXModels("layer_norm_expanded");
+}
 
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 


### PR DESCRIPTION
Merge with https://github.com/opencv/opencv_extra/pull/1032

- [x] add layer norm onnx parser
- [x] add layer norm impl
- [x] add layer norm onnx simplifier for both cases of constants being Constant and Initializer
- [x] add test model generation code for layer_norm_expanded and layer_norm_expanded_initializer

Benchmark:

| Layer | Mean (ms) | Median (ms) | Min (ms) |
| - | - | - | - |
| layer norm expanded | 0.43 | 0.42 | 0.40 |
| layer norm (this pr) | 0.02 | 0.02 | 0.01 |

*: tested with size 1x50x768 on Apple M1.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux OpenCL
```