### PR TITLE
Ensure interarea algorithm usage in resize perfomance test

### DIFF
--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -202,9 +202,9 @@ typedef TestBaseWithParam<tuple<MatType, Size, double> > MatInfo_Size_Scale_Area
 
 PERF_TEST_P(MatInfo_Size_Scale_Area, ResizeArea,
             testing::Combine(
-                testing::Values(CV_8UC1, CV_8UC4),
-                testing::Values(szVGA, szqHD, sz720p),
-                testing::Values(2.4, 3.4, 1.3)
+                testing::Values(CV_8UC1, CV_8UC3, CV_8UC4),
+                testing::Values(szVGA, szqHD, sz720p, sz1080p, sz2160p),
+                testing::Values(0.1, 0.25, 0.81)
                 )
             )
 {


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24408
Sanity data update: https://github.com/opencv/opencv_extra/pull/1108/

Use downscale to ensure inter-area resize.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
