### PR TITLE
Build fix for AVX 256

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -445,7 +445,7 @@ static inline void packData8(char*& inpbuf, float*& inptrIn, int& in_w, int& x0,
             {
                 int k1 = ofstab[k];
 #if CV_SIMD256
-                vx_store(inpbufC_FP32 + k*CONV_NR, vx_load(inptrInC + k1));
+                vx_store(inpbufC_FP32 + k*CONV_NR_FP32, vx_load(inptrInC + k1));
 #elif CV_SIMD128
                 v_float32x4 vv0 = v_load(inptrInC + k1);
                 v_float32x4 vv1 = v_load(inptrInC + k1 + 4);


### PR DESCRIPTION
@zihaomu Our CI environment started failing after you merged this [commit](https://github.com/opencv/opencv/commit/5229312ad2a4fbf9a6abfd6490b265c39587e6f7). 

```
/build/build_cuda/3p/opencv/linux-x64/ubuntu22.04/Debug/modules/dnn/src/layers/cpu_kernels/convolution.cpp: In function 'void cv::dnn::packData8(char*&, float*&, int&, int&, int&, const int*, int, int, int)':
/build/build_cuda/3p/opencv/linux-x64/ubuntu22.04/Debug/modules/dnn/src/layers/cpu_kernels/convolution.cpp:448:43: error: 'CONV_NR' was not declared in this scope; did you mean 'CONV_3D'?
  448 |                 vx_store(inpbufC_FP32 + k*CONV_NR, vx_load(inptrInC + k1));
      |                                           ^~~~~~~
      |                                           CONV_3D
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
