### PR TITLE
fix: remove extra '/O' modifier for '/IO' arguments

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -448,6 +448,15 @@ class ArgInfo(object):
         self.py_outputarg = False
         self.enclosing_arg = enclosing_arg
 
+    def __str__(self):
+        return 'ArgInfo("{}", tp="{}", default="{}", in={}, out={})'.format(
+            self.name, self.tp, self.defval, self.inputarg,
+            self.outputarg
+        )
+
+    def __repr__(self):
+        return str(self)
+
     @property
     def export_name(self):
         if self.name in python_reserved_keywords:

--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -616,6 +616,8 @@ class CppHeaderParser(object):
                                                              ("InputOutputArray", mat),
                                                              ("OutputArray", mat),
                                                              ("noArray", arg_type)]).strip()
+                    if '/IO' in modlist and '/O' in modlist:
+                        modlist.remove('/O')
                     args.append([arg_type, arg_name, defval, modlist])
                 npos = arg_start-1
 


### PR DESCRIPTION
Some functions can have arguments that marked with both `CV_OUT` and `CV_IN_OUT` modifiers. Example `Feature2D::compute`

```cpp
CV_WRAP virtual void compute( InputArray image,
                                  CV_OUT CV_IN_OUT std::vector<KeyPoint>& keypoints,
                                  OutputArray descriptors );
```

Solution: if argument marked as `CV_IN_OUT keep only '/IO' modifier and remove '/O' one.

fixes #23263

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
