### PR TITLE
G-API: Fix compilation error in Standalone mode

### DIFF
--- a/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
+++ b/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
@@ -31,6 +31,7 @@ namespace cv {
     using Size    = gapi::own::Size;
     using Point   = gapi::own::Point;
     using Point2f = gapi::own::Point2f;
+    using Point3f = gapi::own::Point3f;
     using Scalar  = gapi::own::Scalar;
     using Mat     = gapi::own::Mat;
 }  // namespace cv

--- a/modules/gapi/include/opencv2/gapi/own/types.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/types.hpp
@@ -43,6 +43,17 @@ public:
     float y = 0.f;
 };
 
+class Point3f
+{
+public:
+    Point3f() = default;
+    Point3f(float _x, float _y, float _z) : x(_x),  y(_y), z(_z) {}
+
+    float x = 0.f;
+    float y = 0.f;
+    float z = 0.f;
+};
+
 class Rect
 {
 public:


### PR DESCRIPTION
- Point3f was added to type traits but was missing in the "own" package; fixed.

Note to test the build you'd need to get & build ADE first:
```
$ git clone https://github.com/opencv/ade.git
$ mkdir ade_BUILD
$ cd ade_BUILD
$ cmake ../ade -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Release
$ make
$ make install
```

After that:
```
$ mkdir gapi_BUILD
$ cd gapi_BUILD
$ cmake /path/to/opencv/modules/gapi -Dade_DIR=/path/to/ade_BUILD/install/share/ade -DCMAKE_BUILD_TYPE=Release
$ make
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
