### PR TITLE
Update calib3d.hpp

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -263,8 +263,8 @@ The distortion parameters are the radial coefficients \f$k_1\f$, \f$k_2\f$, \f$k
 are the thin prism distortion coefficients. Higher-order coefficients are not considered in OpenCV.
 
 The next figures show two common types of radial distortion: barrel distortion
-(\f$ 1 + k_1 r^2 + k_2 r^4 + k_3 r^6 \f$ monotonically decreasing)
-and pincushion distortion (\f$ 1 + k_1 r^2 + k_2 r^4 + k_3 r^6 \f$ monotonically increasing).
+(\f$ 1 + k_1 r^2 + k_2 r^4 + k_3 r^6 \f$ monotonically increasing)
+and pincushion distortion (\f$ 1 + k_1 r^2 + k_2 r^4 + k_3 r^6 \f$ monotonically decreasing).
 Radial distortion is always monotonic for real lenses,
 and if the estimator produces a non-monotonic result,
 this should be considered a calibration failure.


### PR DESCRIPTION
barrel and pincushion distortion documentation correction

the factor 1 + k_1 r^2 + k_2 r^4 + k_3 r^6 transforms distorted coords in undistorted coords, hence the correction. Barrel has distorted coords smaller than undistorted ones. So the factor must be INCRESASING(r) and not decreasing. Viceversa with pincushion

please check
https://en.wikipedia.org/wiki/Distortion_(optics)

https://www.foamcoreprint.com/blog/what-are-calibration-targets#:~:text=The%20Brown%20distortion%20model%2F%20Brown's,straight%20lines%20on%20camera%20images.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
