### PR TITLE
fix "ImportError: DLL load failed while importing cv2" while installing from pre-built binaries

### DIFF
--- a/doc/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_windows/py_setup_in_windows.markdown
@@ -33,6 +33,8 @@ Installing OpenCV from prebuilt binaries
 
 -#  Copy **cv2.pyd** to **C:/Python27/lib/site-packages**.
 
+-#  Copy the **opencv_world.dll** file to **C:/Python27/lib/site-packages**
+
 -#  Open Python IDLE and type following codes in Python terminal.
     @code
         >>> import cv2 as cv


### PR DESCRIPTION
after copying the **cv2.pyd** file to the **site-packages** directory python interpreter shows error
**"ImportError: DLL load failed while importing cv2: The specified module could not be found."** when installing using pre-built binaries as discussed in the #22072 

file **opencv_world.dll** also need to be copied.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
