### PR TITLE
cmake: debug preprocessor dump for GCC/Clang

### DIFF
--- a/cmake/OpenCVCompilerDumpPreprocessorMacros.cmake
+++ b/cmake/OpenCVCompilerDumpPreprocessorMacros.cmake
@@ -1,0 +1,37 @@
+function(ocv_dump_gcc_preprocessor fname exe extra_flags)
+  set(src "${CMAKE_CURRENT_BINARY_DIR}/preprocessor/empty")
+  file(WRITE "${src}" "")
+  string(REPLACE " " ";" opt "${extra_flags}")
+  execute_process(COMMAND "${exe}" ${opt} -dM -E -
+    RESULT_VARIABLE res
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+    INPUT_FILE "${src}"
+  )
+  set(dump_file "${CMAKE_CURRENT_BINARY_DIR}/preprocessor/${fname}")
+  string(REPLACE "\n" ";" out "${out}")
+  list(SORT out)
+  string(REPLACE ";" "\n" out "${out}")
+  set(out "CMD => ${res}\n${exe} ${extra_flags}\n\nSTDERR\n${err}\n===\n${out}")
+  ocv_update_file("${dump_file}" "${out}")
+  if(res)
+    message(WARNING "ocv_dump_gcc_preprocessor has failed, check output file for details: ${dump_file}")
+  endif()
+endfunction()
+
+# --- Entry here ---
+if(CV_GCC OR CV_CLANG)
+  foreach(LANG CXX)
+    foreach(CFG ${CMAKE_CONFIGURATION_TYPES})
+      string(TOUPPER "${CFG}" CFG)
+      ocv_dump_gcc_preprocessor("dump_${LANG}_${CFG}_baseline.txt"
+        "${CMAKE_${LANG}_COMPILER}"
+        "${CMAKE_${LANG}_FLAGS} ${CMAKE_${LANG}_FLAGS_${CFG}}")
+      foreach(OPT ${CPU_DISPATCH_FINAL})
+        ocv_dump_gcc_preprocessor("dump_${LANG}_${CFG}_${OPT}.txt"
+          "${CMAKE_${LANG}_COMPILER}"
+          "${CMAKE_${LANG}_FLAGS} ${CMAKE_${LANG}_FLAGS_${CFG}} ${CPU_DISPATCH_FLAGS_${OPT}}")
+      endforeach() # OPT
+    endforeach() # CFG
+  endforeach() # LANG
+endif()

--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -529,3 +529,7 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio" AND CMAKE_CXX_COMPILER_ID MATCHES "MS
     endif()
   endif()
 endif()
+
+if(OPENCV_DUMP_PREPROCESSOR_MACROS)
+  include(cmake/OpenCVCompilerDumpPreprocessorMacros.cmake)
+endif()


### PR DESCRIPTION
This is just a small convenience debugging tool: sorted list of predefined preprocessor macros will be written to a set of files in the `<build>/preprocessor` directory.

```
$ cmake -DOPENCV_DUMP_PREPROCESSOR_MACROS=ON ../opencv
...

$ ls preprocessor/
dump_CXX_DEBUG_AVX2.txt        dump_CXX_DEBUG_FP16.txt    dump_CXX_RELEASE_AVX512_SKX.txt  dump_CXX_RELEASE_SSE4_1.txt
dump_CXX_DEBUG_AVX512_SKX.txt  dump_CXX_DEBUG_SSE4_1.txt  dump_CXX_RELEASE_AVX.txt         dump_CXX_RELEASE_SSE4_2.txt
dump_CXX_DEBUG_AVX.txt         dump_CXX_DEBUG_SSE4_2.txt  dump_CXX_RELEASE_baseline.txt    empty
dump_CXX_DEBUG_baseline.txt    dump_CXX_RELEASE_AVX2.txt  dump_CXX_RELEASE_FP16.txt

$ head preprocessor/dump_CXX_RELEASE_baseline.txt 

#define NDEBUG 1
#define _FORTIFY_SOURCE 2
#define _LP64 1
#define _REENTRANT 1
#define _STDC_PREDEF_H 1
#define __ATOMIC_ACQUIRE 2
#define __ATOMIC_ACQ_REL 4
#define __ATOMIC_CONSUME 1
#define __ATOMIC_HLE_ACQUIRE 65536
```
This is not completely accurate information because it does not take in account macros and extra options added via `add_definitions` and properties for specific targets and source files. But it gives generic baseline for majority of OpenCV sources.

To get accurate preprocessor definitions one can use command lines from the `compile_commands.json` file ([CMAKE_EXPORT_COMPILE_COMMANDS](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html)).

I'm not sure about usefulness of this feature, so please vote :+1: :-1: 