### PR TITLE
dnn(tflite): fix wrong axis normalization

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -497,9 +497,8 @@ void TFLiteImporter::parseConcat(const Operator& op, const std::string& opcode, 
     DataLayout inpLayout = layouts[op.inputs()->Get(0)];
     if (inpLayout == DATA_LAYOUT_NHWC) {
         // OpenCV works in NCHW data layout. So change the axis correspondingly.
-        CV_Check(axis, -4 < axis && axis < 4, "");
-        int remap[] = {0, 2, 3, 1};
-        axis = axis > 0 ? axis : 4 + axis;
+        axis = normalize_axis(axis, 4);
+        static const int remap[] = {0, 2, 3, 1};
         axis = remap[axis];
     }
     layerParams.set("axis", axis);


### PR DESCRIPTION
relates #23161

`axis = 0` => `axis = 4` - invalid index of `remap` array.