### PR TITLE
Supress tones of -Wdeprecated-copy warnings

### DIFF
--- a/modules/gapi/cmake/DownloadADE.cmake
+++ b/modules/gapi/cmake/DownloadADE.cmake
@@ -24,6 +24,12 @@ add_library(ade STATIC ${OPENCV_3RDPARTY_EXCLUDE_FROM_ALL}
     ${ADE_include}
     ${ADE_sources}
 )
+
+# https://github.com/opencv/ade/issues/32
+if(CV_CLANG AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.1)
+  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wdeprecated-copy)
+endif()
+
 target_include_directories(ade PUBLIC $<BUILD_INTERFACE:${ADE_root}/include>)
 set_target_properties(ade PROPERTIES
   POSITION_INDEPENDENT_CODE True

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -123,6 +123,9 @@
 //#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
+#if defined(__OPENCV_BUILD) && defined(__APPLE__) && defined(__clang__) && ((__clang_major__*100 + __clang_minor__) >= 1301)
+#pragma clang diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include "opencv2/ts/ts_gtest.h"
 #if defined(__OPENCV_BUILD) && defined(__GNUC__) && __GNUC__ >= 5
 //#pragma GCC diagnostic pop


### PR DESCRIPTION
They jump out of GTest after XCode update to 13.1 on Mac M1.
Merge with https://github.com/opencv/opencv_contrib/pull/3434.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=ubuntu-clang:20.04
buildworker:Custom=linux-1,linux-4
```