### PR TITLE
DNN: Remove unnecessary flags for convolution 

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -258,7 +258,6 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<BaseConvolutionLayer> create(const LayerParams& params);
         bool fusedActivation = false;
         bool fusedAdd = false;
-        bool isConv2D = false; // Should be deleted after fastconv branch support Conv1D and Conv3D.
         bool useWinograd = false; // Flag whether to use Winograd to speed up 3x3 convolution.
     };
 

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -116,9 +116,6 @@ public:
 
         fusedWeights = false;
         fusedBias = false;
-
-        if (kernel_size.size() == 2)
-            isConv2D = true;
     }
 
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE

--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -170,8 +170,8 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
                 // To avoid the order like: conv + activ + add, if we found the conv has been fused with activ, we break.
                 Ptr<ConvolutionLayer> convLayer = ld.layerInstance.dynamicCast<ConvolutionLayer>();
 
-                // Only Conv2D without fusion Activation supports this fusion, other-wise, we skip.
-                if (!convLayer->isConv2D || convLayer->fusedActivation)
+                // Only Convolution layer without fusion Activation supports this fusion, other-wise, we skip.
+                if (convLayer->fusedActivation)
                     break;
 
                 // For now, there are currently two layers in OpenCV that run the Add operator.


### PR DESCRIPTION
Since we have supported the Convolution 1D, 2D, and 3D, we can perform the `Conv_Add` trick for all types of Convolution.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
