### PR TITLE
Remove separator between trackbars.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -2205,21 +2205,6 @@ icvCreateTrackbar( const char* trackbar_name, const char* window_name,
         /* Retrieve current buttons count */
         bcount = (int)SendMessage(window->toolbar.toolbar, TB_BUTTONCOUNT, 0, 0);
 
-        if (bcount > 0)
-        {
-            /* If this is not the first button then we need to
-            separate it from the previous one */
-            tbs.iBitmap = 0;
-            tbs.idCommand = bcount; // Set button id to it's number
-            tbs.iString = 0;
-            tbs.fsStyle = TBSTYLE_SEP;
-            tbs.fsState = TBSTATE_ENABLED;
-            SendMessage(window->toolbar.toolbar, TB_ADDBUTTONS, 1, (LPARAM)&tbs);
-
-            // Retrieve current buttons count
-            bcount = (int)SendMessage(window->toolbar.toolbar, TB_BUTTONCOUNT, 0, 0);
-        }
-
         /* Add a button which we're going to cover with the slider */
         tbs.iBitmap = 0;
         tbs.idCommand = bcount; // Set button id to it's number


### PR DESCRIPTION
Remove separator between 2 or more trackbars. This separator has zero thickness and creates bags in toolbar.