### PR TITLE
Fixed a typo in filter.cpp

### DIFF
--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -3214,7 +3214,7 @@ static bool ocl_filter2D( InputArray _src, OutputArray _dst, int ddepth,
 
     // For smaller filter kernels, there is a special kernel that is more
     // efficient than the general one.
-    UMat kernalDataUMat;
+    UMat kernelDataUMat;
     if (device.isIntel() && (device.type() & ocl::Device::TYPE_GPU) &&
         ((ksize.width < 5 && ksize.height < 5) ||
         (ksize.width == 5 && ksize.height == 5 && cn == 1)))


### PR DESCRIPTION
Fixed typo error in the file. Changed the spelling from "KERNAL" to "KERNEL".
