### PR TITLE
Add missing sanitizer interface include

### DIFF
--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -66,6 +66,7 @@
 
 #if defined(__clang__) && defined(__has_feature)
 #if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
 #define CV_ANNOTATE_MEMORY_IS_INITIALIZED(address, size) \
 __msan_unpoison(address, size)
 #endif


### PR DESCRIPTION
Fixes a bunch of the following errors:
```
error: use of undeclared identifier '__msan_unpoison'
      CV_ANNOTATE_MEMORY_IS_INITIALIZED(w, sizeof(fptype) * std::min(m, n));
```