### PR TITLE
4.x deprecated VideoCapture backends

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -212,6 +212,19 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
         CV_Error_(Error::StsError, ("could not open '%s'", filename.c_str()));
     }
 
+    if (cv::videoio_registry::checkDeprecatedBackend(apiPreference))
+    {
+        CV_LOG_DEBUG(NULL,
+            cv::format("VIDEOIO(%s): backend is removed from OpenCV",
+                cv::videoio_registry::getBackendName((VideoCaptureAPIs) apiPreference).c_str()));
+    }
+    else
+    {
+        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong. "
+            "Please make sure that your computer support chosen backend and OpenCV built "
+            "with right flags.");
+    }
+
     return false;
 }
 
@@ -335,6 +348,19 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
     if (throwOnFail)
     {
         CV_Error_(Error::StsError, ("could not open camera %d", cameraNum));
+    }
+
+    if (cv::videoio_registry::checkDeprecatedBackend(apiPreference))
+    {
+        CV_LOG_DEBUG(NULL,
+            cv::format("VIDEOIO(%s): backend is removed from OpenCV",
+                cv::videoio_registry::getBackendName((VideoCaptureAPIs) apiPreference).c_str()));
+    }
+    else
+    {
+        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong."
+            "Please make sure that your computer support chosen backend and OpenCV built "
+            "with right flags.");
     }
 
     return false;
@@ -640,6 +666,20 @@ bool VideoWriter::open(const String& filename, int apiPreference, int fourcc, do
             }
         }
     }
+
+    if (cv::videoio_registry::checkDeprecatedBackend(apiPreference))
+    {
+        CV_LOG_DEBUG(NULL,
+            cv::format("VIDEOIO(%s): backend is removed from OpenCV",
+                cv::videoio_registry::getBackendName((VideoCaptureAPIs) apiPreference).c_str()));
+    }
+    else
+    {
+        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong."
+            "Please make sure that your computer support chosen backend and OpenCV built "
+            "with right flags.");
+    }
+
     return false;
 }
 

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -183,6 +183,18 @@ static const struct VideoBackendInfo builtin_backends[] =
     // dropped backends: MIL, TYZX
 };
 
+static const struct VideoDeprecatedBackendInfo deprecated_backends[] =
+{
+#ifdef _WIN32
+    {CAP_VFW, "Video for Windows"},
+#endif
+    {CAP_QT, "QuickTime"},
+    {CAP_UNICAP, "Unicap"},
+    {CAP_OPENNI, "OpenNI"},
+    {CAP_OPENNI_ASUS, "OpenNI"},
+    {CAP_GIGANETIX, "GigEVisionSDK"}
+};
+
 bool sortByPriority(const VideoBackendInfo &lhs, const VideoBackendInfo &rhs)
 {
     return lhs.priority > rhs.priority;
@@ -351,6 +363,16 @@ std::vector<VideoBackendInfo> getAvailableBackends_Writer()
     return result;
 }
 
+bool checkDeprecatedBackend(int api) {
+    const int M = sizeof(deprecated_backends) / sizeof(deprecated_backends[0]);
+    for (size_t i = 0; i < M; i++)
+    {
+        if (deprecated_backends[i].id == api)
+            return true;
+    }
+    return false;
+}
+
 cv::String getBackendName(VideoCaptureAPIs api)
 {
     if (api == CAP_ANY)
@@ -362,6 +384,14 @@ cv::String getBackendName(VideoCaptureAPIs api)
         if (backend.id == api)
             return backend.name;
     }
+
+    const int M = sizeof(deprecated_backends) / sizeof(deprecated_backends[0]);
+    for (size_t i = 0; i < M; i++)
+    {
+        if (deprecated_backends[i].id == api)
+            return deprecated_backends[i].name;
+    }
+
     return cv::format("UnknownVideoAPI(%d)", (int)api);
 }
 

--- a/modules/videoio/src/videoio_registry.hpp
+++ b/modules/videoio/src/videoio_registry.hpp
@@ -29,11 +29,17 @@ struct VideoBackendInfo {
     Ptr<IBackendFactory> backendFactory;
 };
 
+struct VideoDeprecatedBackendInfo {
+    VideoCaptureAPIs id;
+    const char* name;
+};
+
 namespace videoio_registry {
 
 std::vector<VideoBackendInfo> getAvailableBackends_CaptureByIndex();
 std::vector<VideoBackendInfo> getAvailableBackends_CaptureByFilename();
 std::vector<VideoBackendInfo> getAvailableBackends_Writer();
+bool checkDeprecatedBackend(int api);
 
 } // namespace
 


### PR DESCRIPTION
Added list of deprecated backends, which not supported by opencv anymore. This needs to give for user more information about chosen backend, when VideoCapture failed trying to use chosen by user  backend. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
