### PR TITLE
Solve error: ambiguous overload for ‘operator!=’ (operand types are ‘__half’ and ‘double’)

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
@@ -111,7 +111,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
              * or there might be several weights
              * or we don't have to scale
              */
-            if (weight != 1.0)
+            if (weight != (T)(1.0))
             {
                 kernels::scale1_with_bias1<T>(stream, output, input, weight, 1.0);
             }

--- a/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/normalize_bbox.hpp
@@ -111,7 +111,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
              * or there might be several weights
              * or we don't have to scale
              */
-            if (weight != (T)(1.0))
+            if (weight != static_cast(T)(1.0))
             {
                 kernels::scale1_with_bias1<T>(stream, output, input, weight, 1.0);
             }

--- a/modules/dnn/src/cuda4dnn/primitives/region.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/region.hpp
@@ -121,7 +121,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                 new_coords
             );
 
-            if (nms_iou_threshold > (T)(0)) {
+            if (nms_iou_threshold > static_cast(T)(0)) {
                 auto output_mat = output_wrapper->getMutableHostMat();
                 CV_Assert(output_mat.type() == CV_32F);
                 for (int i = 0; i < input.get_axis_size(0); i++) {

--- a/modules/dnn/src/cuda4dnn/primitives/region.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/region.hpp
@@ -121,7 +121,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                 new_coords
             );
 
-            if (nms_iou_threshold > 0) {
+            if (nms_iou_threshold > (T)(0)) {
                 auto output_mat = output_wrapper->getMutableHostMat();
                 CV_Assert(output_mat.type() == CV_32F);
                 for (int i = 0; i < input.get_axis_size(0); i++) {


### PR DESCRIPTION
**Remove the error: error: ambiguous overload for ‘operator!=’ (operand types are ‘__half’ and ‘double’) **

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
