### PR TITLE
videoio: fix v4l2 test on older platforms (centos)

### DIFF
--- a/modules/videoio/test/test_v4l2.cpp
+++ b/modules/videoio/test/test_v4l2.cpp
@@ -21,6 +21,20 @@
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <linux/videodev2.h>
 
+// workarounds for older versions
+#ifndef V4L2_PIX_FMT_Y10
+#define V4L2_PIX_FMT_Y10 v4l2_fourcc('Y', '1', '0', ' ')
+#endif
+#ifndef V4L2_PIX_FMT_Y12
+#define V4L2_PIX_FMT_Y12 v4l2_fourcc('Y', '1', '2', ' ')
+#endif
+#ifndef V4L2_PIX_FMT_ABGR32
+#define V4L2_PIX_FMT_ABGR32  v4l2_fourcc('A', 'R', '2', '4')
+#endif
+#ifndef V4L2_PIX_FMT_XBGR32
+#define V4L2_PIX_FMT_XBGR32  v4l2_fourcc('X', 'R', '2', '4')
+#endif
+
 using namespace cv;
 
 namespace opencv_test { namespace {


### PR DESCRIPTION
related #23944

Added FOURCC codes missing on older systems.
