### PR TITLE
dnn: expand refactor with cv::broadcast for onnx models

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1111,6 +1111,12 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<GemmLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS ExpandLayer : public Layer
+    {
+    public:
+        static Ptr<ExpandLayer> create(const LayerParams &params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -158,6 +158,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Reciprocal,     ReciprocalLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Gather,         GatherLayer);
     CV_DNN_REGISTER_LAYER_CLASS(LayerNormalization, LayerNormLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Expand,         ExpandLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Crop,           CropLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Eltwise,        EltwiseLayer);

--- a/modules/dnn/src/layers/expand_layer.cpp
+++ b/modules/dnn/src/layers/expand_layer.cpp
@@ -1,0 +1,117 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv { namespace dnn {
+
+class ExpandLayerImpl CV_FINAL : public ExpandLayer
+{
+public:
+    ExpandLayerImpl(const LayerParams &params) {
+        setParamsFrom(params);
+
+        // shape as param
+        CV_CheckTrue(params.has("shape"), "DNN/Expand: shape is required in Expand layer initialization");
+        DictValue param_shape = params.get("shape");
+        int ndims_shape = param_shape.size();
+        CV_CheckGT(ndims_shape, 0, "DNN/Expand: ndims of shape must be > 0");
+        target_shape.resize(ndims_shape);
+        for (int i = 0; i < ndims_shape; i++) {
+            target_shape[i] = param_shape.get<int>(i);
+        }
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                                 const int requiredOutputs,
+                                 std::vector<MatShape> &outputs,
+                                 std::vector<MatShape> &internals) const CV_OVERRIDE {
+        CV_CheckGE(inputs.size(), static_cast<size_t>(1), "DNN/Expand: one input at least");
+        CV_CheckLE(inputs.size(), static_cast<size_t>(2), "DNN/Expand: two input at most");
+        CV_CheckFalse(target_shape.empty(), "DNN/Expand: shape must known before memory is set");
+
+        auto& moreDimension = inputs[0].size() > target_shape.size() ? inputs[0] : target_shape;
+        auto& lessDimension = inputs[0].size() <= target_shape.size() ? inputs[0] : target_shape;
+
+
+        /*  Example:
+                             i = 3
+                               |
+            moreDimension: 0 1 2 3 4, assign non-aligned dimensions to output shape
+            lessDimension:     0 1 2, when dimension is aligned, check valid dimension (either equal or one of them is 1) and assign bigger one
+        */
+        MatShape outputShape(moreDimension.size(), 1);
+        for (int i = 0; i < moreDimension.size(); i++) {
+            int d = moreDimension[i];
+            int j = i - (moreDimension.size() - lessDimension.size());
+            std::cout << "i = " << i << ", j = " << j << std::endl;
+            if (j >= 0) {
+                if (d == 1 || lessDimension[j] == 1 || d == lessDimension[j]) {
+                    outputShape[i] = std::max(d, lessDimension[j]);
+                } else {
+                    CV_Error(Error::StsBadSize, cv::format("DNN/Expand: invalid dimension, d (%d) != d (%d)", moreDimension[i], lessDimension[j]));
+                }
+            } else {
+                outputShape[i] = d;
+            }
+        }
+        outputs.assign(1, outputShape);
+        return false;
+    }
+
+    virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE {
+        std::vector<Mat> inputs;
+        inputs_arr.getMatVector(inputs);
+
+        const auto &input = inputs[0];
+        const auto input_shape = shape(input);
+
+        auto& moreDimension = input_shape.size() > target_shape.size() ? input_shape : target_shape;
+        auto& lessDimension = input_shape.size() <= target_shape.size() ? input_shape : target_shape;
+
+        MatShape final_target_shape(moreDimension.size(), 1);
+        for (int i = 0; i < moreDimension.size(); i++) {
+            int d = moreDimension[i];
+            int j = i - (moreDimension.size() - lessDimension.size());
+            if (j >= 0) {
+                final_target_shape[i] = std::max(lessDimension[j], d);
+            } else {
+                final_target_shape[i] = d;
+            }
+        }
+        target_shape.clear();
+        target_shape = std::move(final_target_shape);
+    }
+
+    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        if (inputs_arr.depth() == CV_16S)
+        {
+            forward_fallback(inputs_arr, outputs_arr, internals_arr);
+            return;
+        }
+
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        cv::broadcast(inputs[0], target_shape, outputs[0]);
+    }
+
+private:
+    MatShape target_shape;
+};
+
+Ptr<ExpandLayer> ExpandLayer::create(const LayerParams &params) {
+    return makePtr<ExpandLayerImpl>(params);
+}
+
+}}  // cv::dnn

--- a/modules/dnn/src/layers/expand_layer.cpp
+++ b/modules/dnn/src/layers/expand_layer.cpp
@@ -39,7 +39,6 @@ public:
         auto& moreDimension = inputs[0].size() > target_shape.size() ? inputs[0] : target_shape;
         auto& lessDimension = inputs[0].size() <= target_shape.size() ? inputs[0] : target_shape;
 
-
         /*  Example:
                              i = 3
                                |
@@ -50,9 +49,10 @@ public:
         for (int i = 0; i < moreDimension.size(); i++) {
             int d = moreDimension[i];
             int j = i - (moreDimension.size() - lessDimension.size());
-            std::cout << "i = " << i << ", j = " << j << std::endl;
             if (j >= 0) {
-                if (d == 1 || lessDimension[j] == 1 || d == lessDimension[j]) {
+                if (d == 1 || lessDimension[j] == 1 || // broadcast
+                    (d == -1 && lessDimension[j] != -1) || (lessDimension[j] == -1 && d != -1) || // shape deduction from -1
+                    d == lessDimension[j]) { // plain copy
                     outputShape[i] = std::max(d, lessDimension[j]);
                 } else {
                     CV_Error(Error::StsBadSize, cv::format("DNN/Expand: invalid dimension, d (%d) != d (%d)", moreDimension[i], lessDimension[j]));

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2318,6 +2318,16 @@ void ONNXImporter::parseExpand(LayerParams& layerParams, const opencv_onnx::Node
     CV_CheckTypeEQ(mat_input_shape.depth(), CV_32S, "DNN/ONNXImporter-Expand: data type of input shape must be CV_32S");
     layerParams.set("shape", DictValue::arrayInt(mat_input_shape.ptr<int>(), mat_input_shape.total()));
 
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end()) {
+        Mat input = getBlob(node_proto, 0);
+        std::vector<Mat> inputs, expanded;
+        inputs.push_back(input);
+        runLayer(layerParams, inputs, expanded);
+        CV_CheckEQ(expanded.size(), static_cast<size_t>(1), "DNN/Expand: only one output is expected when folding constant");
+        addConstant(node_proto.output(0), expanded[0]);
+        return;
+    }
+
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2319,6 +2319,14 @@ void ONNXImporter::parseExpand(LayerParams& layerParams, const opencv_onnx::Node
     layerParams.set("shape", DictValue::arrayInt(mat_input_shape.ptr<int>(), mat_input_shape.total()));
 
     if (constBlobs.find(node_proto.input(0)) != constBlobs.end()) {
+        bool const_input_1d = false;
+        if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end()) {
+            if (getBlobExtraInfo(node_proto, 0).real_ndims == 1) {
+                const_input_1d = true;
+            }
+        }
+        layerParams.set("const_input_1d", const_input_1d);
+
         Mat input = getBlob(node_proto, 0);
         std::vector<Mat> inputs, expanded;
         inputs.push_back(input);

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2316,6 +2316,9 @@ void ONNXImporter::parseExpand(LayerParams& layerParams, const opencv_onnx::Node
 
     Mat mat_input_shape = getBlob(node_proto, 1);
     CV_CheckTypeEQ(mat_input_shape.depth(), CV_32S, "DNN/ONNXImporter-Expand: data type of input shape must be CV_32S");
+    for (int i = 0; i < mat_input_shape.total(); ++i) {
+        CV_Check(i, *(mat_input_shape.ptr<int>() + i) >= 0, "DNN/ONNXImporter-Expand: invalid shape dimension");
+    }
     layerParams.set("shape", DictValue::arrayInt(mat_input_shape.ptr<int>(), mat_input_shape.total()));
 
     if (constBlobs.find(node_proto.input(0)) != constBlobs.end()) {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -93,8 +93,6 @@ class ONNXImporter
                   const opencv_onnx::NodeProto& node_proto);
     void setParamsDtype(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
 
-    void expandMid(const std::string& prefix, opencv_onnx::NodeProto& node_proto,
-                   const std::string& input, size_t n);
     void lstm_extractConsts(LayerParams& layerParams, const opencv_onnx::NodeProto& lstm_proto, size_t idx, int* blobShape_, int size);
     void lstm_add_reshape(const std::string& input_name, const std::string& output_name, int* layerShape, size_t n);
     std::string lstm_add_slice(int index, const std::string& input_name, int* begin, int* end, size_t n);
@@ -653,37 +651,6 @@ void ONNXImporter::addLayer(LayerParams& layerParams,
         {
             outShapes[node_proto.output(i)] = layerOutShapes[i];
         }
-    }
-}
-
-/** @brief Make N copies of input layer and set them as input to node_proto.
- * @param prefix prefix of new layers' names
- * @param node_proto node which will contain all copies as inputs
- * @param input name of the node to copy
- * @param n number of copies
- */
-void ONNXImporter::expandMid(const std::string& prefix, opencv_onnx::NodeProto& node_proto,
-                             const std::string& input, size_t n)
-{
-    std::vector<std::string> input_names;
-    input_names.reserve(n);
-    for (size_t j = 0; j < n; j++)
-    {
-        LayerParams copyLP;
-        copyLP.name = format("%s/copy_%zu", prefix.c_str(), j);
-        copyLP.type = "Identity";
-        CV_Assert((layer_id.find(copyLP.name) == layer_id.end()) &&
-            "Couldn't copy the node: generated name already exists in the graph.");
-        input_names.push_back(copyLP.name);
-
-        node_proto.set_input(0, input);
-        node_proto.set_output(0, copyLP.name);
-        addLayer(copyLP, node_proto);
-    }
-    node_proto.clear_input();
-    for (size_t i = 0; i < input_names.size(); i++)
-    {
-        node_proto.add_input(input_names[i]);
     }
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -987,9 +987,21 @@ TEST_P(Test_ONNX_layers, MatMulAdd)
 TEST_P(Test_ONNX_layers, Expand)
 {
     testONNXModels("expand");
+}
+
+TEST_P(Test_ONNX_layers, ExpandIdentity) {
     testONNXModels("expand_identity");
+}
+
+TEST_P(Test_ONNX_layers, ExpandBatch) {
     testONNXModels("expand_batch");
+}
+
+TEST_P(Test_ONNX_layers, ExpandChannels) {
     testONNXModels("expand_channels");
+}
+
+TEST_P(Test_ONNX_layers, ExpandNegBatch) {
     testONNXModels("expand_neg_batch");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2643,22 +2643,24 @@ TEST_P(Test_ONNX_layers, Conformance_Gemm_transposeB) {
     testONNXModels("test_gemm_transposeB", pb, 0, 0, false, true, 2);
 }
 
-TEST_P(Test_ONNX_layers, Conformance_Expand_dim_changed) {
+// Note: These tests are converted from onnx/onnx so that they have constant shape as input.
+// TODO: They can be moved into conformance tests once dynamic input is properly supported.
+TEST_P(Test_ONNX_layers, Expand_dim_changed) {
     testONNXModels("test_expand_dim_changed", pb, 0, 0, false, true, 1);
 }
-TEST_P(Test_ONNX_layers, Conformance_Expand_dim_unchanged) {
+TEST_P(Test_ONNX_layers, Expand_dim_unchanged) {
     testONNXModels("test_expand_dim_unchanged", pb, 0, 0, false, true, 1);
 }
-TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model1) {
+TEST_P(Test_ONNX_layers, Expand_shape_model1) {
     testONNXModels("test_expand_shape_model1", pb, 0, 0, false, true, 1);
 }
-TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model2) {
+TEST_P(Test_ONNX_layers, Expand_shape_model2) {
     testONNXModels("test_expand_shape_model2", pb, 0, 0, false, true, 1);
 }
-TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model3) {
+TEST_P(Test_ONNX_layers, Expand_shape_model3) {
     testONNXModels("test_expand_shape_model3", pb, 0, 0, false, true, 1);
 }
-TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model4) {
+TEST_P(Test_ONNX_layers, Expand_shape_model4) {
     testONNXModels("test_expand_shape_model4", pb, 0, 0, false, true, 1);
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2643,6 +2643,25 @@ TEST_P(Test_ONNX_layers, Conformance_Gemm_transposeB) {
     testONNXModels("test_gemm_transposeB", pb, 0, 0, false, true, 2);
 }
 
+TEST_P(Test_ONNX_layers, Conformance_Expand_dim_changed) {
+    testONNXModels("test_expand_dim_changed", pb, 0, 0, false, true, 1);
+}
+TEST_P(Test_ONNX_layers, Conformance_Expand_dim_unchanged) {
+    testONNXModels("test_expand_dim_unchanged", pb, 0, 0, false, true, 1);
+}
+TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model1) {
+    testONNXModels("test_expand_shape_model1", pb, 0, 0, false, true, 1);
+}
+TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model2) {
+    testONNXModels("test_expand_shape_model2", pb, 0, 0, false, true, 1);
+}
+TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model3) {
+    testONNXModels("test_expand_shape_model3", pb, 0, 0, false, true, 1);
+}
+TEST_P(Test_ONNX_layers, Conformance_Expand_shape_model4) {
+    testONNXModels("test_expand_shape_model4", pb, 0, 0, false, true, 1);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24300
Resolves https://github.com/opencv/opencv/issues/24308

Merge with https://github.com/opencv/opencv_extra/pull/1098.

**Motivation:**

Current implementation of ONNX Expand is very limited and hard to maintain. It can go very unefficient, e.g. input of shape [1, 5, 1] and shape of value [1, 5, 256], it leads to 256 x [1, 5, 1] constant nodes along with a concat node. See down below for more details .

https://github.com/opencv/opencv/blob/b870ad46bf1a9bb5f4310db1e09a20f4265b823f/modules/dnn/src/onnx/onnx_importer.cpp#L2485-L2494

Since now we have `cv::broadcast` already, it is time to do a refactor on expand.

Checklist:
- [x] handle all-input-constant case
- [x] fix expand_neg_batch.onnx
- [x] take care of 0d/1d tensor

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
