### PR TITLE
fix the return-type error in `ipp_warpAffine`

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2679,8 +2679,13 @@ static bool ipp_warpAffine( InputArray _src, OutputArray _dst, int interpolation
     }
 
     return true;
+#else
+    CV_UNUSED(_src); CV_UNUSED(_dst); CV_UNUSED(interpolation);
+    CV_UNUSED(borderType); CV_UNUSED(_M); CV_UNUSED(flags);
+    return false;
 #endif
 }
+
 #endif
 
 namespace hal {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] N/A There is a reference to the original bug report and related work
- [ ] N/A There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] N/A The feature is well documented and sample code can be built with the project CMake
fix the return-type compile error in `ipp_warpAffine`

When building OpenCV on Windows with MSVC, if we set cmake option `WITH_IPP` ON and `BUILD_IPP_IW` OFF, then we have macro `HAVE_IPP` / `HAVE_IPP_ICV` but no `HAVE_IPP_IW` / `HAVE_IPP_IW_LL` in `cvconfig.h`, thus the function [ipp_warpAffine](https://github.com/opencv/opencv/blob/27d718b2232ac82f3acc97395b979328d9c03cd8/modules/imgproc/src/imgwarp.cpp#L2622C1-L2685C1) will have an empty body (no return), but its signature returns `bool`.

Just add `return false` and apply `CV_UNUSED` to all its arguments, like what other `ipp_*` functions do.

The compile error on my PC is:

```
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,118): warning C4100: 'flags': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,110): warning C4100: '_M': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,87): warning C4100: 'borderType': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,68): warning C4100: 'interpolation': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,58): warning C4100: '_dst': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2622,40): warning C4100: '_src': unreferenced formal parameter
F:\Library\opencv\modules\imgproc\src\imgwarp.cpp(2683): error C4716: 'cv::ipp_warpAffine': must return a value
```