### PR TITLE
Einsum OpenCL fix

### DIFF
--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -94,6 +94,10 @@ Mat batchwiseMatMul(
             int shape2[] = {static_cast<int>(K), static_cast<int>(N)};
             part2 = part2.reshape(1, sizeof(shape2)/sizeof(shape2[0]), shape2);
 
+            // print type of part1 and part2
+            std::cout << "part1 type: " << part1.type() << " shape: " << part1.size << std::endl;
+            std::cout << "part2 type: " << part2.type() << " shape: " << part2.size << std::endl;
+
             Mat tmp_output;
             cv::gemm(part1, part2, 1.0, cv::Mat(), 1.0, tmp_output);
             int newShape[] = {1, static_cast<int>(M), static_cast<int>(N)};
@@ -123,6 +127,9 @@ Mat batchwiseMatMul(
             reshapedInput2 = input2.reshape(1, 2, shape2);
         }
 
+        // print type of part1 and part2
+        std::cout << "part1 type: " << reshapedInput1.type() << " shape: " << reshapedInput1.size << std::endl;
+        std::cout << "part2 type: " << reshapedInput2.type() << " shape: " << reshapedInput2.size << std::endl;
         Mat tmp_output;
         cv::gemm(reshapedInput1, reshapedInput2, 1.0, cv::Mat(), 1.0, tmp_output);
 


### PR DESCRIPTION
This PR is to solve #24311 issue related to Einsum OpenCL inference 

Currently only print statements have been added to catch type problem in build bot. 



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
