### PR TITLE
improve performance a little bit in dis_flow.cpp

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1068,7 +1068,7 @@ void Mat::push_back(const Mat& elems)
         return;
     }
 
-
+    size.p[0] = elems.size.p[0];
     bool eq = size == elems.size;
     size.p[0] = int(r);
     if( !eq )

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1068,7 +1068,7 @@ void Mat::push_back(const Mat& elems)
         return;
     }
 
-    size.p[0] = elems.size.p[0];
+
     bool eq = size == elems.size;
     size.p[0] = int(r);
     if( !eq )

--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -229,7 +229,7 @@ DISOpticalFlowImpl::DISOpticalFlowImpl()
     int max_possible_scales = 10;
     ws = hs = w = h = 0;
     for (int i = 0; i < max_possible_scales; i++)
-        variational_refinement_processors.push_back(VariationalRefinement::create());
+        variational_refinement_processors.emplace_back(VariationalRefinement::create());
 }
 
 void DISOpticalFlowImpl::prepareBuffers(Mat &I0, Mat &I1, Mat &flow, bool use_flow)


### PR DESCRIPTION
### Pull Request Readiness Checklist

C++11 add emplace_back into STL, it can improve a little bit performance

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
