### PR TITLE
Fix rect_nfa (lsd)

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -955,11 +955,16 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     v_tmp[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
     v_tmp[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
 
+    // Find the vertex with the smallest y coordinate (or the smallest x if there is a tie).
+    int offset = 0;
+    for (int i = 1; i < 4; ++i) {
+        if (AsmallerB_YoverX(v_tmp[i], v_tmp[offset])){
+            offset = i;
+        }
+    }
+
     // Rotate the vertices so that the first one is the one with the smallest y coordinate (or the smallest x if there is a tie).
     // The rest will be then ordered counterclockwise.
-    auto offset = std::min_element(v_tmp, v_tmp + 4, AsmallerB_YoverX) - v_tmp;
-
-    // Rotate the values without using std::rotate
     cv::Point2d ordered_y[4];
     for (int i = 0; i < 4; ++i) {
         ordered_y[i] = v_tmp[(i + offset) % 4];

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -985,7 +985,7 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     {
         if (y < 0 || y >= img_height) continue;
 
-        if(y < int(ceil(ordered_y[1].y)))
+        if(y <= int(ceil(ordered_y[1].y)))
             left_limit = get_limit(ordered_y[0], y, flstep);
         else
             left_limit = get_limit(ordered_y[1], y, slstep);

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -69,12 +69,6 @@ const double DEG_TO_RADS = CV_PI / 180;
 
 #define log_gamma(x) ((x)>15.0?log_gamma_windschitl(x):log_gamma_lanczos(x))
 
-struct edge
-{
-    cv::Point p;
-    bool taken;
-};
-
 /////////////////////////////////////////////////////////////////////////////////////////
 
 inline double distSq(const double x1, const double y1,
@@ -120,10 +114,20 @@ inline bool double_equal(const double& a, const double& b)
     return (abs_diff / abs_max) <= (RELATIVE_ERROR_FACTOR * DBL_EPSILON);
 }
 
-inline bool AsmallerB_XoverY(const edge& a, const edge& b)
-{
-    if (a.p.x == b.p.x) return a.p.y < b.p.y;
-    else return a.p.x < b.p.x;
+// function to sort points by y and then by x
+inline bool AsmallerB_YoverX(const cv::Point2d &a, const cv::Point2d &b) {
+    if (a.y == b.y) return a.x < b.x;
+    else return a.y < b.y;
+}
+
+// function to get the slope of the rectangle for a specific row
+inline double get_slope(cv::Point2d p1, cv::Point2d p2) {
+    return (p2.y != p1.y) ? (p2.x - p1.x) / (p2.y - p1.y) : 0;
+}
+
+// function to get the limit of the rectangle for a specific row
+inline double get_limit(cv::Point2d p, int row, double slope) {
+    return p.x + (row - p.y) * slope;
 }
 
 /**
@@ -945,105 +949,43 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     double dyhw = rec.dy * half_width;
     double dxhw = rec.dx * half_width;
 
-    edge ordered_x[4];
-    edge* min_y = &ordered_x[0];
-    edge* max_y = &ordered_x[0]; // Will be used for loop range
+    cv::Point2d ordered_y[4];
+    ordered_y[0] = cv::Point2d(rec.x1 - dyhw, rec.y1 + dxhw);
+    ordered_y[1] = cv::Point2d(rec.x2 - dyhw, rec.y2 + dxhw);
+    ordered_y[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
+    ordered_y[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
 
-    ordered_x[0].p.x = int(rec.x1 - dyhw); ordered_x[0].p.y = int(rec.y1 + dxhw); ordered_x[0].taken = false;
-    ordered_x[1].p.x = int(rec.x2 - dyhw); ordered_x[1].p.y = int(rec.y2 + dxhw); ordered_x[1].taken = false;
-    ordered_x[2].p.x = int(rec.x2 + dyhw); ordered_x[2].p.y = int(rec.y2 - dxhw); ordered_x[2].taken = false;
-    ordered_x[3].p.x = int(rec.x1 + dyhw); ordered_x[3].p.y = int(rec.y1 - dxhw); ordered_x[3].taken = false;
+    // Rotate the vertices so that the first one is the one with the smallest y coordinate (or the smallest x if there is a tie).
+    // The rest will be then ordered counterclockwise.
+    auto offset = std::min_element(ordered_y, ordered_y + 4, AsmallerB_YoverX) - ordered_y;
+    std::rotate(ordered_y, ordered_y + offset, ordered_y + 4);
 
-    std::sort(ordered_x, ordered_x + 4, AsmallerB_XoverY);
+    double flstep = get_slope(ordered_y[0], ordered_y[1]); //first left step
+    double slstep = get_slope(ordered_y[1], ordered_y[2]); //second left step
 
-    // Find min y. And mark as taken. find max y.
-    for(unsigned int i = 1; i < 4; ++i)
-    {
-        if(min_y->p.y > ordered_x[i].p.y) {min_y = &ordered_x[i]; }
-        if(max_y->p.y < ordered_x[i].p.y) {max_y = &ordered_x[i]; }
-    }
-    min_y->taken = true;
+    double frstep = get_slope(ordered_y[0], ordered_y[3]); //first right step
+    double srstep = get_slope(ordered_y[3], ordered_y[2]); //second right step
 
-    // Find leftmost untaken point;
-    edge* leftmost = 0;
-    for(unsigned int i = 0; i < 4; ++i)
-    {
-        if(!ordered_x[i].taken)
-        {
-            if(!leftmost) // if uninitialized
-            {
-                leftmost = &ordered_x[i];
-            }
-            else if (leftmost->p.x > ordered_x[i].p.x)
-            {
-                leftmost = &ordered_x[i];
-            }
-        }
-    }
-    CV_Assert(leftmost != NULL);
-    leftmost->taken = true;
-
-    // Find rightmost untaken point;
-    edge* rightmost = 0;
-    for(unsigned int i = 0; i < 4; ++i)
-    {
-        if(!ordered_x[i].taken)
-        {
-            if(!rightmost) // if uninitialized
-            {
-                rightmost = &ordered_x[i];
-            }
-            else if (rightmost->p.x < ordered_x[i].p.x)
-            {
-                rightmost = &ordered_x[i];
-            }
-        }
-    }
-    CV_Assert(rightmost != NULL);
-    rightmost->taken = true;
-
-    // Find last untaken point;
-    edge* tailp = 0;
-    for(unsigned int i = 0; i < 4; ++i)
-    {
-        if(!ordered_x[i].taken)
-        {
-            if(!tailp) // if uninitialized
-            {
-                tailp = &ordered_x[i];
-            }
-            else if (tailp->p.x > ordered_x[i].p.x)
-            {
-                tailp = &ordered_x[i];
-            }
-        }
-    }
-    CV_Assert(tailp != NULL);
-    tailp->taken = true;
-
-    double flstep = (min_y->p.y != leftmost->p.y) ?
-                    (min_y->p.x - leftmost->p.x) / (min_y->p.y - leftmost->p.y) : 0; //first left step
-    double slstep = (leftmost->p.y != tailp->p.x) ?
-                    (leftmost->p.x - tailp->p.x) / (leftmost->p.y - tailp->p.x) : 0; //second left step
-
-    double frstep = (min_y->p.y != rightmost->p.y) ?
-                    (min_y->p.x - rightmost->p.x) / (min_y->p.y - rightmost->p.y) : 0; //first right step
-    double srstep = (rightmost->p.y != tailp->p.x) ?
-                    (rightmost->p.x - tailp->p.x) / (rightmost->p.y - tailp->p.x) : 0; //second right step
-
-    double lstep = flstep, rstep = frstep;
-
-    double left_x = min_y->p.x, right_x = min_y->p.x;
+    double top_y = ordered_y[0].y, bottom_y = ordered_y[2].y;
 
     // Loop around all points in the region and count those that are aligned.
-    int min_iter = min_y->p.y;
-    int max_iter = max_y->p.y;
-    for(int y = min_iter; y <= max_iter; ++y)
+    std::vector<cv::Point> points;
+    double left_limit, right_limit;
+    for(int y = (int) ceil(top_y); y <= (int) ceil(bottom_y); ++y)
     {
         if (y < 0 || y >= img_height) continue;
 
-        for(int x = int(left_x); x <= int(right_x); ++x)
-        {
+        if(y < int(ceil(ordered_y[1].y)))
+            left_limit = get_limit(ordered_y[0], y, flstep);
+        else
+            left_limit = get_limit(ordered_y[1], y, slstep);
+
+        if(y < int(ceil(ordered_y[3].y)))
+            right_limit = get_limit(ordered_y[0], y, frstep);
+        else
+            right_limit = get_limit(ordered_y[3], y, srstep);
+
+        for(int x = (int) ceil(left_limit); x <= (int)(right_limit); ++x) {
             if (x < 0 || x >= img_width) continue;
 
             ++total_pts;
@@ -1052,12 +994,6 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
                 ++alg_pts;
             }
         }
-
-        if(y >= leftmost->p.y) { lstep = slstep; }
-        if(y >= rightmost->p.y) { rstep = srstep; }
-
-        left_x += lstep;
-        right_x += rstep;
     }
 
     return nfa(total_pts, alg_pts, rec.p);

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -949,16 +949,21 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     double dyhw = rec.dy * half_width;
     double dxhw = rec.dx * half_width;
 
-    cv::Point2d ordered_y[4];
-    ordered_y[0] = cv::Point2d(rec.x1 - dyhw, rec.y1 + dxhw);
-    ordered_y[1] = cv::Point2d(rec.x2 - dyhw, rec.y2 + dxhw);
-    ordered_y[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
-    ordered_y[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
+    cv::Point2d tmp[4];
+    tmp[0] = cv::Point2d(rec.x1 - dyhw, rec.y1 + dxhw);
+    tmp[1] = cv::Point2d(rec.x2 - dyhw, rec.y2 + dxhw);
+    tmp[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
+    tmp[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
 
     // Rotate the vertices so that the first one is the one with the smallest y coordinate (or the smallest x if there is a tie).
     // The rest will be then ordered counterclockwise.
-    auto offset = std::min_element(ordered_y, ordered_y + 4, AsmallerB_YoverX) - ordered_y;
-    std::rotate(ordered_y, ordered_y + offset, ordered_y + 4);
+    auto offset = std::min_element(tmp, tmp + 4, AsmallerB_YoverX) - tmp;
+
+    // Rotate the values without using std::rotate
+    cv::Point2d ordered_y[4];
+    for (int i = 0; i < 4; ++i) {
+        ordered_y[i] = tmp[(i + offset) % 4];
+    }
 
     double flstep = get_slope(ordered_y[0], ordered_y[1]); //first left step
     double slstep = get_slope(ordered_y[1], ordered_y[2]); //second left step

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -122,7 +122,7 @@ inline bool AsmallerB_YoverX(const cv::Point2d &a, const cv::Point2d &b) {
 
 // function to get the slope of the rectangle for a specific row
 inline double get_slope(cv::Point2d p1, cv::Point2d p2) {
-    return (p2.y != p1.y) ? (p2.x - p1.x) / (p2.y - p1.y) : 0;
+    return ((int) ceil(p2.y) != (int) ceil(p1.y)) ? (p2.x - p1.x) / (p2.y - p1.y) : 0;
 }
 
 // function to get the limit of the rectangle for a specific row

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -1071,7 +1071,7 @@ double LineSegmentDetectorImpl::nfa(const int& n, const int& k, const double& p)
 
     double p_term = p / (1 - p);
 
-    double log1term = (double(n) + 1) - log_gamma(double(k) + 1)
+    double log1term = log_gamma(double(n) + 1) - log_gamma(double(k) + 1)
                 - log_gamma(double(n-k) + 1)
                 + double(k) * log(p) + double(n-k) * log(1.0 - p);
     double term = exp(log1term);

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -949,20 +949,20 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     double dyhw = rec.dy * half_width;
     double dxhw = rec.dx * half_width;
 
-    cv::Point2d tmp[4];
-    tmp[0] = cv::Point2d(rec.x1 - dyhw, rec.y1 + dxhw);
-    tmp[1] = cv::Point2d(rec.x2 - dyhw, rec.y2 + dxhw);
-    tmp[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
-    tmp[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
+    cv::Point2d v_tmp[4];
+    v_tmp[0] = cv::Point2d(rec.x1 - dyhw, rec.y1 + dxhw);
+    v_tmp[1] = cv::Point2d(rec.x2 - dyhw, rec.y2 + dxhw);
+    v_tmp[2] = cv::Point2d(rec.x2 + dyhw, rec.y2 - dxhw);
+    v_tmp[3] = cv::Point2d(rec.x1 + dyhw, rec.y1 - dxhw);
 
     // Rotate the vertices so that the first one is the one with the smallest y coordinate (or the smallest x if there is a tie).
     // The rest will be then ordered counterclockwise.
-    auto offset = std::min_element(tmp, tmp + 4, AsmallerB_YoverX) - tmp;
+    auto offset = std::min_element(v_tmp, v_tmp + 4, AsmallerB_YoverX) - v_tmp;
 
     // Rotate the values without using std::rotate
     cv::Point2d ordered_y[4];
     for (int i = 0; i < 4; ++i) {
-        ordered_y[i] = tmp[(i + offset) % 4];
+        ordered_y[i] = v_tmp[(i + offset) % 4];
     }
 
     double flstep = get_slope(ordered_y[0], ordered_y[1]); //first left step


### PR DESCRIPTION
This is a replacement for https://github.com/opencv/opencv/pull/23052, where I made some mistakes with the branches at the end.

- It fixes the [nfa function](https://github.com/opencv/opencv/blob/a6b178a3d9f5c8df83df01d2bfe3ff53048391ea/modules/imgproc/src/lsd.cpp#L1074) which is missing the first log_gamma call compared with the function in the [binomial_nfa repository](https://github.com/rafael-grompone-von-gioi/binomial_nfa/blob/main/C99/log_binomial_nfa.c#L152).
- It also fixes the logic issue on [rect_nfa function](https://github.com/opencv/opencv/blob/a6b178a3d9f5c8df83df01d2bfe3ff53048391ea/modules/imgproc/src/lsd.cpp#L94), which had a logic issue on the way the pixels inside the rectangle were being checked.

 With the changes to the rect_nfa function, now it checks the same pixels inside the rectangle as the original paper. In the image below I fill a rotated rectangle using the original paper method (blue channel), the old OpenCV method (green channel), and the fixed code (red channel). As you can see, the old calculation had some logic issues.
 ![rect_fill_comparison](https://user-images.githubusercontent.com/43162939/216000586-f6bf2144-7608-4e94-9fce-4306109a7106.png)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
