### PR TITLE
Fixed OpenJPEG 2000 compiler warning for some GCC versions (#23710)

### DIFF
--- a/3rdparty/openjpeg/CMakeLists.txt
+++ b/3rdparty/openjpeg/CMakeLists.txt
@@ -15,6 +15,7 @@ ocv_warnings_disable(CMAKE_C_FLAGS
     -Wimplicit-const-int-float-conversion  # clang
     -Wunused-but-set-variable # clang15
     -Wmissing-prototypes # clang, function opj_t1_ht_decode_cblk
+    -Wmissing-declarations # gcc, function opj_t1_ht_decode_cblk
 )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Address: https://github.com/opencv/opencv/issues/23710
Warning introduced in https://github.com/opencv/opencv/pull/23682
Technically, there is function prototype in openjp2/ht_dec.c:1096. It's only place where the function is used. I added warning suppression.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
