### PR TITLE
Revert PR 24186 as it forces skipping tests

### DIFF
--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -917,41 +917,5 @@ REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows);
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
-// Expected that SkipTestException thrown in the constructor should skip test but not fail
-struct TestFixtureSkip: public ::testing::Test {
-    TestFixtureSkip(bool throwEx = true) {
-        if (throwEx) {
-            throw SkipTestException("Skip test at constructor");
-        }
-    }
-};
-
-TEST_F(TestFixtureSkip, NoBodyRun) {
-    FAIL() << "Unreachable code called";
-}
-
-// Check no test body started in case of skip exception at static SetUpTestCase
-struct TestSetUpTestCaseSkip: public ::testing::Test {
-    static void SetUpTestCase() {
-        throw SkipTestException("Skip test at SetUpTestCase");
-    }
-};
-
-TEST_F(TestSetUpTestCaseSkip, NoBodyRun) {
-    FAIL() << "Unreachable code called";
-}
-TEST_F(TestSetUpTestCaseSkip, NoBodyRun2) {
-    FAIL() << "Unreachable code called";
-}
-
-struct TestSetUpSkip: public ::testing::Test {
-    virtual void SetUp() {
-        throw SkipTestException("Skip test at SetUp");
-    }
-};
-
-TEST_F(TestSetUpSkip, NoBodyRun) {
-    FAIL() << "Unreachable code called";
-}
 
 }} // namespace

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -36,8 +36,6 @@ class NewOpenCVTests(unittest.TestCase):
                     return candidate
         if required:
             self.fail('File ' + filename + ' not found')
-        else:
-            self.skipTest('File ' + filename + ' not found')
         return None
 
 

--- a/modules/ts/src/ts_tags.cpp
+++ b/modules/ts/src/ts_tags.cpp
@@ -11,7 +11,7 @@ namespace cvtest {
 static bool printTestTag = false;
 
 static std::vector<std::string> currentDirectTestTags, currentImpliedTestTags;
-static std::vector<const ::testing::TestCase*> skipped_tests;
+static std::vector<const ::testing::TestInfo*> skipped_tests;
 
 static std::map<std::string, int>& getTestTagsSkipCounts()
 {
@@ -26,7 +26,7 @@ static std::map<std::string, int>& getTestTagsSkipExtraCounts()
 void testTagIncreaseSkipCount(const std::string& tag, bool isMain, bool appendSkipTests)
 {
     if (appendSkipTests)
-        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
+        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
     std::map<std::string, int>& counts = isMain ? getTestTagsSkipCounts() : getTestTagsSkipExtraCounts();
     std::map<std::string, int>::iterator i = counts.find(tag);
     if (i == counts.end())
@@ -280,11 +280,6 @@ static bool isTestTagSkipped(const std::string& testTag, CV_OUT std::string& ski
 
 void checkTestTags()
 {
-    if (std::find(skipped_tests.begin(), skipped_tests.end(),
-                  ::testing::UnitTest::GetInstance()->current_test_case()) != skipped_tests.end()) {
-        throw details::SkipTestExceptionBase(false);
-    }
-
     std::string skipTag;
     const std::vector<std::string>& testTags = currentDirectTestTags;
     {
@@ -312,7 +307,7 @@ void checkTestTags()
             }
             if (found != tags.size())
             {
-                skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
+                skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
                 throw details::SkipTestExceptionBase("Test tags don't pass required tags list (--test_tag parameter)", true);
             }
         }
@@ -346,7 +341,7 @@ void checkTestTags()
 
     if (!skip_message.empty())
     {
-        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_case());
+        skipped_tests.push_back(::testing::UnitTest::GetInstance()->current_test_info());
         throw details::SkipTestExceptionBase(skip_message, true);
     }
 }


### PR DESCRIPTION
Reverts https://github.com/opencv/opencv/pull/24186

Current test skipping issue:
```
./bin/opencv_test_dnn --gtest_filter=Test_Caffe_layers*
...
[       OK ] Test_Caffe_layers.DeConvolution/3 (3 ms)
[ RUN      ] Test_Caffe_layers.InnerProduct/0, where GetParam() = NGRAPH/CPU
[       OK ] Test_Caffe_layers.InnerProduct/0 (8 ms)
[ RUN      ] Test_Caffe_layers.InnerProduct/1, where GetParam() = OCV/OCL
[       OK ] Test_Caffe_layers.InnerProduct/1 (4 ms)
[ RUN      ] Test_Caffe_layers.InnerProduct/2, where GetParam() = OCV/OCL_FP16
[     SKIP ] Test with tag 'dnn_skip_ocl_fp16' is skipped ('dnn_skip_ocl_fp16' is in skip list)
[       OK ] Test_Caffe_layers.InnerProduct/2 (0 ms)
[ RUN      ] Test_Caffe_layers.InnerProduct/3, where GetParam() = OCV/CPU
[     SKIP ] 
[       OK ] Test_Caffe_layers.InnerProduct/3 (0 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/0, where GetParam() = NGRAPH/CPU
[     SKIP ] 
[       OK ] Test_Caffe_layers.Pooling_max/0 (0 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/1, where GetParam() = OCV/OCL
[     SKIP ] 
[       OK ] Test_Caffe_layers.Pooling_max/1 (0 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/2, where GetParam() = OCV/OCL_FP16
[     SKIP ] 
[       OK ] Test_Caffe_layers.Pooling_max/2 (0 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/3, where GetParam() = OCV/CPU
[     SKIP ] 
[       OK ] Test_Caffe_layers.Pooling_max/3 (0 ms)
```
All further tests are skipped.

More focused test invocation works well:
```
./bin/opencv_test_dnn --gtest_filter=Test_Caffe_layers.Pooling_max*
...
[ RUN      ] Test_Caffe_layers.Pooling_max/0, where GetParam() = NGRAPH/CPU
[       OK ] Test_Caffe_layers.Pooling_max/0 (23 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/1, where GetParam() = OCV/OCL
[       OK ] Test_Caffe_layers.Pooling_max/1 (4 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/2, where GetParam() = OCV/OCL_FP16
[       OK ] Test_Caffe_layers.Pooling_max/2 (2 ms)
[ RUN      ] Test_Caffe_layers.Pooling_max/3, where GetParam() = OCV/CPU
[       OK ] Test_Caffe_layers.Pooling_max/3 (1 ms)
[----------] 4 tests from Test_Caffe_layers (30 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (30 ms total)
[  PASSED  ] 4 tests.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
