### PR TITLE
Fixes: Code snippet alignment #24391

### DIFF
--- a/doc/tutorials/others/stitcher.markdown
+++ b/doc/tutorials/others/stitcher.markdown
@@ -27,7 +27,126 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/opencv/opencv/tree/4.x/samples/cpp/stitching.cpp).
 
-@include samples/cpp/stitching.cpp
+```cpp
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/stitching.hpp"
+
+#include <iostream>
+
+using namespace std;
+using namespace cv;
+
+bool divide_images = false;
+Stitcher::Mode mode = Stitcher::PANORAMA;
+vector<Mat> imgs;
+string result_name = "result.jpg";
+
+void printUsage(char** argv);
+int parseCmdArgs(int argc, char** argv);
+
+int main(int argc, char* argv[])
+{
+    int retval = parseCmdArgs(argc, argv);
+    if (retval) return EXIT_FAILURE;
+
+    //![stitching]
+    Mat pano;
+    Ptr<Stitcher> stitcher = Stitcher::create(mode);
+    Stitcher::Status status = stitcher->stitch(imgs, pano);
+
+    if (status != Stitcher::OK)
+    {
+        cout << "Can't stitch images, error code = " << int(status) << endl;
+        return EXIT_FAILURE;
+    }
+    //![stitching]
+
+    imwrite(result_name, pano);
+    cout << "stitching completed successfully\n" << result_name << " saved!";
+    return EXIT_SUCCESS;
+}
+
+
+void printUsage(char** argv)
+{
+    cout <<
+         "Images stitcher.\n\n" << "Usage :\n" << argv[0] <<" [Flags] img1 img2 [...imgN]\n\n"
+         "Flags:\n"
+         "  --d3\n"
+         "      internally creates three chunks of each image to increase stitching success\n"
+         "  --mode (panorama|scans)\n"
+         "      Determines configuration of stitcher. The default is 'panorama',\n"
+         "      mode suitable for creating photo panoramas. Option 'scans' is suitable\n"
+         "      for stitching materials under affine transformation, such as scans.\n"
+         "  --output <result_img>\n"
+         "      The default is 'result.jpg'.\n\n"
+         "Example usage :\n" << argv[0] << " --d3 --mode scans img1.jpg img2.jpg\n";
+}
+
+
+int parseCmdArgs(int argc, char** argv)
+{
+    if (argc == 1)
+    {
+        printUsage(argv);
+        return EXIT_FAILURE;
+    }
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (string(argv[i]) == "--help" || string(argv[i]) == "/?")
+        {
+            printUsage(argv);
+            return EXIT_FAILURE;
+        }
+        else if (string(argv[i]) == "--d3")
+        {
+            divide_images = true;
+        }
+        else if (string(argv[i]) == "--output")
+        {
+            result_name = argv[i + 1];
+            i++;
+        }
+        else if (string(argv[i]) == "--mode")
+        {
+            if (string(argv[i + 1]) == "panorama")
+                mode = Stitcher::PANORAMA;
+            else if (string(argv[i + 1]) == "scans")
+                mode = Stitcher::SCANS;
+            else
+            {
+                cout << "Bad --mode flag value\n";
+                return EXIT_FAILURE;
+            }
+            i++;
+        }
+        else
+        {
+            Mat img = imread(samples::findFile(argv[i]));
+            if (img.empty())
+            {
+                cout << "Can't read image '" << argv[i] << "'\n";
+                return EXIT_FAILURE;
+            }
+
+            if (divide_images)
+            {
+                Rect rect(0, 0, img.cols / 2, img.rows);
+                imgs.push_back(img(rect).clone());
+                rect.x = img.cols / 3;
+                imgs.push_back(img(rect).clone());
+                rect.x = img.cols / 2;
+                imgs.push_back(img(rect).clone());
+            }
+            else
+                imgs.push_back(img);
+        }
+    }
+    return EXIT_SUCCESS;
+}
+```
 
 Explanation
 -----------


### PR DESCRIPTION
I think this problem is because of using @include to call the CPP code file. This has resulted in loss of indentation for every code that was included. **By the way this is common for every code snippet that appears in the documentation.**

Hence using code fences has solved this issue. with preserving the white spaces. But I still don't know if that results in increased run time. Please let me know. I am new here. Requesting for comments.

![pr2-1](https://github.com/opencv/opencv/assets/147172285/2a4bc2b7-7e77-4bdc-a889-cbd5d692493c)
![pr2-2](https://github.com/opencv/opencv/assets/147172285/114ed904-39f1-4720-bb8c-e47bbbb2c971)

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
