### PR TITLE
PR: Fix incorrect detection of Python on Windows because relevant "cmake" variables are prematurely cleared.

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -110,16 +110,6 @@ if(NOT ${found})
     endif()
   endif()
 
-  if(__update_python_vars)
-    # Clear find_host_package side effects
-    unset(PYTHONINTERP_FOUND)
-    unset(PYTHON_EXECUTABLE CACHE)
-    unset(PYTHON_VERSION_STRING)
-    unset(PYTHON_VERSION_MAJOR)
-    unset(PYTHON_VERSION_MINOR)
-    unset(PYTHON_VERSION_PATCH)
-  endif()
-
   if(_found)
     set(_version_major_minor "${_version_major}.${_version_minor}")
 
@@ -261,6 +251,16 @@ if(NOT ${found})
   set(${packages_path} "${_packages_path}" CACHE PATH "Where to install the python packages.")
   set(${numpy_include_dirs} ${_numpy_include_dirs} CACHE PATH "Path to numpy headers")
   set(${numpy_version} "${_numpy_version}" CACHE INTERNAL "")
+
+  if(__update_python_vars)
+    # Clear find_host_package side effects
+    unset(PYTHONINTERP_FOUND)
+    unset(PYTHON_EXECUTABLE CACHE)
+    unset(PYTHON_VERSION_STRING)
+    unset(PYTHON_VERSION_MAJOR)
+    unset(PYTHON_VERSION_MINOR)
+    unset(PYTHON_VERSION_PATCH)
+  endif()
 endif()
 endfunction(find_python)
 


### PR DESCRIPTION
… variables are prematurely cleared.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [NA] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [NA] The feature is well documented and sample code can be built with the project CMake

This PR addresses #8174, ensuring that even though the Python interpreter is found the relevant *cmake* variables are not cleared until the very end of the `find_python` function call.