### PR TITLE
Fix signed integer overflow.

### DIFF
--- a/modules/imgproc/src/stb_truetype.cpp
+++ b/modules/imgproc/src/stb_truetype.cpp
@@ -3530,11 +3530,14 @@ STBTT_DEF unsigned char* stbtt_GetGlyphBitmapSubpixelRealloc(const stbtt_fontinf
                  iy1 = STBTT_max(iy1, y);
              }
          }
-         int w = ix1 - ix0 + 1, h = iy1 - iy0 + 1;
+         int w, h;
          if (ix0 == INT_MAX || iy0 == INT_MAX || ix1 == INT_MIN || iy1 == INT_MIN ) {
              w = h = 0;
              ix0 = pad_x;
              iy0 = pad_y;
+         } else {
+             w = ix1 - ix0 + 1;
+             h = iy1 - iy0 + 1;
          }
          if (width) *width = w;
          if (height) *height = h;


### PR DESCRIPTION
The overflow happens for INT_MAX so the code just needs to be moved down.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
