### PR TITLE
`cuda`: update default PTX behaviour when `CUDA_ARCH_BIN` is unset

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -228,7 +228,7 @@ if(CUDA_FOUND)
     endif()
   endmacro()
 
-  set(__cuda_arch_ptx "")
+  set(__cuda_arch_ptx ${CUDA_ARCH_PTX})
   if(CUDA_GENERATION STREQUAL "Fermi")
     set(__cuda_arch_bin ${_arch_fermi})
   elseif(CUDA_GENERATION STREQUAL "Kepler")
@@ -259,7 +259,7 @@ if(CUDA_FOUND)
     set(__cuda_arch_bin ${CUDA_ARCH_BIN})
   endif()
 
-  if(NOT DEFINED __cuda_arch_bin)
+  if(NOT DEFINED __cuda_arch_bin AND NOT DEFINED __cuda_arch_ptx)
     if(ARM)
       set(__cuda_arch_bin "3.2")
       set(__cuda_arch_ptx "")
@@ -295,6 +295,7 @@ if(CUDA_FOUND)
           ${_arch_lovelace}
           ${_arch_hopper}
       )
+      list(GET __cuda_arch_bin -1 __cuda_arch_ptx)
     endif()
   endif()
 


### PR DESCRIPTION
Currently when `CUDA_ARCH_BIN` isn't specified CMake attempts to build .cu files for the all architechtures it knows about, generating a list of architectures supported by the current CUDA Toolkit (see https://github.com/opencv/opencv/pull/17432).  The idea being that if a user doesn't specify the arch then to be on the safe side it should generate for all architechtures for maximum compatibility.  Additionally if a user just wants to specify a PTX architechture they have to pass `CUDA_ARCH_BIN=` (incurring the overhead of calling `ocv_filter_available_architecture` on all know architectures) in addition to `CUDA_ARCH_PTX=<TAERGET ARCH>` to CMake  to avoid generating binary code for all supported architectures as well.  

This PR proposes that:
1. When `CUDA_ARCH_BIN` and  `CUDA_ARCH_PTX`  are not specified, in addition to binary code for all compute capabilities, PTX code for the highest supported architecture is also generated.  This would ensure that the CUDA device code will **also** run on newer GPU's than the installed CUDA Toolkit, increasing the level of compatibility futher.
2.  When `CUDA_ARCH_PTX` is  passed in isolation only PTX code for the desired CC is generated.

@tomoaki0705 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
