### PR TITLE
RISC-V: fix hardcoded options in RVV 0.7.1 toolchain file

### DIFF
--- a/platforms/linux/riscv64-071-gcc.toolchain.cmake
+++ b/platforms/linux/riscv64-071-gcc.toolchain.cmake
@@ -1,9 +1,8 @@
-set(CMAKE_SYSTEM_NAME "Linux")
-set(CMAKE_C_COMPILER  riscv64-unknown-linux-gnu-gcc)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
 set(CMAKE_CXX_COMPILER riscv64-unknown-linux-gnu-g++)
+set(CMAKE_C_COMPILER  riscv64-unknown-linux-gnu-gcc)
 
-set(CMAKE_CXX_FLAGS ""    CACHE STRING "")
-set(CMAKE_C_FLAGS ""    CACHE STRING "")
-
-set(CMAKE_CXX_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread -D__riscv_vector_071")
-set(CMAKE_C_FLAGS "-static -march=rv64gcvxthead -mabi=lp64v -pthread -D__riscv_vector_071")
+set(CMAKE_CXX_FLAGS_INIT "-march=rv64gcv -mabi=lp64d -D__riscv_vector_071")
+set(CMAKE_C_FLAGS_INIT "-march=rv64gcv -mabi=lp64d -D__riscv_vector_071")


### PR DESCRIPTION
* `CMAKE_*_FLAGS` contained excessive compiler flags
* `CMAKE_SYSTEM_PROCESSOR` was missing
* Used `CMAKE_*_FLAGS_INIT` ([cmake 3.7+](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_INIT.html#variable:CMAKE_%3CLANG%3E_FLAGS_INIT))

Tested with the following configuration:
```
PATH=/opt/riscv64-linux-x86_64-20210618/bin:${PATH} \
cmake \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_TOOLCHAIN_FILE=/opencv/platforms/linux/riscv64-071-gcc.toolchain.cmake \
    -DBUILD_SHARED_LIBS=OFF \
    /opencv
```