### PR TITLE
build fixes for emscripten 3.1.45

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <cstring>
 #include <algorithm>
+#include <emscripten/version.h>
 #include "opencv2/core/saturate.hpp"
 
 #define CV_SIMD128 1

--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -89,9 +89,11 @@ using namespace cv;
 
 using namespace cv::segmentation;  // FIXIT
 
+#ifdef HAVE_OPENCV_OBJDETECT
 using namespace cv::aruco;
 typedef aruco::DetectorParameters aruco_DetectorParameters;
 typedef QRCodeDetectorAruco::Params QRCodeDetectorAruco_Params;
+#endif
 
 #ifdef HAVE_OPENCV_DNN
 using namespace cv::dnn;


### PR DESCRIPTION
Issue 1: emcc no longer provides implicit defines for the emscripten version, instead there's a separate header that provide them
Issue 2: disabling the objdetect module breaks the js build

Other than these small issues, OpenCV seems to work pretty well with the latest emscripten 👌. Not sure that the maintainers would like to do something with that information, like upgrade or something.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```
