### PR TITLE
Added LSTM and GRU tests for various batch and input length sizes

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1271,6 +1271,8 @@ TEST_P(Test_ONNX_layers, gru_cell_batchsize_50_seqlen_1)
             CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
         );
 #endif
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("gru_cell_batchsize_50_seqlen_1", npy, 0, 0, false, false);
 }
 
@@ -1283,6 +1285,8 @@ TEST_P(Test_ONNX_layers, gru_cell_batchsize_5_seqlen_5)
             CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
         );
 #endif
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("gru_cell_batchsize_5_seqlen_5", npy, 0, 0, false, false);
 }
 
@@ -1295,6 +1299,8 @@ TEST_P(Test_ONNX_layers, gru_cell_batchsize_1_seqlen_50)
             CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
         );
 #endif
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("gru_cell_batchsize_1_seqlen_50", npy, 0, 0, false, false);
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1262,6 +1262,42 @@ TEST_P(Test_ONNX_layers, GRU)
     testONNXModels("gru", npy, 0, 0, false, false);
 }
 
+TEST_P(Test_ONNX_layers, gru_cell_batchsize_50_seqlen_1)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)
+    // IE exception: Node GRU_22 was not assigned on any pointed device
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
+        applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16,
+            CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
+        );
+#endif
+    testONNXModels("gru_cell_batchsize_50_seqlen_1", npy, 0, 0, false, false);
+}
+
+TEST_P(Test_ONNX_layers, gru_cell_batchsize_5_seqlen_5)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)
+    // IE exception: Node GRU_22 was not assigned on any pointed device
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
+        applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16,
+            CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
+        );
+#endif
+    testONNXModels("gru_cell_batchsize_5_seqlen_5", npy, 0, 0, false, false);
+}
+
+TEST_P(Test_ONNX_layers, gru_cell_batchsize_1_seqlen_50)
+{
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)
+    // IE exception: Node GRU_22 was not assigned on any pointed device
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
+        applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16,
+            CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION
+        );
+#endif
+    testONNXModels("gru_cell_batchsize_1_seqlen_50", npy, 0, 0, false, false);
+}
+
 TEST_P(Test_ONNX_layers, GRU_bidirectional)
 {
     testONNXModels("gru_bi", npy, 0, 0, false, false);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1337,7 +1337,6 @@ TEST_P(Test_ONNX_layers, LSTM_cell_bidirectional)
 }
 TEST_P(Test_ONNX_layers, LSTM_cell_with_peepholes)
 {
-    //TODO: CHECK IF THIS TEST IS SKIPPED
     testONNXModels("lstm_cell_with_peepholes", npy, 0, 0, false, false);
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1298,6 +1298,21 @@ TEST_P(Test_ONNX_layers, LSTM_cell_with_peepholes)
     testONNXModels("lstm_cell_with_peepholes", npy, 0, 0, false, false);
 }
 
+TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_50_seqlen_1)
+{
+    testONNXModels("lstm_cell_batchsize_50_seqlen_1", npy, 0, 0, false, false);
+}
+
+TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_1_seqlen_50)
+{
+    testONNXModels("lstm_cell_batchsize_1_seqlen_50", npy, 0, 0, false, false);
+}
+
+TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_5_seqlen_5)
+{
+    testONNXModels("lstm_cell_batchsize_5_seqlen_5", npy, 0, 0, false, false);
+}
+
 TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 {
     testONNXModels("ReflectionPad2d");

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1295,21 +1295,28 @@ TEST_P(Test_ONNX_layers, LSTM_cell_bidirectional)
 }
 TEST_P(Test_ONNX_layers, LSTM_cell_with_peepholes)
 {
+    //TODO: CHECK IF THIS TEST IS SKIPPED
     testONNXModels("lstm_cell_with_peepholes", npy, 0, 0, false, false);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_50_seqlen_1)
 {
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_cell_batchsize_50_seqlen_1", npy, 0, 0, false, false);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_1_seqlen_50)
 {
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_cell_batchsize_1_seqlen_50", npy, 0, 0, false, false);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_5_seqlen_5)
 {
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_cell_batchsize_5_seqlen_5", npy, 0, 0, false, false);
 }
 


### PR DESCRIPTION
Added tests with various sequence length and batch sizes

Test data: https://github.com/opencv/opencv_extra/pull/1057

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


