### PR TITLE
Fixed strict type in slerp and spline; Fixed nlerp usage condition

### DIFF
--- a/modules/core/include/opencv2/core/quaternion.inl.hpp
+++ b/modules/core/include/opencv2/core/quaternion.inl.hpp
@@ -745,8 +745,8 @@ Quat<T> Quat<T>::lerp(const Quat<T> &q0, const Quat<T> &q1, const T t)
 template <typename T>
 Quat<T> Quat<T>::slerp(const Quat<T> &q0, const Quat<T> &q1, const T t, QuatAssumeType assumeUnit, bool directChange)
 {
-    Quatd v0(q0);
-    Quatd v1(q1);
+    Quat<T> v0(q0);
+    Quat<T> v1(q1);
     if (!assumeUnit)
     {
         v0 = v0.normalize();
@@ -754,7 +754,7 @@ Quat<T> Quat<T>::slerp(const Quat<T> &q0, const Quat<T> &q1, const T t, QuatAssu
     }
     T cosTheta = v0.dot(v1);
     constexpr T DOT_THRESHOLD = 0.995;
-    if (cosTheta > DOT_THRESHOLD)
+    if (abs(cosTheta) > DOT_THRESHOLD)
     {
         return nlerp(v0, v1, t, QUAT_ASSUME_UNIT);
     }
@@ -843,7 +843,7 @@ Quat<T> Quat<T>::interPoint(const Quat<T> &q0, const Quat<T> &q1,
 template <typename T>
 Quat<T> Quat<T>::spline(const Quat<T> &q0, const Quat<T> &q1, const Quat<T> &q2, const Quat<T> &q3, const T t, QuatAssumeType assumeUnit)
 {
-    Quatd v0(q0), v1(q1), v2(q2), v3(q3);
+    Quat<T> v0(q0), v1(q1), v2(q2), v3(q3);
     if (!assumeUnit)
     {
         v0 = v0.normalize();

--- a/modules/core/include/opencv2/core/quaternion.inl.hpp
+++ b/modules/core/include/opencv2/core/quaternion.inl.hpp
@@ -754,7 +754,7 @@ Quat<T> Quat<T>::slerp(const Quat<T> &q0, const Quat<T> &q1, const T t, QuatAssu
     }
     T cosTheta = v0.dot(v1);
     constexpr T DOT_THRESHOLD = 0.995;
-    if (abs(cosTheta) > DOT_THRESHOLD)
+    if (std::abs(cosTheta) > DOT_THRESHOLD)
     {
         return nlerp(v0, v1, t, QUAT_ASSUME_UNIT);
     }


### PR DESCRIPTION
Fixes #23293

The PR is fixing the issue described in [Issue #23293 ](https://github.com/opencv/opencv/issues/23293)

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
