### PR TITLE
Switch `rows` and `cols` in call to Mat.zeros

### DIFF
--- a/doc/js_tutorials/js_assets/js_contours_begin_contours.html
+++ b/doc/js_tutorials/js_assets/js_contours_begin_contours.html
@@ -41,7 +41,7 @@
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">
 let src = cv.imread('canvasInput');
-let dst = cv.Mat.zeros(src.cols, src.rows, cv.CV_8UC3);
+let dst = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC3);
 cv.cvtColor(src, src, cv.COLOR_RGBA2GRAY, 0);
 cv.threshold(src, src, 120, 200, cv.THRESH_BINARY);
 let contours = new cv.MatVector();


### PR DESCRIPTION
In a JS example, arguments `rows` and `cols` in a call to `Mat.zeros` were switched. The correct order is `rows` then `cols`:
https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html#a56daa006391a670e9cb0cd08e3168c99

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
