### PR TITLE
Fix even input dimensions for INTER_NEAREST_EXACT

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1212,9 +1212,9 @@ static void resizeNN_bitexact( const Mat& src, Mat& dst, double /*fx*/, double /
 {
     Size ssize = src.size(), dsize = dst.size();
     int ifx = ((ssize.width << 16) + dsize.width / 2) / dsize.width; // 16bit fixed-point arithmetic
-    int ifx0 = ifx / 2 - 1;                                     // This method uses center pixel coordinate as Pillow and scikit-images do.
+    int ifx0 = ifx / 2 - ssize.width % 2;                       // This method uses center pixel coordinate as Pillow and scikit-images do.
     int ify = ((ssize.height << 16) + dsize.height / 2) / dsize.height;
-    int ify0 = ify / 2 - 1;
+    int ify0 = ify / 2 - ssize.height % 2;
 
     cv::utils::BufferArea area;
     int* x_ofse = 0;

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -194,7 +194,7 @@ TEST(Resize_Bitexact, Nearest8U)
 
     // 2x decimation
     src[0] = (Mat_<uint8_t>(1, 6) << 0, 1, 2, 3, 4, 5);
-    dst[0] = (Mat_<uint8_t>(1, 3) << 0, 2, 4);
+    dst[0] = (Mat_<uint8_t>(1, 3) << 1, 3, 5);
 
     // decimation odd to 1
     src[1] = (Mat_<uint8_t>(1, 5) << 0, 1, 2, 3, 4);

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -234,6 +234,9 @@ TEST(Resize_Bitexact, Nearest8U)
         Mat calc;
         resize(src[i], calc, dst[i].size(), 0, 0, INTER_NEAREST_EXACT);
         EXPECT_EQ(cvtest::norm(calc, dst[i], cv::NORM_L1), 0);
+
+        resize(src[i].t(), calc, dst[i].t().size(), 0, 0, INTER_NEAREST_EXACT);
+        EXPECT_EQ(cvtest::norm(calc, dst[i].t(), cv::NORM_L1), 0);
     }
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/22204
related: https://github.com/opencv/opencv/issues/9096#issuecomment-1551306017

/cc @Yosshi999

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
