### PR TITLE
gapi: update ADE library to 0.1.2b

### DIFF
--- a/modules/gapi/cmake/DownloadADE.cmake
+++ b/modules/gapi/cmake/DownloadADE.cmake
@@ -1,7 +1,7 @@
 set(ade_src_dir "${OpenCV_BINARY_DIR}/3rdparty/ade")
-set(ade_filename "v0.1.2a.zip")
-set(ade_subdir "ade-0.1.2a")
-set(ade_md5 "fa4b3e25167319cb0fa9432ef8281945")
+set(ade_filename "v0.1.2b.zip")
+set(ade_subdir "ade-0.1.2b")
+set(ade_md5 "4f93a0844dfc463c617d83b09011819a")
 ocv_download(FILENAME ${ade_filename}
              HASH ${ade_md5}
              URL


### PR DESCRIPTION
This update resolves all warnings produced by recent LLVM/Clang when compiling OpenCV.