### PR TITLE
Fix Region layer with OpenVINO in case of different width/height

### DIFF
--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -526,14 +526,14 @@ public:
 
             std::vector<float> x_indices(w * h * anchors);
             auto begin = x_indices.begin();
-            for (int i = 0; i < h; i++)
+            for (int i = 0; i < w; i++)
             {
                 std::fill(begin + i * anchors, begin + (i + 1) * anchors, i);
             }
 
-            for (int j = 1; j < w; j++)
+            for (int j = 1; j < h; j++)
             {
-                std::copy(begin, begin + h * anchors, begin + j * h * anchors);
+                std::copy(begin, begin + w * anchors, begin + j * w * anchors);
             }
             auto horiz = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, box_broad_shape, x_indices.data());
             box_x = std::make_shared<ngraph::op::v1::Add>(box_x, horiz, ngraph::op::AutoBroadcastType::NUMPY);


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/19781

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom

Xbuild_image:Custom=ubuntu-openvino-2021.4.2:20.04
build_image:Custom=ubuntu-openvino-2022.1.0:20.04

test_modules:Custom=dnn,python2,python3,java,gapi,video

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

allow_multiple_commits=1
```