### PR TITLE
Promote colorspace information from decoder public API

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -213,6 +213,9 @@ enum VideoCaptureProperties {
        CAP_PROP_N_THREADS = 70, //!< (**open-only**) Set the maximum number of threads to use. Use 0 to use as many threads as CPU cores (applicable for FFmpeg back-end only).
        CAP_PROP_PTS = 71, //!<  (read-only) FFmpeg back-end only - presentation timestamp of the most recently read frame using the FPS time base.  e.g. fps = 25, VideoCapture::get(\ref CAP_PROP_PTS) = 3, presentation time = 3/25 seconds.
        CAP_PROP_DTS_DELAY = 72, //!<  (read-only) FFmpeg back-end only - maximum difference between presentation (pts) and decompression timestamps (dts) using FPS time base.  e.g. delay is maximum when frame_num = 0, if true, VideoCapture::get(\ref CAP_PROP_PTS) = 0 and VideoCapture::get(\ref CAP_PROP_DTS_DELAY) = 2, dts = -2.  Non zero values usually imply the stream is encoded using B-frames which are not decoded in presentation order.
+       CAP_PROP_CODEC_COLOR_PRIMARIES = 73, //!< (read-only) Color primaries. See [AVCOL_PRI_*](https://github.com/FFmpeg/FFmpeg/blob/n8.0/libavutil/pixfmt.h)
+       CAP_PROP_CODEC_COLOR_TRANSFER = 74, //!< (read-only) Color Transfer Characteristic. See [AVCOL_TRC_*](https://github.com/FFmpeg/FFmpeg/blob/n8.0/libavutil/pixfmt.h)
+       CAP_PROP_CODEC_COLOR_RANGE = 75, //!< (read-only) Visual content value range. See [AVCOL_RANGE_*](https://github.com/FFmpeg/FFmpeg/blob/n8.0/libavutil/pixfmt.h)
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1973,11 +1973,17 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         frame.data = rgb_picture.data[0];
         frame.step = rgb_picture.linesize[0];
 
-        const int* colorspace_coeffs = sws_getCoefficients(sw_picture->colorspace);
-        sws_setColorspaceDetails(img_convert_ctx,
-                                 colorspace_coeffs, sw_picture->color_range,
-                                 colorspace_coeffs, convertRGB? 0: sw_picture->color_range,
-                                 0, 1<<16, 1<<16);
+        if (sw_picture->colorspace != AVCOL_SPC_UNSPECIFIED &&
+            (sw_picture->color_range == AVCOL_RANGE_MPEG || sw_picture->color_range == AVCOL_RANGE_JPEG))
+        {
+            // TODO: map AVColorSpace to SWS_CS_*
+            const int* colorspace_coeffs = sws_getCoefficients(sw_picture->colorspace);
+            int srcRange = sw_picture->color_range == AVCOL_RANGE_MPEG ? 0 : 1;
+            sws_setColorspaceDetails(img_convert_ctx,
+                                     colorspace_coeffs, srcRange,
+                                     colorspace_coeffs, convertRGB? 0 : srcRange,
+                                     0, 1<<16, 1<<16);
+        }
     }
 
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(6, 4, 100)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1972,6 +1972,12 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         frame.height = video_st->CV_FFMPEG_CODEC_FIELD->height;
         frame.data = rgb_picture.data[0];
         frame.step = rgb_picture.linesize[0];
+
+        const int* colorspace_coeffs = sws_getCoefficients(sw_picture->colorspace);
+        sws_setColorspaceDetails(img_convert_ctx,
+                                 colorspace_coeffs, sw_picture->color_range,
+                                 colorspace_coeffs, convertRGB? 0: sw_picture->color_range,
+                                 0, 1<<16, 1<<16);
     }
 
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(6, 4, 100)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1935,6 +1935,9 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         // Also we use coded_width/height to workaround problem with legacy ffmpeg versions (like n0.8)
         int buffer_width = context->coded_width, buffer_height = context->coded_height;
 
+#if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(8, 12 ,100)
+        img_convert_ctx = sws_alloc_context();
+#else
         img_convert_ctx = sws_getCachedContext(
                 img_convert_ctx,
                 buffer_width, buffer_height,
@@ -1954,6 +1957,9 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         rgb_picture.format = result_format;
         rgb_picture.width = buffer_width;
         rgb_picture.height = buffer_height;
+        // rgb_picture.color_range = AVCOL_RANGE_JPEG;
+        // rgb_picture.color_primaries = sw_picture->color_primaries;
+        // rgb_picture.color_trc = sw_picture->color_trc;
         if (0 != av_frame_get_buffer(&rgb_picture, 32))
         {
             CV_WARN("OutOfMemory");
@@ -1972,21 +1978,13 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         frame.height = video_st->CV_FFMPEG_CODEC_FIELD->height;
         frame.data = rgb_picture.data[0];
         frame.step = rgb_picture.linesize[0];
-
-        if (sw_picture->colorspace != AVCOL_SPC_UNSPECIFIED &&
-            (sw_picture->color_range == AVCOL_RANGE_MPEG || sw_picture->color_range == AVCOL_RANGE_JPEG))
-        {
-            // TODO: map AVColorSpace to SWS_CS_*
-            const int* colorspace_coeffs = sws_getCoefficients(sw_picture->colorspace);
-            int srcRange = sw_picture->color_range == AVCOL_RANGE_MPEG ? 0 : 1;
-            sws_setColorspaceDetails(img_convert_ctx,
-                                     colorspace_coeffs, srcRange,
-                                     colorspace_coeffs, convertRGB? 0 : srcRange,
-                                     0, 1<<16, 1<<16);
-        }
     }
+<<<<<<< HEAD
 
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(6, 4, 100)
+=======
+#if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(8, 12 ,100)
+>>>>>>> 69b751de8b (Try sws_scale_frame)
     sws_scale_frame(img_convert_ctx, &rgb_picture, sw_picture);
 #else
     sws_scale(

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1934,6 +1934,8 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         // Some sws_scale optimizations have some assumptions about alignment of data/step/width/height
         // Also we use coded_width/height to workaround problem with legacy ffmpeg versions (like n0.8)
         int buffer_width = context->coded_width, buffer_height = context->coded_height;
+        buffer_width = video_st->CV_FFMPEG_CODEC_FIELD->width;
+        buffer_height = video_st->CV_FFMPEG_CODEC_FIELD->height;
 
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(8, 12 ,100)
         img_convert_ctx = sws_alloc_context();
@@ -1957,9 +1959,11 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         rgb_picture.format = result_format;
         rgb_picture.width = buffer_width;
         rgb_picture.height = buffer_height;
-        // rgb_picture.color_range = AVCOL_RANGE_JPEG;
-        // rgb_picture.color_primaries = sw_picture->color_primaries;
-        // rgb_picture.color_trc = sw_picture->color_trc;
+        rgb_picture.color_range = AVCOL_RANGE_JPEG;
+        rgb_picture.colorspace = AVCOL_SPC_RGB;
+        // rgb_picture.chroma_location = (AVChromaLocation)0;
+        rgb_picture.color_primaries = sw_picture->color_primaries;
+        rgb_picture.color_trc = sw_picture->color_trc;
         if (0 != av_frame_get_buffer(&rgb_picture, 32))
         {
             CV_WARN("OutOfMemory");

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2090,6 +2090,30 @@ double CvCapture_FFMPEG::getProperty( int property_id ) const
         unsigned int fourcc_tag = avcodec_pix_fmt_to_codec_tag(pix_fmt);
         return (fourcc_tag == 0) ? (double)-1 : (double)fourcc_tag;
     }
+    case CAP_PROP_CODEC_COLOR_RANGE:
+    {
+#ifdef CV_FFMPEG_CODECPAR
+        return video_st->codecpar->color_range;
+#else
+        return video_st->codec->color_range;
+#endif
+    }
+    case CAP_PROP_CODEC_COLOR_PRIMARIES:
+    {
+#ifdef CV_FFMPEG_CODECPAR
+        return video_st->codecpar->color_primaries;
+#else
+        return video_st->codec->color_primaries;
+#endif
+    }
+    case CAP_PROP_CODEC_COLOR_TRANSFER:
+    {
+#ifdef CV_FFMPEG_CODECPAR
+        return video_st->codecpar->color_trc;
+#else
+        return video_st->codec->color_trc;
+#endif
+    }
     case CAP_PROP_FORMAT:
         if (rawMode)
             return -1;

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1934,12 +1934,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         // Some sws_scale optimizations have some assumptions about alignment of data/step/width/height
         // Also we use coded_width/height to workaround problem with legacy ffmpeg versions (like n0.8)
         int buffer_width = context->coded_width, buffer_height = context->coded_height;
-        buffer_width = video_st->CV_FFMPEG_CODEC_FIELD->width;
-        buffer_height = video_st->CV_FFMPEG_CODEC_FIELD->height;
 
-#if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(8, 12 ,100)
-        img_convert_ctx = sws_alloc_context();
-#else
         img_convert_ctx = sws_getCachedContext(
                 img_convert_ctx,
                 buffer_width, buffer_height,
@@ -1959,11 +1954,6 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         rgb_picture.format = result_format;
         rgb_picture.width = buffer_width;
         rgb_picture.height = buffer_height;
-        rgb_picture.color_range = AVCOL_RANGE_JPEG;
-        rgb_picture.colorspace = AVCOL_SPC_RGB;
-        // rgb_picture.chroma_location = (AVChromaLocation)0;
-        rgb_picture.color_primaries = sw_picture->color_primaries;
-        rgb_picture.color_trc = sw_picture->color_trc;
         if (0 != av_frame_get_buffer(&rgb_picture, 32))
         {
             CV_WARN("OutOfMemory");
@@ -1983,12 +1973,8 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
         frame.data = rgb_picture.data[0];
         frame.step = rgb_picture.linesize[0];
     }
-<<<<<<< HEAD
 
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(6, 4, 100)
-=======
-#if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(8, 12 ,100)
->>>>>>> 69b751de8b (Try sws_scale_frame)
     sws_scale_frame(img_convert_ctx, &rgb_picture, sw_picture);
 #else
     sws_scale(


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24185

OpenCV uses `sws_getCachedContext` to initialize final frame scaling and color conversion. The function sets default yuv<->rgb conversion coefficients. The patch promotes colorspace information from codec to `sws_scale`.
See https://ffmpeg.org/doxygen/0.9/libswscale_2utils_8c-source.html#l01507

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
