### PR TITLE
Fix focal length estimation from homography matrix

### DIFF
--- a/modules/stitching/src/autocalib.cpp
+++ b/modules/stitching/src/autocalib.cpp
@@ -74,7 +74,11 @@ void focalsFromHomography(const Mat& H, double &f0, double &f1, bool &f0_ok, boo
     d2 = (h[7] - h[6]) * (h[7] + h[6]);
     v1 = -(h[0] * h[1] + h[3] * h[4]) / d1;
     v2 = (h[0] * h[0] + h[3] * h[3] - h[1] * h[1] - h[4] * h[4]) / d2;
-    if (v1 < v2) std::swap(v1, v2);
+    if (v1 < v2)
+    {
+        std::swap(v1, v2);
+        std::swap(d1, d2);
+    }
     if (v1 > 0 && v2 > 0) f1 = std::sqrt(std::abs(d1) > std::abs(d2) ? v1 : v2);
     else if (v1 > 0) f1 = std::sqrt(v1);
     else f1_ok = false;
@@ -84,7 +88,11 @@ void focalsFromHomography(const Mat& H, double &f0, double &f1, bool &f0_ok, boo
     d2 = h[0] * h[0] + h[1] * h[1] - h[3] * h[3] - h[4] * h[4];
     v1 = -h[2] * h[5] / d1;
     v2 = (h[5] * h[5] - h[2] * h[2]) / d2;
-    if (v1 < v2) std::swap(v1, v2);
+    if (v1 < v2)
+    {
+        std::swap(v1, v2);
+        std::swap(d1, d2);
+    }
     if (v1 > 0 && v2 > 0) f0 = std::sqrt(std::abs(d1) > std::abs(d2) ? v1 : v2);
     else if (v1 > 0) f0 = std::sqrt(v1);
     else f0_ok = false;


### PR DESCRIPTION
Add missing denominator swap. See pictures below for before/after comparison. The function was used to create both images. Images were created by stitching two other images (I can provide source material for reproduction if needed). No other parameters were changed between two calls other than the proposed fix. Also tested on pinhole camera model.

Before fix:
![photo_2023-02-13 20 28 55](https://user-images.githubusercontent.com/38436437/218530099-53e49fe0-6851-4875-a5a6-414a268e03aa.jpeg)

After fix:
![photo_2023-02-13 20 28 58](https://user-images.githubusercontent.com/38436437/218530134-ed82bf6c-da81-48b7-b883-683b2a6be084.jpeg)

Related commit: https://github.com/opencv/opencv/commit/60e1eda1495ec7bc64b41220e92bcaf23ece05db

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
