### PR TITLE
imgproc: move stb_truetype functions into cv namespace

### DIFF
--- a/modules/imgproc/src/stb_truetype.cpp
+++ b/modules/imgproc/src/stb_truetype.cpp
@@ -403,6 +403,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef STB_TRUETYPE_IMPLEMENTATION
 
+namespace cv {
+
 #ifndef STBTT_MAX_OVERSAMPLE
 #define STBTT_MAX_OVERSAMPLE   8
 #endif
@@ -4427,6 +4429,8 @@ STBTT_DEF int stbtt_SetInstance(stbtt_fontinfo* info, const int* params, int cou
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
+
+} // namespace cv
 
 #endif // STB_TRUETYPE_IMPLEMENTATION
 

--- a/modules/imgproc/src/stb_truetype.hpp
+++ b/modules/imgproc/src/stb_truetype.hpp
@@ -72,7 +72,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+namespace cv {
 #endif
 
 #define STBTT_FOURCC(a, b, c, d) \


### PR DESCRIPTION
fix https://github.com/opencv/opencv/issues/24121

Move stb_truetype functions() into the cv namespace. This avoids name collisions with other applications and libraries that use stb_truetype.

```
kmtr@ubuntu:~/work/build5-main$ nm lib/libopencv_imgproc.so | c++filt | grep "stbtt_" | head -10
000000000025b180 t cv::stbtt_GetWeight(cv::stbtt_fontinfo const*)
0000000000259d40 t cv::stbtt_Rasterize(cv::stbtt__bitmap*, float, cv::stbtt_vertex*, int, float, float, float, float, int, int, int, void*)
000000000025b080 t cv::stbtt_CreateFont(unsigned char const*, unsigned int, int)
0000000000258a30 t cv::stbtt_GetGlyphBox(cv::stbtt_fontinfo const*, int, int*, int*, int*, int*)
000000000025b120 t cv::stbtt_GetInstance(cv::stbtt_fontinfo const*, cv::stbtt_axisinfo*, int)
000000000025b0f0 t cv::stbtt_ReleaseFont(cv::stbtt_fontinfo**)
000000000025b370 t cv::stbtt_SetInstance(cv::stbtt_fontinfo*, int const*, int, int)
00000000002547e0 t cv::stbtt_SetInstance(cv::stbtt_fontinfo*, int const*, int, int) [clone .part.0]
0000000000258cb0 t cv::stbtt_GetGlyphShape(cv::stbtt_fontinfo const*, int, cv::stbtt_vertex**, int*, int*, int*, int*)
0000000000258720 t cv::stbtt_FindGlyphIndex(cv::stbtt_fontinfo const*, int)
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
