### PR TITLE
[G-API] Pipeline modeling tool: Refactor calculating performance statistics

### DIFF
--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -467,12 +467,6 @@ int main(int argc, char* argv[]) {
             // NB: Pipeline mode from config takes priority over cmd.
             auto pl_mode = cfg_pl_mode.has_value()
                 ? strToPLMode(cfg_pl_mode.value()) : cmd_pl_mode;
-            // NB: Using drop_frames with streaming pipelines will follow to
-            // incorrect performance results.
-            if (drop_frames && pl_mode == PLMode::STREAMING) {
-                throw std::logic_error(
-                        "--drop_frames option is supported only for pipelines in \"regular\" mode");
-            }
 
             builder.setMode(pl_mode);
 

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -424,7 +424,6 @@ int main(int argc, char* argv[]) {
                 auto src = std::make_shared<DummySource>(
                         utils::double_ms_t{latency}, output, drop_frames, std::move(wait_strategy));
                 builder.setSource(src_name, src);
-                builder.setLatency(latency);
             }
 
             const auto& nodes_fn = check_and_get_fn(pl_fn, "nodes", name);

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -401,8 +401,9 @@ int main(int argc, char* argv[]) {
                 if (app_mode == AppMode::BENCHMARK) {
                     latency = 0.0;
                 }
-                auto src = std::make_shared<DummySource>(latency, output, drop_frames);
+                auto src = std::make_shared<DummySource>(utils::double_ms_t{latency}, output, drop_frames);
                 builder.setSource(src_name, src);
+                builder.setLatency(latency);
             }
 
             const auto& nodes_fn = check_and_get_fn(pl_fn, "nodes", name);

--- a/modules/gapi/samples/pipeline_modeling_tool.cpp
+++ b/modules/gapi/samples/pipeline_modeling_tool.cpp
@@ -467,6 +467,12 @@ int main(int argc, char* argv[]) {
             // NB: Pipeline mode from config takes priority over cmd.
             auto pl_mode = cfg_pl_mode.has_value()
                 ? strToPLMode(cfg_pl_mode.value()) : cmd_pl_mode;
+            // NB: Using drop_frames with streaming pipelines will lead to
+            // incorrect performance results.
+            if (drop_frames && pl_mode == PLMode::STREAMING) {
+                throw std::logic_error(
+                        "--drop_frames option is supported only for pipelines in \"regular\" mode");
+            }
 
             builder.setMode(pl_mode);
 

--- a/modules/gapi/samples/pipeline_modeling_tool/dummy_source.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/dummy_source.hpp
@@ -83,14 +83,14 @@ bool DummySource::pull(cv::gapi::wip::Data& data) {
             static_cast<int64_t>((curr_ts - m_next_tick_ts) / m_latency);
         // NB: Shift m_next_tick_ts to the nearest tick before curr_ts.
         m_next_tick_ts += num_frames * m_latency;
-        // NB: if drop_frames is enabled, update currect seq_id and wait for the next tick, otherwise
+        // NB: if drop_frames is enabled, update current seq_id and wait for the next tick, otherwise
         // return last written frame (+2 at the picture above) immediately.
         if (m_drop_frames) {
-            // NB: Shift to tick to the next frame.
+            // NB: Shift tick to the next frame.
             m_next_tick_ts += m_latency;
             // NB: Wait for the next frame.
             m_wait(ts_t{m_next_tick_ts - curr_ts});
-            // NB: Drop already already produced frames + current.
+            // NB: Drop already produced frames + update seq_id for the current.
             m_curr_seq_id += num_frames + 1;
         }
     }

--- a/modules/gapi/samples/pipeline_modeling_tool/dummy_source.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/dummy_source.hpp
@@ -68,7 +68,7 @@ bool DummySource::pull(cv::gapi::wip::Data& data) {
          * NB: New frame will be produced at the m_next_tick_ts point.
          */
         m_wait(ts_t{m_next_tick_ts - curr_ts});
-    } else if (m_latency != 0) {
+    } else if (m_drop_frames && m_latency != 0) {
         /*
          *                                       curr_ts
          *                         +1         +2    |
@@ -85,14 +85,11 @@ bool DummySource::pull(cv::gapi::wip::Data& data) {
          */
         int64_t num_frames =
             static_cast<int64_t>((curr_ts - m_next_tick_ts) / m_latency);
-
         m_curr_seq_id  += num_frames;
         m_next_tick_ts += num_frames * m_latency;
-        if (m_drop_frames) {
-            m_next_tick_ts += m_latency;
-            ++m_curr_seq_id;
-            m_wait(ts_t{m_next_tick_ts - curr_ts});
-        }
+        m_next_tick_ts += m_latency;
+        ++m_curr_seq_id;
+        m_wait(ts_t{m_next_tick_ts - curr_ts});
     }
 
     // NB: Just increase reference counter not to release mat memory

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
@@ -135,13 +135,21 @@ void Pipeline::run() {
     // NB: Allocate outputs for execution
     prepareOutputs();
 
-    // NB: Warm-up
+    // NB: Warm-up iteration invalidates source state
+    // so need to copy it
+    auto orig_src = m_src;
+    auto copy_src = std::make_shared<DummySource>(*m_src);
+
+    // NB: Use copy for warm-up iteration
+    m_src = copy_src;
+
+    // NB: Warm-up iteration
     init();
     run_iter();
     deinit();
 
-    // NB: Reset source
-    m_src = std::make_shared<DummySource>(*m_src);
+    // NB: Now use original source
+    m_src = orig_src;
 
     // NB: Start measuring execution
     init();

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
@@ -119,7 +119,7 @@ void Pipeline::compile() {
 }
 
 void Pipeline::prepareOutputs() {
-    // NB: N-2 buffers + timestamp + ueq_id.
+    // NB: N-2 buffers + timestamp + seq_id.
     m_out_mats.resize(m_num_outputs - 2);
     for (auto& m : m_out_mats) {
         m_pipeline_outputs += cv::gout(m);

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
@@ -164,8 +164,8 @@ void Pipeline::run() {
     // NB: Count how many executions don't fit into camera latency interval.
     m_perf.num_late_frames =
         std::count_if(m_perf.latencies.begin(), m_perf.latencies.end(),
-                [this](int64_t latency) {
-                    return latency > m_latency;
+                [this](double latency) {
+                    return std::isgreater(latency, m_latency);
                 });
 
     m_perf.throughput = (m_perf.latencies.size() / m_perf.elapsed) * 1000;

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline.hpp
@@ -19,21 +19,25 @@ struct PerfReport {
 };
 
 std::string PerfReport::toStr(bool expand) const {
+    const auto to_double_str = [](double val) {
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(3) << val;
+        return ss.str();
+    };
+
     std::stringstream ss;
-    ss << name << ": \n"
-       << "  Warm up time:   " << std::fixed << std::setprecision(3) << warmup_time << " ms\n"
-       << "  Execution time: " << std::fixed << std::setprecision(3) << elapsed << " ms\n"
-       << "  Frames:         " << num_late_frames << "/" << latencies.size() << " (late/all)\n"
-       << "  Latency:\n"
-       << "    first: " << std::fixed << std::setprecision(3) << first_latency << " ms\n"
-       << "    min:   " << std::fixed << std::setprecision(3) << min_latency   << " ms\n"
-       << "    max:   " << std::fixed << std::setprecision(3) << max_latency   << " ms\n"
-       << "    avg:   " << std::fixed << std::setprecision(3) << avg_latency << " ms\n"
-       << "  Throughput: " << std::fixed << std::setprecision(3) << throughput << " FPS";
+    ss << name << ": warm-up: " << to_double_str(warmup_time)
+       << " ms, execution time: " << to_double_str(elapsed)
+       << " ms, throughput: " << to_double_str(throughput)
+       << " FPS, latency: first: " << to_double_str(first_latency)
+       << " ms, min: " << to_double_str(min_latency)
+       << " ms, avg: " << to_double_str(avg_latency)
+       << " ms, max: " << to_double_str(max_latency)
+       << " ms, frames: " << num_late_frames << "/" << latencies.size() << " (late/all)";
     if (expand) {
         for (size_t i = 0; i < latencies.size(); ++i) {
             ss << "\nFrame:" << i << "\nLatency: "
-               << std::fixed << std::setprecision(3) << latencies[i] << " ms";
+               << to_double_str(latencies[i]) << " ms";
         }
     }
 

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -656,16 +656,14 @@ Pipeline::Ptr PipelineBuilder::construct() {
     }
 
     GAPI_Assert(m_state->stop_criterion);
-    if (m_state->mode == PLMode::STREAMING) {
-        GAPI_Assert(graph_inputs.size() == 1);
-        GAPI_Assert(cv::util::holds_alternative<cv::GMat>(graph_inputs[0]));
-        // FIXME: Handle GFrame when NV12 comes.
-        const auto& graph_input = cv::util::get<cv::GMat>(graph_inputs[0]);
-        // NB: In case streaming mode need to expose timestamp in order to
-        // calculate performance metrics.
-        graph_outputs.emplace_back(
-                cv::gapi::streaming::timestamp(graph_input).strip());
+    GAPI_Assert(graph_inputs.size() == 1);
+    GAPI_Assert(cv::util::holds_alternative<cv::GMat>(graph_inputs[0]));
+    // FIXME: Handle GFrame when NV12 comes.
+    const auto& graph_input = cv::util::get<cv::GMat>(graph_inputs[0]);
+    graph_outputs.emplace_back(
+            cv::gapi::streaming::timestamp(graph_input).strip());
 
+    if (m_state->mode == PLMode::STREAMING) {
         return std::make_shared<StreamingPipeline>(std::move(m_state->name),
                                                    cv::GComputation(
                                                        cv::GProtoInputArgs{graph_inputs},

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -369,7 +369,6 @@ private:
     std::unique_ptr<State> m_state;
 };
 
-
 PipelineBuilder::PipelineBuilder() : m_state(new State{}) { };
 
 void PipelineBuilder::addDummy(const CallParams&  call_params,

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -339,6 +339,7 @@ public:
     void setQueueCapacity(const size_t qc);
     void setName(const std::string& name);
     void setStopCriterion(StopCriterion::Ptr stop_criterion);
+    void setLatency(double latency);
 
     Pipeline::Ptr build();
 
@@ -367,12 +368,18 @@ private:
         PLMode                       mode = PLMode::STREAMING;
         std::string                  name;
         StopCriterion::Ptr           stop_criterion;
+        double                       latency;
     };
 
     std::unique_ptr<State> m_state;
 };
 
+
 PipelineBuilder::PipelineBuilder() : m_state(new State{}) { };
+
+void PipelineBuilder::setLatency(double latency) {
+    m_state->latency = latency;
+}
 
 void PipelineBuilder::addDummy(const CallParams&  call_params,
                                const DummyParams& dummy_params) {
@@ -671,7 +678,8 @@ Pipeline::Ptr PipelineBuilder::construct() {
                                                    std::move(m_state->src),
                                                    std::move(m_state->stop_criterion),
                                                    std::move(m_state->compile_args),
-                                                   graph_outputs.size());
+                                                   graph_outputs.size(),
+                                                   m_state->latency);
     }
     GAPI_Assert(m_state->mode == PLMode::REGULAR);
     return std::make_shared<RegularPipeline>(std::move(m_state->name),
@@ -681,7 +689,8 @@ Pipeline::Ptr PipelineBuilder::construct() {
                                              std::move(m_state->src),
                                              std::move(m_state->stop_criterion),
                                              std::move(m_state->compile_args),
-                                             graph_outputs.size());
+                                             graph_outputs.size(),
+                                             m_state->latency);
 }
 
 Pipeline::Ptr PipelineBuilder::build() {

--- a/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/pipeline_builder.hpp
@@ -163,13 +163,10 @@ struct DummyCall {
                         cv::Mat&           out_mat,
                         DummyState&        state) {
             using namespace std::chrono;
-            double total = 0;
-            auto   start = high_resolution_clock::now();
+            auto start_ts = utils::timestamp<utils::double_ms_t>();
             state.mat.copyTo(out_mat);
-            while (total < time) {
-                total = duration_cast<duration<double, std::milli>>(
-                            high_resolution_clock::now() - start).count();
-            }
+            auto elapsed = utils::timestamp<utils::double_ms_t>() - start_ts;
+            utils::busyWait(duration_cast<microseconds>(utils::double_ms_t{time-elapsed}));
         }
     };
 

--- a/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
@@ -52,11 +52,7 @@ inline void generateRandom(cv::Mat& out) {
     }
 }
 
-using ns_t = std::chrono::nanoseconds;
-using ns_100_t = std::chrono::duration<ns_t::rep,
-                                       std::ratio_multiply<std::ratio<100>, ns_t::period>>;
-// NB: It takes portions of 100 nanoseconds.
-inline void sleep(ns_100_t units) {
+inline void sleep(std::chrono::microseconds delay) {
 #if defined(_WIN32)
     // FIXME: Wrap it to RAII and instance only once.
     HANDLE timer = CreateWaitableTimer(NULL, true, NULL);
@@ -65,7 +61,12 @@ inline void sleep(ns_100_t units) {
     }
 
     LARGE_INTEGER li;
-    li.QuadPart = -units.count();
+    // NB: It takes portions of 100 nanoseconds.
+    using ns_t = std::chrono::nanoseconds;
+    using ns_100_t = std::chrono::duration<ns_t::rep,
+                                           std::ratio_multiply<std::ratio<100>, ns_t::period>>;
+    li.QuadPart = -std::chrono::duration_cast<ns_100_t>(delay).count();
+
     if(!SetWaitableTimer(timer, &li, 0, NULL, NULL, false)){
         CloseHandle(timer);
         throw std::logic_error("Failed to set timer");
@@ -76,7 +77,7 @@ inline void sleep(ns_100_t units) {
     }
     CloseHandle(timer);
 #else
-    std::this_thread::sleep_for(units);
+    std::this_thread::sleep_for(delay);
 #endif
 }
 
@@ -94,6 +95,16 @@ typename duration_t::rep timestamp() {
     using namespace std::chrono;
     auto now = high_resolution_clock::now();
     return duration_cast<duration_t>(now.time_since_epoch()).count();
+}
+
+inline void busyWait(std::chrono::microseconds delay) {
+    auto start_ts     = timestamp<std::chrono::microseconds>();
+    auto end_ts       = start_ts;
+    auto time_to_wait = delay.count();
+
+    while (end_ts - start_ts < time_to_wait) {
+        end_ts = timestamp<std::chrono::microseconds>();
+    }
 }
 
 template <typename K, typename V>

--- a/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
@@ -61,10 +61,10 @@ inline void sleep(std::chrono::microseconds delay) {
     }
 
     LARGE_INTEGER li;
-    // NB: It takes portions of 100 nanoseconds.
     using ns_t = std::chrono::nanoseconds;
     using ns_100_t = std::chrono::duration<ns_t::rep,
                                            std::ratio_multiply<std::ratio<100>, ns_t::period>>;
+    // NB: QuadPart takes portions of 100 nanoseconds.
     li.QuadPart = -std::chrono::duration_cast<ns_100_t>(delay).count();
 
     if(!SetWaitableTimer(timer, &li, 0, NULL, NULL, false)){

--- a/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
+++ b/modules/gapi/samples/pipeline_modeling_tool/utils.hpp
@@ -119,18 +119,18 @@ void mergeMapWith(std::map<K, V>& target, const std::map<K, V>& second) {
 }
 
 template <typename T>
-double avg(const std::vector<T>& vec, int startidx=0) {
-    return std::accumulate(vec.begin()+startidx, vec.end(), 0.0) / vec.size();
+double avg(const std::vector<T>& vec) {
+    return std::accumulate(vec.begin(), vec.end(), 0.0) / vec.size();
 }
 
 template <typename T>
-T max(const std::vector<T>& vec, int startidx=0) {
-    return *std::max_element(vec.begin()+startidx, vec.end());
+T max(const std::vector<T>& vec) {
+    return *std::max_element(vec.begin(), vec.end());
 }
 
 template <typename T>
-T min(const std::vector<T>& vec, int startidx=0) {
-    return *std::min_element(vec.begin()+startidx, vec.end());
+T min(const std::vector<T>& vec) {
+    return *std::min_element(vec.begin(), vec.end());
 }
 
 template <typename T>


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Overview
* Added `wait_mode` property for `source`. It has two supported options: `busy`/`sleep`. The reason for adding is that `busy` wait approach works more accurate than `sleep`.
* Report latency for every iteration as `double` instead of `int`. 
* Added `warm-up` iteration.
* Changed the format of reported statistics. Use one line representation to make it easier to parse via regex.
