### PR TITLE
Rewrite SIMD code by using new Universal Intrinsic API : an example.

### DIFF
--- a/modules/core/src/mean.simd.hpp
+++ b/modules/core/src/mean.simd.hpp
@@ -24,7 +24,7 @@ struct SumSqr_SIMD
     }
 };
 
-#if CV_SIMD
+#if CV_SIMD || CV_SIMD_SCALABLE
 
 template <>
 struct SumSqr_SIMD<uchar, int, int>
@@ -39,37 +39,37 @@ struct SumSqr_SIMD<uchar, int, int>
         v_int32 v_sum = vx_setzero_s32();
         v_int32 v_sqsum = vx_setzero_s32();
 
-        const int len0 = len & -v_uint8::nlanes;
+        const int len0 = len & -VTraits<v_uint8>::vlanes();
         while(x < len0)
         {
-            const int len_tmp = min(x + 256*v_uint16::nlanes, len0);
+            const int len_tmp = min(x + 256*VTraits<v_uint16>::vlanes(), len0);
             v_uint16 v_sum16 = vx_setzero_u16();
-            for ( ; x < len_tmp; x += v_uint8::nlanes)
+            for ( ; x < len_tmp; x += VTraits<v_uint8>::vlanes())
             {
                 v_uint16 v_src0 = vx_load_expand(src0 + x);
-                v_uint16 v_src1 = vx_load_expand(src0 + x + v_uint16::nlanes);
-                v_sum16 += v_src0 + v_src1;
+                v_uint16 v_src1 = vx_load_expand(src0 + x + VTraits<v_uint16>::vlanes());
+                v_sum16 = v_add(v_sum16, v_add(v_src0, v_src1));
                 v_int16 v_tmp0, v_tmp1;
                 v_zip(v_reinterpret_as_s16(v_src0), v_reinterpret_as_s16(v_src1), v_tmp0, v_tmp1);
-                v_sqsum += v_dotprod(v_tmp0, v_tmp0) + v_dotprod(v_tmp1, v_tmp1);
+                v_sqsum = v_add(v_sqsum, v_add(v_dotprod(v_tmp0, v_tmp0), v_dotprod(v_tmp1, v_tmp1)));
             }
             v_uint32 v_half0, v_half1;
             v_expand(v_sum16, v_half0, v_half1);
-            v_sum += v_reinterpret_as_s32(v_half0 + v_half1);
+            v_sum = v_add(v_sum, v_reinterpret_as_s32(v_add(v_half0, v_half1)));
         }
-        if (x <= len - v_uint16::nlanes)
+        if (x <= len - VTraits<v_uint16>::vlanes())
         {
             v_uint16 v_src = vx_load_expand(src0 + x);
             v_uint16 v_half = v_combine_high(v_src, v_src);
 
             v_uint32 v_tmp0, v_tmp1;
-            v_expand(v_src + v_half, v_tmp0, v_tmp1);
-            v_sum += v_reinterpret_as_s32(v_tmp0);
+            v_expand(v_add(v_src, v_half), v_tmp0, v_tmp1);
+            v_sum = v_add(v_sum, v_reinterpret_as_s32(v_tmp0));
 
             v_int16 v_tmp2, v_tmp3;
             v_zip(v_reinterpret_as_s16(v_src), v_reinterpret_as_s16(v_half), v_tmp2, v_tmp3);
-            v_sqsum += v_dotprod(v_tmp2, v_tmp2);
-            x += v_uint16::nlanes;
+            v_sqsum = v_add(v_sqsum, v_dotprod(v_tmp2, v_tmp2));
+            x += VTraits<v_uint16>::vlanes();
         }
 
         if (cn == 1)
@@ -79,13 +79,13 @@ struct SumSqr_SIMD<uchar, int, int>
         }
         else
         {
-            int CV_DECL_ALIGNED(CV_SIMD_WIDTH) ar[2 * v_int32::nlanes];
+            int CV_DECL_ALIGNED(CV_SIMD_WIDTH) ar[2 * VTraits<v_int32>::max_nlanes];
             v_store(ar, v_sum);
-            v_store(ar + v_int32::nlanes, v_sqsum);
-            for (int i = 0; i < v_int32::nlanes; ++i)
+            v_store(ar + VTraits<v_int32>::vlanes(), v_sqsum);
+            for (int i = 0; i < VTraits<v_int32>::vlanes(); ++i)
             {
                 sum[i % cn] += ar[i];
-                sqsum[i % cn] += ar[v_int32::nlanes + i];
+                sqsum[i % cn] += ar[VTraits<v_int32>::vlanes() + i];
             }
         }
         v_cleanup();
@@ -106,37 +106,37 @@ struct SumSqr_SIMD<schar, int, int>
         v_int32 v_sum = vx_setzero_s32();
         v_int32 v_sqsum = vx_setzero_s32();
 
-        const int len0 = len & -v_int8::nlanes;
+        const int len0 = len & -VTraits<v_int8>::vlanes();
         while (x < len0)
         {
-            const int len_tmp = min(x + 256 * v_int16::nlanes, len0);
+            const int len_tmp = min(x + 256 * VTraits<v_int16>::vlanes(), len0);
             v_int16 v_sum16 = vx_setzero_s16();
-            for (; x < len_tmp; x += v_int8::nlanes)
+            for (; x < len_tmp; x += VTraits<v_int8>::vlanes())
             {
                 v_int16 v_src0 = vx_load_expand(src0 + x);
-                v_int16 v_src1 = vx_load_expand(src0 + x + v_int16::nlanes);
-                v_sum16 += v_src0 + v_src1;
+                v_int16 v_src1 = vx_load_expand(src0 + x + VTraits<v_int16>::vlanes());
+                v_sum16 = v_add(v_sum16, v_add(v_src0, v_src1));
                 v_int16 v_tmp0, v_tmp1;
                 v_zip(v_src0, v_src1, v_tmp0, v_tmp1);
-                v_sqsum += v_dotprod(v_tmp0, v_tmp0) + v_dotprod(v_tmp1, v_tmp1);
+                v_sqsum = v_add(v_sqsum, v_add(v_dotprod(v_tmp0, v_tmp0), v_dotprod(v_tmp1, v_tmp1)));
             }
             v_int32 v_half0, v_half1;
             v_expand(v_sum16, v_half0, v_half1);
-            v_sum += v_half0 + v_half1;
+            v_sum = v_add(v_sum, v_add(v_half0, v_half1));
         }
-        if (x <= len - v_int16::nlanes)
+        if (x <= len - VTraits<v_int16>::vlanes())
         {
             v_int16 v_src = vx_load_expand(src0 + x);
             v_int16 v_half = v_combine_high(v_src, v_src);
 
             v_int32 v_tmp0, v_tmp1;
-            v_expand(v_src + v_half, v_tmp0, v_tmp1);
-            v_sum += v_tmp0;
+            v_expand(v_add(v_src, v_half), v_tmp0, v_tmp1);
+            v_sum = v_add(v_sum, v_tmp0);
 
             v_int16 v_tmp2, v_tmp3;
             v_zip(v_src, v_half, v_tmp2, v_tmp3);
-            v_sqsum += v_dotprod(v_tmp2, v_tmp2);
-            x += v_int16::nlanes;
+            v_sqsum = v_add(v_sqsum, v_dotprod(v_tmp2, v_tmp2));
+            x += VTraits<v_int16>::vlanes();
         }
 
         if (cn == 1)
@@ -146,13 +146,13 @@ struct SumSqr_SIMD<schar, int, int>
         }
         else
         {
-            int CV_DECL_ALIGNED(CV_SIMD_WIDTH) ar[2 * v_int32::nlanes];
+            int CV_DECL_ALIGNED(CV_SIMD_WIDTH) ar[2 * VTraits<v_int32>::max_nlanes];
             v_store(ar, v_sum);
-            v_store(ar + v_int32::nlanes, v_sqsum);
-            for (int i = 0; i < v_int32::nlanes; ++i)
+            v_store(ar + VTraits<v_int32>::vlanes(), v_sqsum);
+            for (int i = 0; i < VTraits<v_int32>::vlanes(); ++i)
             {
                 sum[i % cn] += ar[i];
-                sqsum[i % cn] += ar[v_int32::nlanes + i];
+                sqsum[i % cn] += ar[VTraits<v_int32>::vlanes() + i];
             }
         }
         v_cleanup();


### PR DESCRIPTION
We introduced scalable RVV as a new Universal Intrinsic backend last summer and also introduced some changing of the Universal Intrinsic API: #22179. In order to make the current SIMD vectorized loops availableto the scalable backend, we need to rewrite the code already written by Universal Intrinsic.

Since there are ~400 SIMD code blocks in ~50 files written by Universal Intinsic., thousands of lines of code need to be rewritten, which will be a huge work if done manually. Then I am developing a (semi-)automated rewriter/refactor based on clang-tidy, that can convert the convert existing code to the new API. The rewriter can already handle about 80% of the cases, and some corner cases are still under development. The link to the rewriter: https://github.com/hanliutong/rewriter

This patch is automatically generated by using the rewriter(except adding the macro `CV_SIMD_SCALABLE`). After building the rewriter (refer to [usage](https://github.com/hanliutong/rewriter#usage) in the readme), use the following command to process `modules/core/src/mean.simd.hpp`
```bash
clang-tidy --load ./libocv_intrinsic_tidy.so \
'--checks=-*,nlanes-check,operator-check,get0-check,lanetype-check' \
-p <path to>/opencv/build/ \
<path to>/opencv/modules/core/src/mean.simd.hpp \
-fix
# Execute the above command twice, in case some operators are not detected in the first time.
```

the clang-tidy will identify the statement that needs to be rewritten and use the new API to give suggestions for modification (the term `FIX IT HINT` in clang-tidy), such as:
1. This is a `nlanes` in vector wrapper class used as loop step, need to be replaced with VTraits member `vlanes`.
``` bash
mean.simd.hpp:152:42: warning: Found nlanes. [nlanes-check]
            for (int i = 0; i < v_int32::nlanes; ++i)
                                ~~~~~~~~~^~~~~~
                                VTraits<v_int32>::vlanes()
```
2. This is also a nlanes in vector wrapper class but is used as array length declaration, which must be a compile-time constant.
Then `nlanes` need to be replaced with VTraits member `max_nlanes`.
```bash
mean.simd.hpp:149:64: warning: Found nlanes as constant. [nlanes-check]
            int CV_DECL_ALIGNED(CV_SIMD_WIDTH) ar[2 * v_int32::nlanes];
                                                      ~~~~~~~~~^~~~~~
                                                      VTraits<v_int32>::max_nlanes
```
3. The overloaded operators are no longer supported in the scalable Universal Intrinsic API, use `v_op` instead.
```bash
mean.simd.hpp:134:19: warning: Found operator. [operator-check]
            v_sum += v_tmp0;
            ~~~~~~^~~~~~~~~
            v_sum = v_add(v_sum, v_tmp0)
```

The rewriter also supports other cases that do not using in this file. Please refer to the [capability](https://github.com/hanliutong/rewriter#capability) part in readme or the [examples](https://github.com/hanliutong/rewriter/tree/master/examples)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=riscv-clang-rvv
Xbuild_image:Custom=riscv-clang-rvv-128
Xbuild_image:Custom=riscv-gcc-rvv-07
test_modules:Custom=core,imgproc,dnn
buildworker:Custom=linux-4
test_timeout:Custom=600
build_contrib:Custom=OFF
```