### PR TITLE
add charuco board check

### DIFF
--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -48,7 +48,16 @@ struct CharucoDetector::CharucoDetectorImpl {
                 if (nearestMarkerIdx[chId][0] == idMaker || nearestMarkerIdx[chId][1] == idMaker) {
                     int nearestCornerId =  nearestMarkerIdx[chId][0] == idMaker ? board.getNearestMarkerCorners()[chId][0] : board.getNearestMarkerCorners()[chId][1];
                     Point2f nearestCorner = mCorners[j].ptr<Point2f>(0)[nearestCornerId];
-                    distance[chId].x = max(distance[chId].x, sqrt(normL2Sqr<float>(nearestCorner - charucoCorner)));
+                    float distToNearest = sqrt(normL2Sqr<float>(nearestCorner - charucoCorner));
+                    distance[chId].x = max(distance[chId].x, distToNearest);
+                    // check that nearestCorner is nearest point
+                    {
+                        Point2f mid1 = (mCorners[j].ptr<Point2f>(0)[(nearestCornerId + 1) % 4]+nearestCorner)*0.5f;
+                        Point2f mid2 = (mCorners[j].ptr<Point2f>(0)[(nearestCornerId + 3) % 4]+nearestCorner)*0.5f;
+                        float tmpDist = min(sqrt(normL2Sqr<float>(mid1 - charucoCorner)), sqrt(normL2Sqr<float>(mid2 - charucoCorner)));
+                        if (tmpDist < distToNearest)
+                            return false;
+                    }
                 }
                 // check distance from the charuco corner to other markers
                 else

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -689,4 +689,32 @@ TEST(Charuco, testmatchImagePoints)
     }
 }
 
+typedef testing::TestWithParam<cv::Size> CharucoBoard;
+INSTANTIATE_TEST_CASE_P(/**/, CharucoBoard, testing::Values(Size(3, 2), Size(3, 2), Size(6, 2), Size(2, 6),
+                                                            Size(3, 4), Size(4, 3), Size(7, 3), Size(3, 7)));
+TEST_P(CharucoBoard, testWrongSizeDetection)
+{
+    cv::Size boardSize = GetParam();
+    ASSERT_FALSE(boardSize.width == boardSize.height);
+    aruco::CharucoBoard board(boardSize, 1.f, 0.5f, aruco::getPredefinedDictionary(aruco::DICT_4X4_50));
+
+    vector<int> detectedCharucoIds, detectedArucoIds;
+    vector<Point2f> detectedCharucoCorners;
+    vector<vector<Point2f>> detectedArucoCorners;
+    Mat boardImage;
+    board.generateImage(boardSize*40, boardImage);
+
+    swap(boardSize.width, boardSize.height);
+    aruco::CharucoDetector detector(aruco::CharucoBoard(boardSize, 1.f, 0.5f, aruco::getPredefinedDictionary(aruco::DICT_4X4_50)));
+    // try detect board with wrong size
+    detector.detectBoard(boardImage, detectedCharucoCorners, detectedCharucoIds, detectedArucoCorners, detectedArucoIds);
+
+    // aruco markers must be found
+    ASSERT_EQ(detectedArucoIds.size(), board.getIds().size());
+    ASSERT_EQ(detectedArucoCorners.size(), board.getIds().size());
+    // charuco corners should not be found in board with wrong size
+    ASSERT_TRUE(detectedCharucoCorners.empty());
+    ASSERT_TRUE(detectedCharucoIds.empty());
+}
+
 }} // namespace


### PR DESCRIPTION
Added charuco board checking to avoid detection of incorrect board.
Fixes #23517


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
