### PR TITLE
`cuda`: Fix `GpuMat::copyTo` and `GpuMat::converTo` python bindings

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -198,16 +198,32 @@ public:
     CV_WRAP GpuMat clone() const;
 
     //! copies the GpuMat content to device memory (Blocking call)
-    CV_WRAP void copyTo(OutputArray dst) const;
+    void copyTo(OutputArray dst) const;
+    //! bindings overload which copies the GpuMat content to device memory (Blocking call)
+    CV_WRAP void copyTo(CV_OUT GpuMat& dst) const {
+        copyTo(static_cast<OutputArray>(dst));
+    }
 
     //! copies the GpuMat content to device memory (Non-Blocking call)
-    CV_WRAP void copyTo(OutputArray dst, Stream& stream) const;
+    void copyTo(OutputArray dst, Stream& stream) const;
+    //! bindings overload which copies the GpuMat content to device memory (Non-Blocking call)
+    CV_WRAP void copyTo(CV_OUT GpuMat& dst, Stream& stream) const {
+        copyTo(static_cast<OutputArray>(dst), stream);
+    }
 
     //! copies those GpuMat elements to "m" that are marked with non-zero mask elements (Blocking call)
-    CV_WRAP void copyTo(OutputArray dst, InputArray mask) const;
+    void copyTo(OutputArray dst, InputArray mask) const;
+    //! bindings overload which copies those GpuMat elements to "m" that are marked with non-zero mask elements (Blocking call)
+    CV_WRAP void copyTo(CV_OUT GpuMat& dst, GpuMat& mask) const {
+        copyTo(static_cast<OutputArray>(dst), static_cast<InputArray>(mask));
+    }
 
     //! copies those GpuMat elements to "m" that are marked with non-zero mask elements (Non-Blocking call)
-    CV_WRAP void copyTo(OutputArray dst, InputArray mask, Stream& stream) const;
+    void copyTo(OutputArray dst, InputArray mask, Stream& stream) const;
+    //! bindings overload which copies those GpuMat elements to "m" that are marked with non-zero mask elements (Non-Blocking call)
+    CV_WRAP void copyTo(CV_OUT GpuMat& dst, GpuMat& mask, Stream& stream) const {
+        copyTo(static_cast<OutputArray>(dst), static_cast<InputArray>(mask), stream);
+    }
 
     //! sets some of the GpuMat elements to s (Blocking call)
     CV_WRAP GpuMat& setTo(Scalar s);
@@ -222,19 +238,31 @@ public:
     CV_WRAP GpuMat& setTo(Scalar s, InputArray mask, Stream& stream);
 
     //! converts GpuMat to another datatype (Blocking call)
-    CV_WRAP void convertTo(OutputArray dst, int rtype) const;
+    void convertTo(OutputArray dst, int rtype) const;
 
     //! converts GpuMat to another datatype (Non-Blocking call)
-    CV_WRAP void convertTo(OutputArray dst, int rtype, Stream& stream) const;
+    void convertTo(OutputArray dst, int rtype, Stream& stream) const;
+    //! bindings overload which converts GpuMat to another datatype (Non-Blocking call)
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, Stream& stream) const {
+        convertTo(static_cast<OutputArray>(dst), rtype, stream);
+    }
 
     //! converts GpuMat to another datatype with scaling (Blocking call)
-    CV_WRAP void convertTo(OutputArray dst, int rtype, double alpha, double beta = 0.0) const;
+    void convertTo(OutputArray dst, int rtype, double alpha, double beta = 0.0) const;
+    //! bindings overload which converts GpuMat to another datatype with scaling(Blocking call)
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha = 1.0, double beta = 0.0) const {
+        convertTo(static_cast<OutputArray>(dst), rtype, alpha, beta);
+    }
 
     //! converts GpuMat to another datatype with scaling (Non-Blocking call)
-    CV_WRAP void convertTo(OutputArray dst, int rtype, double alpha, Stream& stream) const;
+    void convertTo(OutputArray dst, int rtype, double alpha, Stream& stream) const;
 
     //! converts GpuMat to another datatype with scaling (Non-Blocking call)
-    CV_WRAP void convertTo(OutputArray dst, int rtype, double alpha, double beta, Stream& stream) const;
+    void convertTo(OutputArray dst, int rtype, double alpha, double beta, Stream& stream) const;
+    //! bindings overload which converts GpuMat to another datatype with scaling (Non-Blocking call)
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha, double beta, Stream& stream) const {
+        convertTo(static_cast<OutputArray>(dst), rtype, alpha, beta, stream);
+    }
 
     CV_WRAP void assignTo(GpuMat& m, int type = -1) const;
 

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -70,6 +70,74 @@ class cuda_test(NewOpenCVTests):
         self.assertTrue(cuMat.step == 0)
         self.assertTrue(cuMat.size() == (0, 0))
 
+    def test_cuda_convertTo(self):
+        # setup
+        npMat_8UC4 = (np.random.random((128, 128, 4)) * 255).astype(np.uint8)
+        npMat_32FC4 = npMat_8UC4.astype(np.single)
+        new_type = cv.CV_32FC4
+
+        # sync
+        # in/out
+        cuMat_8UC4 = cv.cuda_GpuMat(npMat_8UC4)
+        cuMat_32FC4 = cv.cuda_GpuMat(cuMat_8UC4.size(), new_type)
+        cuMat_32FC4_out = cuMat_8UC4.convertTo(new_type, cuMat_32FC4)
+        self.assertTrue(cuMat_32FC4.cudaPtr() == cuMat_32FC4_out.cudaPtr())
+        npMat_32FC4_out = cuMat_32FC4.download()
+        self.assertTrue(np.array_equal(npMat_32FC4, npMat_32FC4_out))
+        # out
+        cuMat_32FC4_out = cuMat_8UC4.convertTo(new_type)
+        npMat_32FC4_out = cuMat_32FC4.download()
+        self.assertTrue(np.array_equal(npMat_32FC4, npMat_32FC4_out))
+
+        # async
+        stream = cv.cuda.Stream()
+        cuMat_32FC4 = cv.cuda_GpuMat(cuMat_8UC4.size(), new_type)
+        cuMat_32FC4_out = cuMat_8UC4.convertTo(new_type, cuMat_32FC4)
+        # in/out
+        cuMat_32FC4_out = cuMat_8UC4.convertTo(new_type, 1, 0, stream, cuMat_32FC4)
+        self.assertTrue(cuMat_32FC4.cudaPtr() == cuMat_32FC4_out.cudaPtr())
+        npMat_32FC4_out = cuMat_32FC4.download(stream)
+        stream.waitForCompletion()
+        self.assertTrue(np.array_equal(npMat_32FC4, npMat_32FC4_out))
+        # out
+        cuMat_32FC4_out = cuMat_8UC4.convertTo(new_type, 1, 0, stream)
+        npMat_32FC4_out = cuMat_32FC4.download(stream)
+        stream.waitForCompletion()
+        self.assertTrue(np.array_equal(npMat_32FC4, npMat_32FC4_out))
+
+    def test_cuda_copyTo(self):
+        # setup
+        npMat_8UC4 = (np.random.random((128, 128, 4)) * 255).astype(np.uint8)
+
+        # sync
+        # in/out
+        cuMat_8UC4 = cv.cuda_GpuMat(npMat_8UC4)
+        cuMat_8UC4_dst = cv.cuda_GpuMat(cuMat_8UC4.size(), cuMat_8UC4.type())
+        cuMat_8UC4_out = cuMat_8UC4.copyTo(cuMat_8UC4_dst)
+        self.assertTrue(cuMat_8UC4_out.cudaPtr() == cuMat_8UC4_dst.cudaPtr())
+        npMat_8UC4_out = cuMat_8UC4_out.download()
+        self.assertTrue(np.array_equal(npMat_8UC4, npMat_8UC4_out))
+        # out
+        cuMat_8UC4_out =  cuMat_8UC4.copyTo()
+        npMat_8UC4_out = cuMat_8UC4_out.download()
+        self.assertTrue(np.array_equal(npMat_8UC4, npMat_8UC4_out))
+
+        # async
+        stream = cv.cuda.Stream()
+        # in/out
+        cuMat_8UC4 = cv.cuda_GpuMat(npMat_8UC4)
+        cuMat_8UC4_dst = cv.cuda_GpuMat(cuMat_8UC4.size(), cuMat_8UC4.type())
+        cuMat_8UC4_out = cuMat_8UC4.copyTo(cuMat_8UC4_dst, stream)
+        self.assertTrue(cuMat_8UC4_out.cudaPtr() == cuMat_8UC4_out.cudaPtr())
+        npMat_8UC4_out = cuMat_8UC4_dst.download(stream)
+        stream.waitForCompletion()
+        self.assertTrue(np.array_equal(npMat_8UC4, npMat_8UC4_out))
+        # out
+        cuMat_8UC4_out = cuMat_8UC4.copyTo(stream)
+        npMat_8UC4_out = cuMat_8UC4_out.download(stream)
+        stream.waitForCompletion()
+        self.assertTrue(np.array_equal(npMat_8UC4, npMat_8UC4_out))
+
     def test_cuda_denoising(self):
         self.assertEqual(True, hasattr(cv.cuda, 'fastNlMeansDenoising'))
         self.assertEqual(True, hasattr(cv.cuda, 'fastNlMeansDenoisingColored'))


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24038 and added non exhaustive python tests to verify functionality.

@VadimLevin

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
