### PR TITLE
Propagate inputs info for ONNX and TFLite models

### DIFF
--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -1410,8 +1410,8 @@ void Net::Impl::setInput(InputArray blob, const String& name, double scalefactor
             const MatShape& inputShapeLimitation = netInputLayer.shapes[pin.oid];
             if (!inputShapeLimitation.empty())
             {
-                CV_CheckEQ(inputShapeLimitation.size(), blobShape.size(), "");
 #if 0  // TODO: DNNTestNetwork.MobileNet_SSD_Caffe_Different_Width_Height/0
+                CV_CheckEQ(inputShapeLimitation.size(), blobShape.size(), "");
                 const size_t dims = inputShapeLimitation.size();
                 for (size_t dim = 0; dim < dims; dim++)
                 {

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -1400,6 +1400,7 @@ void Net::Impl::setInput(InputArray blob, const String& name, double scalefactor
     Mat blob_ = blob.getMat();  // can't use InputArray directly due MatExpr stuff
     MatShape blobShape = shape(blob_);
 
+#if 0  // TODO: DNNTestNetwork.MobileNet_SSD_Caffe_Different_Width_Height/0
     if (pin.lid == 0)
     {
         CV_Assert(!netInputLayer.empty());
@@ -1410,7 +1411,6 @@ void Net::Impl::setInput(InputArray blob, const String& name, double scalefactor
             const MatShape& inputShapeLimitation = netInputLayer.shapes[pin.oid];
             if (!inputShapeLimitation.empty())
             {
-#if 0  // TODO: DNNTestNetwork.MobileNet_SSD_Caffe_Different_Width_Height/0
                 CV_CheckEQ(inputShapeLimitation.size(), blobShape.size(), "");
                 const size_t dims = inputShapeLimitation.size();
                 for (size_t dim = 0; dim < dims; dim++)
@@ -1419,10 +1419,10 @@ void Net::Impl::setInput(InputArray blob, const String& name, double scalefactor
                         continue;  // don't limit batch
                     CV_CheckEQ(inputShapeLimitation[dim], blobShape[dim], "");
                 }
-#endif
             }
         }
     }
+#endif
 
     LayerData& ld = layers[pin.lid];
     const int numInputs = std::max(pin.oid + 1, (int)ld.requiredOutputs.size());

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -891,6 +891,11 @@ void ONNXImporter::populateNet()
     }
 
     dstNet.setInputsNames(netInputs);
+    if (!hasDynamicShapes)
+    {
+        for (int i = 0; i < netInputs.size(); ++i)
+            dstNet.setInputShape(netInputs[i], outShapes[netInputs[i]]);
+    }
 
     // dump outputs
     for (int i = 0; i < graph_proto.output_size(); ++i)

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -163,8 +163,8 @@ void TFLiteImporter::populateNet()
     CV_Assert(modelTensors);
     layouts.resize(modelTensors->size(), DATA_LAYOUT_UNKNOWN);
     size_t subgraph_inputs_size = subgraph_inputs->size();
-    std::vector<std::string> inputsNames;
-    std::vector<MatShape> inputsShapes;
+    std::vector<std::string> inputsNames(subgraph_inputs_size);
+    std::vector<MatShape> inputsShapes(subgraph_inputs_size);
     for (size_t i = 0; i < subgraph_inputs_size; ++i)
     {
         int idx = subgraph_inputs->Get(i);
@@ -175,14 +175,14 @@ void TFLiteImporter::populateNet()
         layouts[idx] = estimateLayout(*tensor);
 
         // Keep info about origin inputs names and shapes
-        inputsNames.push_back(tensor->name()->str());
+        inputsNames[i] = tensor->name()->str();
         std::vector<int> shape(tensor->shape()->begin(), tensor->shape()->end());
         if (layouts[idx] == DATA_LAYOUT_NHWC) {
             CV_CheckEQ(shape.size(), (size_t)4, "");
             std::swap(shape[2], shape[3]);
             std::swap(shape[1], shape[2]);
         }
-        inputsShapes.push_back(shape);
+        inputsShapes[i] = shape;
     }
 
     dstNet.setInputsNames(inputsNames);

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -163,6 +163,8 @@ void TFLiteImporter::populateNet()
     CV_Assert(modelTensors);
     layouts.resize(modelTensors->size(), DATA_LAYOUT_UNKNOWN);
     size_t subgraph_inputs_size = subgraph_inputs->size();
+    std::vector<std::string> inputsNames;
+    std::vector<MatShape> inputsShapes;
     for (size_t i = 0; i < subgraph_inputs_size; ++i)
     {
         int idx = subgraph_inputs->Get(i);
@@ -171,7 +173,24 @@ void TFLiteImporter::populateNet()
         if (!tensor)
             CV_Error(Error::StsError, cv::format("DNN/TFLite: subgraph input %d (%d) is NULL", (int)i, idx));
         layouts[idx] = estimateLayout(*tensor);
+
+        // Keep info about origin inputs names and shapes
+        inputsNames.push_back(tensor->name()->str());
+        std::vector<int> shape(tensor->shape()->begin(), tensor->shape()->end());
+        if (layouts[idx] == DATA_LAYOUT_NHWC) {
+            CV_CheckEQ(shape.size(), (size_t)4, "");
+            std::swap(shape[2], shape[3]);
+            std::swap(shape[1], shape[2]);
+        }
+        inputsShapes.push_back(shape);
     }
+
+    dstNet.setInputsNames(inputsNames);
+    for (size_t i = 0; i < subgraph_inputs_size; ++i)
+    {
+        dstNet.setInputShape(inputsNames[i], inputsShapes[i]);
+    }
+
     const auto& all_operators = *subgraph_operators;
     const size_t all_operators_size = all_operators.size();
     for (size_t op_idx = 0; op_idx < all_operators_size; ++op_idx)

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -11,6 +11,7 @@ Test for TFLite models loading
 
 #include <opencv2/dnn/layer.details.hpp>  // CV_DNN_REGISTER_LAYER_CLASS
 #include <opencv2/dnn/utils/debug_utils.hpp>
+#include <opencv2/dnn/shape_utils.hpp>
 
 #ifdef OPENCV_TEST_DNN_TFLITE
 
@@ -19,9 +20,21 @@ namespace opencv_test { namespace {
 using namespace cv;
 using namespace cv::dnn;
 
+void testInputShapes(const Net& net, const std::vector<Mat>& inps) {
+    std::vector<MatShape> inLayerShapes;
+    std::vector<MatShape> outLayerShapes;
+    net.getLayerShapes(MatShape(), 0, inLayerShapes, outLayerShapes);
+    ASSERT_EQ(inLayerShapes.size(), inps.size());
+
+    for (int i = 0; i < inps.size(); ++i) {
+        ASSERT_EQ(inLayerShapes[i], shape(inps[i]));
+    }
+}
+
 void testModel(const std::string& modelName, const Mat& input, double l1 = 1e-5, double lInf = 1e-4)
 {
     Net net = readNet(findDataFile("dnn/tflite/" + modelName + ".tflite", false));
+    testInputShapes(net, {input});
     net.setInput(input);
 
     std::vector<String> outNames = net.getUnconnectedOutLayersNames();
@@ -72,6 +85,7 @@ TEST(Test_TFLite, max_unpooling)
     cvtColor(input, input, COLOR_BGR2RGBA);
     input = input.mul(Scalar(1, 1, 1, 0));
     input = blobFromImage(input, 1.0 / 255);
+    testInputShapes(net, {input});
     net.setInput(input);
 
     std::vector<std::vector<Mat> > outs;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Needed for generic applications such as benchmarking pipelines. So OpenCV can tell about the default input shapes specified in the models.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
