### PR TITLE
Reworked calibrate.py

### DIFF
--- a/samples/python/calibrate.py
+++ b/samples/python/calibrate.py
@@ -16,11 +16,13 @@ default values:
     -w: 4
     -h: 6
     -t: chessboard
-    --square_size: 50
-    --marker_size: 25
+    --square_size: 10
+    --marker_size: 5
     --aruco_dict: DICT_4X4_50
     --threads: 4
     <image mask> defaults to ../data/left*.jpg
+
+NOTE: Chessboard size is defined in inner corners. Charuco board size is defined in units.
 '''
 
 # Python 2/3 compatibility
@@ -67,45 +69,38 @@ def main():
     marker_size = float(args.get('--marker_size'))
     aruco_dict_name = str(args.get('--aruco_dict'))
 
-    pattern_size = (height, width)
+    pattern_size = (width, height)
     if pattern_type == 'chessboard':
         pattern_points = np.zeros((np.prod(pattern_size), 3), np.float32)
         pattern_points[:, :2] = np.indices(pattern_size).T.reshape(-1, 2)
         pattern_points *= square_size
-    elif pattern_type == 'charucoboard':
-        pattern_points = np.zeros((np.prod((height-1, width-1)), 3), np.float32)
-        pattern_points[:, :2] = np.indices((height-1, width-1)).T.reshape(-1, 2)
-        pattern_points *= square_size
-    else:
-        print("unknown pattern")
-        return None
 
     obj_points = []
     img_points = []
     h, w = cv.imread(img_names[0], cv.IMREAD_GRAYSCALE).shape[:2]  # TODO: use imquery call to retrieve results
 
     aruco_dicts = {
-        'DICT_4X4_50':cv.aruco.DICT_4X4_50,
-        'DICT_4X4_100':cv.aruco.DICT_4X4_100,
-        'DICT_4X4_250':cv.aruco.DICT_4X4_250,
-        'DICT_4X4_1000':cv.aruco.DICT_4X4_1000,
-        'DICT_5X5_50':cv.aruco.DICT_5X5_50,
-        'DICT_5X5_100':cv.aruco.DICT_5X5_100,
-        'DICT_5X5_250':cv.aruco.DICT_5X5_250,
-        'DICT_5X5_1000':cv.aruco.DICT_5X5_1000,
-        'DICT_6X6_50':cv.aruco.DICT_6X6_50,
-        'DICT_6X6_100':cv.aruco.DICT_6X6_100,
-        'DICT_6X6_250':cv.aruco.DICT_6X6_250,
-        'DICT_6X6_1000':cv.aruco.DICT_6X6_1000,
-        'DICT_7X7_50':cv.aruco.DICT_7X7_50,
-        'DICT_7X7_100':cv.aruco.DICT_7X7_100,
-        'DICT_7X7_250':cv.aruco.DICT_7X7_250,
-        'DICT_7X7_1000':cv.aruco.DICT_7X7_1000,
-        'DICT_ARUCO_ORIGINAL':cv.aruco.DICT_ARUCO_ORIGINAL,
-        'DICT_APRILTAG_16h5':cv.aruco.DICT_APRILTAG_16h5,
-        'DICT_APRILTAG_25h9':cv.aruco.DICT_APRILTAG_25h9,
-        'DICT_APRILTAG_36h10':cv.aruco.DICT_APRILTAG_36h10,
-        'DICT_APRILTAG_36h11':cv.aruco.DICT_APRILTAG_36h11
+        'DICT_4X4_50': cv.aruco.DICT_4X4_50,
+        'DICT_4X4_100': cv.aruco.DICT_4X4_100,
+        'DICT_4X4_250': cv.aruco.DICT_4X4_250,
+        'DICT_4X4_1000': cv.aruco.DICT_4X4_1000,
+        'DICT_5X5_50': cv.aruco.DICT_5X5_50,
+        'DICT_5X5_100': cv.aruco.DICT_5X5_100,
+        'DICT_5X5_250': cv.aruco.DICT_5X5_250,
+        'DICT_5X5_1000': cv.aruco.DICT_5X5_1000,
+        'DICT_6X6_50': cv.aruco.DICT_6X6_50,
+        'DICT_6X6_100': cv.aruco.DICT_6X6_100,
+        'DICT_6X6_250': cv.aruco.DICT_6X6_250,
+        'DICT_6X6_1000': cv.aruco.DICT_6X6_1000,
+        'DICT_7X7_50': cv.aruco.DICT_7X7_50,
+        'DICT_7X7_100': cv.aruco.DICT_7X7_100,
+        'DICT_7X7_250': cv.aruco.DICT_7X7_250,
+        'DICT_7X7_1000': cv.aruco.DICT_7X7_1000,
+        'DICT_ARUCO_ORIGINAL': cv.aruco.DICT_ARUCO_ORIGINAL,
+        'DICT_APRILTAG_16h5': cv.aruco.DICT_APRILTAG_16h5,
+        'DICT_APRILTAG_25h9': cv.aruco.DICT_APRILTAG_25h9,
+        'DICT_APRILTAG_36h10': cv.aruco.DICT_APRILTAG_36h10,
+        'DICT_APRILTAG_36h11': cv.aruco.DICT_APRILTAG_36h11
     }
 
     if (aruco_dict_name not in set(aruco_dicts.keys())):
@@ -130,19 +125,27 @@ def main():
             if found:
                 term = (cv.TERM_CRITERIA_EPS + cv.TERM_CRITERIA_COUNT, 30, 0.1)
                 cv.cornerSubPix(img, corners, (5, 5), (-1, -1), term)
+                frame_img_points = corners.reshape(-1, 2)
+                frame_obj_points = pattern_points
         elif pattern_type == 'charucoboard':
-            corners, _charucoIds, _markerCorners_svg, _markerIds_svg = charuco_detector.detectBoard(img)
-            if (len(corners) == (height-1)*(width-1)):
+            corners, charucoIds, _, _ = charuco_detector.detectBoard(img)
+            if (len(corners) > 0):
+                frame_obj_points, frame_img_points = board.matchImagePoints(corners, charucoIds)
                 found = True
+            else:
+                found = False
         else:
             print("unknown pattern type", pattern_type)
             return None
 
         if debug_dir:
             vis = cv.cvtColor(img, cv.COLOR_GRAY2BGR)
-            cv.drawChessboardCorners(vis, pattern_size, corners, found)
+            if pattern_type == 'chessboard':
+                cv.drawChessboardCorners(vis, pattern_size, corners, found)
+            elif pattern_type == 'charucoboard':
+                cv.aruco.drawDetectedCornersCharuco(vis, corners, charucoIds=charucoIds)
             _path, name, _ext = splitfn(fn)
-            outfile = os.path.join(debug_dir, name + '_chess.png')
+            outfile = os.path.join(debug_dir, name + '_board.png')
             cv.imwrite(outfile, vis)
 
         if not found:
@@ -150,7 +153,7 @@ def main():
             return None
 
         print('           %s... OK' % fn)
-        return (corners.reshape(-1, 2), pattern_points)
+        return (frame_img_points, frame_obj_points)
 
     threads_num = int(args.get('--threads'))
     if threads_num <= 1:
@@ -177,7 +180,7 @@ def main():
     print('')
     for fn in img_names if debug_dir else []:
         _path, name, _ext = splitfn(fn)
-        img_found = os.path.join(debug_dir, name + '_chess.png')
+        img_found = os.path.join(debug_dir, name + '_board.png')
         outfile = os.path.join(debug_dir, name + '_undistorted.png')
 
         img = cv.imread(img_found)


### PR DESCRIPTION
- Fixed width and height swap in board size
- Fixed defaults in command line hint
- Fixed board visualization for Charuco case
- Used matchImagePoints method to handle partially detected Charuco boards

Replaces: https://github.com/opencv/opencv/pull/23757, https://github.com/opencv/opencv/pull/23840

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
