### PR TITLE
better accuracy for _rotatedRectangleIntersection() (proposal for #23546)

### DIFF
--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -195,7 +195,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec2[j].x*normalizationScale ;
             const float C = -(A*pts2[j].x + B*pts2[j].y);
 
-            const float s = adjustToZero(A*x + B*y + C, 1e-6);
+            const float s = adjustToZero(A*x + B*y + C, 1e-6f);
 
             if( s >= 0 )
             {
@@ -238,7 +238,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec1[j].x*normalizationScale ;
             const float C = -(A*pts1[j].x + B*pts1[j].y);
 
-            const float s = adjustToZero(A*x + B*y + C, 1e-6);
+            const float s = adjustToZero(A*x + B*y + C, 1e-6f);
 
             if( s >= 0 )
             {

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,15 +47,9 @@
 namespace cv
 {
 
-static inline float adjustNormalizationScale(float value)
-{
-  float result = std::exp2(std::round(std::log2(value)));//force normalizationScale to be a power of 2 (even negative power)
-  return result;
-}
-
 static inline float adjustToZero(float value, float epsilon)
 {
-    return (std::abs(value)<epsilon) ? 0 : value;
+    return (std::fabs(value)<epsilon) ? 0 : value;
 }
 
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
@@ -133,10 +127,9 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float vx2 = vec2[j].x;
             float vy2 = vec2[j].y;
 
-            float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
+            float normalizationScale  = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
-            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -186,9 +179,8 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         for( int j = 0; j < 4; j++ )
         {
-            float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
+            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -229,9 +221,8 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
+            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -122,9 +122,10 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float vx2 = vec2[j].x;
             float vy2 = vec2[j].y;
 
-            float normalizationScale  = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
+            float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -174,8 +175,9 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         for( int j = 0; j < 4; j++ )
         {
-            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -216,8 +218,9 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,12 +47,6 @@
 namespace cv
 {
 
-static inline float adjustNormalizationScale(float value)
-{
-  float result = std::exp2(std::round(std::log2(value)));//force normalizationScale to be a power of 2 (even negative power)
-  return result;
-}
-
 static inline float adjustToZero(float value, float epsilon)
 {
     return (std::abs(value)<epsilon) ? 0 : value;
@@ -136,7 +130,6 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -188,7 +181,6 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -231,7 +223,6 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             // see which side of the line this point is at
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,6 +47,12 @@
 namespace cv
 {
 
+static inline float adjustNormalizationScale(float value)
+{
+  float result = std::exp2(std::round(std::log2(value)));//force normalizationScale to be a power of 2 (even negative power)
+  return result;
+}
+
 static inline float adjustToZero(float value, float epsilon)
 {
     return (std::abs(value)<epsilon) ? 0 : value;
@@ -130,6 +136,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = adjustNormalizationScale(normalizationScale);
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -181,6 +188,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = adjustNormalizationScale(normalizationScale);
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -223,6 +231,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             // see which side of the line this point is at
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
+            normalizationScale = adjustNormalizationScale(normalizationScale);
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,6 +47,12 @@
 namespace cv
 {
 
+static inline bool _isOnPositiveSide(const Point2f& line_vec, const Point2f& line_pt, const Point2f& pt)
+{
+    return (line_vec.y*(line_pt.x-pt.x) >= line_vec.x*(line_pt.y-pt.y));
+}
+//end _isOnPositiveSide()
+
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
 {
     CV_INSTRUMENT_REGION();
@@ -160,25 +166,19 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         int posSign = 0;
         int negSign = 0;
 
-        const float x = pts1[i].x;
-        const float y = pts1[i].y;
+        const Point2f& pt = pts1[i];
 
         for( int j = 0; j < 4; j++ )
         {
-            // line equation: Ax + By + C = 0
-            // see which side of the line this point is at
-            ////base algorithm
-            //const float A = -vec2[j].y;
-            //const float B = vec2[j].x;
-            //const float C = -(A*pts2[j].x + B*pts2[j].y);
-            //float s = A*x + B*y + C;//then compare to 0
-            //s = (std::fabs(s)<1e-6) ? 0 : s;//trick for numeric stability
-            ////computation reordering for better numerical stability
-            //const float s = vec2[j].y*(pts2[j].x-x)+vec2[j].x*(y-pts2[j].y);
+            // line equation: Ax + By + C = 0 where
+            // A = -vec2[j].y ; B = vec2[j].x ; C = -(A * pts2[j].x + B * pts2[j].y)
+            // check which side of the line this point is at
+            // A*x + B*y + C <> 0
+            // + computation reordered for better numerical stability
 
-            const bool isSPositive = (vec2[j].y*(pts2[j].x-x) >= vec2[j].x*(pts2[j].y-y));
+            const bool isPositive = _isOnPositiveSide(vec2[j], pts2[j], pt);
 
-            if( isSPositive )
+            if( isPositive )
             {
                 posSign++;
             }
@@ -203,25 +203,19 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         int posSign = 0;
         int negSign = 0;
 
-        const float x = pts2[i].x;
-        const float y = pts2[i].y;
+        const Point2f& pt = pts2[i];
 
         for( int j = 0; j < 4; j++ )
         {
-            // line equation: Ax + By + C = 0
-            // see which side of the line this point is at
-            ////base algorithm
-            //const float A = -vec1[j].y ;
-            //const float B = vec1[j].x ;
-            //const float C = -(A*pts1[j].x + B*pts1[j].y);
-            //float s = A*x + B*y + C;//then compare to 0
-            //s = (std::fabs(s)<1e-6) ? 0 : s;//trick for numeric stability
-            ////computation reordering for better numerical stability
-            //const float s = vec1[j].y*(pts1[j].x-x)+vec1[j].x*(y-pts1[j].y);
+            // line equation: Ax + By + C = 0 where
+            // A = -vec1[j].y ; B = vec1[j].x ; C = -(A * pts1[j].x + B * pts1[j].y)
+            // check which side of the line this point is at
+            // A*x + B*y + C <> 0
+            // + computation reordered for better numerical stability
 
-            const bool isSPositive = (vec1[j].y*(pts1[j].x-x) >= vec1[j].x*(pts1[j].y-y));
+            const bool isPositive = _isOnPositiveSide(vec1[j], pts1[j], pt);
 
-            if( isSPositive )
+            if( isPositive )
             {
                 posSign++;
             }

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -51,7 +51,6 @@ static inline bool _isOnPositiveSide(const Point2f& line_vec, const Point2f& lin
 {
     return (line_vec.y*(line_pt.x-pt.x) >= line_vec.x*(line_pt.y-pt.y));
 }
-//end _isOnPositiveSide()
 
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
 {

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,11 +47,6 @@
 namespace cv
 {
 
-static inline float adjustToZero(float value, float epsilon)
-{
-    return (std::fabs(value)<epsilon) ? 0 : value;
-}
-
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
 {
     CV_INSTRUMENT_REGION();
@@ -127,19 +122,10 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float vx2 = vec2[j].x;
             float vy2 = vec2[j].y;
 
-            float normalizationScale  = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
-            //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-
-            vx1 *= normalizationScale;
-            vy1 *= normalizationScale;
-            vx2 *= normalizationScale;
-            vy2 *= normalizationScale;
-
             const float det = vx2*vy1 - vx1*vy2;
-            if (std::abs(det) < 1e-12)//like normalizationScale, we consider accuracy around 1e-6, i.e. 1e-12 when squared
+            if (std::abs(det) < 1e-12)//we consider accuracy around 1e-6, i.e. 1e-12 when squared
               continue;
-            const float detInvScaled = normalizationScale/det;
+            const float detInvScaled = 1.f/det;
 
             const float t1 = (vx2*y21 - vy2*x21)*detInvScaled;
             const float t2 = (vx1*y21 - vy1*x21)*detInvScaled;
@@ -179,15 +165,14 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         for( int j = 0; j < 4; j++ )
         {
-            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            const float A = -vec2[j].y*normalizationScale ;
-            const float B = vec2[j].x*normalizationScale ;
+            /*const float A = -vec2[j].y;
+            const float B = vec2[j].x;
             const float C = -(A*pts2[j].x + B*pts2[j].y);
 
-            const float s = adjustToZero(A*x + B*y + C, 1e-6f);
+            const float s = adjustToZero(A*x + B*y + C, 1e-6f);*/
+            const float s = vec2[j].y*(pts2[j].x-x)+vec2[j].x*(y-pts2[j].y);
 
             if( s >= 0 )
             {
@@ -221,15 +206,12 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            if (std::isinf(normalizationScale ))
-                normalizationScale  = 1.f;
-            const float A = -vec1[j].y*normalizationScale ;
-            const float B = vec1[j].x*normalizationScale ;
+            /*const float A = -vec1[j].y ;
+            const float B = vec1[j].x ;
             const float C = -(A*pts1[j].x + B*pts1[j].y);
 
-            const float s = adjustToZero(A*x + B*y + C, 1e-6f);
+            const float s = adjustToZero(A*x+B*y+C, 1e-6f);*/
+            const float s = vec1[j].y*(pts1[j].x-x)+vec1[j].x*(y-pts1[j].y);
 
             if( s >= 0 )
             {

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -49,6 +49,9 @@ namespace cv
 
 static inline bool _isOnPositiveSide(const Point2f& line_vec, const Point2f& line_pt, const Point2f& pt)
 {
+    //we are interested by the cross product between the line vector (line_vec) and the line-to-pt vector (pt-line_pt)
+    //the sign of the only non-null component of the result determining which side of the line 'pt' is on
+    //the "positive" side meaning depends on the context usage of the current function and how line_vec and line_pt were filled
     return (line_vec.y*(line_pt.x-pt.x) >= line_vec.x*(line_pt.y-pt.y));
 }
 

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -49,7 +49,7 @@ namespace cv
 
 static inline float adjustNormalizationScale(float value)
 {
-  float result = std::exp2(std::round(std::log2(value)));
+  float result = std::exp2(std::round(std::log2(value)));//force normalizationScale to be a power of 2 (even negative power)
   return result;
 }
 
@@ -136,7 +136,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -188,7 +188,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -231,7 +231,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             // see which side of the line this point is at
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -51,28 +51,14 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 {
     CV_INSTRUMENT_REGION();
 
-    typedef double precision_t;
-    typedef cv::Point_<precision_t> point_t;
+    Point2f vec1[4], vec2[4];
+    Point2f pts1[4], pts2[4];
 
-    std::vector<point_t> __highPrecisionIntersections;
-    const bool useHighPrecisionIntersections = !std::is_same<point_t, cv::Point2f>();
-    std::vector<point_t>& _intersection = useHighPrecisionIntersections ? __highPrecisionIntersections : *reinterpret_cast<std::vector<point_t>*>(&intersection);
-
-
-    cv::Point2f _pts1[4], _pts2[4];
-    rect1.points(_pts1);
-    rect2.points(_pts2);
-
-    point_t vec1[4], vec2[4];
-    point_t pts1[4], pts2[4];
-    for(int i = 0 ; i<4 ;++i)
-    {
-        pts1[i] = _pts1[i];
-        pts2[i] = _pts2[i];
-    }
+    rect1.points(pts1);
+    rect2.points(pts2);
 
     // L2 metric
-    precision_t samePointEps = static_cast<precision_t>(1e-6) * static_cast<precision_t>(std::max(rect1.size.area(), rect2.size.area()));
+    float samePointEps = 1e-6f * (float)std::max(rect1.size.area(), rect2.size.area());
 
     int ret = INTERSECT_FULL;
 
@@ -91,17 +77,11 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         if(same)
         {
-            _intersection.resize(4);
+            intersection.resize(4);
 
             for( int i = 0; i < 4; i++ )
             {
-                _intersection[i] = pts1[i];
-            }
-
-            if (useHighPrecisionIntersections)
-            {
-                intersection.resize(_intersection.size());
-                std::copy(_intersection.begin(), _intersection.end(), intersection.begin());
+                intersection[i] = pts1[i];
             }
 
             return INTERSECT_FULL;
@@ -125,7 +105,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         samePointEps = std::min(samePointEps, std::sqrt(vec1[i].x*vec1[i].x+vec1[i].y*vec1[i].y));
         samePointEps = std::min(samePointEps, std::sqrt(vec2[i].x*vec2[i].x+vec2[i].y*vec2[i].y));
     }
-    samePointEps = std::max(static_cast<precision_t>(1e-16), samePointEps);
+    samePointEps = std::max(1e-16f, samePointEps);
 
     // Line test - test all line combos for intersection
     for( int i = 0; i < 4; i++ )
@@ -133,31 +113,31 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         for( int j = 0; j < 4; j++ )
         {
             // Solve for 2x2 Ax=b
-            const precision_t x21 = pts2[j].x - pts1[i].x;
-            const precision_t y21 = pts2[j].y - pts1[i].y;
+            const float x21 = pts2[j].x - pts1[i].x;
+            const float y21 = pts2[j].y - pts1[i].y;
 
-            precision_t vx1 = vec1[i].x;
-            precision_t vy1 = vec1[i].y;
+            float vx1 = vec1[i].x;
+            float vy1 = vec1[i].y;
 
-            precision_t vx2 = vec2[j].x;
-            precision_t vy2 = vec2[j].y;
+            float vx2 = vec2[j].x;
+            float vy2 = vec2[j].y;
 
-            precision_t normalizationScale  = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
+            float normalizationScale  = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
-            normalizationScale  = (normalizationScale < static_cast<precision_t>(1e-12)) ? static_cast<precision_t>(1.) : static_cast<precision_t>(1.)/normalizationScale;
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
             vx2 *= normalizationScale;
             vy2 *= normalizationScale;
 
-            const precision_t det = vx2*vy1 - vx1*vy2;
-            if (std::abs(det) < static_cast<precision_t>(1e-12))//like normalizationScale, we consider accuracy around 1e-6, i.e. 1e-12 when squared
+            const float det = vx2*vy1 - vx1*vy2;
+            if (std::abs(det) < 1e-12)//like normalizationScale, we consider accuracy around 1e-6, i.e. 1e-12 when squared
               continue;
-            const precision_t detInvScaled = normalizationScale/det;
+            const float detInvScaled = normalizationScale/det;
 
-            const precision_t t1 = (vx2*y21 - vy2*x21)*detInvScaled;
-            const precision_t t2 = (vx1*y21 - vy1*x21)*detInvScaled;
+            const float t1 = (vx2*y21 - vy2*x21)*detInvScaled;
+            const float t2 = (vx1*y21 - vy1*x21)*detInvScaled;
 
             // This takes care of parallel lines
             if( cvIsInf(t1) || cvIsInf(t2) || cvIsNaN(t1) || cvIsNaN(t2) )
@@ -165,17 +145,17 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
                 continue;
             }
 
-            if( t1 >= static_cast<precision_t>(0.) && t1 <= static_cast<precision_t>(1.) && t2 >= static_cast<precision_t>(0.) && t2 <= static_cast<precision_t>(1.) )
+            if( t1 >= 0.0f && t1 <= 1.0f && t2 >= 0.0f && t2 <= 1.0f )
             {
-                const precision_t xi = pts1[i].x + vec1[i].x*t1;
-                const precision_t yi = pts1[i].y + vec1[i].y*t1;
+                const float xi = pts1[i].x + vec1[i].x*t1;
+                const float yi = pts1[i].y + vec1[i].y*t1;
 
-                _intersection.push_back(point_t(xi,yi));
+                intersection.push_back(Point2f(xi,yi));
             }
         }
     }
 
-    if( !_intersection.empty() )
+    if( !intersection.empty() )
     {
         ret = INTERSECT_PARTIAL;
     }
@@ -189,20 +169,20 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         int posSign = 0;
         int negSign = 0;
 
-        const precision_t x = pts1[i].x;
-        const precision_t y = pts1[i].y;
+        const float x = pts1[i].x;
+        const float y = pts1[i].y;
 
         for( int j = 0; j < 4; j++ )
         {
-            precision_t normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < static_cast<precision_t>(1e-12)) ? static_cast<precision_t>(1.) : static_cast<precision_t>(1.)/normalizationScale;
+            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            const precision_t A = -vec2[j].y*normalizationScale ;
-            const precision_t B = vec2[j].x*normalizationScale ;
-            const precision_t C = -(A*pts2[j].x + B*pts2[j].y);
+            const float A = -vec2[j].y*normalizationScale ;
+            const float B = vec2[j].x*normalizationScale ;
+            const float C = -(A*pts2[j].x + B*pts2[j].y);
 
-            const precision_t s = A*x + B*y + C;
+            const float s = A*x + B*y + C;
 
             if( s >= 0 )
             {
@@ -216,7 +196,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         if( posSign == 4 || negSign == 4 )
         {
-            _intersection.push_back(pts1[i]);
+            intersection.push_back(pts1[i]);
         }
     }
 
@@ -229,22 +209,22 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         int posSign = 0;
         int negSign = 0;
 
-        const precision_t x = pts2[i].x;
-        const precision_t y = pts2[i].y;
+        const float x = pts2[i].x;
+        const float y = pts2[i].y;
 
         for( int j = 0; j < 4; j++ )
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            precision_t normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
-            normalizationScale  = (normalizationScale < static_cast<precision_t>(1e-12)) ? static_cast<precision_t>(1.) : static_cast<precision_t>(1.)/normalizationScale;
+            float normalizationScale  = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
+            normalizationScale  = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
             if (std::isinf(normalizationScale ))
-                normalizationScale = static_cast<precision_t>(1.);
-            const precision_t A = -vec1[j].y*normalizationScale ;
-            const precision_t B = vec1[j].x*normalizationScale ;
-            const precision_t C = -(A*pts1[j].x + B*pts1[j].y);
+                normalizationScale  = 1.f;
+            const float A = -vec1[j].y*normalizationScale ;
+            const float B = vec1[j].x*normalizationScale ;
+            const float C = -(A*pts1[j].x + B*pts1[j].y);
 
-            const precision_t s = A*x + B*y + C;
+            const float s = A*x + B*y + C;
 
             if( s >= 0 )
             {
@@ -258,34 +238,32 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
 
         if( posSign == 4 || negSign == 4 )
         {
-            _intersection.push_back(pts2[i]);
+            intersection.push_back(pts2[i]);
         }
     }
 
-    int N = (int)_intersection.size();
+    int N = (int)intersection.size();
     if (N == 0)
     {
-        if (useHighPrecisionIntersections)
-          intersection.resize(0);
         return INTERSECT_NONE;
     }
 
     // Get rid of duplicated points
     const int Nstride = N;
-    cv::AutoBuffer<precision_t, 100> distPt(N * N);
+    cv::AutoBuffer<float, 100> distPt(N * N);
     cv::AutoBuffer<int> ptDistRemap(N);
     for (int i = 0; i < N; ++i)
     {
-        const point_t pt0 = _intersection[i];
+        const Point2f pt0 = intersection[i];
         ptDistRemap[i] = i;
         for (int j = i + 1; j < N; )
         {
-            const point_t pt1 = _intersection[j];
-            const precision_t d2 = normL2Sqr<precision_t>(pt1 - pt0);
+            const Point2f pt1 = intersection[j];
+            const float d2 = normL2Sqr<float>(pt1 - pt0);
             if(d2 <= samePointEps)
             {
                 if (j < N - 1)
-                    _intersection[j] =  _intersection[N - 1];
+                    intersection[j] =  intersection[N - 1];
                 N--;
                 continue;
             }
@@ -297,13 +275,13 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
     {
         int minI = 0;
         int minJ = 1;
-        precision_t minD = distPt[1];
+        float minD = distPt[1];
         for (int i = 0; i < N - 1; ++i)
         {
-            const precision_t* pDist = distPt.data() + Nstride * ptDistRemap[i];
+            const float* pDist = distPt.data() + Nstride * ptDistRemap[i];
             for (int j = i + 1; j < N; ++j)
             {
-                const precision_t d = pDist[ptDistRemap[j]];
+                const float d = pDist[ptDistRemap[j]];
                 if (d < minD)
                 {
                     minD = d;
@@ -312,11 +290,11 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
                 }
             }
         }
-        CV_Assert(fabs(normL2Sqr<precision_t>(_intersection[minI] - _intersection[minJ]) - minD) < static_cast<precision_t>(1e-6));  // ptDistRemap is not corrupted
+        CV_Assert(fabs(normL2Sqr<float>(intersection[minI] - intersection[minJ]) - minD) < 1e-6);  // ptDistRemap is not corrupted
         // drop minJ point
         if (minJ < N - 1)
         {
-            _intersection[minJ] =  _intersection[N - 1];
+            intersection[minJ] =  intersection[N - 1];
             ptDistRemap[minJ] = ptDistRemap[N - 1];
         }
         N--;
@@ -325,24 +303,19 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
     // order points
     for (int i = 0; i < N - 1; ++i)
     {
-        point_t diffI = _intersection[i + 1] - _intersection[i];
+        Point2f diffI = intersection[i + 1] - intersection[i];
         for (int j = i + 2; j < N; ++j)
         {
-            point_t diffJ = _intersection[j] - _intersection[i];
+            Point2f diffJ = intersection[j] - intersection[i];
             if (diffI.cross(diffJ) < 0)
             {
-                std::swap(_intersection[i + 1], _intersection[j]);
+                std::swap(intersection[i + 1], intersection[j]);
                 diffI = diffJ;
             }
         }
     }
 
-    _intersection.resize(N);
-    if (useHighPrecisionIntersections)
-    {
-        intersection.resize(_intersection.size());
-        std::copy(_intersection.begin(), _intersection.end(), intersection.begin());
-    }
+    intersection.resize(N);
 
     return ret;
 }

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -167,15 +167,18 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            /*const float A = -vec2[j].y;
-            const float B = vec2[j].x;
-            const float C = -(A*pts2[j].x + B*pts2[j].y);
+            ////base algorithm
+            //const float A = -vec2[j].y;
+            //const float B = vec2[j].x;
+            //const float C = -(A*pts2[j].x + B*pts2[j].y);
+            //float s = A*x + B*y + C;//then compare to 0
+            //s = (std::fabs(s)<1e-6) ? 0 : s;//trick for numeric stability
+            ////computation reordering for better numerical stability
+            //const float s = vec2[j].y*(pts2[j].x-x)+vec2[j].x*(y-pts2[j].y);
 
-            float s = A*x + B*y + C;
-            s = (std::fabs(s)<1e-6) ? 0 : s;*/
-            const float s = vec2[j].y*(pts2[j].x-x)+vec2[j].x*(y-pts2[j].y);
+            const bool isSPositive = (vec2[j].y*(pts2[j].x-x) >= vec2[j].x*(pts2[j].y-y));
 
-            if( s >= 0 )
+            if( isSPositive )
             {
                 posSign++;
             }
@@ -207,15 +210,18 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
-            /*const float A = -vec1[j].y ;
-            const float B = vec1[j].x ;
-            const float C = -(A*pts1[j].x + B*pts1[j].y);
+            ////base algorithm
+            //const float A = -vec1[j].y ;
+            //const float B = vec1[j].x ;
+            //const float C = -(A*pts1[j].x + B*pts1[j].y);
+            //float s = A*x + B*y + C;//then compare to 0
+            //s = (std::fabs(s)<1e-6) ? 0 : s;//trick for numeric stability
+            ////computation reordering for better numerical stability
+            //const float s = vec1[j].y*(pts1[j].x-x)+vec1[j].x*(y-pts1[j].y);
 
-            float s = A*x + B*y + C;
-            s = (std::fabs(s)<1e-6) ? 0 : s;*/
-            const float s = vec1[j].y*(pts1[j].x-x)+vec1[j].x*(y-pts1[j].y);
+            const bool isSPositive = (vec1[j].y*(pts1[j].x-x) >= vec1[j].x*(pts1[j].y-y));
 
-            if( s >= 0 )
+            if( isSPositive )
             {
                 posSign++;
             }

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -53,6 +53,11 @@ static inline float adjustNormalizationScale(float value)
   return result;
 }
 
+static inline float adjustToZero(float value, float epsilon)
+{
+    return (std::abs(value)<epsilon) ? 0 : value;
+}
+
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
 {
     CV_INSTRUMENT_REGION();
@@ -190,7 +195,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec2[j].x*normalizationScale ;
             const float C = -(A*pts2[j].x + B*pts2[j].y);
 
-            const float s = A*x + B*y + C;
+            const float s = adjustToZero(A*x + B*y + C, 1e-6);
 
             if( s >= 0 )
             {
@@ -233,7 +238,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec1[j].x*normalizationScale ;
             const float C = -(A*pts1[j].x + B*pts1[j].y);
 
-            const float s = A*x + B*y + C;
+            const float s = adjustToZero(A*x + B*y + C, 1e-6);
 
             if( s >= 0 )
             {

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -171,7 +171,8 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec2[j].x;
             const float C = -(A*pts2[j].x + B*pts2[j].y);
 
-            const float s = adjustToZero(A*x + B*y + C, 1e-6f);*/
+            float s = A*x + B*y + C;
+            s = (std::fabs(s)<1e-6) ? 0 : s;*/
             const float s = vec2[j].y*(pts2[j].x-x)+vec2[j].x*(y-pts2[j].y);
 
             if( s >= 0 )
@@ -210,7 +211,8 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             const float B = vec1[j].x ;
             const float C = -(A*pts1[j].x + B*pts1[j].y);
 
-            const float s = adjustToZero(A*x+B*y+C, 1e-6f);*/
+            float s = A*x + B*y + C;
+            s = (std::fabs(s)<1e-6) ? 0 : s;*/
             const float s = vec1[j].y*(pts1[j].x-x)+vec1[j].x*(y-pts1[j].y);
 
             if( s >= 0 )

--- a/modules/imgproc/src/intersection.cpp
+++ b/modules/imgproc/src/intersection.cpp
@@ -47,6 +47,12 @@
 namespace cv
 {
 
+static inline float adjustNormalizationScale(float value)
+{
+  float result = std::exp2(std::round(std::log2(value)));
+  return result;
+}
+
 static int _rotatedRectangleIntersection( const RotatedRect& rect1, const RotatedRect& rect2, std::vector<Point2f> &intersection )
 {
     CV_INSTRUMENT_REGION();
@@ -125,7 +131,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             float normalizationScale = std::min(vx1*vx1+vy1*vy1, vx2*vx2+vy2*vy2);//sum of squares : this is >= 0
             //normalizationScale is a square, and we usually limit accuracy around 1e-6, so normalizationScale should be rather limited by ((1e-6)^2)=1e-12
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
 
             vx1 *= normalizationScale;
             vy1 *= normalizationScale;
@@ -177,7 +183,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
         {
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
             // line equation: Ax + By + C = 0
             // see which side of the line this point is at
             const float A = -vec2[j].y*normalizationScale ;
@@ -220,7 +226,7 @@ static int _rotatedRectangleIntersection( const RotatedRect& rect1, const Rotate
             // see which side of the line this point is at
             float normalizationScale = vec2[j].x*vec2[j].x+vec2[j].y*vec2[j].y;
             normalizationScale = (normalizationScale < 1e-12f) ? 1.f : 1.f/normalizationScale;
-            normalizationScale = std::exp2(std::round(std::log2(normalizationScale)));//force normalizationScale to be a power of 2 (even negative power)
+            normalizationScale = adjustNormalizationScale(normalizationScale);//force normalizationScale to be a power of 2 (even negative power)
             if (std::isinf(normalizationScale ))
                 normalizationScale  = 1.f;
             const float A = -vec1[j].y*normalizationScale ;

--- a/modules/imgproc/test/test_intersection.cpp
+++ b/modules/imgproc/test/test_intersection.cpp
@@ -489,17 +489,20 @@ TEST(Imgproc_RotatedRectangleIntersection, regression_19824)
 TEST(Imgproc_RotatedRectangleIntersection, accuracy_23546)
 {
     RotatedRect r1(
-        Point2f(824.6421183672817, 280.28737007069833),
-        Size2f(565.0, 140.0),
-        -177.80506896972656);
+        Point2f(824.6421183672817f, 280.28737007069833f),
+        Size2f(565.0f, 140.0f),
+        -177.80506896972656f);
     RotatedRect r2(
-        Point2f(567.3310438828003, 270.42527355719545),
-        Size2f(275.0, 50.0),
-        92.19493103027344);
+        Point2f(567.3310438828003f, 270.42527355719545f),
+        Size2f(275.0f, 50.0f),
+        92.19493103027344f);
 
-    std::vector<Point2f> intersections;
-    int interType = cv::rotatedRectangleIntersection(r1, r2, intersections);
+    std::vector<Point2f> intersection;
+    double intersectionArea = 0;
+    int interType = cv::rotatedRectangleIntersection(r1, r2, intersection);
+    intersectionArea = (intersection.size() <= 2) ? 0. : cv::contourArea(intersection);
     EXPECT_EQ(INTERSECT_PARTIAL, interType);
-    EXPECT_EQ(intersections.size(), (size_t)4);
+    EXPECT_EQ(intersection.size(), (size_t)4);
+    ASSERT_LE(std::abs(intersectionArea-7000), 1e-1);
 }
 }} // namespace

--- a/modules/imgproc/test/test_intersection.cpp
+++ b/modules/imgproc/test/test_intersection.cpp
@@ -489,17 +489,21 @@ TEST(Imgproc_RotatedRectangleIntersection, regression_19824)
 TEST(Imgproc_RotatedRectangleIntersection, accuracy_23546)
 {
     RotatedRect r1(
-        Point2f(824.6421183672817, 280.28737007069833),
-        Size2f(565.0, 140.0),
-        -177.80506896972656);
+        Point2f(824.6421183672817f, 280.28737007069833f),
+        Size2f(565.0f, 140.0f),
+        -177.80506896972656f);
     RotatedRect r2(
-        Point2f(567.3310438828003, 270.42527355719545),
-        Size2f(275.0, 50.0),
-        92.19493103027344);
+        Point2f(567.3310438828003f, 270.42527355719545f),
+        Size2f(275.0f, 50.0f),
+        92.19493103027344f);
 
-    std::vector<Point2f> intersections;
-    int interType = cv::rotatedRectangleIntersection(r1, r2, intersections);
+    std::vector<Point2f> intersection;
+    double intersectionArea = 0;
+
+    int interType = cv::rotatedRectangleIntersection(r1, r2, intersection);
     EXPECT_EQ(INTERSECT_PARTIAL, interType);
-    EXPECT_EQ(intersections.size(), (size_t)4);
+    EXPECT_EQ(intersection.size(), (size_t)4);
+    intersectionArea = (intersection.size() <= 2) ? 0. : cv::contourArea(intersection);
+    ASSERT_LE(std::abs(intersectionArea-7000), 1e-1);
 }
 }} // namespace

--- a/modules/imgproc/test/test_intersection.cpp
+++ b/modules/imgproc/test/test_intersection.cpp
@@ -489,21 +489,17 @@ TEST(Imgproc_RotatedRectangleIntersection, regression_19824)
 TEST(Imgproc_RotatedRectangleIntersection, accuracy_23546)
 {
     RotatedRect r1(
-        Point2f(824.6421183672817f, 280.28737007069833f),
-        Size2f(565.0f, 140.0f),
-        -177.80506896972656f);
+        Point2f(824.6421183672817, 280.28737007069833),
+        Size2f(565.0, 140.0),
+        -177.80506896972656);
     RotatedRect r2(
-        Point2f(567.3310438828003f, 270.42527355719545f),
-        Size2f(275.0f, 50.0f),
-        92.19493103027344f);
+        Point2f(567.3310438828003, 270.42527355719545),
+        Size2f(275.0, 50.0),
+        92.19493103027344);
 
-    std::vector<Point2f> intersection;
-    double intersectionArea = 0;
-
-    int interType = cv::rotatedRectangleIntersection(r1, r2, intersection);
+    std::vector<Point2f> intersections;
+    int interType = cv::rotatedRectangleIntersection(r1, r2, intersections);
     EXPECT_EQ(INTERSECT_PARTIAL, interType);
-    EXPECT_EQ(intersection.size(), (size_t)4);
-    intersectionArea = (intersection.size() <= 2) ? 0. : cv::contourArea(intersection);
-    ASSERT_LE(std::abs(intersectionArea-7000), 1e-1);
+    EXPECT_EQ(intersections.size(), (size_t)4);
 }
 }} // namespace

--- a/modules/imgproc/test/test_intersection.cpp
+++ b/modules/imgproc/test/test_intersection.cpp
@@ -486,4 +486,20 @@ TEST(Imgproc_RotatedRectangleIntersection, regression_19824)
     EXPECT_LE(intersections.size(), (size_t)7);
 }
 
+TEST(Imgproc_RotatedRectangleIntersection, accuracy_23546)
+{
+    RotatedRect r1(
+        Point2f(824.6421183672817, 280.28737007069833),
+        Size2f(565.0, 140.0),
+        -177.80506896972656);
+    RotatedRect r2(
+        Point2f(567.3310438828003, 270.42527355719545),
+        Size2f(275.0, 50.0),
+        92.19493103027344);
+
+    std::vector<Point2f> intersections;
+    int interType = cv::rotatedRectangleIntersection(r1, r2, intersections);
+    EXPECT_EQ(INTERSECT_PARTIAL, interType);
+    EXPECT_EQ(intersections.size(), (size_t)4);
+}
 }} // namespace


### PR DESCRIPTION
_rotatedRectangleIntersection() can be (statically) customized to use double instead of float for better accuracy

this is a proposal for experimentation around #23546

for better accuracy, _rotatedRectangleIntersection() could use double. It will still return cv::Point2f list for backward compatibility, but the inner computations are controlled by a typedef

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
