### PR TITLE
OpenVINO backend for INT8 models

### DIFF
--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -302,6 +302,14 @@ PERF_TEST_P_(DNNTestNetwork, EfficientDet)
     processNet("dnn/efficientdet-d0.pb", "dnn/efficientdet-d0.pbtxt", "", inp);
 }
 
+
+PERF_TEST_P_(DNNTestNetwork, EfficientDet_int8)
+{
+    Mat inp = imread(findDataFile("dnn/dog416.png"));
+    resize(inp, inp, Size(320, 320));
+    processNet("", "dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", "", inp);
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, dnnBackendsAndTargets());
 
 } // namespace

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -305,6 +305,10 @@ PERF_TEST_P_(DNNTestNetwork, EfficientDet)
 
 PERF_TEST_P_(DNNTestNetwork, EfficientDet_int8)
 {
+    if (target != DNN_TARGET_CPU || (backend != DNN_BACKEND_OPENCV &&
+        backend != DNN_BACKEND_TIMVX && backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)) {
+        throw SkipTestException("");
+    }
     Mat inp = imread(findDataFile("dnn/dog416.png"));
     resize(inp, inp, Size(320, 320));
     processNet("", "dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", "", inp);

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -590,8 +590,8 @@ void InfEngineNgraphNet::init(Target targetId)
             allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
-        ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
-        // ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
+        // ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
+        ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
     }
 
     ppp.build();

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -590,7 +590,8 @@ void InfEngineNgraphNet::init(Target targetId)
             allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
-        ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
+        ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
+        // ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
     }
 
     ppp.build();

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -593,9 +593,7 @@ void InfEngineNgraphNet::init(Target targetId)
         ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
     }
 
-    std::cout << "start build" << std::endl;
     ppp.build();
-    std::cout << "finish build" << std::endl;
 
 #else
 

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -835,7 +835,6 @@ void NgraphBackendLayer::forward(InputArrayOfArrays inputs, OutputArrayOfArrays 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 
 ov::Tensor wrapToNgraphBlob(const Mat& m) {
-    std::cout << "wrapToNgraphBlob " << m.type() << std::endl;
     std::vector<size_t> shape = getShape<size_t>(m);
     if (m.type() == CV_32F)
         return ov::Tensor(ov::element::f32, shape, m.data);
@@ -897,7 +896,6 @@ InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, const std::vector<size
 InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, InferenceEngine::Layout layout)
 {
     std::vector<size_t> shape = getShape<size_t>(m);
-    std::cout << "wrapToNgraphBlob 1" << std::endl;
     return wrapToNgraphBlob(m, shape, layout);
 }
 
@@ -909,8 +907,6 @@ NgraphBackendWrapper::NgraphBackendWrapper(int targetId, const cv::Mat& m)
     : BackendWrapper(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH, targetId)
     , host((Mat*)&m)
 {
-    std::cout << "wrapToNgraphBlob 2" << std::endl;
-
     blob = wrapToNgraphBlob(m);
 }
 

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -590,8 +590,7 @@ void InfEngineNgraphNet::init(Target targetId)
             allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
-        // ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
-        ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
+        ppp.output(i++).tensor().set_element_type(src.get_element_type());
     }
 
     ppp.build();

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -590,10 +590,12 @@ void InfEngineNgraphNet::init(Target targetId)
             allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
-        ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
+        ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
     }
 
+    std::cout << "start build" << std::endl;
     ppp.build();
+    std::cout << "finish build" << std::endl;
 
 #else
 
@@ -835,11 +837,14 @@ void NgraphBackendLayer::forward(InputArrayOfArrays inputs, OutputArrayOfArrays 
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2022_1)
 
 ov::Tensor wrapToNgraphBlob(const Mat& m) {
+    std::cout << "wrapToNgraphBlob " << m.type() << std::endl;
     std::vector<size_t> shape = getShape<size_t>(m);
     if (m.type() == CV_32F)
         return ov::Tensor(ov::element::f32, shape, m.data);
     else if (m.type() == CV_8U)
         return ov::Tensor(ov::element::u8, shape, m.data);
+    else if (m.type() == CV_8SC1)
+        return ov::Tensor(ov::element::i8, shape, m.data);
     else if (m.type() == CV_32SC1)
         return ov::Tensor(ov::element::i32, shape, m.data);
     else
@@ -894,6 +899,7 @@ InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, const std::vector<size
 InferenceEngine::Blob::Ptr wrapToNgraphBlob(const Mat& m, InferenceEngine::Layout layout)
 {
     std::vector<size_t> shape = getShape<size_t>(m);
+    std::cout << "wrapToNgraphBlob 1" << std::endl;
     return wrapToNgraphBlob(m, shape, layout);
 }
 
@@ -905,6 +911,8 @@ NgraphBackendWrapper::NgraphBackendWrapper(int targetId, const cv::Mat& m)
     : BackendWrapper(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH, targetId)
     , host((Mat*)&m)
 {
+    std::cout << "wrapToNgraphBlob 2" << std::endl;
+
     blob = wrapToNgraphBlob(m);
 }
 

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -590,7 +590,7 @@ void InfEngineNgraphNet::init(Target targetId)
             allBlobs[name] = ov::Tensor(src.get_element_type(), outShape, src.data());
         }
 
-        ppp.output(i++).tensor().set_element_type(ov::element::i8);  // Should be always FP32
+        ppp.output(i++).tensor().set_element_type(ov::element::f32);  // Should be always FP32
     }
 
     ppp.build();

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -148,6 +148,9 @@ private:
     InferenceEngine::CNNNetwork t_net;
 };
 
+ngraph::Output<ngraph::Node> ngraphQuantize(ngraph::Output<ngraph::Node> input, float output_sc, float output_zp);
+ngraph::Output<ngraph::Node> ngraphDequantize(ngraph::Output<ngraph::Node> input, float input_sc, float input_zp);
+
 #endif  // HAVE_DNN_NGRAPH
 
 }}  // namespace cv::dnn

--- a/modules/dnn/src/int8layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/int8layers/batch_norm_layer.cpp
@@ -256,7 +256,7 @@ public:
             256 // levels
         );
 
-        std::vector<size_t> shape(input->get_shape().size(), 1);
+        std::vector<size_t> shape(input.get_shape().size(), 1);
         shape[1] = origin_weights.total();
 
         std::shared_ptr<ngraph::Node> res;

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -1513,13 +1513,6 @@ public:
         int nstripes = std::max(getNumThreads(), 1);
         Mat outputInt32 = Mat(shape(outputs[0]), CV_32S);
 
-        // for (int i = 0; i < outputMultiplier.size(); ++i)
-        //     outputMultiplier[i] = 1;
-        // for (int i = 0; i < biasvec.size(); ++i)
-        //     biasvec[i] = 0;
-        // input_zp = 0;
-        // output_zp = 0;
-
         ParallelConv::run(inputs[0], outputInt32, weightsMat, outputMultiplier, biasvec, activationLUT, kernel_size, strides,
                           pads_begin, pads_end, dilations, activ.get(), ngroups, nstripes, input_zp, output_zp);
 

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -671,7 +671,13 @@ public:
             conv_node,
             std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape(shape), outputMultiplier.data())
         );
-        conv_node = std::make_shared<ngraph::op::v5::Round>(conv_node, ngraph::op::v5::Round::RoundMode::HALF_TO_EVEN);
+
+        // TODO: this is strange! Is OpenCV uses different round for depthwise and common convolutions?
+        if (group != 1) {
+            conv_node = std::make_shared<ngraph::op::v5::Round>(conv_node, ngraph::op::v5::Round::RoundMode::HALF_AWAY_FROM_ZERO);
+        } else {
+            conv_node = std::make_shared<ngraph::op::v5::Round>(conv_node, ngraph::op::v5::Round::RoundMode::HALF_TO_EVEN);
+        }
 
         float output_zp_f = output_zp;
         conv_node = std::make_shared<ngraph::op::v1::Add>(

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -571,14 +571,14 @@ public:
         CV_Assert_N(inputs.size() >= 1, nodes.size() >= 1);
         CV_CheckTypeEQ(weightsMat.type(), CV_8S, "");
         auto ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-        std::vector<size_t> dims = ieInpNode->get_shape();
+        std::vector<size_t> dims = ieInpNode.get_shape();
         CV_Check(dims.size(), dims.size() >= 3 && dims.size() <= 5, "");
-        CV_Assert(ieInpNode->get_element_type() == ngraph::element::f32);
-        std::shared_ptr<ngraph::Node> ieWeights = nodes.size() > 1 ? nodes[1].dynamicCast<InfEngineNgraphNode>()->node : nullptr;
+        CV_Assert(ieInpNode.get_element_type() == ngraph::element::f32);
+        ngraph::Output<ngraph::Node> ieWeights;
         if (nodes.size() > 1)
-            CV_Assert(ieWeights);  // dynamic_cast should not fail
+            ieWeights = nodes[1].dynamicCast<InfEngineNgraphNode>()->node;
         const int inpCn = dims[1];
-        const int inpGroupCn = nodes.size() > 1 ? ieWeights->get_shape()[1] : blobs[0].size[1];
+        const int inpGroupCn = nodes.size() > 1 ? ieWeights.get_shape()[1] : blobs[0].size[1];
         const int group = inpCn / inpGroupCn;
 
         std::vector<size_t> kernel_shape;

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -10,6 +10,7 @@
 #include "opencv2/core/hal/hal.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 #include "../op_timvx.hpp"
+#include "../ie_ngraph.hpp"
 #include <iostream>
 #include <numeric>
 
@@ -195,7 +196,8 @@ public:
         }
 #endif
         // Only default backend and Conv1D/Conv2D/Conv3D are supported
-        return backendId == DNN_BACKEND_OPENCV && ksize >= 1 && ksize <= 3;
+        return (backendId == DNN_BACKEND_OPENCV && ksize >= 1 && ksize <= 3) ||
+               backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,
@@ -560,6 +562,88 @@ public:
 #endif  // HAVE_TIMVX
         return Ptr<BackendNode>();
     }
+
+#ifdef HAVE_DNN_NGRAPH
+    virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
+                                        const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
+    {
+        CV_Assert(!blobs.empty());
+        CV_Assert_N(inputs.size() >= 1, nodes.size() >= 1);
+        CV_CheckTypeEQ(weightsMat.type(), CV_8S, "");
+        auto& ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+        std::vector<size_t> dims = ieInpNode->get_shape();
+        CV_Check(dims.size(), dims.size() >= 3 && dims.size() <= 5, "");
+        std::shared_ptr<ngraph::Node> ieWeights = nodes.size() > 1 ? nodes[1].dynamicCast<InfEngineNgraphNode>()->node : nullptr;
+        if (nodes.size() > 1)
+            CV_Assert(ieWeights);  // dynamic_cast should not fail
+        const int inpCn = dims[1];
+        const int inpGroupCn = nodes.size() > 1 ? ieWeights->get_shape()[1] : blobs[0].size[1];
+        const int group = inpCn / inpGroupCn;
+
+        std::vector<size_t> kernel_shape;
+        if (group != 1)
+        {
+            kernel_shape.push_back(group);
+        }
+        kernel_shape.push_back(numOutput / group);
+        kernel_shape.push_back(inpCn / group);
+        std::copy(kernel_size.begin(), kernel_size.end(), back_inserter(kernel_shape));
+
+        if (nodes.size() == 1)
+        {
+            ieWeights = std::make_shared<ngraph::op::Constant>(ngraph::element::i8, kernel_shape, blobs[0].data);
+        }
+        else
+        {
+            auto shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
+                             ngraph::Shape{kernel_shape.size()}, std::vector<int64_t>(kernel_shape.begin(), kernel_shape.end()));
+            ieWeights  = std::make_shared<ngraph::op::v1::Reshape>(ieWeights, shape, true);
+        }
+
+        ngraph::op::PadType pad_type = ngraph::op::PadType::EXPLICIT;
+        if (!padMode.empty())
+            pad_type = padMode == "VALID" ? ngraph::op::PadType::VALID : ngraph::op::PadType::SAME_UPPER;
+
+        std::shared_ptr<ngraph::Node> conv_node;
+        if (group != 1) {
+            conv_node = std::make_shared<ngraph::op::v1::GroupConvolution>(
+                                ieInpNode, ieWeights,
+                                ngraph::Strides(strides),
+                                ngraph::CoordinateDiff(std::vector<std::ptrdiff_t>(pads_begin.begin(), pads_begin.end())),
+                                ngraph::CoordinateDiff(std::vector<std::ptrdiff_t>(pads_end.begin(),   pads_end.end())),
+                                ngraph::Strides(dilations),
+                                pad_type);
+        } else {
+            conv_node = std::make_shared<ngraph::op::v1::Convolution>(
+                                ieInpNode, ieWeights,
+                                ngraph::Strides(strides),
+                                ngraph::CoordinateDiff(std::vector<std::ptrdiff_t>(pads_begin.begin(), pads_begin.end())),
+                                ngraph::CoordinateDiff(std::vector<std::ptrdiff_t>(pads_end.begin(), pads_end.end())),
+                                ngraph::Strides(dilations),
+                                pad_type);
+        }
+
+        // if (hasBias() || fusedBias || nodes.size() == 3)
+        // {
+        //     std::vector<size_t> shape(conv_node->get_shape().size(), 1);
+        //     shape[1] = conv_node->get_shape()[1];
+        //     std::shared_ptr<ngraph::Node> bias;
+        //     if (nodes.size() == 3)
+        //     {
+        //         auto bias_shape = std::make_shared<ngraph::op::Constant>(ngraph::element::i64,
+        //                             ngraph::Shape{shape.size()}, std::vector<int64_t>(shape.begin(), shape.end()));
+        //         bias = std::make_shared<ngraph::op::v1::Reshape>(nodes[2].dynamicCast<InfEngineNgraphNode>()->node, bias_shape, true);
+        //     }
+        //     else
+        //     {
+        //         bias = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape(shape), biasvec.data());
+        //     }
+        //     auto conv_bias = std::make_shared<ngraph::op::v1::Add>(conv_node, bias, ngraph::op::AutoBroadcastType::NUMPY);
+        //     return Ptr<BackendNode>(new InfEngineNgraphNode(conv_bias));
+        // }
+        return Ptr<BackendNode>(new InfEngineNgraphNode(conv_node));
+    }
+#endif  // HAVE_DNN_NGRAPH
 
     class ParallelConv : public cv::ParallelLoopBody
     {

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -1515,6 +1515,7 @@ public:
 
         ParallelConv::run(inputs[0], outputInt32, weightsMat, outputMultiplier, biasvec, activationLUT, kernel_size, strides,
                           pads_begin, pads_end, dilations, activ.get(), ngroups, nstripes, input_zp, output_zp);
+
         outputInt32.convertTo(outputs[0], CV_8S);
 
 #if CV_SSE3

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -664,10 +664,10 @@ public:
         //     conv_node,
         //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape(shape), &outputMultiplier[0])
         // );
-        // conv_node = std::make_shared<ngraph::op::v1::Add>(
-        //     conv_node,
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::i32, ngraph::Shape{1}, &output_zp)
-        // );
+        conv_node = std::make_shared<ngraph::op::v1::Add>(
+            conv_node,
+            std::make_shared<ngraph::op::Constant>(ngraph::element::i32, ngraph::Shape{1}, &output_zp)
+        );
         std::cout << "biasvec[0] " << biasvec[0] << std::endl;
         // conv_node = std::make_shared<ngraph::op::Clamp>(conv_node, -128, 127);
         // conv_node = std::make_shared<ngraph::op::Convert>(conv_node, ngraph::element::i8);
@@ -1504,7 +1504,7 @@ public:
         // for (int i = 0; i < biasvec.size(); ++i)
         //     biasvec[i] = 0;
         input_zp = 0;
-        output_zp = 0;
+        // output_zp = 0;
 
         ParallelConv::run(inputs[0], outputInt32, weightsMat, outputMultiplier, biasvec, activationLUT, kernel_size, strides,
                           pads_begin, pads_end, dilations, activ.get(), ngroups, nstripes, input_zp, output_zp);

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -659,18 +659,18 @@ public:
             }
             conv_node = std::make_shared<ngraph::op::v1::Add>(conv_node, bias, ngraph::op::AutoBroadcastType::NUMPY);
         }
-        // conv_node = std::make_shared<ngraph::op::Convert>(conv_node, ngraph::element::f32);
-        // conv_node = std::make_shared<ngraph::op::v1::Multiply>(
-        //     conv_node,
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape(shape), &outputMultiplier[0])
-        // );
+        conv_node = std::make_shared<ngraph::op::Convert>(conv_node, ngraph::element::f32);
+        conv_node = std::make_shared<ngraph::op::v1::Multiply>(
+            conv_node,
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape(shape), &outputMultiplier[0])
+        );
+        float output_zp_f = output_zp;
         conv_node = std::make_shared<ngraph::op::v1::Add>(
             conv_node,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::i32, ngraph::Shape{1}, &output_zp)
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &output_zp_f)
         );
-        std::cout << "biasvec[0] " << biasvec[0] << std::endl;
-        // conv_node = std::make_shared<ngraph::op::Clamp>(conv_node, -128, 127);
-        // conv_node = std::make_shared<ngraph::op::Convert>(conv_node, ngraph::element::i8);
+        conv_node = std::make_shared<ngraph::op::Clamp>(conv_node, -128, 127);
+        conv_node = std::make_shared<ngraph::op::Convert>(conv_node, ngraph::element::i8);
 
         return Ptr<BackendNode>(new InfEngineNgraphNode(conv_node));
     }
@@ -1499,8 +1499,8 @@ public:
         int nstripes = std::max(getNumThreads(), 1);
         Mat outputInt32 = Mat(shape(outputs[0]), CV_32S);
 
-        for (int i = 0; i < outputMultiplier.size(); ++i)
-            outputMultiplier[i] = 1;
+        // for (int i = 0; i < outputMultiplier.size(); ++i)
+        //     outputMultiplier[i] = 1;
         // for (int i = 0; i < biasvec.size(); ++i)
         //     biasvec[i] = 0;
         input_zp = 0;

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -5,6 +5,7 @@
 #include "../precomp.hpp"
 #include "layers_common.hpp"
 #include "../op_timvx.hpp"
+#include "../ie_ngraph.hpp"
 
 #include <opencv2/dnn/shape_utils.hpp>
 #include <iostream>
@@ -56,7 +57,7 @@ public:
             return tvActType != tvActNotSupported;
         }
 #endif
-        return backendId == DNN_BACKEND_OPENCV;
+        return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,
@@ -243,6 +244,16 @@ public:
 #endif  // HAVE_TIMVX
         return Ptr<BackendNode>();
     }
+
+#ifdef HAVE_DNN_NGRAPH
+    virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
+                                        const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
+    {
+        auto& input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+        // TODO: implement RELU6
+        return new InfEngineNgraphNode(std::make_shared<ngraph::op::Clamp>(input, -128, 127));
+    }
+#endif  // HAVE_DNN_NGRAPH
 
     void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
     {

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -252,6 +252,11 @@ public:
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         std::shared_ptr<ngraph::Node> res = nullptr;
         if (type == "ReLU6Int8") {
+            std::vector<int8_t> data(256);
+            for (int i = 0; i < 256; ++i) {
+                data[i] = i - 128;
+            }
+            CV_Assert(cv::norm(Mat(1, 256, CV_8S, data.data()), activationLUT, NORM_INF) == 0);
             res = input;  // TODO: implement it
         } else if (type == "SigmoidInt8") {
             std::cout << "sigmoid" << std::endl;

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -249,7 +249,7 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        auto& input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+        auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         // TODO: implement RELU6
         return new InfEngineNgraphNode(input);
     }

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -250,67 +250,50 @@ public:
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+
+        float inpLow = -128, inpHigh = 127;
+        float outLow = input_sc * (inpLow - input_zp);
+        float outHigh = input_sc * (inpHigh - input_zp);
+        input = std::make_shared<ngraph::op::FakeQuantize>(input,
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
+            256 // levels
+        );
+
         std::shared_ptr<ngraph::Node> res = nullptr;
         if (type == "ReLU6Int8") {
-            res = input;  // TODO: implement it
+            res = std::make_shared<ngraph::op::Clamp>(input, 0.0f, 6.0f);
         } else if (type == "ReLUInt8") {
-            res = input;  // TODO: implement it
+            if (slope) {
+                auto param = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &slope);
+                res = std::make_shared<ngraph::op::PRelu>(input, param);
+            } else {
+                res = std::make_shared<ngraph::op::Relu>(input);
+            }
         } else if (type == "ELUInt8") {
-            res = input;  // TODO: implement it
+            res = std::make_shared<ngraph::op::Elu>(input, 1.0f);
         } else if (type == "MishInt8") {
-            res = input;  // TODO: implement it
+            res = std::make_shared<ngraph::op::v4::Mish>(input);
         } else if (type == "AbsValInt8") {
-            res = input;  // TODO: implement it
+            res = std::make_shared<ngraph::op::Abs>(input);
         } else if (type == "SigmoidInt8") {
-            std::cout << "sigmoid" << std::endl;
-            std::cout << input_zp << std::endl;
-            std::cout << output_zp << std::endl;
-            std::cout << input_sc << std::endl;
-            std::cout << output_sc << std::endl;
-            float input_zp_f = input_zp;
-            float output_zp_f = output_zp;
-            // float inpLow = -128;
-            // float inpHigh = 127;
-            // float outLow = -128;
-            // float outHigh = 127;
-
-            // outLow = output_sc * (outLow - output_zp);
-            // outHigh = output_sc * (outHigh - output_zp);
-            // inpLow = input_sc * (inpLow - input_zp);
-            // inpHigh = input_sc * (inpHigh - input_zp);
-
-            input = std::make_shared<ngraph::op::Convert>(input, ngraph::element::f32);
-            input = std::make_shared<ngraph::op::v1::Subtract>(
-                input,
-                std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &input_zp_f)
-            );
-            input = std::make_shared<ngraph::op::v1::Multiply>(
-                input,
-                std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &input_sc)
-            );
-
-            // input = std::make_shared<ngraph::op::FakeQuantize>(input,
-            //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-            //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-            //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-            //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-            //     256 // levels
-            // );
             res = std::make_shared<ngraph::op::Sigmoid>(input);
-
-            res = std::make_shared<ngraph::op::v1::Divide>(
-                res,
-                std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &output_sc)
-            );
-            res = std::make_shared<ngraph::op::v1::Add>(
-                res,
-                std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &output_zp_f)
-            );
-            res = std::make_shared<ngraph::op::Clamp>(res, -128, 127);
-            res = std::make_shared<ngraph::op::Convert>(res, ngraph::element::i8);
         } else {
             CV_Error(Error::StsNotImplemented, type + " activation with OpenVINO");
         }
+
+        outLow = -128; outHigh = 127;
+        inpLow = output_sc * (outLow - output_zp);
+        inpHigh = output_sc * (outHigh - output_zp);
+        res = std::make_shared<ngraph::op::FakeQuantize>(res,
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
+            256 // levels
+        );
         return new InfEngineNgraphNode(res);
     }
 #endif  // HAVE_DNN_NGRAPH

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -251,7 +251,7 @@ public:
     {
         auto& input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         // TODO: implement RELU6
-        return new InfEngineNgraphNode(std::make_shared<ngraph::op::Clamp>(input, -128, 127));
+        return new InfEngineNgraphNode(input);
     }
 #endif  // HAVE_DNN_NGRAPH
 

--- a/modules/dnn/src/int8layers/elementwise_layers.cpp
+++ b/modules/dnn/src/int8layers/elementwise_layers.cpp
@@ -252,11 +252,14 @@ public:
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         std::shared_ptr<ngraph::Node> res = nullptr;
         if (type == "ReLU6Int8") {
-            std::vector<int8_t> data(256);
-            for (int i = 0; i < 256; ++i) {
-                data[i] = i - 128;
-            }
-            CV_Assert(cv::norm(Mat(1, 256, CV_8S, data.data()), activationLUT, NORM_INF) == 0);
+            res = input;  // TODO: implement it
+        } else if (type == "ReLUInt8") {
+            res = input;  // TODO: implement it
+        } else if (type == "ELUInt8") {
+            res = input;  // TODO: implement it
+        } else if (type == "MishInt8") {
+            res = input;  // TODO: implement it
+        } else if (type == "AbsValInt8") {
             res = input;  // TODO: implement it
         } else if (type == "SigmoidInt8") {
             std::cout << "sigmoid" << std::endl;

--- a/modules/dnn/src/int8layers/eltwise_layer.cpp
+++ b/modules/dnn/src/int8layers/eltwise_layer.cpp
@@ -374,7 +374,8 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        std::vector<std::shared_ptr<ngraph::Node>> ieInpNodes(nodes.size());
+        CV_Assert(nodes.size() >= 2);
+        std::vector<ngraph::Output<ngraph::Node>> ieInpNodes(nodes.size());
         for (size_t i = 0; i < nodes.size(); i++)
         {
             ieInpNodes[i] = nodes[i].dynamicCast<InfEngineNgraphNode>()->node;

--- a/modules/dnn/src/int8layers/eltwise_layer.cpp
+++ b/modules/dnn/src/int8layers/eltwise_layer.cpp
@@ -410,7 +410,6 @@ public:
             std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &offset)
         );
         res = std::make_shared<ngraph::op::Clamp>(res, -128, 127);
-        res = std::make_shared<ngraph::op::Convert>(res, ngraph::element::i8);
 
         return new InfEngineNgraphNode(res);
     }

--- a/modules/dnn/src/int8layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/int8layers/fully_connected_layer.cpp
@@ -405,8 +405,8 @@ public:
         CV_CheckTypeEQ(blobs[1].type(), CV_32S, "");  // bias
         CV_CheckTypeEQ(outputMultiplier.type(), CV_32F, "");
 
-        std::shared_ptr<ngraph::Node> input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-        std::shared_ptr<ngraph::Node> ieWeights, ieBias, matmul;
+        ngraph::Output<ngraph::Node> input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+        ngraph::Output<ngraph::Node> ieWeights, ieBias, matmul;
         bool transA = false, transB = true;
         size_t numOutput = blobs[0].size[0];
 
@@ -418,7 +418,7 @@ public:
         }
         else
         {
-            std::vector<int> shape(1 + normalize_axis(axis, input->get_shape().size()), 0);
+            std::vector<int> shape(1 + normalize_axis(axis, input.get_shape().size()), 0);
             shape[shape.size() - 1] = -1;
             input = std::make_shared<ngraph::op::v1::Reshape>(
                 input,

--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -308,7 +308,7 @@ public:
                         ngraph::Shape(pads_begin), ngraph::Shape(pads_end), ngraph::Shape(kernel_size),
                         !avePoolPaddedArea, rounding_type, pad_type);
         } else if (type == SUM) {
-            ngraph::Shape inpShape = input->get_shape();
+            ngraph::Shape inpShape = input.get_shape();
             CV_Assert(inpShape.size() == 2 + kernel_size.size());
             std::vector<int64_t> axes;
             for (size_t i = 0; i < kernel_size.size(); i++)

--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -282,23 +282,14 @@ public:
     {
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
 
-        float inpLow = -128, inpHigh = 127;
-        float outLow = input_sc * (inpLow - input_zp);
-        float outHigh = input_sc * (inpHigh - input_zp);
-        input = std::make_shared<ngraph::op::FakeQuantize>(input,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-            256 // levels
-        );
+        input = ngraphDequantize(input, input_sc, input_zp);
 
         ngraph::op::PadType pad_type = ngraph::op::PadType::EXPLICIT;
         if (!padMode.empty())
             pad_type = padMode == "VALID" ? ngraph::op::PadType::VALID : ngraph::op::PadType::SAME_UPPER;
 
         auto rounding_type = ceilMode ? ngraph::op::RoundingType::CEIL : ngraph::op::RoundingType::FLOOR;
-        std::shared_ptr<ngraph::Node> pool;
+        ngraph::Output<ngraph::Node> pool;
         if (type == MAX) {
             pool = std::make_shared<ngraph::op::v1::MaxPool>(input, ngraph::Strides(strides),
                         ngraph::Shape(pads_begin), ngraph::Shape(pads_end), ngraph::Shape(kernel_size),
@@ -322,16 +313,7 @@ public:
             CV_Error(Error::StsNotImplemented, format("INT8 Pooling type: %d", type));
         }
 
-        outLow = -128; outHigh = 127;
-        inpLow = output_sc * (outLow - output_zp);
-        inpHigh = output_sc * (outHigh - output_zp);
-        pool = std::make_shared<ngraph::op::FakeQuantize>(pool,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-            256 // levels
-        );
+        pool = ngraphQuantize(pool, output_sc, output_zp);
 
         return new InfEngineNgraphNode(pool);
     }

--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -280,6 +280,7 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> > &inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
+        CV_Assert(type == MAX);
         auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
 
         ngraph::op::PadType pad_type = ngraph::op::PadType::EXPLICIT;

--- a/modules/dnn/src/int8layers/quantization_utils.cpp
+++ b/modules/dnn/src/int8layers/quantization_utils.cpp
@@ -178,38 +178,18 @@ public:
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs,
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        // OpenVINO quantization technique is described in FakeQuantize layer documentation.
-        // It accepts input and output low/high values and performs computations as follows:
-        // out = round((x - inp_low) / (inp_high - inp_low) * (levels-1)) / (levels-1) * (out_high - out_low) + out_low
-        // where levels are 256
-        // const float outLow = -128;
-        // const float outHigh = 127;
-        // const float inpLow = (outLow - zeropoints[0]) * scales[0];
-        // const float inpHigh = (outHigh - zeropoints[0]) * scales[0];
-
-        float scale = 1.f/scales[0];
-        float zeropoint = static_cast<float>(zeropoints[0]);
-
         const auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-        auto scaled = std::make_shared<ngraph::op::v1::Multiply>(
-            input,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &scale)
-        );
-        auto shifted = std::make_shared<ngraph::op::v1::Add>(
-            scaled,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &zeropoint)
-        );
-        auto quantized = std::make_shared<ngraph::op::Convert>(shifted, ngraph::element::i8);
 
-        // auto quantized = std::make_shared<ngraph::op::FakeQuantize>(input,
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-        //     std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-        //     256 // levels
-        // );
-        // return Ptr<BackendNode>(new InfEngineNgraphNode(quantized));
-
+        float outLow = -128, outHigh = 127;
+        float inpLow = scales[0] * (outLow - zeropoints[0]);
+        float inpHigh = scales[0] * (outHigh - zeropoints[0]);
+        auto quantized = std::make_shared<ngraph::op::FakeQuantize>(input,
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
+            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
+            256 // levels
+        );
         return Ptr<BackendNode>(new InfEngineNgraphNode(quantized));
     }
 #endif  // HAVE_DNN_NGRAPH

--- a/modules/dnn/src/int8layers/quantization_utils.cpp
+++ b/modules/dnn/src/int8layers/quantization_utils.cpp
@@ -179,17 +179,7 @@ public:
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
         const auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-
-        float outLow = -128, outHigh = 127;
-        float inpLow = scales[0] * (outLow - zeropoints[0]);
-        float inpHigh = scales[0] * (outHigh - zeropoints[0]);
-        auto quantized = std::make_shared<ngraph::op::FakeQuantize>(input,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-            256 // levels
-        );
+        auto quantized = ngraphQuantize(input, scales[0], zeropoints[0]);
         return Ptr<BackendNode>(new InfEngineNgraphNode(quantized));
     }
 #endif  // HAVE_DNN_NGRAPH
@@ -313,17 +303,7 @@ public:
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
         const auto input = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-
-        float inpLow = -128, inpHigh = 127;
-        float outLow = scales[0] * (inpLow - zeropoints[0]);
-        float outHigh = scales[0] * (inpHigh - zeropoints[0]);
-        auto quantized = std::make_shared<ngraph::op::FakeQuantize>(input,
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &inpHigh),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outLow),
-            std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &outHigh),
-            256 // levels
-        );
+        auto quantized = ngraphDequantize(input, scales[0], zeropoints[0]);
         return new InfEngineNgraphNode(quantized);
     }
 #endif  // HAVE_DNN_NGRAPH

--- a/modules/dnn/src/int8layers/scale_layer.cpp
+++ b/modules/dnn/src/int8layers/scale_layer.cpp
@@ -191,7 +191,7 @@ public:
 #ifdef HAVE_DNN_NGRAPH
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs, const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
-        std::vector<std::shared_ptr<ngraph::Node>> ieInpNodes(nodes.size());
+        std::vector<ngraph::Output<ngraph::Node>> ieInpNodes(nodes.size());
         for (int i = 0; i < nodes.size(); ++i) {
             ieInpNodes[i] = nodes[i].dynamicCast<InfEngineNgraphNode>()->node;
         }
@@ -209,14 +209,14 @@ public:
 
         CV_Assert(!blobs.empty() || ieInpNodes.size() == 1 + (int)hasWeights + (int)hasBias);
 
-        std::shared_ptr<ngraph::Node> weights = nullptr, bias = nullptr;
+        ngraph::Output<ngraph::Node> weights, bias;
         if (blobs.empty()) {
             if (hasWeights)
                 weights = ieInpNodes[1];
             if (hasBias)
                 bias = ieInpNodes[1 + (int)hasWeights];
         } else {
-            std::vector<size_t> shape = ieInpNodes[0]->get_shape();
+            std::vector<size_t> shape = ieInpNodes[0].get_shape();
             int cAxis = normalize_axis(axis, shape.size());
 
             size_t numWeights = blobs[0].total();
@@ -236,7 +236,7 @@ public:
                 bias = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, shape, blobs[(int)hasWeights].data);
         }
 
-        std::shared_ptr<ngraph::Node> res = ieInpNodes[0];
+        ngraph::Output<ngraph::Node> res = ieInpNodes[0];
         if (hasWeights) {
             res = std::make_shared<ngraph::op::v1::Multiply>(res, weights);
         }

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1076,13 +1076,7 @@ struct MishFunctor : public BaseDefaultFunctor<MishFunctor>
 #ifdef HAVE_DNN_NGRAPH
     std::shared_ptr<ngraph::Node> initNgraphAPI(const ngraph::Output<ngraph::Node>& node)
     {
-        float one = 1.0f;
-        auto constant = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &one);
-        auto exp_node = std::make_shared<ngraph::op::v0::Exp>(node);
-        auto sum = std::make_shared<ngraph::op::v1::Add>(constant, exp_node, ngraph::op::AutoBroadcastType::NUMPY);
-        auto log_node = std::make_shared<ngraph::op::v0::Log>(sum);
-        auto tanh_node = std::make_shared<ngraph::op::Tanh>(log_node);
-        return std::make_shared<ngraph::op::v1::Multiply>(node, tanh_node);
+        return std::make_shared<ngraph::op::v4::Mish>(node);
     }
 #endif  // HAVE_DNN_NGRAPH
 
@@ -1309,10 +1303,7 @@ struct AbsValFunctor : public BaseDefaultFunctor<AbsValFunctor>
 #ifdef HAVE_DNN_NGRAPH
     std::shared_ptr<ngraph::Node> initNgraphAPI(const ngraph::Output<ngraph::Node>& node)
     {
-        float coeff = -0.999999f;
-        // float coeff = preferableTarget == DNN_TARGET_MYRIAD ? -0.999f : -0.999999f;
-        auto slope = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &coeff);
-        return std::make_shared<ngraph::op::PRelu>(node, slope);
+        return std::make_shared<ngraph::op::Abs>(node);
     }
 #endif  // HAVE_DNN_NGRAPH
 

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -386,7 +386,6 @@ public:
     {
         auto& ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         int axis = normalize_axis(axisRaw, ieInpNode.get_shape().size());
-        auto softmax = std::make_shared<ngraph::op::v1::Softmax>(ieInpNode, axis);
         if (logSoftMax) {
             return new InfEngineNgraphNode(std::make_shared<ngraph::op::v5::LogSoftmax>(ieInpNode, axis));
         } else {

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -387,10 +387,11 @@ public:
         auto& ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
         int axis = normalize_axis(axisRaw, ieInpNode.get_shape().size());
         auto softmax = std::make_shared<ngraph::op::v1::Softmax>(ieInpNode, axis);
-        if (logSoftMax)
-            return Ptr<BackendNode>(new InfEngineNgraphNode(std::make_shared<ngraph::op::v0::Log>(softmax)));
-
-        return Ptr<BackendNode>(new InfEngineNgraphNode(softmax));
+        if (logSoftMax) {
+            return new InfEngineNgraphNode(std::make_shared<ngraph::op::v5::LogSoftmax>(ieInpNode, axis));
+        } else {
+            return new InfEngineNgraphNode(std::make_shared<ngraph::op::v1::Softmax>(ieInpNode, axis));
+        }
     }
 #endif  // HAVE_DNN_NGRAPH
 

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -519,8 +519,10 @@ void Net::Impl::allocateLayer(int lid, const LayersShapesMap& layersShapes)
     std::vector<LayerPin> pinsForInternalBlobs;
     blobManager.allocateBlobsForLayer(ld, layerShapesIt->second, pinsForInternalBlobs);
     ld.outputBlobsWrappers.resize(ld.outputBlobs.size());
-    for (int i = 0; i < ld.outputBlobs.size(); ++i)
+    for (int i = 0; i < ld.outputBlobs.size(); ++i) {
+        std::cout << "warp " << ld.outputBlobs[i].type() << std::endl;
         ld.outputBlobsWrappers[i] = wrap(ld.outputBlobs[i]);
+    }
 
     /* CUDA & CANN backend has its own system for internal blobs; we don't need these */
     ld.internalBlobsWrappers.resize((preferableBackend == DNN_BACKEND_CUDA || preferableBackend == DNN_BACKEND_TIMVX || preferableBackend == DNN_BACKEND_CANN) ? 0 : ld.internals.size());

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -519,10 +519,8 @@ void Net::Impl::allocateLayer(int lid, const LayersShapesMap& layersShapes)
     std::vector<LayerPin> pinsForInternalBlobs;
     blobManager.allocateBlobsForLayer(ld, layerShapesIt->second, pinsForInternalBlobs);
     ld.outputBlobsWrappers.resize(ld.outputBlobs.size());
-    for (int i = 0; i < ld.outputBlobs.size(); ++i) {
-        std::cout << "warp " << ld.outputBlobs[i].type() << std::endl;
+    for (int i = 0; i < ld.outputBlobs.size(); ++i)
         ld.outputBlobsWrappers[i] = wrap(ld.outputBlobs[i]);
-    }
 
     /* CUDA & CANN backend has its own system for internal blobs; we don't need these */
     ld.internalBlobsWrappers.resize((preferableBackend == DNN_BACKEND_CUDA || preferableBackend == DNN_BACKEND_TIMVX || preferableBackend == DNN_BACKEND_CANN) ? 0 : ld.internals.size());

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -170,9 +170,10 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
     if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         backendId = DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;  // = getInferenceEngineBackendTypeParam();
 
-    if (netWasQuantized && backendId != DNN_BACKEND_OPENCV && backendId != DNN_BACKEND_TIMVX)
+    if (netWasQuantized && backendId != DNN_BACKEND_OPENCV && backendId != DNN_BACKEND_TIMVX &&
+        backendId != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
     {
-        CV_LOG_WARNING(NULL, "DNN: Only default and TIMVX backends support quantized networks");
+        CV_LOG_WARNING(NULL, "DNN: Only default, TIMVX and OpenVINO backends support quantized networks");
         backendId = DNN_BACKEND_OPENCV;
     }
 

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -176,6 +176,13 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
         CV_LOG_WARNING(NULL, "DNN: Only default, TIMVX and OpenVINO backends support quantized networks");
         backendId = DNN_BACKEND_OPENCV;
     }
+#ifdef HAVE_DNN_NGRAPH
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2023_0))
+    {
+        CV_LOG_WARNING(NULL, "DNN: OpenVINO 2023.0 and higher supports quantized networks");
+        backendId = DNN_BACKEND_OPENCV;
+    }
+#endif
 
     if (preferableBackend != backendId)
     {

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -177,9 +177,9 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
         backendId = DNN_BACKEND_OPENCV;
     }
 #ifdef HAVE_DNN_NGRAPH
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2023_0))
+    if (netWasQuantized && backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2023_0))
     {
-        CV_LOG_WARNING(NULL, "DNN: OpenVINO 2023.0 and higher supports quantized networks");
+        CV_LOG_WARNING(NULL, "DNN: OpenVINO 2023.0 and higher is required to supports quantized networks");
         backendId = DNN_BACKEND_OPENCV;
     }
 #endif

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -48,7 +48,7 @@ public:
         CV_Assert(basePtr_);
         Net::Impl& base = *basePtr_;
         CV_Assert(!base.netWasAllocated);
-        CV_Assert(!base.netWasQuantized);
+        // CV_Assert(!base.netWasQuantized);
         netInputLayer = base.netInputLayer;
         blobsToKeep = base.blobsToKeep;
         layers = base.layers;
@@ -100,6 +100,7 @@ public:
 
     Ptr<BackendWrapper> wrap(Mat& host) override
     {
+        std::cout << "here" << std::endl;
         return Ptr<BackendWrapper>(new NgraphBackendWrapper(preferableTarget, host));
     }
 

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -48,7 +48,6 @@ public:
         CV_Assert(basePtr_);
         Net::Impl& base = *basePtr_;
         CV_Assert(!base.netWasAllocated);
-        // CV_Assert(!base.netWasQuantized);
         netInputLayer = base.netInputLayer;
         blobsToKeep = base.blobsToKeep;
         layers = base.layers;
@@ -100,7 +99,6 @@ public:
 
     Ptr<BackendWrapper> wrap(Mat& host) override
     {
-        std::cout << "here" << std::endl;
         return Ptr<BackendWrapper>(new NgraphBackendWrapper(preferableTarget, host));
     }
 

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -27,6 +27,7 @@
 #define INF_ENGINE_RELEASE_2021_3 2021030000
 #define INF_ENGINE_RELEASE_2021_4 2021040000
 #define INF_ENGINE_RELEASE_2022_1 2022010000
+#define INF_ENGINE_RELEASE_2023_0 2023000000
 
 #ifndef INF_ENGINE_RELEASE
 #warning("IE version have not been provided via command-line. Using 2021.4 by default")

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,12 +251,12 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 597)
-            break;
-        // layer 592: max error 26 -> 14
-        // layer 596: max error 57 -> 27
-        // layer 594: max error 0.148438 -> 0.0625
-        // layer 597: max error 1.04144 -> 0.493313
+        // if (op_outputs->Get(0) == 594)
+        //     break;
+        // layer 592: max error 10 -> 9
+        // layer 596: max error 25 -> 23
+        // layer 594: max error 0.0820312 -> 0.0429688
+        // layer 597: max error 0.456771 -> 0.420229
     }
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,7 +251,7 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 341)
+        if (op_outputs->Get(0) == 342)
             break;
     }
 }

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,7 +251,7 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 333)
+        if (op_outputs->Get(0) == 341)
             break;
     }
 }
@@ -414,7 +414,7 @@ void TFLiteImporter::parseConvolution(const Operator& op, const std::string& opc
         }
     }
     addLayer(layerParams, op);
-    // parseFusedActivation(op, options->fused_activation_function());
+    parseFusedActivation(op, options->fused_activation_function());
 }
 
 void TFLiteImporter::parseDWConvolution(const Operator& op, const std::string& opcode, LayerParams& layerParams) {

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -250,6 +250,9 @@ void TFLiteImporter::populateNet()
             }
             throw;
         }
+        // std::cout << op_outputs->Get(0) << std::endl;
+        if (op_outputs->Get(0) == 332)
+            break;
     }
 }
 
@@ -411,7 +414,7 @@ void TFLiteImporter::parseConvolution(const Operator& op, const std::string& opc
         }
     }
     addLayer(layerParams, op);
-    parseFusedActivation(op, options->fused_activation_function());
+    // parseFusedActivation(op, options->fused_activation_function());
 }
 
 void TFLiteImporter::parseDWConvolution(const Operator& op, const std::string& opcode, LayerParams& layerParams) {

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -250,13 +250,6 @@ void TFLiteImporter::populateNet()
             }
             throw;
         }
-        // std::cout << op_outputs->Get(0) << std::endl;
-        // if (op_outputs->Get(0) == 594)
-        //     break;
-        // layer 592: max error 10 -> 9
-        // layer 596: max error 25 -> 23
-        // layer 594: max error 0.0820312 -> 0.0429688
-        // layer 597: max error 0.456771 -> 0.420229
     }
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,7 +251,7 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 342)
+        if (op_outputs->Get(0) == 397)
             break;
     }
 }

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,7 +251,7 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 332)
+        if (op_outputs->Get(0) == 333)
             break;
     }
 }

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,8 +251,8 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 397)
-            break;
+        // if (op_outputs->Get(0) == 594)
+        //     break;
     }
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,8 +251,12 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        // if (op_outputs->Get(0) == 594)
-        //     break;
+        if (op_outputs->Get(0) == 596)
+            break;
+        // layer 592: max error 27 -> 26
+        // layer 596: max error 97 -> 57
+        // layer 594: max error 0.144531 -> 0.148438
+        // layer 594: max error 1.77227 -> 1.04144
     }
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -251,12 +251,12 @@ void TFLiteImporter::populateNet()
             throw;
         }
         // std::cout << op_outputs->Get(0) << std::endl;
-        if (op_outputs->Get(0) == 596)
+        if (op_outputs->Get(0) == 597)
             break;
-        // layer 592: max error 27 -> 26
-        // layer 596: max error 97 -> 57
-        // layer 594: max error 0.144531 -> 0.148438
-        // layer 594: max error 1.77227 -> 1.04144
+        // layer 592: max error 26 -> 14
+        // layer 596: max error 57 -> 27
+        // layer 594: max error 0.148438 -> 0.0625
+        // layer 597: max error 1.04144 -> 0.493313
     }
 }
 

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -323,7 +323,9 @@ TEST_P(Test_Int8_layers, DISABLED_Softmax_unfused_ONNX)  // FIXIT Support 'Ident
 TEST_P(Test_Int8_layers, Concat)
 {
     testLayer("layer_concat_shared_input", "Caffe", 0.0076, 0.029, 1, 1, true, false);
-    testLayer("concat_axis_1", "TensorFlow", 0.0056, 0.017);
+    if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) {
+        testLayer("concat_axis_1", "TensorFlow", 0.0056, 0.017);
+    }
     testLayer("keras_pad_concat", "TensorFlow", 0.0032, 0.0089);
     testLayer("concat_3d", "TensorFlow", 0.005, 0.014);
     testLayer("concatenation", "ONNX", 0.0032, 0.009);
@@ -401,10 +403,13 @@ TEST_P(Test_Int8_layers, Reshape)
         testLayer("reshape_nchw", "TensorFlow", 0.0089, 0.029);
 
     testLayer("reshape_conv", "TensorFlow", 0.035, 0.054);
-    testLayer("reshape_reduce", "TensorFlow", 0.0042, 0.0078);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        testLayer("reshape_reduce", "TensorFlow", 0.0053, 0.011);
+    else
+        testLayer("reshape_reduce", "TensorFlow", 0.0042, 0.0078);
     testLayer("reshape_as_shape", "TensorFlow", 0.0014, 0.0028);
     testLayer("reshape_no_reorder", "TensorFlow", 0.0014, 0.0028);
-    testLayer("shift_reshape_no_reorder", "TensorFlow", 0.0063, 0.014);
+    testLayer("shift_reshape_no_reorder", "TensorFlow", 0.0063, backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ? 0.016 : 0.014);
     testLayer("dynamic_reshape", "ONNX", 0.0047, 0.0079);
     testLayer("dynamic_reshape_opset_11", "ONNX", 0.0048, 0.0081);
     testLayer("flatten_by_prod", "ONNX", 0.0048, 0.0081);
@@ -492,10 +497,10 @@ TEST_P(Test_Int8_layers, Eltwise)
 
     testLayer("conv_2_inps", "Caffe", 0.0086, 0.0232, 2, 1, true, false);
     testLayer("eltwise_sub", "TensorFlow", 0.015, 0.047);
-    testLayer("eltwise_add_vec", "TensorFlow", 0.037, 0.21); // tflite 0.0095, 0.0365
+    testLayer("eltwise_add_vec", "TensorFlow", 0.037, backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ? 0.24 : 0.21); // tflite 0.0095, 0.0365
     testLayer("eltwise_mul_vec", "TensorFlow", 0.173, 1.14); // tflite 0.0028, 0.017
     testLayer("channel_broadcast", "TensorFlow", 0.0025, 0.0063);
-    testLayer("split_equals", "TensorFlow", 0.02, 0.065);
+    testLayer("split_equals", "TensorFlow", backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ? 0.021 : 0.02, 0.065);
     testLayer("mul", "ONNX", 0.0039, 0.014);
     testLayer("split_max", "ONNX", 0.004, 0.012);
 }

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -554,10 +554,10 @@ public:
         Mat blob = readTensorFromONNX(findDataFile("dnn/onnx/data/input_" + basename + ".pb"));
         Mat ref = readTensorFromONNX(findDataFile("dnn/onnx/data/output_" + basename + ".pb"));
         Net baseNet = readNetFromONNX(onnxmodel);
-        baseNet.setPreferableBackend(backend);
-        baseNet.setPreferableTarget(target);
 
         Net qnet = baseNet.quantize(blob, CV_32F, CV_32F, perChannel);
+        qnet.setPreferableBackend(backend);
+        qnet.setPreferableTarget(target);
         qnet.setInput(blob);
         Mat out = qnet.forward();
 

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -707,9 +707,6 @@ TEST_P(Test_Int8_nets, AlexNet)
 #else
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
 #endif
-    if (backend != DNN_BACKEND_OPENCV)
-        throw SkipTestException("Only OpenCV backend is supported");
-
     if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
@@ -750,8 +747,6 @@ TEST_P(Test_Int8_nets, GoogLeNet)
 TEST_P(Test_Int8_nets, ResNet50)
 {
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
-    if (backend != DNN_BACKEND_OPENCV)
-        throw SkipTestException("Only OpenCV backend is supported");
 
     if (target == DNN_TARGET_OPENCL_FP16 && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -782,6 +777,8 @@ TEST_P(Test_Int8_nets, DenseNet121)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 
     Net net = readNetFromCaffe(findDataFile("dnn/DenseNet_121.prototxt", false),
                                findDataFile("dnn/DenseNet_121.caffemodel", false));
@@ -963,6 +960,8 @@ TEST_P(Test_Int8_nets, opencv_face_detector)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 
     Net net = readNetFromCaffe(findDataFile("dnn/opencv_face_detector.prototxt"),
                                findDataFile("dnn/opencv_face_detector.caffemodel", false));
@@ -1029,7 +1028,8 @@ TEST_P(Test_Int8_nets, FasterRCNN_resnet50)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
-
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 
@@ -1056,7 +1056,8 @@ TEST_P(Test_Int8_nets, FasterRCNN_inceptionv2)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
-
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 
@@ -1087,6 +1088,8 @@ TEST_P(Test_Int8_nets, FasterRCNN_vgg16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 
     Net net = readNetFromCaffe(findDataFile("dnn/faster_rcnn_vgg16.prototxt"),
                                findDataFile("dnn/VGG16_faster_rcnn_final.caffemodel", false));
@@ -1114,6 +1117,8 @@ TEST_P(Test_Int8_nets, FasterRCNN_zf)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 
     Net net = readNetFromCaffe(findDataFile("dnn/faster_rcnn_zf.prototxt"),
                                findDataFile("dnn/ZF_faster_rcnn_final.caffemodel", false));
@@ -1146,6 +1151,9 @@ TEST_P(Test_Int8_nets, RFCN)
                                     0, 12, 0.94786, 132.093, 223.903, 338.077, 566.16);
 
     float confThreshold = 0.8, scoreDiff = 0.15, iouDiff = 0.11;
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) {
+        iouDiff = 0.12;
+    }
     testFaster(net, ref, confThreshold, scoreDiff, iouDiff);
 }
 
@@ -1325,6 +1333,8 @@ TEST_P(Test_Int8_nets, YOLOv4_tiny)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (target == DNN_TARGET_OPENCL && !ocl::Device::getDefault().isIntel())
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 
     const float confThreshold = 0.6;
 

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -200,6 +200,7 @@ TEST_P(Test_Int8_layers, Padding)
 
 TEST_P(Test_Int8_layers, AvePooling)
 {
+    // Some tests failed with OpenVINO due to wrong padded area calculation
     if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         testLayer("layer_pooling_ave", "Caffe", 0.0021, 0.0075);
     testLayer("ave_pool_same", "TensorFlow", 0.00153, 0.0041);
@@ -326,6 +327,7 @@ TEST_P(Test_Int8_layers, Concat)
 {
     testLayer("layer_concat_shared_input", "Caffe", 0.0076, 0.029, 1, 1, true, false);
     if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) {
+        // Crashes with segfault
         testLayer("concat_axis_1", "TensorFlow", 0.0056, 0.017);
     }
     testLayer("keras_pad_concat", "TensorFlow", 0.0032, 0.0089);

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -97,7 +97,7 @@ public:
         for (int i = 0; i < numOuts; i++)
         {
             outs_int8[i].convertTo(outs_dequantized[i], CV_32F, outputScale[i], -(outputScale[i] * outputZp[i]));
-            normAssert(refs[i], outs_dequantized[i], "", l1, lInf);
+            normAssert(refs[i], outs_dequantized[i], basename.c_str(), l1, lInf);
         }
     }
 };
@@ -219,8 +219,6 @@ TEST_P(Test_Int8_layers, MaxPooling)
         throw SkipTestException("Only CPU is supported");
     testLayer("pool_conv_3d", "ONNX", 0.0033, 0.0124);
 
-    /* All the below tests have MaxPooling as last layer, so computeMaxIdx is set to true
-       which is not supported by int8 maxpooling
     testLayer("layer_pooling_max", "Caffe", 0.0021, 0.004);
     testLayer("max_pool_even", "TensorFlow", 0.0048, 0.0139);
     testLayer("max_pool_odd_valid", "TensorFlow", 0.0043, 0.012);
@@ -230,7 +228,7 @@ TEST_P(Test_Int8_layers, MaxPooling)
     testLayer("two_maxpooling_1d", "ONNX", 0.0037, 0.0052);
     testLayer("maxpooling", "ONNX", 0.0034, 0.0065);
     testLayer("two_maxpooling", "ONNX", 0.0025, 0.0052);
-    testLayer("max_pool3d", "ONNX", 0.0028, 0.0069);*/
+    testLayer("max_pool3d", "ONNX", 0.0028, 0.0069);
 }
 
 TEST_P(Test_Int8_layers, Reduce)

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -200,10 +200,12 @@ TEST_P(Test_Int8_layers, Padding)
 
 TEST_P(Test_Int8_layers, AvePooling)
 {
-    testLayer("layer_pooling_ave", "Caffe", 0.0021, 0.0075);
+    if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        testLayer("layer_pooling_ave", "Caffe", 0.0021, 0.0075);
     testLayer("ave_pool_same", "TensorFlow", 0.00153, 0.0041);
     testLayer("average_pooling_1d", "ONNX", 0.002, 0.0048);
-    testLayer("average_pooling", "ONNX", 0.0014, 0.0032);
+    if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        testLayer("average_pooling", "ONNX", 0.0014, 0.0032);
     testLayer("average_pooling_dynamic_axes", "ONNX", 0.0014, 0.006);
 
     if (target != DNN_TARGET_CPU)

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -15,6 +15,9 @@ testing::internal::ParamGenerator< tuple<Backend, Target> > dnnBackendsAndTarget
 #ifdef HAVE_TIMVX
     targets.push_back(make_tuple(DNN_BACKEND_TIMVX, DNN_TARGET_NPU));
 #endif
+#ifdef HAVE_INF_ENGINE
+    targets.push_back(make_tuple(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH, DNN_TARGET_CPU));
+#endif
     return testing::ValuesIn(targets);
 }
 
@@ -66,8 +69,6 @@ public:
             outPath = _tf("onnx/data/output_" + basename);
         }
         ASSERT_FALSE(net.empty());
-        net.setPreferableBackend(backend);
-        net.setPreferableTarget(target);
 
         for (int i = 0; i < numInps; i++)
             inps[i] = blobFromNPY(inpPath + ((numInps > 1) ? cv::format("_%d.npy", i) : ".npy"));
@@ -78,6 +79,8 @@ public:
         qnet = net.quantize(inps, CV_8S, CV_8S, perChannel);
         qnet.getInputDetails(inputScale, inputZp);
         qnet.getOutputDetails(outputScale, outputZp);
+        qnet.setPreferableBackend(backend);
+        qnet.setPreferableTarget(target);
 
         // Quantize inputs to int8
         // int8_value = float_value/scale + zero-point

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2048,12 +2048,16 @@ TEST_P(Test_ONNX_layers, Quantized_Unsqueeze)
 TEST_P(Test_ONNX_layers, Quantized_Resize)
 {
     testONNXModels("quantized_resize_nearest");
-    testONNXModels("quantized_resize_bilinear", npy, 2e-4, 0.003);
-    testONNXModels("quantized_resize_bilinear_align", npy, 3e-4, 0.003);
+    double l1 = backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ? 0.0013 : 2e-4;
+    testONNXModels("quantized_resize_bilinear", npy, l1, 0.003);
+    l1 = backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ? 0.0013 : 3e-4;
+    testONNXModels("quantized_resize_bilinear_align", npy, l1, 0.003);
 }
 
 TEST_P(Test_ONNX_layers, Quantized_Concat)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("quantized_concat");
     testONNXModels("quantized_concat_const_blob");
 }
@@ -2070,6 +2074,8 @@ TEST_P(Test_ONNX_layers, OutputRegistration)
 
 TEST_P(Test_ONNX_layers, QLinearSoftmax)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("qlinearsoftmax_v11", npy, 0.002, 0.002); // 2D coerced
     testONNXModels("qlinearsoftmax_v13", npy, 0.002, 0.002);
 }

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -222,10 +222,7 @@ TEST_P(Test_TFLite, EfficientDet_int8) {
         0, 17, 0.56640625, 0.15983937680721283, 0.35905322432518005, 0.5155506730079651, 0.9409466981887817,
         0, 1, 0.5, 0.14357104897499084, 0.2240825891494751, 0.7183101177215576, 0.9140362739562988
     });
-    double iouDiff = 0.1;
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-        iouDiff = 0.17;
-    normAssertDetections(ref, out, "", 0.5, 0.05, iouDiff);
+    normAssertDetections(ref, out, "", 0.5, 0.05, 0.1);
 }
 
 TEST_P(Test_TFLite, replicate_by_pack) {

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -206,7 +206,7 @@ TEST_P(Test_TFLite, max_unpooling)
 TEST_P(Test_TFLite, EfficientDet_int8) {
     if (target != DNN_TARGET_CPU || (backend != DNN_BACKEND_OPENCV &&
         backend != DNN_BACKEND_TIMVX && backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)) {
-        throw SkipTestException("");
+        throw SkipTestException("Only OpenCV, TimVX and OpenVINO targets support INT8 on CPU");
     }
     Net net = readNet(findDataFile("dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", false));
     net.setPreferableBackend(backend);

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -204,6 +204,10 @@ TEST_P(Test_TFLite, max_unpooling)
 }
 
 TEST_P(Test_TFLite, EfficientDet_int8) {
+    if (target != DNN_TARGET_CPU || (backend != DNN_BACKEND_OPENCV &&
+        backend != DNN_BACKEND_TIMVX && backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)) {
+        throw SkipTestException("");
+    }
     Net net = readNet(findDataFile("dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", false));
     net.setPreferableBackend(backend);
     net.setPreferableTarget(target);
@@ -218,7 +222,10 @@ TEST_P(Test_TFLite, EfficientDet_int8) {
         0, 17, 0.56640625, 0.15983937680721283, 0.35905322432518005, 0.5155506730079651, 0.9409466981887817,
         0, 1, 0.5, 0.14357104897499084, 0.2240825891494751, 0.7183101177215576, 0.9140362739562988
     });
-    normAssertDetections(ref, out, "", 0.5, 0.05, 0.1);
+    double iouDiff = 0.1;
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        iouDiff = 0.17;
+    normAssertDetections(ref, out, "", 0.5, 0.05, iouDiff);
 }
 
 TEST_P(Test_TFLite, replicate_by_pack) {


### PR DESCRIPTION
### Pull Request Readiness Checklist

TODO:
- [x] DetectionOutput layer (https://github.com/opencv/opencv/pull/24069)
- [x] Less FP32 fallbacks (i.e. Sigmoid, eltwise sum)
- [x] Accuracy, performance tests (https://github.com/opencv/opencv/pull/24039)
- [x] Single layer tests (convolution)
- [x] ~~Fixes for OpenVINO 2022.1 (https://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100334)~~


Performace results for object detection model `coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite`:
| backend | performance (median time) |
|---|---|
| OpenCV | 77.42ms |
| OpenVINO 2023.0 | 10.90ms |

CPU: `11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz`

Serialized model per-layer stats (note that Convolution should use `*_I8` primitives if they are quantized correctly): https://gist.github.com/dkurt/7772bbf1907035441bb5454f19f0feef

---

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom

Xbuild_image:Custom=ubuntu-openvino-2021.4.2:20.04
build_image:Custom=ubuntu-openvino-2022.1.0:20.04

test_modules:Custom=dnn,python2,python3,java,gapi,video

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
```