### PR TITLE
Added test for LSTM without hidden state initialisation

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1387,6 +1387,13 @@ TEST_P(Test_ONNX_layers, LSTM_cell_batchsize_5_seqlen_5)
     testONNXModels("lstm_cell_batchsize_5_seqlen_5", npy, 0, 0, false, false);
 }
 
+TEST_P(Test_ONNX_layers, LSTM_init_h0_c0)
+{
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
+    testONNXModels("lstm_init_h0_c0", npy, 0, 0, false, false, 3);
+}
+
 TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 {
     testONNXModels("ReflectionPad2d");


### PR DESCRIPTION

Added test for covering this PR #23475 fixing the issue [#21118](https://github.com/opencv/opencv/issues/21118) where functionality for hidden states as inputs was supported
Test data lives here: #[1062](https://github.com/opencv/opencv_extra/pull/1062)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
