### PR TITLE
Import and export np.float16 in Python

### DIFF
--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -771,9 +771,9 @@ double norm( InputArray _src, int normType, InputArray _mask )
 
     if( normType == NORM_INF )
     {
-        if(depth == CV_64F || depth == CV_16F)
+        if(depth == CV_64F)
             return result.d;
-        else if (depth == CV_32F)
+        else if (depth == CV_32F || depth == CV_16F)
             return result.f;
         else
             return result.i;
@@ -1243,9 +1243,9 @@ double norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask 
 
     if( normType == NORM_INF )
     {
-        if (depth == CV_64F || depth == CV_16F)
+        if (depth == CV_64F)
             return result.d;
-        else if (depth == CV_32F)
+        else if (depth == CV_32F || depth == CV_16F)
             return result.f;
         else
             return result.u;

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -753,7 +753,7 @@ double norm( InputArray _src, int normType, InputArray _mask )
             {
                 int bsz = std::min(total - j, blockSize);
                 hal::cvt16f32f((const float16_t*)ptrs[0], data0, bsz * cn);
-                func((uchar*)data0, ptrs[1], (uchar*)&result.d, bsz, cn);
+                func((uchar*)data0, ptrs[1], (uchar*)&result.f, bsz, cn);
                 ptrs[0] += bsz*esz;
                 if (ptrs[1])
                     ptrs[1] += bsz;
@@ -1224,7 +1224,7 @@ double norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask 
                 int bsz = std::min(total - j, blockSize);
                 hal::cvt16f32f((const float16_t*)ptrs[0], data0, bsz * cn);
                 hal::cvt16f32f((const float16_t*)ptrs[1], data1, bsz * cn);
-                func((uchar*)data0, (uchar*)data1, ptrs[2], (uchar*)&result.d, bsz, cn);
+                func((uchar*)data0, (uchar*)data1, ptrs[2], (uchar*)&result.f, bsz, cn);
                 ptrs[0] += bsz*esz;
                 ptrs[1] += bsz*esz;
                 if (ptrs[2])

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -88,6 +88,7 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
                typenum == NPY_SHORT ? CV_16S :
                typenum == NPY_INT ? CV_32S :
                typenum == NPY_INT32 ? CV_32S :
+               typenum == NPY_HALF ? CV_16F :
                typenum == NPY_FLOAT ? CV_32F :
                typenum == NPY_DOUBLE ? CV_64F : -1;
 

--- a/modules/python/src2/cv2_numpy.cpp
+++ b/modules/python/src2/cv2_numpy.cpp
@@ -39,7 +39,7 @@ UMatData* NumpyAllocator::allocate(int dims0, const int* sizes, int type, void* 
     int typenum = depth == CV_8U ? NPY_UBYTE : depth == CV_8S ? NPY_BYTE :
     depth == CV_16U ? NPY_USHORT : depth == CV_16S ? NPY_SHORT :
     depth == CV_32S ? NPY_INT : depth == CV_32F ? NPY_FLOAT :
-    depth == CV_64F ? NPY_DOUBLE : f*NPY_ULONGLONG + (f^1)*NPY_UINT;
+    depth == CV_64F ? NPY_DOUBLE : depth == CV_16F ? NPY_HALF : f*NPY_ULONGLONG + (f^1)*NPY_UINT;
     int i, dims = dims0;
     cv::AutoBuffer<npy_intp> _sizes(dims + 1);
     for( i = 0; i < dims; i++ )

--- a/modules/python/test/test_norm.py
+++ b/modules/python/test/test_norm.py
@@ -88,7 +88,7 @@ def get_element_types(norm_type):
         return (np.uint8,)
     else:
         return (np.uint8, np.int8, np.uint16, np.int16, np.int32, np.float32,
-                np.float64)
+                np.float64, np.float16)
 
 
 def generate_vector(shape, dtype):


### PR DESCRIPTION
### Pull Request Readiness Checklist

* Also, fixes `cv::norm` with `NORM_INF` and `CV_16F`

resolves https://github.com/opencv/opencv/issues/23687

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
