### PR TITLE
Prefer using `TYPE_CHECKING` condition in `cv2.typing` module

### DIFF
--- a/modules/core/misc/python/package/mat_wrapper/__init__.py
+++ b/modules/core/misc/python/package/mat_wrapper/__init__.py
@@ -4,15 +4,15 @@ import numpy as np
 import cv2 as cv
 from typing import TYPE_CHECKING, Any
 
-# Type subscription is not possible in python 3.8
+# Same as cv2.typing.NumPyArrayGeneric, but avoids circular dependencies
 if TYPE_CHECKING:
-    _NDArray = np.ndarray[Any, np.dtype[np.generic]]
+    _NumPyArrayGeneric = np.ndarray[Any, np.dtype[np.generic]]
 else:
-    _NDArray = np.ndarray
+    _NumPyArrayGeneric = np.ndarray
 
 # NumPy documentation: https://numpy.org/doc/stable/user/basics.subclassing.html
 
-class Mat(_NDArray):
+class Mat(_NumPyArrayGeneric):
     '''
     cv.Mat wrapper for numpy array.
 

--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -395,9 +395,12 @@ class AliasTypeNode(TypeNode):
 
 class ConditionalAliasTypeNode(TypeNode):
     """Type node representing an alias protected by condition checked in runtime.
+    For typing-related conditions, prefer using typing.TYPE_CHECKING. For a full explanation, see:
+    https://github.com/opencv/opencv/pull/23927#discussion_r1256326835
+
     Example:
     ```python
-    if numpy.lib.NumpyVersion(numpy.__version__) > "1.20.0" and sys.version_info >= (3, 9)
+    if typing.TYPE_CHECKING
         NumPyArray = numpy.ndarray[typing.Any, numpy.dtype[numpy.generic]]
     else:
         NumPyArray = numpy.ndarray
@@ -407,10 +410,10 @@ class ConditionalAliasTypeNode(TypeNode):
 
     ConditionalAliasTypeNode(
         "NumPyArray",
-        'numpy.lib.NumpyVersion(numpy.__version__) > "1.20.0" and sys.version_info >= (3, 9)',
+        'typing.TYPE_CHECKING',
         NDArrayTypeNode("NumPyArray"),
         NDArrayTypeNode("NumPyArray", use_numpy_generics=False),
-        condition_required_imports=("import numpy", "import sys")
+        condition_required_imports=("import typing",)
     )
     ```
     """
@@ -468,14 +471,14 @@ class ConditionalAliasTypeNode(TypeNode):
     def numpy_array_(cls, ctype_name: str, export_name: Optional[str] = None,
                      shape: Optional[Tuple[int, ...]] = None,
                      dtype: Optional[str] = None):
+        """Type subscription is not possible in python 3.8 and older numpy versions."""
         return cls(
             ctype_name,
-            ('numpy.lib.NumpyVersion(numpy.__version__) > "1.20.0" '
-             'and sys.version_info >= (3, 9)'),
+            "typing.TYPE_CHECKING",
             NDArrayTypeNode(ctype_name, shape, dtype),
             NDArrayTypeNode(ctype_name, shape, dtype,
                             use_numpy_generics=False),
-            condition_required_imports=("import numpy", "import sys")
+            condition_required_imports=("import typing",)
         )
 
 


### PR DESCRIPTION
Fixes an issue in #23838 that re-introduced #23780 for `NumPyArrayGeneric`, `NumPyArrayFloat32`, `NumPyArrayFloat64` and all their aliases/subtypes/unions. As well as supporting generic static hints in python 3.8.

Read https://github.com/opencv/opencv/pull/23927#discussion_r1256326835 for the full explanation.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
