### PR TITLE
fix: AST nodes required usage imports

### DIFF
--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -759,8 +759,6 @@ def _generate_typing_module(root: NamespaceNode, output_path: Path) -> None:
         output_stream.write(f'    "{alias_name}",\n')
     output_stream.write("]\n\n")
 
-    # HACK: force add cv2.mat_wrapper import to handle MatLike alias
-    required_imports.add("import cv2.mat_wrapper")
     _write_required_imports(required_imports, output_stream)
 
     # Add type checking time definitions as generated __init__.py content

--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -561,13 +561,14 @@ class ContainerTypeNode(AggregatedTypeNode):
     @property
     def required_definition_imports(self) -> Generator[str, None, None]:
         yield "import typing"
-        return super().required_definition_imports
+        yield from super().required_definition_imports
 
     @property
     def required_usage_imports(self) -> Generator[str, None, None]:
         if TypeNode.compatible_to_runtime_usage:
             yield "import typing"
-        return super().required_usage_imports
+        yield from super().required_usage_imports
+
     @abc.abstractproperty
     def type_format(self) -> str:
         pass


### PR DESCRIPTION
Correct fix for #23821

Apart adding `import cv2.mat_wrapper` adds `import cv2.gapi.wip.draw` import to `cv2/typing/__init__.py`

`cv2/typing/__init__.py` imports after fix:

```python
import cv2
import cv2.dnn
import cv2.gapi.wip.draw
import cv2.mat_wrapper
import numpy
import typing
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
