### PR TITLE
Fixed bug with the last 4 bytes in MJPEG encoder

### DIFF
--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -268,7 +268,7 @@ public:
             m_buffer_list[0].finish();
 
             m_data_len = m_buffer_list[0].get_len();
-            m_last_bit_len = m_buffer_list[0].get_bits_free() ? 32 - m_buffer_list[0].get_bits_free() : 0;
+            m_last_bit_len = 32 - m_buffer_list[0].get_bits_free();
 
             return m_buffer_list[0].get_data();
         }
@@ -331,9 +331,14 @@ public:
         }
 
         //bits == 0 means that last element shouldn't be used.
-        m_output_buffer[m_data_len++] = currval;
-
-        m_last_bit_len = -bits;
+        if (bits != 0) {
+            m_output_buffer[m_data_len++] = currval;
+            m_last_bit_len = -bits;
+        }
+        else
+        {
+            m_last_bit_len = 32;
+        }
 
         return &m_output_buffer[0];
     }
@@ -1167,8 +1172,6 @@ public:
         fdct_qtab(_fdct_qtab),
         cat_table(_cat_table)
     {
-#if 0  // disable parallel processing due to buffer overrun bug: https://github.com/opencv/opencv/issues/19634
-
         //empirically found value. if number of pixels is less than that value there is no sense to parallelize it.
         const int min_pixels_count = 96*96;
 
@@ -1193,12 +1196,6 @@ public:
         int max_stripes = (height - 1)/y_step + 1;
 
         stripes_count = std::min(stripes_count, max_stripes);
-
-#else
-        if (nstripes > 1)
-            CV_LOG_ONCE_WARNING(NULL, "VIDEOIO/MJPEG: parallel processing is disabled: https://github.com/opencv/opencv/issues/19634");
-        stripes_count = 1;
-#endif
 
         m_buffer_list.allocate_buffers(stripes_count, (height*width*2)/stripes_count);
     }


### PR DESCRIPTION
resolves #19634
resolves #24171
Enabled parallel processing, that was temporary disabled in #19812 because of the issue #19634
