### PR TITLE
Make LineSegmentDetector deterministic by using stable_sort for order…

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -592,8 +592,8 @@ void LineSegmentDetectorImpl::ll_angle(const double& threshold,
         }
     }
 
-    // Sort
-    std::sort(ordered_points.begin(), ordered_points.end(), compare_norm);
+    // Use stable sort to ensure deterministic region growing and thus overall LSD result determinism.
+    std::stable_sort(ordered_points.begin(), ordered_points.end(), compare_norm);
 }
 
 void LineSegmentDetectorImpl::region_grow(const Point2i& s, std::vector<RegionPoint>& reg,


### PR DESCRIPTION
…ing keypoints prior to region growing

This makes LineSegmentDetector deterministic by using stable_sort for ordering points by norm. Without this change the region growing in LSD is non-determinstic and thus the returned lines are changing between invocations.

This is a replacement for https://github.com/opencv/opencv/pull/23370

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
