### PR TITLE
Fixed bug with Cmake detecting Python environment

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -26,7 +26,7 @@ function(find_python preferred_version min_version library_env include_dir_env
          libs_found libs_version_string libraries library debug_libraries
          debug_library include_path include_dir include_dir2 packages_path
          numpy_include_dirs numpy_version)
-if(NOT ${found})
+if(${found})
   if(" ${executable}" STREQUAL " PYTHON_EXECUTABLE")
     set(__update_python_vars 0)
   else()

--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -26,7 +26,7 @@ function(find_python preferred_version min_version library_env include_dir_env
          libs_found libs_version_string libraries library debug_libraries
          debug_library include_path include_dir include_dir2 packages_path
          numpy_include_dirs numpy_version)
-if(${found})
+if(NOT ${found} OR ${executable})
   if(" ${executable}" STREQUAL " PYTHON_EXECUTABLE")
     set(__update_python_vars 0)
   else()


### PR DESCRIPTION
Fixed cmake error detecting python is modified to the logic of detecting the Python environment.  This detecting Python is certain to cause camke to skip using manually configured Python-related Settings and go directly to the default Python environment. A simple example, using miniconda to build Python environment, base environment Python version is 3.10, opencv_py environment Python version is 3.8, although cmake is configured with opencv_py as the Python environment used in the compilation, However, the cmake configuration will still point to Python in the base environment. By applying the code I modified, this problem will be fixed and camke will be configured with the Python environment selected manually, rather than arbitrarily selecting the default environment.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
