### PR TITLE
Fix encodeStructuredAppend() resulting in only one QR code problem, and false output data fix.

### DIFF
--- a/modules/objdetect/test/test_qrcode_encode.cpp
+++ b/modules/objdetect/test/test_qrcode_encode.cpp
@@ -450,6 +450,32 @@ TEST(Objdetect_QRCode_Encode_Decode_Structured_Append, DISABLED_regression)
 
 #endif // UPDATE_QRCODE_TEST_DATA
 
+CV_ENUM(EncodeModes, QRCodeEncoder::EncodeMode::MODE_NUMERIC,
+                     QRCodeEncoder::EncodeMode::MODE_ALPHANUMERIC,
+                     QRCodeEncoder::EncodeMode::MODE_BYTE)
+
+typedef ::testing::TestWithParam<EncodeModes> Objdetect_QRCode_Encode_Decode_Structured_Append_Parameterized;
+TEST_P(Objdetect_QRCode_Encode_Decode_Structured_Append_Parameterized, regression_22205)
+{
+    const std::string input_data = "the quick brown fox jumps over the lazy dog";
+
+    std::vector<cv::Mat> result_qrcodes;
+
+    cv::QRCodeEncoder::Params params;
+    int encode_mode = GetParam();
+    params.mode = static_cast<cv::QRCodeEncoder::EncodeMode>(encode_mode);
+
+    for(size_t struct_num = 2; struct_num < 5; ++struct_num)
+    {
+        params.structure_number = static_cast<int>(struct_num);
+        cv::Ptr<cv::QRCodeEncoder> encoder = cv::QRCodeEncoder::create(params);
+        encoder->encodeStructuredAppend(input_data, result_qrcodes);
+        EXPECT_EQ(result_qrcodes.size(), struct_num) << "The number of QR Codes requested is not equal"<<
+                                                    "to the one returned";
+    }
+}
+INSTANTIATE_TEST_CASE_P(/**/, Objdetect_QRCode_Encode_Decode_Structured_Append_Parameterized, EncodeModes::all());
+
 TEST(Objdetect_QRCode_Encode_Decode, regression_issue22029)
 {
     const cv::String msg = "OpenCV";


### PR DESCRIPTION
Fixes #22205 and #23105 

While splitting the data to multiple QR codes it constantly cleans the resulting vector(final_qr_codes).
The fix is to just clean the result vector after all work is done with it.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
