### PR TITLE
DNN: fix possible segmentation fault error in winograd on x86

### DIFF
--- a/modules/dnn/src/layers/fast_convolution/fast_convolution.avx2.cpp
+++ b/modules/dnn/src/layers/fast_convolution/fast_convolution.avx2.cpp
@@ -119,7 +119,7 @@ void convBlock_AVX2(int np, const float* a, const float* b, float* c, int ldc, b
 void _fx_winograd_accum_f32(const float* inwptr, const float* wptr,
                        float* outbuf, int Cg, int iblock)
 {
-    CV_Assert(_FX_WINO_IBLOCK == 6 && _FX_WINO_KBLOCK == 4);// && _FX_WINO_ATOM_F32 == 8);
+    CV_Assert(_FX_WINO_IBLOCK == 6 && _FX_WINO_KBLOCK == 4 && _FX_WINO_ATOM_F32 == 8);
     if (iblock > 3)
     {
         for (int atom_id = 0; atom_id < _FX_WINO_NATOMS_F32; atom_id++,

--- a/modules/dnn/src/layers/fast_convolution/fast_convolution.cpp
+++ b/modules/dnn/src/layers/fast_convolution/fast_convolution.cpp
@@ -105,6 +105,12 @@ Ptr<FastConv> initFastConv(
         conv->conv_type = _FX_CONV_TYPE_GENERIC;
 #endif
 
+#if CV_TRY_AVX2
+    // Disabel Winograd when CV_TRY_AVX2 is true, but conv->useAVX2 is false.
+    if (conv->conv_type == _FX_CONV_TYPE_WINOGRAD3X3 && !conv->useAVX2)
+        conv->conv_type = _FX_CONV_TYPE_GENERIC;
+#endif
+
     Mat weightsMat = _weightsMat.getMat();
     auto wShape = shape(weightsMat);
     const size_t wstep = weightsMat.step1();
@@ -257,7 +263,7 @@ Ptr<FastConv> initFastConv(
     // we can always read MR elements starting from any valid index
     {
         int k = 0, nbias = K + VEC_ALIGN;
-        conv->biasBuf.reserve(nbias);
+        conv->biasBuf.resize(nbias);
         float* biasBufPtr = conv->biasBuf.data();
         for(; k < K; k++)
             biasBufPtr[k] = srcBias ? srcBias[k] : 0.f;

--- a/modules/dnn/src/layers/fast_convolution/winograd_3x3s1_f63.cpp
+++ b/modules/dnn/src/layers/fast_convolution/winograd_3x3s1_f63.cpp
@@ -22,7 +22,7 @@ _fx_winograd_accum_f32(const float* inwptr, const float* wptr,
                        float* outbuf, int Cg, int iblock)
  {
 #if CV_NEON && CV_NEON_AARCH64
-    CV_Assert(_FX_WINO_IBLOCK == 6 && _FX_WINO_KBLOCK == 4);
+    CV_Assert(_FX_WINO_IBLOCK == 6 && _FX_WINO_KBLOCK == 4 && _FX_WINO_ATOM_F32 == 4);
     if (iblock > 3)
     {
         for (int atom_id = 0; atom_id < _FX_WINO_NATOMS_F32; atom_id++,
@@ -144,7 +144,7 @@ _fx_winograd_accum_f32(const float* inwptr, const float* wptr,
         }
     }
 #elif CV_SIMD128
-    CV_Assert(_FX_WINO_IBLOCK == 3 && _FX_WINO_KBLOCK == 4);
+    CV_Assert(_FX_WINO_IBLOCK == 3 && _FX_WINO_KBLOCK == 4 && _FX_WINO_ATOM_F32 == 4);
     for (int atom_id = 0; atom_id < _FX_WINO_NATOMS_F32; atom_id++,
             outbuf += _FX_WINO_ATOM_F32)
     {


### PR DESCRIPTION
The segmentation fault error only happens in AVX only platform, while the `CV_TRY_AVX2` is true and `checkHardwareSupport(CPU_AVX2)` is false. And this inconsistency will cause Winograd branch code to enter the wrong memory block. And in AVX only platform, the Winograd can not be speeded up by AVX or AVX2 which will be slower than the generic Convolution branch. So, in short term, I think disabling Winograd is a better solution.

And for a long-term solution, we should support Winograd at https://github.com/opencv/opencv/blob/4.x/modules/dnn/src/layers/layers_common.simd.hpp. After that, OpenCV can automatically generate AVX or AVX2 code for Winograd based on CPU instruction set. I will try to implement this.

detailed discussion: https://github.com/cocoa-xu/evision/issues/153#issuecomment-1374882601.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
