### PR TITLE
dnn onnx: fix not-found constant indices for Gather if shared

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2503,11 +2503,11 @@ void ONNXImporter::parseGather(LayerParams& layerParams, const opencv_onnx::Node
     CV_CheckEQ(node_proto.input_size(), 2, "");
 
     // TODO: get rid of the type conversions and 1-d/0-d special-casing when the time comes
-    if (layer_id.find(node_proto.input(1)) == layer_id.end())
+    if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
     {
         int real_ndims = getBlobExtraInfo(node_proto.input(1)).real_ndims;
         layerParams.set("real_ndims", real_ndims);
-        if (layer_id.find(node_proto.input(0)) == layer_id.end())
+        if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
         {
             std::vector<Mat> inputs, output;
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -243,6 +243,10 @@ TEST_P(Test_ONNX_layers, GatherMulti)
     testONNXModels("gather_multi", npy, 0, 0, false, false);
 }
 
+TEST_P(Test_ONNX_layers, Gather_shared_indices) {
+    testONNXModels("gather_shared_indices", npy, 0, 0, false, false, 1);
+}
+
 TEST_P(Test_ONNX_layers, Convolution3D)
 {
     if (backend == DNN_BACKEND_CUDA && target == DNN_TARGET_CUDA_FP16)


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24319
Merge with https://github.com/opencv/opencv_extra/pull/1101

## Problem

The model in the issue above has several Gather operators which have shared constant `indices` (same name, same category `Constant`, same type, same value). The following piece of code in onnx importer adds an attribute `real_ndims` if `indices` is not a layer

https://github.com/opencv/opencv/blob/7b399c4248fd6a399f2f5a731864448883fdd364/modules/dnn/src/onnx/onnx_importer.cpp#L2506-L2531

, but the following code converts the constant `indices` into a `Const` layer:

https://github.com/opencv/opencv/blob/7b399c4248fd6a399f2f5a731864448883fdd364/modules/dnn/src/onnx/onnx_importer.cpp#L2533-L2551

, which makes problems for later Gather operators who have shared `indices`. For later Gather who have shared `indices`, `indices` have been converted to a `Const` layer in dnn, leading to `real_ndims` non-set.

---

**Similar problems may happen on other operators as well. Need further investigation.**

 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
