### PR TITLE
build: eliminate GCC9 warning from sift.simd.hpp

### DIFF
--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -808,10 +808,17 @@ if( dstMat.type() == CV_32F )
         v_store(dst + k, __dst);
     }
 #endif
+#if defined(__GNUC__) && __GNUC__ >= 9
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"  // iteration XX invokes undefined behavior
+#endif
     for( ; k < len; k++ )
     {
         dst[k] = saturate_cast<uchar>(rawDst[k]*nrm2);
     }
+#if defined(__GNUC__) && __GNUC__ >= 9
+#pragma GCC diagnostic pop
+#endif
 }
 else // CV_8U
 {
@@ -831,9 +838,8 @@ else // CV_8U
 #endif
 
 #if defined(__GNUC__) && __GNUC__ >= 9
-// avoid warning "iteration 7 invokes undefined behavior" on Linux ARM64
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
+#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"  // iteration XX invokes undefined behavior
 #endif
     for( ; k < len; k++ )
     {


### PR DESCRIPTION
relates #22246 #22295

GCC12 still emits this warning on x86 (`cmake ... -DCPU_BASELINE=AVX2 -DCPU_DISPATCH=`)