### PR TITLE
`cuda`: suppress CMP0146 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)  # CMake 3.13+: option() honors normal variables.
 endif()
 
+if(POLICY CMP0146)
+  cmake_policy(SET CMP0146 OLD)  # CMake 3.27+: use CMake FindCUDA if available.
+endif()
+
 #
 # Configure OpenCV CMake hooks
 #


### PR DESCRIPTION
From CMake 3.27 onwards the official [FindCUDA](https://cmake.org/cmake/help/latest/module/FindCUDA.html) module has been depreciated, resulting in the following warning when configuring OpenCV

> CMake Warning (dev) at cmake/OpenCVUtils.cmake:144 (find_package):
>   Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
>   --help-policy CMP0146" for policy details.  Use the cmake_policy command to
>   set the policy and suppress this warning.

This PR forces OLD behaviour to suppress the warning and ensure the official CMake FindCUDA module is still used while available.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
