### PR TITLE
Python bindings for CV_8UC(n) and other types macros

### DIFF
--- a/modules/core/misc/python/pyopencv_core.hpp
+++ b/modules/core/misc/python/pyopencv_core.hpp
@@ -14,8 +14,22 @@ static PyObject* pycvMakeType(PyObject* , PyObject* args, PyObject* kw) {
     return PyInt_FromLong(type);
 }
 
+template <int depth>
+static PyObject* pycvMakeTypeCh(PyObject*, PyObject *value) {
+    int channels = (int)PyLong_AsLong(value);
+    return PyInt_FromLong(CV_MAKETYPE(depth, channels));
+}
+
 #define PYOPENCV_EXTRA_METHODS_CV \
-  {"CV_MAKETYPE", CV_PY_FN_WITH_KW(pycvMakeType), "CV_MAKETYPE(depth, channels) -> retval"},
+  {"CV_MAKETYPE", CV_PY_FN_WITH_KW(pycvMakeType), "CV_MAKETYPE(depth, channels) -> retval"}, \
+  {"CV_8UC", (PyCFunction)(pycvMakeTypeCh<CV_8U>), METH_O, "CV_8UC(channels) -> retval"}, \
+  {"CV_8SC", (PyCFunction)(pycvMakeTypeCh<CV_8S>), METH_O, "CV_8SC(channels) -> retval"}, \
+  {"CV_16UC", (PyCFunction)(pycvMakeTypeCh<CV_16U>), METH_O, "CV_16UC(channels) -> retval"}, \
+  {"CV_16SC", (PyCFunction)(pycvMakeTypeCh<CV_16S>), METH_O, "CV_16SC(channels) -> retval"}, \
+  {"CV_32SC", (PyCFunction)(pycvMakeTypeCh<CV_32S>), METH_O, "CV_32SC(channels) -> retval"}, \
+  {"CV_32FC", (PyCFunction)(pycvMakeTypeCh<CV_32F>), METH_O, "CV_32FC(channels) -> retval"}, \
+  {"CV_64FC", (PyCFunction)(pycvMakeTypeCh<CV_64F>), METH_O, "CV_64FC(channels) -> retval"}, \
+  {"CV_16FC", (PyCFunction)(pycvMakeTypeCh<CV_16F>), METH_O, "CV_16FC(channels) -> retval"},
 
 #endif  // HAVE_OPENCV_CORE
 #endif  // OPENCV_CORE_PYOPENCV_CORE_HPP

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -144,13 +144,14 @@ class Bindings(NewOpenCVTests):
 
     def test_maketype(self):
         data = {
-            cv.CV_8UC3: [cv.CV_8U, 3],
-            cv.CV_16SC1: [cv.CV_16S, 1],
-            cv.CV_32FC4: [cv.CV_32F, 4],
-            cv.CV_64FC2: [cv.CV_64F, 2],
+            cv.CV_8UC3: [cv.CV_8U, 3, cv.CV_8UC],
+            cv.CV_16SC1: [cv.CV_16S, 1, cv.CV_16SC],
+            cv.CV_32FC4: [cv.CV_32F, 4, cv.CV_32FC],
+            cv.CV_64FC2: [cv.CV_64F, 2, cv.CV_64FC],
         }
-        for ref, (depth, channels) in data.items():
+        for ref, (depth, channels, func) in data.items():
             self.assertEqual(ref, cv.CV_MAKETYPE(depth, channels))
+            self.assertEqual(ref, func(channels))
 
 
 class Arguments(NewOpenCVTests):


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/23628#issuecomment-1562468327

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
