### PR TITLE
Force mat_wrapper import to satisfy dependencies for MatLike alias

### DIFF
--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -759,6 +759,8 @@ def _generate_typing_module(root: NamespaceNode, output_path: Path) -> None:
         output_stream.write(f'    "{alias_name}",\n')
     output_stream.write("]\n\n")
 
+    # HACK: force add cv2.mat_wrapper import to handle MatLike alias
+    required_imports.add("import cv2.mat_wrapper")
     _write_required_imports(required_imports, output_stream)
 
     # Add type checking time definitions as generated __init__.py content


### PR DESCRIPTION
Solves:
```
Python 3.9.5 (default, Nov 23 2021, 15:27:38) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cv2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ksenia/Projects/opencv-build-3.9/install/lib/python3.9/site-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File "/home/ksenia/Projects/opencv-build-3.9/install/lib/python3.9/site-packages/cv2/__init__.py", line 175, in bootstrap
    if __load_extra_py_code_for_module("cv2", submodule, DEBUG):
  File "/home/ksenia/Projects/opencv-build-3.9/install/lib/python3.9/site-packages/cv2/__init__.py", line 28, in __load_extra_py_code_for_module
    py_module = importlib.import_module(module_name)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/ksenia/Projects/opencv-build-3.9/install/lib/python3.9/site-packages/cv2/typing/__init__.py", line 73, in <module>
    MatLike = typing.Union[cv2.mat_wrapper.Mat, numpy.ndarray[typing.Any, numpy.dtype[numpy.generic]]]
AttributeError: partially initialized module 'cv2' has no attribute 'mat_wrapper' (most likely due to a circular import)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
