### PR TITLE
optimize Mat::setTo() with memset

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -628,6 +628,45 @@ Mat& Mat::setTo(InputArray _value, InputArray _mask)
 
     CV_IPP_RUN_FAST(ipp_Mat_setTo_Mat(*this, value, mask), *this)
 
+    const bool checkMemsetUsability = mask.empty();
+    if (checkMemsetUsability)
+    {
+        const size_t esz = this->elemSize();
+        AutoBuffer<uchar> rawValueBytes(esz);
+        const size_t rawValueBytesSize = rawValueBytes.size();
+        uchar* rawValueBytesBuf = rawValueBytes.data();
+        uchar* rawValueBytesBufEnd = rawValueBytesBuf+rawValueBytesSize;
+        convertAndUnrollScalar( value, type(), rawValueBytesBuf, this->channels());
+        const uchar referenceByte = *rawValueBytesBuf;
+        const bool isUniformByte = (std::find_if_not(rawValueBytesBuf, rawValueBytesBufEnd, std::bind2nd(std::equal_to<uchar>(), referenceByte)) == rawValueBytesBufEnd);
+        if (isUniformByte)
+        {
+            if (this->isContinuous())
+                memset(this->data, referenceByte, this->total()*esz);
+            else if (this->dims == 2)
+            {
+                for(int row = 0, rowCount = this->rows, colCount = this->cols ; row<rowCount ; ++row)
+                    memset(this->ptr<uchar>(row), referenceByte, colCount*esz);
+            }
+            else
+            {
+                const Mat* arrays[] = {this, nullptr};
+                Mat planes[1];
+                NAryMatIterator itNAry(arrays, planes, 1);
+                for(size_t p = 0 ; p<itNAry.nplanes ; ++p, ++itNAry)
+                {
+                    Mat& plane = itNAry.planes[0];
+                    if (plane.isContinuous())
+                        memset(plane.data, referenceByte, plane.total()*esz);
+                    for(int row = 0, rowsCount = plane.rows, colCount = plane.cols ; row<rowsCount ; ++row)
+                        memset(plane.ptr<uchar>(row), referenceByte, colCount*esz);
+                }
+            }
+
+            return *this;
+        }//end if (isUniformByte)
+    }
+
     size_t esz = mcn > 1 ? elemSize1() : elemSize();
     BinaryFunc copymask = getCopyMaskFunc(esz);
 


### PR DESCRIPTION
If the scalar value used to fill the Mat can be unrolled to a sequence of identical bytes (typically 0), memset() can be used for a performance gain

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

I don't know how to add a test_perf for that