### PR TITLE
remove flags of obsolete VideoCapture backends

### DIFF
--- a/doc/tutorials/app/kinect_openni.markdown
+++ b/doc/tutorials/app/kinect_openni.markdown
@@ -58,7 +58,7 @@ VideoCapture can retrieve the following data:
 
 In order to get depth map from depth sensor use VideoCapture::operator \>\>, e. g. :
 @code{.cpp}
-    VideoCapture capture( CAP_OPENNI );
+    VideoCapture capture( CAP_OPENNI2 );
     for(;;)
     {
         Mat depthMap;
@@ -70,7 +70,7 @@ In order to get depth map from depth sensor use VideoCapture::operator \>\>, e. 
 @endcode
 For getting several data maps use VideoCapture::grab and VideoCapture::retrieve, e.g. :
 @code{.cpp}
-    VideoCapture capture(0); // or CAP_OPENNI
+    VideoCapture capture(0); // or CAP_OPENNI2
     for(;;)
     {
         Mat depthMap;
@@ -88,7 +88,7 @@ For getting several data maps use VideoCapture::grab and VideoCapture::retrieve,
 For setting and getting some property of sensor\` data generators use VideoCapture::set and
 VideoCapture::get methods respectively, e.g. :
 @code{.cpp}
-    VideoCapture capture( CAP_OPENNI );
+    VideoCapture capture( CAP_OPENNI2 );
     capture.set( CAP_OPENNI_IMAGE_GENERATOR_OUTPUT_MODE, CAP_OPENNI_VGA_30HZ );
     cout << "FPS    " << capture.get( CAP_OPENNI_IMAGE_GENERATOR+CAP_PROP_FPS ) << endl;
 @endcode

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -89,7 +89,6 @@ See @ref videoio_overview for more information.
 */
 enum VideoCaptureAPIs {
        CAP_ANY          = 0,            //!< Auto detect == 0
-       CAP_VFW          = 200,          //!< Video For Windows (obsolete, removed)
        CAP_V4L          = 200,          //!< V4L/V4L2 capturing support
        CAP_V4L2         = CAP_V4L,      //!< Same as CAP_V4L
        CAP_FIREWIRE     = 300,          //!< IEEE 1394 drivers
@@ -97,16 +96,11 @@ enum VideoCaptureAPIs {
        CAP_IEEE1394     = CAP_FIREWIRE, //!< Same value as CAP_FIREWIRE
        CAP_DC1394       = CAP_FIREWIRE, //!< Same value as CAP_FIREWIRE
        CAP_CMU1394      = CAP_FIREWIRE, //!< Same value as CAP_FIREWIRE
-       CAP_QT           = 500,          //!< QuickTime (obsolete, removed)
-       CAP_UNICAP       = 600,          //!< Unicap drivers (obsolete, removed)
        CAP_DSHOW        = 700,          //!< DirectShow (via videoInput)
        CAP_PVAPI        = 800,          //!< PvAPI, Prosilica GigE SDK
-       CAP_OPENNI       = 900,          //!< OpenNI (for Kinect)
-       CAP_OPENNI_ASUS  = 910,          //!< OpenNI (for Asus Xtion)
        CAP_ANDROID      = 1000,         //!< Android - not used
        CAP_XIAPI        = 1100,         //!< XIMEA Camera API
        CAP_AVFOUNDATION = 1200,         //!< AVFoundation framework for iOS (OS X Lion will have the same API)
-       CAP_GIGANETIX    = 1300,         //!< Smartek Giganetix GigEVisionSDK
        CAP_MSMF         = 1400,         //!< Microsoft Media Foundation (via videoInput)
        CAP_WINRT        = 1410,         //!< Microsoft Windows Runtime using Media Foundation
        CAP_INTELPERC    = 1500,         //!< RealSense (former Intel Perceptual Computing SDK)

--- a/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
+++ b/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
@@ -11,7 +11,6 @@ enum
 
     CV_CAP_MIL      =100,   // MIL proprietary drivers
 
-    CV_CAP_VFW      =200,   // platform native
     CV_CAP_V4L      =200,
     CV_CAP_V4L2     =200,
 
@@ -28,17 +27,10 @@ enum
     CV_TYZX_COLOR   =402,
     CV_TYZX_Z       =403,
 
-    CV_CAP_QT       =500,   // QuickTime
-
-    CV_CAP_UNICAP   =600,   // Unicap drivers
-
     CV_CAP_DSHOW    =700,   // DirectShow (via videoInput)
     CV_CAP_MSMF     =1400,  // Microsoft Media Foundation (via videoInput)
 
     CV_CAP_PVAPI    =800,   // PvAPI, Prosilica GigE SDK
-
-    CV_CAP_OPENNI   =900,   // OpenNI (for Kinect)
-    CV_CAP_OPENNI_ASUS =910,   // OpenNI (for Asus Xtion)
 
     CV_CAP_ANDROID  =1000,  // Android - not used
     CV_CAP_ANDROID_BACK =CV_CAP_ANDROID+99, // Android back camera - not used

--- a/modules/videoio/misc/gen_dict.json
+++ b/modules/videoio/misc/gen_dict.json
@@ -1,13 +1,11 @@
 {
     "const_ignore_list": [
-        "CV_CAP_OPENNI",
         "CV_CAP_OPENNI2",
         "CV_CAP_PROP_OPENNI_",
         "CV_CAP_INTELPERC",
         "CV_CAP_PROP_INTELPERC_",
         "CV_CAP_ANY",
         "CV_CAP_MIL",
-        "CV_CAP_VFW",
         "CV_CAP_V4L",
         "CV_CAP_V4L2",
         "CV_CAP_FIREWARE",
@@ -17,8 +15,6 @@
         "CV_CAP_CMU1394",
         "CV_CAP_STEREO",
         "CV_CAP_TYZX",
-        "CV_CAP_QT",
-        "CV_CAP_UNICAP",
         "CV_CAP_DSHOW",
         "CV_CAP_PVAPI",
         "CV_CAP_ARAVIS",

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -559,12 +559,6 @@ static vector<Ext_Fourcc_API> generate_Ext_Fourcc_API_nocrash()
     {"mov", "aaaa", CAP_MSMF},
 #endif
 
-#ifdef HAVE_QUICKTIME
-    {"mov", "aaaa", CAP_QT},
-    {"avi", "aaaa", CAP_QT},
-    {"mkv", "aaaa", CAP_QT},
-#endif
-
 #ifdef HAVE_AVFOUNDATION
    {"mov", "aaaa", CAP_AVFOUNDATION},
    {"mp4", "aaaa", CAP_AVFOUNDATION},

--- a/samples/cpp/videocapture_openni.cpp
+++ b/samples/cpp/videocapture_openni.cpp
@@ -123,8 +123,6 @@ int main( int argc, char* argv[] )
     else
     {
         capture.open( CAP_OPENNI2 );
-        if( !capture.isOpened() )
-            capture.open( CAP_OPENNI );
     }
 
     cout << "done." << endl;


### PR DESCRIPTION
Merge with https://github.com/opencv/opencv_contrib/pull/3446
Related issue: https://github.com/opencv/opencv/issues/11810

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
