### PR TITLE
feat: re-export symbols to cv2 level

### DIFF
--- a/modules/python/src2/typing_stubs_generation/nodes/namespace_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/namespace_node.py
@@ -1,14 +1,13 @@
-from typing import Type, Iterable, Sequence, Tuple, Optional, Dict
 import itertools
 import weakref
-
-from .node import ASTNode, ASTNodeType
+from collections import defaultdict
+from typing import Dict, List, Optional, Sequence, Tuple, Type
 
 from .class_node import ClassNode, ClassProperty
-from .function_node import FunctionNode
-from .enumeration_node import EnumerationNode
 from .constant_node import ConstantNode
-
+from .enumeration_node import EnumerationNode
+from .function_node import FunctionNode
+from .node import ASTNode, ASTNodeType
 from .type_node import TypeResolutionError
 
 
@@ -18,6 +17,17 @@ class NamespaceNode(ASTNode):
     NamespaceNode can have other namespaces, classes, functions, enumerations
     and global constants as its children nodes.
     """
+    def __init__(self, name: str, parent: Optional[ASTNode] = None,
+                 export_name: Optional[str] = None) -> None:
+        super().__init__(name, parent, export_name)
+        self.reexported_submodules: List[str] = []
+        """List of reexported submodules"""
+
+        self.reexported_submodules_symbols: Dict[str, List[str]] = defaultdict(list)
+        """Mapping between submodules export names and their symbols re-exported
+        in this module"""
+
+
     @property
     def node_type(self) -> ASTNodeType:
         return ASTNodeType.Namespace


### PR DESCRIPTION
- Re-export native submodules of cv2 package level.
- Re-export  manually registered  symbols like cv2.mat_wrapper.Mat

`__init__.pyi` file import section after patch

```python
# other imports 

# --- Added section ---
from cv2 import Error as Error
from cv2 import aruco as aruco
from cv2 import cuda as cuda
from cv2 import detail as detail
from cv2 import dnn as dnn
from cv2 import fisheye as fisheye
from cv2 import flann as flann
from cv2 import gapi as gapi
from cv2 import ipp as ipp
from cv2 import ml as ml
from cv2 import ocl as ocl
from cv2 import ogl as ogl
from cv2 import parallel as parallel
from cv2 import samples as samples
from cv2 import segmentation as segmentation
from cv2 import utils as utils
from cv2 import videoio_registry as videoio_registry
from cv2.mat_wrapper import Mat as Mat
# --- Added section ---

# Rest of the file is unchanged
```

Resolves: #23777

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
