### PR TITLE
videoio: add support for Orbbec Femto Mega RGB-D camera

### DIFF
--- a/modules/videoio/src/cap_obsensor/obsensor_stream_channel_interface.hpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_stream_channel_interface.hpp
@@ -36,6 +36,7 @@ namespace obsensor {
 #define OBSENSOR_CAM_VID 0x2bc5 // usb vid
 #define OBSENSOR_ASTRA2_PID 0x0660 // pid of Orbbec Astra 2 Camera
 #define OBSENSOR_GEMINI2_PID 0x0670 // pid of Orbbec Gemini 2 Camera
+#define OBSENSOR_FEMTO_MEGA_PID 0x0669 // pid of Orbbec Femto Mega Camera
 
 enum StreamType
 {

--- a/modules/videoio/src/cap_obsensor/obsensor_stream_channel_msmf.cpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_stream_channel_msmf.cpp
@@ -499,7 +499,7 @@ STDMETHODIMP MSMFStreamChannel::OnEvent(DWORD /*sidx*/, IMFMediaEvent* /*event*/
 
 STDMETHODIMP MSMFStreamChannel::OnFlush(DWORD)
 {
-    if (streamState_ == STREAM_STARTING)
+    if (streamState_ != STREAM_STOPED)
     {
         std::unique_lock<std::mutex> lock(streamStateMutex_);
         streamState_ = STREAM_STOPED;

--- a/modules/videoio/src/cap_obsensor/obsensor_uvc_stream_channel.cpp
+++ b/modules/videoio/src/cap_obsensor/obsensor_uvc_stream_channel.cpp
@@ -338,6 +338,24 @@ bool IUvcStreamChannel::getProperty(int propId, uint8_t* recvData, uint32_t* rec
             *recvDataSize = sizeof(CameraParam);
             memcpy(recvData, &param, *recvDataSize);
         }
+        else if(OBSENSOR_FEMTO_MEGA_PID == devInfo_.pid){
+            // return default param
+            CameraParam param;
+            param.p0[0] = 748.370f;
+            param.p0[1] = 748.296f;
+            param.p0[2] = 634.670f;
+            param.p0[3] = 341.196f;
+            param.p1[0] = 374.185f;
+            param.p1[1] = 374.148f;
+            param.p1[2] = 317.335f;
+            param.p1[3] = 170.598f;
+            param.p6[0] = 1280;
+            param.p6[1] = 720;
+            param.p7[0] = 640;
+            param.p7[1] = 360;
+            *recvDataSize = sizeof(CameraParam);
+            memcpy(recvData, &param, *recvDataSize);
+        }
         else{
             rst &= setXu(2, OB_EXT_CMD5, sizeof(OB_EXT_CMD5));
             rst &= getXu(2, &rcvData, &rcvLen);


### PR DESCRIPTION
### videoio: add support for Orbbec Femto Mega RGB-D camera
[ About Femto Mega](https://orbbec3d.com/index/Product/info.html?cate=38&id=11)

### New feature
Be able to open the depth and color stream of the Orbbec Femto Mega Camera

### Bug Fix
OBSensor：Fix the problem that takes too long to turn off the stream on Windows platform

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

OS | Compiler | Camera | Result
-- | -- | -- | --
Windows11 | (VS2022)MSVC17.3 | Femto Mega | Pass
Ubuntu22.04 | GCC11.2 | Femto Mega | Pass


