### PR TITLE
LSTM ONNX Layout Attribute Support 

### DIFF
--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -124,8 +124,8 @@ class LSTMLayerImpl CV_FINAL : public LSTMLayer
     bool useCellClip, usePeephole;
     bool reverse;   // If true, go in negative direction along the time axis
     bool bidirectional;  // If true, produces both forward and reversed directions along time axis
-    layout_t layout;  // If true, uses batch_size x seq_length x num_hidden for input and output, else
-                      // uses seq_length x batch_size x num_hidden
+    layout_t layout;  // If layout == BATCH_SEQ_HID, uses batch_size x seq_length x num_hidden for input and output
+                      // else uses seq_length x batch_size x num_hidden
 
     ActivationFunction f_activation;
     ActivationFunction g_activation;
@@ -299,7 +299,7 @@ public:
         if (useTimestampDim)
         {
             CV_Assert(inp0.size() >= 2 && total(inp0, 2) == _numInp);
-            if (!layout) {
+            if (layout == SEQ_BATCH_HID) {
                 _numSamples = inp0[1];
                 outResShape.push_back(inp0[0]);
             } else {
@@ -362,7 +362,7 @@ public:
         if (useTimestampDim)
         {
             CV_Assert(inp0.dims >= 2 && (int)inp0.total(2) == numInp);
-            if (!layout){
+            if (layout == SEQ_BATCH_HID){
                 numTimeStamps = inp0.size[0];
                 numSamples = inp0.size[1];
             }else{
@@ -401,7 +401,7 @@ public:
         outputs_arr.getMatVector(output);
         internals_arr.getMatVector(internals);
 
-        if (layout){
+        if (layout == BATCH_SEQ_HID){
             //swap axis 0 and 1 input x
             cv::Mat tmp;
             // Since python input is 4 dimentional and C++ input 3 dimentinal
@@ -633,7 +633,7 @@ public:
             }
         }
         // transpose to match batch first output
-        if (layout){
+        if (layout == BATCH_SEQ_HID){
             cv::Mat tmp;
             cv::transposeND(output[0], {1, 0, 2}, tmp);
             output[0] = tmp;
@@ -657,7 +657,7 @@ public:
         // permute to {0, 2, 1, 3};
         cv::Mat newCellState;
         // transpose to match batch first output
-        if (layout){
+        if (layout == BATCH_SEQ_HID){
             cv::transposeND(cOut, {2, 0, 1, 3}, newCellState);
         }
         else{

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -299,7 +299,7 @@ public:
         if (useTimestampDim)
         {
             CV_Assert(inp0.size() >= 2 && total(inp0, 2) == _numInp);
-            if (!layout){
+            if (!layout) {
                 _numSamples = inp0[1];
                 outResShape.push_back(inp0[0]);
             } else {

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -113,14 +113,19 @@ class LSTMLayerImpl CV_FINAL : public LSTMLayer
     MatShape outTailShape;  //shape of single output sample
     MatShape outTsShape;    //shape of N output samples
 
+    enum layout_t : int {
+        SEQ_BATCH_HID = 0,
+        BATCH_SEQ_HID = 1
+    };
+
     bool useTimestampDim;
     bool produceCellOutput;
     float forgetBias, cellClip;
     bool useCellClip, usePeephole;
     bool reverse;   // If true, go in negative direction along the time axis
     bool bidirectional;  // If true, produces both forward and reversed directions along time axis
-    bool layout;  // If true, uses batch_size x seq_length x num_hidden for input and output, else
-                  // uses seq_length x batch_size x num_hidden
+    layout_t layout;  // If true, uses batch_size x seq_length x num_hidden for input and output, else
+                      // uses seq_length x batch_size x num_hidden
 
     ActivationFunction f_activation;
     ActivationFunction g_activation;
@@ -200,7 +205,7 @@ public:
                 }
             }
         }
-        layout = params.get<bool>("layout", false);
+        layout = (layout_t) params.get<int>("layout", SEQ_BATCH_HID);
         useTimestampDim = params.get<bool>("use_timestamp_dim", true);
         produceCellOutput = params.get<bool>("produce_cell_output", false);
         forgetBias = params.get<float>("forget_bias", 0.0f);
@@ -297,7 +302,7 @@ public:
             if (!layout){
                 _numSamples = inp0[1];
                 outResShape.push_back(inp0[0]);
-            }else{
+            } else {
                 _numSamples = inp0[0];
                 outResShape.push_back(inp0[1]);
             }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1683,7 +1683,6 @@ std::string ONNXImporter::lstm_fix_dims(LayerParams& layerParams, const opencv_o
     permuteLP.type = "Permute";
     CV_Assert(layer_id.find(permuteLP.name) == layer_id.end());
 
-    const int layout = layerParams.get<int>("layout", false);
     int order[] = {0, 2, 1, 3};
     permuteLP.set("order", DictValue::arrayInt(order, 4));
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1754,7 +1754,7 @@ void ONNXImporter::parseLSTM(LayerParams& layerParams, const opencv_onnx::NodePr
     const MatShape x_shape = shapeIt->second;
 
     //if layout is 1, change batch and sequence dims
-    const int layout = layerParams.get<int>("layout", false);
+    const int layout = layerParams.get<int>("layout", 0);
     int batch_size, seq_length;
     if (layout == 1){
         batch_size = x_shape[0];
@@ -1807,7 +1807,7 @@ void ONNXImporter::parseLSTM(LayerParams& layerParams, const opencv_onnx::NodePr
 
     bool need_yc = lstm_proto.output_size() > 2 && !lstm_proto.output(2).empty();
     bool need_yh = lstm_proto.output_size() > 1 && !lstm_proto.output(1).empty();
-    bool need_y  = lstm_proto.output_size() > 0 && !lstm_proto.output(0).empty();
+    bool need_y = lstm_proto.output_size() > 0 && !lstm_proto.output(0).empty();
 
     const std::string y_name = need_y ? lstm_proto.output(0) : "";
     const std::string yh_name = need_yh ? lstm_proto.output(1) : "";

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1392,6 +1392,20 @@ TEST_P(Test_ONNX_layers, LSTM_init_h0_c0)
     if(backend == DNN_BACKEND_CUDA)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_init_h0_c0", npy, 0, 0, false, false, 3);
+
+// epsilon is larger because onnx does not match with torch/opencv exactly
+TEST_P(Test_ONNX_layers, LSTM_layout_0)
+{
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
+    testONNXModels("lstm_layout_0", npy, 0.005, 0.005, false, false, 3);
+}
+// epsilon is larger because onnx does not match with torch/opencv exactly
+TEST_P(Test_ONNX_layers, LSTM_layout_1)
+{
+    if(backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
+    testONNXModels("lstm_layout_1", npy, 0.005, 0.005, false, false, 3);
 }
 
 TEST_P(Test_ONNX_layers, Pad2d_Unfused)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1392,7 +1392,7 @@ TEST_P(Test_ONNX_layers, LSTM_init_h0_c0)
     if(backend == DNN_BACKEND_CUDA)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_init_h0_c0", npy, 0, 0, false, false, 3);
-
+}
 // epsilon is larger because onnx does not match with torch/opencv exactly
 TEST_P(Test_ONNX_layers, LSTM_layout_0)
 {

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1394,14 +1394,14 @@ TEST_P(Test_ONNX_layers, LSTM_init_h0_c0)
     testONNXModels("lstm_init_h0_c0", npy, 0, 0, false, false, 3);
 }
 // epsilon is larger because onnx does not match with torch/opencv exactly
-TEST_P(Test_ONNX_layers, LSTM_layout_0)
+TEST_P(Test_ONNX_layers, LSTM_layout_seq)
 {
     if(backend == DNN_BACKEND_CUDA)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_layout_0", npy, 0.005, 0.005, false, false, 3);
 }
 // epsilon is larger because onnx does not match with torch/opencv exactly
-TEST_P(Test_ONNX_layers, LSTM_layout_1)
+TEST_P(Test_ONNX_layers, LSTM_layout_batch)
 {
     if(backend == DNN_BACKEND_CUDA)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);


### PR DESCRIPTION
### Explanation
This PR contains necessary changes to support `layout` attribute. This attributes is present in [ONNX](https://github.com/onnx/onnx/blob/main/docs/Operators.md#lstm) and [Torch](https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html#lstm) (in touch it is name as `batch_first=True`) libraries. When `layout = 1` input to LSTM layer is expected to have batch dimension first -> `[batch_size, sequence_length, features]` vs `layout = 0` - default `[sequence_length, batch_size, features]`

### Test Data
Test data and data generator for PR located here [#1063](https://github.com/opencv/opencv_extra/pull/1063)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
