### PR TITLE
Fix undefined behavior arithmetic in copyMakeBorder and adjustROI.

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -860,14 +860,14 @@ void copyMakeBorder_8u( const uchar* src, size_t srcstep, cv::Size srcroi,
     }
 
     dstroi.width *= elemSize;
-    dst += dststep*top;
 
     for( i = 0; i < top; i++ )
     {
         j = cv::borderInterpolate(i - top, srcroi.height, borderType);
-        memcpy(dst + (i - top)*dststep, dst + j*dststep, dstroi.width);
+        memcpy(dst + i*dststep, dst + (top+j)*dststep, dstroi.width);
     }
 
+    dst += dststep*top;
     for( i = 0; i < bottom; i++ )
     {
         j = cv::borderInterpolate(i + srcroi.height, srcroi.height, borderType);

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1128,7 +1128,7 @@ Mat& Mat::adjustROI( int dtop, int dbottom, int dleft, int dright )
     if(col1 > col2)
         std::swap(col1, col2);
 
-    data += (row1 - ofs.y)*(int64_t)step + (col1 - ofs.x)*(int64_t)esz;
+    data += (row1 - ofs.y)*(std::ptrdiff_t)step + (col1 - ofs.x)*(std::ptrdiff_t)esz;
     rows = row2 - row1; cols = col2 - col1;
     size.p[0] = rows; size.p[1] = cols;
     updateContinuityFlag();

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1128,7 +1128,7 @@ Mat& Mat::adjustROI( int dtop, int dbottom, int dleft, int dright )
     if(col1 > col2)
         std::swap(col1, col2);
 
-    data += (row1 - ofs.y)*step + (col1 - ofs.x)*esz;
+    data += (row1 - ofs.y)*(int64_t)step + (col1 - ofs.x)*(int64_t)esz;
     rows = row2 - row1; cols = col2 - col1;
     size.p[0] = rows; size.p[1] = cols;
     updateContinuityFlag();

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1370,8 +1370,14 @@ TEST(Core_Mat, copyNx1ToVector)
 
 TEST(Core_Mat, copyMakeBoderUndefinedBehavior)
 {
-    cv::Mat1b src = cv::Mat1b::zeros(4,4), dst;
-    cv::copyMakeBorder(src, dst, 2, 2, 2, 2, 4);
+    Mat1b src(4, 4), dst;
+    randu(src, Scalar(10), Scalar(100));
+    // This could trigger a (signed int)*size_t operation which is undefined behavior.
+    cv::copyMakeBorder(src, dst, 1, 1, 1, 1, cv::BORDER_REFLECT_101);
+    EXPECT_EQ(0, cv::norm(src.row(1), dst(Rect(1,0,4,1))));
+    EXPECT_EQ(0, cv::norm(src.row(2), dst(Rect(1,5,4,1))));
+    EXPECT_EQ(0, cv::norm(src.col(1), dst(Rect(0,1,1,4))));
+    EXPECT_EQ(0, cv::norm(src.col(2), dst(Rect(5,1,1,4))));
 }
 
 TEST(Core_Matx, fromMat_)

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1368,6 +1368,12 @@ TEST(Core_Mat, copyNx1ToVector)
     ASSERT_PRED_FORMAT2(cvtest::MatComparator(0, 0), ref_dst16, cv::Mat_<ushort>(dst16));
 }
 
+TEST(Core_Mat, copyMakeBoderUndefinedBehavior)
+{
+    cv::Mat1b src = cv::Mat1b::zeros(4,4), dst;
+    cv::copyMakeBorder(src, dst, 2, 2, 2, 2, 4);
+}
+
 TEST(Core_Matx, fromMat_)
 {
     Mat_<double> a = (Mat_<double>(2,2) << 10, 11, 12, 13);

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1379,6 +1379,13 @@ TEST(MatTestRoi, adjustRoiOverflow)
     ASSERT_EQ(roi.rows, m.rows);
 }
 
+TEST(MatTestRoi, adjustRoiUndefinedBehavior)
+{
+    Mat m(6, 6, CV_8U);
+    Mat roi(m, cv::Range(2, 4), cv::Range(2, 4));
+    // This could trigger a (negative int)*size_t which is undefined behavior.
+    roi.adjustROI(2, 2, 2, 2);
+}
 
 CV_ENUM(SortRowCol, SORT_EVERY_COLUMN, SORT_EVERY_ROW)
 CV_ENUM(SortOrder, SORT_ASCENDING, SORT_DESCENDING)

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1383,8 +1383,10 @@ TEST(MatTestRoi, adjustRoiUndefinedBehavior)
 {
     Mat m(6, 6, CV_8U);
     Mat roi(m, cv::Range(2, 4), cv::Range(2, 4));
-    // This could trigger a (negative int)*size_t which is undefined behavior.
+    // This could trigger a (negative int)*size_t when updating data,
+    // which is undefined behavior.
     roi.adjustROI(2, 2, 2, 2);
+    EXPECT_EQ(m.data, roi.data);
 }
 
 CV_ENUM(SortRowCol, SORT_EVERY_COLUMN, SORT_EVERY_ROW)


### PR DESCRIPTION
This is due to the undefined: negative int multiplied by size_t pointer increment.

To test, compile with:
```
mkdir build
cd build
cmake ../ -DCMAKE_C_FLAGS_INIT="-fsanitize=undefined" -DCMAKE_CXX_FLAGS_INIT="-fsanitize=undefined" -DCMAKE_C_COMPILER="/usr/bin/clang" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=undefined -lubsan"
```
And run:
```
make -j opencv_test_core && ./bin/opencv_test_core --gtest_filter=*UndefinedBehavior*
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
