### PR TITLE
Update PRs & Issue templates to exclude 3.4 from active development

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,12 +15,12 @@ body:
       Please provide the following system information to help us diagnose the bug. For example:
 
       // example for c++ user
-      OpenCV version: 4.6.0
+      OpenCV version: 4.8.0
       Operating System / Platform: Ubuntu 20.04
       Compiler & compiler version: GCC 9.3.0
 
       // example for python user
-      OpenCV python version: 4.6.0.66
+      OpenCV python version: 4.8.0.74
       Operating System / Platform: Ubuntu 20.04
       Python version: 3.9.6
   validations:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,7 +12,7 @@ body:
   attributes:
     label: Describe the doc issue
     description: >
-      Please provide a clear and concise description of what content in https://docs.opencv.org/ is an issue. Note that there are multiple active branches, such as 3.4, 4.x and 5.x, so please specify the branch with the problem.
+      Please provide a clear and concise description of what content in https://docs.opencv.org/ is an issue. Note that there are multiple active branches, such as 4.x and 5.x, so please specify the branch with the problem.
     placeholder: |
       A clear and concise description of what content in https://docs.opencv.org/ is an issue.
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
