### PR TITLE
supporting protobuf v22 and later(with abseil-cpp/C++17)

### DIFF
--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -123,8 +123,3 @@ if(HAVE_PROTOBUF)
     BUILD_PROTOBUF THEN "build (${Protobuf_VERSION})"
     ELSE "${__location} (${Protobuf_VERSION})")
 endif()
-
-if(HAVE_ABSL_STRINGS AND HAVE_ABSL_LOG)
-  list(APPEND CUSTOM_STATUS absl)
-  list(APPEND CUSTOM_STATUS_absl "      abseil-cpp:" "YES (${ABSL_STRINGS_VERSION})" )
-endif()

--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -6,7 +6,6 @@ if(NOT WITH_PROTOBUF)
   return()
 endif()
 
-
 ocv_option(BUILD_PROTOBUF "Force to build libprotobuf runtime from sources" ON)
 ocv_option(PROTOBUF_UPDATE_FILES "Force rebuilding .proto files (protoc should be available)" OFF)
 

--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -80,22 +80,12 @@ endif()
 # And if std::text_view is in abseil-cpp requests C++17 and later.
 
 if(HAVE_PROTOBUF)
-    if("${Protobuf_VERSION}" MATCHES [[[0-9]+.([0-9]+).[0-9]+]])
-        string(COMPARE GREATER "${CMAKE_MATCH_1}" "21" REQUEST_AFTER_CXX17)  # >=22
-
-        if(REQUEST_AFTER_CXX17)
-            string(COMPARE GREATER "${CMAKE_CXX_STANDARD}" "16" USED_AFTER_CXX17)  # >=17
-
-            if(NOT USED_AFTER_CXX17)
-                message("CMAKE_CXX_STANDARD : ${CMAKE_CXX_STANDARD}")
-                message("protobuf           : ${Protobuf_VERSION}")
-                message(FATAL_ERROR "protobuf(v22 and later) and abseil-cpp request CMAKE_CXX_STANDARD=17 and later.")
-            endif()
-
-        endif()
-    else()
-        message(FATAL_ERROR "Protobuf version(${Protobuf_VERSION}) is unexpected to split.")
+  if(NOT (Protobuf_VERSION VERSION_LESS 22))
+    if((CMAKE_CXX_STANDARD EQUAL 98) OR (CMAKE_CXX_STANDARD LESS 17))
+      message(STATUS "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is too old to support protobuf(${Protobuf_VERSION}) and/or abseil-cpp. Use C++17 or later. Turning HAVE_PROTOBUF off")
+      set(HAVE_PROTOBUF FALSE)
     endif()
+  endif()
 endif()
 
 if(HAVE_PROTOBUF AND PROTOBUF_UPDATE_FILES AND NOT COMMAND PROTOBUF_GENERATE_CPP)

--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -67,6 +67,38 @@ else()
   endif()
 endif()
 
+# See https://github.com/opencv/opencv/issues/24369
+# In Protocol Buffers v22.0 and later drops C++11 support and depends abseil-cpp.
+#   Details: https://protobuf.dev/news/2022-08-03/
+# And if std::text_view is in abseil-cpp requests C++17 and later.
+if(HAVE_PROTOBUF)
+    if("${Protobuf_VERSION}" MATCHES [[[0-9]+.([0-9]+).[0-9]+]])
+        string(COMPARE GREATER_EQUAL "${CMAKE_MATCH_1}" "22" REQUEST_ABSL)
+
+        if(REQUEST_ABSL)
+            string(COMPARE GREATER_EQUAL "${CMAKE_CXX_STANDARD}" "17" USED_AFTER_CXX17)
+            if(NOT USED_AFTER_CXX17)
+                message("CMAKE_CXX_STANDARD : ${CMAKE_CXX_STANDARD}")
+                message("protobuf           : ${Protobuf_VERSION}")
+                message(FATAL_ERROR "protobuf(v22 and later) and abseil-cpp request CMAKE_CXX_STANDARD=17 and later.")
+            endif()
+
+            ocv_check_modules(ABSL_STRINGS absl_strings)
+            if(NOT ABSL_STRINGS_FOUND)
+                message(FATAL_ERROR "protobuf(v22 and later) requests abseil-cpp(strings), but missing.")
+            endif()
+
+            ocv_check_modules(ABSL_LOG absl_log)
+            if(NOT ABSL_LOG_FOUND)
+                message(FATAL_ERROR "protobuf(v22 and later) requests abseil-cpp(log), but missing.")
+            endif()
+
+        endif()
+    else()
+        message(FATAL_ERROR "Protobuf version(${Protobuf_VERSION}) is unexpected to split.")
+    endif()
+endif()
+
 if(HAVE_PROTOBUF AND PROTOBUF_UPDATE_FILES AND NOT COMMAND PROTOBUF_GENERATE_CPP)
   message(FATAL_ERROR "Can't configure protobuf dependency (BUILD_PROTOBUF=${BUILD_PROTOBUF} PROTOBUF_UPDATE_FILES=${PROTOBUF_UPDATE_FILES})")
 endif()
@@ -88,4 +120,9 @@ if(HAVE_PROTOBUF)
   list(APPEND CUSTOM_STATUS_protobuf "    Protobuf:"
     BUILD_PROTOBUF THEN "build (${Protobuf_VERSION})"
     ELSE "${__location} (${Protobuf_VERSION})")
+endif()
+
+if(HAVE_ABSL_STRINGS AND HAVE_ABSL_LOG)
+  list(APPEND CUSTOM_STATUS absl)
+  list(APPEND CUSTOM_STATUS_absl "      abseil-cpp:" "YES (${ABSL_STRINGS_VERSION})" )
 endif()

--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -71,12 +71,14 @@ endif()
 # In Protocol Buffers v22.0 and later drops C++11 support and depends abseil-cpp.
 #   Details: https://protobuf.dev/news/2022-08-03/
 # And if std::text_view is in abseil-cpp requests C++17 and later.
+
 if(HAVE_PROTOBUF)
     if("${Protobuf_VERSION}" MATCHES [[[0-9]+.([0-9]+).[0-9]+]])
-        string(COMPARE GREATER_EQUAL "${CMAKE_MATCH_1}" "22" REQUEST_ABSL)
+        string(COMPARE GREATER "${CMAKE_MATCH_1}" "21" REQUEST_ABSL)  # >=22
 
         if(REQUEST_ABSL)
-            string(COMPARE GREATER_EQUAL "${CMAKE_CXX_STANDARD}" "17" USED_AFTER_CXX17)
+            string(COMPARE GREATER "${CMAKE_CXX_STANDARD}" "16" USED_AFTER_CXX17)  # >=17
+
             if(NOT USED_AFTER_CXX17)
                 message("CMAKE_CXX_STANDARD : ${CMAKE_CXX_STANDARD}")
                 message("protobuf           : ${Protobuf_VERSION}")

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -249,6 +249,10 @@ ocv_create_module(${libs} ${dnn_runtime_libs})
 ocv_add_samples()
 ocv_add_accuracy_tests(${dnn_runtime_libs})
 
+if(NOT BUILD_PROTOBUF)
+  ocv_target_compile_definitions(opencv_test_dnn PRIVATE "OPENCV_DNN_EXTERNAL_PROTOBUF=1")
+endif()
+
 set(perf_path "${CMAKE_CURRENT_LIST_DIR}/perf")
 file(GLOB_RECURSE perf_srcs "${perf_path}/*.cpp")
 file(GLOB_RECURSE perf_hdrs "${perf_path}/*.hpp" "${perf_path}/*.h")
@@ -313,3 +317,4 @@ if(OPENCV_TEST_DNN_TFLITE)
     ocv_target_compile_definitions(opencv_perf_dnn PRIVATE "OPENCV_TEST_DNN_TFLITE=1")
   endif()
 endif()
+

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -317,4 +317,3 @@ if(OPENCV_TEST_DNN_TFLITE)
     ocv_target_compile_definitions(opencv_perf_dnn PRIVATE "OPENCV_TEST_DNN_TFLITE=1")
   endif()
 endif()
-

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -145,15 +145,6 @@ if(NOT BUILD_PROTOBUF)
   list(APPEND include_dirs ${Protobuf_INCLUDE_DIRS})
 endif()
 
-if(HAVE_ABSL_STRINGS)
-  list(APPEND libs ${ABSL_STRINGS_LIBRARIES})
-  list(APPEND include_dirs ${ABSL_STRTRINGS_INCLUDE_DIRS})
-endif()
-if(HAVE_ABSL_LOG)
-  list(APPEND libs ${ABSL_LOG_LIBRARIES})
-  list(APPEND include_dirs ${ABSL_LOG_INCLUDE_DIRS})
-endif()
-
 set(sources_options "")
 
 list(APPEND libs ${LAPACK_LIBRARIES})

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -145,6 +145,15 @@ if(NOT BUILD_PROTOBUF)
   list(APPEND include_dirs ${Protobuf_INCLUDE_DIRS})
 endif()
 
+if(HAVE_ABSL_STRINGS)
+  list(APPEND libs ${ABSL_STRINGS_LIBRARIES})
+  list(APPEND include_dirs ${ABSL_STRTRINGS_INCLUDE_DIRS})
+endif()
+if(HAVE_ABSL_LOG)
+  list(APPEND libs ${ABSL_LOG_LIBRARIES})
+  list(APPEND include_dirs ${ABSL_LOG_INCLUDE_DIRS})
+endif()
+
 set(sources_options "")
 
 list(APPEND libs ${LAPACK_LIBRARIES})

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -250,7 +250,9 @@ ocv_add_samples()
 ocv_add_accuracy_tests(${dnn_runtime_libs})
 
 if(NOT BUILD_PROTOBUF)
-  ocv_target_compile_definitions(opencv_test_dnn PRIVATE "OPENCV_DNN_EXTERNAL_PROTOBUF=1")
+  if(TARGET opencv_test_dnn)
+    ocv_target_compile_definitions(opencv_test_dnn PRIVATE "OPENCV_DNN_EXTERNAL_PROTOBUF=1")
+  endif()
 endif()
 
 set(perf_path "${CMAKE_CURRENT_LIST_DIR}/perf")

--- a/modules/dnn/src/caffe/caffe_io.cpp
+++ b/modules/dnn/src/caffe/caffe_io.cpp
@@ -1130,7 +1130,17 @@ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
     parser.AllowUnknownField(true);
     parser.SetRecursionLimit(1000);
 #endif
-    return parser.Parse(&input, proto);
+    const bool ret = parser.Parse(&input, proto);
+
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    if(!ret)
+    {
+        LOG(ERROR) << "Some data requires patched protobuf (available in OpenCV source tree only).";
+        CV_Error_(Error::StsError,("Some data requires patched protobuf (available in OpenCV source tree only)."));
+    }
+#endif
+
+    return ret;
 }
 
 bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
@@ -1148,7 +1158,17 @@ bool ReadProtoFromTextBuffer(const char* data, size_t len, Message* proto) {
     parser.AllowUnknownField(true);
     parser.SetRecursionLimit(1000);
 #endif
-    return parser.Parse(&input, proto);
+    const bool ret = parser.Parse(&input, proto);
+
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    if(!ret)
+    {
+        LOG(ERROR) << "Some data requires patched protobuf (available in OpenCV source tree only).";
+        CV_Error_(Error::StsError,("Some data requires patched protobuf (available in OpenCV source tree only)."));
+    }
+#endif
+
+    return ret;
 }
 
 

--- a/modules/dnn/src/caffe/caffe_io.cpp
+++ b/modules/dnn/src/caffe/caffe_io.cpp
@@ -1130,17 +1130,7 @@ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
     parser.AllowUnknownField(true);
     parser.SetRecursionLimit(1000);
 #endif
-    const bool ret = parser.Parse(&input, proto);
-
-#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
-    if(!ret)
-    {
-        LOG(ERROR) << "Some data requires patched protobuf (available in OpenCV source tree only).";
-        CV_Error_(Error::StsError,("Some data requires patched protobuf (available in OpenCV source tree only)."));
-    }
-#endif
-
-    return ret;
+    return parser.Parse(&input, proto);
 }
 
 bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
@@ -1158,17 +1148,7 @@ bool ReadProtoFromTextBuffer(const char* data, size_t len, Message* proto) {
     parser.AllowUnknownField(true);
     parser.SetRecursionLimit(1000);
 #endif
-    const bool ret = parser.Parse(&input, proto);
-
-#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
-    if(!ret)
-    {
-        LOG(ERROR) << "Some data requires patched protobuf (available in OpenCV source tree only).";
-        CV_Error_(Error::StsError,("Some data requires patched protobuf (available in OpenCV source tree only)."));
-    }
-#endif
-
-    return ret;
+    return parser.Parse(&input, proto);
 }
 
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -762,17 +762,17 @@ TEST_F(Layer_RNN_Test, get_set_test)
     EXPECT_EQ(shape(outputs[1]), shape(nT, nS, nH));
 }
 
-#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Accum)
-#else
-TEST_P(Test_Caffe_layers, DISABLED_Accum)  // requires patched protobuf (available in OpenCV source tree only)
-#endif
 {
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    throw SkipTestException("Requires patched protobuf");
+#else
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL, CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 
     testLayerUsingCaffeModels("accum", false, false, 0.0, 0.0, 2);
     testLayerUsingCaffeModels("accum_ref", false, false, 0.0, 0.0, 2);
+#endif
 }
 
 TEST_P(Test_Caffe_layers, FlowWarp)
@@ -790,43 +790,43 @@ TEST_P(Test_Caffe_layers, ChannelNorm)
     testLayerUsingCaffeModels("channel_norm", false, false);
 }
 
-#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, DataAugmentation)
-#else
-TEST_P(Test_Caffe_layers, DISABLED_DataAugmentation)  // requires patched protobuf (available in OpenCV source tree only)
-#endif
 {
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    throw SkipTestException("Requires patched protobuf");
+#else
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     testLayerUsingCaffeModels("data_augmentation", true, false);
     testLayerUsingCaffeModels("data_augmentation_2x1", true, false);
     testLayerUsingCaffeModels("data_augmentation_8x6", true, false);
+#endif
 }
 
-#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Resample)
-#else
-TEST_P(Test_Caffe_layers, DISABLED_Resample)  // requires patched protobuf (available in OpenCV source tree only)
-#endif
 {
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    throw SkipTestException("Requires patched protobuf");
+#else
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2023000000)
     if (backend != DNN_BACKEND_OPENCV)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
 #endif
     testLayerUsingCaffeModels("nearest_2inps", false, false, 0.0, 0.0, 2);
     testLayerUsingCaffeModels("nearest", false, false);
+#endif
 }
 
-#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Correlation)
-#else
-TEST_P(Test_Caffe_layers, DISABLED_Correlation)  // requires patched protobuf (available in OpenCV source tree only)
-#endif
 {
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    throw SkipTestException("Requires patched protobuf");
+#else
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER,
                      CV_TEST_TAG_DNN_SKIP_OPENCL, CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     testLayerUsingCaffeModels("correlation", false, false, 0.0, 0.0, 2);
+#endif
 }
 
 TEST_P(Test_Caffe_layers, Convolution2Inputs)
@@ -1667,12 +1667,11 @@ private:
     int outWidth, outHeight, zoomFactor;
 };
 
-#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Interp)
-#else
-TEST_P(Test_Caffe_layers, DISABLED_Interp)  // requires patched protobuf (available in OpenCV source tree only)
-#endif
 {
+#ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
+    throw SkipTestException("Requires patched protobuf");
+#else
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2021030000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_MYRIAD)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);  // exception
@@ -1696,6 +1695,7 @@ TEST_P(Test_Caffe_layers, DISABLED_Interp)  // requires patched protobuf (availa
 
     // Test an implemented layer.
     testLayerUsingCaffeModels("layer_interp", false, false);
+#endif
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_Caffe_layers, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -762,7 +762,11 @@ TEST_F(Layer_RNN_Test, get_set_test)
     EXPECT_EQ(shape(outputs[1]), shape(nT, nS, nH));
 }
 
+#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Accum)
+#else
+TEST_P(Test_Caffe_layers, DISABLED_Accum)  // requires patched protobuf (available in OpenCV source tree only)
+#endif
 {
     if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL, CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -786,7 +790,11 @@ TEST_P(Test_Caffe_layers, ChannelNorm)
     testLayerUsingCaffeModels("channel_norm", false, false);
 }
 
+#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, DataAugmentation)
+#else
+TEST_P(Test_Caffe_layers, DISABLED_DataAugmentation)  // requires patched protobuf (available in OpenCV source tree only)
+#endif
 {
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -795,7 +803,11 @@ TEST_P(Test_Caffe_layers, DataAugmentation)
     testLayerUsingCaffeModels("data_augmentation_8x6", true, false);
 }
 
+#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Resample)
+#else
+TEST_P(Test_Caffe_layers, DISABLED_Resample)  // requires patched protobuf (available in OpenCV source tree only)
+#endif
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2023000000)
     if (backend != DNN_BACKEND_OPENCV)
@@ -805,7 +817,11 @@ TEST_P(Test_Caffe_layers, Resample)
     testLayerUsingCaffeModels("nearest", false, false);
 }
 
+#ifndef OPENCV_DNN_EXTERNAL_PROTOBUF
 TEST_P(Test_Caffe_layers, Correlation)
+#else
+TEST_P(Test_Caffe_layers, DISABLED_Correlation)  // requires patched protobuf (available in OpenCV source tree only)
+#endif
 {
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER,


### PR DESCRIPTION
fix https://github.com/opencv/opencv/issues/24369
related https://github.com/opencv/opencv/issues/23791

1. This patch supports external protobuf v22 and later, it required abseil-cpp and c++17.
    Even if the built-in protobuf is upgraded to v22 or later, 
    the dependency on abseil-cpp and the requirement for C++17 will continue.
2. Some test for caffe required patched protobuf, so this patch disable them.

This patch is tested by following libraries.
-  Protobuf:                    /usr/local/lib/libprotobuf.so (4.24.4)
-  abseil-cpp:                YES (20230125)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
