### PR TITLE
fix type cast in drawDetectedMarkers, drawDetectedCornersCharuco, drawDetectedDiamonds

### DIFF
--- a/modules/objdetect/misc/python/test/test_objdetect_aruco.py
+++ b/modules/objdetect/misc/python/test/test_objdetect_aruco.py
@@ -394,5 +394,69 @@ class aruco_objdetect_test(NewOpenCVTests):
         self.assertEqual(2, img_points.shape[2])
         np.testing.assert_array_equal(chessboard_corners, obj_points[:, :, :2].reshape(-1, 2))
 
+    def test_draw_detected_markers(self):
+        detected_points = [[[10, 10], [50, 10], [50, 50], [10, 50]]]
+        img = np.zeros((60, 60), dtype=np.uint8)
+
+        # add extra dimension in Python to create Nx4 Mat with 2 channels
+        points1 = np.array(detected_points).reshape(-1, 4, 1, 2)
+        img = cv.aruco.drawDetectedMarkers(img, points1, borderColor=255)
+
+        # check that the marker borders are painted
+        contours, _ = cv.findContours(img, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(img[10, 10], 255)
+        self.assertEqual(img[50, 10], 255)
+        self.assertEqual(img[50, 50], 255)
+        self.assertEqual(img[10, 50], 255)
+
+        # must throw Exception without extra dimension
+        points2 = np.array(detected_points)
+        with self.assertRaises(Exception):
+            img = cv.aruco.drawDetectedMarkers(img, points2, borderColor=255)
+
+    def test_draw_detected_charuco(self):
+        detected_points = [[[10, 10], [50, 10], [50, 50], [10, 50]]]
+        img = np.zeros((60, 60), dtype=np.uint8)
+
+        # add extra dimension in Python to create Nx1 Mat with 2 channels
+        points = np.array(detected_points).reshape(-1, 1, 2)
+        img = cv.aruco.drawDetectedCornersCharuco(img, points, cornerColor=255)
+
+        # check that the 4 charuco corners are painted
+        contours, _ = cv.findContours(img, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+        self.assertEqual(len(contours), 4)
+        for contour in contours:
+            center_x = round(np.average(contour[:, 0, 0]))
+            center_y = round(np.average(contour[:, 0, 1]))
+            center = [center_x, center_y]
+            self.assertTrue(center in detected_points[0])
+
+        # must throw Exception without extra dimension
+        points2 = np.array(detected_points)
+        with self.assertRaises(Exception):
+            img = cv.aruco.drawDetectedCornersCharuco(img, points2, borderColor=255)
+
+    def test_draw_detected_diamonds(self):
+        detected_points = [[[10, 10], [50, 10], [50, 50], [10, 50]]]
+        img = np.zeros((60, 60), dtype=np.uint8)
+
+        # add extra dimension in Python to create Nx4 Mat with 2 channels
+        points = np.array(detected_points).reshape(-1, 4, 1, 2)
+        img = cv.aruco.drawDetectedDiamonds(img, points, borderColor=255)
+
+        # check that the diamonds borders are painted
+        contours, _ = cv.findContours(img, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(img[10, 10], 255)
+        self.assertEqual(img[50, 10], 255)
+        self.assertEqual(img[50, 50], 255)
+        self.assertEqual(img[10, 50], 255)
+
+        # must throw Exception without extra dimension
+        points2 = np.array(detected_points)
+        with self.assertRaises(Exception):
+            img = cv.aruco.drawDetectedDiamonds(img, points2, borderColor=255)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -1315,24 +1315,26 @@ void drawDetectedMarkers(InputOutputArray _image, InputArrayOfArrays _corners,
     int nMarkers = (int)_corners.total();
     for(int i = 0; i < nMarkers; i++) {
         Mat currentMarker = _corners.getMat(i);
-        CV_Assert(currentMarker.total() == 4 && currentMarker.type() == CV_32FC2);
+        CV_Assert(currentMarker.total() == 4 && currentMarker.channels() == 2);
+        if (currentMarker.type() != CV_32SC2)
+            currentMarker.convertTo(currentMarker, CV_32SC2);
 
         // draw marker sides
         for(int j = 0; j < 4; j++) {
-            Point2f p0, p1;
-            p0 = currentMarker.ptr<Point2f>(0)[j];
-            p1 = currentMarker.ptr<Point2f>(0)[(j + 1) % 4];
+            Point p0, p1;
+            p0 = currentMarker.ptr<Point>(0)[j];
+            p1 = currentMarker.ptr<Point>(0)[(j + 1) % 4];
             line(_image, p0, p1, borderColor, 1);
         }
         // draw first corner mark
-        rectangle(_image, currentMarker.ptr<Point2f>(0)[0] - Point2f(3, 3),
-                  currentMarker.ptr<Point2f>(0)[0] + Point2f(3, 3), cornerColor, 1, LINE_AA);
+        rectangle(_image, currentMarker.ptr<Point>(0)[0] - Point(3, 3),
+                  currentMarker.ptr<Point>(0)[0] + Point(3, 3), cornerColor, 1, LINE_AA);
 
         // draw ID
         if(_ids.total() != 0) {
-            Point2f cent(0, 0);
+            Point cent(0, 0);
             for(int p = 0; p < 4; p++)
-                cent += currentMarker.ptr<Point2f>(0)[p];
+                cent += currentMarker.ptr<Point>(0)[p];
             cent = cent / 4.;
             stringstream s;
             s << "id=" << _ids.getMat().ptr<int>(0)[i];


### PR DESCRIPTION
- drawDetectedMarkers(), drawDetectedCornersCharuco(), drawDetectedDiamonds() uses only `Point2f` (`CV_32FC2`) for detected corners. But this corners are casted to `int` later in the code.
- drawDetectedMarkers(), drawDetectedDiamonds() has a requirement on CV_32FC2 for corners. This requirement is lost in drawDetectedCornersCharuco().

Strict input data requirements have been removed. Added only the requirement to have 2 channels. The input corners are then casted to CV_32SC2.

added tests


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
