### PR TITLE
Add Contributor Metrics Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 ### Contributing
 
+![https://github.com/monoclehq](https://open-source-assets.middlewarehq.com/svgs/opencv-opencv-contributor-metrics-dark-widget.svg)
+
 Please read the [contribution guidelines](https://github.com/opencv/opencv/wiki/How_to_contribute) before starting work on a pull request.
 
 #### Summary of the guidelines:


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

## Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
- A widget showcasing recent contributions can be motivating for new contributors.
- This widget is already present in some selected opensource repositories- [RocketChat/Apps.GitHub22](https://github.com/RocketChat/Apps.Github22), [RocketChat/EmbeddedChat](https://github.com/RocketChat/EmbeddedChat), [RocketChat/RC4Community](https://github.com/RocketChat/RC4Community) etc. and has helped in community building around those projects. 
- A number of  students had mentioned their rank on this widget in their GSoC 2023 proposal for RocketChat. Hence, this can be great motivator for student contributors. 

## Proposed Changes
- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics regularly and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 2 months.

![image](https://github.com/opencv/opencv/assets/70485812/b663e0c3-442e-4977-835c-2f288ebde0e7)

