### PR TITLE
Fixed segfault when reading Caffe model

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -125,6 +125,7 @@ public:
         {
             const google::protobuf::UnknownField& field = unknownFields.field(i);
             CV_Assert(field.type() == google::protobuf::UnknownField::TYPE_GROUP);
+            CV_CheckGE(field.group().field_count(), 2, "UnknownField should have at least 2 items: name and value");
             std::string fieldName = field.group().field(0).length_delimited();
             std::string fieldValue = field.group().field(1).length_delimited();
             params.set(fieldName, fieldValue);


### PR DESCRIPTION
Added assert to avoid segfault when reading a Caffe model.
It is not clear why OpenCV expects 2 values, but the model contains only one.
The model file is from this repository https://github.com/TimoSaemann/ENet
