### PR TITLE
fix compilation error on Windows ARM, use vaddq_f32 instead of +=

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/conv_block.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv_block.simd.hpp
@@ -452,13 +452,13 @@ void convBlockMR1_F32(int np, const float * a, const float * b, float *c, const 
 
     if (init_c)
     {
-        c0 += vld1q_f32(c);
-        c1 += vld1q_f32(c + 4);
-        c2 += vld1q_f32(c + 8);
-        c3 += vld1q_f32(c + 12);
-        c4 += vld1q_f32(c + 16);
-        c5 += vld1q_f32(c + 20);
-        c6 += vld1q_f32(c + 24);
+        c0 = vaddq_f32(c0, vld1q_f32(c));
+        c1 = vaddq_f32(c1, vld1q_f32(c + 4));
+        c2 = vaddq_f32(c2, vld1q_f32(c + 8));
+        c3 = vaddq_f32(c3, vld1q_f32(c + 12));
+        c4 = vaddq_f32(c4, vld1q_f32(c + 16));
+        c5 = vaddq_f32(c5, vld1q_f32(c + 20));
+        c6 = vaddq_f32(c6, vld1q_f32(c + 24));
     }
 
     if (ifMinMaxAct)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
