### PR TITLE
Fix memory leak and handle realloc failure

### DIFF
--- a/modules/dnn/src/torch/THDiskFile.cpp
+++ b/modules/dnn/src/torch/THDiskFile.cpp
@@ -375,15 +375,21 @@ static long THDiskFile_readString(THFile *self, const char *format, char **str_)
     long total = TBRS_BSZ;
     long pos = 0L;
 
+    if (p == NULL)
+        THError("read error: failed to allocate buffer");
     for (;;)
     {
       if(total-pos == 0) /* we need more space! */
       {
         total += TBRS_BSZ;
-        p = (char*)THRealloc(p, total);
+        char *new_p = (char*)THRealloc(p, total);
+        if (new_p == NULL)
+        {
+          THFree(p);
+          THError("read error: failed to reallocate buffer");
+        }
+        p = new_p;
       }
-      if (p == NULL)
-        THError("read error: failed to allocate buffer");
       pos += fread(p+pos, 1, total-pos, dfself->handle);
       if (pos < total) /* eof? */
       {
@@ -409,15 +415,21 @@ static long THDiskFile_readString(THFile *self, const char *format, char **str_)
     long pos = 0L;
     long size;
 
+    if (p == NULL)
+        THError("read error: failed to allocate buffer");
     for (;;)
     {
       if(total-pos <= 1) /* we can only write '\0' in there! */
       {
         total += TBRS_BSZ;
-        p = (char*)THRealloc(p, total);
+        char *new_p = (char*)THRealloc(p, total);
+        if (new_p == NULL)
+        {
+          THFree(p);
+          THError("read error: failed to reallocate buffer");
+        }
+        p = new_p;
       }
-      if (p == NULL)
-        THError("read error: failed to allocate buffer");
       if (fgets(p+pos, total-pos, dfself->handle) == NULL) /* eof? */
       {
         if(pos == 0L)


### PR DESCRIPTION
In the previous code, there was a memory leak issue where the previously allocated memory was not freed upon a failed realloc operation. This commit addresses the problem by releasing the old memory before setting the pointer to NULL in case of a realloc failure. This ensures that memory is properly managed and avoids potential memory leaks.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
