### PR TITLE
Python typing refinement for dnn_registerLayer/dnn_unregisterLayer functions

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -7,15 +7,18 @@ from typing import cast, Sequence, Callable, Iterable
 from .nodes import (NamespaceNode, FunctionNode, OptionalTypeNode, TypeNode,
                     ClassProperty, PrimitiveTypeNode, ASTNodeTypeNode,
                     AggregatedTypeNode, CallableTypeNode, AnyTypeNode,
-                    TupleTypeNode, UnionTypeNode)
+                    TupleTypeNode, UnionTypeNode, ProtocolClassNode,
+                    DictTypeNode, ClassTypeNode)
 from .ast_utils import (find_function_node, SymbolName,
                         for_each_function_overload)
+from .types_conversion import create_type_node
 
 
 def apply_manual_api_refinement(root: NamespaceNode) -> None:
     refine_highgui_module(root)
     refine_cuda_module(root)
     export_matrix_type_constants(root)
+    refine_dnn_module(root)
     # Export OpenCV exception class
     builtin_exception = root.add_class("Exception")
     builtin_exception.is_exported = False
@@ -188,6 +191,86 @@ def refine_highgui_module(root: NamespaceNode) -> None:
             ),
             FunctionNode.Arg("param", OptionalTypeNode(AnyTypeNode("void*")),
                              default_value="None")
+        ]
+    )
+
+
+def refine_dnn_module(root: NamespaceNode) -> None:
+    if "dnn" not in root.namespaces:
+        return
+    dnn_module = root.namespaces["dnn"]
+
+    """
+    class LayerProtocol(Protocol):
+        def __init__(
+            self, params: dict[str, DictValue],
+            blobs: typing.Sequence[cv2.typing.MatLike]
+        ) -> None: ...
+
+        def getMemoryShapes(
+            self, inputs: typing.Sequence[typing.Sequence[int]]
+        ) -> typing.Sequence[typing.Sequence[int]]: ...
+
+        def forward(
+            self, inputs: typing.Sequence[cv2.typing.MatLike]
+        ) -> typing.Sequence[cv2.typing.MatLike]: ...
+    """
+    layer_proto = ProtocolClassNode("LayerProtocol", dnn_module)
+    layer_proto.add_function(
+        "__init__",
+        arguments=[
+            FunctionNode.Arg(
+                "params",
+                DictTypeNode(
+                    "LayerParams", PrimitiveTypeNode.str_(),
+                    create_type_node("cv::dnn::DictValue")
+                )
+            ),
+            FunctionNode.Arg("blobs", create_type_node("vector<cv::Mat>"))
+        ]
+    )
+    layer_proto.add_function(
+        "getMemoryShapes",
+        arguments=[
+            FunctionNode.Arg("inputs",
+                             create_type_node("vector<vector<int>>"))
+        ],
+        return_type=FunctionNode.RetType(
+            create_type_node("vector<vector<int>>")
+        )
+    )
+    layer_proto.add_function(
+        "forward",
+        arguments=[
+            FunctionNode.Arg("inputs", create_type_node("vector<cv::Mat>"))
+        ],
+        return_type=FunctionNode.RetType(create_type_node("vector<cv::Mat>"))
+    )
+
+    """
+    def dnn_registerLayer(layerTypeName: str,
+                          layerClass: typing.Type[LayerProtocol]) -> None: ...
+    """
+    root.add_function(
+        "dnn_registerLayer",
+        arguments=[
+            FunctionNode.Arg("layerTypeName", PrimitiveTypeNode.str_()),
+            FunctionNode.Arg(
+                "layerClass",
+                ClassTypeNode(ASTNodeTypeNode(
+                    layer_proto.export_name, f"dnn.{layer_proto.export_name}"
+                ))
+            )
+        ]
+    )
+
+    """
+    def dnn_unregisterLayer(layerTypeName: str) -> None: ...
+    """
+    root.add_function(
+        "dnn_unregisterLayer",
+        arguments=[
+            FunctionNode.Arg("layerTypeName", PrimitiveTypeNode.str_())
         ]
     )
 

--- a/modules/python/src2/typing_stubs_generation/ast_utils.py
+++ b/modules/python/src2/typing_stubs_generation/ast_utils.py
@@ -1,5 +1,5 @@
 from typing import (NamedTuple, Sequence, Tuple, Union, List,
-                    Dict, Callable, Optional, Generator)
+                    Dict, Callable, Optional, Generator, cast)
 import keyword
 
 from .nodes import (ASTNode, NamespaceNode, ClassNode, FunctionNode,
@@ -204,9 +204,7 @@ def create_function_node_in_scope(scope: Union[NamespaceNode, ClassNode],
                 outlist = variant.py_outlist
             for _, argno in outlist:
                 assert argno >= 0, \
-                    "Logic Error! Outlist contains function return type: {}".format(
-                        outlist
-                    )
+                    f"Logic Error! Outlist contains function return type: {outlist}"
 
                 ret_types.append(create_type_node(variant.args[argno].tp))
 
@@ -379,7 +377,7 @@ def get_enclosing_namespace(
                 node.full_export_name, node.native_name
             )
         if class_node_callback:
-            class_node_callback(parent_node)
+            class_node_callback(cast(ClassNode, parent_node))
         parent_node = parent_node.parent
     return parent_node
 
@@ -395,12 +393,14 @@ def get_enum_module_and_export_name(enum_node: EnumerationNode) -> Tuple[str, st
     Returns:
         Tuple[str, str]: a pair of enum export name and its full module name.
     """
+    enum_export_name = enum_node.export_name
+
     def update_full_export_name(class_node: ClassNode) -> None:
         nonlocal enum_export_name
         enum_export_name = class_node.export_name + "_" + enum_export_name
 
-    enum_export_name = enum_node.export_name
-    namespace_node = get_enclosing_namespace(enum_node, update_full_export_name)
+    namespace_node = get_enclosing_namespace(enum_node,
+                                             update_full_export_name)
     return enum_export_name, namespace_node.full_export_name
 
 

--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -1,6 +1,6 @@
 from .node import ASTNode, ASTNodeType
 from .namespace_node import NamespaceNode
-from .class_node import ClassNode, ClassProperty
+from .class_node import ClassNode, ClassProperty, ProtocolClassNode
 from .function_node import FunctionNode
 from .enumeration_node import EnumerationNode
 from .constant_node import ConstantNode
@@ -8,5 +8,5 @@ from .type_node import (
     TypeNode, OptionalTypeNode, UnionTypeNode, NoneTypeNode, TupleTypeNode,
     ASTNodeTypeNode, AliasTypeNode, SequenceTypeNode, AnyTypeNode,
     AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode,
-    CallableTypeNode,
+    CallableTypeNode, DictTypeNode
 )

--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -8,5 +8,5 @@ from .type_node import (
     TypeNode, OptionalTypeNode, UnionTypeNode, NoneTypeNode, TupleTypeNode,
     ASTNodeTypeNode, AliasTypeNode, SequenceTypeNode, AnyTypeNode,
     AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode,
-    CallableTypeNode, DictTypeNode
+    CallableTypeNode, DictTypeNode, ClassTypeNode
 )

--- a/modules/python/src2/typing_stubs_generation/nodes/class_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/class_node.py
@@ -63,8 +63,9 @@ class ClassNode(ASTNode):
         return 1 + sum(base.weight for base in self.bases)
 
     @property
-    def children_types(self) -> Tuple[Type[ASTNode], ...]:
-        return (ClassNode, FunctionNode, EnumerationNode, ConstantNode)
+    def children_types(self) -> Tuple[ASTNodeType, ...]:
+        return (ASTNodeType.Class, ASTNodeType.Function,
+                ASTNodeType.Enumeration, ASTNodeType.Constant)
 
     @property
     def node_type(self) -> ASTNodeType:
@@ -72,19 +73,19 @@ class ClassNode(ASTNode):
 
     @property
     def classes(self) -> Dict[str, "ClassNode"]:
-        return self._children[ClassNode]
+        return self._children[ASTNodeType.Class]
 
     @property
     def functions(self) -> Dict[str, FunctionNode]:
-        return self._children[FunctionNode]
+        return self._children[ASTNodeType.Function]
 
     @property
     def enumerations(self) -> Dict[str, EnumerationNode]:
-        return self._children[EnumerationNode]
+        return self._children[ASTNodeType.Enumeration]
 
     @property
     def constants(self) -> Dict[str, ConstantNode]:
-        return self._children[ConstantNode]
+        return self._children[ASTNodeType.Constant]
 
     def add_class(self, name: str,
                   bases: Sequence["weakref.ProxyType[ClassNode]"] = (),
@@ -179,3 +180,11 @@ class ClassNode(ASTNode):
                     self.full_export_name, root.full_export_name, errors
                 )
             )
+
+
+class ProtocolClassNode(ClassNode):
+    def __init__(self, name: str, parent: Optional[ASTNode] = None,
+                 export_name: Optional[str] = None,
+                 properties: Sequence[ClassProperty] = ()) -> None:
+        super().__init__(name, parent, export_name, bases=(),
+                         properties=properties)

--- a/modules/python/src2/typing_stubs_generation/nodes/constant_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/constant_node.py
@@ -1,4 +1,4 @@
-from typing import Type, Optional, Tuple
+from typing import Optional, Tuple
 
 from .node import ASTNode, ASTNodeType
 
@@ -14,7 +14,7 @@ class ConstantNode(ASTNode):
         self._value_type = "int"
 
     @property
-    def children_types(self) -> Tuple[Type[ASTNode], ...]:
+    def children_types(self) -> Tuple[ASTNodeType, ...]:
         return ()
 
     @property

--- a/modules/python/src2/typing_stubs_generation/nodes/enumeration_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/enumeration_node.py
@@ -18,8 +18,8 @@ class EnumerationNode(ASTNode):
         self.is_scoped = is_scoped
 
     @property
-    def children_types(self) -> Tuple[Type[ASTNode], ...]:
-        return (ConstantNode, )
+    def children_types(self) -> Tuple[ASTNodeType, ...]:
+        return (ASTNodeType.Constant, )
 
     @property
     def node_type(self) -> ASTNodeType:
@@ -27,7 +27,7 @@ class EnumerationNode(ASTNode):
 
     @property
     def constants(self) -> Dict[str, ConstantNode]:
-        return self._children[ConstantNode]
+        return self._children[ASTNodeType.Constant]
 
     def add_constant(self, name: str, value: str) -> ConstantNode:
         return self._add_child(ConstantNode, name, value=value)

--- a/modules/python/src2/typing_stubs_generation/nodes/function_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/function_node.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Sequence, Type, Optional, Tuple, List
+from typing import NamedTuple, Sequence, Optional, Tuple, List
 
 from .node import ASTNode, ASTNodeType
 from .type_node import TypeNode, NoneTypeNode, TypeResolutionError
@@ -98,7 +98,7 @@ class FunctionNode(ASTNode):
         return ASTNodeType.Function
 
     @property
-    def children_types(self) -> Tuple[Type[ASTNode], ...]:
+    def children_types(self) -> Tuple[ASTNodeType, ...]:
         return ()
 
     def add_overload(self, arguments: Sequence["FunctionNode.Arg"] = (),

--- a/modules/python/src2/typing_stubs_generation/nodes/namespace_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/namespace_node.py
@@ -1,7 +1,7 @@
 import itertools
 import weakref
 from collections import defaultdict
-from typing import Dict, List, Optional, Sequence, Tuple, Type
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from .class_node import ClassNode, ClassProperty
 from .constant_node import ConstantNode
@@ -33,29 +33,29 @@ class NamespaceNode(ASTNode):
         return ASTNodeType.Namespace
 
     @property
-    def children_types(self) -> Tuple[Type[ASTNode], ...]:
-        return (NamespaceNode, ClassNode, FunctionNode,
-                EnumerationNode, ConstantNode)
+    def children_types(self) -> Tuple[ASTNodeType, ...]:
+        return (ASTNodeType.Namespace, ASTNodeType.Class, ASTNodeType.Function,
+                ASTNodeType.Enumeration, ASTNodeType.Constant)
 
     @property
     def namespaces(self) -> Dict[str, "NamespaceNode"]:
-        return self._children[NamespaceNode]
+        return self._children[ASTNodeType.Namespace]
 
     @property
     def classes(self) -> Dict[str, ClassNode]:
-        return self._children[ClassNode]
+        return self._children[ASTNodeType.Class]
 
     @property
     def functions(self) -> Dict[str, FunctionNode]:
-        return self._children[FunctionNode]
+        return self._children[ASTNodeType.Function]
 
     @property
     def enumerations(self) -> Dict[str, EnumerationNode]:
-        return self._children[EnumerationNode]
+        return self._children[ASTNodeType.Enumeration]
 
     @property
     def constants(self) -> Dict[str, ConstantNode]:
-        return self._children[ConstantNode]
+        return self._children[ASTNodeType.Constant]
 
     def add_namespace(self, name: str) -> "NamespaceNode":
         return self._add_child(NamespaceNode, name)

--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -839,6 +839,21 @@ class CallableTypeNode(AggregatedTypeNode):
         yield from super().required_usage_imports
 
 
+class ClassTypeNode(ContainerTypeNode):
+    """Type node representing types themselves (refer to typing.Type)
+    """
+    def __init__(self, value: TypeNode) -> None:
+        super().__init__(value.ctype_name, (value,))
+
+    @property
+    def type_format(self) -> str:
+        return "typing.Type[{}]"
+
+    @property
+    def types_separator(self) -> str:
+        return ", "
+
+
 def _resolve_symbol(root: Optional[ASTNode], full_symbol_name: str) -> Optional[ASTNode]:
     """Searches for a symbol with the given full export name in the AST
     starting from the `root`.


### PR DESCRIPTION
This patch introduces typings generation for `dnn_registerLayer`/`dnn_unregisterLayer` manually defined in [`cv2/modules/dnn/misc/python/pyopencv_dnn.hpp`](https://github.com/opencv/opencv/blob/4.x/modules/dnn/misc/python/pyopencv_dnn.hpp)

Updates:

- Add `LayerProtocol` to `cv2/dnn/__init__.pyi`:

    ```python
    class LayerProtocol(Protocol):
        def __init__(
            self, params: dict[str, DictValue],
            blobs: typing.Sequence[cv2.typing.MatLike]
        ) -> None: ...

        def getMemoryShapes(
            self, inputs: typing.Sequence[typing.Sequence[int]]
        ) -> typing.Sequence[typing.Sequence[int]]: ...

        def forward(
            self, inputs: typing.Sequence[cv2.typing.MatLike]
        ) -> typing.Sequence[cv2.typing.MatLike]: ...
    ```

- Add `dnn_registerLayer` function to `cv2/__init__.pyi`:

    ```python
    def dnn_registerLayer(layerTypeName: str,
                          layerClass: typing.Type[LayerProtocol]) -> None: ...
    ```

- Add `dnn_unregisterLayer` function to `cv2/__init__.pyi`:

    ```python
    def dnn_unregisterLayer(layerTypeName: str) -> None: ...
    ```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
