### PR TITLE
DNN : fix bug in layer fusion

### DIFF
--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -247,7 +247,7 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
                     {
                         // fuse naryEltwise layer
                         // bias must already be computed to fuse => bias layer must appear before convolution
-                        if (biasLayerData->id < ld.id)
+                        if (biasLayerData->id < ld.id && biasLayerData->consumers.size() == 1)
                         {
                             // conv + naryEltwise.
                             CV_Assert_N(biasLayerData->outputBlobs.size() == 1, ld.inputBlobs.size() == 1);


### PR DESCRIPTION
Bug #23351
The `Conv_Add` fusion strategy wants to bypass the biasLayerData(Add layer). But the strategy only works when its consumer size is 1.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
