### PR TITLE
Added check that YUYV input of cvtColor has even width.

### DIFF
--- a/modules/imgproc/src/color.simd_helpers.hpp
+++ b/modules/imgproc/src/color.simd_helpers.hpp
@@ -72,7 +72,7 @@ struct Set<i0, -1, -1>
 
 enum SizePolicy
 {
-    TO_YUV, FROM_YUV, NONE
+    TO_YUV, FROM_YUV, FROM_UYVY, NONE
 };
 
 template< typename VScn, typename VDcn, typename VDepth, SizePolicy sizePolicy = NONE >
@@ -103,6 +103,10 @@ struct CvtHelper
         case FROM_YUV:
             CV_Assert( sz.width % 2 == 0 && sz.height % 3 == 0);
             dstSz = Size(sz.width, sz.height * 2 / 3);
+            break;
+        case FROM_UYVY:
+            CV_Assert( sz.width % 2 == 0);
+            dstSz = sz;
             break;
         case NONE:
         default:

--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -354,7 +354,7 @@ void cvtColorYUV2BGR(InputArray _src, OutputArray _dst, int dcn, bool swapb, boo
 
 void cvtColorOnePlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool swapb, int uidx, int ycn)
 {
-    CvtHelper< Set<2>, Set<3, 4>, Set<CV_8U> > h(_src, _dst, dcn);
+    CvtHelper< Set<2>, Set<3, 4>, Set<CV_8U>, FROM_UYVY > h(_src, _dst, dcn);
 
     hal::cvtOnePlaneYUVtoBGR(h.src.data, h.src.step, h.dst.data, h.dst.step, h.src.cols, h.src.rows,
                              dcn, swapb, uidx, ycn);

--- a/modules/imgproc/test/test_cvtyuv.cpp
+++ b/modules/imgproc/test/test_cvtyuv.cpp
@@ -724,4 +724,13 @@ INSTANTIATE_TEST_CASE_P(cvt422, Imgproc_ColorYUV,
                       (int)COLOR_YUV2RGBA_YUY2, (int)COLOR_YUV2BGRA_YUY2, (int)COLOR_YUV2RGBA_YVYU, (int)COLOR_YUV2BGRA_YVYU,
                       (int)COLOR_YUV2GRAY_UYVY, (int)COLOR_YUV2GRAY_YUY2));
 
-}} // namespace
+}
+
+TEST(cvtColorUYVY, size_issue_21035)
+{
+    Mat input = Mat::zeros(1, 1, CV_8UC2);
+    Mat output;
+    EXPECT_THROW(cv::cvtColor(input, output, cv::COLOR_YUV2BGR_UYVY), cv::Exception);
+}
+
+} // namespace


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/21035

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
