### PR TITLE
Increase the test threshold of FastRCNN_vgg166 and FastRCNN_zf when FAST_MATH enable

### DIFF
--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -731,7 +731,7 @@ TEST_P(Test_Caffe_nets, FasterRCNN_vgg16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
 
-    double scoreDiff = 0.0, iouDiff = 0.0;
+    double scoreDiff = 0.001, iouDiff = 0.03;
 #if defined(INF_ENGINE_RELEASE)
     if (target == DNN_TARGET_MYRIAD)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
@@ -779,7 +779,7 @@ TEST_P(Test_Caffe_nets, FasterRCNN_zf)
                                            0, 7, 0.988779, 469.849, 75.1756, 718.64, 186.762,
                                            0, 12, 0.967198, 138.588, 206.843, 329.766, 553.176);
 
-    double scoreDiff = 0.0, iouDiff = 0.0;
+    double scoreDiff = 0.003, iouDiff = 0.07;
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) {
         scoreDiff = 0.02;
         iouDiff = 0.13;


### PR DESCRIPTION
This PR is used to finish https://github.com/opencv/opencv/issues/24016 and https://github.com/opencv/opencv/issues/24017

When enable the `FAST MATH` option, the accuracy will drop a little, but the results are still acceptable. So I change the threshold that make test can pass on Ubuntu. The results visualization are below.

**FasterRCNN_vgg16**
| Real | Excepted|
|-|-|
|![real vgg](https://github.com/opencv/opencv/assets/49567307/c15cc69b-4a96-42a9-a113-e64669512b41)|![excepted vgg](https://github.com/opencv/opencv/assets/49567307/0461445e-27c5-452e-aa25-14aecd81160e)|

**detail**


  | real score | expected score | score diff | IoU
-- | -- | -- | -- | --
CAR | 0.997029 | 0.997022 | 7E-06 | 0.970774
DOG | 0.993107 | 0.993028 | 7.9E-05 | 0.976928
BICYCLE | 0.9484 | 0.949398 | 0.000998 | 0.993465





**FasterRCNN_zf**
| Real | Excepted|
|--|--|
|![real zf](https://github.com/opencv/opencv/assets/49567307/925bf2ed-294f-4862-816e-8198790d82ce)|![excepted zf](https://github.com/opencv/opencv/assets/49567307/7a0ef8f0-c882-4da3-ac5f-a3504a3b93ab)|

**detail**


  | real score | expected score | score diff | IoU
-- | -- | -- | -- | --
CAR | 0.986261 | 0.988779 | 0.002518 | 0.938888
DOG | 0.967198 | 0.967198 | 0 | 0.999996
BICYCLE | 0.901209 | 0.90121 | 1E-06 | 0.999997



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
