### PR TITLE
Fix ONNX parser for single-layer LSTM hidden and cell states

### DIFF
--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -266,7 +266,7 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert((!usePeephole && blobs.size() == 5) || (usePeephole && blobs.size() == 8));
-        CV_Assert(inputs.size() == 1);
+        CV_Assert(inputs.size() <= 3);
         const MatShape& inp0 = inputs[0];
 
         const Mat &Wh = blobs[0], &Wx = blobs[1];
@@ -326,7 +326,7 @@ public:
         inputs_arr.getMatVector(input);
 
         CV_Assert((!usePeephole && blobs.size() == 5) || (usePeephole && blobs.size() == 8));
-        CV_Assert(input.size() == 1);
+        CV_Assert(input.size() <= 3);
         const Mat& inp0 = input[0];
 
         Mat &Wh = blobs[0], &Wx = blobs[1];
@@ -383,8 +383,18 @@ public:
             Mat Wh = blobs[0];
             Mat Wx = blobs[1];
             Mat bias = blobs[2];
-            Mat h_0 = blobs[3];
-            Mat c_0 = blobs[4];
+
+            Mat h_0, c_0;  
+            // input hx and cx are prodived as input, replace with zeros
+            if (input.size() == 3){
+                h_0 = input[1].reshape(1, input[1].size[0] * input[1].size[1]);
+                c_0 = input[2].reshape(1, input[2].size[0] * input[2].size[1]);
+            } else {
+                h_0 = blobs[3];
+                c_0 = blobs[4];
+            }
+
+            
             Mat pI, pF, pO;
 
             Wh = Wh.rowRange(i * Wh.rows / numDirs, (i + 1) * Wh.rows / numDirs);

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -173,9 +173,14 @@ public:
             CV_CheckEQ(Wh.rows, Wx.rows, "");
             CV_CheckEQ(Wh.rows, (1 + static_cast<int>(bidirectional))*4*Wh.cols, "");
             CV_CheckEQ(Wh.rows, (int)bias.total(), "");
-            CV_CheckEQ(hInternal.cols, Wh.cols, "");
-            CV_CheckEQ(hInternal.cols, cInternal.cols, "");
-            CV_CheckEQ(hInternal.rows, cInternal.rows, "");
+            // Only perform these checks if hInternal and cInternal are not empty matrices
+            // e.g. inputs are not given by a user
+            if (!hInternal.empty() && !cInternal.empty())
+            {
+                CV_CheckEQ(hInternal.cols, Wh.cols, "");
+                CV_CheckEQ(hInternal.cols, cInternal.cols, "");
+                CV_CheckEQ(hInternal.rows, cInternal.rows, "");
+            }
             CV_Assert(Wh.type() == Wx.type() && Wx.type() == bias.type());
 
             // Peephole weights.

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -384,7 +384,7 @@ public:
             Mat Wx = blobs[1];
             Mat bias = blobs[2];
 
-            Mat h_0, c_0;  
+            Mat h_0, c_0;
             // input hx and cx are not prodived as input, replace with zeros
             if (input.size() == 3){
                 h_0 = input[1].reshape(1, input[1].size[0] * input[1].size[1]);
@@ -394,7 +394,7 @@ public:
                 c_0 = blobs[4];
             }
 
-            
+
             Mat pI, pF, pO;
 
             Wh = Wh.rowRange(i * Wh.rows / numDirs, (i + 1) * Wh.rows / numDirs);

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -266,7 +266,7 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert((!usePeephole && blobs.size() == 5) || (usePeephole && blobs.size() == 8));
-        CV_Assert(inputs.size() <= 3);
+        CV_Assert((inputs.size() == 1 || inputs.size() == 3));
         const MatShape& inp0 = inputs[0];
 
         const Mat &Wh = blobs[0], &Wx = blobs[1];
@@ -326,7 +326,7 @@ public:
         inputs_arr.getMatVector(input);
 
         CV_Assert((!usePeephole && blobs.size() == 5) || (usePeephole && blobs.size() == 8));
-        CV_Assert(input.size() <= 3);
+        CV_Assert((input.size() == 1 || input.size() == 3));
         const Mat& inp0 = input[0];
 
         Mat &Wh = blobs[0], &Wx = blobs[1];
@@ -385,7 +385,7 @@ public:
             Mat bias = blobs[2];
 
             Mat h_0, c_0;  
-            // input hx and cx are prodived as input, replace with zeros
+            // input hx and cx are not prodived as input, replace with zeros
             if (input.size() == 3){
                 h_0 = input[1].reshape(1, input[1].size[0] * input[1].size[1]);
                 c_0 = input[2].reshape(1, input[2].size[0] * input[2].size[1]);

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -175,10 +175,13 @@ public:
             CV_CheckEQ(Wh.rows, (int)bias.total(), "");
             // Only perform these checks if hInternal and cInternal are not empty matrices
             // e.g. inputs are not given by a user
-            if (!hInternal.empty() && !cInternal.empty())
-            {
+            if(!hInternal.empty()){
                 CV_CheckEQ(hInternal.cols, Wh.cols, "");
-                CV_CheckEQ(hInternal.cols, cInternal.cols, "");
+            }
+            if(!cInternal.empty()){
+                CV_CheckEQ(cInternal.cols, Wh.cols, "");
+            }
+            if (!hInternal.empty() && !cInternal.empty()){ //otherwise check in forward
                 CV_CheckEQ(hInternal.rows, cInternal.rows, "");
             }
             CV_Assert(Wh.type() == Wx.type() && Wx.type() == bias.type());
@@ -390,13 +393,16 @@ public:
             Mat bias = blobs[2];
 
             Mat h_0, c_0;
-            // input hx and cx are not prodived as input, replace with zeros
-            if (input.size() == 3){
-                h_0 = input[1].reshape(1, input[1].size[0] * input[1].size[1]);
-                c_0 = input[2].reshape(1, input[2].size[0] * input[2].size[1]);
-            } else {
-                h_0 = blobs[3];
-                c_0 = blobs[4];
+            // // input hx and cx are not prodived as input, replace with zeros
+            // Handle h_0 and c_0 based on input size
+            h_0 = (input.size() >= 2) ? input[1].reshape(1, input[1].size[0] * input[1].size[1]) : blobs[3];
+            c_0 = (input.size() == 3) ? input[2].reshape(1, input[2].size[0] * input[2].size[1]) : blobs[4];
+
+            // Perform checks if input size is 2 or 3
+            if (input.size() >= 2) {
+                CV_CheckEQ(h_0.cols, Wh.cols, "");
+                CV_CheckEQ(h_0.cols, c_0.cols, "");
+                CV_CheckEQ(h_0.rows, c_0.rows, "");
             }
 
 

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -393,7 +393,6 @@ public:
             Mat bias = blobs[2];
 
             Mat h_0, c_0;
-            // // input hx and cx are not prodived as input, replace with zeros
             // Handle h_0 and c_0 based on input size
             h_0 = (input.size() >= 2) ? input[1].reshape(1, input[1].size[0] * input[1].size[1]) : blobs[3];
             c_0 = (input.size() == 3) ? input[2].reshape(1, input[2].size[0] * input[2].size[1]) : blobs[4];

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1579,7 +1579,7 @@ void ONNXImporter::lstm_extractConsts(LayerParams& layerParams, const opencv_onn
         Mat blob;
         if (idx < lstm_proto.input_size() && !lstm_proto.input(idx).empty())
         {
-            if ((idx == 5 or idx == 6) and (constBlobs.find(lstm_proto.input(idx)) == constBlobs.end()))
+            if ((idx == 5 || idx == 6) && (constBlobs.find(lstm_proto.input(idx)) == constBlobs.end()))
             {
                 blob = Mat(blobShape, CV_32FC1, 0.);
             }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1554,7 +1554,7 @@ void transformBlobs(std::vector<Mat>& blobs)
     blobs[0] = Wh;
     blobs[1] = Wx;
     blobs[2] = b.reshape(1, 1);
-    // assing reshpaed state of they are given
+
     if (!blobs[3].empty()){
         blobs[3] = h0;
     }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1520,10 +1520,11 @@ void transformBlobs(std::vector<Mat>& blobs)
     Mat h0, c0;
     // check weather input is dynamic or not: hx, cx are given by user.
     // Resahpe if only they are given
-    bool dyn_input = (blobs[3].empty() && blobs[4].empty()) ? true : false;
-    if (!dyn_input){
+    if (!blobs[3].empty()){
         h0 = blobs[3];
         h0 = h0.reshape(1, h0.size[0] * h0.size[1]);
+    }
+    if (!blobs[4].empty()){
         c0 = blobs[4];
         c0 = c0.reshape(1, c0.size[0] * c0.size[1]);
     }
@@ -1554,8 +1555,10 @@ void transformBlobs(std::vector<Mat>& blobs)
     blobs[1] = Wx;
     blobs[2] = b.reshape(1, 1);
     // assing reshpaed state of they are given
-    if(!dyn_input){
+    if (!blobs[3].empty()){
         blobs[3] = h0;
+    }
+    if (!blobs[4].empty()){
         blobs[4] = c0;
     }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1583,7 +1583,7 @@ void ONNXImporter::lstm_extractConsts(LayerParams& layerParams, const opencv_onn
             {
                 blob = Mat(blobShape, CV_32FC1, 0.);
             }
-            else 
+            else
             {
                 blob = getBlob(lstm_proto, idx);
                 CV_Assert(shape(blob) == blobShape);
@@ -1768,7 +1768,7 @@ void ONNXImporter::parseLSTM(LayerParams& layerParams, const opencv_onnx::NodePr
     const std::string y_name = need_y ? lstm_proto.output(0) : "";
     const std::string yh_name = [&](){
         if(constBlobs.find(lstm_proto.input(5)) == constBlobs.end() &&
-           constBlobs.find(lstm_proto.input(6)) == constBlobs.end() && 
+           constBlobs.find(lstm_proto.input(6)) == constBlobs.end() &&
            num_directions == 1)
            {
                 return need_yh ? lstm_proto.output(2) : "";
@@ -1779,7 +1779,7 @@ void ONNXImporter::parseLSTM(LayerParams& layerParams, const opencv_onnx::NodePr
 
     const std::string yc_name = [&](){
         if(constBlobs.find(lstm_proto.input(5)) == constBlobs.end() &&
-           constBlobs.find(lstm_proto.input(6)) == constBlobs.end() && 
+           constBlobs.find(lstm_proto.input(6)) == constBlobs.end() &&
            num_directions == 1)
            {
                 return need_yc ? lstm_proto.output(1) : "";

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -65,6 +65,7 @@ public:
         for (int i = 0; i < numInps; ++i)
             net.setInput(inps[i], inputNames[i]);
         Mat out = net.forward("");
+
         if (useSoftmax)
         {
             LayerParams lp;
@@ -1234,11 +1235,6 @@ TEST_P(Test_ONNX_layers, DISABLED_LSTM_bidirectional)
 TEST_P(Test_ONNX_layers, LSTM_hidden)
 {
     testONNXModels("hidden_lstm", npy, 0, 0, false, false);
-}
-
-TEST_P(Test_ONNX_layers, LSTM_sample)
-{
-    testONNXModels("sample_lstm", npy, 0, 0, false, false, 3);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_hidden_bidirectional)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -65,7 +65,6 @@ public:
         for (int i = 0; i < numInps; ++i)
             net.setInput(inps[i], inputNames[i]);
         Mat out = net.forward("");
-
         if (useSoftmax)
         {
             LayerParams lp;
@@ -1235,6 +1234,11 @@ TEST_P(Test_ONNX_layers, DISABLED_LSTM_bidirectional)
 TEST_P(Test_ONNX_layers, LSTM_hidden)
 {
     testONNXModels("hidden_lstm", npy, 0, 0, false, false);
+}
+
+TEST_P(Test_ONNX_layers, LSTM_sample)
+{
+    testONNXModels("sample_lstm", npy, 0, 0, false, false, 3);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_hidden_bidirectional)


### PR DESCRIPTION
### Fix ONNX parser for single-layer LSTM hidden and cell states

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


This PR addresses #21118 [issue](https://github.com/opencv/opencv/issues/21118). The problem is that the ONNX parser is unable to read the hidden state and cell state for single-layer LSTMs. This PR fixes the issue by updating the parser to correctly read hidden and cell states.
