### PR TITLE
added argument to print notice in `roiSelector.cpp`

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -520,16 +520,17 @@ Controls: use `space` or `enter` to finish selection, use key `c` to cancel sele
 @param showCrosshair if true crosshair of selection rectangle will be shown.
 @param fromCenter if true center of selection will match initial mouse position. In opposite case a corner of
 selection rectangle will correspont to the initial mouse position.
+@param printNotice if true a notice to select ROI or cancel selection will be printed in console.
 @return selected ROI or empty rect if selection canceled.
 
 @note The function sets it's own mouse callback for specified window using cv::setMouseCallback(windowName, ...).
 After finish of work an empty callback will be set for the used window.
  */
-CV_EXPORTS_W Rect selectROI(const String& windowName, InputArray img, bool showCrosshair = true, bool fromCenter = false);
+CV_EXPORTS_W Rect selectROI(const String& windowName, InputArray img, bool showCrosshair = true, bool fromCenter = false, bool printNotice = true);
 
 /** @overload
  */
-CV_EXPORTS_W Rect selectROI(InputArray img, bool showCrosshair = true, bool fromCenter = false);
+CV_EXPORTS_W Rect selectROI(InputArray img, bool showCrosshair = true, bool fromCenter = false, bool printNotice = true);
 
 /** @brief Allows users to select multiple ROIs on the given image.
 
@@ -543,12 +544,13 @@ use `esc` to terminate multiple ROI selection process.
 @param showCrosshair if true crosshair of selection rectangle will be shown.
 @param fromCenter if true center of selection will match initial mouse position. In opposite case a corner of
 selection rectangle will correspont to the initial mouse position.
+@param printNotice if true a notice to select ROI or cancel selection will be printed in console.
 
 @note The function sets it's own mouse callback for specified window using cv::setMouseCallback(windowName, ...).
 After finish of work an empty callback will be set for the used window.
  */
 CV_EXPORTS_W void selectROIs(const String& windowName, InputArray img,
-                             CV_OUT std::vector<Rect>& boundingBoxes, bool showCrosshair = true, bool fromCenter = false);
+                             CV_OUT std::vector<Rect>& boundingBoxes, bool showCrosshair = true, bool fromCenter = false, bool printNotice = true);
 
 /** @brief Creates a trackbar and attaches it to the specified window.
 

--- a/modules/highgui/src/roiSelector.cpp
+++ b/modules/highgui/src/roiSelector.cpp
@@ -88,7 +88,10 @@ class ROISelector
     void select(const String &windowName, Mat img, std::vector<Rect> &boundingBoxes,
                 bool showCrosshair = true, bool fromCenter = true, bool printNotice = true)
     {
-        printf("Finish the selection process by pressing ESC button!\n");
+        if(printNotice)
+        {
+            printf("Finish the selection process by pressing ESC button!\n");
+        }
         boundingBoxes.clear();
         key = 0;
 

--- a/modules/highgui/src/roiSelector.cpp
+++ b/modules/highgui/src/roiSelector.cpp
@@ -13,11 +13,14 @@ namespace
 class ROISelector
 {
   public:
-    Rect select(const String &windowName, Mat img, bool showCrossair = true, bool fromCenter = true)
+    Rect select(const String &windowName, Mat img, bool showCrossair = true, bool fromCenter = true, bool printNotice = true)
     {
-        // show notice to user
-        printf("Select a ROI and then press SPACE or ENTER button!\n");
-        printf("Cancel the selection process by pressing c button!\n");
+        if(printNotice)
+        {
+            // show notice to user
+            printf("Select a ROI and then press SPACE or ENTER button!\n");
+            printf("Cancel the selection process by pressing c button!\n");
+        }
 
         key = 0;
         imageSize = img.size();
@@ -83,7 +86,7 @@ class ROISelector
     }
 
     void select(const String &windowName, Mat img, std::vector<Rect> &boundingBoxes,
-                bool showCrosshair = true, bool fromCenter = true)
+                bool showCrosshair = true, bool fromCenter = true, bool printNotice = true)
     {
         printf("Finish the selection process by pressing ESC button!\n");
         boundingBoxes.clear();
@@ -92,7 +95,7 @@ class ROISelector
         // while key is not ESC (27)
         for (;;)
         {
-            Rect temp = select(windowName, img, showCrosshair, fromCenter);
+            Rect temp = select(windowName, img, showCrosshair, fromCenter, printNotice);
             if (key == 27)
                 break;
             if (temp.width > 0 && temp.height > 0)
@@ -195,21 +198,21 @@ class ROISelector
 };
 }
 
-Rect cv::selectROI(InputArray img, bool showCrosshair, bool fromCenter)
+Rect cv::selectROI(InputArray img, bool showCrosshair, bool fromCenter, bool printNotice)
 {
     ROISelector selector;
-    return selector.select("ROI selector", img.getMat(), showCrosshair, fromCenter);
+    return selector.select("ROI selector", img.getMat(), showCrosshair, fromCenter, printNotice);
 }
 
-Rect cv::selectROI(const String& windowName, InputArray img, bool showCrosshair, bool fromCenter)
+Rect cv::selectROI(const String& windowName, InputArray img, bool showCrosshair, bool fromCenter, bool printNotice)
 {
     ROISelector selector;
-    return selector.select(windowName, img.getMat(), showCrosshair, fromCenter);
+    return selector.select(windowName, img.getMat(), showCrosshair, fromCenter, printNotice);
 }
 
 void cv::selectROIs(const String& windowName, InputArray img,
-                             std::vector<Rect>& boundingBox, bool showCrosshair, bool fromCenter)
+                             std::vector<Rect>& boundingBox, bool showCrosshair, bool fromCenter, bool printNotice)
 {
     ROISelector selector;
-    selector.select(windowName, img.getMat(), boundingBox, showCrosshair, fromCenter);
+    selector.select(windowName, img.getMat(), boundingBox, showCrosshair, fromCenter, printNotice);
 }


### PR DESCRIPTION
Related Issue : https://github.com/opencv/opencv/issues/23175

I've added a printNotice argument to `selectROI` (and it's overload) and `selectROIs` functions.
I've also updated the function declarations in `highgui.hpp`.
Tested by building locally.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
