### PR TITLE
Fix detect diamonds api

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
@@ -104,7 +104,7 @@ public:
      */
     CV_WRAP void detectDiamonds(InputArray image, OutputArrayOfArrays diamondCorners, OutputArray diamondIds,
                                 InputOutputArrayOfArrays markerCorners = noArray(),
-                                InputOutputArrayOfArrays markerIds = noArray()) const;
+                                InputOutputArray markerIds = noArray()) const;
 protected:
     struct CharucoDetectorImpl;
     Ptr<CharucoDetectorImpl> charucoDetectorImpl;

--- a/modules/objdetect/misc/python/test/test_objdetect_aruco.py
+++ b/modules/objdetect/misc/python/test/test_objdetect_aruco.py
@@ -238,6 +238,27 @@ class aruco_objdetect_test(NewOpenCVTests):
             self.assertEqual(charucoIds[i], i)
         np.testing.assert_allclose(gold_corners, charucoCorners.reshape(-1, 2), 0.01, 0.1)
 
+    def test_detect_diamonds(self):
+        aruco_dict = cv.aruco.getPredefinedDictionary(cv.aruco.DICT_6X6_250)
+        board_size = (3, 3)
+        board = cv.aruco.CharucoBoard(board_size, 1.0, .8, aruco_dict)
+        charuco_detector = cv.aruco.CharucoDetector(board)
+        cell_size = 120
+
+        image = board.generateImage((cell_size*board_size[0], cell_size*board_size[1]))
+
+        list_gold_corners = [(cell_size, cell_size), (2*cell_size, cell_size), (2*cell_size, 2*cell_size),
+                             (cell_size, 2*cell_size)]
+        gold_corners = np.array(list_gold_corners, dtype=np.float32)
+
+        diamond_corners, diamond_ids, marker_corners, marker_ids = charuco_detector.detectDiamonds(image)
+
+        self.assertEqual(diamond_ids.size, 4)
+        self.assertEqual(marker_ids.size, 4)
+        for i in range(0, 4):
+            self.assertEqual(diamond_ids[0][0][i], i)
+        np.testing.assert_allclose(gold_corners, np.array(diamond_corners, dtype=np.float32).reshape(-1, 2), 0.01, 0.1)
+
     # check no segfault when cameraMatrix or distCoeffs are not initialized
     def test_charuco_no_segfault_params(self):
         dictionary = cv.aruco.getPredefinedDictionary(cv.aruco.DICT_4X4_1000)

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -315,7 +315,7 @@ void CharucoDetector::detectBoard(InputArray image, OutputArray charucoCorners, 
 }
 
 void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
-                                     InputOutputArrayOfArrays inMarkerCorners, InputOutputArrayOfArrays inMarkerIds) const {
+                                     InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) const {
     CV_Assert(getBoard().getChessboardSize() == Size(3, 3));
     CV_Assert((inMarkerCorners.empty() && inMarkerIds.empty() && !image.empty()) || (inMarkerCorners.total() == inMarkerIds.total()));
 


### PR DESCRIPTION
`detectDiamonds` cannot be called from python, reproducer:

```
import numpy as np
import cv2 as cv

detector = cv.aruco.CharucoDetector(
    cv.aruco.CharucoBoard(
        (3, 3), 200.0, 100.0,
        cv.aruco.getPredefinedDictionary(cv.aruco.DICT_4X4_250)
    )
)
image = np.zeros((640, 480, 1), dtype=np.uint8)
res = detector.detectDiamonds(image)
print(res)
```

The error in `detectDiamonds` API fixed by replacing `InputOutputArrayOfArrays markerIds` with `InputOutputArray markerIds`.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
