### PR TITLE
Fixed removePhaseSwitches in tf_graph_simplifier

### DIFF
--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -1120,15 +1120,16 @@ void removePhaseSwitches(tensorflow::GraphDef& net)
             inpName = inpName.substr(1 + (int)inpName.find('^'), inpName.rfind(':'));
             nodesMapIt = nodesMap.find(inpName);
             CV_Assert(nodesMapIt != nodesMap.end());
-
             int inpNodeId = nodesMapIt->second;
+
+            CV_CheckGT(numConsumers[inpNodeId], 0,
+                       "Input node of the current node should have at least one output node");
             if (numConsumers[inpNodeId] == 1)
             {
                 mergeOpSubgraphNodes.push(inpNodeId);
                 nodesToRemove.push_back(inpNodeId);
             }
-            else if (numConsumers[inpNodeId] > 0)
-                numConsumers[inpNodeId] -= 1;
+            numConsumers[inpNodeId] -= 1;
         }
     }
     std::sort(nodesToRemove.begin(), nodesToRemove.end());


### PR DESCRIPTION
Fixed removePhaseSwitches algorithm in tf_graph_simplifier.

The algorithm finds some specific nodes that should be removed. These nodes have input nodes which probably become useless. So there is a BFS-like algorithm that removes all these nodes. It has numConsumers map that keeps the current number of outputs for each node. The algorithm decreases some numComsumers values after each node deleting, but there is a mistake in this operation.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56435