### PR TITLE
Port to 5.x: Undistortion grid fix

### DIFF
--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2384,7 +2384,7 @@ to compute the optimal new camera matrix.
  */
 CV_EXPORTS void getUndistortRectangles(InputArray cameraMatrix, InputArray distCoeffs,
                                        InputArray R, InputArray newCameraMatrix, Size imgSize,
-                                       Rect_<float>& inner, Rect_<float>& outer );
+                                       Rect_<double>& inner, Rect_<double>& outer );
 
 /** @brief Returns the new camera intrinsic matrix based on the free scaling parameter.
 

--- a/modules/3d/src/calibration_base.cpp
+++ b/modules/3d/src/calibration_base.cpp
@@ -1363,27 +1363,27 @@ void cv::projectPoints( InputArray _opoints,
 
 void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs,
               InputArray R, InputArray newCameraMatrix, Size imgSize,
-              Rect_<float>& inner, Rect_<float>& outer )
+              Rect_<double>& inner, Rect_<double>& outer )
 {
     const int N = 9;
     int x, y, k;
-    Mat _pts(1, N*N, CV_32FC2);
-    Point2f* pts = _pts.ptr<Point2f>();
+    Mat _pts(1, N*N, CV_64FC2);
+    Point2d* pts = _pts.ptr<Point2d>();
 
     for( y = k = 0; y < N; y++ )
         for( x = 0; x < N; x++ )
-            pts[k++] = Point2f((float)x*imgSize.width/(N-1), (float)y*imgSize.height/(N-1));
+            pts[k++] = Point2d((double)x*(imgSize.width-1)/(N-1), (double)y*(imgSize.height-1)/(N-1));
 
     undistortPoints(_pts, _pts, _cameraMatrix, _distCoeffs, R, newCameraMatrix);
 
-    float iX0=-FLT_MAX, iX1=FLT_MAX, iY0=-FLT_MAX, iY1=FLT_MAX;
-    float oX0=FLT_MAX, oX1=-FLT_MAX, oY0=FLT_MAX, oY1=-FLT_MAX;
+    double iX0=-FLT_MAX, iX1=FLT_MAX, iY0=-FLT_MAX, iY1=FLT_MAX;
+    double oX0=FLT_MAX, oX1=-FLT_MAX, oY0=FLT_MAX, oY1=-FLT_MAX;
     // find the inscribed rectangle.
     // the code will likely not work with extreme rotation matrices (R) (>45%)
     for( y = k = 0; y < N; y++ )
         for( x = 0; x < N; x++ )
         {
-            Point2f p = pts[k++];
+            Point2d p = pts[k++];
             oX0 = MIN(oX0, p.x);
             oX1 = MAX(oX1, p.x);
             oY0 = MIN(oY0, p.y);
@@ -1398,15 +1398,15 @@ void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs
             if( y == N-1 )
                 iY1 = MIN(iY1, p.y);
         }
-    inner = Rect_<float>(iX0, iY0, iX1-iX0, iY1-iY0);
-    outer = Rect_<float>(oX0, oY0, oX1-oX0, oY1-oY0);
+    inner = Rect_<double>(iX0, iY0, iX1-iX0, iY1-iY0);
+    outer = Rect_<double>(oX0, oY0, oX1-oX0, oY1-oY0);
 }
 
 cv::Mat cv::getOptimalNewCameraMatrix( InputArray _cameraMatrix, InputArray _distCoeffs,
                                   Size imgSize, double alpha, Size newImgSize,
                                   Rect* validPixROI, bool centerPrincipalPoint )
 {
-    Rect_<float> inner, outer;
+    Rect_<double> inner, outer;
     newImgSize = newImgSize.width*newImgSize.height != 0 ? newImgSize : imgSize;
 
     Mat cameraMatrix = _cameraMatrix.getMat(), M;
@@ -1436,10 +1436,10 @@ cv::Mat cv::getOptimalNewCameraMatrix( InputArray _cameraMatrix, InputArray _dis
 
         if( validPixROI )
         {
-            inner = cv::Rect_<float>((float)((inner.x - cx0)*s + cx),
-                                     (float)((inner.y - cy0)*s + cy),
-                                     (float)(inner.width*s),
-                                     (float)(inner.height*s));
+            inner = cv::Rect_<double>((double)((inner.x - cx0)*s + cx),
+                                      (double)((inner.y - cy0)*s + cy),
+                                      (double)(inner.width*s),
+                                      (double)(inner.height*s));
             Rect r(cvCeil(inner.x), cvCeil(inner.y), cvFloor(inner.width), cvFloor(inner.height));
             r &= Rect(0, 0, newImgSize.width, newImgSize.height);
             *validPixROI = r;

--- a/modules/3d/test/test_undistort.cpp
+++ b/modules/3d/test/test_undistort.cpp
@@ -157,6 +157,104 @@ void CV_DefaultNewCameraMatrixTest::prepare_to_validation( int /*test_case_idx*/
 
 //---------
 
+class CV_GetOptimalNewCameraMatrixNoDistortionTest : public cvtest::ArrayTest
+{
+public:
+    CV_GetOptimalNewCameraMatrixNoDistortionTest();
+protected:
+    int prepare_test_case (int test_case_idx);
+    void prepare_to_validation(int test_case_idx);
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types);
+    void run_func();
+
+private:
+    cv::Mat camera_mat;
+    cv::Mat distortion_coeffs;
+    cv::Mat new_camera_mat;
+
+    cv::Size img_size;
+    double alpha;
+    bool center_principal_point;
+
+    int matrix_type;
+
+    static const int MAX_X = 2048;
+    static const int MAX_Y = 2048;
+};
+
+CV_GetOptimalNewCameraMatrixNoDistortionTest::CV_GetOptimalNewCameraMatrixNoDistortionTest()
+{
+    test_array[INPUT].push_back(NULL); // camera_mat
+    test_array[INPUT].push_back(NULL); // distortion_coeffs
+    test_array[OUTPUT].push_back(NULL); // new_camera_mat
+    test_array[REF_OUTPUT].push_back(NULL);
+
+    alpha = 0.0;
+    center_principal_point = false;
+    matrix_type = 0;
+}
+
+void CV_GetOptimalNewCameraMatrixNoDistortionTest::get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types)
+{
+    cvtest::ArrayTest::get_test_array_types_and_sizes(test_case_idx, sizes, types);
+    RNG& rng = ts->get_rng();
+    matrix_type = types[INPUT][0] = types[INPUT][1] = types[OUTPUT][0] = types[REF_OUTPUT][0] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
+    sizes[INPUT][0] = sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = cvSize(3,3);
+    sizes[INPUT][1] = cvSize(1,4);
+}
+
+int CV_GetOptimalNewCameraMatrixNoDistortionTest::prepare_test_case(int test_case_idx)
+{
+    int code = cvtest::ArrayTest::prepare_test_case( test_case_idx );
+
+    if (code <= 0)
+        return code;
+
+    RNG& rng = ts->get_rng();
+
+    alpha = cvtest::randReal(rng);
+    center_principal_point = ((cvtest::randInt(rng) % 2)!=0);
+
+    // Generate random camera matrix. Use floating point precision for source to avoid precision loss
+    img_size.width = cvtest::randInt(rng) % MAX_X + 1;
+    img_size.height = cvtest::randInt(rng) % MAX_Y + 1;
+    const float aspect_ratio = static_cast<float>(img_size.width) / img_size.height;
+    float cam_array[9] = {0,0,0,0,0,0,0,0,1};
+    cam_array[2] = static_cast<float>((img_size.width - 1)*0.5);  // center
+    cam_array[5] = static_cast<float>((img_size.height - 1)*0.5); // center
+    cam_array[0] = static_cast<float>(MAX(img_size.width, img_size.height)/(0.9 - cvtest::randReal(rng)*0.6));
+    cam_array[4] = aspect_ratio*cam_array[0];
+
+    Mat& input_camera_mat = test_mat[INPUT][0];
+    cvtest::convert(Mat(3, 3, CV_32F, cam_array), input_camera_mat, input_camera_mat.type());
+    camera_mat = input_camera_mat;
+
+    // Generate zero distortion matrix
+    const Mat zero_dist_coeffs = Mat::zeros(1, 4, CV_32F);
+    Mat& input_dist_coeffs = test_mat[INPUT][1];
+    cvtest::convert(zero_dist_coeffs, input_dist_coeffs, input_dist_coeffs.type());
+    distortion_coeffs = input_dist_coeffs;
+
+    return code;
+}
+
+void CV_GetOptimalNewCameraMatrixNoDistortionTest::run_func()
+{
+    new_camera_mat = cv::getOptimalNewCameraMatrix(camera_mat, distortion_coeffs, img_size, alpha, img_size, NULL, center_principal_point);
+}
+
+void CV_GetOptimalNewCameraMatrixNoDistortionTest::prepare_to_validation(int /*test_case_idx*/)
+{
+    const Mat& src = test_mat[INPUT][0];
+    Mat& dst = test_mat[REF_OUTPUT][0];
+    cvtest::copy(src, dst);
+
+    Mat& output = test_mat[OUTPUT][0];
+    cvtest::convert(new_camera_mat, output, output.type());
+}
+
+//---------
+
 class CV_UndistortPointsTest : public cvtest::ArrayTest
 {
 public:
@@ -991,6 +1089,7 @@ double CV_InitInverseRectificationMapTest::get_success_error_level( int /*test_c
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST(Calib3d_DefaultNewCameraMatrix, accuracy) { CV_DefaultNewCameraMatrixTest test; test.safe_run(); }
+TEST(Calib3d_GetOptimalNewCameraMatrixNoDistortion, accuracy) { CV_GetOptimalNewCameraMatrixNoDistortionTest test; test.safe_run(); }
 TEST(Calib3d_UndistortPoints, accuracy) { CV_UndistortPointsTest test; test.safe_run(); }
 TEST(Calib3d_InitUndistortRectifyMap, accuracy) { CV_InitUndistortRectifyMapTest test; test.safe_run(); }
 TEST(DISABLED_Calib3d_InitInverseRectificationMap, accuracy) { CV_InitInverseRectificationMapTest test; test.safe_run(); }

--- a/modules/stereo/src/stereo_geom.cpp
+++ b/modules/stereo/src/stereo_geom.cpp
@@ -236,7 +236,7 @@ void stereoRectify( InputArray _cameraMatrix1, InputArray _distCoeffs1,
 
     alpha = MIN(alpha, 1.);
 
-    cv::Rect_<float> inner1, inner2, outer1, outer2;
+    cv::Rect_<double> inner1, inner2, outer1, outer2;
     getUndistortRectangles(cameraMatrix1, distCoeffs1, _R1, _P1, imageSize, inner1, outer1);
     getUndistortRectangles(cameraMatrix2, distCoeffs2, _R2, _P2, imageSize, inner2, outer2);
 


### PR DESCRIPTION
Original issue: https://github.com/opencv/opencv/issues/23304
Original patch to 4.x: https://github.com/opencv/opencv/pull/23305

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
