### PR TITLE
dnn: add shared fastNorm kernel for mvn, instance norm and layer norm

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1127,6 +1127,7 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS LayerNormLayer : public Layer
     {
     public:
+        bool hasBias; // Deprecated, preserve for compatibility
         int axis;
         float epsilon;
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1127,7 +1127,7 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS LayerNormLayer : public Layer
     {
     public:
-        bool hasBias; // Deprecated, preserve for compatibility
+        CV_DEPRECATED_EXTERNAL bool hasBias; // Deprecated, preserve for compatibility
         int axis;
         float epsilon;
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1127,7 +1127,6 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS LayerNormLayer : public Layer
     {
     public:
-        bool hasBias;
         int axis;
         float epsilon;
 

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -131,4 +131,3 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
 }
 
 }} // cv::dnn
- 

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -1,0 +1,124 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../../precomp.hpp"
+#include "fast_norm.hpp"
+
+namespace cv { namespace dnn {
+
+// // Assume axes has been normalized
+// static std::vector<int> getTransposePermutation(const MatShape &input_shape, const std::vector<int> normed_axes) {
+//     std::vector<int> perm{};
+//     bool need_trans = false;
+//     for (size_t i = 0, num_axes = normed_axes.size(), num_dims = input_shape.size(); i < num_axes; i++) {
+//         if (normed_axes[i] != num_dims - num_axes + i) {
+//             need_trans = true;
+//             break;
+//         }
+//     }
+
+//     if (need_trans) {
+//         perm.clear();
+//         auto normed_axis = normed_axes.begin();
+//         for (size_t axis = 0, num_dims = input_shape.size(); axis < num_dims; axis++) {
+//             if (normed_axis != normed_axes.end() && axis == *normed_axis) {
+//                 ++normed_axis;
+//             } else {
+//                 perm.push_back(static_cast<int>(axis));
+//             }
+//         }
+//         perm.insert(perm.end(), normed_axes.begin(), normed_axes.end());
+//     }
+
+//     return perm;
+// }
+
+// static std::vector<int> getInvertedTransposePermutation(const std::vector<int> perm) {
+//     std::vector<int> inverted_perm(perm.size());
+//     for (size_t i = 0; i < perm.size(); i++) {
+//         inverted_perm[perm[i]] = i;
+//     }
+//     return inverted_perm;
+// }
+
+/*
+
+| Norm          | input | scale    | bias               | axis         |
+| ------------- | ----- | -------- | ------------------ | ------------ |
+| layer norm    | d>=n  | d[axis:] | optional, d[axis:] | -1, [-d, d]  |
+| instance norm | d>=3  | d[axis]  | d[axis]            | 1            |
+| mvn           | d>=4  | N/A      | N/A                | [0, 2, 3]    |
+
+// onnx layer norm: https://github.com/onnx/onnx/blob/main/docs/Operators.md#LayerNormalization
+// onnx instance norm: https://github.com/onnx/onnx/blob/main/docs/Operators.md#InstanceNormalization
+// onnx mvn: https://github.com/onnx/onnx/blob/main/docs/Operators.md#MeanVarianceNormalization
+
+*/
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int axis) {
+    // const auto input_shape = shape(input);
+
+    // // Normalize axes
+    // std::vector<int> normed_axes;
+    // std::transform(axes.begin(), axes.end(), std::back_inserter(normed_axes),
+    //                [input_shape] (int axis) { return normalize_axis(axis, static_cast<int>(input_shape.size())); });
+
+    // if (axes.size() > static_cast<size_t>(1)) { // mvn
+    //     std::vector<int> transpose_permutation = getTransposePermutation(input_shape, normed_axes);
+    //     int axis = static_cast<int>(input_shape.size() - normed_axes.size());
+
+    //     if (!transpose_permutation.empty()) {
+    //         Mat transposed_input;
+    //         cv::transposeND(input, transpose_permutation, transposed_input);
+
+    //         Mat transposed_output(input_shape, CV_32F);
+    //         fastMVNKernel(input, scale, bias, transposed_output, epsilon, axis);
+
+    //         auto inverted_perm = getInvertedTransposePermutation(transpose_permutation);
+    //         cv::transposeND(transposed_output, inverted_perm, output);
+
+    //         return;
+    //     } else {
+    //         fastMVNKernel(input, scale, bias, output, epsilon, axis);
+    //     }
+    // }
+
+
+    // TODO: check shape?
+
+    const auto input_shape = shape(input);
+
+    size_t loops = std::accumulate(input_shape.begin() + axis + 1, input_shape.end(), static_cast<size_t>(1), std::multiplies<size_t>()),
+           norm_size = static_cast<size_t>(total(input_shape, 2));
+    float inv_norm_size = 1.0 / norm_size;
+
+    auto fn = [&](const Range &r) {
+        const auto *input_data = input.ptr<const float>();
+        const auto *scale_data = scale.ptr<const float>();
+        const auto *bias_data = bias.ptr<const float>();
+        auto *output_data = output.ptr<float>();
+        for (int i = r.start; i < r.end; i++) {
+            const auto *x = input_data + norm_size * i;
+            auto *y = output_data + norm_size * i;
+
+            float mean = 0.f, mean_square = 0.f;
+            for (int j = 0; j < norm_size; j++) {
+                float v = x[j];
+                mean += v;
+                mean_square += v * v;
+            }
+
+            mean *= inv_norm_size;
+            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
+            float inv_stdev = 1.f / mean_square;
+
+            for (size_t j = 0; j < norm_size; j++) {
+                y[j] = scale_data[j] * (x[j] - mean) * inv_stdev + bias_data[j];
+            }
+        }
+    };
+    double nstripes = loops * norm_size * (1 / 1024.0);
+    parallel_for_(Range(0, loops), fn, nstripes);
+}
+
+}} // cv::dnn

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -55,7 +55,7 @@ namespace cv { namespace dnn {
 // onnx mvn: https://github.com/onnx/onnx/blob/main/docs/Operators.md#MeanVarianceNormalization
 
 */
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int axis) {
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int normalized_axis) {
     // const auto input_shape = shape(input);
 
     // // Normalize axes
@@ -87,9 +87,11 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
     // TODO: check shape?
 
     const auto input_shape = shape(input);
+    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
 
-    size_t loops = std::accumulate(input_shape.begin() + axis + 1, input_shape.end(), static_cast<size_t>(1), std::multiplies<size_t>()),
-           norm_size = static_cast<size_t>(total(input_shape, 2));
+    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
+           norm_size = static_cast<size_t>(total(input_shape, normalized_axis));
     float inv_norm_size = 1.0 / norm_size;
 
     auto fn = [&](const Range &r) {

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -7,85 +7,45 @@
 
 namespace cv { namespace dnn {
 
-// // Assume axes has been normalized
-// static std::vector<int> getTransposePermutation(const MatShape &input_shape, const std::vector<int> normed_axes) {
-//     std::vector<int> perm{};
-//     bool need_trans = false;
-//     for (size_t i = 0, num_axes = normed_axes.size(), num_dims = input_shape.size(); i < num_axes; i++) {
-//         if (normed_axes[i] != num_dims - num_axes + i) {
-//             need_trans = true;
-//             break;
-//         }
-//     }
+//  Mean-Variance-Normalization speedup by multi-threading.
+void fastNorm(const Mat &input, Mat &output, float epsilon, int normalized_axis, bool normalize_variance) {
+    const auto input_shape = shape(input);
+    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
 
-//     if (need_trans) {
-//         perm.clear();
-//         auto normed_axis = normed_axes.begin();
-//         for (size_t axis = 0, num_dims = input_shape.size(); axis < num_dims; axis++) {
-//             if (normed_axis != normed_axes.end() && axis == *normed_axis) {
-//                 ++normed_axis;
-//             } else {
-//                 perm.push_back(static_cast<int>(axis));
-//             }
-//         }
-//         perm.insert(perm.end(), normed_axes.begin(), normed_axes.end());
-//     }
+    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
+           norm_size = static_cast<size_t>(total(input_shape, normalized_axis));
+    float inv_norm_size = 1.0 / norm_size;
 
-//     return perm;
-// }
+    auto fn = [&](const Range &r) {
+        const auto *input_data = input.ptr<const float>();
+        auto *output_data = output.ptr<float>();
+        for (int i = r.start; i < r.end; i++) {
+            const auto *x = input_data + norm_size * i;
+            auto *y = output_data + norm_size * i;
 
-// static std::vector<int> getInvertedTransposePermutation(const std::vector<int> perm) {
-//     std::vector<int> inverted_perm(perm.size());
-//     for (size_t i = 0; i < perm.size(); i++) {
-//         inverted_perm[perm[i]] = i;
-//     }
-//     return inverted_perm;
-// }
+            float mean = 0.f, mean_square = 0.f;
+            for (int j = 0; j < norm_size; j++) {
+                float v = x[j];
+                mean += v;
+                mean_square += v * v;
+            }
 
-/*
+            mean *= inv_norm_size;
+            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
+            float inv_stdev = normalize_variance ? 1.f / mean_square : 1.f;
 
-| Norm          | input | scale    | bias               | axis         |
-| ------------- | ----- | -------- | ------------------ | ------------ |
-| layer norm    | d>=n  | d[axis:] | optional, d[axis:] | -1, [-d, d]  |
-| instance norm | d>=3  | d[axis]  | d[axis]            | 1            |
-| mvn           | d>=4  | N/A      | N/A                | [0, 2, 3]    |
+            for (size_t j = 0; j < norm_size; j++) {
+                y[j] = (x[j] - mean) * inv_stdev;
+            }
+        }
+    };
+    double nstripes = loops * norm_size * (1 / 1024.0);
+    parallel_for_(Range(0, loops), fn, nstripes);
+}
 
-// onnx layer norm: https://github.com/onnx/onnx/blob/main/docs/Operators.md#LayerNormalization
-// onnx instance norm: https://github.com/onnx/onnx/blob/main/docs/Operators.md#InstanceNormalization
-// onnx mvn: https://github.com/onnx/onnx/blob/main/docs/Operators.md#MeanVarianceNormalization
-
-*/
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int normalized_axis) {
-    // const auto input_shape = shape(input);
-
-    // // Normalize axes
-    // std::vector<int> normed_axes;
-    // std::transform(axes.begin(), axes.end(), std::back_inserter(normed_axes),
-    //                [input_shape] (int axis) { return normalize_axis(axis, static_cast<int>(input_shape.size())); });
-
-    // if (axes.size() > static_cast<size_t>(1)) { // mvn
-    //     std::vector<int> transpose_permutation = getTransposePermutation(input_shape, normed_axes);
-    //     int axis = static_cast<int>(input_shape.size() - normed_axes.size());
-
-    //     if (!transpose_permutation.empty()) {
-    //         Mat transposed_input;
-    //         cv::transposeND(input, transpose_permutation, transposed_input);
-
-    //         Mat transposed_output(input_shape, CV_32F);
-    //         fastMVNKernel(input, scale, bias, transposed_output, epsilon, axis);
-
-    //         auto inverted_perm = getInvertedTransposePermutation(transpose_permutation);
-    //         cv::transposeND(transposed_output, inverted_perm, output);
-
-    //         return;
-    //     } else {
-    //         fastMVNKernel(input, scale, bias, output, epsilon, axis);
-    //     }
-    // }
-
-
-    // TODO: check shape?
-
+// LayerNormalization speedup by multi-threading. Bias is absent.
+void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, int normalized_axis) {
     const auto input_shape = shape(input);
     CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
     CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
@@ -97,7 +57,6 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
     auto fn = [&](const Range &r) {
         const auto *input_data = input.ptr<const float>();
         const auto *scale_data = scale.ptr<const float>();
-        const auto *bias_data = bias.ptr<const float>();
         auto *output_data = output.ptr<float>();
         for (int i = r.start; i < r.end; i++) {
             const auto *x = input_data + norm_size * i;
@@ -115,7 +74,55 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
             float inv_stdev = 1.f / mean_square;
 
             for (size_t j = 0; j < norm_size; j++) {
-                y[j] = scale_data[j] * (x[j] - mean) * inv_stdev + bias_data[j];
+                y[j] = scale_data[j] * (x[j] - mean) * inv_stdev;
+            }
+        }
+    };
+    double nstripes = loops * norm_size * (1 / 1024.0);
+    parallel_for_(Range(0, loops), fn, nstripes);
+}
+
+/*  Normalization speedup by mutli-threading. It supports
+
+    1. LayerNorm that has scale/bias of shape input.shape[axis:]
+    2. Channel-wise scale/bias. It needs to be broadcast to shape (C)+input.shape[axis:]
+
+*/
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int normalized_axis) {
+    const auto input_shape = shape(input);
+    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
+    CV_CheckEQ(scale.total(), bias.total(), "fastNorm: scale and bias should have the same shape");
+
+    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
+           norm_size = static_cast<size_t>(total(input_shape, normalized_axis)),
+           scale_total = scale.total();
+    float inv_norm_size = 1.0 / norm_size;
+
+    auto fn = [&](const Range &r) {
+        const auto *input_data = input.ptr<const float>();
+        const auto *scale_data = scale.ptr<const float>();
+        const auto *bias_data = bias.ptr<const float>();
+        auto *output_data = output.ptr<float>();
+        for (int i = r.start; i < r.end; i++) {
+            const auto *x = input_data + norm_size * i;
+            const auto *s = scale_data + (norm_size * i) % scale_total;
+            const auto *b = bias_data + (norm_size * i) % scale_total;
+            auto *y = output_data + norm_size * i;
+
+            float mean = 0.f, mean_square = 0.f;
+            for (int j = 0; j < norm_size; j++) {
+                float v = x[j];
+                mean += v;
+                mean_square += v * v;
+            }
+
+            mean *= inv_norm_size;
+            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
+            float inv_stdev = 1.f / mean_square;
+
+            for (size_t j = 0; j < norm_size; j++) {
+                y[j] = s[j] * (x[j] - mean) * inv_stdev + b[j];
             }
         }
     };
@@ -124,3 +131,4 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
 }
 
 }} // cv::dnn
+ 

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -7,14 +7,12 @@
 
 namespace cv { namespace dnn {
 
-//  Mean-Variance-Normalization speedup by multi-threading.
-void fastNorm(const Mat &input, Mat &output, float epsilon, int normalized_axis, bool normalize_variance) {
+void fastNorm(const Mat &input, Mat &output, float epsilon, size_t normalized_axis, bool normalize_variance) {
     const auto input_shape = shape(input);
-    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
-    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
 
-    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
-           norm_size = static_cast<size_t>(total(input_shape, normalized_axis));
+    size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis))),
+           norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
     float inv_norm_size = 1.0 / norm_size;
 
     auto fn = [&](const Range &r) {
@@ -44,14 +42,12 @@ void fastNorm(const Mat &input, Mat &output, float epsilon, int normalized_axis,
     parallel_for_(Range(0, loops), fn, nstripes);
 }
 
-// LayerNormalization speedup by multi-threading. Bias is absent.
-void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, int normalized_axis) {
+void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, size_t normalized_axis) {
     const auto input_shape = shape(input);
-    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
-    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
 
-    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
-           norm_size = static_cast<size_t>(total(input_shape, normalized_axis));
+    size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis))),
+           norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
     float inv_norm_size = 1.0 / norm_size;
 
     auto fn = [&](const Range &r) {
@@ -82,21 +78,13 @@ void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, in
     parallel_for_(Range(0, loops), fn, nstripes);
 }
 
-/*  Normalization speedup by mutli-threading. It supports
-
-    1. LayerNorm that has scale/bias of shape input.shape[axis:]
-    2. Channel-wise scale/bias. It needs to be broadcast to shape (C)+input.shape[axis:]
-
-*/
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int normalized_axis) {
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, size_t normalized_axis) {
     const auto input_shape = shape(input);
-    CV_CheckGE(normalized_axis, 0, "fastNorm: axis out of range");
-    CV_CheckLT(normalized_axis, static_cast<int>(input_shape.size()), "fastNorm: axis out of range");
+    CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
     CV_CheckEQ(scale.total(), bias.total(), "fastNorm: scale and bias should have the same shape");
 
-    size_t loops = static_cast<size_t>(total(input_shape, 0, normalized_axis)),
-           norm_size = static_cast<size_t>(total(input_shape, normalized_axis)),
-           scale_total = scale.total();
+    size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis))),
+           norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
     float inv_norm_size = 1.0 / norm_size;
 
     auto fn = [&](const Range &r) {
@@ -106,8 +94,6 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
         auto *output_data = output.ptr<float>();
         for (int i = r.start; i < r.end; i++) {
             const auto *x = input_data + norm_size * i;
-            const auto *s = scale_data + (norm_size * i) % scale_total;
-            const auto *b = bias_data + (norm_size * i) % scale_total;
             auto *y = output_data + norm_size * i;
 
             float mean = 0.f, mean_square = 0.f;
@@ -122,7 +108,48 @@ void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, 
             float inv_stdev = 1.f / mean_square;
 
             for (size_t j = 0; j < norm_size; j++) {
-                y[j] = s[j] * (x[j] - mean) * inv_stdev + b[j];
+                y[j] = scale_data[j] * (x[j] - mean) * inv_stdev + bias_data[j];
+            }
+        }
+    };
+    double nstripes = loops * norm_size * (1 / 1024.0);
+    parallel_for_(Range(0, loops), fn, nstripes);
+}
+
+void fastNormChannel(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon) {
+    const auto input_shape = shape(input);
+    CV_CheckEQ(scale.total(), bias.total(), "fastNormChannel: scale and bias should have the same shape");
+    CV_CheckGE(input.dims, 3, "fastNormChannel: input dimension >= 3");
+
+    size_t N = input_shape[0], C = input_shape[1];
+    size_t loops = N * C,
+           norm_size = static_cast<size_t>(total(input_shape, 2));
+    float inv_norm_size = 1.0 / norm_size;
+
+    auto fn = [&](const Range &r) {
+        const auto *input_data = input.ptr<const float>();
+        const auto *scale_data = scale.ptr<const float>();
+        const auto *bias_data = bias.ptr<const float>();
+        auto *output_data = output.ptr<float>();
+        for (int i = r.start; i < r.end; i++) {
+            const auto *x = input_data + norm_size * i;
+            auto *y = output_data + norm_size * i;
+
+            float mean = 0.f, mean_square = 0.f;
+            for (int j = 0; j < norm_size; j++) {
+                float v = x[j];
+                mean += v;
+                mean_square += v * v;
+            }
+
+            mean *= inv_norm_size;
+            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
+            float inv_stdev = 1.f / mean_square;
+
+            size_t c = i % C;
+            float s = scale_data[c], b = bias_data[c];
+            for (size_t j = 0; j < norm_size; j++) {
+                y[j] = s * (x[j] - mean) * inv_stdev + b;
             }
         }
     };

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
@@ -9,7 +9,7 @@
 
 namespace cv { namespace dnn {
 
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, int axis = 0);
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int axis = 0);
 
 }} // cv::dnn
 

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
@@ -9,9 +9,17 @@
 
 namespace cv { namespace dnn {
 
-void fastNorm(const Mat &input, Mat &output, float epsilon, int axis = 0, bool normalize_variance = true);
-void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, int axis = 0);
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int axis = 0);
+// Normalization speedup by multi-threading, mainly for Caffe MVN layer which has normalize_variance parameter.
+void fastNorm(const Mat &input, Mat &output, float epsilon, size_t normalized_axis = 0, bool normalize_variance = true);
+
+// Normalization speedup by multi-threading with absent bias. Mainly for LayerNormalization.
+void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, size_t normalized_axis = 0);
+
+// Normalization speedup by multi-threading with scale and bias. Mainly for LayerNormalization.
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, size_t normalized_axis = 0);
+
+// Channel-wise Normalization speedup by multi-threading. Scale and bias should have the same shape (C). Input should have dimension >= 3.
+void fastNormChannel(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon);
 
 }} // cv::dnn
 

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
@@ -1,0 +1,16 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_FAST_NORM_HPP
+#define OPENCV_DNN_FAST_NORM_HPP
+
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv { namespace dnn {
+
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, int axis = 0);
+
+}} // cv::dnn
+
+#endif // OPENCV_DNN_FAST_NORM_HPP

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.hpp
@@ -9,6 +9,8 @@
 
 namespace cv { namespace dnn {
 
+void fastNorm(const Mat &input, Mat &output, float epsilon, int axis = 0, bool normalize_variance = true);
+void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, int axis = 0);
 void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, int axis = 0);
 
 }} // cv::dnn

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -85,9 +85,9 @@ public:
 
         if (inputs.size() == 3) {
             const auto &bias = inputs[2];
-            fastNorm(input, scale, bias, output, epsilon, axis);
+            fastNorm(input, scale, bias, output, epsilon, static_cast<size_t>(axis));
         } else {
-            fastNorm(input, scale, output, epsilon, axis);
+            fastNorm(input, scale, output, epsilon, static_cast<size_t>(axis));
         }
     }
 };

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -4,6 +4,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
+#include "cpu_kernels/fast_norm.hpp"
 
 namespace cv { namespace dnn {
 
@@ -15,11 +16,8 @@ public:
         setParamsFrom(params);
 
         // standard attr
-        axis = params.get<int>("axis", 0);
+        axis = params.get<int>("axis", -1);
         epsilon = params.get<float>("epsilon", 1e-5);
-
-        // opencv attr
-        hasBias = params.get<bool>("hasBias", false);
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
@@ -46,104 +44,25 @@ public:
         CV_CheckEQ(x_ndims - axis, w_ndims, "LayerNorm: shape of weight does not match with given axis and shape of input");
         for (int i = 0; i < w_ndims; ++i)
             CV_CheckEQ(x_shape[axis+i], w_shape[i], "LayerNorm: weight dimensions does not match with input dimensions");
-        if (hasBias)
+        if (inputs.size() == static_cast<int>(3))
         {
-            CV_CheckEQ(inputs.size(), (size_t)3, "");
             auto b_shape = inputs[2];
             CV_CheckEQ(w_shape.size(), b_shape.size(), "LayerNorm: shape of weight does not match with shape of bias");
             for (size_t i = 0; i < w_shape.size(); ++i)
                 CV_CheckEQ(w_shape[i], b_shape[i], "LayerNorm: bias dimensions does not match with weight dimensions");
         }
 
-        // only one output is needed; Mean & InvStdDev are not needed
-        // in inference and should beomitted in onnx importer
         outputs.assign(1, inputs[0]);
         return false;
     }
 
-    template<bool hasBias>
-    class LayerNormInvoker : public ParallelLoopBody
-    {
-    public:
-        const Mat& src;
-        const float* scaleData;
-        const float* biasData;
-        Mat& dst;
-
-        float epsilon;
-
-        int total;
-        int normSize;
-        float invNormSize;
-
-        LayerNormInvoker(const Mat& src_, const Mat& scale, const Mat* b, Mat& dst_, int axis, float epsilon_)
-            : src(src_), scaleData(scale.ptr<float>()), biasData(nullptr), dst(dst_), epsilon(epsilon_)
-        {
-            if (hasBias)
-            {
-                CV_Assert(b != nullptr);
-                CV_Assert(b->isContinuous());
-                biasData = (const float*)b->ptr<float>();
-            }
-
-            auto dstShape = shape(dst);
-            total = std::accumulate(dstShape.begin(), dstShape.begin() + axis, 1, std::multiplies<int>());
-            normSize = std::accumulate(dstShape.begin() + axis, dstShape.end(), 1, std::multiplies<int>());
-            invNormSize = 1.0f / normSize;
-        }
-
-        static void run(const Mat& src, const Mat& scale, const Mat* b, Mat& dst, int axis, float epsilon)
-        {
-            CV_Assert(src.isContinuous());
-            CV_Assert(dst.isContinuous());
-            CV_CheckTypeEQ(src.type(), CV_32F, "DNN/LayerNorm: only support float32");
-            CV_CheckTypeEQ(src.type(), dst.type(), "");
-            CV_Assert(scale.isContinuous());
-
-            CV_CheckGE(epsilon, 0.0f, "");
-
-            LayerNormInvoker p(src, scale, b, dst, axis, epsilon);
-
-            double nstripes = ((size_t)p.total * p.normSize) * (1 / 1024.0);
-            // double nstripes = ((size_t)p.total) * (1 / 1024.0);
-            parallel_for_(Range(0, p.total), p, nstripes);
-        }
-
-        void operator()(const Range& r) const CV_OVERRIDE
-        {
-            int stripeStart = r.start;
-            int stripeEnd = r.end;
-
-            const float* srcData = src.ptr<float>();
-            float* dstData = dst.ptr<float>();
-
-            for (int ofs = stripeStart; ofs < stripeEnd; ++ofs)
-            {
-                const float* first = srcData + ofs * normSize;
-                float* dstFirst = dstData + ofs * normSize;
-
-                float mean = 0;
-                float meanSquare = 0;
-                for (int h = 0; h < normSize; ++h)
-                {
-                    float v = first[h];
-                    mean += v;
-                    meanSquare += v * v;
-                }
-                mean *= invNormSize;
-                meanSquare = std::sqrt(std::max(0.f, meanSquare * invNormSize - mean * mean) + epsilon);
-                float invMeanSquare = 1.0f / meanSquare;
-                for (int h = 0; h < normSize; ++h)
-                {
-                    float v = (first[h] - mean) * invMeanSquare * scaleData[h];
-                    if (hasBias) {
-                        v = v + biasData[h];
-                    }
-                    dstFirst[h] = v;
-                }
-            }
-        }
-    };
+    virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE {
+        std::vector<Mat> inputs;
+        inputs_arr.getMatVector(inputs);
+        
+        const auto input_shape = shape(inputs[0]);
+        axis = normalize_axis(axis, static_cast<int>(input_shape.size()));
+    }
 
     void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
     {
@@ -160,11 +79,13 @@ public:
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);
 
-        if (hasBias) {
-            LayerNormInvoker<true>::run(inputs[0], inputs[1], &inputs[2], outputs[0], axis, epsilon);
-        } else {
-            LayerNormInvoker<false>::run(inputs[0], inputs[1], nullptr, outputs[0], axis, epsilon);
-        }
+        const auto &input = inputs[0];
+        const auto &scale = inputs[1];
+        const auto scale_shape = shape(scale);
+        const auto &bias = inputs.size() == 3 ? inputs[2] : Mat::zeros(static_cast<int>(scale_shape.size()), scale_shape.data(), CV_32F);
+        auto &output = outputs[0];
+
+        fastNorm(input, scale, bias, output, epsilon, axis);
     }
 };
 

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -59,7 +59,7 @@ public:
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE {
         std::vector<Mat> inputs;
         inputs_arr.getMatVector(inputs);
-        
+
         const auto input_shape = shape(inputs[0]);
         axis = normalize_axis(axis, static_cast<int>(input_shape.size()));
     }

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -82,10 +82,14 @@ public:
         const auto &input = inputs[0];
         const auto &scale = inputs[1];
         const auto scale_shape = shape(scale);
-        const auto &bias = inputs.size() == 3 ? inputs[2] : Mat::zeros(static_cast<int>(scale_shape.size()), scale_shape.data(), CV_32F);
         auto &output = outputs[0];
 
-        fastNorm(input, scale, bias, output, epsilon, axis);
+        if (inputs.size() == 3) {
+            const auto &bias = inputs[2];
+            fastNorm(input, scale, bias, output, epsilon, axis);
+        } else {
+            fastNorm(input, scale, output, epsilon, axis);
+        }
     }
 };
 

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -81,7 +81,6 @@ public:
 
         const auto &input = inputs[0];
         const auto &scale = inputs[1];
-        const auto scale_shape = shape(scale);
         auto &output = outputs[0];
 
         if (inputs.size() == 3) {

--- a/modules/dnn/src/layers/mvn_layer.cpp
+++ b/modules/dnn/src/layers/mvn_layer.cpp
@@ -323,27 +323,9 @@ public:
 
         if (fuse_batch_norm) { // channel-wise scale/bias of shape (C)
             CV_CheckTrue(normVariance, "DNN/MVN: not supported");
-
-            const auto input_shape = shape(input);
-            CV_CheckGE(input_shape.size(), static_cast<size_t>(3), "DNN/MVN: input dimension >= 3 is needed");
-
-            size_t C = scale.total();
-            CV_CheckEQ(C, static_cast<size_t>(input_shape[1]), "DNN/MVN: invalid channel");
-            MatShape base_shape(input_shape.size() - 1, 1);
-            base_shape[0] = C; // (C, 1, 1, ..., 1)
-
-            Mat broadcast_scale(base_shape, CV_32F, scale.ptr<void>());
-            Mat broadcast_bias(base_shape, CV_32F, shift.ptr<void>());
-
-            // broadcast scale and bias if needed
-            MatShape broadcast_shape{input_shape.begin() + 1, input_shape.end()}; // (C, D1, D2, ..., Dn)
-            broadcast(broadcast_scale, broadcast_shape, broadcast_scale);
-            broadcast(broadcast_bias, broadcast_shape, broadcast_bias);
-
-            int axis = 2;
-            fastNorm(input, broadcast_scale, broadcast_bias, outputs[0], eps, axis);
+            fastNormChannel(input, scale, shift, outputs[0], eps);
         } else {
-            int axis = acrossChannels ? 1 : 2;
+            size_t axis = acrossChannels ? 1 : 2;
             fastNorm(input, outputs[0], eps, axis, normVariance);
         }
     }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3112,12 +3112,6 @@ void ONNXImporter::parseLayerNorm(LayerParams& layerParams, const opencv_onnx::N
     axis = (axis + inputDims) % inputDims;
     layerParams.set("axis", axis);
 
-    // check if bias existed
-    bool hasBias = false;
-    if (node_proto.input_size() > 2)
-        hasBias = true;
-    layerParams.set("hasBias", hasBias);
-
     // constants as constant inputs
     for (size_t i = 1; i < node_proto.input_size(); i++)
     {

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -570,10 +570,10 @@ TEST_P(Test_Torch_nets, FastNeuralStyle_accuracy)
         }
         else if (target == DNN_TARGET_CPU_FP16)
         {
-            normAssert(out, refBlob, "", 0.62, 25);
+            normAssert(out, refBlob, "", 0.64, 25);
         }
         else
-            normAssert(out, refBlob, "", 0.5, 1.11);
+            normAssert(out, refBlob, "", 0.5, 1.16);
     }
 }
 


### PR DESCRIPTION
Relates https://github.com/opencv/opencv/pull/24378#issuecomment-1756906570

TODO:

- [x] add fastNorm
- [x] refactor layer norm with fastNorm
- [x] refactor mvn with fastNorm
- [ ] add onnx mvn in importer (in a new PR?)
- [ ] refactor instance norm with fastNorm (in another PR https://github.com/opencv/opencv/pull/24378, need to merge this one first though)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
