### PR TITLE
Added test with V4L CAP_PROP_CONVERT_RGB=false.

### DIFF
--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -223,6 +223,35 @@ TEST(DISABLED_videoio_camera, v4l_read_framesize)
     capture.release();
 }
 
+TEST(DISABLED_videoio_camera, v4l_rgb_convert)
+{
+    VideoCapture capture(CAP_V4L2);
+    ASSERT_TRUE(capture.isOpened());
+    std::cout << "Camera 0 via " << capture.getBackendName() << " backend" << std::endl;
+    std::cout << " Frame width: " << capture.get(CAP_PROP_FRAME_WIDTH) << std::endl;
+    std::cout << "      height: " << capture.get(CAP_PROP_FRAME_HEIGHT) << std::endl;
+    std::cout << "Pixel format: " << capture.get(cv::CAP_PROP_FORMAT) << std::endl;
+    if (capture.get(CAP_PROP_FOURCC) != VideoWriter::fourcc('Y', 'U', 'Y', 'V'))
+    {
+        throw SkipTestException("Camera does not support YUYV format");
+    }
+    capture.set(cv::CAP_PROP_CONVERT_RGB, 0);
+    std::cout << "New pixel format: " << capture.get(cv::CAP_PROP_FORMAT) << std::endl;
+
+    cv::Mat frame;
+    for (int i = 0; i < 10; i++)
+    {
+        int pixel_type  = (int)capture.get(cv::CAP_PROP_FORMAT);
+        int channels    = CV_MAT_CN(pixel_type);
+        int pixel_bytes = CV_ELEM_SIZE(pixel_type);
+
+        // YUYV is expected for most of popular USB cam (COLOR_YUV2BGR_YUYV conversion)
+        EXPECT_EQ(2, channels);
+        EXPECT_EQ(2, pixel_bytes);
+
+        capture >> frame;
+    }
+}
 
 static
 utils::Paths getTestCameras()


### PR DESCRIPTION
Test for https://github.com/opencv/opencv/pull/24180

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
