### PR TITLE
WIP: Fix segfault in QRCodeDetector.detectAndDecodeCurved

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -1973,6 +1973,29 @@ vector<vector<float> > QRDecode::computeSpline(const vector<int> &x_arr, const v
     return S;
 }
 
+// get horizontal_order and update x_arr, y_arr if necessary
+static inline bool setHorizontalOrder(vector<int>& x_arr, vector<int>& y_arr) {
+    bool horizontal_order = abs(x_arr.front() - x_arr.back()) > abs(y_arr.front() - y_arr.back());
+    int countX = 0, countY = 0;
+    for (size_t i = 1ull; i < x_arr.size(); i++) {
+        if (x_arr[i] == x_arr[i-1])
+            countX++;
+        if (y_arr[i] == y_arr[i-1])
+            countY++;
+    }
+    if (countX != 0 || countY != 0) {
+        vector<int>& newX = countX < countY ? x_arr : y_arr;
+        const int delta = newX.back() > newX.front() ? 1 : -1;
+        horizontal_order = countX < countY ? true : false;
+        if (min(countX, countY) > 0)
+            for (size_t i = 1ull; i < x_arr.size(); i++) {
+                if (newX[i] == newX[i-1])
+                    newX[i] += delta;
+            }
+    }
+    return horizontal_order;
+}
+
 bool QRDecode::createSpline(vector<vector<Point2f> > &spline_lines)
 {
     int start, end;
@@ -1987,11 +2010,11 @@ bool QRDecode::createSpline(vector<vector<Point2f> > &spline_lines)
 
         for (size_t j = 0; j < spline_points.size(); j++)
         {
-            x_arr.push_back(cvRound(spline_points[j].x));
-            y_arr.push_back(cvRound(spline_points[j].y));
+            x_arr.push_back(spline_points[j].x);
+            y_arr.push_back(spline_points[j].y);
         }
 
-        bool horizontal_order = abs(x_arr.front() - x_arr.back()) > abs(y_arr.front() - y_arr.back());
+        bool horizontal_order = setHorizontalOrder(x_arr, y_arr);
         vector<int>& second_arr = horizontal_order ? x_arr : y_arr;
         vector<int>& first_arr  = horizontal_order ? y_arr : x_arr;
 

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -1983,6 +1983,9 @@ static inline bool setHorizontalOrder(vector<int>& x_arr, vector<int>& y_arr) {
         if (y_arr[i] == y_arr[i-1])
             countY++;
     }
+    // Only the points of the function can be interpolated using splines.
+    // Contour points may not be a function, there may be several points with the same x coordinate and different y.
+    // We are adding a small offset in x coord to fix this problem. This should not significantly affect the final answer.
     if (countX != 0 || countY != 0) {
         vector<int>& newX = countX < countY ? x_arr : y_arr;
         const int delta = newX.back() > newX.front() ? 1 : -1;

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -635,6 +635,18 @@ TEST_P(Objdetect_QRCode_detectAndDecodeMulti, decode_9_qrcodes_version7)
     }
 }
 
+TEST(Objdetect_QRCode_Curved_Test, detect_regression_22892)
+{
+    const std::string name_current_image = "issue_22892.png";
+    const std::string root = "qrcode/curved/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat src = imread(image_path);
+    auto qcd = QRCodeDetector();
+    vector<Point2f> points;
+    ASSERT_NO_THROW(qcd.detectAndDecodeCurved(src, points));
+}
+
 #endif // UPDATE_QRCODE_TEST_DATA
 
 }} // namespace


### PR DESCRIPTION
fixes https://github.com/opencv/opencv/issues/22892
merge with https://github.com/opencv/opencv_extra/pull/1072

The issue is in spline interpolation. Only the points of the function can be interpolated using splines, but the contour points may not be a function. There may be several points with the same x coordinate and different y. It results in getting NaN when calculating spline.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
