### PR TITLE
Fix partially unknown Mat

### DIFF
--- a/modules/core/misc/python/package/mat_wrapper/__init__.py
+++ b/modules/core/misc/python/package/mat_wrapper/__init__.py
@@ -1,12 +1,18 @@
 __all__ = []
 
-import sys
 import numpy as np
 import cv2 as cv
+from typing import TYPE_CHECKING, Any
+
+# Type subscription is not possible in python 3.8
+if TYPE_CHECKING:
+    _NDArray = np.ndarray[Any, np.dtype[np.generic]]
+else:
+    _NDArray = np.ndarray
 
 # NumPy documentation: https://numpy.org/doc/stable/user/basics.subclassing.html
 
-class Mat(np.ndarray):
+class Mat(_NDArray):
     '''
     cv.Mat wrapper for numpy array.
 


### PR DESCRIPTION
Closes #23780 by specifying `ndarray`'s generic types. The use of `TYPE_CHECKING` and a type alias allows this to keep compatibility with all Python versions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
