### PR TITLE
Avoid double-checked locking with TSAN in parallel

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -263,7 +263,9 @@ namespace {
         void recordException(const cv::String& msg)
 #endif
         {
+#ifndef CV_THREAD_SANITIZER
             if (!hasException)
+#endif
             {
                 cv::AutoLock lock(cv::getInitializationMutex());
                 if (!hasException)


### PR DESCRIPTION
Omit the first check of the double-checked locking pattern in `recordException()` in parallel.cpp when `CV_THREAD_SANITIZER` is defined. This should only slow `recordException()` down when the thread sanitizer is used, and avoids the TSAN data race warning.

`CV_THREAD_SANITIZER` is defined in `cvdef.h` which is included by `core.hpp` which is included by `utility.hpp` which is included by `precomp.hpp` which is included by `parallel.cpp`. If this is too indirect, `#include "cvdef.h"` can be added in `parallel.cpp`.

### Original report

https://github.com/opencv/opencv/blob/52855a39ad5c3d5ae9b983e6add43163ca474b84/modules/core/src/parallel.cpp#L266-L291

Clang's thread sanitizer found the following when running an internal fuzz target:
```
WARNING: ThreadSanitizer: data race (pid=8714)
Read of size 1 by thread T6:
    #0 cv::(anonymous namespace)::ParallelLoopBodyWrapperContext::recordException() OpenCV/modules/core/src/parallel.cpp:278
    #1 cv::(anonymous namespace)::ParallelLoopBodyWrapper::operator()(cv::Range const&) const third_party/OpenCV/modules/core/src/parallel.cpp:357
Previous write of size 1 at 0x7ffc7c20ee58 by main thread (mutexes: write M0):
    #0 cv::(anonymous namespace)::ParallelLoopBodyWrapperContext::recordException() third_party/OpenCV/modules/core/src/parallel.cpp:283
    #1 cv::(anonymous namespace)::ParallelLoopBodyWrapper::operator()(cv::Range const&) const third_party/OpenCV/modules/core/src/parallel.cpp:357

Location is stack of main thread.
Location is global '??'

Mutex M0 created at:
    #3 cv::getInitializationMutex() third_party/OpenCV/modules/core/src/system.cpp:93
Thread T6 (running) created by main thread at:
    #1 cv::WorkerThread::WorkerThread(cv::ThreadPool&, unsigned int) third_party/OpenCV/modules/core/src/parallel_impl.cpp:241

SUMMARY: ThreadSanitizer: data race third_party/OpenCV/modules/core/src/parallel.cpp:278 in cv::(anonymous namespace)::ParallelLoopBodyWrapperContext::recordException()
```

I believe it is a false positive in this case. As long as `pException` is not accessed until all threads are joined (in `finalize()` only), I do not see how the lack of order guarantee in the body of the second `!hasException` condition is an issue (unlike the anti-pattern DCLP singleton initialization).

In other words, I think the code at head works as intended as long as C++ guarantees the following, and I guess it does:
- The second `if (!hasException)` is not optimized out by the first `if (!hasException)`
- `std::lock_guard` happens before the second `if (!hasException)`
- The second `if (!hasException)` happens before `hasException = true;`
- The second `if (!hasException)` happens before `exception = std::current_exception();`

TSAN may be triggered because it detects a read during a write, or maybe it sees a branching on the first `if (!hasException)` that differs depending on the run. But the data race here has no effect: it is the purpose of the double-checked locking pattern.

### Alternatives

The current solution is simple but I considered other options. Feel free to pick any or suggest another.

- Just remove the first check all the time because `recordException()` is not performance-critical.
- `std::call_once()`:
  ```cpp
  bool hasException;
  std::once_flag flagException;
  std::exception_ptr pException;
  void recordException()
  {
      std::call_once(flagException, [this] {
          hasException = true;
          pException = std::current_exception();
      });
  }
  ```
- Something similar to https://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/

### Related

- https://github.com/opencv/opencv/pull/21612
- https://github.com/opencv/opencv/pull/8713
- https://github.com/opencv/opencv/pull/20803
- https://github.com/opencv/opencv/pull/20841
- https://github.com/opencv/opencv/issues/20606

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
