### PR TITLE
DNN/CUDA: let ADD operator run on CUDA

### DIFF
--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -55,7 +55,7 @@ struct Layer_Slice : public TestBaseWithParam<tuple<Backend, Target> >
     }
 };
 
-static std::set<std::string> nary_eltwise_cuda_deny_ops = {"add", "equal", "greater", "less", "mean", "mul", "pow", "sub"};
+static std::set<std::string> nary_eltwise_cuda_deny_ops = {"equal", "greater", "less", "mean", "pow", "sub"};
 
 struct Layer_NaryEltwise : public TestBaseWithParam<tuple<Backend, Target> >
 {

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -112,7 +112,7 @@ public:
                     op == OPERATION::LESS_EQUAL
             );
         if (op == OPERATION::MAX || op == OPERATION::MIN || op == OPERATION::SUM ||
-            op == OPERATION::PROD || op == OPERATION::DIV)
+            op == OPERATION::PROD || op == OPERATION::DIV || op == OPERATION::ADD)
             return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
         return backendId == DNN_BACKEND_OPENCV;
     }
@@ -688,6 +688,7 @@ public:
                 case OPERATION::SUM: return cuda4dnn::EltwiseOpType::SUM;
                 case OPERATION::PROD: return cuda4dnn::EltwiseOpType::PRODUCT;
                 case OPERATION::DIV: return cuda4dnn::EltwiseOpType::DIV;
+                case OPERATION::ADD: return cuda4dnn::EltwiseOpType::SUM;
                 default: CV_Error(Error::StsNotImplemented, "Other operators except MAX, MIN, SUM, PRODUCT and DIV are not supported with cuda.");
             }
         }();


### PR DESCRIPTION
This PR will fix https://github.com/opencv/opencv/issues/23234. 
After fix this problem, the inference time of palm detection model has improved **from 200+ms to 30+ms** on CUDA.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
