### PR TITLE
[GSoC] Update octree methods and create frame for PCC

### DIFF
--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2526,12 +2526,12 @@ public:
     explicit Octree(int maxDepth);
 
     /** @overload
-    * @brief Create an Octree from the PointCloud data with the specific max depth.
+    * @brief Create an Octree from the PointCloud data with the specific resolution.
     *
     * @param pointCloud Point cloud data.
-    * @param maxDepth The max depth of the Octree.
+    * @param resolution The size of the octree leaf node.
     */
-    Octree(const std::vector<Point3f> &pointCloud, int maxDepth);
+    Octree(const std::vector<Point3f> &pointCloud, double resolution);
 
     /** @overload
     * @brief Create an empty Octree.
@@ -2552,14 +2552,36 @@ public:
     */
     bool insertPoint(const Point3f& point);
 
-    /** @brief Read point cloud data and create OctreeNode.
+    /** @overload
+    * @brief Insert a point data with color to a OctreeNode.
     *
-    * This function is only called when the octree is being created.
+    * @param point The point data in Point3f format.
+    * @param color The color attribute of point in Point3f format.
+    * @return Returns whether the insertion is successful.
+    */
+    bool insertPoint(const Point3f& point,const Point3f &color);
+
+    /** @brief Read point cloud data without color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
     * @param pointCloud PointCloud data.
-    * @param maxDepth The max depth of the Octree.
+    * @param resolution The size of the Octree leaf node.
     * @return Returns whether the creation is successful.
     */
-    bool create(const std::vector<Point3f> &pointCloud, int maxDepth = -1);
+    bool create(const std::vector<Point3f> &pointCloud,double resolution);
+
+    /** @overload
+    * @brief Read point cloud data with color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
+    * @param pointCloud PointCloud data.
+    * @param colorAttribute The color attribute of point cloud in Point3f format.
+    * @param resolution The size of the Octree leaf node.
+    * @return Returns whether the creation is successful.
+    */
+    bool create(const std::vector<Point3f> &pointCloud,const std::vector<Point3f> &colorAttribute,double resolution);
 
     /** @brief Determine whether the point is within the space range of the specific cube.
      *
@@ -2596,7 +2618,16 @@ public:
     */
     bool deletePoint(const Point3f& point);
 
-    /** @brief Radius Nearest Neighbor Search in Octree
+    /** @brief restore point cloud data from Octree.
+    *
+    * Restore the point cloud data from existing octree. The points in same leaf node will be seen as the same point.
+    * This point is the center of the leaf node. If the resolution is small, it will work as a downSampling function.
+    * @param restorePointCloud The output point cloud data.
+    * @param restoreColor The color attribute of point cloud data
+    */
+    void getPointCloudByOctree(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor);
+
+    /** @brief Radius Nearest Neighbor Search in Octree.
     *
     * Search all points that are less than or equal to radius.
     * And return the number of searched points.

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -12,8 +12,8 @@
 
 namespace cv{
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, unsigned long x_key, unsigned long y_key,
-                     unsigned long z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key, size_t y_key,
+                     size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
 
 // Locate the OctreeNode corresponding to the input point from the given OctreeNode.
 static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node,OctreeKey& key,size_t depthMask);
@@ -94,7 +94,7 @@ bool _isPointInBound(const Point3f& _point, const Point3f& _origin, double _size
 struct Octree::Impl
 {
 public:
-    Impl():maxDepth(-1), size(0), origin(0,0,0), resolution(0)
+    Impl():maxDepth(0), size(0), origin(0,0,0), resolution(0)
     {}
 
     ~Impl()
@@ -103,7 +103,7 @@ public:
     // The pointer to Octree root node.
     Ptr <OctreeNode> rootNode = nullptr;
     //! Max depth of the Octree. And depth must be greater than zero
-    int maxDepth;
+    size_t maxDepth;
     //! The size of the cube of the .
     double size;
     //! The origin coordinate of root node.
@@ -116,7 +116,7 @@ public:
 
 Octree::Octree() : p(new Impl)
 {
-    p->maxDepth = -1;
+    p->maxDepth = 0;
     p->size = 0;
     p->origin = Point3f(0,0,0);
 }
@@ -160,9 +160,9 @@ bool Octree::insertPoint(const Point3f& point,const Point3f &color)
     {
         return false;
     }
-    OctreeKey key(floor((point.x - this->p->origin.x) / resolution),
-                  floor((point.y - this->p->origin.y) / resolution),
-                  floor((point.z - this->p->origin.z) / resolution));
+    OctreeKey key((size_t)floor((point.x - this->p->origin.x) / resolution),
+                  (size_t)floor((point.y - this->p->origin.y) / resolution),
+                  (size_t)floor((point.z - this->p->origin.z) / resolution));
 
     bool result = insertPointRecurse(p->rootNode, point, color, p->maxDepth, key, depthMask);
     return result;
@@ -199,7 +199,7 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, const std::vector<Po
     double maxSize = max(max(maxBound.x - minBound.x, maxBound.y - minBound.y), maxBound.z - minBound.z);
     //To use bit operation, the length of the root cube should be power of 2.
     maxSize=double(1<<int(ceil(log2(maxSize))));
-    p->maxDepth = ceil(log2(maxSize / resolution));
+    p->maxDepth = (size_t)ceil(log2(maxSize / resolution));
     this->p->size = (1<<p->maxDepth)*resolution;
     this->p->origin = Point3f(float(floor(minBound.x / resolution) * resolution),
                               float(floor(minBound.y / resolution) * resolution),
@@ -247,7 +247,7 @@ void Octree::clear()
     }
 
     p->size = 0;
-    p->maxDepth = -1;
+    p->maxDepth = 0;
     p->origin = Point3f (0,0,0); // origin coordinate
 }
 
@@ -296,9 +296,9 @@ bool Octree::isPointInBound(const Point3f& _point) const
 
 bool Octree::deletePoint(const Point3f& point)
 {
-    OctreeKey key=OctreeKey(floor((point.x - this->p->origin.x) / p->resolution),
-                            floor((point.y - this->p->origin.y) / p->resolution),
-                            floor((point.z - this->p->origin.z) / p->resolution));
+    OctreeKey key=OctreeKey((size_t)floor((point.x - this->p->origin.x) / p->resolution),
+                            (size_t)floor((point.y - this->p->origin.y) / p->resolution),
+                            (size_t)floor((point.z - this->p->origin.z) / p->resolution));
     size_t depthMask=1 << (p->maxDepth - 1);
     Ptr<OctreeNode> node = index(point, p->rootNode,key,depthMask);
 
@@ -415,8 +415,8 @@ void Octree::getPointCloudByOctree(std::vector<Point3f> &restorePointCloud, std:
     getPointRecurse(restorePointCloud, restoreColor, 0, 0, 0, root, resolution, p->origin, p->hasColor);
 }
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, unsigned long x_key,
-                     unsigned long y_key,unsigned long z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori,
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key,
+                     size_t y_key,size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori,
                      bool hasColor) {
     OctreeNode node = *_node;
     if (node.isLeaf) {
@@ -433,9 +433,9 @@ void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3
     unsigned char y_mask = 2;
     unsigned char z_mask = 4;
     for (unsigned char i = 0; i < 8; i++) {
-        unsigned long x_copy = x_key;
-        unsigned long y_copy = y_key;
-        unsigned long z_copy = z_key;
+        size_t x_copy = x_key;
+        size_t y_copy = y_key;
+        size_t z_copy = z_key;
         if (!node.children[i].empty()) {
             size_t x_offSet = !!(x_mask & i);
             size_t y_offSet = !!(y_mask & i);

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -30,16 +30,16 @@ static void radiusNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& qu
 static void KNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& query, const int K,
                              float& smallestDist, std::vector<PQueueElem<Point3f> >& candidatePoint);
 
-OctreeNode::OctreeNode():children(OCTREE_CHILD_NUM, nullptr),neigh(OCTREE_NEIGH_SIZE, nullptr), depth(0), size(0), origin(0,0,0), parentIndex(-1),pointNum(0)
+OctreeNode::OctreeNode():children(OCTREE_CHILD_NUM, nullptr), depth(0), size(0), origin(0,0,0),
+                                    pointNum(0),neigh(OCTREE_NEIGH_SIZE, nullptr),parentIndex(-1)
 {
 }
 
 OctreeNode::OctreeNode(int _depth, double _size, const Point3f &_origin, const Point3f &_color,
-                       int _parentIndex, int _pointNum) : children(OCTREE_CHILD_NUM),
-                                                          neigh(OCTREE_NEIGH_SIZE), depth(_depth),
-                                                          size(_size), origin(_origin),
-                                                          color(_color), parentIndex(_parentIndex),
-                                                          pointNum(_pointNum) {
+                       int _parentIndex, int _pointNum) : children(OCTREE_CHILD_NUM), depth(_depth),
+                                                          size(_size), origin(_origin),color(_color),pointNum(_pointNum),
+                                                          neigh(OCTREE_NEIGH_SIZE),parentIndex(_parentIndex)
+                                                          {
 }
 
 bool OctreeNode::empty() const

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -88,7 +88,7 @@ public:
     //! color attribute of octree node.
     Point3f color;
     //! RAHTCoefficient of octree node, used for color attribute compression.
-    Point3f RAHTCoefficient;
+    Point3f RAHTCoefficient=Point3f(0,0,0);
     //! Number of point cloud in this node.
     int pointNum;
 

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -55,10 +55,12 @@ public:
     * to the depth of Octree.
     * @param _size The length of the OctreeNode. In space, every OctreeNode represents a cube.
     * @param _origin The absolute coordinates of the center of the cube.
+    * @param _color THe color attribute of octreeNode.
     * @param _parentIndex The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
+    * @param _pointNum The number of point in this cube.
     */
-    OctreeNode(int _depth, double _size, const Point3f& _origin, int _parentIndex);
+    OctreeNode(int _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex, int _pointNum);
 
     //! returns true if the rootNode is NULL.
     bool empty() const;
@@ -83,6 +85,26 @@ public:
     //! And the center of cube is `center = origin + Point3f(size/2, size/2, size/2)`.
     Point3f origin;
 
+    //! color attribute of octree node.
+    Point3f color;
+    //! RAHTCoefficient of octree node, used for color attribute compression.
+    Point3f RAHTCoefficient;
+    //! Number of point cloud in this node.
+    int pointNum;
+
+    /**  The list of 6 adjacent neighbor node.
+        *    index mapping:
+        *     +z                        [101]
+        *      |                          |    [110]
+        *      |                          |  /
+        *      O-------- +x    [001]----{000} ----[011]
+        *     /                       /   |
+        *    /                   [010]    |
+        *  +y                           [100]
+        *  index 000, 111 are reserved
+        */
+    std::vector< Ptr<OctreeNode> > neigh;
+
     /**  The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
     */
@@ -95,5 +117,56 @@ public:
     std::vector<Point3f> pointList;
 };
 
+/** @brief Key for pointCloud, used to compute the child node index through bit operations.
+
+When building the octree, the point cloud data is firstly voxelized/discretized: by inserting
+all the points into a voxel coordinate system. For example, when resolution is set to 0.01, a point
+with coordinate Point3f(0.251,0.502,0.753) would be transformed to:(0.251/0.01,0.502/0.01,0.753/0.01)
+=(25,50,75). And the OctreeKey will be (x_key:1_1001,y_key:11_0010,z_key:100_1011). Assume the Octree->depth
+is 100_0000, It can quickly calculate the index of the child nodes at each layer.
+layer	    Depth Mask	    x&Depth Mask	    y&Depth Mask	    z&Depth Mask	    Child Index(0-7)
+1	        100_0000	    0	                0	                1	                4
+2	        10_0000	        0	                1	                0	                2
+3	        1_0000	        1	                1	                0	                3
+4	        1000	        1	                0	                1	                5
+5	        100	            0	                0	                0	                0
+6	        10	            0	                1	                1	                6
+7	        1	            1	                0	                1	                5
+*/
+
+class OctreeKey{
+public:
+    size_t x_key;
+    size_t y_key;
+    size_t z_key;
+
+public:
+    OctreeKey():x_key(0),y_key(0),z_key(0){};
+    OctreeKey(size_t x,size_t y,size_t z):x_key(x),y_key(y),z_key(z){};
+
+    /** @brief compute the child node index through bit operations.
+    *
+    * @param mask The mask of specify layer.
+    * @return the index of child(0-7)
+    */
+    inline unsigned char findChildIdxByMask(size_t mask) const{
+        return static_cast<unsigned char>((!!(z_key&mask))<<2)|((!!(y_key&mask))<<1)|(!!(x_key&mask));
+    }
+
+    /** @brief get occupancy code from node.
+    *
+    * The occupancy code type is unsigned char that represents whether the eight child nodes of the octree node exist
+    * If a octree node has 3 child which indexes are 0,1,7, then the occupancy code of this node is 1000_0011
+    * @param node The octree node.
+    * @return the occupancy code(0000_0000-1111_1111)
+    */
+    static inline unsigned char getBitPattern(OctreeNode &node) {
+        unsigned char res=0;
+        for (unsigned char i=0; i<node.children.size();i++){
+            res|=static_cast<unsigned char>((!node.children[i].empty()) << i);
+        }
+        return res;
+    }
+};
 }
 #endif //OPENCV_3D_SRC_OCTREE_HPP

--- a/modules/3d/src/pcc.h
+++ b/modules/3d/src/pcc.h
@@ -1,0 +1,94 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Author: Yuhang Wang <yuhangwang0012@gmail.com>
+//         Chengwei Ye <broweigg@gmail.com>
+//         Zhangjie Cheng <zhangjiec01@gmail.com>
+
+#ifndef OPENCV_PCC_H
+#define OPENCV_PCC_H
+
+#include <vector>
+#include "opencv2/core.hpp"
+#include "octree.hpp"
+#include "opencv2/3d.hpp"
+
+namespace cv {
+
+
+/** @brief class to serialize or deserialize pointcloud data
+ *
+ * A class for "encoding" pointcloud data to a
+ * meaningful, unevenly distributed char vector,
+ * so that it can be further compressed by Entropy coding.
+ * And the opposite "decoding" way as well.
+ *
+ * The current implementation is to represent pointcloud as Octree,
+ * then traverse OctreeNodes to get vector of "occupancy code".
+*/
+class OctreeSerializeCoder {
+private:
+    Octree *octree;
+    float resolution;
+public:
+
+    OctreeSerializeCoder();
+
+    OctreeSerializeCoder(float resolution);
+
+    //! encode Pointcloud data to serialized char vector
+    void encode(const std::vector<Point3f> &pointCloud,
+                        std::vector<unsigned char> &serializedVector);
+
+    //! decode Pointcloud data from serialized char vector
+    void decode(const std::vector<unsigned char> &serializedVector,
+                        std::vector<Point3f> &pointCloud);
+};
+
+/** @brief Class to reduce vectorized data size by EntropyCoding
+ *
+ * The algorithm used here is Range Coding Algorithm.
+ *
+*/
+class EntropyCoder {
+public:
+    //! encode char vector to bit stream
+    void encodeCharVectorToStream(const std::vector<unsigned char> &inputCharVector,
+                                  std::ostream &outputStream);
+
+    //! decode char vector from bit stream
+    void decodeStreamToCharVector(const std::istream &inputStream,
+                                  std::vector<unsigned char> &outputCharVector);
+};
+
+/** @brief pointcloud compression class
+ *
+ * This class enables user to do compression and decompression to pointcloud,
+ * currently based on Octree,
+ * may support other method (like kd-tree, etc.) in future if necessary.
+ *
+*/
+class PointCloudCompression{
+private:
+    OctreeSerializeCoder _coder;
+    EntropyCoder _entropyCoder;
+public:
+    /** @brief User compress the pointcloud to stream
+     *
+     * @param pointCloud the pointcloud to compress
+     * @param outputStream the output compressed bit stream destination
+    */
+    void compress(const std::vector<Point3f> &pointCloud, std::ostream &outputStream);
+
+    /** @brief User decompress(recover) pointcloud from stream
+     *
+     * @param inputStream the input compressed bit stream source
+     * @param pointCloud the output pointcloud
+    */
+    void decompress(std::istream &inputStream, const std::vector<Point3f> &pointCloud);
+};
+
+}
+
+#endif //OPENCV_PCC_H

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -24,7 +24,7 @@ protected:
         RNG& rng_Point = theRNG(); // set random seed for fixing output 3D point.
 
         // Generate 3D PointCloud
-        for(int i = 0; i < pointCloudSize; i++)
+        for(unsigned int i = 0; i < pointCloudSize; i++)
         {
             float _x = 10 * (float)rng_Point.uniform(pmin.x, pmax.x)/scale;
             float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -40,7 +40,6 @@ protected:
         float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;
         float _z = 10 * (float)rng_Point.uniform(pmin.z, pmax.z)/scale;
         restPoint = Point3f(_x, _y, _z);
-
     }
 
 public:

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -53,7 +53,7 @@ public:
     //Color attribute of pointCloud from octree
     std::vector<Point3f> restorePointCloudColor;
 
-    int pointCloudSize;
+    unsigned int pointCloudSize;
     Point3f restPoint;
     Octree treeTest;
     double resolution;
@@ -84,7 +84,7 @@ TEST_F(OctreeTest, RadiusSearchTest)
     std::vector<Point3f> outputPoints;
     std::vector<float> outputSquareDist;
     EXPECT_NO_THROW(treeTest.radiusNNSearch(restPoint, radius, outputPoints, outputSquareDist));
-    EXPECT_EQ(outputPoints.size(),5);
+    EXPECT_EQ(outputPoints.size(),(unsigned int)5);
 
     //The outputPoints should be unordered, so in some resolution, this test will fail because it specified the order of output.
     EXPECT_FLOAT_EQ(outputPoints[0].x, -8.88461112976f);

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -24,7 +24,7 @@ protected:
         RNG& rng_Point = theRNG(); // set random seed for fixing output 3D point.
 
         // Generate 3D PointCloud
-        for(unsigned int i = 0; i < pointCloudSize; i++)
+        for(size_t i = 0; i < pointCloudSize; i++)
         {
             float _x = 10 * (float)rng_Point.uniform(pmin.x, pmax.x)/scale;
             float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;
@@ -52,7 +52,7 @@ public:
     //Color attribute of pointCloud from octree
     std::vector<Point3f> restorePointCloudColor;
 
-    unsigned int pointCloudSize;
+    size_t pointCloudSize;
     Point3f restPoint;
     Octree treeTest;
     double resolution;


### PR DESCRIPTION
## PR for GSoC Point Cloud Compression
[Issue for GSoC 2023](https://github.com/opencv/opencv/issues/23624)

* We are **updating the Octree method create() by using OctreeKey**: Through voxelization, directly calculate the leaf nodes that the point cloud belongs to, and omit the judgment whether the point cloud is in the range when inserted. The index of the child node is calculated by bit operation.
* We are also **introducing a new header file pcc.h (Point Cloud Compression) with API framework**.
* We added tests for restoring point clouds from an octree.
* Currently, the features related to octree creation and point cloud compression are part of the internal API, which means they are not directly accessible to users. However, our plan for the future is to **include only the 'PointCloudCompression' class in the 'opencv2/3d.hpp' header file**. This will provide an interface for utilizing the point cloud compression functionality.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
