### PR TITLE
check keydown event characters length on macos

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -618,7 +618,7 @@ CV_IMPL int cvWaitKey (int maxWait)
          inMode:NSDefaultRunLoopMode
          dequeue:YES];
 
-        if([event type] == NSKeyDown) {
+        if([event type] == NSKeyDown && [[event characters] length]) {
             returnCode = [[event characters] characterAtIndex:0];
             break;
         }


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/21401

Check keydown event characters length before returning the pressed character code

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
