### PR TITLE
fixed float compare to 0 for fast-math

### DIFF
--- a/modules/core/src/has_non_zero.simd.hpp
+++ b/modules/core/src/has_non_zero.simd.hpp
@@ -53,7 +53,7 @@ inline bool hasNonZero_(const float* src, size_t len )
             #endif
         }
         for( ; !res && (i < len); i++ )
-            res |= (src[i] != 0);
+            res |= (src[i] != 0) || std::isnan(src[i]);//isnan() is needed under fast-math
     }
     return res;
 }
@@ -78,7 +78,7 @@ inline bool hasNonZero_(const double* src, size_t len )
             #endif
         }
         for( ; !res && (i < len); i++ )
-            res |= (src[i] != 0);
+            res |= (src[i] != 0) || std::isnan(src[i]);//isnan() is needed under fast-math
     }
     return res;
 }

--- a/modules/core/src/has_non_zero.simd.hpp
+++ b/modules/core/src/has_non_zero.simd.hpp
@@ -53,7 +53,7 @@ inline bool hasNonZero_(const float* src, size_t len )
             #endif
         }
         for( ; !res && (i < len); i++ )
-            res |= (src[i] != 0) || std::isnan(src[i]);//isnan() is needed under fast-math
+            res |= (src[i] != 0) || cvIsNaN(src[i]);//isnan() is needed under fast-math
     }
     return res;
 }
@@ -78,7 +78,7 @@ inline bool hasNonZero_(const double* src, size_t len )
             #endif
         }
         for( ; !res && (i < len); i++ )
-            res |= (src[i] != 0) || std::isnan(src[i]);//isnan() is needed under fast-math
+            res |= (src[i] != 0) || cvIsNaN(src[i]);//isnan() is needed under fast-math
     }
     return res;
 }

--- a/modules/core/test/test_hasnonzero.cpp
+++ b/modules/core/test/test_hasnonzero.cpp
@@ -81,6 +81,26 @@ INSTANTIATE_TEST_CASE_P(Core, HasNonZeroNegZeros,
     )
 );
 
+typedef testing::TestWithParam<std::tuple<int, Size> > HasNonZeroNaNValues;
+
+TEST_P(HasNonZeroNaNValues, hasNonZeroNaNValues)
+{
+    const int type = std::get<0>(GetParam());
+    const Size size = std::get<1>(GetParam());
+
+    Mat m = Mat(size, type);
+
+    m.setTo(Scalar::all(std::numeric_limits<double>::quiet_NaN()));
+    EXPECT_TRUE(hasNonZero(m));
+}
+
+INSTANTIATE_TEST_CASE_P(Core, HasNonZeroNaNValues,
+    testing::Combine(
+        testing::Values(CV_32FC1, CV_64FC1),
+        testing::Values(Size(1, 1), Size(320, 240), Size(127, 113), Size(1, 113))
+    )
+);
+
 typedef testing::TestWithParam<std::tuple<int, Size> > HasNonZeroLimitValues;
 
 TEST_P(HasNonZeroLimitValues, hasNonZeroLimitValues)
@@ -94,9 +114,6 @@ TEST_P(HasNonZeroLimitValues, hasNonZeroLimitValues)
     EXPECT_TRUE(hasNonZero(m));
 
     m.setTo(Scalar::all(-std::numeric_limits<double>::infinity()));
-    EXPECT_TRUE(hasNonZero(m));
-
-    m.setTo(Scalar::all(std::numeric_limits<double>::quiet_NaN()));
     EXPECT_TRUE(hasNonZero(m));
 
     m.setTo((CV_MAT_DEPTH(type) == CV_64F) ? Scalar::all(std::numeric_limits<double>::epsilon()) : Scalar::all(std::numeric_limits<float>::epsilon()));


### PR DESCRIPTION
Bug #24019

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
