### PR TITLE
Increase eps for Test_Torch_nets.FastNeuralStyle_accuracy to prevent sporadic test failres with CUDA.

### DIFF
--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -566,14 +566,14 @@ TEST_P(Test_Torch_nets, FastNeuralStyle_accuracy)
         }
         else if(target == DNN_TARGET_CUDA_FP16)
         {
-            normAssert(out, refBlob, "", 0.6, 25);
+            normAssert(out, refBlob, "", 0.6, 26);
         }
         else if (target == DNN_TARGET_CPU_FP16)
         {
             normAssert(out, refBlob, "", 0.62, 25);
         }
         else
-            normAssert(out, refBlob, "", 0.5, 1.1);
+            normAssert(out, refBlob, "", 0.5, 1.11);
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/23947

Issue 1:
```
 [ RUN      ] Test_Torch_nets.FastNeuralStyle_accuracy/0, where GetParam() = CUDA/CUDA
/home/ci/opencv/modules/dnn/test/test_common.impl.hpp:79: Failure
Expected: (normInf) <= (lInf), actual: 1.10242 vs 1.1
  |ref| = 255
[  FAILED  ] Test_Torch_nets.FastNeuralStyle_accuracy/0, where GetParam() = CUDA/CUDA (188 ms)
```

Issue 2:
```
[ RUN      ] Test_Torch_nets.FastNeuralStyle_accuracy/1, where GetParam() = CUDA/CUDA_FP16
/home/ci/opencv/modules/dnn/test/test_common.impl.hpp:79: Failure
Expected: (normInf) <= (lInf), actual: 25.654 vs 25
  |ref| = 255
[  FAILED  ] Test_Torch_nets.FastNeuralStyle_accuracy/1, where GetParam() = CUDA/CUDA_FP16 (1900 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
