### PR TITLE
ChArUco pre460 pattern support

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -146,6 +146,18 @@ public:
     CV_WRAP CharucoBoard(const Size& size, float squareLength, float markerLength,
                          const Dictionary &dictionary, InputArray ids = noArray());
 
+    /** @brief set legacy chessboard pattern.
+     *
+     * Legacy setting creates chessboard patterns starting with a white box in the upper left corner
+     * if there is an even row count of chessboard boxes, otherwise it starts with a black box.
+     * This setting ensures compatibility to patterns created with OpenCV versions prior OpenCV 4.6.0.
+     * See https://github.com/opencv/opencv/issues/23152.
+     *
+     * Default value: false.
+     */
+    CV_WRAP void setLegacyPattern(bool legacyPattern);
+    CV_WRAP bool getLegacyPattern() const;
+
     CV_WRAP Size getChessboardSize() const;
     CV_WRAP float getSquareLength() const;
     CV_WRAP float getMarkerLength() const;

--- a/modules/objdetect/test/test_aruco_utils.cpp
+++ b/modules/objdetect/test/test_aruco_utils.cpp
@@ -8,12 +8,12 @@
 namespace opencv_test {
 
 vector<Point2f> getAxis(InputArray _cameraMatrix, InputArray _distCoeffs, InputArray _rvec,
-                        InputArray _tvec, float length, const float offset) {
+                        InputArray _tvec, float length, const Point2f offset) {
     vector<Point3f> axis;
-    axis.push_back(Point3f(offset, offset, 0.f));
-    axis.push_back(Point3f(length+offset, offset, 0.f));
-    axis.push_back(Point3f(offset, length+offset, 0.f));
-    axis.push_back(Point3f(offset, offset, length));
+    axis.push_back(Point3f(offset.x, offset.y, 0.f));
+    axis.push_back(Point3f(length+offset.x, offset.y, 0.f));
+    axis.push_back(Point3f(offset.x, length+offset.y, 0.f));
+    axis.push_back(Point3f(offset.x, offset.y, length));
     vector<Point2f> axis_to_img;
     projectPoints(axis, _rvec, _tvec, _cameraMatrix, _distCoeffs, axis_to_img);
     return axis_to_img;

--- a/modules/objdetect/test/test_aruco_utils.hpp
+++ b/modules/objdetect/test/test_aruco_utils.hpp
@@ -10,7 +10,7 @@ namespace opencv_test {
 static inline double deg2rad(double deg) { return deg * CV_PI / 180.; }
 
 vector<Point2f> getAxis(InputArray _cameraMatrix, InputArray _distCoeffs, InputArray _rvec, InputArray _tvec,
-                        float length, const float offset = 0.f);
+                        float length, const Point2f offset = Point2f(0, 0));
 
 vector<Point2f> getMarkerById(int id, const vector<vector<Point2f> >& corners, const vector<int>& ids);
 


### PR DESCRIPTION
Add support for certain ChArUco board patterns as they had been generated with OpenCV contrib version prior 4.6.0.

The pull request adds a `setLegacyParameter(bool)` method to the Charuco class to allow switching to the old board design as described in https://github.com/opencv/opencv/issues/23152.

Default setting for this parameter is `false´ to remain compatible with OpenCV contrib 4.6.0 and OpenCV 4.7.0.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
