### PR TITLE
Fix reference counting errors in registerNewType

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -284,6 +284,7 @@ static bool init_submodule(PyObject * root, const char * name, PyMethodDef * met
 static inline
 bool registerTypeInModuleScope(PyObject* module, const char* type_name, PyObject* type_obj)
 {
+    Py_INCREF(type_obj); /// Give PyModule_AddObject a reference to steal.
     if (PyModule_AddObject(module, type_name, type_obj) < 0)
     {
         PyErr_Format(PyExc_ImportError,

--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -338,8 +338,10 @@ PyObject* pyopencv_from(const TYPE& src)                                        
         if (!registerNewType(m, #EXPORT_NAME, (PyObject*)pyopencv_##CLASS_ID##_TypePtr, SCOPE)) \
         { \
             printf("Failed to register a new type: " #EXPORT_NAME  ", base (" #BASE ") in " SCOPE " \n"); \
+            Py_DECREF(pyopencv_##CLASS_ID##_TypePtr); \
             ERROR_HANDLER; \
         } \
+        Py_DECREF(pyopencv_##CLASS_ID##_TypePtr); \
     }
 
 // Debug module load:


### PR DESCRIPTION
Fixes #23059 

Fix reference counting error in registerNewType so it no longer double-steals sometimes.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- N/A There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Edit: Fixes bug, not just related.