### PR TITLE
cmake: don't export external target twice

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -1632,13 +1632,19 @@ function(ocv_add_external_target name inc link def)
   endif()
 endfunction()
 
+set(__OPENCV_EXPORTED_EXTERNAL_TARGETS "" CACHE INTERNAL "")
 function(ocv_install_used_external_targets)
   if(NOT BUILD_SHARED_LIBS
       AND NOT (CMAKE_VERSION VERSION_LESS "3.13.0")  # upgrade CMake: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2152
   )
     foreach(tgt in ${ARGN})
       if(tgt MATCHES "^ocv\.3rdparty\.")
-        install(TARGETS ${tgt} EXPORT OpenCVModules)
+        list(FIND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}" _found)
+        if(_found EQUAL -1)  # don't export target twice
+          install(TARGETS ${tgt} EXPORT OpenCVModules)
+          list(APPEND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}")
+          set(__OPENCV_EXPORTED_EXTERNAL_TARGETS "${__OPENCV_EXPORTED_EXTERNAL_TARGETS}" CACHE INTERNAL "")
+        endif()
       endif()
     endforeach()
   endif()


### PR DESCRIPTION
fixup #23842

Error message on `-DWITH_OPENVINO=ON -DBUILD_SHARED_LIBS=OFF`:
```
CMake Error: install(EXPORT "OpenCVModules" ...) includes target "ocv.3rdparty.openvino" more than once in the export set.
CMake Error in CMakeLists.txt:
  given target "ocv.3rdparty.openvino" more than once.
```