### PR TITLE
Fixed out-of-bound waring in cv::Mat::foreEach impl.

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -670,19 +670,9 @@ void Mat::forEach_impl(const Functor& operation) {
         }
         // ! Call operator for each elements in this row. 2d mat special version.
         inline void rowCall2(const int row, const int COLS) const {
-            union Index{
-                int body[2];
-                operator const int*() const {
-                    return reinterpret_cast<const int*>(this);
-                }
-                int& operator[](const int i) {
-                    return body[i];
-                }
-            } idx = {{row, 0}};
-            // Special union is needed to avoid
-            // "error: array subscript is above array bounds [-Werror=array-bounds]"
-            // when call the functor `op` such that access idx[3].
+            CV_Assert(mat->dims <= 2);
 
+            int idx[2] = {row, 0};
             _Tp* pixel = &(mat->template at<_Tp>(idx));
             const _Tp* const pixel_end = pixel + COLS;
             while(pixel < pixel_end) {


### PR DESCRIPTION
Issue: https://github.com/opencv/opencv/issues/22218

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
