### PR TITLE
Fix Objective-C generator handling of base class names

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -290,7 +290,7 @@ class ClassInfo(GeneralInfo):
         self.member_classes = [] # Only relevant for modules
         self.member_enums = [] # Only relevant for modules
         if decl[1]:
-            self.base = re.sub(r"^.*:", "", decl[1].split(",")[0]).strip().replace(self.objc_name, "")
+            self.base = re.sub(r"^.*:", "", decl[1].split(",")[0]).strip()
             if self.base:
                 self.is_base_class = False
                 self.native_ptr_name = "nativePtr" + self.objc_name


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

Fixes issue blocking #23264

I think at some point I was trying to solve an issue with conflicting class names by appending the module name to the class name. This resulted in problems where the class with the conflicting name was later used as a base class.
Whatever the original problem - I have confirmed that this change has no impact on the current Objective-C wrappers for modules in both **opencv** and **opencv_contrib**