### PR TITLE
Optimize&Fix fitEllipse sample

### DIFF
--- a/samples/cpp/fitellipse.cpp
+++ b/samples/cpp/fitellipse.cpp
@@ -218,6 +218,11 @@ int main( int argc, char** argv )
     return 0;
 }
 
+inline static bool isGoodBox(const RotatedRect& box) {
+    //size.height >= size.width awalys,only if the pts are on a line or at the same point,size.width=0
+    return (box.size.height <= box.size.width * 30) && (box.size.width > 0);
+}
+
 // Define trackbar callback function. This function finds contours,
 // draws them, and approximates by ellipses.
 void processImage(int /*h*/, void*)
@@ -276,39 +281,30 @@ void processImage(int /*h*/, void*)
     {
         vector<Point2f> pts = points[i];
 
-        if (pts.size()<=5) {
+        //At least 5 points can fit an ellipse
+        if (pts.size()<5) {
             continue;
         }
         if (fitEllipseQ) {
             box = fitEllipse(pts);
-            if( MAX(box.size.width, box.size.height) > MIN(box.size.width, box.size.height)*30 ||
-               MAX(box.size.width, box.size.height) <= 0 ||
-               MIN(box.size.width, box.size.height) <= 0){continue;};
+            if (isGoodBox(box)) {
+                paper.drawEllipseWithBox(box, fitEllipseColor, 3);
+            }
         }
         if (fitEllipseAMSQ) {
             boxAMS = fitEllipseAMS(pts);
-            if( MAX(boxAMS.size.width, boxAMS.size.height) > MIN(boxAMS.size.width, boxAMS.size.height)*30 ||
-               MAX(box.size.width, box.size.height) <= 0 ||
-               MIN(box.size.width, box.size.height) <= 0){continue;};
+            if (isGoodBox(boxAMS)) {
+                paper.drawEllipseWithBox(boxAMS, fitEllipseAMSColor, 2);
+            }
         }
         if (fitEllipseDirectQ) {
             boxDirect = fitEllipseDirect(pts);
-            if( MAX(boxDirect.size.width, boxDirect.size.height) > MIN(boxDirect.size.width, boxDirect.size.height)*30 ||
-               MAX(box.size.width, box.size.height) <= 0 ||
-               MIN(box.size.width, box.size.height) <= 0 ){continue;};
+            if (isGoodBox(boxDirect)){
+                paper.drawEllipseWithBox(boxDirect, fitEllipseDirectColor, 1);
+            }
         }
 
-        if (fitEllipseQ) {
-            paper.drawEllipseWithBox(box, fitEllipseColor, 3);
-        }
-        if (fitEllipseAMSQ) {
-            paper.drawEllipseWithBox(boxAMS, fitEllipseAMSColor, 2);
-        }
-        if (fitEllipseDirectQ) {
-            paper.drawEllipseWithBox(boxDirect, fitEllipseDirectColor, 1);
-        }
-
-        paper.drawPoints(pts, cv::Scalar(255,255,255));
+        paper.drawPoints(pts, fitEllipseTrueColor);
     }
 
     imshow("result", paper.img);


### PR DESCRIPTION
1). At least 5 points can fit an ellipse
2). The result of fitEllipse、 fitEllipseAMS、fitEllipseDirect maybe different,I think it's better to draw the different result,rather than "continue".
3). Need to check the size of boxAMS/boxDirect ,not the size of box,after fitEllipseAMS、fitEllipseDirect.
               

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
