### PR TITLE
fix charuco matchImagePoints

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -58,14 +58,22 @@ public:
     CV_WRAP const Point3f& getRightBottomCorner() const;
 
     /** @brief Given a board configuration and a set of detected markers, returns the corresponding
-     * image points and object points to call solvePnP()
+     * image points and object points, can be used in solvePnP()
      *
      * @param detectedCorners List of detected marker corners of the board.
-     * For CharucoBoard class you can set list of charuco corners.
-     * @param detectedIds List of identifiers for each marker or list of charuco identifiers for each corner.
-     * For CharucoBoard class you can set list of charuco identifiers for each corner.
-     * @param objPoints Vector of vectors of board marker points in the board coordinate space.
-     * @param imgPoints Vector of vectors of the projections of board marker corner points.
+     * For cv::Board and cv::GridBoard the method expects std::vector<std::vector<Point2f>> or std::vector<Mat> with Aruco marker corners.
+     * For cv::CharucoBoard the method expects std::vector<Point2f> or Mat with ChAruco corners (chess board corners matched with Aruco markers).
+     *
+     * @param detectedIds List of identifiers for each marker or charuco corner.
+     * For any Board class the method expects std::vector<int> or Mat.
+     *
+     * @param objPoints Vector of marker points in the board coordinate space.
+     * For any Board class the method expects std::vector<cv::Point3f> objectPoints or cv::Mat
+     *
+     * @param imgPoints Vector of marker points in the image coordinate space.
+     * For any Board class the method expects std::vector<cv::Point2f> objectPoints or cv::Mat
+     *
+     * @sa solvePnP
      */
     CV_WRAP void matchImagePoints(InputArrayOfArrays detectedCorners, InputArray detectedIds,
                                   OutputArray objPoints, OutputArray imgPoints) const;

--- a/modules/objdetect/misc/python/test/test_objdetect_aruco.py
+++ b/modules/objdetect/misc/python/test/test_objdetect_aruco.py
@@ -313,5 +313,32 @@ class aruco_objdetect_test(NewOpenCVTests):
                         reprErr = cv.norm(charucoCorners[i] - projectedCharucoCorners[currentId])
                         self.assertLessEqual(reprErr, 5)
 
+    def test_aruco_match_image_points(self):
+        aruco_dict = cv.aruco.getPredefinedDictionary(cv.aruco.DICT_4X4_50)
+        board_size = (3, 4)
+        board = cv.aruco.GridBoard(board_size, 5.0, 1.0, aruco_dict)
+        aruco_corners = np.array(board.getObjPoints())[:, :, :2]
+        aruco_ids = board.getIds()
+        obj_points, img_points = board.matchImagePoints(aruco_corners, aruco_ids)
+        aruco_corners = aruco_corners.reshape(-1, 2)
+
+        self.assertEqual(aruco_corners.shape[0], obj_points.shape[0])
+        self.assertEqual(img_points.shape[0], obj_points.shape[0])
+        self.assertEqual(2, img_points.shape[2])
+        np.testing.assert_array_equal(aruco_corners, obj_points[:, :, :2].reshape(-1, 2))
+
+    def test_charuco_match_image_points(self):
+        aruco_dict = cv.aruco.getPredefinedDictionary(cv.aruco.DICT_4X4_50)
+        board_size = (3, 4)
+        board = cv.aruco.CharucoBoard(board_size, 5.0, 1.0, aruco_dict)
+        chessboard_corners = np.array(board.getChessboardCorners())[:, :2]
+        chessboard_ids = board.getIds()
+        obj_points, img_points = board.matchImagePoints(chessboard_corners, chessboard_ids)
+
+        self.assertEqual(chessboard_corners.shape[0], obj_points.shape[0])
+        self.assertEqual(img_points.shape[0], obj_points.shape[0])
+        self.assertEqual(2, img_points.shape[2])
+        np.testing.assert_array_equal(chessboard_corners, obj_points[:, :, :2].reshape(-1, 2))
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -656,4 +656,31 @@ TEST(Charuco, issue_14014)
     EXPECT_EQ(Size(4, 1), rejectedPoints[0].size()); // check dimension of rejected corners after successfully refine
 }
 
+
+TEST(Charuco, testmatchImagePoints)
+{
+    aruco::CharucoBoard board(Size(2, 3), 1.f, 0.5f, aruco::getPredefinedDictionary(aruco::DICT_4X4_50));
+    auto chessboardPoints = board.getChessboardCorners();
+
+    vector<int> detectedIds;
+    vector<Point2f> detectedCharucoCorners;
+    for (const Point3f& point : chessboardPoints) {
+        detectedIds.push_back((int)detectedCharucoCorners.size());
+        detectedCharucoCorners.push_back({2.f*point.x, 2.f*point.y});
+    }
+
+    vector<Point3f> objPoints;
+    vector<Point2f> imagePoints;
+    board.matchImagePoints(detectedCharucoCorners, detectedIds, objPoints, imagePoints);
+
+    ASSERT_EQ(detectedCharucoCorners.size(), objPoints.size());
+    ASSERT_EQ(detectedCharucoCorners.size(), imagePoints.size());
+
+    for (size_t i = 0ull; i < detectedCharucoCorners.size(); i++) {
+        EXPECT_EQ(detectedCharucoCorners[i], imagePoints[i]);
+        EXPECT_EQ(chessboardPoints[i].x, objPoints[i].x);
+        EXPECT_EQ(chessboardPoints[i].y, objPoints[i].y);
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
The problem was in python bindings in `void matchImagePoints(InputArrayOfArrays detectedCorners, InputArray detectedIds, OutputArray objPoints, OutputArray imgPoints)`. 

`detectedCorners` may include aruco marker corners as `vector<vector<Point2f>>` or `vector<Mat>`. Any `Mat` in `vector<Mat>` must have 4 rows for 4 corners for one marker (one marker has 4 corners).

`detectedCorners` may include Charuco corners as `vector<Point2f>` or `Mat`. Python bindings add extra dimension to `detectedCorners` and therefore `vector<Mat>` case is additionally  processed for charuco corners.


Until the PR merge, you can using custom `matchImagePoints()`:

```
def matchImagePoints(charuco_board, charuco_corners, charuco_ids):
    objPoints = []
    imgPoints = []
    for i in range(0, len(charuco_ids)):
        index = charuco_ids[i]
        objPoints.append(charuco_board.getChessboardCorners()[index])
        # objPoints[-1][0][1] = charuco_board.getRightBottomCorner()[1] - objPoints[-1][0][1]  #  set old axis direction
        imgPoints.append(charuco_corners[i])
    return np.array(objPoints), np.array(imgPoints)
```



Use sample from https://github.com/opencv/opencv/pull/23139 to see problem.

args:
-w=5 -h=7 -sl=0.04 -ml=0.02 -d=10 -v=choriginal.jpg

With fix:
![image](https://user-images.githubusercontent.com/22337800/212574516-20a89a7f-6ea2-4d52-a4f6-ccb0ca7fd090.png)



`detectedCorners` includes charuco corners in this case. Python bindings add extra dimension to `detectedCorners` and therefore without fix `detectedCorners` processed as aruco marker corners and `matchImagePoints` returns bad values:

![image](https://user-images.githubusercontent.com/22337800/212574560-b9923895-b697-4220-a6ca-64747cd70bdb.png)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
