### PR TITLE
feat: update NumPy type to Mat type fail message

### DIFF
--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -5,6 +5,7 @@
 
 #include "cv2_convert.hpp"
 #include "cv2_numpy.hpp"
+#include "cv2_util.hpp"
 #include "opencv2/core/utils/logger.hpp"
 
 PyTypeObject* pyopencv_Mat_TypePtr = nullptr;
@@ -22,6 +23,26 @@ static std::string pycv_dumpArray(const T* arr, int n)
         out << " " << arr[i];
     out << " ]";
     return out.str();
+}
+
+static inline std::string getArrayTypeName(PyArrayObject* arr)
+{
+    PyArray_Descr* dtype = PyArray_DESCR(arr);
+    PySafeObject dtype_str(PyObject_Str(reinterpret_cast<PyObject*>(dtype)));
+    if (!dtype_str)
+    {
+        // Fallback to typenum value
+        return cv::format("%d", PyArray_TYPE(arr));
+    }
+    std::string type_name;
+    if (!getUnicodeString(dtype_str, type_name))
+    {
+        // Failed to get string from bytes object - clear set TypeError and
+        // fallback to typenum value
+        PyErr_Clear();
+        return cv::format("%d", PyArray_TYPE(arr));
+    }
+    return type_name;
 }
 
 //======================================================================================================================
@@ -102,7 +123,9 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
         }
         else
         {
-            failmsg("%s data type = %d is not supported", info.name, typenum);
+            const std::string dtype_name = getArrayTypeName(oarr);
+            failmsg("%s data type = %s is not supported", info.name,
+                    dtype_name.c_str());
             return false;
         }
     }

--- a/modules/python/src2/cv2_util.hpp
+++ b/modules/python/src2/cv2_util.hpp
@@ -42,7 +42,7 @@ private:
 
 /**
  * Light weight RAII wrapper for `PyObject*` owning references.
- * In comparisson to C++11 `std::unique_ptr` with custom deleter, it provides
+ * In comparison to C++11 `std::unique_ptr` with custom deleter, it provides
  * implicit conversion functions that might be useful to initialize it with
  * Python functions those returns owning references through the `PyObject**`
  * e.g. `PyErr_Fetch` or directly pass it to functions those want to borrow
@@ -68,6 +68,10 @@ public:
     operator PyObject**()
     {
         return &obj_;
+    }
+
+    operator bool() {
+        return static_cast<bool>(obj_);
     }
 
     PyObject* release()

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -219,6 +219,14 @@ class Arguments(NewOpenCVTests):
         #res6 = cv.utils.dumpInputArray([a, b])
         #self.assertEqual(res6, "InputArrayOfArrays: empty()=false kind=0x00050000 flags=0x01050000 total(-1)=2 dims(-1)=1 size(-1)=2x1 type(0)=CV_32FC1 dims(0)=4 size(0)=[2 3 4 5]")
 
+    def test_unsupported_numpy_data_types_string_description(self):
+        for dtype in (object, str, np.complex128):
+            test_array = np.zeros((4, 4, 3), dtype=dtype)
+            msg = ".*type = {} is not supported".format(test_array.dtype)
+            self.assertRaisesRegex(
+                Exception, msg, cv.utils.dumpInputArray, test_array
+            )
+
     def test_20968(self):
         pixel = np.uint8([[[40, 50, 200]]])
         _ = cv.cvtColor(pixel, cv.COLOR_RGB2BGR)  # should not raise exception


### PR DESCRIPTION
Output string representation of NumPy array type if it is not convertible to OpenCV Mat type

Example output from the test:

```
cv2.error: OpenCV(4.8.0-dev) :-1: error: (-5:Bad argument) in function 'dumpInputArray'
> Overload resolution failed:
>  - argument data type = object is not supported
>  - Expected Ptr<cv::UMat> for argument 'argument'
```

Resolves: #23106

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
