### PR TITLE
[Build] popcnt is not supported on windows ARM

### DIFF
--- a/3rdparty/openjpeg/openjp2/ht_dec.c
+++ b/3rdparty/openjpeg/openjp2/ht_dec.c
@@ -69,7 +69,7 @@ static OPJ_BOOL only_cleanup_pass_is_decoded = OPJ_FALSE;
 static INLINE
 OPJ_UINT32 population_count(OPJ_UINT32 val)
 {
-#ifdef OPJ_COMPILER_MSVC
+#if defined(OPJ_COMPILER_MSVC) && (defined(_M_IX86) || defined(_M_AMD64))
     return (OPJ_UINT32)__popcnt(val);
 #elif (defined OPJ_COMPILER_GNUC)
     return (OPJ_UINT32)__builtin_popcount(val);


### PR DESCRIPTION
### Pull Request Readiness Checklist
This PR fixes the issue: #24006 
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
