### PR TITLE
Added missing index for skipping subgraph simplification 

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -808,7 +808,7 @@ public:
                         const Ptr<ImportNodeWrapper> node_to_check = net->getNode(i);
                         int numInp = node_to_check->getNumInputs();
                         for (int inp = 0; inp < numInp; ++inp) {
-                            if (i != nodeToMatch && inpNodeName == node_to_check->getInputName(0)) {
+                            if (i != nodeToMatch && inpNodeName == node_to_check->getInputName(inp)) {
                                 // Another node has the same input node, so it cannot be merged.
                                 return false;
                             }


### PR DESCRIPTION
Added missing index for skipping branched subgraph simplification (such subgraphs are not valid for simplification)

This PR partially fixes issue reported here [#21634](https://github.com/opencv/opencv/issues/21634) 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
