### PR TITLE
Fix error of `POSE_PAIRS` in pose estimation doc

### DIFF
--- a/doc/js_tutorials/js_assets/js_pose_estimation.html
+++ b/doc/js_tutorials/js_assets/js_pose_estimation.html
@@ -147,7 +147,7 @@ if (dataset === 'COCO') {
                    ["Neck", "LShoulder"], ["RShoulder", "RElbow"],
                    ["RElbow", "RWrist"], ["LShoulder", "LElbow"],
                    ["LElbow", "LWrist"], ["Nose", "REye"],
-                   ["REye", "REar"], ["Neck", "LEye"],
+                   ["REye", "REar"], ["Nose", "LEye"],
                    ["LEye", "LEar"], ["Neck", "MidHip"],
                    ["MidHip", "RHip"], ["RHip", "RKnee"],
                    ["RKnee", "RAnkle"], ["RAnkle", "RBigToe"],


### PR DESCRIPTION
doc/js_tutorials/js_assets/js_pose_estimation.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
