### PR TITLE
Backport to 3.4: cvIsInf() fix

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -295,7 +295,7 @@ CV_INLINE int cvIsInf( double value )
 #elif defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__PPC64__)
     Cv64suf ieee754;
     ieee754.f = value;
-    return (ieee754.u & 0x7fffffff00000000) ==
+    return (ieee754.u & 0x7fffffffffffffff) ==
                         0x7ff0000000000000;
 #else
     Cv64suf ieee754;

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3992,6 +3992,13 @@ TEST(Core_FastMath, InlineNaN)
     EXPECT_EQ( cvIsNaN((double) NAN), 1);
     EXPECT_EQ( cvIsNaN((double) -NAN), 1);
     EXPECT_EQ( cvIsNaN(0.0), 0);
+
+    // Regression: check the +/-Inf cases
+    Cv64suf suf;
+    suf.u = 0x7FF0000000000000UL;
+    EXPECT_EQ( cvIsNaN(suf.f), 0);
+    suf.u = 0xFFF0000000000000UL;
+    EXPECT_EQ( cvIsNaN(suf.f), 0);
 }
 
 TEST(Core_FastMath, InlineIsInf)
@@ -4003,6 +4010,13 @@ TEST(Core_FastMath, InlineIsInf)
     EXPECT_EQ( cvIsInf((double) HUGE_VAL), 1);
     EXPECT_EQ( cvIsInf((double) -HUGE_VAL), 1);
     EXPECT_EQ( cvIsInf(0.0), 0);
+
+    // Regression: check the cases of 0x7FF00000xxxxxxxx
+    Cv64suf suf;
+    suf.u = 0x7FF0000000000001UL;
+    EXPECT_EQ( cvIsInf(suf.f), 0);
+    suf.u = 0x7FF0000012345678UL;
+    EXPECT_EQ( cvIsInf(suf.f), 0);
 }
 
 }} // namespace


### PR DESCRIPTION
Backport of the fix from #23098 

Sometimes `cvIsInf(double)` assumes NaN as Inf. This PR fixes that and adds some regression tests

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
