### PR TITLE
Add missing ”v_popcount“ for RVV and enable tests.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1651,6 +1651,10 @@ inline v_uint32 v_popcount(const v_uint32& a)
 {
     return v_hadd(v_hadd(v_popcount(vreinterpret_u8m1(a))));
 }
+inline v_uint64 v_popcount(const v_uint64& a)
+{
+    return v_hadd(v_hadd(v_hadd(v_popcount(vreinterpret_u8m1(a)))));
+}
 
 inline v_uint8 v_popcount(const v_int8& a)
 {
@@ -1663,6 +1667,11 @@ inline v_uint16 v_popcount(const v_int16& a)
 inline v_uint32 v_popcount(const v_int32& a)
 {
     return v_popcount(v_abs(a));\
+}
+inline v_uint64 v_popcount(const v_int64& a)
+{
+    // max(0 - a) is used, since v_abs does not support 64-bit integers.
+    return v_popcount(v_reinterpret_as_u64(vmax(a, v_sub(v_setzero_s64(), a), VTraits<v_int64>::vlanes())));
 }
 
 

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -2048,6 +2048,7 @@ void test_hal_intrin_uint64()
         .test_rotate<0>().test_rotate<1>()
         .test_extract_n<0>().test_extract_n<1>()
         .test_extract_highest()
+        .test_popcount()
         //.test_broadcast_element<0>().test_broadcast_element<1>()
         ;
 }
@@ -2069,6 +2070,7 @@ void test_hal_intrin_int64()
         .test_extract_highest()
         //.test_broadcast_element<0>().test_broadcast_element<1>()
         .test_cvt64_double()
+        .test_popcount()
         ;
 }
 


### PR DESCRIPTION
I'm currently rewrite more code to the scalable Universal Intrinsic and I found that the Universal Intrinsic function `v_popcount` is missing for 64-bits integer in scalable RVV backend. This patch adds the missing implementation

BTW, according to the [documentation](https://github.com/opencv/opencv/blob/6af4a029417b0ed6e393610b5d7d99a13eb06219/modules/core/include/opencv2/core/hal/intrin_cpp.hpp#L820C1-L834C2) below , `v_popcount`  is designed for all integer type, but the unit test for 64-bit integer type is missing. I also enable the test in this patch.


```cpp
/** @brief Count the 1 bits in the vector lanes and return result as corresponding unsigned type

Scheme:
@code
{A1 A2 A3 ...} => {popcount(A1), popcount(A2), popcount(A3), ...}
@endcode
For all integer types. */
template<typename _Tp, int n>
inline v_reg<typename V_TypeTraits<_Tp>::abs_type, n> v_popcount(const v_reg<_Tp, n>& a)
....
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
