### PR TITLE
Change Scalar assignment in Python from single value

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -446,5 +446,11 @@ class dnn_test(NewOpenCVTests):
 
             normAssert(self, real_output, gold_output, "", getDefaultThreshold(target))
 
+    def test_scalefactor_assign(self):
+        params = cv.dnn.Image2BlobParams()
+        self.assertEqual(params.scalefactor, (1.0, 1.0, 1.0, 1.0))
+        params.scalefactor = 2.0
+        self.assertEqual(params.scalefactor, (2.0, 0.0, 0.0, 0.0))
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -327,7 +327,7 @@ bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo& info)
         }
     } else {
         if (PyFloat_Check(o) || PyInt_Check(o)) {
-            s[0] = PyFloat_AsDouble(o);
+            s = PyFloat_AsDouble(o);
         } else {
             failmsg("Scalar value for argument '%s' is not numeric", info.name);
             return false;


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/23764

I don't think that `scalefactor` as a `Scalar` is a good idea. Is there models with different scales for channels?

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
