### PR TITLE
fix python sample code (tst_scene_render) 

### DIFF
--- a/samples/python/tst_scene_render.py
+++ b/samples/python/tst_scene_render.py
@@ -25,7 +25,7 @@ class TestSceneRender():
         if bgImg is not None:
             self.sceneBg = bgImg.copy()
         else:
-            self.sceneBg = np.zeros(defaultSize, defaultSize, np.uint8)
+            self.sceneBg = np.zeros((defaultSize, defaultSize,3), np.uint8)
 
         self.w = self.sceneBg.shape[0]
         self.h = self.sceneBg.shape[1]
@@ -85,7 +85,7 @@ class TestSceneRender():
             img[self.currentCenter[0]:self.currentCenter[0]+self.foreground.shape[0],
              self.currentCenter[1]:self.currentCenter[1]+self.foreground.shape[1]] = self.foreground
         else:
-            self.currentRect = self.initialRect + np.int( 30*cos(self.time*self.speed) + 50*sin(self.time*self.speed))
+            self.currentRect = self.initialRect + int( 30*cos(self.time*self.speed) + 50*sin(self.time*self.speed))
             if self.deformation:
                 self.currentRect[1:3] += int(self.h/20*cos(self.time))
             cv.fillConvexPoly(img, self.currentRect, (0, 0, 255))
@@ -102,6 +102,8 @@ def main():
     fgr = cv.imread(cv.samples.findFile('box.png'))
 
     render = TestSceneRender(backGr, fgr)
+    #render = TestSceneRender(None, fgr)
+    #render = TestSceneRender(backGr)
 
     while True:
 

--- a/samples/python/tst_scene_render.py
+++ b/samples/python/tst_scene_render.py
@@ -102,8 +102,6 @@ def main():
     fgr = cv.imread(cv.samples.findFile('box.png'))
 
     render = TestSceneRender(backGr, fgr)
-    #render = TestSceneRender(None, fgr)
-    #render = TestSceneRender(backGr)
 
     while True:
 


### PR DESCRIPTION
Fix bug of python sample code (samples/python/tst_scene_render.py) when backGr or fgr is None (#24114)

1) pass shape tuple to np.zeros arguments instead of integers
2) change np.int to int

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [o] I agree to contribute to the project under Apache 2 License.
- [o] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [o] The PR is proposed to the proper branch
- [o] There is a reference to the original bug report and related work
- [o] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [o] The feature is well documented and sample code can be built with the project CMake
