### PR TITLE
build(ios): disable workaround for CMake 3.25.1+

### DIFF
--- a/platforms/ios/cmake/Toolchains/common-ios-toolchain.cmake
+++ b/platforms/ios/cmake/Toolchains/common-ios-toolchain.cmake
@@ -98,8 +98,17 @@ if(NOT DEFINED IPHONEOS_DEPLOYMENT_TARGET)
 endif()
 
 if(NOT __IN_TRY_COMPILE)
-  set(_xcodebuild_wrapper "${CMAKE_BINARY_DIR}/xcodebuild_wrapper")
-  if(NOT EXISTS "${_xcodebuild_wrapper}")
+  set(_xcodebuild_wrapper "")
+  if(NOT (CMAKE_VERSION VERSION_LESS "3.25.1"))  # >= 3.25.1
+    # no workaround is required (#23156)
+  elseif(NOT (CMAKE_VERSION VERSION_LESS "3.25.0"))  # >= 3.25.0 < 3.25.1
+    if(NOT OPENCV_SKIP_MESSAGE_ISSUE_23156)
+      message(FATAL_ERROR "OpenCV: Please upgrade CMake to 3.25.1+. Current CMake version is ${CMAKE_VERSION}. Details: https://github.com/opencv/opencv/issues/23156")
+    endif()
+  else()  # < 3.25.0, apply workaround from #13912
+    set(_xcodebuild_wrapper "${CMAKE_BINARY_DIR}/xcodebuild_wrapper")
+  endif()
+  if(_xcodebuild_wrapper AND NOT EXISTS "${_xcodebuild_wrapper}")
     set(_xcodebuild_wrapper_tmp "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/xcodebuild_wrapper")
     if(NOT DEFINED CMAKE_MAKE_PROGRAM)  # empty since CMake 3.10
       find_program(XCODEBUILD_PATH "xcodebuild")
@@ -119,7 +128,9 @@ if(NOT __IN_TRY_COMPILE)
     configure_file("${CMAKE_CURRENT_LIST_DIR}/xcodebuild_wrapper.in" "${_xcodebuild_wrapper_tmp}" @ONLY)
     file(COPY "${_xcodebuild_wrapper_tmp}" DESTINATION ${CMAKE_BINARY_DIR} FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
   endif()
-  set(CMAKE_MAKE_PROGRAM "${_xcodebuild_wrapper}" CACHE INTERNAL "" FORCE)
+  if(_xcodebuild_wrapper)
+    set(CMAKE_MAKE_PROGRAM "${_xcodebuild_wrapper}" CACHE INTERNAL "" FORCE)
+  endif()
 endif()
 
 # Standard settings


### PR DESCRIPTION
fixes #23156