### PR TITLE
different interpolation by double image

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -289,7 +289,7 @@ public:
     */
     CV_WRAP static Ptr<SIFT> create(int nfeatures = 0, int nOctaveLayers = 3,
         double contrastThreshold = 0.04, double edgeThreshold = 10,
-        double sigma = 1.6);
+        double sigma = 1.6, bool enable_precise_upscale = true);
 
     /** @brief Create SIFT with specified descriptorType.
     @param nfeatures The number of best features to retain. The features are ranked by their scores
@@ -316,7 +316,7 @@ public:
     */
     CV_WRAP static Ptr<SIFT> create(int nfeatures, int nOctaveLayers,
         double contrastThreshold, double edgeThreshold,
-        double sigma, int descriptorType);
+        double sigma, int descriptorType, bool enable_precise_upscale = true);
 
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
 

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -286,6 +286,10 @@ public:
 
     @param sigma The sigma of the Gaussian applied to the input image at the octave \#0. If your image
     is captured with a weak camera with soft lenses, you might want to reduce the number.
+
+    @param enable_precise_upscale Whether to enable precise upscaling in the scale pyramid, which maps
+    index \f$\texttt{x}\f$ to \f$\texttt{2x}\f$. This prevents localization bias. The option
+    to disable it (which is deprecated and issues a warning) is provided to keep the original behavior.
     */
     CV_WRAP static Ptr<SIFT> create(int nfeatures = 0, int nOctaveLayers = 3,
         double contrastThreshold = 0.04, double edgeThreshold = 10,
@@ -313,6 +317,10 @@ public:
     is captured with a weak camera with soft lenses, you might want to reduce the number.
 
     @param descriptorType The type of descriptors. Only CV_32F and CV_8U are supported.
+
+    @param enable_precise_upscale Whether to enable precise upscaling in the scale pyramid, which maps
+    index \f$\texttt{x}\f$ to \f$\texttt{2x}\f$. This prevents localization bias. The option
+    to disable it (which is deprecated and issues a warning) is provided to keep the original behavior.
     */
     CV_WRAP static Ptr<SIFT> create(int nfeatures, int nOctaveLayers,
         double contrastThreshold, double edgeThreshold,

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -188,12 +188,16 @@ static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma
     if( doubleImageSize )
     {
         sig_diff = sqrtf( std::max(sigma * sigma - SIFT_INIT_SIGMA * SIFT_INIT_SIGMA * 4, 0.01f) );
+
         Mat dbl;
-#if DoG_TYPE_SHORT
-        resize(gray_fpt, dbl, Size(gray_fpt.cols*2, gray_fpt.rows*2), 0, 0, INTER_LINEAR_EXACT);
-#else
-        resize(gray_fpt, dbl, Size(gray_fpt.cols*2, gray_fpt.rows*2), 0, 0, INTER_LINEAR);
-#endif
+        dbl.create(Size(gray_fpt.cols*2, gray_fpt.rows*2), gray_fpt.type());
+
+        Mat H = Mat::zeros(2, 3, CV_32F);
+        H.at<float>(0, 0) = 0.5f;
+        H.at<float>(1, 1) = 0.5f;
+
+        cv::warpAffine(gray_fpt, dbl, H, dbl.size(), INTER_LINEAR | WARP_INVERSE_MAP, BORDER_REFLECT);
+
         Mat result;
         GaussianBlur(dbl, result, Size(), sig_diff, sig_diff);
         return result;

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -72,6 +72,7 @@
 #include "precomp.hpp"
 #include <opencv2/core/hal/hal.hpp>
 #include <opencv2/core/utils/tls.hpp>
+#include <opencv2/core/utils/logger.hpp>
 
 #include "sift.simd.hpp"
 #include "sift.simd_declarations.hpp" // defines CV_CPU_DISPATCH_MODES_ALL=AVX2,...,BASELINE based on CMakeLists.txt content
@@ -88,7 +89,8 @@ class SIFT_Impl : public SIFT
 public:
     explicit SIFT_Impl( int nfeatures = 0, int nOctaveLayers = 3,
                           double contrastThreshold = 0.04, double edgeThreshold = 10,
-                          double sigma = 1.6, int descriptorType = CV_32F );
+                          double sigma = 1.6, int descriptorType = CV_32F,
+                          bool enable_precise_upscale = true );
 
     //! returns the descriptor size in floats (128)
     int descriptorSize() const CV_OVERRIDE;
@@ -136,24 +138,25 @@ protected:
     CV_PROP_RW double edgeThreshold;
     CV_PROP_RW double sigma;
     CV_PROP_RW int descriptor_type;
+    CV_PROP_RW bool enable_precise_upscale;
 };
 
 Ptr<SIFT> SIFT::create( int _nfeatures, int _nOctaveLayers,
-                     double _contrastThreshold, double _edgeThreshold, double _sigma )
+                     double _contrastThreshold, double _edgeThreshold, double _sigma, bool enable_precise_upscale )
 {
     CV_TRACE_FUNCTION();
 
-    return makePtr<SIFT_Impl>(_nfeatures, _nOctaveLayers, _contrastThreshold, _edgeThreshold, _sigma, CV_32F);
+    return makePtr<SIFT_Impl>(_nfeatures, _nOctaveLayers, _contrastThreshold, _edgeThreshold, _sigma, CV_32F, enable_precise_upscale);
 }
 
 Ptr<SIFT> SIFT::create( int _nfeatures, int _nOctaveLayers,
-                     double _contrastThreshold, double _edgeThreshold, double _sigma, int _descriptorType )
+                     double _contrastThreshold, double _edgeThreshold, double _sigma, int _descriptorType, bool enable_precise_upscale )
 {
     CV_TRACE_FUNCTION();
 
     // SIFT descriptor supports 32bit floating point and 8bit unsigned int.
     CV_Assert(_descriptorType == CV_32F || _descriptorType == CV_8U);
-    return makePtr<SIFT_Impl>(_nfeatures, _nOctaveLayers, _contrastThreshold, _edgeThreshold, _sigma, _descriptorType);
+    return makePtr<SIFT_Impl>(_nfeatures, _nOctaveLayers, _contrastThreshold, _edgeThreshold, _sigma, _descriptorType, enable_precise_upscale);
 }
 
 String SIFT::getDefaultName() const
@@ -170,7 +173,7 @@ unpackOctave(const KeyPoint& kpt, int& octave, int& layer, float& scale)
     scale = octave >= 0 ? 1.f/(1 << octave) : (float)(1 << -octave);
 }
 
-static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma )
+static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma, bool enable_precise_upscale )
 {
     CV_TRACE_FUNCTION();
 
@@ -190,14 +193,20 @@ static Mat createInitialImage( const Mat& img, bool doubleImageSize, float sigma
         sig_diff = sqrtf( std::max(sigma * sigma - SIFT_INIT_SIGMA * SIFT_INIT_SIGMA * 4, 0.01f) );
 
         Mat dbl;
-        dbl.create(Size(gray_fpt.cols*2, gray_fpt.rows*2), gray_fpt.type());
+        if (enable_precise_upscale) {
+            dbl.create(Size(gray_fpt.cols*2, gray_fpt.rows*2), gray_fpt.type());
+            Mat H = Mat::zeros(2, 3, CV_32F);
+            H.at<float>(0, 0) = 0.5f;
+            H.at<float>(1, 1) = 0.5f;
 
-        Mat H = Mat::zeros(2, 3, CV_32F);
-        H.at<float>(0, 0) = 0.5f;
-        H.at<float>(1, 1) = 0.5f;
-
-        cv::warpAffine(gray_fpt, dbl, H, dbl.size(), INTER_LINEAR | WARP_INVERSE_MAP, BORDER_REFLECT);
-
+            cv::warpAffine(gray_fpt, dbl, H, dbl.size(), INTER_LINEAR | WARP_INVERSE_MAP, BORDER_REFLECT);
+        } else {
+#if DoG_TYPE_SHORT
+            resize(gray_fpt, dbl, Size(gray_fpt.cols*2, gray_fpt.rows*2), 0, 0, INTER_LINEAR_EXACT);
+#else
+            resize(gray_fpt, dbl, Size(gray_fpt.cols*2, gray_fpt.rows*2), 0, 0, INTER_LINEAR);
+#endif
+        }
         Mat result;
         GaussianBlur(dbl, result, Size(), sig_diff, sig_diff);
         return result;
@@ -463,10 +472,14 @@ static void calcDescriptors(const std::vector<Mat>& gpyr, const std::vector<KeyP
 //////////////////////////////////////////////////////////////////////////////////////////
 
 SIFT_Impl::SIFT_Impl( int _nfeatures, int _nOctaveLayers,
-           double _contrastThreshold, double _edgeThreshold, double _sigma, int _descriptorType )
+           double _contrastThreshold, double _edgeThreshold, double _sigma, int _descriptorType, bool _enable_precise_upscale)
     : nfeatures(_nfeatures), nOctaveLayers(_nOctaveLayers),
-    contrastThreshold(_contrastThreshold), edgeThreshold(_edgeThreshold), sigma(_sigma), descriptor_type(_descriptorType)
+    contrastThreshold(_contrastThreshold), edgeThreshold(_edgeThreshold), sigma(_sigma), descriptor_type(_descriptorType),
+    enable_precise_upscale(_enable_precise_upscale)
 {
+    if (!enable_precise_upscale) {
+        CV_LOG_WARNING(NULL, "precise upscale disabled, this is now deprecated as it was found to induce a location bias");
+    }
 }
 
 int SIFT_Impl::descriptorSize() const
@@ -520,7 +533,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
         actualNOctaves = maxOctave - firstOctave + 1;
     }
 
-    Mat base = createInitialImage(image, firstOctave < 0, (float)sigma);
+    Mat base = createInitialImage(image, firstOctave < 0, (float)sigma, enable_precise_upscale);
     std::vector<Mat> gpyr;
     int nOctaves = actualNOctaves > 0 ? actualNOctaves : cvRound(std::log( (double)std::min( base.cols, base.rows ) ) / std::log(2.) - 2) - firstOctave;
 

--- a/modules/features2d/src/sift.dispatch.cpp
+++ b/modules/features2d/src/sift.dispatch.cpp
@@ -478,7 +478,7 @@ SIFT_Impl::SIFT_Impl( int _nfeatures, int _nOctaveLayers,
     enable_precise_upscale(_enable_precise_upscale)
 {
     if (!enable_precise_upscale) {
-        CV_LOG_WARNING(NULL, "precise upscale disabled, this is now deprecated as it was found to induce a location bias");
+        CV_LOG_ONCE_INFO(NULL, "precise upscale disabled, this is now deprecated as it was found to induce a location bias");
     }
 }
 

--- a/modules/features2d/test/test_descriptors_regression.impl.hpp
+++ b/modules/features2d/test/test_descriptors_regression.impl.hpp
@@ -183,7 +183,7 @@ protected:
             resize(dbl, downsized_back, Size(dbl.cols/2, dbl.rows/2), 0, 0, INTER_NEAREST);
 
             cv::Mat diff = (image != downsized_back);
-            ASSERT_TRUE(cv::countNonZero(diff) == 0);
+            ASSERT_EQ(0, cv::norm(image, downsized_back, NORM_INF));
         }
         catch(...)
         {

--- a/modules/features2d/test/test_descriptors_regression.impl.hpp
+++ b/modules/features2d/test/test_descriptors_regression.impl.hpp
@@ -4,6 +4,34 @@
 
 namespace opencv_test { namespace {
 
+static void double_image(Mat& src, Mat& dst) {
+
+    dst.create(Size(src.cols*2, src.rows*2), src.type());
+
+    Mat H = Mat::zeros(2, 3, CV_32F);
+    H.at<float>(0, 0) = 0.5f;
+    H.at<float>(1, 1) = 0.5f;
+    cv::warpAffine(src, dst, H, dst.size(), INTER_LINEAR | WARP_INVERSE_MAP, BORDER_REFLECT);
+
+}
+
+static Mat prepare_img(bool rows_indexed) {
+    int rows = 5;
+    int columns = 5;
+    Mat img(rows, columns, CV_32F);
+
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < columns; j++) {
+            if (rows_indexed) {
+                img.at<float>(i, j) = (float)i;
+            } else {
+                img.at<float>(i, j) = (float)j;
+            }
+        }
+    }
+    return img;
+}
+
 /****************************************************************************************\
 *                     Regression tests for descriptor extractors.                        *
 \****************************************************************************************/
@@ -142,6 +170,25 @@ protected:
         catch(...)
         {
             ts->printf( cvtest::TS::LOG, "compute() on nonempty image and empty keypoints must not generate exception (1).\n");
+            ts->set_failed_test_info( cvtest::TS::FAIL_INVALID_TEST_DATA );
+        }
+
+        image = prepare_img(false);
+        Mat dbl;
+        try
+        {
+            double_image(image, dbl);
+
+            Mat downsized_back(dbl.rows/2, dbl.cols/2, CV_32F);
+            resize(dbl, downsized_back, Size(dbl.cols/2, dbl.rows/2), 0, 0, INTER_NEAREST);
+
+            cv::Mat diff = (image != downsized_back);
+            ASSERT_TRUE(cv::countNonZero(diff) == 0);
+        }
+        catch(...)
+        {
+            ts->printf( cvtest::TS::LOG, "double_image() must not generate exception (1).\n");
+            ts->printf( cvtest::TS::LOG, "double_image() when downsized back by NEAREST must generate the same original image (1).\n");
             ts->set_failed_test_info( cvtest::TS::FAIL_INVALID_TEST_DATA );
         }
 

--- a/modules/features2d/test/test_descriptors_regression.impl.hpp
+++ b/modules/features2d/test/test_descriptors_regression.impl.hpp
@@ -4,6 +4,9 @@
 
 namespace opencv_test { namespace {
 
+/****************************************************************************************\
+*                     Regression tests for descriptor extractors.                        *
+\****************************************************************************************/
 static void double_image(Mat& src, Mat& dst) {
 
     dst.create(Size(src.cols*2, src.rows*2), src.type());
@@ -32,9 +35,6 @@ static Mat prepare_img(bool rows_indexed) {
     return img;
 }
 
-/****************************************************************************************\
-*                     Regression tests for descriptor extractors.                        *
-\****************************************************************************************/
 static void writeMatInBin( const Mat& mat, const string& filename )
 {
     FILE* f = fopen( filename.c_str(), "wb");

--- a/modules/features2d/test/test_detectors_invariance.cpp
+++ b/modules/features2d/test/test_detectors_invariance.cpp
@@ -37,7 +37,7 @@ INSTANTIATE_TEST_CASE_P(AKAZE_DESCRIPTOR_KAZE, DetectorRotationInvariance,
  */
 
 INSTANTIATE_TEST_CASE_P(SIFT, DetectorScaleInvariance,
-                        Value(IMAGE_BIKES, SIFT::create(0, 3, 0.09), 0.65f, 0.98f));
+                        Value(IMAGE_BIKES, SIFT::create(0, 3, 0.09), 0.60f, 0.98f));
 
 INSTANTIATE_TEST_CASE_P(BRISK, DetectorScaleInvariance,
                         Value(IMAGE_BIKES, BRISK::create(), 0.08f, 0.49f));

--- a/modules/features2d/test/test_detectors_invariance.impl.hpp
+++ b/modules/features2d/test/test_detectors_invariance.impl.hpp
@@ -25,7 +25,6 @@ void matchKeyPoints(const vector<KeyPoint>& keypoints0, const Mat& H,
         perspectiveTransform(Mat(points0), points0t, H);
 
     matches.clear();
-    vector<uchar> usedMask(keypoints1.size(), 0);
     for(int i0 = 0; i0 < static_cast<int>(keypoints0.size()); i0++)
     {
         int nearestPointIndex = -1;
@@ -33,8 +32,6 @@ void matchKeyPoints(const vector<KeyPoint>& keypoints0, const Mat& H,
         const float r0 =  0.5f * keypoints0[i0].size;
         for(size_t i1 = 0; i1 < keypoints1.size(); i1++)
         {
-            if(nearestPointIndex >= 0 && usedMask[i1])
-                continue;
 
             float r1 = 0.5f * keypoints1[i1].size;
             float intersectRatio = calcIntersectRatio(points0t.at<Point2f>(i0), r0,
@@ -47,8 +44,6 @@ void matchKeyPoints(const vector<KeyPoint>& keypoints0, const Mat& H,
         }
 
         matches.push_back(DMatch(i0, nearestPointIndex, maxIntersectRatio));
-        if(nearestPointIndex >= 0)
-            usedMask[nearestPointIndex] = 1;
     }
 }
 

--- a/modules/features2d/test/test_invariance_utils.hpp
+++ b/modules/features2d/test/test_invariance_utils.hpp
@@ -75,8 +75,8 @@ void scaleKeyPoints(const vector<KeyPoint>& src, vector<KeyPoint>& dst, float sc
     dst.resize(src.size());
     for (size_t i = 0; i < src.size(); i++) {
         dst[i] = src[i];
-        dst[i].pt.x *= scale;
-        dst[i].pt.y *= scale;
+        dst[i].pt.x = dst[i].pt.x * scale + (scale - 1.0f) / 2.0f;
+        dst[i].pt.y = dst[i].pt.y * scale + (scale - 1.0f) / 2.0f;
         dst[i].size *= scale;
     }
 }


### PR DESCRIPTION
Fixing https://github.com/opencv/opencv/issues/23123
See also: https://github.com/vicsyl/dog_precision

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


Even though by detector scale invariance test for SIFT the constrains had to be relaxed for the test to pass, the change improved other test metrics in SIFT detector/descriptor/scale/rotation invariance tests. Even metrics for detector scale invariance test for SIFT are better after the change for different parameters. See my comment at [test_detectors_invariance.cpp](https://github.com/opencv/opencv/pull/23124/files/ceef3c3e79953572b04c769060894d16eebbae5d#diff-85bb8de4fd45cfaf437e085f60aa40a55ee3964a45c082044e3a851989f0937d) for more details. 

Note that the scaling of keypoint locations was changed so that is corresponds to homography:

$$H_{gt} = \begin{bmatrix} 
s & 0 & (s-1) / 2 \\
0 & s & (s-1) / 2 \\
0 & 0 & 1\\
\end{bmatrix}$$

See my comment in [test_invariance_utils.hpp](https://github.com/opencv/opencv/pull/23124/files/ceef3c3e79953572b04c769060894d16eebbae5d#diff-90d8b430d0b79032ba9755336a01f41fd5314c22cdd288dde53afa6fe99b5b0a).

The performance tests didn't show performance regression:

```
feature2d_detect.detect

WITH FIX:

 leuven/img1.png  samples=25   mean= 705.39   median= 704.76   min= 685.41   stddev=14.78 (2.1%)
stitching/a3.png  samples=10   mean= 631.09   median= 626.15   min= 615.54   stddev=16.39 (2.6%)
stitching/s2.jpg  samples=10   mean=1339.58   median=1339.54   min=1319.43   stddev=19.54 (1.5%)

WITHOUT FIX:

 leuven/img1.png  samples=10   mean= 707.30   median= 699.30   min= 693.54   stddev=20.09 (2.8%)
stitching/a3.png  samples=10   mean= 621.38   median= 616.74   min= 614.41   stddev= 8.80 (1.4%)
stitching/s2.jpg  samples=10   mean=1347.98   median=1351.27   min=1312.30   stddev=23.25 (1.7%)

feature2d_detectAndExtract.detectAndExtract

WITH FIX:

 leuven/img1.png   samples=10   mean=831.68  median= 834.14   min= 815.27   stddev=10.76 (1.3%)
stitching/a3.png   samples=10   mean=865.91  median= 858.49   min= 843.43   stddev=23.24 (2.7%)
stitching/s2.jpg   samples=10  mean=1913.42  median=1908.38   min=1861.93   stddev=46.72 (2.4%)

WITHOUT FIX:

 leuven/img1.png  samples=10   mean= 819.67   median= 816.28   min= 810.95   stddev=10.62 (1.3%)
stitching/a3.png  samples=10   mean= 841.28   median= 838.84   min= 826.58   stddev=13.54 (1.6%)
stitching/s2.jpg  samples=10   mean=1958.65   median=1952.93   min=1937.43   stddev=18.01 (0.9%)

```
