### PR TITLE
G-API: fix static build with OpenVINO

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -254,6 +254,7 @@ ocv_target_link_libraries(${the_module} PRIVATE ade)
 
 if(TARGET ocv.3rdparty.openvino AND OPENCV_GAPI_WITH_OPENVINO)
   ocv_target_link_libraries(${the_module} PRIVATE ocv.3rdparty.openvino)
+  ocv_install_used_external_targets(ocv.3rdparty.openvino)
 endif()
 
 if(HAVE_TBB)


### PR DESCRIPTION
Need to register external dependency if dnn module is not used:

```
-DWITH_OPENVINO=ON -DBUILD_opencv_dnn=OFF -DBUILD_SHARED_LIBS=OFF
```

Similar to https://github.com/opencv/opencv/blame/1db1422fbdc1a03d1523b50ad9b05d72cbd39616/modules/dnn/CMakeLists.txt#L241