### PR TITLE
[GSoC] Update octree methods and create frames for PCC

### DIFF
--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2688,7 +2688,7 @@ public:
     *
     * @param maxDepth The max depth of the Octree. The maxDepth > -1.
     */
-    explicit Octree(int maxDepth);
+    explicit Octree(size_t maxDepth);
 
     /** @overload
     * @brief Create an Octree from the PointCloud data with the specific resolution.
@@ -2705,7 +2705,7 @@ public:
     * @param size Initial Cube size.
     * @param origin Initial center coordinate.
     */
-    Octree(int maxDepth, double size, const Point3f& origin);
+    Octree(size_t maxDepth, double size, const Point3f& origin);
 
     //! Default destructor
     ~Octree();
@@ -2756,7 +2756,7 @@ public:
     bool isPointInBound(const Point3f& point) const;
 
     //! Set MaxDepth for Octree.
-    void setMaxDepth(int maxDepth);
+    void setMaxDepth(size_t maxDepth);
 
     //! Set Box Size for Octree.
     void setSize(double size);

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2691,12 +2691,12 @@ public:
     explicit Octree(int maxDepth);
 
     /** @overload
-    * @brief Create an Octree from the PointCloud data with the specific max depth.
+    * @brief Create an Octree from the PointCloud data with the specific resolution.
     *
     * @param pointCloud Point cloud data.
-    * @param maxDepth The max depth of the Octree.
+    * @param resolution The size of the octree leaf node.
     */
-    Octree(const std::vector<Point3f> &pointCloud, int maxDepth);
+    Octree(const std::vector<Point3f> &pointCloud, double resolution);
 
     /** @overload
     * @brief Create an empty Octree.
@@ -2717,14 +2717,36 @@ public:
     */
     bool insertPoint(const Point3f& point);
 
-    /** @brief Read point cloud data and create OctreeNode.
+    /** @overload
+    * @brief Insert a point data with color to a OctreeNode.
     *
-    * This function is only called when the octree is being created.
+    * @param point The point data in Point3f format.
+    * @param color The color attribute of point in Point3f format.
+    * @return Returns whether the insertion is successful.
+    */
+    bool insertPoint(const Point3f& point,const Point3f &color);
+
+    /** @brief Read point cloud data without color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
     * @param pointCloud PointCloud data.
-    * @param maxDepth The max depth of the Octree.
+    * @param resolution The size of the Octree leaf node.
     * @return Returns whether the creation is successful.
     */
-    bool create(const std::vector<Point3f> &pointCloud, int maxDepth = -1);
+    bool create(const std::vector<Point3f> &pointCloud,double resolution);
+
+    /** @overload
+    * @brief Read point cloud data with color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
+    * @param pointCloud PointCloud data.
+    * @param colorAttribute The color attribute of point cloud in Point3f format.
+    * @param resolution The size of the Octree leaf node.
+    * @return Returns whether the creation is successful.
+    */
+    bool create(const std::vector<Point3f> &pointCloud,const std::vector<Point3f> &colorAttribute,double resolution);
 
     /** @brief Determine whether the point is within the space range of the specific cube.
      *
@@ -2761,7 +2783,16 @@ public:
     */
     bool deletePoint(const Point3f& point);
 
-    /** @brief Radius Nearest Neighbor Search in Octree
+    /** @brief restore point cloud data from Octree.
+    *
+    * Restore the point cloud data from existing octree. The points in same leaf node will be seen as the same point.
+    * This point is the center of the leaf node. If the resolution is small, it will work as a downSampling function.
+    * @param restorePointCloud The output point cloud data.
+    * @param restoreColor The color attribute of point cloud data
+    */
+    void getPointCloudByOctree(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor);
+
+    /** @brief Radius Nearest Neighbor Search in Octree.
     *
     * Search all points that are less than or equal to radius.
     * And return the number of searched points.

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2684,36 +2684,66 @@ public:
     Octree();
 
     /** @overload
-    * @brief Create an empty Octree and set the maximum depth.
-    *
-    * @param maxDepth The max depth of the Octree. The maxDepth > -1.
-    */
-    explicit Octree(int maxDepth);
+     * @brief Creates an empty Octree with given maximum depth
+     * 
+     * @param maxDepth The max depth of the Octree
+     * @param origin Initial center coordinate
+     * @param withColors Whether to keep per-point colors or not
+     * @return resulting Octree
+     */
+    static Octree createWithDepth(int maxDepth, const Point3f& origin = { }, bool withColors = false);
+
+    //TODO: different arg order, less overloads
 
     /** @overload
      * @brief Create an Octree from the PointCloud data with the specific maxDepth
-     *
-     * @param pointCloud Point cloud data
-     * @param maxDepth Max depth of the octree, should be non-negative
+     * 
+     * @param pointCloud point cloud data, should be 3-channel float array
+     * @param maxDepth Max depth of the octree
+     * @return resulting Octree
      */
-    Octree(const std::vector<Point3f> &pointCloud, int maxDepth);
+    static Octree createWithDepth(InputArray pointCloud, int maxDepth);
 
     /** @overload
-    * @brief Create an Octree from the PointCloud data with the specific resolution.
-    *
-    * @param pointCloud Point cloud data.
-    * @param resolution The size of the octree leaf node.
-    */
-    Octree(const std::vector<Point3f> &pointCloud, double resolution);
+     * @brief Create an Octree from the PointCloud data with the specific maxDepth
+     * 
+     * @param pointCloud point cloud data, should be 3-channel float array
+     * @param colors color attribute of point cloud in the same 3-channel float format
+     * @param maxDepth Max depth of the octree
+     * @return resulting Octree
+     */
+    static Octree createWithDepth(InputArray pointCloud, InputArray colors, int maxDepth);
+
+    //TODO: different arg order, less overloads
 
     /** @overload
-    * @brief Create an empty Octree.
-    *
-    * @param maxDepth Max depth.
-    * @param size Initial Cube size.
-    * @param origin Initial center coordinate.
-    */
-    Octree(int maxDepth, double size, const Point3f& origin);
+     * @brief Creates an empty Octree with given resolution
+     * 
+     * @param resolution The size of the octree leaf node
+     * @param origin Initial center coordinate
+     * @param withColors Whether to keep per-point colors or not
+     * @return resulting Octree
+     */
+    static Octree createWithResolution(double resolution, const Point3f& origin = { }, bool withColors = false);
+
+    /** @overload
+     * @brief Create an Octree from the PointCloud data with the specific resolution
+     * 
+     * @param pointCloud point cloud data, should be 3-channel float array
+     * @param resolution The size of the octree leaf node
+     * @return Octree 
+     */
+    static Octree createWithResolution(InputArray pointCloud, double resolution);
+
+     /** @overload
+     * @brief Create an Octree from the PointCloud data with the specific resolution
+     * 
+     * @param pointCloud point cloud data, should be 3-channel float array
+     * @param colors color attribute of point cloud in the same 3-channel float format
+     * @param resolution The size of the octree leaf node
+     * @return Octree 
+     */
+    static Octree createWithResolution(InputArray pointCloud, InputArray colors, double resolution);
 
     //! Default destructor
     ~Octree();
@@ -2725,51 +2755,7 @@ public:
     * @param color The color attribute of point in Point3f format.
     * @return Returns whether the insertion is successful.
     */
-    bool insertPoint(const Point3f& point, const Point3f& color = Point3f());
-
-    /** @brief Read point cloud data without color and create OctreeNode.
-    *
-    * This function is only called when the octree is being created. The maxDepth of octree is calculated
-    * by resolution.
-    * @param pointCloud PointCloud data.
-    * @param resolution The size of the Octree leaf node.
-    * @return Returns whether the creation is successful.
-    */
-    void create(const std::vector<Point3f> &pointCloud, double resolution);
-
-    /** @brief Read point cloud data without color and create OctreeNode.
-    *
-    * This function is only called when the octree is being created. The maxDepth of octree is calculated
-    * by resolution.
-    * @param pointCloud PointCloud data.
-    * @param maxDepth Max depth
-    * @return Returns whether the creation is successful.
-    */
-    void create(const std::vector<Point3f> &pointCloud, int maxDepth);
-
-    /** @overload
-    * @brief Read point cloud data with color and create OctreeNode.
-    *
-    * This function is only called when the octree is being created. The maxDepth of octree is calculated
-    * by resolution.
-    * @param pointCloud PointCloud data.
-    * @param colorAttribute The color attribute of point cloud in Point3f format.
-    * @param resolution The size of the Octree leaf node.
-    * @return Returns whether the creation is successful.
-    */
-    void create(const std::vector<Point3f> &pointCloud, const std::vector<Point3f> &colorAttribute, double resolution);
-
-    /** @overload
-    * @brief Read point cloud data with color and create OctreeNode.
-    *
-    * This function is only called when the octree is being created. The maxDepth of octree is calculated
-    * by resolution.
-    * @param pointCloud PointCloud data.
-    * @param colorAttribute The color attribute of point cloud in Point3f format.
-    * @param maxDepth Max depth
-    * @return Returns whether the creation is successful.
-    */
-    void create(const std::vector<Point3f> &pointCloud, const std::vector<Point3f> &colorAttribute, int maxDepth);
+    bool insertPoint(const Point3f& point, const Point3f& color = { });
 
     /** @brief Determine whether the point is within the space range of the specific cube.
      *
@@ -2777,15 +2763,6 @@ public:
      * @return If point is in bound, return ture. Otherwise, false.
      */
     bool isPointInBound(const Point3f& point) const;
-
-    //! Set MaxDepth for Octree.
-    void setMaxDepth(int maxDepth);
-
-    //! Set Box Size for Octree.
-    void setSize(double size);
-
-    //! Set Origin coordinates for Octree.
-    void setOrigin(const Point3f& origin);
 
     //! returns true if the rootnode is NULL.
     bool empty() const;
@@ -2801,7 +2778,7 @@ public:
     * Delete the corresponding element from the pointList in the corresponding leaf node. If the leaf node
     * does not contain other points after deletion, this node will be deleted. In the same way,
     * its parent node may also be deleted if its last child is deleted.
-    * @param point The point coordinates.
+    * @param point The point coordinates, comparison is epsilon-based
     * @return return ture if the point is deleted successfully.
     */
     bool deletePoint(const Point3f& point);
@@ -2810,10 +2787,10 @@ public:
     *
     * Restore the point cloud data from existing octree. The points in same leaf node will be seen as the same point.
     * This point is the center of the leaf node. If the resolution is small, it will work as a downSampling function.
-    * @param restorePointCloud The output point cloud data.
-    * @param restoreColor The color attribute of point cloud data
+    * @param restoredPointCloud The output point cloud data, can be replaced by noArray() if not needed
+    * @param restoredColor The color attribute of point cloud data, can be omitted if not needed
     */
-    void getPointCloudByOctree(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor);
+    void getPointCloudByOctree(OutputArray restoredPointCloud, OutputArray restoredColor = noArray());
 
     /** @brief Radius Nearest Neighbor Search in Octree.
     *
@@ -2821,21 +2798,56 @@ public:
     * And return the number of searched points.
     * @param query Query point.
     * @param radius Retrieved radius value.
-    * @param pointSet Point output. Contains searched points, and output vector is not in order.
-    * @param squareDistSet Dist output. Contains searched squared distance, and output vector is not in order.
+    * @param pointSet Point output. Contains searched points in 3-float format, and output vector is not in order,
+    * can be replaced by noArray() if not needed
+    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order,
+    * can be omitted if not needed
     * @return the number of searched points.
     */
-    int radiusNNSearch(const Point3f& query, float radius, std::vector<Point3f> &pointSet, std::vector<float> &squareDistSet) const;
+    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray squareDists = noArray()) const;
+
+    /** @overload
+    *  @brief Radius Nearest Neighbor Search in Octree.
+    *
+    * Search all points that are less than or equal to radius.
+    * And return the number of searched points.
+    * @param query Query point.
+    * @param radius Retrieved radius value.
+    * @param pointSet Point output. Contains searched points in 3-float format, and output vector is not in order,
+    * can be replaced by noArray() if not needed
+    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() or omitted if not needed
+    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order.
+    * @return the number of searched points.
+    */
+    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray colors = noArray(),
+                       OutputArray squareDists = noArray()) const;
 
     /** @brief K Nearest Neighbor Search in Octree.
     *
     * Find the K nearest neighbors to the query point.
     * @param query Query point.
     * @param K
-    * @param pointSet Point output. Contains K points, arranged in order of distance from near to far.
-    * @param squareDistSet Dist output. Contains K squared distance, arranged in order of distance from near to far.
+    * @param pointSet Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
+    * can be replaced by noArray() if not needed
+    * @param squareDistSet Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
+    * can be omitted if not needed
     */
-    void KNNSearch(const Point3f& query, const int K, std::vector<Point3f> &pointSet, std::vector<float> &squareDistSet) const;
+    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray squareDists = noArray()) const;
+
+    /** @overload
+    *  @brief K Nearest Neighbor Search in Octree.
+    *
+    * Find the K nearest neighbors to the query point.
+    * @param query Query point.
+    * @param K
+    * @param pointSet Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
+    * can be replaced by noArray() if not needed
+    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() or omitted if not needed
+    * @param squareDistSet Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
+    * can be omitted if not needed
+    */
+    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors = noArray(),
+                   OutputArray squareDists = noArray()) const;
 
 protected:
     struct Impl;

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2688,7 +2688,7 @@ public:
     *
     * @param maxDepth The max depth of the Octree. The maxDepth > -1.
     */
-    explicit Octree(size_t maxDepth);
+    explicit Octree(int maxDepth);
 
     /** @overload
     * @brief Create an Octree from the PointCloud data with the specific resolution.
@@ -2705,7 +2705,7 @@ public:
     * @param size Initial Cube size.
     * @param origin Initial center coordinate.
     */
-    Octree(size_t maxDepth, double size, const Point3f& origin);
+    Octree(int maxDepth, double size, const Point3f& origin);
 
     //! Default destructor
     ~Octree();
@@ -2756,7 +2756,7 @@ public:
     bool isPointInBound(const Point3f& point) const;
 
     //! Set MaxDepth for Octree.
-    void setMaxDepth(size_t maxDepth);
+    void setMaxDepth(int maxDepth);
 
     //! Set Box Size for Octree.
     void setSize(double size);

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2691,30 +2691,17 @@ public:
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
      */
-    static Octree createWithDepth(int maxDepth, const Point3f& origin = { }, bool withColors = false);
-
-    //TODO: different arg order, less overloads
+    static Octree createWithDepth(int maxDepth, double size, const Point3f& origin = { }, bool withColors = false);
 
     /** @overload
      * @brief Create an Octree from the PointCloud data with the specific maxDepth
      * 
-     * @param pointCloud point cloud data, should be 3-channel float array
      * @param maxDepth Max depth of the octree
-     * @return resulting Octree
-     */
-    static Octree createWithDepth(InputArray pointCloud, int maxDepth);
-
-    /** @overload
-     * @brief Create an Octree from the PointCloud data with the specific maxDepth
-     * 
      * @param pointCloud point cloud data, should be 3-channel float array
      * @param colors color attribute of point cloud in the same 3-channel float format
-     * @param maxDepth Max depth of the octree
      * @return resulting Octree
      */
-    static Octree createWithDepth(InputArray pointCloud, InputArray colors, int maxDepth);
-
-    //TODO: different arg order, less overloads
+    static Octree createWithDepth(int maxDepth, InputArray pointCloud, InputArray colors = noArray());
 
     /** @overload
      * @brief Creates an empty Octree with given resolution
@@ -2724,26 +2711,17 @@ public:
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
      */
-    static Octree createWithResolution(double resolution, const Point3f& origin = { }, bool withColors = false);
-
-    /** @overload
-     * @brief Create an Octree from the PointCloud data with the specific resolution
-     * 
-     * @param pointCloud point cloud data, should be 3-channel float array
-     * @param resolution The size of the octree leaf node
-     * @return Octree 
-     */
-    static Octree createWithResolution(InputArray pointCloud, double resolution);
+    static Octree createWithResolution(double resolution, double size, const Point3f& origin = { }, bool withColors = false);
 
      /** @overload
      * @brief Create an Octree from the PointCloud data with the specific resolution
      * 
+     * @param resolution The size of the octree leaf node
      * @param pointCloud point cloud data, should be 3-channel float array
      * @param colors color attribute of point cloud in the same 3-channel float format
-     * @param resolution The size of the octree leaf node
-     * @return Octree 
+     * @return resulting octree
      */
-    static Octree createWithResolution(InputArray pointCloud, InputArray colors, double resolution);
+    static Octree createWithResolution(double resolution, InputArray pointCloud, InputArray colors = noArray());
 
     //! Default destructor
     ~Octree();
@@ -2815,12 +2793,12 @@ public:
     * @param radius Retrieved radius value.
     * @param pointSet Point output. Contains searched points in 3-float format, and output vector is not in order,
     * can be replaced by noArray() if not needed
-    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() or omitted if not needed
-    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order.
+    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() if not needed
+    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order,
+    * can be replaced by noArray() if not needed
     * @return the number of searched points.
     */
-    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray colors = noArray(),
-                       OutputArray squareDists = noArray()) const;
+    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray colors, OutputArray squareDists) const;
 
     /** @brief K Nearest Neighbor Search in Octree.
     *
@@ -2842,12 +2820,11 @@ public:
     * @param K
     * @param pointSet Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
     * can be replaced by noArray() if not needed
-    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() or omitted if not needed
+    * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() if not needed
     * @param squareDistSet Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
-    * can be omitted if not needed
+    * can be replaced by noArray() if not needed
     */
-    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors = noArray(),
-                   OutputArray squareDists = noArray()) const;
+    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors, OutputArray squareDists) const;
 
 protected:
     struct Impl;

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2691,6 +2691,14 @@ public:
     explicit Octree(int maxDepth);
 
     /** @overload
+     * @brief Create an Octree from the PointCloud data with the specific maxDepth
+     *
+     * @param pointCloud Point cloud data
+     * @param maxDepth Max depth of the octree, should be non-negative
+     */
+    Octree(const std::vector<Point3f> &pointCloud, int maxDepth);
+
+    /** @overload
     * @brief Create an Octree from the PointCloud data with the specific resolution.
     *
     * @param pointCloud Point cloud data.
@@ -2710,13 +2718,6 @@ public:
     //! Default destructor
     ~Octree();
 
-    /** @brief Insert a point data to a OctreeNode.
-    *
-    * @param point The point data in Point3f format.
-    * @return Returns whether the insertion is successful.
-    */
-    bool insertPoint(const Point3f& point);
-
     /** @overload
     * @brief Insert a point data with color to a OctreeNode.
     *
@@ -2724,7 +2725,7 @@ public:
     * @param color The color attribute of point in Point3f format.
     * @return Returns whether the insertion is successful.
     */
-    bool insertPoint(const Point3f& point,const Point3f &color);
+    bool insertPoint(const Point3f& point, const Point3f& color = Point3f());
 
     /** @brief Read point cloud data without color and create OctreeNode.
     *
@@ -2734,7 +2735,17 @@ public:
     * @param resolution The size of the Octree leaf node.
     * @return Returns whether the creation is successful.
     */
-    bool create(const std::vector<Point3f> &pointCloud,double resolution);
+    void create(const std::vector<Point3f> &pointCloud, double resolution);
+
+    /** @brief Read point cloud data without color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
+    * @param pointCloud PointCloud data.
+    * @param maxDepth Max depth
+    * @return Returns whether the creation is successful.
+    */
+    void create(const std::vector<Point3f> &pointCloud, int maxDepth);
 
     /** @overload
     * @brief Read point cloud data with color and create OctreeNode.
@@ -2746,7 +2757,19 @@ public:
     * @param resolution The size of the Octree leaf node.
     * @return Returns whether the creation is successful.
     */
-    bool create(const std::vector<Point3f> &pointCloud,const std::vector<Point3f> &colorAttribute,double resolution);
+    void create(const std::vector<Point3f> &pointCloud, const std::vector<Point3f> &colorAttribute, double resolution);
+
+    /** @overload
+    * @brief Read point cloud data with color and create OctreeNode.
+    *
+    * This function is only called when the octree is being created. The maxDepth of octree is calculated
+    * by resolution.
+    * @param pointCloud PointCloud data.
+    * @param colorAttribute The color attribute of point cloud in Point3f format.
+    * @param maxDepth Max depth
+    * @return Returns whether the creation is successful.
+    */
+    void create(const std::vector<Point3f> &pointCloud, const std::vector<Point3f> &colorAttribute, int maxDepth);
 
     /** @brief Determine whether the point is within the space range of the specific cube.
      *

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2685,8 +2685,9 @@ public:
 
     /** @overload
      * @brief Creates an empty Octree with given maximum depth
-     * 
+     *
      * @param maxDepth The max depth of the Octree
+     * @param size bounding box size for the Octree
      * @param origin Initial center coordinate
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
@@ -2695,7 +2696,7 @@ public:
 
     /** @overload
      * @brief Create an Octree from the PointCloud data with the specific maxDepth
-     * 
+     *
      * @param maxDepth Max depth of the octree
      * @param pointCloud point cloud data, should be 3-channel float array
      * @param colors color attribute of point cloud in the same 3-channel float format
@@ -2705,8 +2706,9 @@ public:
 
     /** @overload
      * @brief Creates an empty Octree with given resolution
-     * 
+     *
      * @param resolution The size of the octree leaf node
+     * @param size bounding box size for the Octree
      * @param origin Initial center coordinate
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
@@ -2715,7 +2717,7 @@ public:
 
      /** @overload
      * @brief Create an Octree from the PointCloud data with the specific resolution
-     * 
+     *
      * @param resolution The size of the octree leaf node
      * @param pointCloud point cloud data, should be 3-channel float array
      * @param colors color attribute of point cloud in the same 3-channel float format
@@ -2776,9 +2778,9 @@ public:
     * And return the number of searched points.
     * @param query Query point.
     * @param radius Retrieved radius value.
-    * @param pointSet Point output. Contains searched points in 3-float format, and output vector is not in order,
+    * @param points Point output. Contains searched points in 3-float format, and output vector is not in order,
     * can be replaced by noArray() if not needed
-    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order,
+    * @param squareDists Dist output. Contains searched squared distance in floats, and output vector is not in order,
     * can be omitted if not needed
     * @return the number of searched points.
     */
@@ -2791,10 +2793,10 @@ public:
     * And return the number of searched points.
     * @param query Query point.
     * @param radius Retrieved radius value.
-    * @param pointSet Point output. Contains searched points in 3-float format, and output vector is not in order,
+    * @param points Point output. Contains searched points in 3-float format, and output vector is not in order,
     * can be replaced by noArray() if not needed
     * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() if not needed
-    * @param squareDistSet Dist output. Contains searched squared distance in floats, and output vector is not in order,
+    * @param squareDists Dist output. Contains searched squared distance in floats, and output vector is not in order,
     * can be replaced by noArray() if not needed
     * @return the number of searched points.
     */
@@ -2804,10 +2806,10 @@ public:
     *
     * Find the K nearest neighbors to the query point.
     * @param query Query point.
-    * @param K
-    * @param pointSet Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
+    * @param K amount of nearest neighbors to find
+    * @param points Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
     * can be replaced by noArray() if not needed
-    * @param squareDistSet Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
+    * @param squareDists Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
     * can be omitted if not needed
     */
     void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray squareDists = noArray()) const;
@@ -2817,11 +2819,11 @@ public:
     *
     * Find the K nearest neighbors to the query point.
     * @param query Query point.
-    * @param K
-    * @param pointSet Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
+    * @param K amount of nearest neighbors to find
+    * @param points Point output. Contains K points in 3-float format, arranged in order of distance from near to far,
     * can be replaced by noArray() if not needed
     * @param colors Color output. Contains colors corresponding to points in pointSet, can be replaced by noArray() if not needed
-    * @param squareDistSet Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
+    * @param squareDists Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
     * can be replaced by noArray() if not needed
     */
     void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors, OutputArray squareDists) const;

--- a/modules/3d/include/opencv2/3d.hpp
+++ b/modules/3d/include/opencv2/3d.hpp
@@ -2676,10 +2676,9 @@ CV_EXPORTS_W bool solvePnP( InputArray objectPoints, InputArray imagePoints,
  * children[7]: origin == (1, 1, 1), size == 1, furthest from child 0
  */
 
-class CV_EXPORTS Octree {
-
+class CV_EXPORTS_W Octree
+{
 public:
-
     //! Default constructor.
     Octree();
 
@@ -2692,7 +2691,7 @@ public:
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
      */
-    static Octree createWithDepth(int maxDepth, double size, const Point3f& origin = { }, bool withColors = false);
+    CV_WRAP static Ptr<Octree> createWithDepth(int maxDepth, double size, const Point3f& origin = { }, bool withColors = false);
 
     /** @overload
      * @brief Create an Octree from the PointCloud data with the specific maxDepth
@@ -2702,7 +2701,7 @@ public:
      * @param colors color attribute of point cloud in the same 3-channel float format
      * @return resulting Octree
      */
-    static Octree createWithDepth(int maxDepth, InputArray pointCloud, InputArray colors = noArray());
+    CV_WRAP static Ptr<Octree> createWithDepth(int maxDepth, InputArray pointCloud, InputArray colors = noArray());
 
     /** @overload
      * @brief Creates an empty Octree with given resolution
@@ -2713,7 +2712,7 @@ public:
      * @param withColors Whether to keep per-point colors or not
      * @return resulting Octree
      */
-    static Octree createWithResolution(double resolution, double size, const Point3f& origin = { }, bool withColors = false);
+    CV_WRAP static Ptr<Octree> createWithResolution(double resolution, double size, const Point3f& origin = { }, bool withColors = false);
 
      /** @overload
      * @brief Create an Octree from the PointCloud data with the specific resolution
@@ -2723,7 +2722,7 @@ public:
      * @param colors color attribute of point cloud in the same 3-channel float format
      * @return resulting octree
      */
-    static Octree createWithResolution(double resolution, InputArray pointCloud, InputArray colors = noArray());
+    CV_WRAP static Ptr<Octree> createWithResolution(double resolution, InputArray pointCloud, InputArray colors = noArray());
 
     //! Default destructor
     ~Octree();
@@ -2735,23 +2734,23 @@ public:
     * @param color The color attribute of point in Point3f format.
     * @return Returns whether the insertion is successful.
     */
-    bool insertPoint(const Point3f& point, const Point3f& color = { });
+    CV_WRAP bool insertPoint(const Point3f& point, const Point3f& color = { });
 
     /** @brief Determine whether the point is within the space range of the specific cube.
      *
      * @param point The point coordinates.
      * @return If point is in bound, return ture. Otherwise, false.
      */
-    bool isPointInBound(const Point3f& point) const;
+    CV_WRAP bool isPointInBound(const Point3f& point) const;
 
     //! returns true if the rootnode is NULL.
-    bool empty() const;
+    CV_WRAP bool empty() const;
 
     /** @brief Reset all octree parameter.
     *
     *  Clear all the nodes of the octree and initialize the parameters.
     */
-    void clear();
+    CV_WRAP void clear();
 
     /** @brief Delete a given point from the Octree.
     *
@@ -2761,7 +2760,7 @@ public:
     * @param point The point coordinates, comparison is epsilon-based
     * @return return ture if the point is deleted successfully.
     */
-    bool deletePoint(const Point3f& point);
+    CV_WRAP bool deletePoint(const Point3f& point);
 
     /** @brief restore point cloud data from Octree.
     *
@@ -2770,7 +2769,7 @@ public:
     * @param restoredPointCloud The output point cloud data, can be replaced by noArray() if not needed
     * @param restoredColor The color attribute of point cloud data, can be omitted if not needed
     */
-    void getPointCloudByOctree(OutputArray restoredPointCloud, OutputArray restoredColor = noArray());
+    CV_WRAP void getPointCloudByOctree(OutputArray restoredPointCloud, OutputArray restoredColor = noArray());
 
     /** @brief Radius Nearest Neighbor Search in Octree.
     *
@@ -2784,7 +2783,7 @@ public:
     * can be omitted if not needed
     * @return the number of searched points.
     */
-    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray squareDists = noArray()) const;
+    CV_WRAP int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray squareDists = noArray()) const;
 
     /** @overload
     *  @brief Radius Nearest Neighbor Search in Octree.
@@ -2800,7 +2799,7 @@ public:
     * can be replaced by noArray() if not needed
     * @return the number of searched points.
     */
-    int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray colors, OutputArray squareDists) const;
+    CV_WRAP int radiusNNSearch(const Point3f& query, float radius, OutputArray points, OutputArray colors, OutputArray squareDists) const;
 
     /** @brief K Nearest Neighbor Search in Octree.
     *
@@ -2812,7 +2811,7 @@ public:
     * @param squareDists Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
     * can be omitted if not needed
     */
-    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray squareDists = noArray()) const;
+    CV_WRAP void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray squareDists = noArray()) const;
 
     /** @overload
     *  @brief K Nearest Neighbor Search in Octree.
@@ -2826,7 +2825,7 @@ public:
     * @param squareDists Dist output. Contains K squared distance in floats, arranged in order of distance from near to far,
     * can be replaced by noArray() if not needed
     */
-    void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors, OutputArray squareDists) const;
+    CV_WRAP void KNNSearch(const Point3f& query, const int K, OutputArray points, OutputArray colors, OutputArray squareDists) const;
 
 protected:
     struct Impl;

--- a/modules/3d/misc/python/test/test_octree.py
+++ b/modules/3d/misc/python/test/test_octree.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import os
+import numpy as np
+import math
+import unittest
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class octree_test(NewOpenCVTests):
+    def assertBool(self, val, gold):
+        if (val != gold):
+            self.fail('Value is %s while it should be %s' % (repr(val), repr(gold)))
+
+    def test_octree_basic_test(self):
+        pointCloudSize = 1000
+        resolution = 0.0001
+        scale = 1 << 20
+
+        pointCloud = np.random.randint(-scale, scale, size=(pointCloudSize, 3)) * (10.0 / scale)
+        pointCloud = pointCloud.astype(np.float32)
+
+        octree = cv.Octree_createWithResolution(resolution, pointCloud)
+
+        restPoint = np.random.randint(-scale, scale, size=(1, 3)) * (10.0 / scale)
+        restPoint = [restPoint[0, 0], restPoint[0, 1], restPoint[0, 2]]
+
+        self.assertBool(octree.isPointInBound(restPoint), True)
+        self.assertBool(octree.deletePoint(restPoint), False)
+        self.assertBool(octree.insertPoint(restPoint), True)
+        self.assertBool(octree.deletePoint(restPoint), True)
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/3d/misc/python/test/test_octree.py
+++ b/modules/3d/misc/python/test/test_octree.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-# Python 2/3 compatibility
-from __future__ import print_function
-
 import os
 import numpy as np
 import math
@@ -12,10 +9,6 @@ import cv2 as cv
 from tests_common import NewOpenCVTests
 
 class octree_test(NewOpenCVTests):
-    def assertBool(self, val, gold):
-        if (val != gold):
-            self.fail('Value is %s while it should be %s' % (repr(val), repr(gold)))
-
     def test_octree_basic_test(self):
         pointCloudSize = 1000
         resolution = 0.0001
@@ -29,10 +22,10 @@ class octree_test(NewOpenCVTests):
         restPoint = np.random.randint(-scale, scale, size=(1, 3)) * (10.0 / scale)
         restPoint = [restPoint[0, 0], restPoint[0, 1], restPoint[0, 2]]
 
-        self.assertBool(octree.isPointInBound(restPoint), True)
-        self.assertBool(octree.deletePoint(restPoint), False)
-        self.assertBool(octree.insertPoint(restPoint), True)
-        self.assertBool(octree.deletePoint(restPoint), True)
+        self.assertTrue(octree.isPointInBound(restPoint))
+        self.assertFalse(octree.deletePoint(restPoint))
+        self.assertTrue(octree.insertPoint(restPoint))
+        self.assertTrue(octree.deletePoint(restPoint))
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -112,43 +112,43 @@ Octree::Octree() :
     p(makePtr<Impl>())
 { }
 
-Octree Octree::createWithDepth(int maxDepth, double size, const Point3f& origin, bool withColors)
+Ptr<Octree> Octree::createWithDepth(int maxDepth, double size, const Point3f& origin, bool withColors)
 {
     CV_Assert(maxDepth > 0);
     CV_Assert(size > 0);
 
-    Octree octree;
-    octree.p = makePtr<Impl>(maxDepth, size, origin, /*resolution*/ 0, withColors);
+    Ptr<Octree> octree = makePtr<Octree>();
+    octree->p = makePtr<Impl>(maxDepth, size, origin, /*resolution*/ 0, withColors);
     return octree;
 }
 
-Octree Octree::createWithDepth(int maxDepth, InputArray pointCloud, InputArray colors)
+Ptr<Octree> Octree::createWithDepth(int maxDepth, InputArray pointCloud, InputArray colors)
 {
     CV_Assert(maxDepth > 0);
 
-    Octree octree;
-    octree.p->maxDepth = maxDepth;
-    octree.p->fill(/* useResolution */ false, pointCloud, colors);
+    Ptr<Octree> octree = makePtr<Octree>();
+    octree->p->maxDepth = maxDepth;
+    octree->p->fill(/* useResolution */ false, pointCloud, colors);
     return octree;
 }
 
-Octree Octree::createWithResolution(double resolution, double size, const Point3f& origin, bool withColors)
+Ptr<Octree> Octree::createWithResolution(double resolution, double size, const Point3f& origin, bool withColors)
 {
     CV_Assert(resolution > 0);
     CV_Assert(size > 0);
 
-    Octree octree;
-    octree.p = makePtr<Impl>(/*maxDepth*/ 0, size, origin, resolution, withColors);
+    Ptr<Octree> octree = makePtr<Octree>();
+    octree->p = makePtr<Impl>(/*maxDepth*/ 0, size, origin, resolution, withColors);
     return octree;
 }
 
-Octree Octree::createWithResolution(double resolution, InputArray pointCloud, InputArray colors)
+Ptr<Octree> Octree::createWithResolution(double resolution, InputArray pointCloud, InputArray colors)
 {
     CV_Assert(resolution > 0);
 
-    Octree octree;
-    octree.p->resolution = resolution;
-    octree.p->fill(/* useResolution */ true, pointCloud, colors);
+    Ptr<Octree> octree = makePtr<Octree>();
+    octree->p->resolution = resolution;
+    octree->p->fill(/* useResolution */ true, pointCloud, colors);
     return octree;
 }
 

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -12,8 +12,8 @@
 
 namespace cv{
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, unsigned long x_key, unsigned long y_key,
-                     unsigned long z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key, size_t y_key,
+                     size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
 
 // Locate the OctreeNode corresponding to the input point from the given OctreeNode.
 static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node,OctreeKey& key,size_t depthMask);
@@ -94,7 +94,7 @@ bool _isPointInBound(const Point3f& _point, const Point3f& _origin, double _size
 struct Octree::Impl
 {
 public:
-    Impl():maxDepth(-1), size(0), origin(0,0,0), resolution(0)
+    Impl():maxDepth(0), size(0), origin(0,0,0), resolution(0)
     {}
 
     ~Impl()
@@ -103,7 +103,7 @@ public:
     // The pointer to Octree root node.
     Ptr <OctreeNode> rootNode = nullptr;
     //! Max depth of the Octree. And depth must be greater than zero
-    int maxDepth;
+    size_t maxDepth;
     //! The size of the cube of the .
     double size;
     //! The origin coordinate of root node.
@@ -116,7 +116,7 @@ public:
 
 Octree::Octree() : p(new Impl)
 {
-    p->maxDepth = -1;
+    p->maxDepth = 0;
     p->size = 0;
     p->origin = Point3f(0,0,0);
 }
@@ -160,9 +160,9 @@ bool Octree::insertPoint(const Point3f& point,const Point3f &color)
     {
         return false;
     }
-    OctreeKey key(floor((point.x - this->p->origin.x) / resolution),
-                  floor((point.y - this->p->origin.y) / resolution),
-                  floor((point.z - this->p->origin.z) / resolution));
+    OctreeKey key((size_t)floor((point.x - this->p->origin.x) / resolution),
+                  (size_t)floor((point.y - this->p->origin.y) / resolution),
+                  (size_t)floor((point.z - this->p->origin.z) / resolution));
 
     bool result = insertPointRecurse(p->rootNode, point, color, p->maxDepth, key, depthMask);
     return result;
@@ -199,7 +199,7 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, const std::vector<Po
     double maxSize = max(max(maxBound.x - minBound.x, maxBound.y - minBound.y), maxBound.z - minBound.z);
     //To use bit operation, the length of the root cube should be power of 2.
     maxSize=double(1<<int(ceil(log2(maxSize))));
-    p->maxDepth = ceil(log2(maxSize / resolution));
+    p->maxDepth = (size_t)ceil(log2(maxSize / resolution));
     this->p->size = (1<<p->maxDepth)*resolution;
     this->p->origin = Point3f(float(floor(minBound.x / resolution) * resolution),
                               float(floor(minBound.y / resolution) * resolution),
@@ -247,7 +247,7 @@ void Octree::clear()
     }
 
     p->size = 0;
-    p->maxDepth = -1;
+    p->maxDepth = 0;
     p->origin = Point3f (0,0,0); // origin coordinate
 }
 
@@ -296,9 +296,9 @@ bool Octree::isPointInBound(const Point3f& _point) const
 
 bool Octree::deletePoint(const Point3f& point)
 {
-    OctreeKey key=OctreeKey(floor((point.x - this->p->origin.x) / p->resolution),
-                            floor((point.y - this->p->origin.y) / p->resolution),
-                            floor((point.z - this->p->origin.z) / p->resolution));
+    OctreeKey key=OctreeKey((size_t)floor((point.x - this->p->origin.x) / p->resolution),
+                            (size_t)floor((point.y - this->p->origin.y) / p->resolution),
+                            (size_t)floor((point.z - this->p->origin.z) / p->resolution));
     size_t depthMask=1 << (p->maxDepth - 1);
     Ptr<OctreeNode> node = index(point, p->rootNode,key,depthMask);
 
@@ -415,8 +415,8 @@ void Octree::getPointCloudByOctree(std::vector<Point3f> &restorePointCloud, std:
     getPointRecurse(restorePointCloud, restoreColor, 0, 0, 0, root, resolution, p->origin, p->hasColor);
 }
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, unsigned long x_key,
-                     unsigned long y_key,unsigned long z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori,
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key,
+                     size_t y_key,size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori,
                      bool hasColor) {
     OctreeNode node = *_node;
     if (node.isLeaf) {
@@ -433,9 +433,9 @@ void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3
     unsigned char y_mask = 2;
     unsigned char z_mask = 4;
     for (unsigned char i = 0; i < 8; i++) {
-        unsigned long x_copy = x_key;
-        unsigned long y_copy = y_key;
-        unsigned long z_copy = z_key;
+        size_t x_copy = x_key;
+        size_t y_copy = y_key;
+        size_t z_copy = z_key;
         if (!node.children[i].empty()) {
             size_t x_offSet = !!(x_mask & i);
             size_t y_offSet = !!(y_mask & i);

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -576,20 +576,17 @@ void OctreeNode::KNNSearchRecurse(const Point3f& query, const int K,
 {
     std::vector<std::pair<float, int>> priorityQue;
 
-    Ptr<OctreeNode> child;
-    float dist = 0;
-    Point3f center; // the OctreeNode Center
-
     // Add the non-empty OctreeNode to priorityQue
     for(size_t i = 0; i < 8; i++)
     {
-        if(!this->children[i].empty())
+        Ptr<OctreeNode> child = this->children[i];
+        if(child)
         {
-            float halfSize = float(this->children[i]->size * 0.5);
+            float halfSize = float(child->size * 0.5);
 
-            center = this->children[i]->origin + Point3f(halfSize, halfSize, halfSize);
+            Point3f center = child->origin + Point3f(halfSize, halfSize, halfSize);
 
-            dist = SquaredDistance(query, center);
+            float dist = SquaredDistance(query, center);
             priorityQue.emplace_back(dist, int(i));
         }
     }
@@ -599,7 +596,7 @@ void OctreeNode::KNNSearchRecurse(const Point3f& query, const int K,
         {
             return std::get<0>(a) < std::get<0>(b);
         });
-    child = this->children[std::get<1>(priorityQue.back())];
+    Ptr<OctreeNode> child = this->children[std::get<1>(priorityQue.back())];
 
     while (!priorityQue.empty() && child->overlap(query, smallestDist))
     {
@@ -611,7 +608,7 @@ void OctreeNode::KNNSearchRecurse(const Point3f& query, const int K,
         {
             for (size_t i = 0; i < child->pointList.size(); i++)
             {
-                dist = SquaredDistance(child->pointList[i], query);
+                float dist = SquaredDistance(child->pointList[i], query);
 
                 if ( dist + dist * std::numeric_limits<float>::epsilon() <= smallestDist )
                 {

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -161,7 +161,7 @@ bool Octree::insertPoint(const Point3f& point, const Point3f &color)
 
 bool Octree::Impl::insertPoint(const Point3f& point, const Point3f &color)
 {
-    size_t depthMask = (size_t)(1 << (this->maxDepth - 1));
+    size_t depthMask = (size_t)(1UL << (this->maxDepth - 1));
 
     if(this->rootNode.empty())
     {
@@ -250,7 +250,7 @@ void Octree::Impl::fill(bool useResolution, InputArray _points, InputArray _colo
     // to calculate maxDepth from resolution or vice versa
     if (useResolution)
     {
-        this->maxDepth = ceil(log2(maxSize / this->resolution));
+        this->maxDepth = (int)ceil(log2(maxSize / this->resolution));
     }
     else
     {
@@ -641,7 +641,7 @@ void OctreeNode::KNNSearchRecurse(const Point3f& query, const int K,
                 }
             }
 
-            std::sort(candidatePoint.begin(), candidatePoint.end(), 
+            std::sort(candidatePoint.begin(), candidatePoint.end(),
                 [](const std::tuple<float, Point3f, Point3f>& a, const std::tuple<float, Point3f, Point3f>& b) -> bool
                 {
                     return std::get<0>(a) < std::get<0>(b);

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -30,16 +30,16 @@ static void radiusNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& qu
 static void KNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& query, const int K,
                              float& smallestDist, std::vector<PQueueElem<Point3f> >& candidatePoint);
 
-OctreeNode::OctreeNode():children(OCTREE_CHILD_NUM, nullptr),neigh(OCTREE_NEIGH_SIZE, nullptr), depth(0), size(0), origin(0,0,0), parentIndex(-1),pointNum(0)
+OctreeNode::OctreeNode():children(OCTREE_CHILD_NUM, nullptr), depth(0), size(0), origin(0,0,0),
+                                    pointNum(0),neigh(OCTREE_NEIGH_SIZE, nullptr),parentIndex(-1)
 {
 }
 
 OctreeNode::OctreeNode(int _depth, double _size, const Point3f &_origin, const Point3f &_color,
-                       int _parentIndex, int _pointNum) : children(OCTREE_CHILD_NUM),
-                                                          neigh(OCTREE_NEIGH_SIZE), depth(_depth),
-                                                          size(_size), origin(_origin),
-                                                          color(_color), parentIndex(_parentIndex),
-                                                          pointNum(_pointNum) {
+                       int _parentIndex, int _pointNum) : children(OCTREE_CHILD_NUM), depth(_depth),
+                                                          size(_size), origin(_origin),color(_color),pointNum(_pointNum),
+                                                          neigh(OCTREE_NEIGH_SIZE),parentIndex(_parentIndex)
+                                                          {
 }
 
 bool OctreeNode::empty() const

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -450,13 +450,13 @@ static float SquaredDistance(const Point3f& query, const Point3f& origin)
     return diff.dot(diff);
 }
 
-static bool overlap(const OctreeNode& node, const Point3f& query, float squareRadius)
+bool OctreeNode::overlap(const Point3f& query, float squareRadius) const
 {
-    float halfSize = float(node.size * 0.5);
-    Point3f center = node.origin + Point3f( halfSize, halfSize, halfSize );
+    float halfSize = float(this->size * 0.5);
+    Point3f center = this->origin + Point3f( halfSize, halfSize, halfSize );
 
     float dist = SquaredDistance(center, query);
-    float temp = float(node.size) * float(node.size) * 3.0f;
+    float temp = float(this->size) * float(this->size) * 3.0f;
 
     return ( dist + dist * std::numeric_limits<float>::epsilon() ) <= float(temp * 0.25f + squareRadius + sqrt(temp * squareRadius)) ;
 }
@@ -470,7 +470,7 @@ void radiusNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& query, fl
     // iterate eight children.
     for(size_t i = 0; i< 8; i++)
     {
-        if( !node->children[i].empty() && overlap(*node->children[i], query, squareRadius))
+        if( !node->children[i].empty() && node->children[i]->overlap(query, squareRadius))
         {
             if(!node->children[i]->isLeaf)
             {
@@ -540,7 +540,7 @@ void KNNSearchRecurse(const Ptr<OctreeNode>& node, const Point3f& query, const i
     std::sort(priorityQue.rbegin(), priorityQue.rend());
     child = node->children[priorityQue.back().t];
 
-    while (!priorityQue.empty() && overlap(*child, query, smallestDist))
+    while (!priorityQue.empty() && child->overlap(query, smallestDist))
     {
         if (!child->isLeaf)
         {

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -19,7 +19,7 @@ void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3
 static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node,OctreeKey& key,size_t depthMask);
 
 static bool _isPointInBound(const Point3f& _point, const Point3f& _origin, double _size);
-static bool insertPointRecurse( Ptr<OctreeNode>& node, const Point3f& point, const Point3f &color, int maxDepth
+static bool insertPointRecurse( Ptr<OctreeNode>& node, const Point3f& point, const Point3f &color, size_t maxDepth
         ,const OctreeKey &key, size_t depthMask);
 bool deletePointRecurse( Ptr<OctreeNode>& node);
 
@@ -35,7 +35,7 @@ OctreeNode::OctreeNode():children(OCTREE_CHILD_NUM, nullptr), depth(0), size(0),
 {
 }
 
-OctreeNode::OctreeNode(int _depth, double _size, const Point3f &_origin, const Point3f &_color,
+OctreeNode::OctreeNode(size_t _depth, double _size, const Point3f &_origin, const Point3f &_color,
                        int _parentIndex, int _pointNum) : children(OCTREE_CHILD_NUM), depth(_depth),
                                                           size(_size), origin(_origin),color(_color),pointNum(_pointNum),
                                                           neigh(OCTREE_NEIGH_SIZE),parentIndex(_parentIndex)
@@ -121,7 +121,7 @@ Octree::Octree() : p(new Impl)
     p->origin = Point3f(0,0,0);
 }
 
-Octree::Octree(int _maxDepth, double _size, const Point3f& _origin ) : p(new Impl)
+Octree::Octree(size_t _maxDepth, double _size, const Point3f& _origin ) : p(new Impl)
 {
     p->maxDepth = _maxDepth;
     p->size = _size;
@@ -134,7 +134,7 @@ Octree::Octree(const std::vector<Point3f>& _pointCloud, double resolution) : p(n
     this->create(_pointCloud,v, resolution);
 }
 
-Octree::Octree(int _maxDepth) : p(new Impl)
+Octree::Octree(size_t _maxDepth) : p(new Impl)
 {
     p->maxDepth = _maxDepth;
     p->size = 0;
@@ -150,7 +150,7 @@ bool Octree::insertPoint(const Point3f& point){
 bool Octree::insertPoint(const Point3f& point,const Point3f &color)
 {
     double resolution=p->resolution;
-    size_t depthMask=1 << (p->maxDepth - 1);
+    size_t depthMask=(size_t)1 << (p->maxDepth - 1);
     if(p->rootNode.empty())
     {
         p->rootNode = new OctreeNode( 0, p->size, p->origin,  color, -1, 0);
@@ -223,7 +223,7 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, double resolution) {
     return this->create(pointCloud, v, resolution);
 }
 
-void Octree::setMaxDepth(int _maxDepth)
+void Octree::setMaxDepth(size_t _maxDepth)
 {
     if(_maxDepth )
         this->p->maxDepth = _maxDepth;
@@ -299,7 +299,7 @@ bool Octree::deletePoint(const Point3f& point)
     OctreeKey key=OctreeKey((size_t)floor((point.x - this->p->origin.x) / p->resolution),
                             (size_t)floor((point.y - this->p->origin.y) / p->resolution),
                             (size_t)floor((point.z - this->p->origin.z) / p->resolution));
-    size_t depthMask=1 << (p->maxDepth - 1);
+    size_t depthMask=(size_t)1 << (p->maxDepth - 1);
     Ptr<OctreeNode> node = index(point, p->rootNode,key,depthMask);
 
     if(!node.empty())
@@ -376,7 +376,7 @@ bool deletePointRecurse(Ptr<OctreeNode>& _node)
     }
 }
 
-bool insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point,const Point3f &color, int maxDepth,const OctreeKey &key,
+bool insertPointRecurse( Ptr<OctreeNode>& _node,  const Point3f& point,const Point3f &color, size_t maxDepth,const OctreeKey &key,
                          size_t depthMask)
 {
     OctreeNode &node = *_node;

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -161,7 +161,7 @@ bool Octree::insertPoint(const Point3f& point, const Point3f &color)
 
 bool Octree::Impl::insertPoint(const Point3f& point, const Point3f &color)
 {
-    size_t depthMask = (size_t)(1UL << (this->maxDepth - 1));
+    size_t depthMask = (size_t)(1ULL << (this->maxDepth - 1));
 
     if(this->rootNode.empty())
     {

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -615,7 +615,7 @@ void OctreeNode::KNNSearchRecurse(const Point3f& query, const int K,
         {
             return std::get<0>(a) < std::get<0>(b);
         });
-    child = this->children[std::get<0>(priorityQue.back())];
+    child = this->children[std::get<1>(priorityQue.back())];
 
     while (!priorityQue.empty() && child->overlap(query, smallestDist))
     {

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -8,11 +8,12 @@
 
 namespace cv{
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key, size_t y_key,
-                     size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor,
+                     size_t x_key, size_t y_key, size_t z_key,
+                     Ptr<OctreeNode> _node, double resolution, Point3f ori, bool hasColor);
 
 // Locate the OctreeNode corresponding to the input point from the given OctreeNode.
-static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node, OctreeKey& key, size_t depthMask);
+static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode> node, OctreeKey& key, size_t depthMask);
 
 OctreeNode::OctreeNode() :
     children(),
@@ -285,7 +286,7 @@ bool Octree::empty() const
     return p->rootNode.empty();
 }
 
-Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& _node, OctreeKey &key, size_t depthMask)
+Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode> _node, OctreeKey &key, size_t depthMask)
 {
     OctreeNode &node = *_node;
 
@@ -439,9 +440,9 @@ void Octree::getPointCloudByOctree(OutputArray restorePointCloud, OutputArray re
     }
 }
 
-void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor, size_t x_key,
-                     size_t y_key,size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori,
-                     bool hasColor)
+void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3f> &restoreColor,
+                     size_t x_key, size_t y_key, size_t z_key,
+                     Ptr<OctreeNode> _node, double resolution, Point3f ori, bool hasColor)
 {
     OctreeNode node = *_node;
     if (node.isLeaf)

--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -12,7 +12,7 @@ void getPointRecurse(std::vector<Point3f> &restorePointCloud, std::vector<Point3
                      size_t z_key, Ptr<OctreeNode> &_node, double resolution, Point3f ori, bool hasColor);
 
 // Locate the OctreeNode corresponding to the input point from the given OctreeNode.
-static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node,OctreeKey& key,size_t depthMask);
+static Ptr<OctreeNode> index(const Point3f& point, Ptr<OctreeNode>& node, OctreeKey& key, size_t depthMask);
 
 OctreeNode::OctreeNode() :
     children(),
@@ -85,7 +85,7 @@ public:
     // The pointer to Octree root node.
     Ptr <OctreeNode> rootNode = nullptr;
     //! Max depth of the Octree. And depth must be greater than zero
-    size_t maxDepth;
+    int maxDepth;
     //! The size of the cube of the .
     double size;
     //! The origin coordinate of root node.
@@ -103,7 +103,7 @@ Octree::Octree() : p(new Impl)
     p->origin = Point3f(0,0,0);
 }
 
-Octree::Octree(size_t _maxDepth, double _size, const Point3f& _origin ) : p(new Impl)
+Octree::Octree(int _maxDepth, double _size, const Point3f& _origin ) : p(new Impl)
 {
     p->maxDepth = _maxDepth;
     p->size = _size;
@@ -116,7 +116,7 @@ Octree::Octree(const std::vector<Point3f>& _pointCloud, double resolution) : p(n
     this->create(_pointCloud,v, resolution);
 }
 
-Octree::Octree(size_t _maxDepth) : p(new Impl)
+Octree::Octree(int _maxDepth) : p(new Impl)
 {
     p->maxDepth = _maxDepth;
     p->size = 0;
@@ -181,9 +181,9 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, const std::vector<Po
 
     double maxSize = max(max(maxBound.x - minBound.x, maxBound.y - minBound.y), maxBound.z - minBound.z);
     //To use bit operation, the length of the root cube should be power of 2.
-    maxSize=double(1<<int(ceil(log2(maxSize))));
-    p->maxDepth = (size_t)ceil(log2(maxSize / resolution));
-    this->p->size = (1<<p->maxDepth)*resolution;
+    maxSize=double(1 << int(ceil(log2(maxSize))));
+    p->maxDepth = ceil(log2(maxSize / resolution));
+    this->p->size = (1 << p->maxDepth)*resolution;
     this->p->origin = Point3f(float(floor(minBound.x / resolution) * resolution),
                               float(floor(minBound.y / resolution) * resolution),
                               float(floor(minBound.z / resolution) * resolution));
@@ -202,12 +202,13 @@ bool Octree::create(const std::vector<Point3f> &pointCloud, const std::vector<Po
     return true;
 }
 
-bool Octree::create(const std::vector<Point3f> &pointCloud, double resolution) {
+bool Octree::create(const std::vector<Point3f> &pointCloud, double resolution)
+{
     std::vector<Point3f> v;
     return this->create(pointCloud, v, resolution);
 }
 
-void Octree::setMaxDepth(size_t _maxDepth)
+void Octree::setMaxDepth(int _maxDepth)
 {
     if(_maxDepth )
         this->p->maxDepth = _maxDepth;

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -85,8 +85,6 @@ public:
     //! returns true if the rootNode is NULL.
     bool empty() const;
 
-    bool isPointInBound(const Point3f& _point, const Point3f& _origin, double _size) const;
-
     bool isPointInBound(const Point3f& _point) const;
 
     //! Contains 8 pointers to its 8 children.

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -60,7 +60,7 @@ public:
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
     * @param _pointNum The number of point in this cube.
     */
-    OctreeNode(int _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex, int _pointNum);
+    OctreeNode(size_t _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex, int _pointNum);
 
     //! returns true if the rootNode is NULL.
     bool empty() const;
@@ -76,7 +76,7 @@ public:
     Ptr<OctreeNode> parent = nullptr;
 
     //! The depth of the current node. The depth of the root node is 0, and the leaf node is equal to the depth of Octree.
-    int depth;
+    size_t depth;
 
     //! The length of the OctreeNode. In space, every OctreeNode represents a cube.
     double size;

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -72,8 +72,6 @@ public:
 
     bool overlap(const Point3f& query, float squareRadius) const;
 
-    void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
-
     void KNNSearchRecurse(const Point3f& query, const int K, float& smallestDist, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
 
     //! Contains 8 pointers to its 8 children.

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -94,6 +94,7 @@ public:
 
     void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<PQueueElem<Point3f> >& candidatePoint) const;
 
+    void KNNSearchRecurse(const Point3f& query, const int K, float& smallestDist, std::vector<PQueueElem<Point3f> >& candidatePoint) const;
 
     //! Contains 8 pointers to its 8 children.
     std::array<Ptr<OctreeNode>, 8> children;

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -92,6 +92,8 @@ public:
     void insertPointRecurse(const Point3f& point, const Point3f &color, int maxDepth,
                             const OctreeKey &key, size_t depthMask);
 
+    void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<PQueueElem<Point3f> >& candidatePoint) const;
+
 
     //! Contains 8 pointers to its 8 children.
     std::array<Ptr<OctreeNode>, 8> children;

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -88,7 +88,7 @@ public:
     //! color attribute of octree node.
     Point3f color;
     //! RAHTCoefficient of octree node, used for color attribute compression.
-    Point3f RAHTCoefficient;
+    Point3f RAHTCoefficient=Point3f(0,0,0);
     //! Number of point cloud in this node.
     int pointNum;
 

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -18,22 +18,6 @@
 
 namespace cv
 {
-
-// For nearest neighbor search
-template<typename T>
-struct PQueueElem
-{
-    PQueueElem() : dist(0), t(0) {}
-    PQueueElem(float _dist, T _t) : dist(_dist), t(_t) {}
-    float dist;
-    T t;
-
-    bool operator<(const PQueueElem<T> p1) const
-    {
-        return (this->dist < p1.dist);
-    }
-};
-
 // Forward declaration
 class OctreeKey;
 
@@ -76,11 +60,10 @@ public:
     * to the depth of Octree.
     * @param _size The length of the OctreeNode. In space, every OctreeNode represents a cube.
     * @param _origin The absolute coordinates of the center of the cube.
-    * @param _color THe color attribute of octreeNode.
     * @param _parentIndex The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
     */
-    OctreeNode(int _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex);
+    OctreeNode(int _depth, double _size, const Point3f& _origin, int _parentIndex);
 
     //! returns true if the rootNode is NULL.
     bool empty() const;
@@ -92,9 +75,9 @@ public:
     void insertPointRecurse(const Point3f& point, const Point3f &color, int maxDepth,
                             const OctreeKey &key, size_t depthMask);
 
-    void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<PQueueElem<Point3f> >& candidatePoint) const;
+    void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
 
-    void KNNSearchRecurse(const Point3f& query, const int K, float& smallestDist, std::vector<PQueueElem<Point3f> >& candidatePoint) const;
+    void KNNSearchRecurse(const Point3f& query, const int K, float& smallestDist, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
 
     //! Contains 8 pointers to its 8 children.
     std::array<Ptr<OctreeNode>, 8> children;
@@ -112,10 +95,8 @@ public:
     //! And the center of cube is `center = origin + Point3f(size/2, size/2, size/2)`.
     Point3f origin;
 
-    //! color attribute of octree node.
-    Point3f color;
     //! RAHTCoefficient of octree node, used for color attribute compression.
-    Point3f RAHTCoefficient=Point3f(0,0,0);
+    Point3f RAHTCoefficient = { };
     //! Number of point cloud in this node.
     int pointNum;
 
@@ -142,6 +123,9 @@ public:
 
     //! Contains pointers to all point cloud data in this node.
     std::vector<Point3f> pointList;
+
+    //! color attribute of octree node.
+    std::vector<Point3f> colorList;
 };
 
 /** @brief Key for pointCloud, used to compute the child node index through bit operations.

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -13,9 +13,29 @@
 #define OPENCV_3D_SRC_OCTREE_HPP
 
 #include <vector>
+#include <array>
 #include "opencv2/core.hpp"
 
-namespace cv {
+namespace cv
+{
+
+// For nearest neighbor search
+template<typename T>
+struct PQueueElem
+{
+    PQueueElem() : dist(0), t(0) {}
+    PQueueElem(float _dist, T _t) : dist(_dist), t(_t) {}
+    float dist;
+    T t;
+
+    bool operator<(const PQueueElem<T> p1) const
+    {
+        return (this->dist < p1.dist);
+    }
+};
+
+// Forward declaration
+class OctreeKey;
 
 /** @brief OctreeNode for Octree.
 
@@ -41,7 +61,8 @@ within the node, which will be used for octree indexing and mapping from point c
 in an octree, each leaf node contains at least one point cloud data. Similarly, every intermediate OctreeNode
 contains at least one non-empty child pointer, except for the root node.
 */
-class OctreeNode{
+class OctreeNode
+{
 public:
 
     /**
@@ -58,9 +79,8 @@ public:
     * @param _color THe color attribute of octreeNode.
     * @param _parentIndex The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
-    * @param _pointNum The number of point in this cube.
     */
-    OctreeNode(size_t _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex, int _pointNum);
+    OctreeNode(int _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex);
 
     //! returns true if the rootNode is NULL.
     bool empty() const;
@@ -70,13 +90,13 @@ public:
     bool isPointInBound(const Point3f& _point) const;
 
     //! Contains 8 pointers to its 8 children.
-    std::vector< Ptr<OctreeNode> > children;
+    std::array<Ptr<OctreeNode>, 8> children;
 
     //! Point to the parent node of the current node. The root node has no parent node and the value is NULL.
     Ptr<OctreeNode> parent = nullptr;
 
     //! The depth of the current node. The depth of the root node is 0, and the leaf node is equal to the depth of Octree.
-    size_t depth;
+    int depth;
 
     //! The length of the OctreeNode. In space, every OctreeNode represents a cube.
     double size;
@@ -103,7 +123,7 @@ public:
         *  +y                           [100]
         *  index 000, 111 are reserved
         */
-    std::vector< Ptr<OctreeNode> > neigh;
+    std::array<Ptr<OctreeNode>, 8> neigh;
 
     /**  The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
@@ -124,33 +144,35 @@ all the points into a voxel coordinate system. For example, when resolution is s
 with coordinate Point3f(0.251,0.502,0.753) would be transformed to:(0.251/0.01,0.502/0.01,0.753/0.01)
 =(25,50,75). And the OctreeKey will be (x_key:1_1001,y_key:11_0010,z_key:100_1011). Assume the Octree->depth
 is 100_0000, It can quickly calculate the index of the child nodes at each layer.
-layer	    Depth Mask	    x&Depth Mask	    y&Depth Mask	    z&Depth Mask	    Child Index(0-7)
-1	        100_0000	    0	                0	                1	                4
-2	        10_0000	        0	                1	                0	                2
-3	        1_0000	        1	                1	                0	                3
-4	        1000	        1	                0	                1	                5
-5	        100	            0	                0	                0	                0
-6	        10	            0	                1	                1	                6
-7	        1	            1	                0	                1	                5
+layer    Depth Mask   x&Depth Mask    y&Depth Mask    z&Depth Mask    Child Index(0-7)
+1        100_0000     0               0               1               4
+2        10_0000      0               1               0               2
+3        1_0000       1               1               0               3
+4        1000         1               0               1               5
+5        100          0               0               0               0
+6        10           0               1               1               6
+7        1            1               0               1               5
 */
 
-class OctreeKey{
+class OctreeKey
+{
 public:
     size_t x_key;
     size_t y_key;
     size_t z_key;
 
 public:
-    OctreeKey():x_key(0),y_key(0),z_key(0){};
-    OctreeKey(size_t x,size_t y,size_t z):x_key(x),y_key(y),z_key(z){};
+    OctreeKey() : x_key(0), y_key(0), z_key(0) { }
+    OctreeKey(size_t x, size_t y, size_t z) : x_key(x), y_key(y), z_key(z) { }
 
     /** @brief compute the child node index through bit operations.
     *
     * @param mask The mask of specify layer.
     * @return the index of child(0-7)
     */
-    inline unsigned char findChildIdxByMask(size_t mask) const{
-        return static_cast<unsigned char>((!!(z_key&mask))<<2)|((!!(y_key&mask))<<1)|(!!(x_key&mask));
+    inline unsigned char findChildIdxByMask(size_t mask) const
+    {
+        return static_cast<unsigned char>((!!(z_key & mask))<<2) | ((!!(y_key & mask))<<1) | (!!(x_key & mask));
     }
 
     /** @brief get occupancy code from node.
@@ -160,13 +182,16 @@ public:
     * @param node The octree node.
     * @return the occupancy code(0000_0000-1111_1111)
     */
-    static inline unsigned char getBitPattern(OctreeNode &node) {
-        unsigned char res=0;
-        for (unsigned char i=0; i<node.children.size();i++){
-            res|=static_cast<unsigned char>((!node.children[i].empty()) << i);
+    static inline unsigned char getBitPattern(OctreeNode &node)
+    {
+        unsigned char res = 0;
+        for (unsigned char i = 0; i < node.children.size(); i++)
+        {
+            res |= static_cast<unsigned char>((!node.children[i].empty()) << i);
         }
         return res;
     }
 };
+
 }
 #endif //OPENCV_3D_SRC_OCTREE_HPP

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -72,9 +72,6 @@ public:
 
     bool overlap(const Point3f& query, float squareRadius) const;
 
-    void insertPointRecurse(const Point3f& point, const Point3f &color, int maxDepth,
-                            const OctreeKey &key, size_t depthMask);
-
     void radiusNNSearchRecurse(const Point3f& query, float squareRadius, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
 
     void KNNSearchRecurse(const Point3f& query, const int K, float& smallestDist, std::vector<std::tuple<float, Point3f, Point3f>>& candidatePoint) const;
@@ -97,8 +94,6 @@ public:
 
     //! RAHTCoefficient of octree node, used for color attribute compression.
     Point3f RAHTCoefficient = { };
-    //! Number of point cloud in this node.
-    int pointNum;
 
     /**  The list of 6 adjacent neighbor node.
         *    index mapping:

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -55,10 +55,12 @@ public:
     * to the depth of Octree.
     * @param _size The length of the OctreeNode. In space, every OctreeNode represents a cube.
     * @param _origin The absolute coordinates of the center of the cube.
+    * @param _color THe color attribute of octreeNode.
     * @param _parentIndex The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
+    * @param _pointNum The number of point in this cube.
     */
-    OctreeNode(int _depth, double _size, const Point3f& _origin, int _parentIndex);
+    OctreeNode(int _depth, double _size, const Point3f& _origin, const Point3f& _color, int _parentIndex, int _pointNum);
 
     //! returns true if the rootNode is NULL.
     bool empty() const;
@@ -83,6 +85,26 @@ public:
     //! And the center of cube is `center = origin + Point3f(size/2, size/2, size/2)`.
     Point3f origin;
 
+    //! color attribute of octree node.
+    Point3f color;
+    //! RAHTCoefficient of octree node, used for color attribute compression.
+    Point3f RAHTCoefficient;
+    //! Number of point cloud in this node.
+    int pointNum;
+
+    /**  The list of 6 adjacent neighbor node.
+        *    index mapping:
+        *     +z                        [101]
+        *      |                          |    [110]
+        *      |                          |  /
+        *      O-------- +x    [001]----{000} ----[011]
+        *     /                       /   |
+        *    /                   [010]    |
+        *  +y                           [100]
+        *  index 000, 111 are reserved
+        */
+    std::vector< Ptr<OctreeNode> > neigh;
+
     /**  The serial number of the child of the current node in the parent node,
     * the range is (-1~7). Among them, only the root node's _parentIndex is -1.
     */
@@ -95,5 +117,56 @@ public:
     std::vector<Point3f> pointList;
 };
 
+/** @brief Key for pointCloud, used to compute the child node index through bit operations.
+
+When building the octree, the point cloud data is firstly voxelized/discretized: by inserting
+all the points into a voxel coordinate system. For example, when resolution is set to 0.01, a point
+with coordinate Point3f(0.251,0.502,0.753) would be transformed to:(0.251/0.01,0.502/0.01,0.753/0.01)
+=(25,50,75). And the OctreeKey will be (x_key:1_1001,y_key:11_0010,z_key:100_1011). Assume the Octree->depth
+is 100_0000, It can quickly calculate the index of the child nodes at each layer.
+layer	    Depth Mask	    x&Depth Mask	    y&Depth Mask	    z&Depth Mask	    Child Index(0-7)
+1	        100_0000	    0	                0	                1	                4
+2	        10_0000	        0	                1	                0	                2
+3	        1_0000	        1	                1	                0	                3
+4	        1000	        1	                0	                1	                5
+5	        100	            0	                0	                0	                0
+6	        10	            0	                1	                1	                6
+7	        1	            1	                0	                1	                5
+*/
+
+class OctreeKey{
+public:
+    size_t x_key;
+    size_t y_key;
+    size_t z_key;
+
+public:
+    OctreeKey():x_key(0),y_key(0),z_key(0){};
+    OctreeKey(size_t x,size_t y,size_t z):x_key(x),y_key(y),z_key(z){};
+
+    /** @brief compute the child node index through bit operations.
+    *
+    * @param mask The mask of specify layer.
+    * @return the index of child(0-7)
+    */
+    inline unsigned char findChildIdxByMask(size_t mask) const{
+        return static_cast<unsigned char>((!!(z_key&mask))<<2)|((!!(y_key&mask))<<1)|(!!(x_key&mask));
+    }
+
+    /** @brief get occupancy code from node.
+    *
+    * The occupancy code type is unsigned char that represents whether the eight child nodes of the octree node exist
+    * If a octree node has 3 child which indexes are 0,1,7, then the occupancy code of this node is 1000_0011
+    * @param node The octree node.
+    * @return the occupancy code(0000_0000-1111_1111)
+    */
+    static inline unsigned char getBitPattern(OctreeNode &node) {
+        unsigned char res=0;
+        for (unsigned char i=0; i<node.children.size();i++){
+            res|=static_cast<unsigned char>((!node.children[i].empty()) << i);
+        }
+        return res;
+    }
+};
 }
 #endif //OPENCV_3D_SRC_OCTREE_HPP

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -87,6 +87,9 @@ public:
 
     bool isPointInBound(const Point3f& _point) const;
 
+    bool overlap(const Point3f& query, float squareRadius) const;
+
+
     //! Contains 8 pointers to its 8 children.
     std::array<Ptr<OctreeNode>, 8> children;
 

--- a/modules/3d/src/octree.hpp
+++ b/modules/3d/src/octree.hpp
@@ -89,12 +89,15 @@ public:
 
     bool overlap(const Point3f& query, float squareRadius) const;
 
+    void insertPointRecurse(const Point3f& point, const Point3f &color, int maxDepth,
+                            const OctreeKey &key, size_t depthMask);
+
 
     //! Contains 8 pointers to its 8 children.
     std::array<Ptr<OctreeNode>, 8> children;
 
     //! Point to the parent node of the current node. The root node has no parent node and the value is NULL.
-    Ptr<OctreeNode> parent = nullptr;
+    OctreeNode* parent;
 
     //! The depth of the current node. The depth of the root node is 0, and the leaf node is equal to the depth of Octree.
     int depth;

--- a/modules/3d/src/pcc.h
+++ b/modules/3d/src/pcc.h
@@ -1,0 +1,94 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Author: Yuhang Wang <yuhangwang0012@gmail.com>
+//         Chengwei Ye <broweigg@gmail.com>
+//         Zhangjie Cheng <zhangjiec01@gmail.com>
+
+#ifndef OPENCV_PCC_H
+#define OPENCV_PCC_H
+
+#include <vector>
+#include "opencv2/core.hpp"
+#include "octree.hpp"
+#include "opencv2/3d.hpp"
+
+namespace cv {
+
+
+/** @brief class to serialize or deserialize pointcloud data
+ *
+ * A class for "encoding" pointcloud data to a
+ * meaningful, unevenly distributed char vector,
+ * so that it can be further compressed by Entropy coding.
+ * And the opposite "decoding" way as well.
+ *
+ * The current implementation is to represent pointcloud as Octree,
+ * then traverse OctreeNodes to get vector of "occupancy code".
+*/
+class OctreeSerializeCoder {
+private:
+    Octree *octree;
+    float resolution;
+public:
+
+    OctreeSerializeCoder();
+
+    OctreeSerializeCoder(float resolution);
+
+    //! encode Pointcloud data to serialized char vector
+    void encode(const std::vector<Point3f> &pointCloud,
+                        std::vector<unsigned char> &serializedVector);
+
+    //! decode Pointcloud data from serialized char vector
+    void decode(const std::vector<unsigned char> &serializedVector,
+                        std::vector<Point3f> &pointCloud);
+};
+
+/** @brief Class to reduce vectorized data size by EntropyCoding
+ *
+ * The algorithm used here is Range Coding Algorithm.
+ *
+*/
+class EntropyCoder {
+public:
+    //! encode char vector to bit stream
+    void encodeCharVectorToStream(const std::vector<unsigned char> &inputCharVector,
+                                  std::ostream &outputStream);
+
+    //! decode char vector from bit stream
+    void decodeStreamToCharVector(const std::istream &inputStream,
+                                  std::vector<unsigned char> &outputCharVector);
+};
+
+/** @brief pointcloud compression class
+ *
+ * This class enables user to do compression and decompression to pointcloud,
+ * currently based on Octree,
+ * may support other method (like kd-tree, etc.) in future if necessary.
+ *
+*/
+class PointCloudCompression{
+private:
+    OctreeSerializeCoder _coder;
+    EntropyCoder _entropyCoder;
+public:
+    /** @brief User compress the pointcloud to stream
+     *
+     * @param pointCloud the pointcloud to compress
+     * @param outputStream the output compressed bit stream destination
+    */
+    void compress(const std::vector<Point3f> &pointCloud, std::ostream &outputStream);
+
+    /** @brief User decompress(recover) pointcloud from stream
+     *
+     * @param inputStream the input compressed bit stream source
+     * @param pointCloud the output pointcloud
+    */
+    void decompress(std::istream &inputStream, const std::vector<Point3f> &pointCloud);
+};
+
+}
+
+#endif //OPENCV_PCC_H

--- a/modules/3d/src/precomp.hpp
+++ b/modules/3d/src/precomp.hpp
@@ -67,6 +67,7 @@
 #include "opencv2/3d/detail/kinfu_frame.hpp"
 
 #include <atomic>
+#include <algorithm>
 #include <functional>
 #include <limits>
 #include <stack>

--- a/modules/3d/src/precomp.hpp
+++ b/modules/3d/src/precomp.hpp
@@ -69,6 +69,7 @@
 #include <atomic>
 #include <functional>
 #include <limits>
+#include <stack>
 #include <vector>
 #include <list>
 #include <set>

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -32,8 +32,8 @@ protected:
             pointCloud.push_back(Point3f(_x, _y, _z));
         }
 
-        // Generate Octree From PointCloud.
-        treeTest.create(pointCloud, resolution);
+        // Generate Octree From PointCloud
+        treeTest = Octree::createWithResolution(resolution, pointCloud);
 
         // Randomly generate another 3D point.
         float _x = 10 * (float)rng_Point.uniform(pmin.x, pmax.x)/scale;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -24,7 +24,7 @@ protected:
         RNG& rng_Point = theRNG(); // set random seed for fixing output 3D point.
 
         // Generate 3D PointCloud
-        for(int i = 0; i < pointCloudSize; i++)
+        for(unsigned int i = 0; i < pointCloudSize; i++)
         {
             float _x = 10 * (float)rng_Point.uniform(pmin.x, pmax.x)/scale;
             float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -54,25 +54,25 @@ public:
 
     size_t pointCloudSize;
     Point3f restPoint;
-    Octree treeTest;
+    Ptr<Octree> treeTest;
     double resolution;
 };
 
 TEST_F(OctreeTest, BasicFunctionTest)
 {
     // Check if the point in Bound.
-    EXPECT_TRUE(treeTest.isPointInBound(restPoint));
-    EXPECT_FALSE(treeTest.isPointInBound(restPoint + Point3f(60, 60, 60)));
+    EXPECT_TRUE(treeTest->isPointInBound(restPoint));
+    EXPECT_FALSE(treeTest->isPointInBound(restPoint + Point3f(60, 60, 60)));
 
     // insert, delete Test.
-    EXPECT_FALSE(treeTest.deletePoint(restPoint));
-    EXPECT_FALSE(treeTest.insertPoint(restPoint + Point3f(60, 60, 60)));
-    EXPECT_TRUE(treeTest.insertPoint(restPoint));
-    EXPECT_TRUE(treeTest.deletePoint(restPoint));
+    EXPECT_FALSE(treeTest->deletePoint(restPoint));
+    EXPECT_FALSE(treeTest->insertPoint(restPoint + Point3f(60, 60, 60)));
+    EXPECT_TRUE(treeTest->insertPoint(restPoint));
+    EXPECT_TRUE(treeTest->deletePoint(restPoint));
 
-    EXPECT_FALSE(treeTest.empty());
-    EXPECT_NO_THROW(treeTest.clear());
-    EXPECT_TRUE(treeTest.empty());
+    EXPECT_FALSE(treeTest->empty());
+    EXPECT_NO_THROW(treeTest->clear());
+    EXPECT_TRUE(treeTest->empty());
 }
 
 TEST_F(OctreeTest, RadiusSearchTest)
@@ -80,7 +80,7 @@ TEST_F(OctreeTest, RadiusSearchTest)
     float radius = 2.0f;
     std::vector<Point3f> outputPoints;
     std::vector<float> outputSquareDist;
-    EXPECT_NO_THROW(treeTest.radiusNNSearch(restPoint, radius, outputPoints, outputSquareDist));
+    EXPECT_NO_THROW(treeTest->radiusNNSearch(restPoint, radius, outputPoints, outputSquareDist));
     EXPECT_EQ(outputPoints.size(),(unsigned int)5);
 
     // The output is unsorted, so let's sort it before checking
@@ -111,7 +111,7 @@ TEST_F(OctreeTest, KNNSearchTest)
     int K = 10;
     std::vector<Point3f> outputPoints;
     std::vector<float> outputSquareDist;
-    EXPECT_NO_THROW(treeTest.KNNSearch(restPoint, K, outputPoints, outputSquareDist));
+    EXPECT_NO_THROW(treeTest->KNNSearch(restPoint, K, outputPoints, outputSquareDist));
 
     // this output should be sorted
     EXPECT_FLOAT_EQ(outputPoints[0].x, -8.118486404418f);
@@ -126,7 +126,7 @@ TEST_F(OctreeTest, KNNSearchTest)
 
 TEST_F(OctreeTest, restoreTest) {
     //restore the pointCloud data from octree.
-    EXPECT_NO_THROW(treeTest.getPointCloudByOctree(restorePointCloudData,restorePointCloudColor));
+    EXPECT_NO_THROW(treeTest->getPointCloudByOctree(restorePointCloudData,restorePointCloudColor));
 
     //The points in same leaf node will be seen as the same point. So if the resolution is small,
     //it will work as a downSampling function.
@@ -135,8 +135,8 @@ TEST_F(OctreeTest, restoreTest) {
     //The distance between the restore point cloud data and origin data should less than resolution.
     std::vector<Point3f> outputPoints;
     std::vector<float> outputSquareDist;
-    EXPECT_NO_THROW(treeTest.getPointCloudByOctree(restorePointCloudData,restorePointCloudColor));
-    EXPECT_NO_THROW(treeTest.KNNSearch(restorePointCloudData[0], 1, outputPoints, outputSquareDist));
+    EXPECT_NO_THROW(treeTest->getPointCloudByOctree(restorePointCloudData,restorePointCloudColor));
+    EXPECT_NO_THROW(treeTest->KNNSearch(restorePointCloudData[0], 1, outputPoints, outputSquareDist));
     EXPECT_LE(abs(outputPoints[0].x-restorePointCloudData[0].x),resolution);
     EXPECT_LE(abs(outputPoints[0].y-restorePointCloudData[0].y),resolution);
     EXPECT_LE(abs(outputPoints[0].z-restorePointCloudData[0].z),resolution);

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -40,7 +40,6 @@ protected:
         float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;
         float _z = 10 * (float)rng_Point.uniform(pmin.z, pmax.z)/scale;
         restPoint = Point3f(_x, _y, _z);
-
     }
 
 public:

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -53,7 +53,7 @@ public:
     //Color attribute of pointCloud from octree
     std::vector<Point3f> restorePointCloudColor;
 
-    int pointCloudSize;
+    unsigned int pointCloudSize;
     Point3f restPoint;
     Octree treeTest;
     double resolution;
@@ -84,7 +84,7 @@ TEST_F(OctreeTest, RadiusSearchTest)
     std::vector<Point3f> outputPoints;
     std::vector<float> outputSquareDist;
     EXPECT_NO_THROW(treeTest.radiusNNSearch(restPoint, radius, outputPoints, outputSquareDist));
-    EXPECT_EQ(outputPoints.size(),5);
+    EXPECT_EQ(outputPoints.size(),(unsigned int)5);
 
     //The outputPoints should be unordered, so in some resolution, this test will fail because it specified the order of output.
     EXPECT_FLOAT_EQ(outputPoints[0].x, -8.88461112976f);

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -24,7 +24,7 @@ protected:
         RNG& rng_Point = theRNG(); // set random seed for fixing output 3D point.
 
         // Generate 3D PointCloud
-        for(unsigned int i = 0; i < pointCloudSize; i++)
+        for(size_t i = 0; i < pointCloudSize; i++)
         {
             float _x = 10 * (float)rng_Point.uniform(pmin.x, pmax.x)/scale;
             float _y = 10 * (float)rng_Point.uniform(pmin.y, pmax.y)/scale;
@@ -52,7 +52,7 @@ public:
     //Color attribute of pointCloud from octree
     std::vector<Point3f> restorePointCloudColor;
 
-    unsigned int pointCloudSize;
+    size_t pointCloudSize;
     Point3f restPoint;
     Octree treeTest;
     double resolution;

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -66,10 +66,8 @@ TEST_F(OctreeTest, BasicFunctionTest)
 
     // insert, delete Test.
     EXPECT_FALSE(treeTest.deletePoint(restPoint));
-
     EXPECT_FALSE(treeTest.insertPoint(restPoint + Point3f(60, 60, 60)));
     EXPECT_TRUE(treeTest.insertPoint(restPoint));
-
     EXPECT_TRUE(treeTest.deletePoint(restPoint));
 
     EXPECT_FALSE(treeTest.empty());

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -14,10 +14,10 @@ protected:
     void SetUp() override
     {
         pointCloudSize = 1000;
-        resolution=0.0001;
+        resolution = 0.0001;
         int scale;
         Point3i pmin, pmax;
-        scale = 1<<20;
+        scale = 1 << 20;
         pmin = Point3i(-scale, -scale, -scale);
         pmax = Point3i(scale, scale, scale);
 
@@ -113,15 +113,27 @@ TEST_F(OctreeTest, KNNSearchTest)
     std::vector<float> outputSquareDist;
     EXPECT_NO_THROW(treeTest->KNNSearch(restPoint, K, outputPoints, outputSquareDist));
 
-    // this output should be sorted
-    EXPECT_FLOAT_EQ(outputPoints[0].x, -8.118486404418f);
-    EXPECT_FLOAT_EQ(outputPoints[0].y, -0.528564453125f);
-    EXPECT_FLOAT_EQ(outputPoints[1].x, -8.405818939208f);
-    EXPECT_FLOAT_EQ(outputPoints[1].y, -2.991247177124f);
-    EXPECT_FLOAT_EQ(outputPoints[2].x, -8.88461112976f);
-    EXPECT_FLOAT_EQ(outputPoints[2].y, -1.881799697875f);
-    EXPECT_FLOAT_EQ(outputPoints[3].x, -6.551313400268f);
-    EXPECT_FLOAT_EQ(outputPoints[3].y, -0.708484649658f);
+    // The output is unsorted, so let's sort it before checking
+    std::map<float, Point3f> sortResults;
+    for (int i = 0; i < (int)outputPoints.size(); i++)
+    {
+        sortResults[outputSquareDist[i]] = outputPoints[i];
+    }
+
+    std::vector<Point3f> goldVals = {
+        { -8.118486404418f, -0.528564453125f, 0.f },
+        { -8.405818939208f, -2.991247177124f, 0.f },
+        { -8.884611129760f, -1.881799697875f, 0.f },
+        { -6.551313400268f, -0.708484649658f, 0.f }
+    };
+
+    auto it = sortResults.begin();
+    for (int i = 0; i < (int)goldVals.size(); i++, it++)
+    {
+        Point3f p = it->second;
+        EXPECT_FLOAT_EQ(goldVals[i].x, p.x);
+        EXPECT_FLOAT_EQ(goldVals[i].y, p.y);
+    }
 }
 
 TEST_F(OctreeTest, restoreTest) {
@@ -137,9 +149,9 @@ TEST_F(OctreeTest, restoreTest) {
     std::vector<float> outputSquareDist;
     EXPECT_NO_THROW(treeTest->getPointCloudByOctree(restorePointCloudData,restorePointCloudColor));
     EXPECT_NO_THROW(treeTest->KNNSearch(restorePointCloudData[0], 1, outputPoints, outputSquareDist));
-    EXPECT_LE(abs(outputPoints[0].x-restorePointCloudData[0].x),resolution);
-    EXPECT_LE(abs(outputPoints[0].y-restorePointCloudData[0].y),resolution);
-    EXPECT_LE(abs(outputPoints[0].z-restorePointCloudData[0].z),resolution);
+    EXPECT_LE(abs(outputPoints[0].x - restorePointCloudData[0].x), resolution);
+    EXPECT_LE(abs(outputPoints[0].y - restorePointCloudData[0].y), resolution);
+    EXPECT_LE(abs(outputPoints[0].z - restorePointCloudData[0].z), resolution);
 }
 
 } // namespace

--- a/modules/3d/test/test_octree.cpp
+++ b/modules/3d/test/test_octree.cpp
@@ -83,15 +83,27 @@ TEST_F(OctreeTest, RadiusSearchTest)
     EXPECT_NO_THROW(treeTest.radiusNNSearch(restPoint, radius, outputPoints, outputSquareDist));
     EXPECT_EQ(outputPoints.size(),(unsigned int)5);
 
-    //The outputPoints should be unordered, so in some resolution, this test will fail because it specified the order of output.
-    EXPECT_FLOAT_EQ(outputPoints[0].x, -8.88461112976f);
-    EXPECT_FLOAT_EQ(outputPoints[0].y, -1.881799697875f);
-    EXPECT_FLOAT_EQ(outputPoints[1].x, -8.405818939208f);
-    EXPECT_FLOAT_EQ(outputPoints[1].y, -2.991247177124f);
-    EXPECT_FLOAT_EQ(outputPoints[2].x, -8.1184864044189f);
-    EXPECT_FLOAT_EQ(outputPoints[2].y, -0.528564453125f);
-    EXPECT_FLOAT_EQ(outputPoints[3].x, -6.551313400268f);
-    EXPECT_FLOAT_EQ(outputPoints[3].y, -0.708484649658f);
+    // The output is unsorted, so let's sort it before checking
+    std::map<float, Point3f> sortResults;
+    for (int i = 0; i < (int)outputPoints.size(); i++)
+    {
+        sortResults[outputSquareDist[i]] = outputPoints[i];
+    }
+
+    std::vector<Point3f> goldVals = {
+        {-8.1184864044189f, -0.528564453125f, 0.f},
+        {-8.405818939208f,  -2.991247177124f, 0.f},
+        {-8.88461112976f,   -1.881799697875f, 0.f},
+        {-6.551313400268f,  -0.708484649658f, 0.f}
+    };
+
+    auto it = sortResults.begin();
+    for (int i = 0; i < (int)goldVals.size(); i++, it++)
+    {
+        Point3f p = it->second;
+        EXPECT_FLOAT_EQ(goldVals[i].x, p.x);
+        EXPECT_FLOAT_EQ(goldVals[i].y, p.y);
+    }
 }
 
 TEST_F(OctreeTest, KNNSearchTest)
@@ -101,6 +113,7 @@ TEST_F(OctreeTest, KNNSearchTest)
     std::vector<float> outputSquareDist;
     EXPECT_NO_THROW(treeTest.KNNSearch(restPoint, K, outputPoints, outputSquareDist));
 
+    // this output should be sorted
     EXPECT_FLOAT_EQ(outputPoints[0].x, -8.118486404418f);
     EXPECT_FLOAT_EQ(outputPoints[0].y, -0.528564453125f);
     EXPECT_FLOAT_EQ(outputPoints[1].x, -8.405818939208f);


### PR DESCRIPTION
## PR for GSoC Point Cloud Compression
[Issue for GSoC 2023](https://github.com/opencv/opencv/issues/23624)

* We are **updating the Octree method create() by using OctreeKey**: Through voxelization, directly calculate the leaf nodes that the point cloud belongs to, and omit the judgment whether the point cloud is in the range when inserted. The index of the child node is calculated by bit operation.
* We are also **introducing a new header file pcc.h (Point Cloud Compression) with API framework**.
* We added tests for restoring point clouds from an octree.
* Currently, the features related to octree creation and point cloud compression are part of the internal API, which means they are not directly accessible to users. However, our plan for the future is to **include only the 'PointCloudCompression' class in the 'opencv2/3d.hpp' header file**. This will provide an interface for utilizing the point cloud compression functionality.

The previous PR of this was closed due to repo name conflicts, therefore we resubmitted in this PR.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
