### PR TITLE
Fix misaligned-pointer-use in intrin_sse.hpp

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1924,11 +1924,7 @@ OPENCV_HAL_IMPL_SSE_EXPAND(v_int32x4,  v_int64x2,   int,      _v128_cvtepi32_epi
 #define OPENCV_HAL_IMPL_SSE_EXPAND_Q(_Tpvec, _Tp, intrin)  \
     inline _Tpvec v_load_expand_q(const _Tp* ptr)          \
     {                                                      \
-        int tmp;                                           \
-        /* Copy misaligned ptr to aligned &tmp */          \
-        /* (memcpy() should be optimized out) */           \
-        memcpy(&tmp, ptr, 4);                              \
-        __m128i a = _mm_cvtsi32_si128(tmp);                \
+        __m128i a = _mm_loadu_si32(ptr);                   \
         return _Tpvec(intrin(a));                          \
     }
 

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1924,7 +1924,11 @@ OPENCV_HAL_IMPL_SSE_EXPAND(v_int32x4,  v_int64x2,   int,      _v128_cvtepi32_epi
 #define OPENCV_HAL_IMPL_SSE_EXPAND_Q(_Tpvec, _Tp, intrin)  \
     inline _Tpvec v_load_expand_q(const _Tp* ptr)          \
     {                                                      \
-        __m128i a = _mm_cvtsi32_si128(*(const int*)ptr);   \
+        int tmp;                                           \
+        /* Copy misaligned ptr to aligned &tmp */          \
+        /* (memcpy() should be optimized out) */           \
+        memcpy(&tmp, ptr, 4);                              \
+        __m128i a = _mm_cvtsi32_si128(tmp);                \
         return _Tpvec(intrin(a));                          \
     }
 

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1921,11 +1921,12 @@ OPENCV_HAL_IMPL_SSE_EXPAND(v_int16x8,  v_int32x4,   short,    _v128_cvtepi16_epi
 OPENCV_HAL_IMPL_SSE_EXPAND(v_uint32x4, v_uint64x2,  unsigned, _v128_cvtepu32_epi64)
 OPENCV_HAL_IMPL_SSE_EXPAND(v_int32x4,  v_int64x2,   int,      _v128_cvtepi32_epi64)
 
-#define OPENCV_HAL_IMPL_SSE_EXPAND_Q(_Tpvec, _Tp, intrin)  \
-    inline _Tpvec v_load_expand_q(const _Tp* ptr)          \
-    {                                                      \
-        __m128i a = _mm_loadu_si32(ptr);                   \
-        return _Tpvec(intrin(a));                          \
+#define OPENCV_HAL_IMPL_SSE_EXPAND_Q(_Tpvec, _Tp, intrin)          \
+    inline _Tpvec v_load_expand_q(const _Tp* ptr)                  \
+    {                                                              \
+        typedef int CV_DECL_ALIGNED(1) unaligned_int;              \
+        __m128i a = _mm_cvtsi32_si128(*(const unaligned_int*)ptr); \
+        return _Tpvec(intrin(a));                                  \
     }
 
 OPENCV_HAL_IMPL_SSE_EXPAND_Q(v_uint32x4, uchar, _v128_cvtepu8_epi32)


### PR DESCRIPTION
`ptr` may generate a `misaligned-pointer-use` warning with some sanitizers when cast to `int*`.
`memcpy()` it to the aligned `int tmp`.

`summary.py` of `run.py -t core` at 3.4 head and with patch gave this report: [opencv_summary_report.txt](https://github.com/opencv/opencv/files/10393334/opencv_summary_report.txt)
The geometric mean and average of the right-most column is 0.98. The median is 0.99.
I guess this "speed loss" comes from performance testing imprecision.

Thanks to @vrabaud for this fix.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.