### PR TITLE
DNN: make GEMM can be supported with transA and transB in CUDA

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -374,6 +374,10 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<SoftmaxLayerInt8> create(const LayerParams& params);
     };
 
+    /**
+     * `InnerProduct`, `MatMul` and `Gemm` operations are all implemented by Fully Connected Layer.
+     * Parameter `is_matmul` is used to distinguish `MatMul` and `Gemm` from `InnerProduct`.
+     */
     class CV_EXPORTS InnerProductLayer : public Layer
     {
     public:

--- a/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
@@ -12,6 +12,8 @@
 #include "../csl/tensor.hpp"
 #include "../csl/tensor_ops.hpp"
 
+#include "../kernels/scale_shift.hpp"
+
 #include <opencv2/core.hpp>
 
 #include <utility>
@@ -23,7 +25,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
     public:
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
-        MatMulOp(csl::Stream stream_, csl::cublas::Handle handle, const Mat& constInp)
+        MatMulOp(csl::Stream stream_, csl::cublas::Handle handle, const Mat& constInp, const Mat& bias, bool _transA, bool _transB)
             : stream(std::move(stream_)), cublasHandle(std::move(handle))
         {
             if (!constInp.empty())
@@ -31,6 +33,15 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                 constTensor = csl::makeTensorHeader<T>(constInp);
                 csl::copyMatToTensor<T>(constInp, constTensor, stream);
             }
+
+            if (!bias.empty())
+            {
+                biasTensor = csl::makeTensorHeader<T>(bias);
+                csl::copyMatToTensor<T>(bias, biasTensor, stream);
+            }
+
+            transA = _transA;
+            transB = _transB;
         }
 
         void forward(
@@ -69,50 +80,72 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                 CV_Assert(input2.get_axis_size(i) == size);
             }
 
-            auto m = input1.get_axis_size(-2);
-            auto n = input1.get_axis_size(-1);
-            auto b = input1.size() / m / n;
-            int k;
-            if (constTensor.empty())
+            int m1, n1, b1, m2, n2, b2;
+            if (transA)
             {
-                k = input2.get_axis_size(-1);
-                CV_Assert(input2.get_axis_size(-2) == n);
+                m1 = input1.get_axis_size(-1);
+                n1 = input1.get_axis_size(-2);
             }
             else
             {
-                k = input2.get_axis_size(-2);
-                CV_Assert(input2.get_axis_size(-1) == n);
+                m1 = input1.get_axis_size(-2);
+                n1 = input1.get_axis_size(-1);
             }
-            CV_Assert(output.get_axis_size(-2) == m);
-            CV_Assert(output.get_axis_size(-1) == k);
+
+            if (transB)
+            {
+                m2 = input2.get_axis_size(-1);
+                n2 = input2.get_axis_size(-2);
+            }
+            else
+            {
+                m2 = input2.get_axis_size(-2);
+                n2 = input2.get_axis_size(-1);
+            }
+
+            b1 = input1.size() / m1 / n1;
+            b2 = input2.size() / m2 / n2;
+            CV_Assert(b1 == b2);
+            CV_Assert(n1 == m2);
+            CV_Assert(output.get_axis_size(-2) == m1);
+            CV_Assert(output.get_axis_size(-1) == n2);
 
             if (get_effective_rank(output) <= 2)
             {
-                CV_Assert(b == 1);
+                CV_Assert(b2 == 1);
                 CV_Assert(get_effective_rank(input1) <= 2);
                 CV_Assert(get_effective_rank(input2) <= 2);
-                csl::tensor_ops::gemm<T>(cublasHandle, 0.0, output, 1.0, false, input1, !constTensor.empty(), input2);
+                csl::tensor_ops::gemm<T>(cublasHandle, 0.0, output, 1.0, transA, input1, transB, input2);
+                // used for GEMM
+                if (!biasTensor.empty())
+                    kernels::biasN<T>(stream, output, output, 1, biasTensor);
             }
             else
             {
                 CV_Assert(rank >= 3);
-                input1.reshape(b, m, n);
-                if (constTensor.empty())
-                    input2.reshape(b, n, k);
+                if (transA)
+                    input1.reshape(b1, n1, m1);
                 else
-                    input2.reshape(b, k, n);
-                output.reshape(b, m, k);
+                    input1.reshape(b1, m1, n1);
+
+                if (transB)
+                    input2.reshape(b2, n2, m2);
+                else
+                    input2.reshape(b2, m2, n2);
+
+                output.reshape(b1, m1, n2);
                 input1.squeeze_to(3);
                 input2.squeeze_to(3);
                 output.squeeze_to(3);
-                csl::tensor_ops::gemmStridedBatched<T>(cublasHandle, 0.0, output, 1.0, false, input1, !constTensor.empty(), input2);
+                csl::tensor_ops::gemmStridedBatched<T>(cublasHandle, 0.0, output, 1.0, transA, input1, transB, input2);
             }
         }
 
     private:
         csl::Stream stream;
         csl::cublas::Handle cublasHandle;
-        csl::Tensor<T> constTensor;
+        csl::Tensor<T> constTensor, biasTensor;
+        bool transA, transB;
     };
 
 }}} /* namespace cv::dnn::cuda4dnn */

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2056,6 +2056,7 @@ void ONNXImporter::parseGemm(LayerParams& layerParams, const opencv_onnx::NodePr
     }
 
     layerParams.set("bias_term", node_proto.input_size() == 3);
+    layerParams.set("is_matmul", true);
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1745,6 +1745,11 @@ TEST_P(Test_ONNX_layers, Gemm)
     testONNXModels("gemm_first_const");
 }
 
+TEST_P(Test_ONNX_layers, Gemm_bias)
+{
+    testONNXModels("gemm_vector_bias");
+}
+
 TEST_P(Test_ONNX_layers, Quantized_Convolution)
 {
     // The difference of QOperator and QDQ format:


### PR DESCRIPTION
**Merge with:** https://github.com/opencv/opencv_extra/pull/1033

This PR tries to make `GEMM` can be supported with `transA` and `transB` in CUDA. It's a follow-up to https://github.com/opencv/opencv/pull/22882
`GEMM` onnx documentation: https://github.com/onnx/onnx/blob/main/docs/Operators.md#Gemm

Because `MatMul` can be seen as a specific case of `GEMM`, I put the `GEMM` into `MatMulOp`. This may make it possible to implement the whole GEMM operation: `αAB+βC` in the future.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-1
docker_image:Custom=ubuntu-cuda:16.04
```