### PR TITLE
Add missing properties to error class

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -3,7 +3,8 @@ __all__ = [
 ]
 
 from typing import Sequence, Callable
-from .nodes import NamespaceNode, FunctionNode, OptionalTypeNode
+
+from .nodes import NamespaceNode, FunctionNode, OptionalTypeNode, ClassProperty, PrimitiveTypeNode
 from .ast_utils import find_function_node, SymbolName
 
 
@@ -11,7 +12,7 @@ def apply_manual_api_refinement(root: NamespaceNode) -> None:
     # Export OpenCV exception class
     builtin_exception = root.add_class("Exception")
     builtin_exception.is_exported = False
-    root.add_class("error", (builtin_exception, ))
+    root.add_class("error", (builtin_exception, ), ERROR_CLASS_PROPERTIES)
     for symbol_name, refine_symbol in NODES_TO_REFINE.items():
         refine_symbol(root, symbol_name)
 
@@ -46,3 +47,11 @@ NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "resize"): make_optional_arg("dsize"),
     SymbolName(("cv", ), (), "calcHist"): make_optional_arg("mask"),
 }
+ERROR_CLASS_PROPERTIES = (
+    ClassProperty("code", PrimitiveTypeNode.int_(), False),
+    ClassProperty("err", PrimitiveTypeNode.str_(), False),
+    ClassProperty("file", PrimitiveTypeNode.str_(), False),
+    ClassProperty("func", PrimitiveTypeNode.str_(), False),
+    ClassProperty("line", PrimitiveTypeNode.int_(), False),
+    ClassProperty("msg", PrimitiveTypeNode.str_(), False),
+)

--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -7,5 +7,5 @@ from .constant_node import ConstantNode
 from .type_node import (
     TypeNode, OptionalTypeNode, UnionTypeNode, NoneTypeNode, TupleTypeNode,
     ASTNodeTypeNode, AliasTypeNode, SequenceTypeNode, AnyTypeNode,
-    AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode,
+    AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode
 )


### PR DESCRIPTION
May close #23925 . I am not sure this actually works because I can't figure out how to generate python bindings myself. But it looks right based on available API.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
