### PR TITLE
build: suppress warning

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/matmul.hpp
@@ -38,8 +38,8 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             const std::vector<cv::Ptr<BackendWrapper>>& outputs,
             csl::Workspace& workspace) override
         {
-            CV_Assert((inputs.size() == 2 && constTensor.empty() ||
-                       inputs.size() == 1 && !constTensor.empty()) && outputs.size() == 1);
+            CV_Assert(((inputs.size() == 2 && constTensor.empty()) ||
+                       (inputs.size() == 1 && !constTensor.empty())) && outputs.size() == 1);
 
             auto input1_wrapper = inputs[0].dynamicCast<wrapper_type>();
             auto input1 = input1_wrapper->getView();


### PR DESCRIPTION
### Pull Request Readiness Checklist

When building with GCC 7.5, I see following warning message.

```
In file included from /opencv-fork/modules/core/include/opencv2/core.hpp:53:0,
                 from /opencv-fork/modules/dnn/src/layers/../precomp.hpp:49,
                 from /opencv-fork/modules/dnn/src/layers/fully_connected_layer.cpp:43:
/opencv-fork/modules/dnn/src/layers/../cuda4dnn/primitives/matmul.hpp: In instantiation of ‘void cv::dnn::cuda4dnn::MatMulOp<T>::forward(const std::vector<cv::Ptr<cv::dnn::dnn4_v20221220::BackendWrapper> >&, const std::vector<cv::Ptr<cv::dnn::dnn4_v20221220::BackendWrapper> >&, cv::dnn::cuda4dnn::csl::Workspace&) [with T = float]’:
/opencv-fork/modules/dnn/src/layers/fully_connected_layer.cpp:871:1:   required from here
/opencv-fork/modules/dnn/src/layers/../cuda4dnn/primitives/matmul.hpp:41:43: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
             CV_Assert((inputs.size() == 2 && constTensor.empty() ||
/opencv-fork/modules/core/include/opencv2/core/base.hpp:342:38: note: in definition of macro ‘CV_Assert’
 #define CV_Assert( expr ) do { if(!!(expr)) ; else cv::error( cv::Error::StsAssert, #expr, CV_Func, __FILE__, __LINE__ ); } while(0)
                                      ^~~~
/opencv-fork/modules/dnn/src/layers/../cuda4dnn/primitives/matmul.hpp: In instantiation of ‘void cv::dnn::cuda4dnn::MatMulOp<T>::forward(const std::vector<cv::Ptr<cv::dnn::dnn4_v20221220::BackendWrapper> >&, const std::vector<cv::Ptr<cv::dnn::dnn4_v20221220::BackendWrapper> >&, cv::dnn::cuda4dnn::csl::Workspace&) [with T = __half]’:
/opencv-fork/modules/dnn/src/layers/fully_connected_layer.cpp:871:1:   required from here
/opencv-fork/modules/dnn/src/layers/../cuda4dnn/primitives/matmul.hpp:41:43: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
             CV_Assert((inputs.size() == 2 && constTensor.empty() ||
/opencv-fork/modules/core/include/opencv2/core/base.hpp:342:38: note: in definition of macro ‘CV_Assert’
 #define CV_Assert( expr ) do { if(!!(expr)) ; else cv::error( cv::Error::StsAssert, #expr, CV_Func, __FILE__, __LINE__ ); } while(0)
                                      ^~~~
```

It's not really important, but I think it's worth fixing this warning.
This line happens from 4.x branch, so starting from here.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
