### PR TITLE
Fix bug at blobFromImagesWithParams

### DIFF
--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -5,6 +5,7 @@
 #include "precomp.hpp"
 
 #include <opencv2/imgproc.hpp>
+#include <opencv2/core/utils/logger.hpp>
 
 
 namespace cv {
@@ -100,13 +101,27 @@ void blobFromImagesWithParams(InputArrayOfArrays images_, OutputArray blob_, con
     images_.getMatVector(images);
     CV_Assert(!images.empty());
 
-    int nch = images[0].channels();
-    Scalar scalefactor = param.scalefactor;
-
     if (param.ddepth == CV_8U)
     {
-        CV_Assert(scalefactor == Scalar::all(1.0) && "Scaling is not supported for CV_8U blob depth");
+        CV_Assert(param.scalefactor == Scalar::all(1.0) && "Scaling is not supported for CV_8U blob depth");
         CV_Assert(param.mean == Scalar() && "Mean subtraction is not supported for CV_8U blob depth");
+    }
+
+    int nch = images[0].channels();
+    Scalar scalefactor = param.scalefactor;
+    Scalar mean = param.mean;
+
+    if (param.swapRB)
+    {
+        if (nch > 2)
+        {
+            std::swap(mean[0], mean[2]);
+            std::swap(scalefactor[0], scalefactor[2]);
+        }
+        else
+        {
+            CV_LOG_WARNING(NULL, "Red/blue color swapping requires at least three image channels.");
+        }
     }
 
     for (size_t i = 0; i < images.size(); i++)
@@ -126,32 +141,24 @@ void blobFromImagesWithParams(InputArrayOfArrays images_, OutputArray blob_, con
                           size);
                 images[i] = images[i](crop);
             }
+            else if (param.paddingmode == DNN_PMODE_LETTERBOX)
+            {
+                float resizeFactor = std::min(size.width / (float)imgSize.width,
+                                              size.height / (float)imgSize.height);
+                int rh = int(imgSize.height * resizeFactor);
+                int rw = int(imgSize.width * resizeFactor);
+                resize(images[i], images[i], Size(rw, rh), INTER_LINEAR);
+
+                int top = (size.height - rh)/2;
+                int bottom = size.height - top - rh;
+                int left = (size.width - rw)/2;
+                int right = size.width - left - rw;
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT);
+            }
             else
             {
-                if (param.paddingmode == DNN_PMODE_LETTERBOX)
-                {
-                    float resizeFactor = std::min(size.width / (float)imgSize.width,
-                                                  size.height / (float)imgSize.height);
-                    int rh = int(imgSize.height * resizeFactor);
-                    int rw = int(imgSize.width * resizeFactor);
-                    resize(images[i], images[i], Size(rw, rh), INTER_LINEAR);
-
-                    int top = (size.height - rh)/2;
-                    int bottom = size.height - top - rh;
-                    int left = (size.width - rw)/2;
-                    int right = size.width - left - rw;
-                    copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT);
-                }
-                else
-                    resize(images[i], images[i], size, 0, 0, INTER_LINEAR);
+                resize(images[i], images[i], size, 0, 0, INTER_LINEAR);
             }
-        }
-
-        Scalar mean = param.mean;
-        if (param.swapRB)
-        {
-            std::swap(mean[0], mean[2]);
-            std::swap(scalefactor[0], scalefactor[2]);
         }
 
         if (images[i].depth() == CV_8U && param.ddepth == CV_32F)
@@ -220,18 +227,22 @@ void blobFromImagesWithParams(InputArrayOfArrays images_, OutputArray blob_, con
             CV_Assert(image.depth() == blob_.depth());
             CV_Assert(image.channels() == image0.channels());
             CV_Assert(image.size() == image0.size());
-            if (param.swapRB)
+            if (nch > 2 && param.swapRB)
             {
                 Mat tmpRB;
                 cvtColor(image, tmpRB, COLOR_BGR2RGB);
                 tmpRB.copyTo(Mat(tmpRB.rows, tmpRB.cols, subMatType, blob.ptr((int)i, 0)));
             }
             else
+            {
                 image.copyTo(Mat(image.rows, image.cols, subMatType, blob.ptr((int)i, 0)));
+            }
         }
     }
     else
+    {
         CV_Error(Error::StsUnsupportedFormat, "Unsupported data layout in blobFromImagesWithParams function.");
+    }
 }
 
 void imagesFromBlob(const cv::Mat& blob_, OutputArrayOfArrays images_)

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -120,6 +120,28 @@ TEST(blobFromImageWithParams_4ch, letter_box)
     EXPECT_EQ(0, cvtest::norm(targetBlob, blob, NORM_INF));
 }
 
+TEST(blobFromImagesWithParams_4ch, multi_image)
+{
+    Mat img(10, 10, CV_8UC4, cv::Scalar(0, 1, 2, 3));
+    Scalar scalefactor(0.1, 0.2, 0.3, 0.4);
+
+    Image2BlobParams param;
+    param.scalefactor = scalefactor;
+    param.datalayout = DNN_LAYOUT_NHWC;
+
+    Mat blobs = blobFromImagesWithParams(std::vector<Mat> { img, 2*img }, param);
+    vector<Range> ranges;
+    ranges.push_back(Range(0, 1));
+    ranges.push_back(Range(0, blobs.size[1]));
+    ranges.push_back(Range(0, blobs.size[2]));
+    ranges.push_back(Range(0, blobs.size[3]));
+    Mat blob0 = blobs(ranges);
+    ranges[0] = Range(1, 2);
+    Mat blob1 = blobs(ranges);
+
+    EXPECT_EQ(0, cvtest::norm(2*blob0, blob1, NORM_INF));
+}
+
 TEST(readNet, Regression)
 {
     Net net = readNet(findDataFile("dnn/squeezenet_v1.1.prototxt"),


### PR DESCRIPTION
## `blobFromImagesWithParams`(image-s) apply swap scalefactor for every images when swapRB is true. This patch moves the swap scalefactor code out of the loop, that fix the above issue.

We would like to improve the recently introduced function `blobFromImagesWithParams` with respect to three minor issues that we noticed:

- Currently, `mean` and `scalefactor` are recreated for every image, even though they should be reused. Maybe the compiler is smart enough to optimize this, still we think the variable should be created / swapped before the main loop.
- Next, we would like to improve the function's robustness with respect to inconsistent arguments, i.e. if a single-channel image is passed but `swapRB` is true, as explained below.
- Finally, we made some minor modifications to follow the coding guidelines (`if - else if - else` instead of nested else).

Function wise, there are two improvements from this:

1. Currently, if the user passes a single-channel image in combination with `mean` and `scalefactor` values, but unintentionally sets `swapRB` to true, the whole result can be silently zeroed. The `mean` and `scalefactor` arrays will only contain a single value (whereas the other indices' values remain 0), but `swapRB` will swap out the true mean / scalefactor values and swap in zeros for these instead. There is no warning or assertion, only the whole image will be zeroed by the following multiplication. Therefore, we suggest to only swap these values if the image is not a single-channel image, i.e. `mean` and `scalefactor` contain correct values for all channels, therefore add `if (nch > 2)`.
2. Next, a related issue exists in combination with `DNN_LAYOUT_NHWC`. If the user passes this in combination with a single-channel image and `swapRB` is true, the function produces the following error:
```
OpenCV\modules\core\src\copy.cpp:320: error: (-215:Assertion failed) channels() == CV_MAT_CN(dtype) in function 'cv::Mat::copyTo'
```
This results from first converting the image to RGB (even though it is grayscale instead of the expected BGR layout) and, thereafter, copying the resulting three-channel image into the single-channel blob. This is avoided by checking `nch > 2` here, too, which is also consistent to the function's implementation of the `DNN_LAYOUT_NCHW` case.

Both changes can be summarized such that `swapRB` only has an effect if the image has at least three channels. Most importantly, nothing changes at all if the arguments are consistent.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
