### PR TITLE
Update matchTemplate with mask docstring

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3866,9 +3866,12 @@ is \f$W \times H\f$ and templ is \f$w \times h\f$ , then result is \f$(W-w+1) \t
 @param method Parameter specifying the comparison method, see #TemplateMatchModes
 @param mask Optional mask. It must have the same size as templ. It must either have the same number
             of channels as template or only one channel, which is then used for all template and
-            image channels. If the data type is #CV_8U, the mask is interpreted as a binary mask,
+            image channels.
+            - If the data type is #CV_8U, the mask is interpreted as a binary mask,
             meaning only elements where mask is nonzero are used and are kept unchanged independent
-            of the actual mask value (weight equals 1). For data tpye #CV_32F, the mask values are
+            of the actual mask value (weight equals 1). To keep compatibility to other masks in OpenCV,
+            all nonzero values are converted to ones inplace.
+            - For data type #CV_32F, the mask values are
             used as weights. The exact formulas are documented in #TemplateMatchModes.
  */
 CV_EXPORTS_W void matchTemplate( InputArray image, InputArray templ,

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3866,12 +3866,9 @@ is \f$W \times H\f$ and templ is \f$w \times h\f$ , then result is \f$(W-w+1) \t
 @param method Parameter specifying the comparison method, see #TemplateMatchModes
 @param mask Optional mask. It must have the same size as templ. It must either have the same number
             of channels as template or only one channel, which is then used for all template and
-            image channels.
-            - If the data type is #CV_8U, the mask is interpreted as a binary mask,
+            image channels. If the data type is #CV_8U, the mask is interpreted as a binary mask,
             meaning only elements where mask is nonzero are used and are kept unchanged independent
-            of the actual mask value (weight equals 1). To keep compatibility to other masks in OpenCV,
-            all nonzero values are converted to ones inplace.
-            - For data type #CV_32F, the mask values are
+            of the actual mask value (weight equals 1). For data tpye #CV_32F, the mask values are
             used as weights. The exact formulas are documented in #TemplateMatchModes.
  */
 CV_EXPORTS_W void matchTemplate( InputArray image, InputArray templ,

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -780,8 +780,9 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
     if (mask.depth() == CV_8U)
     {
         // To keep compatibility to other masks in OpenCV: CV_8U masks are binary masks
-        threshold(mask, mask, 0/*threshold*/, 1.0/*maxVal*/, THRESH_BINARY);
-        mask.convertTo(mask, CV_32F);
+        Mat maskBin;
+        threshold(mask, maskBin, 0/*threshold*/, 1.0/*maxVal*/, THRESH_BINARY);
+        maskBin.convertTo(mask, CV_32F);
     }
 
     Size corrSize(img.cols - templ.cols + 1, img.rows - templ.rows + 1);


### PR DESCRIPTION
* Update the documentation
* Minor optimizations to mask2 calculation

resolves https://github.com/opencv/opencv/issues/23585 alternatively to https://github.com/opencv/opencv/pull/23615

docs preview: https://pullrequest.opencv.org/buildbot/export/pr/23651/docs/df/dfb/group__imgproc__object.html#ga586ebfb0a7fb604b35a23d85391329be

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
