### PR TITLE
perf: drop runtime time adjustment calibration

### DIFF
--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -454,9 +454,6 @@ private:
     performance_metrics metrics;
     void validateMetrics();
 
-    static int64 _timeadjustment;
-    static int64 _calibrate();
-
     static void warmup_impl(cv::Mat m, WarmUpType wtype);
     static int getSizeInBytes(cv::InputArray a);
     static cv::Size getSize(cv::InputArray a);


### PR DESCRIPTION
This may unexpectedly broke performance reports and provide wrong results due to measurement **in runtime**.

- it measures a time between exiting of `startTimer()`, `iter++` and calling of `stopTimer()`. Critical code path is minimized for this flow.
- on properly configured system its value is almost zero: about 10-11 clock ticks (ns, on Linux x86). By comparing to 1'000'000 clock ticks of 1ms sample measurement - it is a nothing.
- other values are not expected (and not observed during the 5+ years). Other values would just break the numbers in the performance report.
- this value is already ignored (forced to 0) for `PERF_STRATEGY_SIMPLE` which is default since [2014](https://github.com/opencv/opencv/blame/4.7.0/modules/ts/src/ts_perf.cpp#L37).

Lets remove this unnecessary step of performance tests startup.