### PR TITLE
fixing typo in stitching parameter names

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/motion_estimators.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/motion_estimators.hpp
@@ -353,8 +353,8 @@ void CV_EXPORTS_W waveCorrect(CV_IN_OUT std::vector<Mat> &rmats, WaveCorrectKind
 // Auxiliary functions
 
 // Returns matches graph representation in DOT language
-String CV_EXPORTS_W matchesGraphAsString(std::vector<String> &pathes, std::vector<MatchesInfo> &pairwise_matches,
-                                            float conf_threshold);
+String CV_EXPORTS_W matchesGraphAsString(std::vector<String> &paths, std::vector<MatchesInfo> &pairwise_matches,
+                                         float conf_threshold);
 
 CV_EXPORTS_W std::vector<int>  leaveBiggestComponent(
         std::vector<ImageFeatures> &features,

--- a/modules/stitching/src/motion_estimators.cpp
+++ b/modules/stitching/src/motion_estimators.cpp
@@ -1018,13 +1018,13 @@ void waveCorrect(std::vector<Mat> &rmats, WaveCorrectKind kind)
 
 //////////////////////////////////////////////////////////////////////////////
 
-String matchesGraphAsString(std::vector<String> &pathes, std::vector<MatchesInfo> &pairwise_matches,
-                                float conf_threshold)
+String matchesGraphAsString(std::vector<String> &paths, std::vector<MatchesInfo> &pairwise_matches,
+                            float conf_threshold)
 {
     std::stringstream str;
     str << "graph matches_graph{\n";
 
-    const int num_images = static_cast<int>(pathes.size());
+    const int num_images = static_cast<int>(paths.size());
     std::set<std::pair<int,int> > span_tree_edges;
     DisjointSets comps(num_images);
 
@@ -1050,12 +1050,12 @@ String matchesGraphAsString(std::vector<String> &pathes, std::vector<MatchesInfo
         std::pair<int,int> edge = *itr;
         if (span_tree_edges.find(edge) != span_tree_edges.end())
         {
-            String name_src = pathes[edge.first];
+            String name_src = paths[edge.first];
             size_t prefix_len = name_src.find_last_of("/\\");
             if (prefix_len != String::npos) prefix_len++; else prefix_len = 0;
             name_src = name_src.substr(prefix_len, name_src.size() - prefix_len);
 
-            String name_dst = pathes[edge.second];
+            String name_dst = paths[edge.second];
             prefix_len = name_dst.find_last_of("/\\");
             if (prefix_len != String::npos) prefix_len++; else prefix_len = 0;
             name_dst = name_dst.substr(prefix_len, name_dst.size() - prefix_len);
@@ -1072,7 +1072,7 @@ String matchesGraphAsString(std::vector<String> &pathes, std::vector<MatchesInfo
     {
         if (comps.size[comps.findSetByElem((int)i)] == 1)
         {
-            String name = pathes[i];
+            String name = paths[i];
             size_t prefix_len = name.find_last_of("/\\");
             if (prefix_len != String::npos) prefix_len++; else prefix_len = 0;
             name = name.substr(prefix_len, name.size() - prefix_len);


### PR DESCRIPTION
Fixing a typo in file `modules/stitching/include/opencv2/stitching/detail/motion_estimators.hpp` and `motion_estimators.cpp`, since the correct plural of "path" is "paths", not "pathes".
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
