### PR TITLE
[DOC] Complete documentation for calcOpticalFlowFarneback

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -186,7 +186,7 @@ CV_EXPORTS_W void calcOpticalFlowPyrLK( InputArray prevImg, InputArray nextImg,
 
 @param prev first 8-bit single-channel input image.
 @param next second input image of the same size and the same type as prev.
-@param flow computed flow image that has the same size as prev and type CV_32FC2.
+@param flow computed flow image that is a UMat with the same size as prev and type CV_32FC2.
 @param pyr_scale parameter, specifying the image scale (\<1) to build pyramids for each image;
 pyr_scale=0.5 means a classical pyramid, where each next layer is twice smaller than the previous
 one.
@@ -205,7 +205,7 @@ good value would be poly_sigma=1.5.
  -   **OPTFLOW_USE_INITIAL_FLOW** uses the input flow as an initial flow approximation.
  -   **OPTFLOW_FARNEBACK_GAUSSIAN** uses the Gaussian \f$\texttt{winsize}\times\texttt{winsize}\f$
      filter instead of a box filter of the same size for optical flow estimation; usually, this
-     option gives z more accurate flow than with a box filter, at the cost of lower speed;
+     option gives a more accurate flow than with a box filter, at the cost of lower speed;
      normally, winsize for a Gaussian window should be set to a larger value to achieve the same
      level of robustness.
 


### PR DESCRIPTION
### Description

When argument `flow` is a cv::Mat, function [calcOpticalFlowFarneback](https://github.com/opencv/opencv/blob/4.x/modules/video/src/optflowgf.cpp#L1194) raises an `ipp::IwException at memory location ...`

This happens because this [function](https://github.com/opencv/opencv/blob/4.x/modules/video/src/optflowgf.cpp#L1098) checks if input is a cv::UMat.

This PR simply completes documentation for argument `flow`.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
