### PR TITLE
Moved cmake compile definitions to cvconfig.h

### DIFF
--- a/cmake/OpenCVDetectFlatbuffers.cmake
+++ b/cmake/OpenCVDetectFlatbuffers.cmake
@@ -2,7 +2,7 @@ if(WITH_FLATBUFFERS)
   set(HAVE_FLATBUFFERS 1)
   set(flatbuffers_VERSION "23.5.9")
   ocv_install_3rdparty_licenses(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/LICENSE.txt")
-  ocv_add_external_target(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/include" "" "HAVE_FLATBUFFERS=1")
+  ocv_add_external_target(flatbuffers "${OpenCV_SOURCE_DIR}/3rdparty/flatbuffers/include" "" "")
   set(CUSTOM_STATUS_flatbuffers "    Flatbuffers:" "builtin/3rdparty (${flatbuffers_VERSION})")
 endif()
 

--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -152,4 +152,8 @@
 /* Library QR-code decoding */
 #cmakedefine HAVE_QUIRC
 
+#cmakedefine HAVE_ANDROID_MEDIANDK
+
+#cmakedefine HAVE_FLATBUFFERS
+
 #endif // OPENCV_CVCONFIG_H_INCLUDED

--- a/modules/videoio/cmake/detect_android_mediandk.cmake
+++ b/modules/videoio/cmake/detect_android_mediandk.cmake
@@ -2,5 +2,5 @@
 if(ANDROID AND ANDROID_NATIVE_API_LEVEL GREATER 20)
   set(HAVE_ANDROID_MEDIANDK TRUE)
   set(libs "-landroid -llog -lmediandk")
-  ocv_add_external_target(android_mediandk "" "${libs}" "HAVE_ANDROID_MEDIANDK")
+  ocv_add_external_target(android_mediandk "" "${libs}" "")
 endif()

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -6,6 +6,8 @@
 
 #include "videoio_registry.hpp"
 
+#include "cvconfig.h"
+
 #include "opencv2/videoio/registry.hpp"
 
 #include "opencv2/core/utils/filesystem.private.hpp" // OPENCV_HAVE_FILESYSTEM_SUPPORT


### PR DESCRIPTION
Moved HAVE_ANDROID_MEDIANDK and HAVE_FLATBUFFERS from cmake compile definitions to cvconfig.h so Android SDK can be converted to AAR library