### PR TITLE
fix WarpPerspectiveLine_ProcessNN_CV_SIMD for AArch64

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2872,8 +2872,10 @@ void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0
             v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
             v_x1 += v_2;
 
-            v_X0 = v_round(v_fX0, v_fX1);
-            v_Y0 = v_round(v_fY0, v_fY1);
+            v_float32x4 v_fX = v_cvt_f32(v_fX0, v_fX1);
+            v_float32x4 v_fY = v_cvt_f32(v_fY0, v_fY1);
+            v_X0 = v_trunc(v_fX);
+            v_Y0 = v_trunc(v_fY);
         }
 
         // 4-7
@@ -2891,8 +2893,10 @@ void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0
             v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
             v_x1 += v_2;
 
-            v_X1 = v_round(v_fX0, v_fX1);
-            v_Y1 = v_round(v_fY0, v_fY1);
+            v_float32x4 v_fX = v_cvt_f32(v_fX0, v_fX1);
+            v_float32x4 v_fY = v_cvt_f32(v_fY0, v_fY1);
+            v_X1 = v_trunc(v_fX);
+            v_Y1 = v_trunc(v_fY);
         }
 
         // 8-11
@@ -2910,8 +2914,10 @@ void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0
             v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
             v_x1 += v_2;
 
-            v_X2 = v_round(v_fX0, v_fX1);
-            v_Y2 = v_round(v_fY0, v_fY1);
+            v_float32x4 v_fX = v_cvt_f32(v_fX0, v_fX1);
+            v_float32x4 v_fY = v_cvt_f32(v_fY0, v_fY1);
+            v_X2 = v_trunc(v_fX);
+            v_Y2 = v_trunc(v_fY);
         }
 
         // 12-15
@@ -2929,8 +2935,10 @@ void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0
             v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
             v_x1 += v_2;
 
-            v_X3 = v_round(v_fX0, v_fX1);
-            v_Y3 = v_round(v_fY0, v_fY1);
+            v_float32x4 v_fX = v_cvt_f32(v_fX0, v_fX1);
+            v_float32x4 v_fY = v_cvt_f32(v_fY0, v_fY1);
+            v_X3 = v_trunc(v_fX);
+            v_Y3 = v_trunc(v_fY);
         }
 
         // convert to 16s


### PR DESCRIPTION
This function has a fast path using Neon instructions which gives results different from the slow path.

The fast path is using rounding which converts any number with a fractional part >= 0.5 to the next integer (for example 100.5 is converted to 101 instead of 100).

Using truncation fixes the problem.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
