### PR TITLE
imgcodecs: removing unnecessary if statement

### DIFF
--- a/modules/imgcodecs/src/bitstrm.cpp
+++ b/modules/imgcodecs/src/bitstrm.cpp
@@ -444,9 +444,8 @@ void  WBaseStream::close()
 
 void  WBaseStream::release()
 {
-    if( m_start )
-        delete[] m_start;
-    m_start = m_end = m_current = 0;
+    delete[] m_start;
+    m_start = m_end = m_current = nullptr;
 }
 
 


### PR DESCRIPTION
removing this unnecessary if statement because deleting a null pointer has no effect. 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
