### PR TITLE
Include keypoint positions in sorting of points by norm to tie-break

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -389,6 +389,12 @@ public:
     // Compare norm
     static inline bool compare_norm( const normPoint& n1, const normPoint& n2 )
     {
+        if (n1.norm == n2.norm) {
+          if (n1.p.x == n2.p.x) {
+            return n1.p.y > n2.p.y;
+          }
+          return n1.p.x > n2.p.x;
+        }
         return (n1.norm > n2.norm);
     }
 };


### PR DESCRIPTION
This makes LineSegmentDetector deterministic by including keypoint positions as tie-breaker when sorting the seed points by norm. Without this change the region growing in LSD is non-determinstic and thus the returned lines are changing between invocations.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
