### PR TITLE
feat: re-export cv2.typing module as typing

### DIFF
--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -163,11 +163,11 @@ class AnyTypeNode(TypeNode):
     """
     @property
     def typename(self) -> str:
-        return "typing.Any"
+        return "_typing.Any"
 
     @property
     def required_usage_imports(self) -> Generator[str, None, None]:
-        yield "import typing"
+        yield "import typing as _typing"
 
 
 class PrimitiveTypeNode(TypeNode):
@@ -474,11 +474,11 @@ class ConditionalAliasTypeNode(TypeNode):
         """Type subscription is not possible in python 3.8 and older numpy versions."""
         return cls(
             ctype_name,
-            "typing.TYPE_CHECKING",
+            "_typing.TYPE_CHECKING",
             NDArrayTypeNode(ctype_name, shape, dtype),
             NDArrayTypeNode(ctype_name, shape, dtype,
                             use_numpy_generics=False),
-            condition_required_imports=("import typing",)
+            condition_required_imports=("import typing as _typing",)
         )
 
 
@@ -499,14 +499,14 @@ class NDArrayTypeNode(TypeNode):
         if self._use_numpy_generics:
             # NOTE: Shape is not fully supported yet
             dtype = self.dtype if self.dtype is not None else "numpy.generic"
-            return f"numpy.ndarray[typing.Any, numpy.dtype[{dtype}]]"
+            return f"numpy.ndarray[_typing.Any, numpy.dtype[{dtype}]]"
         return "numpy.ndarray"
 
     @property
     def required_usage_imports(self) -> Generator[str, None, None]:
         yield "import numpy"
         # if self.shape is None:
-        yield "import typing"
+        yield "import typing as _typing"
 
 
 class ASTNodeTypeNode(TypeNode):
@@ -668,13 +668,13 @@ class ContainerTypeNode(AggregatedTypeNode):
 
     @property
     def required_definition_imports(self) -> Generator[str, None, None]:
-        yield "import typing"
+        yield "import typing as _typing"
         yield from super().required_definition_imports
 
     @property
     def required_usage_imports(self) -> Generator[str, None, None]:
         if TypeNode.compatible_to_runtime_usage:
-            yield "import typing"
+            yield "import typing as _typing"
         yield from super().required_usage_imports
 
     @abc.abstractproperty
@@ -695,7 +695,7 @@ class SequenceTypeNode(ContainerTypeNode):
 
     @property
     def type_format(self) -> str:
-        return "typing.Sequence[{}]"
+        return "_typing.Sequence[{}]"
 
     @property
     def types_separator(self) -> str:
@@ -709,7 +709,7 @@ class TupleTypeNode(ContainerTypeNode):
     @property
     def type_format(self) -> str:
         if TypeNode.compatible_to_runtime_usage:
-            return "typing.Tuple[{}]"
+            return "_typing.Tuple[{}]"
         return "tuple[{}]"
 
     @property
@@ -723,7 +723,7 @@ class UnionTypeNode(ContainerTypeNode):
     @property
     def type_format(self) -> str:
         if TypeNode.compatible_to_runtime_usage:
-            return "typing.Union[{}]"
+            return "_typing.Union[{}]"
         return "{}"
 
     @property
@@ -743,7 +743,7 @@ class OptionalTypeNode(ContainerTypeNode):
     @property
     def type_format(self) -> str:
         if TypeNode.compatible_to_runtime_usage:
-            return "typing.Optional[{}]"
+            return "_typing.Optional[{}]"
         return "{} | None"
 
     @property
@@ -769,7 +769,7 @@ class DictTypeNode(ContainerTypeNode):
     @property
     def type_format(self) -> str:
         if TypeNode.compatible_to_runtime_usage:
-            return "typing.Dict[{}]"
+            return "_typing.Dict[{}]"
         return "dict[{}]"
 
     @property
@@ -810,32 +810,32 @@ class CallableTypeNode(AggregatedTypeNode):
 
     @property
     def typename(self) -> str:
-        return 'typing.Callable[[{}], {}]'.format(
+        return '_typing.Callable[[{}], {}]'.format(
             ', '.join(arg.typename for arg in self.arg_types),
             self.ret_type.typename
         )
 
     @property
     def full_typename(self) -> str:
-        return 'typing.Callable[[{}], {}]'.format(
+        return '_typing.Callable[[{}], {}]'.format(
             ', '.join(arg.full_typename for arg in self.arg_types),
             self.ret_type.full_typename
         )
 
     def relative_typename(self, module: str) -> str:
-        return 'typing.Callable[[{}], {}]'.format(
+        return '_typing.Callable[[{}], {}]'.format(
             ', '.join(arg.relative_typename(module) for arg in self.arg_types),
             self.ret_type.relative_typename(module)
         )
 
     @property
     def required_definition_imports(self) -> Generator[str, None, None]:
-        yield "import typing"
+        yield "import typing as _typing"
         yield from super().required_definition_imports
 
     @property
     def required_usage_imports(self) -> Generator[str, None, None]:
-        yield "import typing"
+        yield "import typing as _typing"
         yield from super().required_usage_imports
 
 
@@ -847,7 +847,7 @@ class ClassTypeNode(ContainerTypeNode):
 
     @property
     def type_format(self) -> str:
-        return "typing.Type[{}]"
+        return "_typing.Type[{}]"
 
     @property
     def types_separator(self) -> str:


### PR DESCRIPTION
Import Python `typing` module as `_typing` to avoid name clashes.

resolves opencv/opencv-python#901
resolves #24352

Changes:

```python
# __init__.pyi

# Import section update

import typing as _typing

# Re-export section update

from cv2 import typing as typing

# Python `typing` module usage update

@_typing.overload
def solveLP(Func: UMat, Constr: UMat, z: UMat | None = ...) -> tuple[int, UMat]: ...

```

Test file content:

```python
import typing
import cv2
import cv2.typing

if typing.TYPE_CHECKING:
    reveal_type(cv2.typing.MatLike)
    reveal_type(cv2.imdecode)
    reveal_type(cv2.cuda.unregisterPageLocked)
```

Command: `mypy test.py`

Output:

```shell
test.py:6: note: Revealed type is "typing._SpecialForm"
test.py:7: note: Revealed type is "Overload(def (buf: Union[cv2.mat_wrapper.Mat, numpy.ndarray[Any, numpy.dtype[numpy.generic]]], flags: builtins.int) -> Union[cv2.mat_wrapper.Mat, numpy.ndarray[Any, numpy.dtype[numpy.generic]]], def (buf: cv2.UMat, flags: builtins.int) -> Union[cv2.mat_wrapper.Mat, numpy.ndarray[Any, numpy.dtype[numpy.generic]]])"
test.py:8: note: Revealed type is "def (m: Union[cv2.mat_wrapper.Mat, numpy.ndarray[Any, numpy.dtype[numpy.generic]]])"
```

FYI: @Avasam, @rassie

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
