### PR TITLE
Fix harmless ASAN error.

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -932,13 +932,14 @@ void ellipse2Poly( Point center, Size axes, int angle,
         Point pt;
         pt.x = cvRound(_pts[i].x);
         pt.y = cvRound(_pts[i].y);
-        if (pt != prevPt) {
+        if (i == 0 || pt != prevPt) {
             pts.push_back(pt);
             prevPt = pt;
         }
     }
 
     // If there are no points, it's a zero-size polygon
+    CV_Assert( !pts.empty() );
     if (pts.size() == 1) {
         pts.assign(2, center);
     }
@@ -1001,6 +1002,7 @@ void ellipse2Poly( Point2d center, Size2d axes, int angle,
     }
 
     // If there are no points, it's a zero-size polygon
+    CV_Assert( !pts.empty() );
     if( pts.size() == 1) {
         pts.assign(2,center);
     }
@@ -1021,7 +1023,6 @@ EllipseEx( Mat& img, Point2l center, Size2l axes,
 
     std::vector<Point2l> v;
     Point2l prevPt(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
-    v.resize(0);
     for (unsigned int i = 0; i < _v.size(); ++i)
     {
         Point2l pt;
@@ -1029,14 +1030,14 @@ EllipseEx( Mat& img, Point2l center, Size2l axes,
         pt.y = (int64)cvRound(_v[i].y / XY_ONE) << XY_SHIFT;
         pt.x += cvRound(_v[i].x - pt.x);
         pt.y += cvRound(_v[i].y - pt.y);
-        if (pt != prevPt) {
+        if (i == 0 || pt != prevPt) {
             v.push_back(pt);
             prevPt = pt;
         }
     }
 
     // If there are no points, it's a zero-size polygon
-    if (v.size() == 1) {
+    if (v.size() <= 1) {
         v.assign(2, center);
     }
 

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -932,7 +932,7 @@ void ellipse2Poly( Point center, Size axes, int angle,
         Point pt;
         pt.x = cvRound(_pts[i].x);
         pt.y = cvRound(_pts[i].y);
-        if (i == 0 || pt != prevPt) {
+        if (pt != prevPt) {
             pts.push_back(pt);
             prevPt = pt;
         }
@@ -1030,7 +1030,7 @@ EllipseEx( Mat& img, Point2l center, Size2l axes,
         pt.y = (int64)cvRound(_v[i].y / XY_ONE) << XY_SHIFT;
         pt.x += cvRound(_v[i].x - pt.x);
         pt.y += cvRound(_v[i].y - pt.y);
-        if (i == 0 || pt != prevPt) {
+        if (pt != prevPt) {
             v.push_back(pt);
             prevPt = pt;
         }

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -921,4 +921,11 @@ TEST(Drawing, circle_overflow)
     cv::circle(matrix, cv::Point(275, -2147483318), 2147483647, kBlue, 1, 8, 0);
 }
 
+TEST(Drawing, circle_memory_access)
+{
+    cv::Mat1b matrix = cv::Mat1b::zeros(10, 10);
+    cv::Scalar kBlue = cv::Scalar(0, 0, 255);
+    cv::circle(matrix, cv::Point(-1, -1), 0, kBlue, 2, 8, 16);
+}
+
 }} // namespace


### PR DESCRIPTION
For an empty radius, &v[0] would be accessed (though the called functions would not use it due to v.size() being 0). Also add checks for emptyness and fix the first element checks, in case we get INT_MAX to compare to.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
