### PR TITLE
fix: typing module enums references

### DIFF
--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -1,4 +1,4 @@
-from .node import ASTNode
+from .node import ASTNode, ASTNodeType
 from .namespace_node import NamespaceNode
 from .class_node import ClassNode, ClassProperty
 from .function_node import FunctionNode

--- a/modules/python/src2/typing_stubs_generation/nodes/node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/node.py
@@ -1,7 +1,7 @@
 import abc
 import enum
 import itertools
-from typing import (Iterator, Type, TypeVar, Iterable, Dict,
+from typing import (Iterator, Type, TypeVar, Dict,
                     Optional, Tuple, DefaultDict)
 from collections import defaultdict
 

--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -418,6 +418,10 @@ class ASTNodeTypeNode(TypeNode):
         self._ast_node: Optional[weakref.ProxyType[ASTNode]] = None
 
     @property
+    def ast_node(self):
+        return self._ast_node
+
+    @property
     def typename(self) -> str:
         if self._ast_node is None:
             return self._typename

--- a/modules/python/src2/typing_stubs_generator.py
+++ b/modules/python/src2/typing_stubs_generator.py
@@ -12,6 +12,7 @@ if sys.version_info >= (3, 6):
     from contextlib import contextmanager
 
     from typing import Dict, Set, Any, Sequence, Generator, Union
+    import traceback
 
     from pathlib import Path
 
@@ -46,10 +47,12 @@ if sys.version_info >= (3, 6):
 
                     try:
                         ret_type = func(*args, **kwargs)
-                    except Exception as e:
+                    except Exception:
                         self.has_failure = True
                         warnings.warn(
-                            'Typing stubs generation has failed. Reason: {}'.format(e)
+                            "Typing stubs generation has failed.\n{}".format(
+                                traceback.format_exc()
+                            )
                         )
                         if ret_type_on_failure is None:
                             return None


### PR DESCRIPTION
Enum names exist only during type checking.
During runtime they should be denoted as named integral types

This patch fixes circular import issue introduced by #23798.

Before patch `TermCriteria` was defined as follows:
```python
TermCriteria = typing.Tuple[cv2.TermCriteria_Type, int, float]
"""Any type providing sequence protocol is supported"""
```
which works fine during type checking, but introduces runtime failure:
```python
>>> import cv2
...
    TermCriteria = tuple[cv2.TermCriteria_Type, int, float]  # Any type providing sequence protocol is supported
                         ^^^^^^^^^^^^^^^^^^^^^
AttributeError: partially initialized module 'cv2' has no attribute 'TermCriteria_Type' (most likely due to a circular import)
```

Generated `__init__.py` after patch will hide `cv2.TermCriteria_Type` enumeration by `typing.TYPE_CHECKNIG` guard.

```python
if typing.TYPE_CHECKING:
    TermCriteria_Type = cv2.TermCriteria_Type
else:
    TermCriteria_Type = int

TermCriteria = typing.Tuple[TermCriteria_Type, int, float]
"""Any type providing sequence protocol is supported"""
```

So everything can be imported without any issues
```python
>>> import cv2
>>> import cv2.typing
>>> cv2.typing.TermCriteria
typing.Tuple[int, int, float]
>>> 
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
