### PR TITLE
Fixed warnings in videoio module

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -260,6 +260,10 @@ typedef uint32_t __u32;
 #define V4L2_CID_IRIS_ABSOLUTE (V4L2_CID_CAMERA_CLASS_BASE+17)
 #endif
 
+#ifndef v4l2_fourcc_be
+#define v4l2_fourcc_be(a, b, c, d) (v4l2_fourcc(a, b, c, d) | (1U << 31))
+#endif
+
 #ifndef V4L2_PIX_FMT_Y10
 #define V4L2_PIX_FMT_Y10 v4l2_fourcc('Y', '1', '0', ' ')
 #endif

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -61,7 +61,7 @@ inline std::string fourccToStringSafe(int fourcc)
 {
     std::string res = fourccToString(fourcc);
     // TODO: return hex values for invalid characters
-    std::transform(res.begin(), res.end(), res.begin(), [](uint8_t c) { return (c >= '0' && c <= 'z') ? c : (c == ' ' ? '_' : 'x'); });
+    std::transform(res.begin(), res.end(), res.begin(), [](char c) -> char { return (c >= '0' && c <= 'z') ? c : (c == ' ' ? '_' : 'x'); });
     return res;
 }
 

--- a/modules/videoio/test/test_v4l2.cpp
+++ b/modules/videoio/test/test_v4l2.cpp
@@ -22,6 +22,9 @@
 #include <linux/videodev2.h>
 
 // workarounds for older versions
+#ifndef v4l2_fourcc_be
+#define v4l2_fourcc_be(a, b, c, d) (v4l2_fourcc(a, b, c, d) | (1U << 31))
+#endif
 #ifndef V4L2_PIX_FMT_Y10
 #define V4L2_PIX_FMT_Y10 v4l2_fourcc('Y', '1', '0', ' ')
 #endif


### PR DESCRIPTION
MSVC warrning:
```
 622>C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\algorithm(2650,24): warning C4244: '=': conversion from 'int' to 'char', possible loss of data [C:\build\precommit-contrib_windows64\build\modules\videoio\opencv_test_videoio.vcxproj]
```


ARMv7 Linux build issue:
```
/build/4_x_ARMv7-lin/opencv/modules/videoio/src/cap_v4l.cpp: In member function 'bool cv::CvCaptureCAM_V4L::autosetup_capture_mode_v4l2()':
/build/4_x_ARMv7-lin/opencv/modules/videoio/src/cap_v4l.cpp:276:62: error: 'v4l2_fourcc_be' was not declared in this scope
 #define V4L2_PIX_FMT_Y16_BE v4l2_fourcc_be('Y', '1', '6', ' ')
                                                              ^
```


```
allow_multiple_commits=1
```