### PR TITLE
Fix javadoc generation

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1353,7 +1353,7 @@ def sanitize_java_documentation_string(doc, type):
                 indexDiff += 1
             lines[index + indexDiff] = lines[index + indexDiff][0:i] + lines[index + indexDiff][i + 1:]
         else:
-            if listInd and (not line or line == "*" or line.startswith("@note")):
+            if listInd and (not line or line == "*" or line.strip().startswith("@note") or line.strip().startswith("@param")):
                 lines.insert(index + indexDiff, "  "*len(listInd) + "</li>")
                 indexDiff += 1
                 del listInd[-1]


### PR DESCRIPTION
I've met a javadoc generation error on Ubuntu 22:
```
  [javadoc] /build-docs/modules/java/jar/opencv/java/org/opencv/calib3d/Calib3d.java:11320: error: element not closed: ul
  [javadoc]      * <ul>
  [javadoc]        ^
  [javadoc] /build-docs/modules/java/jar/opencv/java/org/opencv/calib3d/Calib3d.java:11348: error: unexpected end tag: </li>
  [javadoc]      *   </li>
  [javadoc]          ^
  [javadoc] /build-docs/modules/java/jar/opencv/java/org/opencv/calib3d/Calib3d.java:11349: error: unexpected end tag: </ul>
  [javadoc]      * </ul>
  [javadoc]        ^
```
Reason: a list of items in the parameter description does not generate good html, `</ul>` and `</li>` elements are added after the following `@param` item. It looks as follows and my version of javadoc (17.0.6) fails:
```
@param first param
<ul>
<li>abc</li>
<li>def
@param second param
</li>
</ul>
```