### PR TITLE
Added CMake configuration OPENCV_DNN_BACKEND_DEFAULT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1672,6 +1672,10 @@ else()
   endif()
 endif()
 
+if(BUILD_opencv_dnn)
+    status("    Default DNN backend:" ${OPENCV_DNN_BACKEND_DEFAULT})
+endif()
+
 if(WITH_EIGEN OR HAVE_EIGEN)
   status("    Eigen:"      HAVE_EIGEN       THEN "YES (ver ${EIGEN_WORLD_VERSION}.${EIGEN_MAJOR_VERSION}.${EIGEN_MINOR_VERSION})" ELSE NO)
 endif()

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -227,6 +227,9 @@ if(TARGET ocv.3rdparty.openvino AND OPENCV_DNN_OPENVINO)
   endif()
 endif()
 
+set(OPENCV_DNN_BACKEND_DEFAULT "DNN_BACKEND_OPENCV" CACHE STRING "Default backend used by the DNN module")
+ocv_append_source_file_compile_definitions("${CMAKE_CURRENT_LIST_DIR}/src/dnn_params.cpp" "OPENCV_DNN_BACKEND_DEFAULT=${OPENCV_DNN_BACKEND_DEFAULT}")
+
 
 ocv_install_used_external_targets(${libs} ${dnn_runtime_libs})
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -69,9 +69,7 @@ CV__DNN_INLINE_NS_BEGIN
      */
     enum Backend
     {
-        //! DNN_BACKEND_DEFAULT equals to DNN_BACKEND_INFERENCE_ENGINE if
-        //! OpenCV is built with Intel OpenVINO or
-        //! DNN_BACKEND_OPENCV otherwise.
+        //! DNN_BACKEND_DEFAULT equals to OPENCV_DNN_BACKEND_DEFAULT, which can be defined using CMake or a configuration parameter
         DNN_BACKEND_DEFAULT = 0,
         DNN_BACKEND_HALIDE,
         DNN_BACKEND_INFERENCE_ENGINE,            //!< Intel OpenVINO computational backend
@@ -688,9 +686,6 @@ CV__DNN_INLINE_NS_BEGIN
          * @brief Ask network to use specific computation backend where it supported.
          * @param[in] backendId backend identifier.
          * @see Backend
-         *
-         * If OpenCV is compiled with Intel's Inference Engine library, DNN_BACKEND_DEFAULT
-         * means DNN_BACKEND_INFERENCE_ENGINE. Otherwise it equals to DNN_BACKEND_OPENCV.
          */
         CV_WRAP void setPreferableBackend(int backendId);
 

--- a/modules/dnn/src/dnn_params.cpp
+++ b/modules/dnn/src/dnn_params.cpp
@@ -36,7 +36,7 @@ bool getParam_DNN_OPENCL_ALLOW_ALL_DEVICES()
 int getParam_DNN_BACKEND_DEFAULT()
 {
     static int PARAM_DNN_BACKEND_DEFAULT = (int)utils::getConfigurationParameterSizeT("OPENCV_DNN_BACKEND_DEFAULT",
-            (size_t)DNN_BACKEND_OPENCV
+            (size_t)OPENCV_DNN_BACKEND_DEFAULT
     );
     return PARAM_DNN_BACKEND_DEFAULT;
 }


### PR DESCRIPTION
Until some recent changes were made, OpenCV selected the default DNN backend either as `DNN_BACKEND_INFERENCE_ENGINE`, if available, or `DNN_BACKEND_OPENCV`, otherwise. Recently, this was removed because OpenCV supports multiple plugins/backends, as discussed in #24085.

This patch has two aims: First, fix the documentation since there is no extended default backend logic anymore. Next, it introduces a CMake variable `OPENCV_DNN_BACKEND_DEFAULT` that can be used to define a user-specific default backend. If this is not set, it defaults to `DNN_BACKEND_OPENCV`. Still, compiling with OpenVINO/Inference Engine support allows to default to it by adding the CMake argument `-D "OPENCV_DNN_BACKEND_DEFAULT=DNN_BACKEND_INFERENCE_ENGINE"`. Selecting a different default backend is similarly possible, only define `OPENCV_DNN_BACKEND_DEFAULT` accordingly (e.g. for CUDA). In any case, defining a configuration parameter (e.g. as an environment variable) overrules the compiled-in default such that no existing logic is changed.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
