### PR TITLE
Aruco/Charuco test case fixes for floating point for loops

### DIFF
--- a/modules/objdetect/test/test_arucodetection.cpp
+++ b/modules/objdetect/test/test_arucodetection.cpp
@@ -247,7 +247,7 @@ void CV_ArucoDetectionPerspective::run(int) {
     aruco::ArucoDetector detector(aruco::getPredefinedDictionary(aruco::DICT_6X6_250), params);
 
     // detect from different positions
-    for(double distance = 0.1; distance < 0.7; distance += 0.2) {
+    for(double distance : {0.1, 0.3, 0.5, 0.7}) {
         for(int pitch = 0; pitch < 360; pitch += (distance == 0.1? 60:180)) {
             for(int yaw = 70; yaw <= 120; yaw += 40){
                 int currentId = iter % 250;

--- a/modules/objdetect/test/test_boarddetection.cpp
+++ b/modules/objdetect/test/test_boarddetection.cpp
@@ -51,7 +51,7 @@ void CV_ArucoBoardPose::run(int) {
     aruco::DetectorParameters detectorParameters = detector.getDetectorParameters();
 
     // for different perspectives
-    for(double distance = 0.2; distance <= 0.4; distance += 0.15) {
+    for(double distance : {0.2, 0.35}) {
         for(int yaw = -55; yaw <= 50; yaw += 25) {
             for(int pitch = -55; pitch <= 50; pitch += 25) {
                 vector<int> tmpIds;
@@ -162,7 +162,7 @@ void CV_ArucoRefine::run(int) {
     aruco::DetectorParameters detectorParameters = detector.getDetectorParameters();
 
     // for different perspectives
-    for(double distance = 0.2; distance <= 0.4; distance += 0.2) {
+    for(double distance : {0.2, 0.4}) {
         for(int yaw = -60; yaw < 60; yaw += 30) {
             for(int pitch = -60; pitch <= 60; pitch += 30) {
                 aruco::GridBoard gridboard(Size(3, 3), 0.02f, 0.005f, detector.getDictionary());

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -213,7 +213,7 @@ void CV_CharucoPoseEstimation::run(int) {
 
     Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
     // for different perspectives
-    for(double distance : {0.2, 0.3}) {
+    for(double distance : {0.2, 0.25}) {
         for(int yaw = -55; yaw <= 50; yaw += 25) {
             for(int pitch = -55; pitch <= 50; pitch += 25) {
 
@@ -244,18 +244,6 @@ void CV_CharucoPoseEstimation::run(int) {
                     detector.setCharucoParameters(charucoParameters);
                     detector.detectBoard(img, charucoCorners, charucoIds, corners, ids);
                 }
-
-                // // create debug images
-                // Mat rgb_image;
-                // cv::cvtColor(img, rgb_image, COLOR_GRAY2RGB);
-                // aruco::drawDetectedCornersCharuco(rgb_image, charucoCorners, charucoIds);
-                // aruco::drawDetectedMarkers(rgb_image, corners, ids);
-                // cv::imwrite("Debug_CV_CharucoPoseEstimation"
-                //  + (legacyPattern ? std::string("_legacy") : std::string(""))
-                //  + "_dist" + std::to_string(distance)
-                //  + "_yaw" + std::to_string(yaw)
-                //  + "_pitch" + std::to_string(pitch) + ".png", rgb_image);
-
                 ASSERT_EQ(ids.size(), board.getIds().size());
                 if(charucoIds.size() == 0) continue;
 
@@ -323,7 +311,7 @@ void CV_CharucoDiamondDetection::run(int) {
 
     int iter = 0;
     Mat cameraMatrix = Mat::eye(3, 3, CV_64FC1);
-    Size imgSize(750, 750);
+    Size imgSize(500, 500);
     aruco::DetectorParameters params;
     params.minDistanceToBorder = 0;
     float squareLength = 0.03f;
@@ -333,7 +321,7 @@ void CV_CharucoDiamondDetection::run(int) {
     aruco::CharucoDetector detector(board);
 
 
-    cameraMatrix.at<double>(0, 0) = cameraMatrix.at< double >(1, 1) = 1000;
+    cameraMatrix.at<double>(0, 0) = cameraMatrix.at< double >(1, 1) = 650;
     cameraMatrix.at<double>(0, 2) = imgSize.width / 2;
     cameraMatrix.at<double>(1, 2) = imgSize.height / 2;
 
@@ -344,7 +332,7 @@ void CV_CharucoDiamondDetection::run(int) {
     detector.setCharucoParameters(charucoParameters);
 
     // for different perspectives
-    for(double distance : {0.2, 0.3}) {
+    for(double distance : {0.2, 0.22}) {
         for(int yaw = -50; yaw <= 50; yaw += 25) {
             for(int pitch = -50; pitch <= 50; pitch += 25) {
 
@@ -375,16 +363,6 @@ void CV_CharucoDiamondDetection::run(int) {
                 vector<Vec4i> diamondIds;
 
                 detector.detectDiamonds(img, diamondCorners, diamondIds, corners, ids);
-
-                // // create debug images
-                // Mat rgb_image;
-                // cv::cvtColor(img, rgb_image, COLOR_GRAY2RGB);
-                // aruco::drawDetectedDiamonds(rgb_image, diamondCorners, diamondIds);
-                // aruco::drawDetectedMarkers(rgb_image, corners, ids);
-                // cv::imwrite(std::string("Debug_CV_CharucoDiamondDetection")
-                //  + "_dist" + std::to_string(distance)
-                //  + "_yaw" + std::to_string(yaw)
-                //  + "_pitch" + std::to_string(pitch) + ".png", rgb_image);
 
                 // check detect
                 if(ids.size() != 4) {

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -109,7 +109,7 @@ void CV_CharucoDetection::run(int) {
     Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
 
     // for different perspectives
-    for(double distance = 0.2; distance <= 0.4; distance += 0.2) {
+    for(double distance : {0.2, 0.4}) {
         for(int yaw = -55; yaw <= 50; yaw += 25) {
             for(int pitch = -55; pitch <= 50; pitch += 25) {
 
@@ -213,7 +213,7 @@ void CV_CharucoPoseEstimation::run(int) {
 
     Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
     // for different perspectives
-    for(double distance = 0.2; distance <= 0.3; distance += 0.1) {
+    for(double distance : {0.2, 0.3}) {
         for(int yaw = -55; yaw <= 50; yaw += 25) {
             for(int pitch = -55; pitch <= 50; pitch += 25) {
 
@@ -244,6 +244,18 @@ void CV_CharucoPoseEstimation::run(int) {
                     detector.setCharucoParameters(charucoParameters);
                     detector.detectBoard(img, charucoCorners, charucoIds, corners, ids);
                 }
+
+                // // create debug images
+                // Mat rgb_image;
+                // cv::cvtColor(img, rgb_image, COLOR_GRAY2RGB);
+                // aruco::drawDetectedCornersCharuco(rgb_image, charucoCorners, charucoIds);
+                // aruco::drawDetectedMarkers(rgb_image, corners, ids);
+                // cv::imwrite("Debug_CV_CharucoPoseEstimation"
+                //  + (legacyPattern ? std::string("_legacy") : std::string(""))
+                //  + "_dist" + std::to_string(distance)
+                //  + "_yaw" + std::to_string(yaw)
+                //  + "_pitch" + std::to_string(pitch) + ".png", rgb_image);
+
                 ASSERT_EQ(ids.size(), board.getIds().size());
                 if(charucoIds.size() == 0) continue;
 
@@ -311,7 +323,7 @@ void CV_CharucoDiamondDetection::run(int) {
 
     int iter = 0;
     Mat cameraMatrix = Mat::eye(3, 3, CV_64FC1);
-    Size imgSize(500, 500);
+    Size imgSize(750, 750);
     aruco::DetectorParameters params;
     params.minDistanceToBorder = 0;
     float squareLength = 0.03f;
@@ -321,7 +333,7 @@ void CV_CharucoDiamondDetection::run(int) {
     aruco::CharucoDetector detector(board);
 
 
-    cameraMatrix.at<double>(0, 0) = cameraMatrix.at< double >(1, 1) = 650;
+    cameraMatrix.at<double>(0, 0) = cameraMatrix.at< double >(1, 1) = 1000;
     cameraMatrix.at<double>(0, 2) = imgSize.width / 2;
     cameraMatrix.at<double>(1, 2) = imgSize.height / 2;
 
@@ -332,7 +344,7 @@ void CV_CharucoDiamondDetection::run(int) {
     detector.setCharucoParameters(charucoParameters);
 
     // for different perspectives
-    for(double distance = 0.2; distance <= 0.3; distance += 0.1) {
+    for(double distance : {0.2, 0.3}) {
         for(int yaw = -50; yaw <= 50; yaw += 25) {
             for(int pitch = -50; pitch <= 50; pitch += 25) {
 
@@ -363,6 +375,16 @@ void CV_CharucoDiamondDetection::run(int) {
                 vector<Vec4i> diamondIds;
 
                 detector.detectDiamonds(img, diamondCorners, diamondIds, corners, ids);
+
+                // // create debug images
+                // Mat rgb_image;
+                // cv::cvtColor(img, rgb_image, COLOR_GRAY2RGB);
+                // aruco::drawDetectedDiamonds(rgb_image, diamondCorners, diamondIds);
+                // aruco::drawDetectedMarkers(rgb_image, corners, ids);
+                // cv::imwrite(std::string("Debug_CV_CharucoDiamondDetection")
+                //  + "_dist" + std::to_string(distance)
+                //  + "_yaw" + std::to_string(yaw)
+                //  + "_pitch" + std::to_string(pitch) + ".png", rgb_image);
 
                 // check detect
                 if(ids.size() != 4) {


### PR DESCRIPTION
Aruco/Charuco test case `for` loop fixes as discussed in https://github.com/opencv/opencv/pull/23153

There are some test loops in the aruco/charuco module that do not work as intended due to floating point imprecision.

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
