### PR TITLE
Support VideoCapture CAP_PROP_AUTO_WB and CV_CAP_PROP_WHITE_BALANCE_BLUE_U for DShow

### DIFF
--- a/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
+++ b/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
@@ -113,6 +113,7 @@ enum
     CV_CAP_PROP_AUTOFOCUS     =39,
     CV_CAP_PROP_SAR_NUM       =40,
     CV_CAP_PROP_SAR_DEN       =41,
+    CV_CAP_PROP_AUTO_WB       =44,
 
     CV_CAP_PROP_AUTOGRAB      =1024, // property for videoio class CvCapture_Android only
     CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025, // readonly, tricky property, returns cpnst char* indeed

--- a/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
+++ b/modules/videoio/include/opencv2/videoio/legacy/constants_c.h
@@ -113,7 +113,6 @@ enum
     CV_CAP_PROP_AUTOFOCUS     =39,
     CV_CAP_PROP_SAR_NUM       =40,
     CV_CAP_PROP_SAR_DEN       =41,
-    CV_CAP_PROP_AUTO_WB       =44,
 
     CV_CAP_PROP_AUTOGRAB      =1024, // property for videoio class CvCapture_Android only
     CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025, // readonly, tricky property, returns cpnst char* indeed

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -1859,7 +1859,7 @@ bool videoInput::setVideoSettingFilter(int deviceID, long Property, long lValue,
     DebugPrintOut("Current value: %ld Flags %ld (%s)\n", CurrVal, CapsFlags, (CapsFlags == 1 ? "Auto" : (CapsFlags == 2 ? "Manual" : "Unknown")));
 
     if (useDefaultValue) {
-        hr = pAMVideoProcAmp->Set(Property, Default, VideoProcAmp_Flags_Auto);
+        hr = pAMVideoProcAmp->Set(Property, Default, Flags);
     }
     else{
         // Perhaps add a check that lValue and Flags are within the range acquired from GetRange above
@@ -2389,6 +2389,9 @@ int videoInput::getVideoPropertyFromCV(int cv_property){
             return VideoProcAmp_ColorEnable;
 
         case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
+            return VideoProcAmp_WhiteBalance;
+
+        case CV_CAP_PROP_AUTO_WB:
             return VideoProcAmp_WhiteBalance;
 
         case  CV_CAP_PROP_BACKLIGHT:
@@ -3397,6 +3400,11 @@ double VideoCapture_DShow::getProperty(int propIdx) const
             return (double)current_value;
         break;
 
+    case CV_CAP_PROP_AUTO_WB:
+        if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
+            return (double)flags == CameraControl_Flags_Auto ? 1.0 : 0.0;
+        break;
+
     // camera properties
     case CV_CAP_PROP_PAN:
     case CV_CAP_PROP_TILT:
@@ -3539,6 +3547,24 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
         return true;
     }
 
+    // set the same as setVideoSettingFilter default arguments.
+    long flags = 0L;
+    bool useDefaultValue = false;
+    switch (propIdx)
+    {
+        case CV_CAP_PROP_AUTO_WB:
+        case CV_CAP_PROP_AUTO_EXPOSURE:
+            useDefaultValue = true;
+            if (cvRound(propVal) == 1)
+                flags = VideoProcAmp_Flags_Auto;
+            else
+                flags = VideoProcAmp_Flags_Manual;
+            break;
+        case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
+            flags = VideoProcAmp_Flags_Manual;
+            break;
+    }
+
     //video Filter properties
     switch (propIdx)
     {
@@ -3550,9 +3576,10 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
     case CV_CAP_PROP_GAMMA:
     case CV_CAP_PROP_MONOCHROME:
     case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
+    case CV_CAP_PROP_AUTO_WB:
     case CV_CAP_PROP_BACKLIGHT:
     case CV_CAP_PROP_GAIN:
-        return g_VI.setVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), (long)propVal);
+        return g_VI.setVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), (long)propVal, flags, useDefaultValue);
     }
 
     //camera properties

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2391,7 +2391,7 @@ int videoInput::getVideoPropertyFromCV(int cv_property){
         case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
             return VideoProcAmp_WhiteBalance;
 
-        case CV_CAP_PROP_AUTO_WB:
+        case cv::VideoCaptureProperties::CAP_PROP_AUTO_WB:
             return VideoProcAmp_WhiteBalance;
 
         case  CV_CAP_PROP_BACKLIGHT:
@@ -3400,7 +3400,7 @@ double VideoCapture_DShow::getProperty(int propIdx) const
             return (double)current_value;
         break;
 
-    case CV_CAP_PROP_AUTO_WB:
+    case cv::VideoCaptureProperties::CAP_PROP_AUTO_WB:
         if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
             return (double)flags == CameraControl_Flags_Auto ? 1.0 : 0.0;
         break;
@@ -3552,7 +3552,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
     bool useDefaultValue = false;
     switch (propIdx)
     {
-        case CV_CAP_PROP_AUTO_WB:
+        case cv::VideoCaptureProperties::CAP_PROP_AUTO_WB:
         case CV_CAP_PROP_AUTO_EXPOSURE:
             useDefaultValue = true;
             if (cvRound(propVal) == 1)
@@ -3576,7 +3576,7 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
     case CV_CAP_PROP_GAMMA:
     case CV_CAP_PROP_MONOCHROME:
     case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
-    case CV_CAP_PROP_AUTO_WB:
+    case cv::VideoCaptureProperties::CAP_PROP_AUTO_WB:
     case CV_CAP_PROP_BACKLIGHT:
     case CV_CAP_PROP_GAIN:
         return g_VI.setVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), (long)propVal, flags, useDefaultValue);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [OK] I agree to contribute to the project under Apache 2 License.
- [OK] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [OK] The PR is proposed to the proper branch
- [OK] There is a reference to the original bug report and related work
https://github.com/opencv/opencv/issues/19621
https://github.com/opencv/opencv/issues/21408

### Before apply this pull request console output.

before AWB setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: -1

after AWB disable setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: -1

after AWB enable setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: -1

after Manual WB(and Disable AWB) setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: -1

### After apply this pull request console output.

before AWB setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: 0

after AWB disable setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 4000
CAP_PROP_AUTO_WB: 0

after AWB enable setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 4000
CAP_PROP_AUTO_WB: 1

after Manual WB(and Disable AWB) setting
CAP_PROP_WHITE_BALANCE_BLUE_U: 2000
CAP_PROP_AUTO_WB: 0

### Test Code
[OpenCvVideoCapTest.zip](https://github.com/opencv/opencv/files/10825399/OpenCvVideoCapTest.zip)
