### PR TITLE
videoio: fix camera opening with GStreamer plugin

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -2825,8 +2825,6 @@ CvResult CV_API_CALL cv_capture_open_with_params(
     if (!handle)
         return CV_ERROR_FAIL;
     *handle = NULL;
-    if (!filename)
-        return CV_ERROR_FAIL;
     GStreamerCapture *cap = 0;
     try
     {


### PR DESCRIPTION
related #24133, #23056, #23937

Steps to reproduce:
* build OpenCV with GStreamer backend as plugin (`-DVIDEOIO_PLUGIN_LIST=gstreamer`)
* open camera by index using GStreamer backend (`VideoCapture cap(0, CAP_GSTREAMER)`)

Result: failure, capture is not opened, when using GStreamer backend as built-in camera can be opened

This was happening due to bug in plugin wrapper.