### PR TITLE
feat: add matrix type stubs generation

### DIFF
--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -103,9 +103,6 @@ def _generate_typing_stubs(root: NamespaceNode, output_path: Path) -> None:
 
     _write_reexported_symbols_section(root, output_stream)
 
-    # Write constants section, because constants don't impose any dependencies
-    _generate_section_stub(StubSection("# Constants", ConstantNode), root,
-                           output_stream, 0)
     # NOTE: Enumerations require special handling, because all enumeration
     # constants are exposed as module attributes
     has_enums = _generate_section_stub(StubSection("# Enumerations", EnumerationNode),


### PR DESCRIPTION
Adds missing typing stubs:

- Matrix depths: `CV_8U`, `CV_8S` and etc.
- Matrix type constants: `CV_8UC1`, `CV_32FC3` and etc.
- Matrix type factory functions: `CV_*(channels) -> int` and `CV_MAKETYPE`

Resolves: #23910

Added content of `__init__.pyi`:

``` python
# Constants
CV_8U: int
CV_8UC1: int
CV_8UC2: int
CV_8UC3: int
CV_8UC4: int
CV_8S: int
CV_8SC1: int
CV_8SC2: int
CV_8SC3: int
CV_8SC4: int
CV_16U: int
CV_16UC1: int
CV_16UC2: int
CV_16UC3: int
CV_16UC4: int
CV_16S: int
CV_16SC1: int
CV_16SC2: int
CV_16SC3: int
CV_16SC4: int
CV_32S: int
CV_32SC1: int
CV_32SC2: int
CV_32SC3: int
CV_32SC4: int
CV_32F: int
CV_32FC1: int
CV_32FC2: int
CV_32FC3: int
CV_32FC4: int
CV_64F: int
CV_64FC1: int
CV_64FC2: int
CV_64FC3: int
CV_64FC4: int
CV_16F: int
CV_16FC1: int
CV_16FC2: int
CV_16FC3: int
CV_16FC4: int

def CV_8UC(channels: int) -> int: ...

def CV_8SC(channels: int) -> int: ...

def CV_16UC(channels: int) -> int: ...

def CV_16SC(channels: int) -> int: ...

def CV_32SC(channels: int) -> int: ...

def CV_32FC(channels: int) -> int: ...

def CV_64FC(channels: int) -> int: ...

def CV_16FC(channels: int) -> int: ...

def CV_MAKETYPE(depth: int, channels: int) -> int: ...
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
