### PR TITLE
imgproc: add basic IntelligentScissorsMB performance test

### DIFF
--- a/modules/imgproc/perf/perf_intelligent_scissors.cpp
+++ b/modules/imgproc/perf/perf_intelligent_scissors.cpp
@@ -6,23 +6,15 @@
 namespace opencv_test { namespace {
 
 
-Mat getTestImage(int flags = IMREAD_COLOR)
-{
-    static Mat m;
-    if (m.empty())
-    {
-        m = imread(findDataFile("cv/shared/lena.png"), flags);
-    }
-    return m.clone();
-}
-
 typedef perf::TestBaseWithParam<int> TestIntelligentScissorsMB;
 
 PERF_TEST_P(TestIntelligentScissorsMB, buildMap, testing::Values( IMREAD_GRAYSCALE, IMREAD_COLOR ))
 {
     const int flags = GetParam();
 
-    const Mat image = getTestImage(flags);
+    const Mat image = imread(findDataFile("cv/shared/lena.png"), flags);
+    ASSERT_TRUE(!image.empty());
+
     const Point source_point(275, 63);
 
     segmentation::IntelligentScissorsMB tool;

--- a/modules/imgproc/perf/perf_intelligent_scissors.cpp
+++ b/modules/imgproc/perf/perf_intelligent_scissors.cpp
@@ -16,7 +16,7 @@ Mat getTestImage(int flags = IMREAD_COLOR)
     return m.clone();
 }
 
-typedef perf::TestBaseWithParam<bool> TestIntelligentScissorsMB;
+typedef perf::TestBaseWithParam<int> TestIntelligentScissorsMB;
 
 PERF_TEST_P(TestIntelligentScissorsMB, buildMap, testing::Values( IMREAD_GRAYSCALE, IMREAD_COLOR ))
 {

--- a/modules/imgproc/perf/perf_intelligent_scissors.cpp
+++ b/modules/imgproc/perf/perf_intelligent_scissors.cpp
@@ -1,0 +1,42 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "perf_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+
+Mat getTestImage(int flags = IMREAD_COLOR)
+{
+    static Mat m;
+    if (m.empty())
+    {
+        m = imread(findDataFile("cv/shared/lena.png"), flags);
+    }
+    return m.clone();
+}
+
+typedef perf::TestBaseWithParam<bool> TestIntelligentScissorsMB;
+
+PERF_TEST_P(TestIntelligentScissorsMB, buildMap, testing::Values( IMREAD_GRAYSCALE, IMREAD_COLOR ))
+{
+    const int flags = GetParam();
+
+    const Mat image = getTestImage(flags);
+    const Point source_point(275, 63);
+
+    segmentation::IntelligentScissorsMB tool;
+    tool.applyImage(image);
+
+    PERF_SAMPLE_BEGIN()
+    for (size_t idx = 1; idx <= 100; ++idx)
+    {
+        tool.buildMap(source_point);
+    }
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}
+
+
+}} // namespace


### PR DESCRIPTION
Adding basic performance test that can be used before and after the #21959 changes etc. as per @asmorkalov's https://github.com/opencv/opencv/pull/21959#issuecomment-1565240926 comment.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
