### PR TITLE
Fix dupe word typos in comments

### DIFF
--- a/3rdparty/cpufeatures/cpu-features.c
+++ b/3rdparty/cpufeatures/cpu-features.c
@@ -734,7 +734,7 @@ android_cpuInit(void)
 #ifdef __arm__
     {
         /* Extract architecture from the "CPU Architecture" field.
-         * The list is well-known, unlike the the output of
+         * The list is well-known, unlike the output of
          * the 'Processor' field which can vary greatly.
          *
          * See the definition of the 'proc_arch' array in

--- a/3rdparty/libpng/pngrutil.c
+++ b/3rdparty/libpng/pngrutil.c
@@ -364,7 +364,7 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
     * be gained by using this when it is known *if* the zlib stream itself does
     * not record the number; however, this is an illusion: the original writer
     * of the PNG may have selected a lower window size, and we really must
-    * follow that because, for systems with with limited capabilities, we
+    * follow that because, for systems with limited capabilities, we
     * would otherwise reject the application's attempts to use a smaller window
     * size (zlib doesn't have an interface to say "this or lower"!).
     *

--- a/3rdparty/openexr/IlmImf/ImfCRgbaFile.h
+++ b/3rdparty/openexr/IlmImf/ImfCRgbaFile.h
@@ -93,7 +93,7 @@ typedef struct ImfRgba ImfRgba;
 #define IMF_VERSION_NUMBER      2
 
 /*
-** Line order; values must the the same as in Imf::LineOrder.
+** Line order; values must be the same as in Imf::LineOrder.
 */
 
 #define IMF_INCREASING_Y	0

--- a/3rdparty/openexr/IlmImf/ImfMisc.cpp
+++ b/3rdparty/openexr/IlmImf/ImfMisc.cpp
@@ -348,7 +348,7 @@ copyIntoFrameBuffer (const char *& readPtr,
     else if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
         // Convert the pixels from the file's machine-
         // independent representation, and store the
@@ -485,7 +485,7 @@ copyIntoFrameBuffer (const char *& readPtr,
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         // Copy the results into the frame buffer.
         //
 
@@ -769,7 +769,7 @@ copyIntoDeepFrameBuffer (const char *& readPtr,
     else if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
         // Convert the pixels from the file's machine-
         // independent representation, and store the
@@ -1050,7 +1050,7 @@ copyIntoDeepFrameBuffer (const char *& readPtr,
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         // Copy the results into the frame buffer.
         //
 
@@ -1439,7 +1439,7 @@ copyFromFrameBuffer (char *& writePtr,
     if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
 
         switch (type)
@@ -1480,7 +1480,7 @@ copyFromFrameBuffer (char *& writePtr,
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         //
 
         switch (type)
@@ -1549,7 +1549,7 @@ copyFromDeepFrameBuffer (char *& writePtr,
     if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
 
         switch (type)
@@ -1624,7 +1624,7 @@ copyFromDeepFrameBuffer (char *& writePtr,
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         //
 
         switch (type)

--- a/3rdparty/openjpeg/openjp2/jp2.c
+++ b/3rdparty/openjpeg/openjp2/jp2.c
@@ -147,7 +147,7 @@ static OPJ_BOOL opj_jp2_write_ftyp(opj_jp2_t *jp2,
                                    opj_event_mgr_t * p_manager);
 
 /**
- * Reads a a FTYP box - File type box
+ * Reads a FTYP box - File type box
  *
  * @param   p_header_data   the data contained in the FTYP box.
  * @param   jp2             the jpeg2000 file codec.
@@ -2578,7 +2578,7 @@ static OPJ_BOOL opj_jp2_read_jp(opj_jp2_t *jp2,
 }
 
 /**
- * Reads a a FTYP box - File type box
+ * Reads a FTYP box - File type box
  *
  * @param   p_header_data   the data contained in the FTYP box.
  * @param   jp2             the jpeg2000 file codec.

--- a/doc/tutorials/dnn/dnn_pytorch_tf_classification/tf_cls_model_conversion_tutorial.md
+++ b/doc/tutorials/dnn/dnn_pytorch_tf_classification/tf_cls_model_conversion_tutorial.md
@@ -136,7 +136,7 @@ tf.io.write_graph(graph_or_graph_def=frozen_tf_func.graph,
 
 After the successful execution of the above code, we will get a frozen graph in ``models/mobilenet.pb``.
 
-* read TF frozen graph with with cv.dnn.readNetFromTensorflow passing the obtained in the previous step ``mobilenet.pb`` into it:
+* read TF frozen graph with cv.dnn.readNetFromTensorflow passing the obtained in the previous step ``mobilenet.pb`` into it:
 
 ```python
 # get TF frozen graph path


### PR DESCRIPTION
Fix duplicated word typos in comments. The errors were first found with a regex search, then all of them manually checked. I've only committed those that are highly likely to be a typo.
