### PR TITLE
feat: add highgui functions to typing stubs

### DIFF
--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -7,5 +7,6 @@ from .constant_node import ConstantNode
 from .type_node import (
     TypeNode, OptionalTypeNode, UnionTypeNode, NoneTypeNode, TupleTypeNode,
     ASTNodeTypeNode, AliasTypeNode, SequenceTypeNode, AnyTypeNode,
-    AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode
+    AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode,
+    CallableTypeNode,
 )


### PR DESCRIPTION
Manually add typing stubs for functions defined in `cv2_highgui.hpp`:
- `createTrackbar`

    ```python
     def createTrackbar(trackbarName: str,
                   windowName: str,
                   value: int,
                   count: int,
                   onChange: Callable[[int], None]) -> None: ...
    ```

- `createButton`

    ```python
    def createButton(buttonName: str,
                     onChange: Callable[[tuple[int] | tuple[int, Any]], None],
                     userData: Any | None = ...,
                     buttonType: int = ...,
                     initialButtonState: int = ...) -> None: ...
    ```

- `setMouseCallback`

    ```python
    def setMouseCallback(
        windowName: str,
        onMouse: Callback[[int, int, int, int, Any | None], None],
        param: Any | None = ...
    ) -> None: ...
    ```

closes opencv/opencv-python#875

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
