### PR TITLE
Fix typo `confindece`

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -190,22 +190,22 @@ public:
     estimation used in the inliers classification step
     @param num_matches_thresh2 Minimum number of matches required for the 2D projective transform
     re-estimation on inliers
-    @param matches_confindece_thresh Matching confidence threshold to take the match into account.
+    @param matches_confidence_thresh Matching confidence threshold to take the match into account.
     The threshold was determined experimentally and set to 3 by default.
      */
     CV_WRAP BestOf2NearestMatcher(bool try_use_gpu = false, float match_conf = 0.3f, int num_matches_thresh1 = 6,
-                          int num_matches_thresh2 = 6, double matches_confindece_thresh = 3.);
+                          int num_matches_thresh2 = 6, double matches_confidence_thresh = 3.);
 
     CV_WRAP void collectGarbage() CV_OVERRIDE;
     CV_WRAP static Ptr<BestOf2NearestMatcher> create(bool try_use_gpu = false, float match_conf = 0.3f, int num_matches_thresh1 = 6,
-        int num_matches_thresh2 = 6, double matches_confindece_thresh = 3.);
+        int num_matches_thresh2 = 6, double matches_confidence_thresh = 3.);
 
 protected:
 
     void match(const ImageFeatures &features1, const ImageFeatures &features2, MatchesInfo &matches_info) CV_OVERRIDE;
     int num_matches_thresh1_;
     int num_matches_thresh2_;
-    double matches_confindece_thresh_;
+    double matches_confidence_thresh_;
     Ptr<FeaturesMatcher> impl_;
 };
 

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -365,7 +365,7 @@ void FeaturesMatcher::match(const std::vector<ImageFeatures> &features, std::vec
 
 //////////////////////////////////////////////////////////////////////////////
 
-BestOf2NearestMatcher::BestOf2NearestMatcher(bool try_use_gpu, float match_conf, int num_matches_thresh1, int num_matches_thresh2, double matches_confindece_thresh)
+BestOf2NearestMatcher::BestOf2NearestMatcher(bool try_use_gpu, float match_conf, int num_matches_thresh1, int num_matches_thresh2, double matches_confidence_thresh)
 {
     CV_UNUSED(try_use_gpu);
 
@@ -383,13 +383,13 @@ BestOf2NearestMatcher::BestOf2NearestMatcher(bool try_use_gpu, float match_conf,
     is_thread_safe_ = impl_->isThreadSafe();
     num_matches_thresh1_ = num_matches_thresh1;
     num_matches_thresh2_ = num_matches_thresh2;
-    matches_confindece_thresh_ = matches_confindece_thresh;
+    matches_confidence_thresh_ = matches_confidence_thresh;
 }
 
 Ptr<BestOf2NearestMatcher> BestOf2NearestMatcher::create(bool try_use_gpu, float match_conf, int num_matches_thresh1, int num_matches_thresh2,
-                                                         double matches_confindece_thresh)
+                                                         double matches_confidence_thresh)
 {
-    return makePtr<BestOf2NearestMatcher>(try_use_gpu, match_conf, num_matches_thresh1, num_matches_thresh2, matches_confindece_thresh);
+    return makePtr<BestOf2NearestMatcher>(try_use_gpu, match_conf, num_matches_thresh1, num_matches_thresh2, matches_confidence_thresh);
 }
 
 
@@ -440,7 +440,7 @@ void BestOf2NearestMatcher::match(const ImageFeatures &features1, const ImageFea
 
     // Set zero confidence to remove matches between too close images, as they don't provide
     // additional information anyway.
-    matches_info.confidence = matches_info.confidence > matches_confindece_thresh_ ? 0. : matches_info.confidence;
+    matches_info.confidence = matches_info.confidence > matches_confidence_thresh_ ? 0. : matches_info.confidence;
 
     // Check if we should try to refine motion
     if (matches_info.num_inliers < num_matches_thresh2_)


### PR DESCRIPTION
Fixes #22632

Simply search & replaced all instances of `confindece`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [N/A] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
