### PR TITLE
Fix v_pack_store alignment issue on Windows 32-bit.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -721,14 +721,13 @@ namespace CV__SIMD_NAMESPACE {
     //! @}
 
     #ifndef OPENCV_HAL_HAVE_LOAD_STORE_BFLOAT16
-
     inline v_float32 vx_load_expand(const bfloat16_t* ptr)
     {
         v_uint32 v = vx_load_expand((const ushort*)ptr);
         return v_reinterpret_as_f32(v_shl<16>(v));
     }
 
-    inline void v_pack_store(const bfloat16_t* ptr, v_float32 v)
+    inline void v_pack_store(const bfloat16_t* ptr, const v_float32& v)
     {
         v_int32 iv = v_shr<16>(v_reinterpret_as_s32(v));
         v_pack_store((short*)ptr, iv);


### PR DESCRIPTION
Nightly build issue: https://pullrequest.opencv.org/buildbot/builders/5_x-win32-vc14/builds/100205
The issue introduced in: https://github.com/opencv/opencv/pull/23865

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
