### PR TITLE
Warnings fix on Windows.

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -573,7 +573,7 @@ static void findStereoCorrespondenceBM_SIMD( const Mat& left, const Mat& right,
 
                 sad8 = v_reinterpret_as_s16(vx_load(hsad + d + v_int16::nlanes)) - v_reinterpret_as_s16(vx_load(hsad_sub + d + v_int16::nlanes)) + v_reinterpret_as_s16(vx_load(sad + d + v_int16::nlanes));
                 v_store(sad + d + v_int16::nlanes, v_reinterpret_as_u16(sad8));
-                mind8 = v_max(mind8, (minsad8 > sad8) & vx_setall_s16((short)d+v_int16::nlanes));
+                mind8 = v_max(mind8, (minsad8 > sad8) & vx_setall_s16((short)(d+v_int16::nlanes)));
                 minsad8 = v_min(minsad8, sad8);
             }
             if( d <= ndisp - v_int16::nlanes )

--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -1961,7 +1961,7 @@ void SGBM3WayMainLoop::accumulateCostsRight(const BufferSGBM3Way &mem, int x,
         v_store_aligned(leftBuf+D-v_int16::nlanes, res);
 
         min_sum_cost_reg = v_min(min_sum_cost_reg,res);
-        min_sum_pos_reg = min_sum_pos_reg + ((min_sum_cost_reg == res) & (vx_setall_s16((short)D-v_int16::nlanes) - min_sum_pos_reg));
+        min_sum_pos_reg = min_sum_pos_reg + ((min_sum_cost_reg == res) & (vx_setall_s16((short)(D-v_int16::nlanes)) - min_sum_pos_reg));
         min_pos(min_sum_cost_reg,min_sum_pos_reg, min_cost, optimal_disp);
     }
     else
@@ -2076,7 +2076,7 @@ void SGBM3WayMainLoop::impl(const Range& range) const
                 v_int16 thresh_reg = vx_setall_s16((short)(thresh+1));
                 v_int16 d1 = vx_setall_s16((short)(best_d-1));
                 v_int16 d2 = vx_setall_s16((short)(best_d+1));
-                v_int16 eight_reg = vx_setall_s16(v_int16::nlanes);
+                v_int16 eight_reg = vx_setall_s16((short)v_int16::nlanes);
                 v_int16 cur_d = vx_load(idx_row);
                 v_int16 mask;
 

--- a/modules/video/src/tracking/tracker_vit.cpp
+++ b/modules/video/src/tracking/tracker_vit.cpp
@@ -72,11 +72,11 @@ protected:
 static void crop_image(const Mat& src, Mat& dst, Rect box, int factor)
 {
     int x = box.x, y = box.y, w = box.width, h = box.height;
-    int crop_sz = ceil(sqrt(w * h) * factor);
+    int crop_sz = cvCeil(sqrt(w * h) * factor);
 
-    int x1 = round(x + 0.5 * w - crop_sz * 0.5);
+    int x1 = x + (w - crop_sz) / 2;
     int x2 = x1 + crop_sz;
-    int y1 = round(y + 0.5 * h - crop_sz * 0.5);
+    int y1 = y + (h - crop_sz) / 2;
     int y2 = y1 + crop_sz;
 
     int x1_pad = std::max(0, -x1);
@@ -110,14 +110,14 @@ static Mat hann1d(int sz, bool centered = true) {
 
     if(centered) {
         for(int i = 0; i < sz; i++) {
-            float val = 0.5 * (1 - std::cos((2 * M_PI / (sz + 1)) * (i + 1)));
+            float val = 0.5f * (1.f - std::cos(static_cast<float>(2 * M_PI / (sz + 1)) * (i + 1)));
             data[i] = val;
         }
     }
     else {
         int half_sz = sz / 2;
         for(int i = 0; i <= half_sz; i++) {
-            float val = 0.5 * (1 + std::cos((2 * M_PI / (sz + 2)) * i));
+            float val = 0.5f * (1.f + std::cos(static_cast<float>(2 * M_PI / (sz + 2)) * i));
             data[i] = val;
             data[sz - 1 - i] = val;
         }
@@ -140,14 +140,14 @@ static Mat hann2d(Size size, bool centered = true) {
 
 static Rect returnfromcrop(float x, float y, float w, float h, Rect res_Last)
 {
-    int cropwindowwh = 4 * sqrt(res_Last.width * res_Last.height);
-    int x0 = res_Last.x + 0.5 * res_Last.width - 0.5 * cropwindowwh;
-    int y0 = res_Last.y + 0.5 * res_Last.height - 0.5 * cropwindowwh;
+    int cropwindowwh = 4 * cvFloor(sqrt(res_Last.width * res_Last.height));
+    int x0 = res_Last.x + (res_Last.width - cropwindowwh) / 2;
+    int y0 = res_Last.y + (res_Last.height - cropwindowwh) / 2;
     Rect finalres;
-    finalres.x = x * cropwindowwh + x0;
-    finalres.y = y * cropwindowwh + y0;
-    finalres.width = w * cropwindowwh;
-    finalres.height = h * cropwindowwh;
+    finalres.x = cvFloor(x * cropwindowwh + x0);
+    finalres.y = cvFloor(y * cropwindowwh + y0);
+    finalres.width = cvFloor(w * cropwindowwh);
+    finalres.height = cvFloor(h * cropwindowwh);
     return finalres;
 }
 
@@ -186,7 +186,7 @@ bool TrackerVitImpl::update(InputArray image_, Rect &boundingBoxRes)
     double maxVal;
     Point maxLoc;
     minMaxLoc(conf_map, nullptr, &maxVal, nullptr, &maxLoc);
-    tracking_score = maxVal;
+    tracking_score = static_cast<float>(maxVal);
 
     float cx = (maxLoc.x + offset_map.at<float>(0, maxLoc.y, maxLoc.x)) / 16;
     float cy = (maxLoc.y + offset_map.at<float>(1, maxLoc.y, maxLoc.x)) / 16;

--- a/modules/video/test/test_trackers.cpp
+++ b/modules/video/test/test_trackers.cpp
@@ -162,7 +162,7 @@ TEST(NanoTrack, accuracy_NanoTrack_V2)
 
 TEST(vittrack, accuracy_vittrack)
 {
-    std::string model = cvtest::findDataFile("dnn/onnx/models/vitTracker.onnx", false);
+    std::string model = cvtest::findDataFile("dnn/onnx/models/vitTracker.onnx");
     cv::TrackerVit::Params params;
     params.net = model;
     cv::Ptr<Tracker> tracker = TrackerVit::create(params);


### PR DESCRIPTION
Related: https://github.com/opencv/opencv/pull/24201
Warnings: https://pullrequest.opencv.org/buildbot/builders/precommit_windows64/builds/102818/steps/compile%20release/logs/warnings%20%2816%29

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
