### PR TITLE
Emscripten fix when no aruco - 4.8.0

### DIFF
--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -89,9 +89,11 @@ using namespace cv;
 
 using namespace cv::segmentation;  // FIXIT
 
+#ifdef HAVE_OPENCV_ARUCO
 using namespace cv::aruco;
 typedef aruco::DetectorParameters aruco_DetectorParameters;
 typedef QRCodeDetectorAruco::Params QRCodeDetectorAruco_Params;
+#endif
 
 #ifdef HAVE_OPENCV_DNN
 using namespace cv::dnn;


### PR DESCRIPTION

Issue: Emscripten builds without extra modules since June 15 changes. 

Version 4.8.0+ issue 
```
/Users/~/SOURCE/apothecary/apothecary/build/opencv/build_emscripten/build/modules/js_bindings_generator/gen/bindings.cpp:111:21:
 error: expected namespace name
  111 | using namespace cv::aruco;
      |                 ~~~~^
/Users/~/SOURCE/apothecary/apothecary/build/opencv/build_emscripten/build/modules/js_bindings_generator/gen/bindings.cpp:112:9: 
error: use of undeclared identifier 'aruco'
  112 | typedef aruco::DetectorParameters aruco_DetectorParameters;
      |         ^
/Users/~/SOURCE/apothecary/apothecary/build/opencv/build_emscripten/build/modules/js_bindings_generator/gen/bindings.cpp:113:9: 
error: use of undeclared identifier 'QRCodeDetectorAruco'
  113 | typedef QRCodeDetectorAruco::Params QRCodeDetectorAruco_Params;
      |         ^
```

Caused by: https://github.com/opencv/opencv/commit/61488885b54da3cd2a7fafc99c80ff491689e865


Proposed fix: Return of the define. This will mean QR params will also need that define 
@asmorkalov



- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
