### PR TITLE
remove unsupported unsupported unicode “”

### DIFF
--- a/cmake/templates/opencv_run_all_tests_unix.sh.in
+++ b/cmake/templates/opencv_run_all_tests_unix.sh.in
@@ -18,7 +18,7 @@ EOF
 # Parse options
 
 COLOR_OUTPUT=0
-while getopts “hc” OPTION
+while getopts "hc" OPTION
 do
     case $OPTION in
         h)

--- a/doc/py_tutorials/py_feature2d/py_fast/py_fast.markdown
+++ b/doc/py_tutorials/py_feature2d/py_fast/py_fast.markdown
@@ -133,7 +133,7 @@ nonmaxSuppression:
 Additional Resources
 --------------------
 
--#  Edward Rosten and Tom Drummond, “Machine learning for high speed corner detection” in 9th
+-#  Edward Rosten and Tom Drummond, "Machine learning for high speed corner detection" in 9th
     European Conference on Computer Vision, vol. 1, 2006, pp. 430–443.
 2.  Edward Rosten, Reid Porter, and Tom Drummond, "Faster and better: a machine learning approach to
     corner detection" in IEEE Trans. Pattern Analysis and Machine Intelligence, 2010, vol 32, pp.

--- a/modules/calib3d/src/usac/quality.cpp
+++ b/modules/calib3d/src/usac/quality.cpp
@@ -410,9 +410,9 @@ public:
      * 1.  Check whether j-th data point is consistent with the
      * model
      * 2.  Compute the likelihood ratio λj eq. (1)
-     * 3.  If λj >  A, decide the model is ’bad’ (model ”re-jected”),
+     * 3.  If λj >  A, decide the model is ’bad’ (model "re-jected"),
      * else increment j or continue testing
-     * 4.  If j = N the number of correspondences decide model ”accepted”
+     * 4.  If j = N the number of correspondences decide model "accepted"
      *
      * Verifies model and returns model score.
 

--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -90,7 +90,7 @@ public:
      */
     CV_WRAP void generateImage(Size outSize, OutputArray img, int marginSize = 0, int borderBits = 1) const;
 
-    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to “protected” (need to fix bindings first)
+    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     Board();
 
     struct Impl;
@@ -122,7 +122,7 @@ public:
     CV_WRAP float getMarkerLength() const;
     CV_WRAP float getMarkerSeparation() const;
 
-    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to “protected” (need to fix bindings first)
+    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     GridBoard();
 };
 
@@ -187,7 +187,7 @@ public:
      */
     CV_WRAP bool checkCharucoCornersCollinear(InputArray charucoIds) const;
 
-    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to “protected” (need to fix bindings first)
+    CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     CharucoBoard();
 };
 

--- a/platforms/scripts/pylintrc
+++ b/platforms/scripts/pylintrc
@@ -6,7 +6,7 @@ disable=all
 # Tests
 enable=bad-indentation,       # Used when an unexpected number of indentation’s tabulations or spaces has been found.
        mixed-indentation,     # Used when there are some mixed tabs and spaces in a module.
-       unnecessary-semicolon, # Used when a statement is ended by a semi-colon (”;”), which isn’t necessary.
+       unnecessary-semicolon, # Used when a statement is ended by a semi-colon (";"), which isn’t necessary.
        unused-variable        # Used when a variable is defined but not used. (Use _var to ignore var).
 
 


### PR DESCRIPTION
MSVS compiler always gives a warning of `“”`. The `“”` should only be used in Chinese. So, I think we should replace them with `""`.

[warning C4819](https://stackoverflow.com/questions/10501634/warning-c4819-how-to-find-the-character-that-has-to-be-saved-in-unicode)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
