### PR TITLE
dnn: several fixes for tf importer

### DIFF
--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -622,6 +622,8 @@ public:
     }
 };
 
+// TODO: need to remove this or match only if Shape
+//       has only one output that goes to Reshape
 class ReshapeAsShapeSubgraph : public Subgraph
 {
 public:
@@ -936,6 +938,40 @@ Mat getTensorContentRef_(const tensorflow::TensorProto& tensor)
     }
 
     return m;
+}
+
+bool isTensorContentEmpty(const tensorflow::TensorProto& tensor) {
+    const std::string& content = tensor.tensor_content();
+    switch (tensor.dtype()) {
+#define TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT(tf_data_type, data_type, get_val) \
+        case tf_data_type: {                                                       \
+            if (content.empty()) {                                                 \
+                const RepeatedField<data_type>& field = tensor.get_val();          \
+                return field.empty();                                              \
+            } else {                                                               \
+                return false;                                                      \
+            }                                                                      \
+        } break;
+        TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT(tensorflow::DT_FLOAT, float, float_val);
+        TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT(tensorflow::DT_DOUBLE, double, double_val);
+        TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT(tensorflow::DT_INT32, int, int_val);
+        TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT(tensorflow::DT_HALF, int32_t, half_val);
+#undef TF_GRAPH_SIMPLIFIER_CHECK_TENSOR_CONTENT
+        case tensorflow::DT_QUINT8:
+        {
+            if (content.empty()) {
+                const std::string& field = tensor.string_val(0);
+                return field.empty();
+            } else {
+                return false;
+            }
+            break;
+        }
+        default:
+            CV_Error(Error::StsError, "Tensor's data type is not supported");
+            break;
+    }
+    return true;
 }
 
 Mat getTensorContent(const tensorflow::TensorProto& tensor, bool forceCopy)

--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.hpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.hpp
@@ -19,6 +19,8 @@ void RemoveIdentityOps(tensorflow::GraphDef& net);
 
 void simplifySubgraphs(tensorflow::GraphDef& net);
 
+bool isTensorContentEmpty(const tensorflow::TensorProto& tensor);
+
 Mat getTensorContent(const tensorflow::TensorProto& tensor, bool forceCopy = true);
 
 void releaseTensor(tensorflow::TensorProto* tensor);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -593,6 +593,7 @@ private:
     void parseExpandDims         (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
     void parseSquare             (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
     void parseArg                (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
+    // void parseShape              (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
 
     void parseCustomLayer        (tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams);
 };
@@ -673,6 +674,7 @@ TFImporter::DispatchMap TFImporter::buildDispatchMap()
     dispatch["ExpandDims"] = &TFImporter::parseExpandDims;
     dispatch["Square"] = &TFImporter::parseSquare;
     dispatch["ArgMax"] = dispatch["ArgMin"] = &TFImporter::parseArg;
+    // dispatch["Shape"] = &TFImporter::parseShape;
 
     return dispatch;
 }
@@ -1667,7 +1669,10 @@ void TFImporter::parseStridedSlice(tensorflow::GraphDef& net, const tensorflow::
     const int num_inputs = layer.input_size();
 
     CV_CheckEQ(num_inputs, 4, "");
-    Mat begins = getTensorContent(getConstBlob(layer, value_id, 1));
+    Mat begins(1, 1, CV_32SC1, Scalar(0)); // default to be 0 if empty
+    if (value_id.find(layer.input(1)) != value_id.end()) {
+        begins = getTensorContent(getConstBlob(layer, value_id, 1)); // this may be empty if it is a scalar zero
+    }
     Mat ends = getTensorContent(getConstBlob(layer, value_id, 2));
     Mat strides = getTensorContent(getConstBlob(layer, value_id, 3));
     CV_CheckTypeEQ(begins.type(), CV_32SC1, "");
@@ -1740,7 +1745,8 @@ void TFImporter::parseMul(tensorflow::GraphDef& net, const tensorflow::NodeDef& 
         // Multiplication by constant.
         CV_CheckEQ(num_inputs, 2, "");
         Mat scaleMat = getTensorContent(getConstBlob(layer, value_id));
-        CV_Assert(scaleMat.type() == CV_32FC1);
+        // CV_Assert(scaleMat.type() == CV_32FC1); // TODO: convert int32_t to float
+
         if (type == "RealDiv")
         {
             if (constId == 0)
@@ -2658,6 +2664,10 @@ void TFImporter::parseArg(tensorflow::GraphDef& net, const tensorflow::NodeDef& 
     connect(layer_id, dstNet, parsePin(layer.input(0)), id, 0);
 }
 
+// void TFImporter::parseShape(tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams) {
+//     ;
+// }
+
 void TFImporter::parseCustomLayer(tensorflow::GraphDef& net, const tensorflow::NodeDef& layer, LayerParams& layerParams)
 {
     // Importer does not know how to map this TensorFlow's operation onto OpenCV's layer.
@@ -2877,7 +2887,7 @@ static void addConstNodes(tensorflow::GraphDef& net, std::map<String, int>& cons
         const tensorflow::NodeDef &layer = net.node(li);
         String name = layer.name();
         String type = layer.op();
-
+        
         //CV_LOG_DEBUG(NULL, "DNN/TF: layer_id=" << li << " - '" << name << "' @ " << type);
 
         try
@@ -2933,8 +2943,8 @@ static void addConstNodes(tensorflow::GraphDef& net, std::map<String, int>& cons
             else if (type != "Const")
                 continue;  // only Const parameters are supported
 
-            if (layer.attr().find("value") != layer.attr().end())
-            {
+            if (layer.attr().find("value") != layer.attr().end() &&
+                !isTensorContentEmpty(layer.attr().at("value").tensor())) {
                 CV_Assert(const_layers.insert(std::make_pair(name, li)).second);
             }
             layers_to_ignore.insert(name);
@@ -3003,6 +3013,18 @@ void TFImporter::populateNet()
         << ". Number of nodes = " << netBin.node_size()
     );
 
+    // auto print_net = [](tensorflow::GraphDef& net, std::string tag) {
+    //     std::cout << tag << std::endl;
+    //     int layer_size = net.node_size();
+    //     for (int li = 0; li < layer_size; ++li) {
+    //         const tensorflow::NodeDef& layer = net.node(li);
+    //         std::cout << "id: " << li << ", layer type: " << layer.op() << ", layer: " << layer.name() << std::endl;
+    //     }
+    // };
+
+    // std::cout << "netTxtSize=" << netTxtSize << std::endl;
+
+    // print_net(netBin, "Very beginning!");
     if (netTxtSize)
     {
         CV_LOG_INFO(NULL, "DNN/TF: parsing config"
@@ -3022,14 +3044,19 @@ void TFImporter::populateNet()
     {
         removePhaseSwitches(netBin);
         CV_LOG_DEBUG(NULL, "DNN/TF: removePhaseSwitches(model) => " << netBin.node_size() << " nodes");
+        // print_net(netBin, "After remove Phase Switches");
 
         RemoveIdentityOps(netBin);
         CV_LOG_DEBUG(NULL, "DNN/TF: RemoveIdentityOps(model) => " << netBin.node_size() << " nodes");
+        // print_net(netBin, "After remove identity ops");
 
         simplifySubgraphs(netBin);
         CV_LOG_DEBUG(NULL, "DNN/TF: simplifySubgraphs(model) => " << netBin.node_size() << " nodes");
+        // print_net(netBin, "After simplify subgraphs");
+
         sortByExecutionOrder(netBin);
         CV_LOG_DEBUG(NULL, "DNN/TF: sortByExecutionOrder(model) => " << netBin.node_size() << " nodes");
+        // print_net(netBin, "After sort execution order");
     }
 
     tensorflow::GraphDef& net = netTxtSize != 0 ? netTxt : netBin;


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/23872

Checklist:
1. [ ] remove `ReshapeAsShapeSubgraph` in tf_graph_simplifier or match only if Shape has only one output to Reshape.
2. [x] fix strided slice with empty begin.
3. [ ] add Shape for tf_importer (need to upgrade `graph.pb.h` to have `output_size()` like `NodeProto` in `onnx.pb.h` for shape inference during importing.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
