### PR TITLE
RISC-V: fix compilation in RVV scalable mode

### DIFF
--- a/modules/3d/src/pointcloud/utils.hpp
+++ b/modules/3d/src/pointcloud/utils.hpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <array>
 #include <algorithm>
+#include <cstdint>
 
 
 namespace cv {

--- a/modules/3d/src/ptcloud/sampling.cpp
+++ b/modules/3d/src/ptcloud/sampling.cpp
@@ -272,7 +272,7 @@ int farthestPointSampling(OutputArray sampled_point_flags, InputArray input_pts,
         float max_dist_square = 0;
         int next_pt = sampled_cnt;
         int i = sampled_cnt;
-#ifdef CV_SIMD
+#if CV_SIMD
         v_float32 v_last_p_x = vx_setall_f32(last_pt_x);
         v_float32 v_last_p_y = vx_setall_f32(last_pt_y);
         v_float32 v_last_p_z = vx_setall_f32(last_pt_z);

--- a/modules/3d/src/rgbd/tsdf_functions.hpp
+++ b/modules/3d/src/rgbd/tsdf_functions.hpp
@@ -41,11 +41,13 @@ struct RGBTsdfVoxel
 
 typedef Vec<uchar, sizeof(RGBTsdfVoxel)> VecRGBTsdfVoxel;
 
+#if CV_SIMD128
 inline v_float32x4 tsdfToFloat_INTR(const v_int32x4& num)
 {
     v_float32x4 num128 = v_setall_f32(-1.f / 128.f);
     return v_cvt_f32(num) * num128;
 }
+#endif
 
 inline TsdfType floatToTsdf(float num)
 {

--- a/modules/3d/src/usac/estimator.cpp
+++ b/modules/3d/src/usac/estimator.cpp
@@ -638,7 +638,7 @@ public:
             return errors_cache;
 
         int i = 0;
-#ifdef CV_SIMD
+#if CV_SIMD
         v_float32 v_a = vx_setall_f32(a);
         v_float32 v_b = vx_setall_f32(b);
         v_float32 v_c = vx_setall_f32(c);
@@ -718,7 +718,7 @@ public:
             return errors_cache;
 
         int i = 0;
-#ifdef CV_SIMD
+#if CV_SIMD
         v_float32 v_center_x = vx_setall_f32(center_x);
         v_float32 v_center_y = vx_setall_f32(center_y);
         v_float32 v_center_z = vx_setall_f32(center_z);

--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -720,7 +720,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_int32 vx_load_expand_q(const schar * ptr) { return VXPREFIX(_load_expand_q)(ptr); }
     //! @}
 
-    #ifndef OPENCV_HAL_HAVE_LOAD_STORE_BFLOAT16
+    #ifndef OPENCV_HAL_HAVE_PACK_STORE_BFLOAT16
     inline v_float32 vx_load_expand(const bfloat16_t* ptr)
     {
         v_uint32 v = vx_load_expand((const ushort*)ptr);
@@ -730,7 +730,7 @@ namespace CV__SIMD_NAMESPACE {
     inline void v_pack_store(const bfloat16_t* ptr, const v_float32& v)
     {
         v_int32 iv = v_shr<16>(v_reinterpret_as_s32(v));
-        v_pack_store((short*)ptr, iv);
+        cv::v_pack_store((short*)ptr, iv);
     }
 
     #endif
@@ -967,6 +967,9 @@ namespace CV__SIMD_NAMESPACE {
         OPENCV_HAL_WRAP_CMP(v_float64x4)
         #endif
     #endif
+    OPENCV_HAL_WRAP_CMP_OP(v_int64, lt, <) \
+    OPENCV_HAL_WRAP_CMP_OP(v_int64, gt, >) \
+
 
     //////////// get0 ////////////
     #define OPENCV_HAL_WRAP_GRT0(_Tpvec) \
@@ -1110,7 +1113,7 @@ namespace CV__SIMD_NAMESPACE {
 #define CV_SIMD 0
 #endif
 
-#if (!defined CV_SIMD_64F) || (!CV_SIMD_64F)
+#if !CV_SIMD_64F && !CV_SIMD_SCALABLE_64F
 typedef struct v_float64 { int dummy; } v_float64;
 #endif
 


### PR DESCRIPTION
Tested with Clang 16 and GCC 13 (RISC-V RVV scalable variant). Also on x86_64 (default Ubuntu 22.04 GCC).

```
force_builders=Custom
build_image:Custom=riscv-clang-rvv
Xbuild_image:Custom=riscv-clang-rvv-128
Xbuild_image:Custom=riscv-gcc-rvv-07
test_modules:Custom=core,imgproc,dnn
buildworker:Custom=linux-1
test_timeout:Custom=600
build_contrib:Custom=OFF
```