### PR TITLE
Added QR_Code data flip support, flip and retry after first ECC failure

### DIFF
--- a/3rdparty/quirc/include/quirc.h
+++ b/3rdparty/quirc/include/quirc.h
@@ -165,6 +165,8 @@ void quirc_extract(const struct quirc *q, int index,
 /* Decode a QR-code, returning the payload data. */
 quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 				  struct quirc_data *data);
+/* flip the QR code horizontaly (mirror flip) */
+void quirc_flip(struct quirc_code *code);
 
 #ifdef __cplusplus
 }

--- a/3rdparty/quirc/src/decode.c
+++ b/3rdparty/quirc/src/decode.c
@@ -917,3 +917,18 @@ quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 
 	return QUIRC_SUCCESS;
 }
+
+void quirc_flip(struct quirc_code *code)
+{
+	struct quirc_code flipped = {0};
+	unsigned int offset = 0;
+	for (int y = 0; y < code->size; y++) {
+		for (int x = 0; x < code->size; x++) {
+			if (grid_bit(code, y, x)) {
+				flipped.cell_bitmap[offset >> 3u] |= (1u << (offset & 7u));
+			}
+			offset++;
+		}
+	}
+	memcpy(&code->cell_bitmap, &flipped.cell_bitmap, sizeof(flipped.cell_bitmap));
+}

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2732,6 +2732,12 @@ bool QRDecode::decodingProcess()
 
     quirc_data qr_code_data;
     quirc_decode_error_t errorCode = quirc_decode(&qr_code, &qr_code_data);
+
+    if(errorCode ==  QUIRC_ERROR_DATA_ECC){
+        quirc_flip(&qr_code);
+        errorCode = quirc_decode(&qr_code, &qr_code_data);
+    }
+
     if (errorCode != 0) { return false; }
 
     for (int i = 0; i < qr_code_data.payload_len; i++)

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -708,6 +708,38 @@ TEST(Objdetect_QRCode_detect, detect_regression_21287)
 #endif
 }
 
+TEST(Objdetect_QRCode_detect_flipped, regression_23249)
+{
+
+    const std::vector<std::pair<std::string, std::string>> flipped_images =
+    // image name , expected result
+    {{"flipped_1.png", "The key is /qrcod_OMevpf"},
+     {"flipped_2.png", "A26"}};
+
+    const std::string root = "qrcode/flipped/";
+
+    for(const auto &flipped_image : flipped_images){
+        const std::string &image_name = flipped_image.first;
+        const std::string &expect_msg = flipped_image.second;
+
+        std::string image_path = findDataFile(root + image_name);
+        Mat src = imread(image_path);
+        ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
+        QRCodeDetector qrcode;
+        std::vector<Point> corners;
+        Mat straight_barcode;
+        cv::String decoded_info;
+        EXPECT_TRUE(qrcode.detect(src, corners));
+        EXPECT_TRUE(!corners.empty());
+        std::string decoded_msg;
+        #ifdef HAVE_QUIRC
+            EXPECT_NO_THROW(decoded_msg = qrcode.decode(src, corners, straight_barcode));
+            ASSERT_FALSE(straight_barcode.empty()) << "Can't decode qrimage.";
+            EXPECT_EQ(expect_msg, decoded_msg);
+        #endif
+    }
+}
+
 // @author Kumataro, https://github.com/Kumataro
 TEST(Objdetect_QRCode_decode, decode_regression_21929)
 {


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/1046

Fixes  #23249, fixes  #23155, fixes #20724

Added quirc_flip() method to horizontally flip the data.
When the decoder fails to ECC the data we flip the image, and try one more time.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
