### PR TITLE
dnn: fix inconsistent input dtype for nary eltwise layers

### DIFF
--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -126,6 +126,8 @@ public:
         ngraph::element::Type dType;
         if (blobs[0].depth() == CV_32F) {
             dType = ngraph::element::f32;
+        } else if (blobs[0].depth() == CV_32S {
+            dType = ngraph::element::i32;
         } else if (blobs[0].depth() == CV_8S) {
             dType = ngraph::element::i8;
         } else {

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -80,6 +80,7 @@ public:
 
         std::vector<Mat> outputs;
         outputs_arr.getMatVector(outputs);
+        blobs[0].convertTo(blobs[0], outputs[0].type());
         blobs[0].copyTo(outputs[0]);
     }
 

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -80,8 +80,7 @@ public:
 
         std::vector<Mat> outputs;
         outputs_arr.getMatVector(outputs);
-        blobs[0].convertTo(blobs[0], outputs[0].type());
-        blobs[0].copyTo(outputs[0]);
+        blobs[0].convertTo(outputs[0], outputs[0].type());
     }
 
 #ifdef HAVE_CANN
@@ -164,7 +163,11 @@ public:
         auto context = reinterpret_cast<csl::CSLContext*>(context_);
 
         CV_Assert(blobs.size() == 1);
-        return make_cuda_node<cuda4dnn::ConstOp>(preferableTarget, std::move(context->stream), blobs[0]);
+        Mat blob = blobs[0];
+        if (blob.type() != CV_32F) {
+            blob.converTo(blob, CV_32F);
+        }
+        return make_cuda_node<cuda4dnn::ConstOp>(preferableTarget, std::move(context->stream), blob);
     }
 #endif
 

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -64,7 +64,7 @@ public:
         outs.getUMatVector(outputs);
         if (outs.depth() == CV_16S) {
             auto blob = blobs[0];
-            if (blob.type() == CV_32S) {
+            if (blob.type() != CV_32F) {
                 blob.convertTo(blob, CV_32F);
             }
             convertFp16(blob, outputs[0]);

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -126,7 +126,7 @@ public:
         ngraph::element::Type dType;
         if (blobs[0].depth() == CV_32F) {
             dType = ngraph::element::f32;
-        } else if (blobs[0].depth() == CV_32S {
+        } else if (blobs[0].depth() == CV_32S) {
             dType = ngraph::element::i32;
         } else if (blobs[0].depth() == CV_8S) {
             dType = ngraph::element::i8;

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -167,7 +167,7 @@ public:
         CV_Assert(blobs.size() == 1);
         Mat blob = blobs[0];
         if (blob.type() != CV_32F) {
-            blob.converTo(blob, CV_32F);
+            blob.convertTo(blob, CV_32F);
         }
         return make_cuda_node<cuda4dnn::ConstOp>(preferableTarget, std::move(context->stream), blob);
     }

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -62,10 +62,15 @@ public:
     {
         std::vector<UMat> outputs;
         outs.getUMatVector(outputs);
-        if (outs.depth() == CV_16S)
-            convertFp16(blobs[0], outputs[0]);
+        if (outs.depth() == CV_16S) {
+            auto blob = blobs[0];
+            if (blob.type() == CV_32S) {
+                blob.convertTo(blob, CV_32F);
+            }
+            convertFp16(blob, outputs[0]);
+        }
         else
-            blobs[0].copyTo(outputs[0]);
+            blobs[0].convertTo(outputs[0], outputs[0].type());
         return true;
     }
 #endif

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -383,7 +383,7 @@ void runLayer(LayerParams& params, const std::vector<Mat>& inputs,
     {
         inpShapes[i] = shape(inputs[i]);
         if (i > 0 && ddepth != inputs[i].depth())
-            CV_Error(Error::StsNotImplemented, "Mixed input data types.");
+            CV_Error(Error::StsNotImplemented, cv::format("Mixed input data types. Required type: %d, actual type: %d", ddepth, inputs[i].depth()));
 
         // Quantize and Dequantize layer have different output type than input.
         if (params.type != "Quantize" && params.type != "Dequantize")
@@ -2820,11 +2820,7 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
         std::vector<Mat> inputs, output;
         for (size_t i = 0; i < node_proto.input_size(); ++i)
         {
-            auto input_i = getBlob(node_proto, i);
-            if (input_i.type() != CV_32F) {
-                input_i.convertTo(input_i, CV_32F);
-            }
-            inputs.push_back(input_i);
+            inputs.push_back(getBlob(node_proto, i));
         }
         runLayer(layerParams, inputs, output);
         CV_Assert(output.size() == 1);
@@ -2838,9 +2834,6 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
             if (layer_id.find(node_proto.input(i)) == layer_id.end())
             {
                 Mat inp = getBlob(node_proto, i);
-                if (inp.type() != CV_32F) {
-                    inp.convertTo(inp, CV_32F);
-                }
                 // for cases like a tensor of shape (2,), it will be loaded as shape (2, 1) in OpenCV Mat,
                 // but for correct broadcast, we need to make it of shape (1, 2)
                 if (constBlobsExtraInfo.find(node_proto.input(i)) != constBlobsExtraInfo.end())

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2820,6 +2820,10 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
         std::vector<Mat> inputs, output;
         for (size_t i = 0; i < node_proto.input_size(); ++i)
         {
+            auto input_i = getBlob(node_proto, i);
+            if (i == 1) {
+                input_i.convertTo(input_i, CV_32F);
+            }
             inputs.push_back(getBlob(node_proto, i));
         }
         runLayer(layerParams, inputs, output);
@@ -2834,6 +2838,9 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
             if (layer_id.find(node_proto.input(i)) == layer_id.end())
             {
                 Mat inp = getBlob(node_proto, i);
+                if (i == 1) {
+                    inp.convertTo(inp, CV_32F);
+                }
                 // for cases like a tensor of shape (2,), it will be loaded as shape (2, 1) in OpenCV Mat,
                 // but for correct broadcast, we need to make it of shape (1, 2)
                 if (constBlobsExtraInfo.find(node_proto.input(i)) != constBlobsExtraInfo.end())

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2821,10 +2821,10 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
         for (size_t i = 0; i < node_proto.input_size(); ++i)
         {
             auto input_i = getBlob(node_proto, i);
-            if (i == 1) {
+            if (input_i.type() != CV_32F) {
                 input_i.convertTo(input_i, CV_32F);
             }
-            inputs.push_back(getBlob(node_proto, i));
+            inputs.push_back(input_i);
         }
         runLayer(layerParams, inputs, output);
         CV_Assert(output.size() == 1);
@@ -2838,7 +2838,7 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
             if (layer_id.find(node_proto.input(i)) == layer_id.end())
             {
                 Mat inp = getBlob(node_proto, i);
-                if (i == 1) {
+                if (inp.type() != CV_32F) {
                     inp.convertTo(inp, CV_32F);
                 }
                 // for cases like a tensor of shape (2,), it will be loaded as shape (2, 1) in OpenCV Mat,

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -675,6 +675,9 @@ TEST_P(Test_ONNX_layers, Compare_GT)
 
     testONNXModels("greater");
 }
+TEST_P(Test_ONNX_layers, Greater_input_dtype_int64) {
+    testONNXModels("greater_input_dtype_int64");
+}
 
 TEST_P(Test_ONNX_layers, Compare_LT)
 {


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24385
Merge with https://github.com/opencv/opencv_extra/pull/1107
Relates https://github.com/opencv/opencv/pull/24092#discussion_r1353964405

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
