### PR TITLE
CV_MAKETYPE Python binding

### DIFF
--- a/modules/core/misc/python/pyopencv_core.hpp
+++ b/modules/core/misc/python/pyopencv_core.hpp
@@ -1,0 +1,21 @@
+#ifndef OPENCV_CORE_PYOPENCV_CORE_HPP
+#define OPENCV_CORE_PYOPENCV_CORE_HPP
+
+#ifdef HAVE_OPENCV_CORE
+
+static PyObject* pycvMakeType(PyObject* , PyObject* args, PyObject* kw) {
+    const char *keywords[] = { "depth", "channels", NULL };
+
+    int64_t depth, channels;
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "ll", (char**)keywords, &depth, &channels))
+        return NULL;
+
+    int64_t type = CV_MAKETYPE(depth, channels);
+    return PyInt_FromLong(type);
+}
+
+#define PYOPENCV_EXTRA_METHODS_CV \
+  {"CV_MAKETYPE", CV_PY_FN_WITH_KW(pycvMakeType), "CV_MAKETYPE(depth, channels) -> retval"},
+
+#endif  // HAVE_OPENCV_CORE
+#endif  // OPENCV_CORE_PYOPENCV_CORE_HPP

--- a/modules/core/misc/python/pyopencv_core.hpp
+++ b/modules/core/misc/python/pyopencv_core.hpp
@@ -6,11 +6,11 @@
 static PyObject* pycvMakeType(PyObject* , PyObject* args, PyObject* kw) {
     const char *keywords[] = { "depth", "channels", NULL };
 
-    int64_t depth, channels;
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "ll", (char**)keywords, &depth, &channels))
+    int depth, channels;
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "ii", (char**)keywords, &depth, &channels))
         return NULL;
 
-    int64_t type = CV_MAKETYPE(depth, channels);
+    int type = CV_MAKETYPE(depth, channels);
     return PyInt_FromLong(type);
 }
 

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -142,6 +142,15 @@ class Bindings(NewOpenCVTests):
         with self.assertRaises(AttributeError):
             obj.except_ = 32
 
+    def test_maketype(self):
+        data = {
+            cv.CV_8UC3: [cv.CV_8U, 3],
+            cv.CV_16SC1: [cv.CV_16S, 1],
+            cv.CV_32FC4: [cv.CV_32F, 4],
+            cv.CV_64FC2: [cv.CV_64F, 2],
+        }
+        for ref, (depth, channels) in data.items():
+            self.assertEqual(ref, cv.CV_MAKETYPE(depth, channels))
 
 
 class Arguments(NewOpenCVTests):


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/23628

```python
import cv2 as cv

t = cv.CV_MAKETYPE(cv.CV_32F, 4)
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
