### PR TITLE
Fixed bug when MSMF webcamera doesn't start when build with VIDEOIO_PLUGIN_ALL

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -2719,8 +2719,6 @@ CvResult CV_API_CALL cv_capture_open_with_params(
     if (!handle)
         return CV_ERROR_FAIL;
     *handle = NULL;
-    if (!filename)
-        return CV_ERROR_FAIL;
     CaptureT* cap = 0;
     try
     {


### PR DESCRIPTION
Fixed #23937 and #23056
