### PR TITLE
fix charuco checkBoard

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -166,11 +166,11 @@ public:
      */
     CV_WRAP std::vector<Point3f> getChessboardCorners() const;
 
-    /** @brief get CharucoBoard::nearestMarkerIdx
+    /** @brief get CharucoBoard::nearestMarkerIdx, for each charuco corner, nearest marker index in ids array
      */
     CV_PROP std::vector<std::vector<int> > getNearestMarkerIdx() const;
 
-    /** @brief get CharucoBoard::nearestMarkerCorners
+    /** @brief get CharucoBoard::nearestMarkerCorners, for each charuco corner, nearest marker corner id of each marker
      */
     CV_PROP std::vector<std::vector<int> > getNearestMarkerCorners() const;
 

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -319,8 +319,9 @@ struct CharucoBoardImpl : Board::Impl {
     // vector of chessboard 3D corners precalculated
     std::vector<Point3f> chessboardCorners;
 
-    // for each charuco corner, nearest marker id and nearest marker corner id of each marker
+    // for each charuco corner, nearest marker index in ids array
     std::vector<std::vector<int> > nearestMarkerIdx;
+    // for each charuco corner, nearest marker corner id of each marker
     std::vector<std::vector<int> > nearestMarkerCorners;
 
     void createCharucoBoard();

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -717,4 +717,58 @@ TEST_P(CharucoBoard, testWrongSizeDetection)
     ASSERT_TRUE(detectedCharucoIds.empty());
 }
 
+TEST(Charuco, testSeveralBoardsWithCustomIds)
+{
+    Size res{500, 500};
+    Mat K = (Mat_<double>(3,3) <<
+        0.5*res.width, 0, 0.5*res.width,
+        0, 0.5*res.height, 0.5*res.height,
+        0, 0, 1);
+
+    Mat expected_corners = (Mat_<float>(9,2) <<
+        200, 200,
+        250, 200,
+        300, 200,
+        200, 250,
+        250, 250,
+        300, 250,
+        200, 300,
+        250, 300,
+        300, 300
+    );
+
+
+    aruco::Dictionary dict = cv::aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+    vector<int> ids1 = {0, 1, 33, 3, 4, 5, 6, 8}, ids2 = {7, 9, 44, 11, 12, 13, 14, 15};
+    aruco::CharucoBoard board1(Size(4, 4), 1.f, .8f, dict, ids1), board2(Size(4, 4), 1.f, .8f, dict, ids2);
+
+    // generate ChArUco board
+    Mat gray;
+    {
+        Mat gray1, gray2;
+        board1.generateImage(Size(res.width, res.height), gray1, 150);
+        board2.generateImage(Size(res.width, res.height), gray2, 150);
+        hconcat(gray1, gray2, gray);
+    }
+
+    aruco::CharucoParameters charucoParameters;
+    charucoParameters.cameraMatrix = K;
+    aruco::CharucoDetector detector1(board1, charucoParameters), detector2(board2, charucoParameters);
+
+    vector<int> ids;
+    vector<Mat> corners;
+    Mat c_ids1, c_ids2, c_corners1, c_corners2;
+
+    detector1.detectBoard(gray, c_corners1, c_ids1, corners, ids);
+    detector2.detectBoard(gray, c_corners2, c_ids2, corners, ids);
+
+    ASSERT_EQ(ids.size(), size_t(16));
+    ASSERT_EQ(c_corners1.rows, expected_corners.rows);
+    EXPECT_NEAR(0, cvtest::norm(expected_corners, c_corners1.reshape(1), NORM_INF), 3e-1);
+
+    ASSERT_EQ(c_corners2.rows, expected_corners.rows);
+    expected_corners.col(0) += 500;
+    EXPECT_NEAR(0, cvtest::norm(expected_corners, c_corners2.reshape(1), NORM_INF), 3e-1);
+}
+
 }} // namespace


### PR DESCRIPTION
Fixes #23905

checkBoard() is an internal function that checks that the found board has the correct structure

1. fixed a bug with checking extraneous markers:
```
                if (find(boardIds.begin(), boardIds.end(), idMaker) == boardIds.end())
                    continue;
```
2. fixed an indexing bug:
```
                const int nearestMarkerId1 = boardIds[nearestMarkerIdx[chId][0]];
                const int nearestMarkerId2 = boardIds[nearestMarkerIdx[chId][1]];
```
3. updated docs for getNearestMarkerIdx()/getNearestMarkerCorners()
4. added `checkBoardStructure` flag, this flag allows you to return the old behavior or use your custom board structure check.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
