### PR TITLE
Fixed tests execution with Python 2.7

### DIFF
--- a/modules/python/src2/cv2_util.hpp
+++ b/modules/python/src2/cv2_util.hpp
@@ -71,7 +71,7 @@ public:
     }
 
     operator bool() {
-        return static_cast<bool>(obj_);
+        return obj_ != nullptr;
     }
 
     PyObject* release()

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -223,9 +223,14 @@ class Arguments(NewOpenCVTests):
         for dtype in (object, str, np.complex128):
             test_array = np.zeros((4, 4, 3), dtype=dtype)
             msg = ".*type = {} is not supported".format(test_array.dtype)
-            self.assertRaisesRegex(
-                Exception, msg, cv.utils.dumpInputArray, test_array
-            )
+            if sys.version_info[0] < 3:
+                self.assertRaisesRegexp(
+                    Exception, msg, cv.utils.dumpInputArray, test_array
+                )
+            else:
+                self.assertRaisesRegex(
+                    Exception, msg, cv.utils.dumpInputArray, test_array
+                )
 
     def test_20968(self):
         pixel = np.uint8([[[40, 50, 200]]])


### PR DESCRIPTION
Fix for BuildBot. 
Regression introduced in https://github.com/opencv/opencv/pull/23958
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
