### PR TITLE
AGP 8.0 build.gradle namespace and aidl buildFeature requirement added

### DIFF
--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -89,7 +89,6 @@ else()
   ocv_update(OPENCV_NAMESPACE_DECLARATION "")
 endif()
 
-
 # force reusing of the same CMake version
 if(NOT OPENCV_SKIP_ANDROID_FORCE_CMAKE)
   if(NOT DEFINED _CMAKE_INSTALL_DIR)

--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -82,6 +82,14 @@ foreach(fname ${GRADLE_WRAPPER_FILES})
   install(FILES "${OpenCV_SOURCE_DIR}/platforms/android/gradle-wrapper/${fname}" DESTINATION "${ANDROID_INSTALL_SAMPLES_DIR}/${__dir}" COMPONENT samples ${__permissions})
 endforeach()
 
+# set build.gradle namespace
+if(ANDROID_GRADLE_PLUGIN_VERSION VERSION_GREATER_EQUAL "7.3.0")
+  ocv_update(OPENCV_NAMESPACE_DECLARATION "namespace 'org.opencv'")
+else()
+  ocv_update(OPENCV_NAMESPACE_DECLARATION "")
+endif()
+
+
 # force reusing of the same CMake version
 if(NOT OPENCV_SKIP_ANDROID_FORCE_CMAKE)
   if(NOT DEFINED _CMAKE_INSTALL_DIR)

--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -89,12 +89,15 @@ else()
   ocv_update(OPENCV_ANDROID_NAMESPACE_DECLARATION "")
 endif()
 
-# set android gradle java version in build.gradle
+# set android gradle java version in build.gradle and set aidl config
 if(NOT (ANDROID_GRADLE_PLUGIN_VERSION VERSION_LESS "8.0.0"))
   # AGP-8.0 requires a minimum JDK version of JDK17
   ocv_update(ANDROID_GRADLE_JAVA_VERSION_INIT "17")
+  # Enable aidl configuration for OpenCV compile with AGP-8.0
+  ocv_update(ANDROID_GRADLE_BUILD_FEATURE_AIDL "buildFeatures { aidl true }")
 else()
   ocv_update(ANDROID_GRADLE_JAVA_VERSION_INIT "1_8")
+  ocv_update(ANDROID_GRADLE_BUILD_FEATURE_AIDL "")
 endif()
 
 set(ANDROID_GRADLE_JAVA_VERSION "${ANDROID_GRADLE_JAVA_VERSION_INIT}" CACHE STRING "Android Gradle Java version")

--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -83,10 +83,10 @@ foreach(fname ${GRADLE_WRAPPER_FILES})
 endforeach()
 
 # set build.gradle namespace
-if(ANDROID_GRADLE_PLUGIN_VERSION VERSION_GREATER_EQUAL "7.3.0")
-  ocv_update(OPENCV_NAMESPACE_DECLARATION "namespace 'org.opencv'")
+if(NOT (ANDROID_GRADLE_PLUGIN_VERSION VERSION_LESS "7.3.0"))
+  ocv_update(OPENCV_ANDROID_NAMESPACE_DECLARATION "namespace 'org.opencv'")
 else()
-  ocv_update(OPENCV_NAMESPACE_DECLARATION "")
+  ocv_update(OPENCV_ANDROID_NAMESPACE_DECLARATION "")
 endif()
 
 # force reusing of the same CMake version

--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -89,6 +89,17 @@ else()
   ocv_update(OPENCV_ANDROID_NAMESPACE_DECLARATION "")
 endif()
 
+# set android gradle java version in build.gradle
+if(NOT (ANDROID_GRADLE_PLUGIN_VERSION VERSION_LESS "8.0.0"))
+  # AGP-8.0 requires a minimum JDK version of JDK17
+  ocv_update(ANDROID_GRADLE_JAVA_VERSION_INIT "17")
+else()
+  ocv_update(ANDROID_GRADLE_JAVA_VERSION_INIT "1_8")
+endif()
+
+set(ANDROID_GRADLE_JAVA_VERSION "${ANDROID_GRADLE_JAVA_VERSION_INIT}" CACHE STRING "Android Gradle Java version")
+message(STATUS "Android Gradle Java version: ${ANDROID_GRADLE_JAVA_VERSION}")
+
 # force reusing of the same CMake version
 if(NOT OPENCV_SKIP_ANDROID_FORCE_CMAKE)
   if(NOT DEFINED _CMAKE_INSTALL_DIR)

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -115,8 +115,9 @@ android {
         }
     }
 
-    buildFeatures {
-        aidl true
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_@ANDROID_GRADLE_JAVA_VERSION_INIT@
+        targetCompatibility JavaVersion.VERSION_@ANDROID_GRADLE_JAVA_VERSION_INIT@
     }
 
     buildTypes {

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -97,7 +97,7 @@ def openCVersionCode = ((@OPENCV_VERSION_MAJOR@ * 100 + @OPENCV_VERSION_MINOR@) 
 println "OpenCV: " +openCVersionName + " " + project.buildscript.sourceFile
 
 android {
-    @OPENCV_NAMESPACE_DECLARATION@
+    @OPENCV_ANDROID_NAMESPACE_DECLARATION@
     compileSdkVersion @ANDROID_COMPILE_SDK_VERSION@
 
     defaultConfig {

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -115,6 +115,10 @@ android {
         }
     }
 
+    buildFeatures {
+        aidl true
+    }
+
     buildTypes {
         debug {
             packagingOptions {

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -120,6 +120,8 @@ android {
         targetCompatibility JavaVersion.VERSION_@ANDROID_GRADLE_JAVA_VERSION_INIT@
     }
 
+    @ANDROID_GRADLE_BUILD_FEATURE_AIDL@
+
     buildTypes {
         debug {
             packagingOptions {

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -97,6 +97,7 @@ def openCVersionCode = ((@OPENCV_VERSION_MAJOR@ * 100 + @OPENCV_VERSION_MINOR@) 
 println "OpenCV: " +openCVersionName + " " + project.buildscript.sourceFile
 
 android {
+    @OPENCV_NAMESPACE_DECLARATION@
     compileSdkVersion @ANDROID_COMPILE_SDK_VERSION@
 
     defaultConfig {


### PR DESCRIPTION
Hello,

Android Gradle Plugin version 8.0 is asking for namespace. This is become mandatory and after I update my AGP to 8.0, I got this error 


```
Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

android {
    namespace 'com.example.namespace'
}

If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

This change fix this future releases. However I am not sure how opencv wants to user namespace I used "org.opencv" if there is a different namespace please let me know so I can changed that too. Also should I add namepsace into "opencv/modules/java/android_sdk/android_gradle_lib/build.gradle" here ?


### Sources

Android developer link: https://developer.android.com/studio/preview/features#namespace-dsl
Issue Tracker Google: https://issuetracker.google.com/issues/191813691?pli=1#comment19






### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
