### PR TITLE
Open CV_CPU_NEON_DOTPROD on Apple silicon devices

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -243,6 +243,7 @@ std::wstring GetTempFileNameWinRT(std::wstring prefix)
 #if defined __MACH__ && defined __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_time.h>
+#include <sys/sysctl.h>
 #endif
 
 #endif
@@ -626,6 +627,14 @@ struct HWFeatures
     #endif
     #if (defined __ARM_FP  && (((__ARM_FP & 0x2) != 0) && defined __ARM_NEON__))
         have[CV_CPU_FP16] = true;
+    #endif
+    #if (defined __ARM_FEATURE_DOTPROD)
+        int has_feat_dotprod = 0;
+        size_t has_feat_dotprod_size = sizeof(has_feat_dotprod);
+        sysctlbyname("hw.optional.arm.FEAT_DotProd", &has_feat_dotprod, &has_feat_dotprod_size, NULL, 0);
+        if (has_feat_dotprod) {
+            have[CV_CPU_NEON_DOTPROD] = true;
+        }
     #endif
     #elif (defined __clang__)
     #if (defined __ARM_NEON__ || (defined __ARM_NEON && defined __aarch64__))


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/23085.

After https://github.com/opencv/opencv/pull/22271 was merged, OpenCV can no longer initialize on M1 macs due to missing the required `NEON_DOTPROD` feature. This patch simply checks if `__ARM_FEATURE_DOTPROD` is enabled (which should be true when compiling for M1 macs), and turns on `CV_CPU_NEON_DOTPROD` if this feature is supported in runtime.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
