### PR TITLE
Multi-channel Mat initialization support for cv::Mat::ones and cv::Mat::eye

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -673,6 +673,7 @@ public:
     Scalar_();
     Scalar_(_Tp v0, _Tp v1, _Tp v2=0, _Tp v3=0);
     Scalar_(_Tp v0);
+    Scalar_(_Tp v, int n);
 
     Scalar_(const Scalar_& s);
     Scalar_(Scalar_&& s) CV_NOEXCEPT;
@@ -2144,6 +2145,16 @@ Scalar_<_Tp>::Scalar_(_Tp v0, _Tp v1, _Tp v2, _Tp v3)
     this->val[1] = v1;
     this->val[2] = v2;
     this->val[3] = v3;
+}
+
+template<typename _Tp>
+Scalar_<_Tp>::Scalar_(_Tp v, const int n)
+{
+    CV_Assert(n <= 4);
+    for (size_t i = 0; i < n; i++)
+    {
+        this->val[i] = v;
+    }
 }
 
 template<typename _Tp> inline

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -1685,11 +1685,11 @@ void MatOp_Initializer::assign(const MatExpr& e, Mat& m, int _type) const
         m.create(e.a.dims, e.a.size, _type);
 
     if( e.flags == 'I' && e.a.dims <= 2 )
-        setIdentity(m, Scalar(e.alpha));
+        setIdentity(m, Scalar(e.alpha, e.a.channels()));
     else if( e.flags == '0' )
         m = Scalar();
     else if( e.flags == '1' )
-        m = Scalar(e.alpha);
+        m = Mat(e.a.size(), e.a.type(), Scalar(e.alpha, e.a.channels()));
     else
         CV_Error(CV_StsError, "Invalid matrix initializer type");
 }

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -419,6 +419,20 @@ bool CV_OperationsTest::TestMat()
         CHECK_DIFF_FLT(mt.inv() * mt, d1);
 
         CHECK_DIFF_FLT(mt.inv() * (2*mt - mt), d1);
+
+        ///// Initalize Mat with ones and eye
+        Mat e = cv::Mat::eye(2, 2, CV_32FC3);
+        Mat o = cv::Mat::ones(2, 2, CV_32FC3);
+
+        float e_[2][6] = {{1, 1, 1, 0, 0, 0}, {0, 0, 0, 1, 1, 1}};
+        Mat e_ans(2, 2, e.type(), e_);
+        float o_[2][6] = {{1, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1}};
+        Mat o_ans(2, 2, o.type(), o_);
+
+        CHECK_DIFF(e, e_ans);
+        CHECK_DIFF(e_ans, e);
+        CHECK_DIFF(o, o_ans);
+        CHECK_DIFF(o_ans, o);
 #endif
     }
     catch (const test_excep& e)


### PR DESCRIPTION
The original cv::Mat::ones and cv::Mat::eye functions only support one-channel type Mat initialization. For example, as for cv::Mat::ones, in case of multi-channel type, only the first channel will be initialized with 1's and the others will be set to 0's in case of multi-channel type. This goes against the common cognition of users and affects the consistency of the results they obtain and the expected results.

This commit makes cv::Mat::ones and cv::Mat::eye functions support multi-channel Mat initialization so that all channels of multi-channel type (CV_XXC2/CV_XXC3/CV_XXC4) can be initialized with a specified value.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [N/A] There is a reference to the original bug report and related work
- [N/A] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [N/A] The feature is well documented and sample code can be built with the project CMake
