### PR TITLE
QRCodeDetector: don't floodFill with outside-of-image seedPoint

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -571,10 +571,10 @@ bool QRDetect::computeTransformationPoints()
     {
         Mat mask = Mat::zeros(bin_barcode.rows + 2, bin_barcode.cols + 2, CV_8UC1);
         uint8_t next_pixel, future_pixel = 255;
-        int count_test_lines = 0, index = cvRound(localization_points[i].x);
-        for (; index < bin_barcode.cols - 1; index++)
+        int count_test_lines = 0, index_c = cvRound(localization_points[i].x), index_r = cvRound(localization_points[i].y);
+        for (; index_c < bin_barcode.cols - 1 && index_r < bin_barcode.rows; index_c++)
         {
-            next_pixel = bin_barcode.ptr<uint8_t>(cvRound(localization_points[i].y))[index + 1];
+            next_pixel = bin_barcode.ptr<uint8_t>(index_r)[index_c + 1];
             if (next_pixel == future_pixel)
             {
                 future_pixel = static_cast<uint8_t>(~future_pixel);
@@ -582,7 +582,7 @@ bool QRDetect::computeTransformationPoints()
                 if (count_test_lines == 2)
                 {
                     floodFill(bin_barcode, mask,
-                              Point(index + 1, cvRound(localization_points[i].y)), 255,
+                              Point(index_c + 1, index_r), 255,
                               0, Scalar(), Scalar(), FLOODFILL_MASK_ONLY);
                     break;
                 }


### PR DESCRIPTION
Naive change for the #21532 issue.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
  - Looks like 3.4 rather than 4.x could be alternative target branch?
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
