### PR TITLE
feat: add typing stub for redirectError

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -25,6 +25,29 @@ def apply_manual_api_refinement(root: NamespaceNode) -> None:
     version_constant = root.add_constant("__version__", "<unused>")
     version_constant._value_type = "str"
 
+    """
+    def redirectError(
+        onError: Callable[[int, str, str, str, int], None] | None
+    ) -> None: ...
+    """
+    root.add_function("redirectError", [
+        FunctionNode.Arg(
+            "onError",
+            OptionalTypeNode(
+                CallableTypeNode(
+                    "ErrorCallback",
+                    [
+                        PrimitiveTypeNode.int_(),
+                        PrimitiveTypeNode.str_(),
+                        PrimitiveTypeNode.str_(),
+                        PrimitiveTypeNode.str_(),
+                        PrimitiveTypeNode.int_()
+                    ]
+                )
+            )
+        )
+    ])
+
 
 def export_matrix_type_constants(root: NamespaceNode) -> None:
     MAX_PREDEFINED_CHANNELS = 4


### PR DESCRIPTION
`redirectError` is defined in `cv2_util.cpp` and manually exported in `cv2.cpp`

Python interface for `redirectError`:

```python
def redirectError(
    onError: Callable[[int, str, str, str, int], None] | None
) -> None: ...
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
