### PR TITLE
Fix : Code snippet alignment #24391

### DIFF
--- a/modules/dnn/src/darknet/darknet_importer.cpp
+++ b/modules/dnn/src/darknet/darknet_importer.cpp
@@ -219,7 +219,7 @@ Net readNetFromDarknet(const String &cfgFile, const String &darknetModel /*= Str
         return readNetFromDarknet(cfgStream, darknetModelStream);
     }
     else
-        return readNetFromDarknet(cfgStream);
+        return readNetFromDarknet(cfgStream); 
 }
 
 struct BufferStream : public std::streambuf

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -922,8 +922,8 @@ namespace cv {
                     {
                         int crop_height = getParam<int>(layer_params, "crop_height", 224);
                         int crop_width = getParam<int>(layer_params, "crop_width", 224);
-                        int flip = getParam<int>(layer_params, "flip", 1);
-                        int exposure = getParam<int>(layer_params, "exposure", 1);
+                        bool flip = getParam<bool>(layer_params, "flip", true);
+                        float exposure = getParam<float>(layer_params, "exposure", 1.0);
                         int saturation = getParam<int>(layer_params, "saturation", 1);
                         int angle = getParam<int>(layer_params, "angle", 0);
                         setParams.setCrop(crop_height, crop_width, flip, exposure, saturation, angle);

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -178,6 +178,26 @@ namespace cv {
                     fused_layer_names.push_back(last_layer);
                 }
 
+                void setCrop(int crop_height, int crop_width, int flip, int exposure, int saturation, int angle)
+                {
+                    cv::dnn::LayerParams crop_param;
+                    crop_param.type = "Crop";
+
+                    darknet::LayerParameter lp;
+                    std::string layer_name = cv::format("crop_%d", layer_id);
+
+                    lp.layer_name = layer_name;
+                    lp.layer_type = crop_param.type;
+                    lp.layerParams = crop_param;
+                    lp.bottom_indexes.push_back(last_layer);
+                    last_layer = layer_name;
+                    net->layers.push_back(lp);
+
+                    layer_id++;
+                    fused_layer_names.push_back(last_layer);
+                }
+
+
                 cv::dnn::LayerParams getParamFullyConnected(int output)
                 {
                     cv::dnn::LayerParams params;
@@ -897,6 +917,16 @@ namespace cv {
 
                         setParams.setPermute(false);
                         setParams.setYolo(classes, mask_vec, anchors_vec, thresh, nms_threshold, scale_x_y, new_coords);
+                    }
+                    else if (layer_type == "crop")
+                    {
+                        int crop_height = getParam<int>(layer_params, "crop_height", 224);
+                        int crop_width = getParam<int>(layer_params, "crop_width", 224);
+                        int flip = getParam<int>(layer_params, "flip", 1);
+                        int exposure = getParam<int>(layer_params, "exposure", 1);
+                        int saturation = getParam<int>(layer_params, "saturation", 1);
+                        int angle = getParam<int>(layer_params, "angle", 0);
+                        setParams.setCrop(crop_height, crop_width, flip, exposure, saturation, angle);
                     }
                     else {
                         CV_Error(cv::Error::StsParseError, "Unknown layer type: " + layer_type);


### PR DESCRIPTION
I think this problem is because of using @include to call the cpp code file. this has resulted in loss of indentation for every code that was included. hence using code fences has solved this issue. with preserving the white spaces. but i still dont know if that results in increased run time. pls let me know. Im new here. requesting for comments.
![desk-pull](https://github.com/opencv/opencv/assets/147172285/88c807c5-7833-4413-8baf-889a62b80728)

the preview can also be viewed at:
https://vscode.dev/github/Dhanwanth1803/opencv/blob/docs-stitcherapiiew-0d4b1c28-af1f-4c7d-af27-db14ed925c9d


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
