### PR TITLE
Reformulated some pointer arithmetic to avoid (unsigned) overflow

### DIFF
--- a/modules/imgproc/src/filter.simd.hpp
+++ b/modules/imgproc/src/filter.simd.hpp
@@ -44,6 +44,8 @@
 #include "opencv2/core/hal/intrin.hpp"
 #include "filter.hpp"
 
+#include <cstddef>
+
 #if defined(CV_CPU_BASELINE_MODE)
 #if IPP_VERSION_X100 >= 710
 #define USE_IPP_SEP_FILTERS 1
@@ -304,7 +306,7 @@ void FilterEngine__apply(FilterEngine& this_, const Mat& src, Mat& dst, const Si
     FilterEngine__start(this_, wsz, src.size(), ofs);
     int y = this_.startY - ofs.y;
     FilterEngine__proceed(this_,
-            src.ptr() + y*src.step,
+            src.ptr() + y * (ptrdiff_t)src.step,
             (int)src.step,
             this_.endY - this_.startY,
             dst.ptr(),


### PR DESCRIPTION
Although unsigned overflow is well-defined by the C++ standard, it is often unintentional or confusing and so UBSan has an option to warn about it.

It warned here:

`Addition of unsigned offset to 0x00017fd31b97 overflowed to 0x00017fd30c97`

In my own use of OpenCV at least, this is the only case of unsigned overflow.

I reformunated the pointer arithmetic to either add or subtract based on the sign of y. It's easier to understand this way vs always adding and wrapping around to an address *smaller* than the base address.
