### PR TITLE
fix warning in pointPolygonTest

### DIFF
--- a/modules/imgproc/src/geometry.cpp
+++ b/modules/imgproc/src/geometry.cpp
@@ -146,7 +146,6 @@ double cv::pointPolygonTest( InputArray _contour, Point2f pt, bool measureDist )
     else
     {
         Point2f v0, v;
-        Point iv;
 
         if( is_float )
         {


### PR DESCRIPTION
This PR fix warning in pointPolygonTest, remove unused variables

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
