### PR TITLE
add dynamic window in aruco cornerRefinement

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -36,6 +36,7 @@ struct CV_EXPORTS_W_SIMPLE DetectorParameters {
         minMarkerDistanceRate = 0.05;
         cornerRefinementMethod = (int)CORNER_REFINE_NONE;
         cornerRefinementWinSize = 5;
+        relativeCornerRefinmentWinSize = 0.3f;
         cornerRefinementMaxIterations = 30;
         cornerRefinementMinAccuracy = 0.1;
         markerBorderBits = 1;
@@ -108,8 +109,26 @@ struct CV_EXPORTS_W_SIMPLE DetectorParameters {
     /** @brief default value CORNER_REFINE_NONE */
     CV_PROP_RW int cornerRefinementMethod;
 
-    /// window size for the corner refinement process (in pixels) (default 5).
+    /** @brief maximum window size for the corner refinement process (in pixels) (default 5).
+     *
+     * The window size may decrease if the ArUco marker is too small, check relativeCornerRefinmentWinSize.
+     * The final window size is calculated as:
+     * min(cornerRefinementWinSize, averageArucoModuleSize*relativeCornerRefinmentWinSize),
+     * where averageArucoModuleSize is average module size of ArUco marker in pixels.
+     * (ArUco marker is composed of black and white modules)
+     */
     CV_PROP_RW int cornerRefinementWinSize;
+
+    /** @brief Dynamic window size for corner refinement relative to Aruco module size (default 0.3).
+     *
+     * The final window size is calculated as:
+     * min(cornerRefinementWinSize, averageArucoModuleSize*relativeCornerRefinmentWinSize),
+     * where averageArucoModuleSize is average module size of ArUco marker in pixels.
+     * (ArUco marker is composed of black and white modules)
+     * In the case of markers located far from each other, it may be useful to increase the value of the parameter to 0.4-0.5.
+     * In the case of markers located close to each other, it may be useful to decrease the parameter value to 0.1-0.2.
+     */
+    CV_PROP_RW float relativeCornerRefinmentWinSize;
 
     /// maximum number of iterations for stop criteria of the corner refinement process (default 30).
     CV_PROP_RW int cornerRefinementMaxIterations;

--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -35,6 +35,8 @@ static inline bool readWrite(DetectorParameters &params, const FileNode* readNod
     check |= readWriteParameter("minMarkerDistanceRate", params.minMarkerDistanceRate, readNode, writeStorage);
     check |= readWriteParameter("cornerRefinementMethod", params.cornerRefinementMethod, readNode, writeStorage);
     check |= readWriteParameter("cornerRefinementWinSize", params.cornerRefinementWinSize, readNode, writeStorage);
+    check |= readWriteParameter("relativeCornerRefinmentWinSize", params.relativeCornerRefinmentWinSize, readNode,
+                                writeStorage);
     check |= readWriteParameter("cornerRefinementMaxIterations", params.cornerRefinementMaxIterations,
                                 readNode, writeStorage);
     check |= readWriteParameter("cornerRefinementMinAccuracy", params.cornerRefinementMinAccuracy,
@@ -847,6 +849,16 @@ struct ArucoDetector::ArucoDetectorImpl {
                       const RefineParameters& _refineParams): dictionary(_dictionary),
                       detectorParams(_detectorParams), refineParams(_refineParams) {}
 
+    float getAverageArucoPinSize(vector<Point2f> markerCorners) {
+        float averageArucoModuleSize = 0.f;
+        int numPins = dictionary.markerSize + detectorParams.markerBorderBits * 2;
+        for (size_t i = 0ull; i < markerCorners.size(); i++) {
+            averageArucoModuleSize += sqrt(normL2Sqr<float>(Point2f(markerCorners[i] - markerCorners[(i+1ull)%markerCorners.size()])));
+        }
+        averageArucoModuleSize /= ((float)markerCorners.size()*numPins);
+        return averageArucoModuleSize;
+}
+
 };
 
 ArucoDetector::ArucoDetector(const Dictionary &_dictionary,
@@ -951,13 +963,15 @@ void ArucoDetector::detectMarkers(InputArray _image, OutputArrayOfArrays _corner
                     const float scale_init = (float) grey_pyramid[closest_pyr_image_idx].cols / grey.cols;
                     findCornerInPyrImage(scale_init, closest_pyr_image_idx, grey_pyramid, Mat(candidates[i]), detectorParams);
                 }
-                else
-                cornerSubPix(grey, Mat(candidates[i]),
-                             Size(detectorParams.cornerRefinementWinSize, detectorParams.cornerRefinementWinSize),
-                             Size(-1, -1),
-                             TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
-                                          detectorParams.cornerRefinementMaxIterations,
-                                          detectorParams.cornerRefinementMinAccuracy));
+                else {
+                    int cornerRefinementWinSize = std::max(1, cvRound(detectorParams.relativeCornerRefinmentWinSize*
+                                                                      arucoDetectorImpl->getAverageArucoPinSize(candidates[i])));
+                    cornerRefinementWinSize = min(cornerRefinementWinSize, detectorParams.cornerRefinementWinSize);
+                    cornerSubPix(grey, Mat(candidates[i]), Size(cornerRefinementWinSize, cornerRefinementWinSize), Size(-1, -1),
+                                 TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
+                                              detectorParams.cornerRefinementMaxIterations,
+                                              detectorParams.cornerRefinementMinAccuracy));
+                }
             }
         });
     }
@@ -1223,8 +1237,13 @@ void ArucoDetector::refineDetectedMarkers(InputArray _image, const Board& _board
                 CV_Assert(detectorParams.cornerRefinementWinSize > 0 &&
                           detectorParams.cornerRefinementMaxIterations > 0 &&
                           detectorParams.cornerRefinementMinAccuracy > 0);
+
+                std::vector<Point2f> marker(closestRotatedMarker.begin<Point2f>(), closestRotatedMarker.end<Point2f>());
+                int cornerRefinementWinSize = std::max(1, cvRound(detectorParams.relativeCornerRefinmentWinSize*
+                                                                  arucoDetectorImpl->getAverageArucoPinSize(marker)));
+                cornerRefinementWinSize = min(cornerRefinementWinSize, detectorParams.cornerRefinementWinSize);
                 cornerSubPix(grey, closestRotatedMarker,
-                             Size(detectorParams.cornerRefinementWinSize, detectorParams.cornerRefinementWinSize),
+                             Size(cornerRefinementWinSize, cornerRefinementWinSize),
                              Size(-1, -1), TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS,
                                                         detectorParams.cornerRefinementMaxIterations,
                                                         detectorParams.cornerRefinementMinAccuracy));


### PR DESCRIPTION
Fixes #24113
cornerRefinementMethod=CORNER_REFINE_SUBPIX  does not work correctly with markers that are too close to each other.

Now `cornerRefinementWinSize` is recalculated for each marker as:
`cornerRefinementWinSize = min(cornerRefinementWinSize, averageArucoPinSize*relativeCornerRefinmentWinSize)
`
relativeCornerRefinmentWinSize=0.3 by default and could be changed

![image](https://github.com/opencv/opencv/assets/22337800/1e3d3b59-d20c-4a9a-b656-1688575ef9bf)

Also the method has been tested by the [benchmark](https://github.com/opencv/opencv_benchmarks/pull/7), 289 aruco boards like this were tested:

![perspective_none_gaussNoise_33](https://github.com/opencv/opencv/assets/22337800/b625ddcb-549a-4a5b-a813-c0c61f71d9f0)

command line to generate and run (also need set cornerRefinementMethod: 1 and cornerRefinementWinSize: 10 in aruco_params.yml):

```
objdetect_benchmark.py --marker_length_rate=0.1 --board_x=6 -p=res --rel_center_y=0.53 --rel_center_x=0.56 --synthetic_object=aruco
```

tested with cornerRefinementWinSize=10
error in pixels with **old** cornerRefinementMethod:
![image](https://github.com/opencv/opencv/assets/22337800/f20a4c73-854e-4fa1-8704-8d3ecf0465b2)
mean detected error in pixels 5.912010732442689

error in pixels with **new** cornerRefinementMethod:
![image](https://github.com/opencv/opencv/assets/22337800/f55c26e0-0b7c-4c5d-b43b-3fd777cd1b6e)
mean detected error in pixels 0.991642490414958


command line to show histogram:
```
--configuration=show -d1=old.json --marker_length_rate=0.1 --board_x=6 -p=res --rel_center_y=0.53 --rel_center_x=0.56 --synthetic_object=aruco
```

[new.json.txt](https://github.com/opencv/opencv/files/12825866/new.json.txt)
[old.json.txt](https://github.com/opencv/opencv/files/12825867/old.json.txt)



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
