### PR TITLE
fix: recursively re-export nested submodules in typing stubs

### DIFF
--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -621,11 +621,16 @@ def _populate_reexported_symbols(root: NamespaceNode) -> None:
     # Re-export all submodules to allow referencing symbols in submodules
     # without submodule import. Example:
     # `cv2.aruco.ArucoDetector` should be accessible without `import cv2.aruco`
-    for submodule in root.namespaces.values():
-        root.reexported_submodules.append(submodule.export_name)
+    def _reexport_submodule(ns: NamespaceNode) -> None:
+        for submodule in ns.namespaces.values():
+            ns.reexported_submodules.append(submodule.export_name)
+            _reexport_submodule(submodule)
+
+    _reexport_submodule(root)
 
     # Special cases, symbols defined in possible pure Python submodules should be
     root.reexported_submodules_symbols["mat_wrapper"].append("Mat")
+
 
 def _write_reexported_symbols_section(module: NamespaceNode, output_stream: StringIO) -> None:
     """Write re-export section for the given module.


### PR DESCRIPTION
Addresses the same issue as #23809 , but also handles nested modules case

e.g. adds the following section to `cv2/gapi/__init__.pyi`:

```python
from cv2.gapi import core as core
from cv2.gapi import ie as ie
from cv2.gapi import imgproc as imgproc
from cv2.gapi import oak as oak
from cv2.gapi import onnx as onnx
from cv2.gapi import ov as ov
from cv2.gapi import own as own
from cv2.gapi import render as render
from cv2.gapi import streaming as streaming
from cv2.gapi import video as video
from cv2.gapi import wip as wip

```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [] There is a reference to the original bug report and related work
- [] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
