### PR TITLE
Fix typos in aruco_detector.hpp

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -269,13 +269,13 @@ public:
      * and its corresponding identifier.
      * Note that this function does not perform pose estimation.
      * @note The function does not correct lens distortion or takes it into account. It's recommended to undistort
-     * input image with corresponging camera model, if camera parameters are known
+     * input image with corresponding camera model, if camera parameters are known
      * @sa undistort, estimatePoseSingleMarkers,  estimatePoseBoard
      */
     CV_WRAP void detectMarkers(InputArray image, OutputArrayOfArrays corners, OutputArray ids,
                                OutputArrayOfArrays rejectedImgPoints = noArray()) const;
 
-    /** @brief Refind not detected markers based on the already detected and the board layout
+    /** @brief Refine not detected markers based on the already detected and the board layout
      *
      * @param image input image
      * @param board layout of markers in the board.


### PR DESCRIPTION
Fixed two typos:
"corresponging" -> "corresponding"
"Refind" -> "Refine"

### Pull Request Readiness Checklist

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch (to my knowledge)
- [X] There is a reference to the original bug report and related work (N.A.)
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name. (N.A.)
- [X] The feature is well documented and sample code can be built with the project CMake (N.A.)
