### PR TITLE
Fix Heap-buffer-overflow READ in opj_jp2_apply_pclr

### DIFF
--- a/3rdparty/openjpeg/openjp2/jp2.c
+++ b/3rdparty/openjpeg/openjp2/jp2.c
@@ -1108,7 +1108,7 @@ static OPJ_BOOL opj_jp2_apply_pclr(opj_image_t *image,
         pcol = cmap[i].pcol;
         src = old_comps[cmp].data;
         assert(src); /* verified above */
-        max = new_comps[pcol].w * new_comps[pcol].h;
+        max = new_comps[i].w * new_comps[i].h;
 
         /* Direct use: */
         if (cmap[i].mtyp == 0) {


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47342

The read overflow triggered by reading `src[j]` in
```cpp
            for (j = 0; j < max; ++j) {
                dst[j] = src[j];
            }
```
The max is calculated as `new_comps[pcol].w * new_comps[pcol].h`, however the `src = old_comps[cmp].data;` which may have different `w` and `h` dimensions.

The patch was contributed to the third party library openjpeg https://github.com/uclouvain/openjpeg/pull/1441
Normally I would suggest to update to openjpeg 2.5.1 when released, but there was no release in 4 months and from security point of view I suggest to make the hot fix for now and bump the version when available. The tracking issue was created - https://github.com/opencv/opencv/issues/23066

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (the one that is fuzzed)
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
