### PR TITLE
[G-API] Handle meta from multiple inputs in IE backend

### DIFF
--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -1384,6 +1384,11 @@ struct Infer: public cv::detail::KernelTag {
                     }
             }
 
+            for (auto &&p : uu.params.const_inputs) {
+                const auto ii = inputs.at(p.first);
+                ii->setPrecision(toIE(p.second.first.depth()));
+            }
+
             // FIXME: This isn't the best place to call reshape function.
             // Сorrect solution would be to do this in compile() method of network,
             // but now input meta isn't passed to compile() method.
@@ -1506,6 +1511,12 @@ struct InferROI: public cv::detail::KernelTag {
                 const_cast<IEUnit::InputFramesDesc &>(uu.net_input_params)
                             .set_param(input_name, ii->getTensorDesc());
             }
+
+            for (auto &&p : uu.params.const_inputs) {
+                const auto ii = inputs.at(p.first);
+                ii->setPrecision(toIE(p.second.first.depth()));
+            }
+
             configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
         } else {
             GAPI_Assert(uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import);
@@ -1624,6 +1635,12 @@ struct InferList: public cv::detail::KernelTag {
             if (!input_reshape_table.empty()) {
                 const_cast<IE::CNNNetwork *>(&uu.net)->reshape(input_reshape_table);
             }
+
+            for (auto &&p : uu.params.const_inputs) {
+                const auto ii = inputs.at(p.first);
+                ii->setPrecision(toIE(p.second.first.depth()));
+            }
+
             configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
         } else {
             GAPI_Assert(uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Import);
@@ -1770,6 +1787,11 @@ struct InferList2: public cv::detail::KernelTag {
                     }
                     if (isApplicableForResize(ii->getTensorDesc())) {
                         ii->getPreProcess().setResizeAlgorithm(IE::RESIZE_BILINEAR);
+                    }
+
+                    for (auto &&p : uu.params.const_inputs) {
+                        const auto ii = inputs.at(p.first);
+                        ii->setPrecision(toIE(p.second.first.depth()));
                     }
 
                     // FIXME: This isn't the best place to call reshape function.

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -1489,7 +1489,8 @@ struct InferROI: public cv::detail::KernelTag {
         // only in the loadNetwork case.
         if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
             // 0th is ROI, 1st is input image
-            auto ii = uu.net.getInputsInfo().at(input_name);
+            auto inputs = uu.net.getInputsInfo();
+            auto ii = inputs.at(input_name);
             configureInputInfo(ii, mm);
             if (uu.params.layer_names_to_reshape.find(input_name) !=
                 uu.params.layer_names_to_reshape.end()) {
@@ -1513,8 +1514,7 @@ struct InferROI: public cv::detail::KernelTag {
             }
 
             for (auto &&p : uu.params.const_inputs) {
-                const auto ii = inputs.at(p.first);
-                ii->setPrecision(toIE(p.second.first.depth()));
+                inputs.at(p.first)->setPrecision(toIE(p.second.first.depth()));
             }
 
             configureOutputPrecision(uu.net.getOutputsInfo(), uu.params.output_precision);
@@ -1778,8 +1778,9 @@ struct InferList2: public cv::detail::KernelTag {
                 // NB: Configuring input precision and network reshape must be done
                 // only in the loadNetwork case.
                 if (uu.params.kind == cv::gapi::ie::detail::ParamDesc::Kind::Load) {
+                    auto inputs = uu.net.getInputsInfo();
                     // This is a cv::Rect -- configure the IE preprocessing
-                    auto ii = uu.net.getInputsInfo().at(input_name);
+                    auto ii = inputs.at(input_name);
                     configureInputInfo(ii, mm_0);
                     if (uu.params.layer_names_to_reshape.find(input_name) !=
                         uu.params.layer_names_to_reshape.end()) {
@@ -1790,8 +1791,7 @@ struct InferList2: public cv::detail::KernelTag {
                     }
 
                     for (auto &&p : uu.params.const_inputs) {
-                        const auto ii = inputs.at(p.first);
-                        ii->setPrecision(toIE(p.second.first.depth()));
+                        inputs.at(p.first)->setPrecision(toIE(p.second.first.depth()));
                     }
 
                     // FIXME: This isn't the best place to call reshape function.


### PR DESCRIPTION
### Overview

Since `IE backend` implements "streaming"  [`run(IInput&, IOutput&)`](https://github.com/opencv/opencv/blob/4.x/modules/gapi/src/compiler/gislandmodel.cpp#L387)method it must take care of propagating meta from inputs.

The handling implemented the same way as for the default `GIslandModel::run`: https://github.com/opencv/opencv/blob/4.x/modules/gapi/src/compiler/gislandmodel.cpp#L436-L440
Since `post` is done in `PostOutputs` / `PostOutputsList` callback functions, meta collected and moved to `IECallContext`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
