### PR TITLE
Fix build regression in Quirc

### DIFF
--- a/3rdparty/quirc/src/decode.c
+++ b/3rdparty/quirc/src/decode.c
@@ -920,10 +920,14 @@ quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 
 void quirc_flip(struct quirc_code *code)
 {
-	struct quirc_code flipped = {0};
+	struct quirc_code flipped;
 	unsigned int offset = 0;
-	for (int y = 0; y < code->size; y++) {
-		for (int x = 0; x < code->size; x++) {
+	int y;
+	int x;
+
+	memset(&flipped, 0, sizeof(flipped));
+	for (y = 0; y < code->size; y++) {
+		for (x = 0; x < code->size; x++) {
 			if (grid_bit(code, y, x)) {
 				flipped.cell_bitmap[offset >> 3u] |= (1u << (offset & 7u));
 			}


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/23275
Buildbot report: https://pullrequest.opencv.org/buildbot/builders/4_x_ARMv7-lin/builds/100067/steps/compile%20release/logs/stdio

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
