### PR TITLE
fix broken links and outdated information for documentation of Orbbec camera

### DIFF
--- a/doc/tutorials/app/orbbec_astra.markdown
+++ b/doc/tutorials/app/orbbec_astra.markdown
@@ -9,7 +9,7 @@ Using Orbbec Astra 3D cameras {#tutorial_orbbec_astra}
 
 ### Introduction
 
-This tutorial is devoted to the Astra Series of Orbbec 3D cameras (https://orbbec3d.com/product-astra-pro/).
+This tutorial is devoted to the Astra Series of Orbbec 3D cameras (https://orbbec3d.com/index/Product/info.html?cate=38&id=36).
 That cameras have a depth sensor in addition to a common color sensor. The depth sensors can be read using
 the open source OpenNI API with @ref cv::VideoCapture class. The video stream is provided through the regular
 camera interface.
@@ -18,9 +18,11 @@ camera interface.
 
 In order to use the Astra camera's depth sensor with OpenCV you should do the following steps:
 
--#  Download the latest version of Orbbec OpenNI SDK (from here <https://orbbec3d.com/develop/>).
+-#  Download the latest version of Orbbec OpenNI SDK (from here <https://orbbec3d.com/index/download.html>).
     Unzip the archive, choose the build according to your operating system and follow installation
-    steps provided in the Readme file. For instance, if you use 64bit GNU/Linux run:
+    steps provided in the Readme file.
+
+-#  For SDK <= 2.3.0.63, if you use 64bit GNU/Linux run to install:
     @code{.bash}
     $ cd Linux/OpenNI-Linux-x64-2.3.0.63/
     $ sudo ./install.sh
@@ -31,17 +33,53 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
     @code{.bash}
     $ source OpenNIDevEnvironment
     @endcode
-
--#  Run the following commands to verify that OpenNI library and header files can be found. You should see
-    something similar in your terminal:
+    To verify that the source command works and OpenNI library and header files can be found, run the following
+    command and you should see something similar in your terminal:
     @code{.bash}
     $ echo $OPENNI2_INCLUDE
     /home/user/OpenNI_2.3.0.63/Linux/OpenNI-Linux-x64-2.3.0.63/Include
     $ echo $OPENNI2_REDIST
     /home/user/OpenNI_2.3.0.63/Linux/OpenNI-Linux-x64-2.3.0.63/Redist
     @endcode
-    If the above two variables are empty, then you need to source `OpenNIDevEnvironment` again. Now you can
-    configure OpenCV with OpenNI support enabled by setting the `WITH_OPENNI2` flag in CMake.
+    If the above two variables are empty, then you need to source `OpenNIDevEnvironment` again.
+
+-#  For SDK >= 2.3.0.86, it does not provide `install.sh` any more. You need to copy the following content:
+    @code{.text}
+    # Check if user is root/running with sudo
+    if [ `whoami` != root ]; then
+        echo Please run this script with sudo
+        exit
+    fi
+
+    ORIG_PATH=`pwd`
+    cd `dirname $0`
+    SCRIPT_PATH=`pwd`
+    cd $ORIG_PATH
+
+    if [ "`uname -s`" != "Darwin" ]; then
+        # Install UDEV rules for USB device
+        cp ${SCRIPT_PATH}/orbbec-usb.rules /etc/udev/rules.d/558-orbbec-usb.rules
+        echo "usb rules file install at /etc/udev/rules.d/558-orbbec-usb.rules"
+    fi
+
+    OUT_FILE="$SCRIPT_PATH/OpenNIDevEnvironment"
+    echo "export OPENNI2_INCLUDE=$SCRIPT_PATH/../sdk/Include" > $OUT_FILE
+    echo "export OPENNI2_REDIST=$SCRIPT_PATH/../sdk/libs" >> $OUT_FILE
+    chmod a+r $OUT_FILE
+    echo "exit"
+    @endcode
+    and make your own `install.sh` for installation:
+    @code{.bash}
+    $ cd OpenNI_2.3.0.86_202210111154_4c8f5aa4_beta6_linux
+    $ vim install.sh # copy the above content into this file
+    $ sudo ./install.sh
+    $ source OpenNIDevEnvironment
+    $ echo $OPENNI2_INCLUDE # verify if it has the correct ooutput
+    $ echo $OPENNI2_REDIST  # verify if it has the correct ooutput
+    @endcode
+
+
+-#  Now you can configure OpenCV with OpenNI support enabled by setting the `WITH_OPENNI2` flag in CMake.
     You may also like to enable the `BUILD_EXAMPLES` flag to get a code sample working with your Astra camera.
     Run the following commands in the directory containing OpenCV source code to enable OpenNI support:
     @code{.bash}

--- a/doc/tutorials/app/orbbec_astra.markdown
+++ b/doc/tutorials/app/orbbec_astra.markdown
@@ -22,7 +22,7 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
     Unzip the archive, choose the build according to your operating system and follow installation
     steps provided in the Readme file.
 
--#  For SDK <= 2.3.0.63, if you use 64bit GNU/Linux run to install:
+-#  For instance, if you use 64bit GNU/Linux run:
     @code{.bash}
     $ cd Linux/OpenNI-Linux-x64-2.3.0.63/
     $ sudo ./install.sh
@@ -43,7 +43,8 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
     @endcode
     If the above two variables are empty, then you need to source `OpenNIDevEnvironment` again.
 
--#  For SDK >= 2.3.0.86, it does not provide `install.sh` any more. You need to copy the following content:
+    @note Orbbec OpenNI SDK version 2.3.0.86 and newer does not provide `install.sh` any more.
+    You can use the following script to initialize environment:
     @code{.text}
     # Check if user is root/running with sudo
     if [ `whoami` != root ]; then
@@ -68,16 +69,6 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
     chmod a+r $OUT_FILE
     echo "exit"
     @endcode
-    and make your own `install.sh` for installation:
-    @code{.bash}
-    $ cd OpenNI_2.3.0.86_202210111154_4c8f5aa4_beta6_linux
-    $ vim install.sh # copy the above content into this file
-    $ sudo ./install.sh
-    $ source OpenNIDevEnvironment
-    $ echo $OPENNI2_INCLUDE # verify if it has the correct ooutput
-    $ echo $OPENNI2_REDIST  # verify if it has the correct ooutput
-    @endcode
-
 
 -#  Now you can configure OpenCV with OpenNI support enabled by setting the `WITH_OPENNI2` flag in CMake.
     You may also like to enable the `BUILD_EXAMPLES` flag to get a code sample working with your Astra camera.


### PR DESCRIPTION
Resolves the documentation issue from https://github.com/opencv/opencv/issues/23579.

Orbbec is moving to support UVC directly so they do not provide the old `install.sh` for OpenNI SDK >= 2.3.0.86. Also in their new release of OpenNI SDK, paths of include headers and libraries are changed. Changing our cmake script for this change does not make sense since we cannot make this kind of change everytime they update. So just added a subsection providing `install.sh` for users as a workaround on our side.

@Lecrapouille You may also take a look at this pull request.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
