### PR TITLE
(docs) Depthmap py_tutorial: add reference to cv.StereoBM class documentation 

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_depthmap/py_depthmap.markdown
+++ b/doc/py_tutorials/py_calib3d/py_depthmap/py_depthmap.markdown
@@ -44,7 +44,7 @@ from matplotlib import pyplot as plt
 imgL = cv.imread('tsukuba_l.png', cv.IMREAD_GRAYSCALE)
 imgR = cv.imread('tsukuba_r.png', cv.IMREAD_GRAYSCALE)
 
-stereo = cv.StereoBM_create(numDisparities=16, blockSize=15)
+stereo = cv.StereoBM.create(numDisparities=16, blockSize=15)
 disparity = stereo.compute(imgL,imgR)
 plt.imshow(disparity,'gray')
 plt.show()
@@ -63,6 +63,9 @@ There are some parameters when you get familiar with StereoBM, and you may need 
 - uniqueness_ratio: Another post-filtering step. If the best matching disparity is not sufficiently better than every other disparity in the search range, the pixel is filtered out. You can try tweaking this if texture_threshold and the speckle filtering are still letting through spurious matches.
 - prefilter_size and prefilter_cap: The pre-filtering phase, which normalizes image brightness and enhances texture in preparation for block matching. Normally you should not need to adjust these.
 
+These parameters are set with dedicated setters and getters after the algoritm
+initialization, such as `setTextureThreshold`, `setSpeckleRange`, `setUniquenessRatio`,
+and more. See cv::StereoBM documentation for details.
 
 Additional Resources
 --------------------


### PR DESCRIPTION
Explain parameter usage as well.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
