### PR TITLE
 imgproc/cvtColor: fixed invalid read in BGR2HLS

### DIFF
--- a/modules/imgproc/src/color_hsv.simd.hpp
+++ b/modules/imgproc/src/color_hsv.simd.hpp
@@ -813,11 +813,10 @@ struct RGB2HLS_b
         //TODO: fix that when v_interleave is available
         float CV_DECL_ALIGNED(CV_SIMD_WIDTH) interTmpM[VTraits<v_float32>::max_nlanes*3];
         v_store_interleave(interTmpM, vx_setall_f32(1.f), vx_setall_f32(255.f), vx_setall_f32(255.f));
-        v_float32 mhls0, mhls1, mhls2, mhls3;
+        v_float32 mhls0, mhls1, mhls2;
         mhls0 = vx_load_aligned(interTmpM);
         mhls1 = vx_load_aligned(interTmpM + fsize);
         mhls2 = vx_load_aligned(interTmpM + 2*fsize);
-        mhls3 = vx_load_aligned(interTmpM + 3*fsize);
 #endif
 
         for(int i = 0; i < n; i += BLOCK_SIZE, dst += BLOCK_SIZE*3 )


### PR DESCRIPTION
related PR #22520

* `mhls3` is read outside of array `interTmpM` (3 elements), it is not used anywhere
* ~replacing `max_nlanes` with `vlanes` for array size is still in question, I think it should be OK~ It was not OK :smiley: 