### PR TITLE
Skip test on SkipTestException at fixture's constructor

### DIFF
--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -919,12 +919,14 @@ INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
 // Expected that SkipTestException thrown in the constructor should skip test but not fail
 struct TestFixtureSkip: public ::testing::Test {
-    CV_NORETURN TestFixtureSkip() {
-        throw SkipTestException("Skip test at constructor");
+    TestFixtureSkip() {
+        findDataFile("missed_file", false);
     }
 };
 
-TEST_F(TestFixtureSkip, NoBodyRun) {}
+TEST_F(TestFixtureSkip, NoBodyRun) {
+    FAIL() << "Unreachable code called";
+}
 
 // Check no test body started in case of skip exception at static SetUpTestCase
 struct TestSetUpTestCaseSkip: public ::testing::Test {

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -924,9 +924,7 @@ struct TestFixtureSkip: public ::testing::Test {
     }
 };
 
-TEST_F(TestFixtureSkip, NoBodyRun) {
-    FAIL() << "Unreachable code called";
-}
+TEST_F(TestFixtureSkip, NoBodyRun) {}
 
 // Check no test body started in case of skip exception at static SetUpTestCase
 struct TestSetUpTestCaseSkip: public ::testing::Test {

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -919,8 +919,10 @@ INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
 // Expected that SkipTestException thrown in the constructor should skip test but not fail
 struct TestFixtureSkip: public ::testing::Test {
-    TestFixtureSkip() {
-        findDataFile("missed_file", false);
+    TestFixtureSkip(bool throwEx = true) {
+        if (throwEx) {
+            throw SkipTestException("Skip test at constructor");
+        }
     }
 };
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -13,6 +13,10 @@
 #include <thread>
 #endif
 
+#ifdef _MSC_VER
+# pragma warning(disable:4702)  // unreachable code
+#endif
+
 namespace opencv_test { namespace {
 
 TEST(Core_OutputArrayCreate, _1997)

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -924,7 +924,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 // Expected that SkipTestException thrown in the constructor should skip test but not fail
 struct TestFixtureSkip: public ::testing::Test {
     TestFixtureSkip() {
-        throw SkipTestException("");
+        throw SkipTestException("Skip test at constructor");
     }
 };
 
@@ -932,7 +932,7 @@ TEST_F(TestFixtureSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 
-
+// Check no test body started in case of skip exception at static SetUpTestCase
 struct TestSetUpTestCaseSkip: public ::testing::Test {
     static void SetUpTestCase() {
         throw SkipTestException("Skip test at SetUpTestCase");
@@ -943,6 +943,16 @@ TEST_F(TestSetUpTestCaseSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 TEST_F(TestSetUpTestCaseSkip, NoBodyRun2) {
+    FAIL() << "Unreachable code called";
+}
+
+struct TestSetUpSkip: public ::testing::Test {
+    virtual void SetUp() {
+        throw SkipTestException("Skip test at SetUp");
+    }
+};
+
+TEST_F(TestSetUpSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -13,10 +13,6 @@
 #include <thread>
 #endif
 
-#ifdef _MSC_VER
-# pragma warning(disable:4702)  // unreachable code
-#endif
-
 namespace opencv_test { namespace {
 
 TEST(Core_OutputArrayCreate, _1997)

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -917,5 +917,15 @@ REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows);
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
+// Expected that SkipTestException thrown in the constructor should skip test but not fail
+struct TestFixtureSkip: public ::testing::Test {
+    TestFixtureSkip() {
+        throw SkipTestException("");
+    }
+};
+
+TEST_F(TestFixtureSkip, NoBodyRun) {
+    FAIL() << "Unreachable code called";
+}
 
 }} // namespace

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -932,4 +932,18 @@ TEST_F(TestFixtureSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 
+
+struct TestSetUpTestCaseSkip: public ::testing::Test {
+    static void SetUpTestCase() {
+        throw SkipTestException("Skip test at SetUpTestCase");
+    }
+};
+
+TEST_F(TestSetUpTestCaseSkip, NoBodyRun) {
+    FAIL() << "Unreachable code called";
+}
+TEST_F(TestSetUpTestCaseSkip, NoBodyRun2) {
+    FAIL() << "Unreachable code called";
+}
+
 }} // namespace

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -919,7 +919,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
 // Expected that SkipTestException thrown in the constructor should skip test but not fail
 struct TestFixtureSkip: public ::testing::Test {
-    TestFixtureSkip() {
+    CV_NORETURN TestFixtureSkip() {
         throw SkipTestException("Skip test at constructor");
     }
 };

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -36,6 +36,8 @@ class NewOpenCVTests(unittest.TestCase):
                     return candidate
         if required:
             self.fail('File ' + filename + ' not found')
+        else:
+            self.skipTest('File ' + filename + ' not found')
         return None
 
 

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -47,6 +47,9 @@ bool checkBigDataTests();
        } \
     } \
 
+struct DummyTest : public ::testing::Test {
+  virtual void TestBody() CV_OVERRIDE {}
+};
 
 #undef TEST
 #define TEST_(test_case_name, test_name, parent_class, bodyMethodName, BODY_ATTR, BODY_IMPL) \
@@ -60,6 +63,17 @@ bool checkBigDataTests();
       GTEST_DISALLOW_COPY_AND_ASSIGN_(\
           GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\
     };\
+    class test_case_name##test_name##_factory : public ::testing::internal::TestFactoryBase { \
+     public:\
+      virtual ::testing::Test* CreateTest() { \
+        try { \
+          return new GTEST_TEST_CLASS_NAME_(test_case_name, test_name); \
+        } catch (const cvtest::details::SkipTestExceptionBase& e) { \
+          printf("[     SKIP ] %s\n", e.what()); \
+          return new DummyTest(); \
+        } \
+      } \
+    };\
     \
     ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_case_name, test_name)\
       ::test_info_ =\
@@ -69,8 +83,7 @@ bool checkBigDataTests();
             (::testing::internal::GetTestTypeId()), \
             parent_class::SetUpTestCase, \
             parent_class::TearDownTestCase, \
-            new ::testing::internal::TestFactoryImpl<\
-                GTEST_TEST_CLASS_NAME_(test_case_name, test_name)>);\
+            new test_case_name##test_name##_factory);\
     void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::TestBody() BODY_IMPL( #test_case_name "_" #test_name ) \
     void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::bodyMethodName()
 
@@ -113,6 +126,17 @@ bool checkBigDataTests();
       GTEST_DISALLOW_COPY_AND_ASSIGN_(\
           GTEST_TEST_CLASS_NAME_(test_fixture, test_name));\
     };\
+    class test_fixture##test_name##_factory : public ::testing::internal::TestFactoryBase { \
+     public:\
+      virtual ::testing::Test* CreateTest() { \
+        try { \
+          return new GTEST_TEST_CLASS_NAME_(test_fixture, test_name); \
+        } catch (const cvtest::details::SkipTestExceptionBase& e) { \
+          printf("[     SKIP ] %s\n", e.what()); \
+          return new DummyTest(); \
+        } \
+      } \
+    };\
     \
     ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_fixture, test_name)\
       ::test_info_ =\
@@ -122,8 +146,7 @@ bool checkBigDataTests();
             (::testing::internal::GetTypeId<test_fixture>()), \
             test_fixture::SetUpTestCase, \
             test_fixture::TearDownTestCase, \
-            new ::testing::internal::TestFactoryImpl<\
-                GTEST_TEST_CLASS_NAME_(test_fixture, test_name)>);\
+            new test_fixture##test_name##_factory);\
     void GTEST_TEST_CLASS_NAME_(test_fixture, test_name)::TestBody() CV__TEST_BODY_IMPL( #test_fixture "_" #test_name ) \
     void GTEST_TEST_CLASS_NAME_(test_fixture, test_name)::Body()
 

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -47,6 +47,15 @@ bool checkBigDataTests();
        } \
     } \
 
+#define CV__TEST_SETUP_IMPL(parent_class) \
+    { \
+      try { \
+        parent_class::SetUp(); \
+      } catch (const cvtest::details::SkipTestExceptionBase& e) { \
+        printf("[     SKIP ] %s\n", e.what()); \
+      } \
+    }
+
 struct DummyTest : public ::testing::Test {
   virtual void TestBody() CV_OVERRIDE {}
 };
@@ -122,6 +131,7 @@ struct DummyTest : public ::testing::Test {
      private:\
       virtual void TestBody() CV_OVERRIDE;\
       virtual void Body(); \
+      virtual void SetUp() CV_OVERRIDE; \
       static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;\
       GTEST_DISALLOW_COPY_AND_ASSIGN_(\
           GTEST_TEST_CLASS_NAME_(test_fixture, test_name));\
@@ -148,6 +158,7 @@ struct DummyTest : public ::testing::Test {
             test_fixture::TearDownTestCase, \
             new test_fixture##test_name##_factory);\
     void GTEST_TEST_CLASS_NAME_(test_fixture, test_name)::TestBody() CV__TEST_BODY_IMPL( #test_fixture "_" #test_name ) \
+    void GTEST_TEST_CLASS_NAME_(test_fixture, test_name)::SetUp() CV__TEST_SETUP_IMPL(test_fixture) \
     void GTEST_TEST_CLASS_NAME_(test_fixture, test_name)::Body()
 
 // Don't use directly

--- a/modules/ts/src/ts_tags.cpp
+++ b/modules/ts/src/ts_tags.cpp
@@ -11,7 +11,7 @@ namespace cvtest {
 static bool printTestTag = false;
 
 static std::vector<std::string> currentDirectTestTags, currentImpliedTestTags;
-static std::vector<const ::testing::TestInfo*> skipped_tests;
+static std::vector<const ::testing::TestCase*> skipped_tests;
 
 static std::map<std::string, int>& getTestTagsSkipCounts()
 {
@@ -26,7 +26,7 @@ static std::map<std::string, int>& getTestTagsSkipExtraCounts()
 void testTagIncreaseSkipCount(const std::string& tag, bool isMain, bool appendSkipTests)
 {
     if (appendSkipTests)
-        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
+        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
     std::map<std::string, int>& counts = isMain ? getTestTagsSkipCounts() : getTestTagsSkipExtraCounts();
     std::map<std::string, int>::iterator i = counts.find(tag);
     if (i == counts.end())
@@ -280,6 +280,11 @@ static bool isTestTagSkipped(const std::string& testTag, CV_OUT std::string& ski
 
 void checkTestTags()
 {
+    if (std::find(skipped_tests.begin(), skipped_tests.end(),
+                  ::testing::UnitTest::GetInstance()->current_test_case()) != skipped_tests.end()) {
+        throw details::SkipTestExceptionBase(false);
+    }
+
     std::string skipTag;
     const std::vector<std::string>& testTags = currentDirectTestTags;
     {
@@ -307,7 +312,7 @@ void checkTestTags()
             }
             if (found != tags.size())
             {
-                skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
+                skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
                 throw details::SkipTestExceptionBase("Test tags don't pass required tags list (--test_tag parameter)", true);
             }
         }
@@ -341,7 +346,7 @@ void checkTestTags()
 
     if (!skip_message.empty())
     {
-        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
+        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
         throw details::SkipTestExceptionBase(skip_message, true);
     }
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

In case of `SkipTestException` throws in the fixture's constructor, test should be skipped. Reproducer added to `core` module tests.

related: https://github.com/opencv/opencv/pull/24157

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Win64 OpenCL
```