### PR TITLE
Remove explitit transB attribute from MatMul perf test

### DIFF
--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -678,7 +678,6 @@ PERF_TEST_P_(Layer_FullyConnected, fc)
     lp.set("axis", input.dims - 1);
     lp.set("is_matmul", weights.dims > 2);
     lp.set("bias_term", false);
-    lp.set("transB", true);
     lp.set("num_output", (int)weights.total(0, weights.dims - 1));
     lp.blobs.resize(1, weights);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves broken perf test: https://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/100322

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
