### PR TITLE
A Byte of Python link broken

### DIFF
--- a/doc/py_tutorials/py_setup/py_intro/py_intro.markdown
+++ b/doc/py_tutorials/py_setup/py_intro/py_intro.markdown
@@ -79,7 +79,7 @@ Below is the list of contributors who submitted tutorials to OpenCV-Python.
 Additional Resources
 --------------------
 
--#  A Quick guide to Python - [A Byte of Python](http://swaroopch.com/notes/python/)
+-#  A Quick guide to Python - [A Byte of Python](https://www.freecodecamp.org/news/the-python-guide-for-beginners/)
 2.  [NumPy Quickstart tutorial](https://numpy.org/devdocs/user/quickstart.html)
 3.  [NumPy Reference](https://numpy.org/devdocs/reference/index.html#reference)
 4.  [OpenCV Documentation](http://docs.opencv.org/)


### PR DESCRIPTION
"A Quick guide to Python - A Byte of Python" is broken and leads to a 404 error page. So, as suggested by @KinzaaSheikh in the issue https://github.com/opencv/opencv/issues/23147  I've changed the link to freecodecamp.org website
Please look into if the changes are suitable

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
