### PR TITLE
Include pixel-based uncertainty in ArUco marker detection

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -263,6 +263,9 @@ public:
      * The identifiers have the same order than the markers in the imgPoints array.
      * @param rejectedImgPoints contains the imgPoints of those squares whose inner code has not a
      * correct codification. Useful for debugging purposes.
+     * @param markersUnc contains the normalized uncertainty [0;1] of the markers' detection,
+     * defined as percentage of incorrect pixel detections, with 0 describing a pixel perfect detection.
+     * The uncertainties are of type float (e.g. std::vector<float>)
      *
      * Performs marker detection in the input image. Only markers included in the specific dictionary
      * are searched. For each detected marker, it returns the 2D position of its corner in the image
@@ -273,7 +276,7 @@ public:
      * @sa undistort, estimatePoseSingleMarkers,  estimatePoseBoard
      */
     CV_WRAP void detectMarkers(InputArray image, OutputArrayOfArrays corners, OutputArray ids,
-                               OutputArrayOfArrays rejectedImgPoints = noArray()) const;
+                               OutputArrayOfArrays rejectedImgPoints = noArray(), OutputArray markersUnc = noArray()) const;
 
     /** @brief Refind not detected markers based on the already detected and the board layout
      *

--- a/modules/objdetect/include/opencv2/objdetect/aruco_dictionary.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_dictionary.hpp
@@ -64,6 +64,12 @@ class CV_EXPORTS_W_SIMPLE Dictionary {
      */
     CV_WRAP int getDistanceToId(InputArray bits, int id, bool allRotations = true) const;
 
+    /** @brief Given a matrix containing the percentage of white pixels in each marker cell, returns the normalized marker uncertainty [0;1] for the specific id.
+     * The uncertainty is defined as percentage of incorrect pixel detections, with 0 describing a pixel perfect detection.
+     * The rotation is set to 0,1,2,3 for [0, 90, 180, 270] deg CCW rotations.
+     * If typ == 2, the uncertainty is computed for an inverted marker.
+     */
+    CV_WRAP float getMarkerUnc(InputArray whitePixelRatio, int id, int rotation = 0, int borderBits = 1, int typ = 1) const;
 
     /** @brief Generate a canonical marker image
      */

--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -429,10 +429,10 @@ static void _detectCandidates(InputArray _grayImage, vector<vector<vector<Point2
   * the border bits
   */
 static Mat _extractBits(InputArray _image, const vector<Point2f>& corners, int markerSize,
-                        int markerBorderBits, int cellSize, double cellMarginRate, double minStdDevOtsu) {
+                        int markerBorderBits, int cellSize, double cellMarginRate, double minStdDevOtsu, OutputArray _whitePixRatio = noArray()) {
     CV_Assert(_image.getMat().channels() == 1);
     CV_Assert(corners.size() == 4ull);
-    CV_Assert(markerBorderBits > 0 && cellSize > 0 && cellMarginRate >= 0 && cellMarginRate <= 1);
+    CV_Assert(markerBorderBits > 0 && cellSize > 0 && cellMarginRate >= 0 && cellMarginRate < 0.5);
     CV_Assert(minStdDevOtsu >= 0);
 
     // number of bits in the marker
@@ -455,6 +455,7 @@ static Mat _extractBits(InputArray _image, const vector<Point2f>& corners, int m
 
     // output image containing the bits
     Mat bits(markerSizeWithBorders, markerSizeWithBorders, CV_8UC1, Scalar::all(0));
+    Mat whitePixRatio(markerSizeWithBorders, markerSizeWithBorders, CV_32FC1, Scalar::all(0));
 
     // check if standard deviation is enough to apply Otsu
     // if not enough, it probably means all bits are the same color (black or white)
@@ -465,10 +466,15 @@ static Mat _extractBits(InputArray _image, const vector<Point2f>& corners, int m
     meanStdDev(innerRegion, mean, stddev);
     if(stddev.ptr< double >(0)[0] < minStdDevOtsu) {
         // all black or all white, depending on mean value
-        if(mean.ptr< double >(0)[0] > 127)
+        if(mean.ptr< double >(0)[0] > 127){
             bits.setTo(1);
-        else
+            whitePixRatio.setTo(1);
+        }
+        else {
             bits.setTo(0);
+            whitePixRatio.setTo(0);
+        }
+        if(_whitePixRatio.needed()) whitePixRatio.copyTo(_whitePixRatio);
         return bits;
     }
 
@@ -485,8 +491,38 @@ static Mat _extractBits(InputArray _image, const vector<Point2f>& corners, int m
             // count white pixels on each cell to assign its value
             size_t nZ = (size_t) countNonZero(square);
             if(nZ > square.total() / 2) bits.at<unsigned char>(y, x) = 1;
+
+            if(_whitePixRatio.needed()){
+
+                // Get white pixel ratio from the complete cell
+                if(cellMarginPixels > 0){
+                    // Consider the full cell. If perspectiveRemoveIgnoredMarginPerCell != 0, manually include the pixels of the margins
+                    Mat topRect = resultImg(Rect(Xstart - cellMarginPixels, Ystart - cellMarginPixels, cellSize, cellMarginPixels));
+                    size_t nZMarginPixels = (size_t) countNonZero(topRect);
+                    size_t totalMarginPixels = topRect.total();
+
+                    Mat leftRect = resultImg(Rect(Xstart - cellMarginPixels, Ystart, cellMarginPixels, cellSize - 2 * cellMarginPixels));
+                    nZMarginPixels += (size_t) countNonZero(leftRect);
+                    totalMarginPixels += leftRect.total();
+
+                    Mat bottomRect = resultImg(Rect(Xstart - cellMarginPixels, Ystart + cellSize - 2 * cellMarginPixels, cellSize, cellMarginPixels));
+                    nZMarginPixels += (size_t) countNonZero(bottomRect);
+                    totalMarginPixels += bottomRect.total();
+
+                    Mat rightRect = resultImg(Rect(Xstart + cellSize - 2 * cellMarginPixels, Ystart, cellMarginPixels, cellSize - 2 * cellMarginPixels));
+                    nZMarginPixels += (size_t) countNonZero(rightRect);
+                    totalMarginPixels += rightRect.total();
+
+                    whitePixRatio.at<float>(y, x) = (nZ + nZMarginPixels) / (float)(square.total() + totalMarginPixels);
+                }
+                else {
+                    whitePixRatio.at<float>(y, x) = (nZ / (float)square.total());
+                }
+            }
         }
     }
+
+    if(_whitePixRatio.needed()) whitePixRatio.copyTo(_whitePixRatio);
 
     return bits;
 }
@@ -527,7 +563,7 @@ static int _getBorderErrors(const Mat &bits, int markerSize, int borderSize) {
  */
 static uint8_t _identifyOneCandidate(const Dictionary& dictionary, InputArray _image,
                                      const vector<Point2f>& _corners, int& idx,
-                                     const DetectorParameters& params, int& rotation,
+                                     const DetectorParameters& params, int& rotation, float& markerUnc,
                                      const float scale = 1.f) {
     CV_DbgAssert(_corners.size() == 4);
     CV_DbgAssert(_image.getMat().total() != 0);
@@ -541,10 +577,11 @@ static uint8_t _identifyOneCandidate(const Dictionary& dictionary, InputArray _i
         scaled_corners[i].y = _corners[i].y * scale;
     }
 
+    Mat whitePixRatio;
     Mat candidateBits =
         _extractBits(_image, scaled_corners, dictionary.markerSize, params.markerBorderBits,
                      params.perspectiveRemovePixelPerCell,
-                     params.perspectiveRemoveIgnoredMarginPerCell, params.minOtsuStdDev);
+                     params.perspectiveRemoveIgnoredMarginPerCell, params.minOtsuStdDev, whitePixRatio);
 
     // analyze border bits
     int maximumErrorsInBorder =
@@ -575,6 +612,9 @@ static uint8_t _identifyOneCandidate(const Dictionary& dictionary, InputArray _i
     // try to indentify the marker
     if(!dictionary.identify(onlyBits, idx, rotation, params.errorCorrectionRate))
         return 0;
+
+    // Only compute the uncertainty if the optional param in ArucoDetector::detectMarkers is set.
+    if(int(markerUnc - 0.01) != -1) markerUnc = dictionary.getMarkerUnc(whitePixRatio, idx, rotation, params.markerBorderBits, typ);
 
     return typ;
 }
@@ -618,14 +658,16 @@ static void _identifyCandidates(InputArray grey,
                                 vector<vector<vector<Point> > >& _contoursSet, const Dictionary &_dictionary,
                                 vector<vector<Point2f> >& _accepted, vector<vector<Point> >& _contours, vector<int>& ids,
                                 const DetectorParameters &params,
-                                OutputArrayOfArrays _rejected = noArray()) {
+                                OutputArrayOfArrays _rejected = noArray(),  OutputArray _markersUnc = noArray()) {
     CV_DbgAssert(grey.getMat().total() != 0);
     CV_DbgAssert(grey.getMat().type() == CV_8UC1);
     int ncandidates = (int)_candidatesSet[0].size();
     vector<vector<Point2f> > accepted;
     vector<vector<Point2f> > rejected;
     vector<vector<Point> > contours;
+    vector<float> markersUnc;
 
+    vector<float> markersUncTmp(ncandidates, 1.f);
     vector<int> idsTmp(ncandidates, -1);
     vector<int> rotated(ncandidates, 0);
     vector<uint8_t> validCandidates(ncandidates, 0);
@@ -639,6 +681,7 @@ static void _identifyCandidates(InputArray grey,
         vector<vector<Point> >& contourS = params.detectInvertedMarker ? _contoursSet[1] : _contoursSet[0];
 
         for(int i = begin; i < end; i++) {
+            float currMarkerUnc = (_markersUnc.needed()) ? 1.f : -1.f;
             int currId = -1;
             // implements equation (4)
             if (params.useAruco3Detection) {
@@ -647,14 +690,16 @@ static void _identifyCandidates(InputArray grey,
                 const size_t nearestImgId = _findOptPyrImageForCanonicalImg(image_pyr, grey.cols(), perimeterOfContour, min_perimeter);
                 const float scale = image_pyr[nearestImgId].cols / static_cast<float>(grey.cols());
 
-                validCandidates[i] = _identifyOneCandidate(_dictionary, image_pyr[nearestImgId], candidates[i], currId, params, rotated[i], scale);
+                validCandidates[i] = _identifyOneCandidate(_dictionary, image_pyr[nearestImgId], candidates[i], currId, params, rotated[i], currMarkerUnc, scale);
             }
             else {
-                validCandidates[i] = _identifyOneCandidate(_dictionary, grey, candidates[i], currId, params, rotated[i]);
+                validCandidates[i] = _identifyOneCandidate(_dictionary, grey, candidates[i], currId, params, rotated[i], currMarkerUnc);
             }
 
-            if(validCandidates[i] > 0)
+            if(validCandidates[i] > 0){
                 idsTmp[i] = currId;
+                markersUncTmp[i] = currMarkerUnc;
+            }
         }
     });
 
@@ -672,6 +717,7 @@ static void _identifyCandidates(InputArray grey,
             // add valid candidate
             accepted.push_back(_candidatesSet[set][i]);
             ids.push_back(idsTmp[i]);
+            markersUnc.push_back(markersUncTmp[i]);
 
             contours.push_back(_contoursSet[set][i]);
 
@@ -687,6 +733,10 @@ static void _identifyCandidates(InputArray grey,
 
     if(_rejected.needed()) {
         _copyVector2Output(rejected, _rejected);
+    }
+
+    if(_markersUnc.needed()){
+        Mat(markersUnc).copyTo(_markersUnc);
     }
 }
 
@@ -856,7 +906,7 @@ ArucoDetector::ArucoDetector(const Dictionary &_dictionary,
 }
 
 void ArucoDetector::detectMarkers(InputArray _image, OutputArrayOfArrays _corners, OutputArray _ids,
-                                  OutputArrayOfArrays _rejectedImgPoints) const {
+                                  OutputArrayOfArrays _rejectedImgPoints, OutputArray _markersUnc) const {
     CV_Assert(!_image.empty());
     DetectorParameters& detectorParams = arucoDetectorImpl->detectorParams;
     const Dictionary& dictionary = arucoDetectorImpl->dictionary;
@@ -935,7 +985,7 @@ void ArucoDetector::detectMarkers(InputArray _image, OutputArrayOfArrays _corner
 
     /// STEP 2: Check candidate codification (identify markers)
     _identifyCandidates(grey, grey_pyramid, candidatesSet, contoursSet, dictionary,
-                        candidates, contours, ids, detectorParams, _rejectedImgPoints);
+                        candidates, contours, ids, detectorParams, _rejectedImgPoints, _markersUnc);
 
     /// STEP 3: Corner refinement :: use corner subpix
     if (detectorParams.cornerRefinementMethod == CORNER_REFINE_SUBPIX) {

--- a/modules/objdetect/src/aruco/aruco_dictionary.cpp
+++ b/modules/objdetect/src/aruco/aruco_dictionary.cpp
@@ -111,6 +111,75 @@ bool Dictionary::identify(const Mat &onlyBits, int &idx, int &rotation, double m
 }
 
 
+float Dictionary::getMarkerUnc(InputArray _whitePixRatio, int id, int rotation, int borderSize, int typ) const {
+
+    CV_Assert(id >= 0 && id < bytesList.rows);
+    const int sizeWithBorders = markerSize + 2 * borderSize;
+
+    Mat whitePixRatio = _whitePixRatio.getMat();
+
+    CV_Assert(markerSize > 0 && whitePixRatio.cols == sizeWithBorders && whitePixRatio.rows == sizeWithBorders);
+
+    // Get border uncertainty. Assuming black borders, the uncertainty is the ratio of white pixels.
+    float tempBorderUnc = 0.f;
+    for(int y = 0; y < sizeWithBorders; y++) {
+        for(int k = 0; k < borderSize; k++) {
+            // Left and right vertical sides
+            tempBorderUnc += whitePixRatio.ptr<float>(y)[k];
+            tempBorderUnc += whitePixRatio.ptr<float>(y)[sizeWithBorders - 1 - k];
+        }
+    }
+    for(int x = borderSize; x < sizeWithBorders - borderSize; x++) {
+        for(int k = 0; k < borderSize; k++) {
+            // Top and bottom horizontal sides
+            tempBorderUnc += whitePixRatio.ptr<float>(k)[x];
+            tempBorderUnc += whitePixRatio.ptr<float>(sizeWithBorders - 1 - k)[x];
+        }
+    }
+
+    // Get the ground truth bits and rotate them:
+    Mat groundTruthbits = getBitsFromByteList(bytesList.rowRange(id, id + 1), markerSize);
+    CV_Assert(groundTruthbits.cols == markerSize && groundTruthbits.rows == markerSize);
+
+    if(rotation == 1){
+        // 90 deg CCW
+        transpose(groundTruthbits, groundTruthbits);
+        flip(groundTruthbits, groundTruthbits,0);
+
+    } else if (rotation == 2){
+        // 180 deg CCW
+        flip(groundTruthbits, groundTruthbits,-1);
+
+    } else if (rotation == 3){
+        // 90 deg CW
+        transpose(groundTruthbits, groundTruthbits);
+        flip(groundTruthbits, groundTruthbits,1);
+    }
+
+    // Get the inner marker uncertainty. For a white or black cell, the uncertainty is the ratio of black or white pixels respectively.
+    float tempInnerUnc = 0.f;
+    for(int y = borderSize; y < markerSize + borderSize; y++) {
+        for(int x = borderSize; x < markerSize + borderSize; x++) {
+            if(groundTruthbits.ptr<unsigned char>(y - borderSize)[x - borderSize] != 0){
+                // Ground truth bit is white, therefore the uncertainty is the ratio of black pixels.
+                tempInnerUnc += 1.f - whitePixRatio.ptr<float>(y)[x];
+            } else {
+                // Ground truth bit is black, therefore the uncertainty is the ratio of white pixels.
+                tempInnerUnc += whitePixRatio.ptr<float>(y)[x];
+            }
+        }
+    }
+
+    // Compute the overall normalized marker uncertainty
+    float normalizedMarkerUnc = (tempInnerUnc + tempBorderUnc) / (sizeWithBorders * sizeWithBorders);
+
+    // Invert uncertainty for white markers
+    if(typ == 2) normalizedMarkerUnc = 1.f - normalizedMarkerUnc;
+
+    return normalizedMarkerUnc;
+}
+
+
 int Dictionary::getDistanceToId(InputArray bits, int id, bool allRotations) const {
 
     CV_Assert(id >= 0 && id < bytesList.rows);

--- a/modules/objdetect/test/test_arucodetection.cpp
+++ b/modules/objdetect/test/test_arucodetection.cpp
@@ -311,6 +311,148 @@ void CV_ArucoDetectionPerspective::run(int) {
 
 
 /**
+ * @brief Draw 2D synthetic markers, temper with some pixels, detect them and compute their uncertainty.
+ */
+class CV_ArucoDetectionUnc : public cvtest::BaseTest {
+    public:
+    CV_ArucoDetectionUnc(ArucoAlgParams arucoAlgParam) : arucoAlgParams(arucoAlgParam) {}
+
+    protected:
+    void run(int);
+    ArucoAlgParams arucoAlgParams;
+};
+
+
+void CV_ArucoDetectionUnc::run(int) {
+
+    aruco::DetectorParameters params;
+    aruco::ArucoDetector detector(aruco::getPredefinedDictionary(aruco::DICT_6X6_250), params);
+
+    // Params to test
+    float ingnoreMarginPerCell[3] = {0.0, 0.1, 0.2};
+    int borderBitsTest[3] = {1,2,3};
+
+    const int markerSidePixels = 150;
+    const int imageSize = (markerSidePixels * 2) + 3 * (markerSidePixels / 2);
+
+    // 25 images containing 4 markers.
+    for(int i = 0; i < 25; i++) {
+
+        // Modify default params
+        params.perspectiveRemovePixelPerCell = 6 + i;
+        params.perspectiveRemoveIgnoredMarginPerCell = ingnoreMarginPerCell[i % 3];
+        params.markerBorderBits = borderBitsTest[i % 3];
+
+        // draw synthetic image
+        vector<float > groundTruthUncs;
+        vector<int> groundTruthIds;
+        Mat img = Mat(imageSize, imageSize, CV_8UC1, Scalar::all(255));
+
+        // Invert the pixel value of a % of each cell [0%, 2%, 4%, ..., 48%]
+        float invertPixelPercent = 2 * i / 100.f;
+        int markerSizeWithBorders = 6 + 2 * params.markerBorderBits;
+        int cellSidePixelsSize = markerSidePixels / markerSizeWithBorders;
+        int cellSidePixelsInvert = int(sqrt(invertPixelPercent) * cellSidePixelsSize);
+        int cellMarginPixels = (cellSidePixelsSize - cellSidePixelsInvert) / 2; // Invert center of the cell
+
+        float groundTruthUnc;
+
+        // Generate 4 markers
+        for(int y = 0; y < 2; y++) {
+            for(int x = 0; x < 2; x++) {
+                Mat marker;
+                int id = i * 4 + y * 2 + x;
+                groundTruthIds.push_back(id);
+
+                // Generate marker
+                aruco::generateImageMarker(detector.getDictionary(), id, markerSidePixels, marker, params.markerBorderBits);
+
+                // Test all 4 rotations: [0, 90, 180, 270]
+                if(y == 0 && x == 0){
+                    // Rotate 90 deg CCW
+                    cv::transpose(marker, marker);
+                    cv::flip(marker, marker,0);
+                } else if (y == 0 && x == 1){
+                    // Rotate 90 deg CW
+                    cv::transpose(marker, marker);
+                    cv::flip(marker, marker,1);
+                } else if (y == 1 && x == 0){
+                    // Rotate 180 deg CCW
+                    cv::flip(marker, marker,-1);
+                }
+
+                // Invert the pixel value of a % of each cell [0%, 2%, 4%, ..., 48%]
+                if(cellSidePixelsInvert > 0){
+                    // loop over each cell
+                    for(int k = 0; k < markerSizeWithBorders; k++) {
+                        for(int p = 0; p < markerSizeWithBorders; p++) {
+                            int Xstart = p * (cellSidePixelsSize) + cellMarginPixels;
+                            int Ystart = k * (cellSidePixelsSize) + cellMarginPixels;
+                            Mat square(marker, Rect(Xstart, Ystart, cellSidePixelsInvert, cellSidePixelsInvert));
+                            square = ~square;
+                        }
+                    }
+                }
+
+                // Assume a perfect marker detection and thus a ground truth equal to the percentage of inverted pixels.
+                groundTruthUnc = markerSizeWithBorders * markerSizeWithBorders * cellSidePixelsInvert * cellSidePixelsInvert / (float)(markerSidePixels * markerSidePixels);
+                groundTruthUncs.push_back(groundTruthUnc);
+
+                // Make sure that the marker is still detected when it was highly tempered.
+                if(groundTruthUnc >= 0.2) params.perspectiveRemoveIgnoredMarginPerCell = 0;
+
+                // Copy marker into full image
+                Point2f firstCorner =
+                    Point2f(markerSidePixels / 2.f + x * (1.5f * markerSidePixels),
+                            markerSidePixels / 2.f + y * (1.5f * markerSidePixels));
+                Mat aux = img.colRange((int)firstCorner.x, (int)firstCorner.x + markerSidePixels)
+                              .rowRange((int)firstCorner.y, (int)firstCorner.y + markerSidePixels);
+
+                marker.copyTo(aux);
+            }
+        }
+
+        // Test inverted markers
+        if(ArucoAlgParams::DETECT_INVERTED_MARKER == arucoAlgParams){
+            img = ~img;
+            params.detectInvertedMarker = true;
+        }
+
+        detector.setDetectorParameters(params);
+
+        // detect markers and compute uncertainty
+        vector<vector<Point2f> > corners, rejected;
+        vector<int> ids;
+        vector<float> markerUnc;
+
+        detector.detectMarkers(img, corners, ids, rejected, markerUnc);
+
+        // check detection results
+        for(unsigned int m = 0; m < groundTruthIds.size(); m++) {
+            int idx = -1;
+            for(unsigned int k = 0; k < ids.size(); k++) {
+                if(groundTruthIds[m] == ids[k]) {
+                    idx = (int)k;
+                    break;
+                }
+            }
+            if(idx == -1) {
+                ts->printf(cvtest::TS::LOG, "Marker not detected");
+                ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+                return;
+            }
+            double dist = (double)cv::abs(groundTruthUncs[m] - markerUnc[idx]);  // TODO cvtest
+            if(dist > 0.05) {
+                ts->printf(cvtest::TS::LOG, "Marker uncertainty: %.2f is incorrect. (GT: %.2f )", markerUnc[idx], groundTruthUncs[m]);
+                ts->printf(cvtest::TS::LOG, "");
+                ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
+                return;
+            }
+        }
+    }
+}
+
+/**
  * @brief Check max and min size in marker detection parameters
  */
 class CV_ArucoDetectionMarkerSize : public cvtest::BaseTest {
@@ -537,6 +679,18 @@ TEST(CV_ArucoDetectionMarkerSize, algorithmic) {
 
 TEST(CV_ArucoBitCorrection, algorithmic) {
     CV_ArucoBitCorrection test;
+    test.safe_run();
+}
+
+typedef CV_ArucoDetectionUnc CV_InvertedArucoDetectionUnc;
+
+TEST(CV_ArucoDetectionUnc, algorithmic) {
+    CV_ArucoDetectionUnc test(ArucoAlgParams::USE_DEFAULT);
+    test.safe_run();
+}
+
+TEST(CV_InvertedArucoDetectionUnc, algorithmic) {
+    CV_InvertedArucoDetectionUnc test(ArucoAlgParams::DETECT_INVERTED_MARKER);
     test.safe_run();
 }
 


### PR DESCRIPTION
The aim of this pull request is to compute a **pixel-based uncertainty** of the marker detection. The uncertainty [0;1] is defined as the percentage of incorrectly detected pixels, with 0 describing a pixel perfect detection. Currently it is possible to get the normalized Hamming distance between the detected marker and the dictionary ground truth [Dictionary::getDistanceToId()](https://github.com/opencv/opencv/blob/4.x/modules/objdetect/src/aruco/aruco_dictionary.cpp#L114) However, this distance is based on the extracted bits and we lose information in the [majority count step](https://github.com/opencv/opencv/blob/4.x/modules/objdetect/src/aruco/aruco_detector.cpp#L487). For example, even if each cell has 49% incorrect pixels, we still obtain a perfect Hamming distance.

**Implementation tests**: Generate 25 synthetic images containing 4 markers each (with different ids). Invert a given percentage of pixels in each cell of the marker [0, 2, 4, ..., 48]%. Assuming a perfect detection, define the ground truth uncertainty as the percentage of inverted pixels. The test is passed if `abs(computedUnc - groundTruthUnc) < 0.05` where `0.05` accounts for minor detection inaccuracies.

- Performed for both regular and inverted markers
- Markers in all 4 possible rotations [0, 90, 180, 270]
- Different set of detection params:
    - `perspectiveRemovePixelPerCell`
    - `perspectiveRemoveIgnoredMarginPerCell`
    - `markerBorderBits`

The code properly builds locally and all the tests in `opencv_test_objdetect` and `opencv_test_core` passed. Please let me know if there are any further modifications needed. 

Thanks!


I've also pushed minor unrelated improvement (let me know if you want a separate PR) in the [bit extraction method](https://github.com/opencv/opencv/blob/4.x/modules/objdetect/src/aruco/aruco_detector.cpp#L435). `CV_Assert(perspectiveRemoveIgnoredMarginPerCell <=1)` should be `< 0.5`. Since there are margins on both sides of the cell, the margins must be smaller than half of the cell. When setting `perspectiveRemoveIgnoredMarginPerCell >= 0.5`, `opencv_test_objdetect` fails. Note: 0.499 is ok because `int()` will floor the result, thus `cellMarginPixels = int(cellMarginRate * cellSize)` will be smaller than `cellSize / 2`



### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] The feature is well documented and sample code can be built with the project CMake
