### PR TITLE
USAC fix: GraphCut fails to allocate big dense matrices

### DIFF
--- a/modules/calib3d/src/precomp.hpp
+++ b/modules/calib3d/src/precomp.hpp
@@ -53,6 +53,8 @@
 
 #include "opencv2/core/ocl.hpp"
 
+#include <set>
+
 #define GET_OPTIMIZED(func) (func)
 
 

--- a/modules/calib3d/test/test_usac.cpp
+++ b/modules/calib3d/test/test_usac.cpp
@@ -416,7 +416,7 @@ TEST (usac_Affine2D, accuracy) {
 
 TEST(usac_testUsacParams, accuracy) {
     std::vector<int> gt_inliers;
-    const int pts_size = 1500;
+    const int pts_size = 150000;
     cv::RNG &rng = cv::theRNG();
     const cv::UsacParams usac_params = cv::UsacParams();
     cv::Mat pts1, pts2, K1, K2, mask, model, rvec, tvec, R;


### PR DESCRIPTION
### TODO:
- [x] rebase it on 4.x without other USAC code

### Bug description

The bug arises in #22884 when setting a number of points to numbers like 60000 and bigger.
For N samples GraphCut tries to allocate an edge connectivity matrix of size NxN and segfaults on big numbers, see [here](https://github.com/opencv/opencv/blob/9208dcb07c015e1fda44e40bb07b43c700b4bf46/modules/calib3d/src/usac/local_optimization.cpp#L43).

### Changes

The solution is to use `std::set<int>` instead of `std::vector<bool>`.
Despite theoretically longer read/write time, like O(log N) vs O(1), I've got +30% performance on my machine, probably because of CPU caching.

The bug reproducer is just a `usac_testUsacParams.accuracy` test with bigger `pts_size`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
