### PR TITLE
Disable finite-math-only option with ENABLE_FAST_MATH=1 case to handle NaN and Inf checks correctly

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -108,6 +108,7 @@ elseif(CV_ICC)
 elseif(CV_GCC OR CV_CLANG)
   if(ENABLE_FAST_MATH)
     add_extra_compiler_option(-ffast-math)
+    add_extra_compiler_option(-fno-finite-math-only)
   endif()
 endif()
 


### PR DESCRIPTION
Relates to https://github.com/opencv/opencv_contrib/issues/3150
 
`-fast-math` option includes -ffinite-math-only option. Compiler expects that floats/doubles could not be NaN/Inf and does optimization accordingly. In particular __builtin_isnan and related built-in returns invalid result or optimized out by compiler.

Related discussion in GCC issue tracker: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84949
Stackoverflow question: https://stackoverflow.com/questions/69463347/why-does-gcc-ffast-math-disable-the-correct-result-of-isnan-and-isinf

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
