### PR TITLE
Warning supression fix for XCode 13.1 and newer. Backport #23203

### DIFF
--- a/3rdparty/libpng/CMakeLists.txt
+++ b/3rdparty/libpng/CMakeLists.txt
@@ -66,6 +66,11 @@ if(PPC64LE OR PPC64)
   endif()
 endif()
 
+if(APPLE AND CV_CLANG AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.1)
+  ocv_warnings_disable(CMAKE_C_FLAGS -Wnull-pointer-subtraction)
+  ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-but-set-variable)
+endif()
+
 # ----------------------------------------------------------------------------------
 #         Define the library target:
 # ----------------------------------------------------------------------------------

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -559,12 +559,9 @@ void CV_CameraCalibrationTest::run( int start_from )
         i = 0;
         double dx,dy;
         double rx,ry;
-        double meanDx,meanDy;
         double maxDx = 0.0;
         double maxDy = 0.0;
 
-        meanDx = 0;
-        meanDy = 0;
         for( currImage = 0; currImage < numImages; currImage++ )
         {
             double imageMeanDx = 0;
@@ -575,9 +572,6 @@ void CV_CameraCalibrationTest::run( int start_from )
                 ry = reprojectPoints[i].y;
                 dx = rx - imagePoints[i].x;
                 dy = ry - imagePoints[i].y;
-
-                meanDx += dx;
-                meanDy += dy;
 
                 imageMeanDx += dx*dx;
                 imageMeanDy += dy*dy;
@@ -600,9 +594,6 @@ void CV_CameraCalibrationTest::run( int start_from )
             if(perViewErrors[currImage] == 0.0)
                 perViewErrors[currImage] = goodPerViewErrors[currImage];
         }
-
-        meanDx /= numImages * etalonSize.width * etalonSize.height;
-        meanDy /= numImages * etalonSize.width * etalonSize.height;
 
         /* ========= Compare parameters ========= */
 

--- a/modules/flann/include/opencv2/flann/index_testing.h
+++ b/modules/flann/include/opencv2/flann/index_testing.h
@@ -246,7 +246,6 @@ void test_index_precisions(NNIndex<Distance>& index, const Matrix<typename Dista
     float p2;
 
     int c1 = 1;
-    float p1;
 
     float time;
     DistanceType dist;
@@ -270,7 +269,6 @@ void test_index_precisions(NNIndex<Distance>& index, const Matrix<typename Dista
         precision = precisions[i];
         while (p2<precision) {
             c1 = c2;
-            p1 = p2;
             c2 *=2;
             p2 = search_with_ground_truth(index, inputData, testData, matches, nn, c2, time, dist, distance, skipMatches);
             if ((maxTime> 0)&&(time > maxTime)&&(p2<precision)) return;

--- a/modules/ml/src/kdtree.cpp
+++ b/modules/ml/src/kdtree.cpp
@@ -120,16 +120,13 @@ medianPartition( size_t* ofs, int a, int b, const float* vals )
     }
 
     float pivot = vals[ofs[middle]];
-    int less = 0, more = 0;
     for( k = a0; k < middle; k++ )
     {
         CV_Assert(vals[ofs[k]] <= pivot);
-        less += vals[ofs[k]] < pivot;
     }
     for( k = b0; k > middle; k-- )
     {
         CV_Assert(vals[ofs[k]] >= pivot);
-        more += vals[ofs[k]] > pivot;
     }
 
     return vals[ofs[middle]];

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -122,6 +122,9 @@
 //#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
+#if defined(__OPENCV_BUILD) && defined(__APPLE__) && defined(__clang__) && ((__clang_major__*100 + __clang_minor__) >= 1301)
+#pragma clang diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include "opencv2/ts/ts_gtest.h"
 #if defined(__OPENCV_BUILD) && defined(__GNUC__) && __GNUC__ >= 5
 //#pragma GCC diagnostic pop

--- a/modules/video/test/test_optflowpyrlk.cpp
+++ b/modules/video/test/test_optflowpyrlk.cpp
@@ -65,7 +65,7 @@ void CV_OptFlowPyrLKTest::run( int )
     const int bad_points_max = 8;
 
     /* test parameters */
-    double  max_err = 0., sum_err = 0;
+    double  max_err = 0.;
     int     pt_cmpd = 0;
     int     pt_exceed = 0;
     int     merr_i = 0, merr_j = 0, merr_k = 0, merr_nan = 0;
@@ -175,7 +175,6 @@ void CV_OptFlowPyrLKTest::run( int )
             }
 
             pt_exceed += err > success_error_level;
-            sum_err += err;
             pt_cmpd++;
         }
         else


### PR DESCRIPTION
Backport of #23203
Backport of https://github.com/opencv/opencv_contrib/pull/3434
Merge with https://github.com/opencv/opencv_contrib/pull/3435

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
build_image:Custom=ubuntu-clang:18.04
buildworker:Custom=linux-1,linux-4
```