### PR TITLE
dnn: fix HAVE_TIMVX macro definition in dnn test

### DIFF
--- a/cmake/OpenCVFindTIMVX.cmake
+++ b/cmake/OpenCVFindTIMVX.cmake
@@ -58,6 +58,7 @@ if(TIMVX_FOUND AND TIMVX_VIV_FOUND)
     message(STATUS "TIM-VX: Found TIM-VX library: ${TIMVX_LIB}")
     set(TIMVX_LIBRARY   ${TIMVX_LIB})
     set(TIMVX_INCLUDE_DIR   ${TIMVX_INC_DIR})
+    ocv_add_external_target(timvx "${TIMVX_INC_DIR}" "${TIMVX_LIBRARY}" "HAVE_TIMVX")
 
     message(STATUS "TIM-VX: Found VIVANTE SDK libraries: ${VIVANTE_SDK_DIR}/lib")
     link_directories(${VIVANTE_SDK_DIR}/lib)

--- a/cmake/OpenCVFindTIMVX.cmake
+++ b/cmake/OpenCVFindTIMVX.cmake
@@ -58,7 +58,6 @@ if(TIMVX_FOUND AND TIMVX_VIV_FOUND)
     message(STATUS "TIM-VX: Found TIM-VX library: ${TIMVX_LIB}")
     set(TIMVX_LIBRARY   ${TIMVX_LIB})
     set(TIMVX_INCLUDE_DIR   ${TIMVX_INC_DIR})
-    ocv_add_external_target(timvx "${TIMVX_INC_DIR}" "${TIMVX_LIBRARY}" "HAVE_TIMVX")
 
     message(STATUS "TIM-VX: Found VIVANTE SDK libraries: ${VIVANTE_SDK_DIR}/lib")
     link_directories(${VIVANTE_SDK_DIR}/lib)

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -295,10 +295,10 @@ if(TARGET ocv.3rdparty.cann AND OPENCV_TEST_DNN_CANN)
   endif()
 endif()
 
-ocv_option(OPENCV_TEST_DNN_TIMVX "Build test with TIM-VX" (TARGET ocv.3rdparty.timvx))
-if(TARGET ocv.3rdparty.timvx AND OPENCV_TEST_DNN_TIMVX)
+ocv_option(OPENCV_TEST_DNN_TIMVX "Build test with TIM-VX" (HAVE_TIMVX))
+if(OPENCV_TEST_DNN_TIMVX)
   if(TARGET opencv_test_dnn)
-    ocv_target_link_libraries(opencv_test_dnn ocv.3rdparty.timvx)
+  ocv_target_compile_definitions(opencv_test_dnn PRIVATE "HAVE_TIMVX=1")
   endif()
 endif()
 

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -295,6 +295,13 @@ if(TARGET ocv.3rdparty.cann AND OPENCV_TEST_DNN_CANN)
   endif()
 endif()
 
+ocv_option(OPENCV_TEST_DNN_TIMVX "Build test with TIM-VX" (TARGET ocv.3rdparty.timvx))
+if(TARGET ocv.3rdparty.timvx AND OPENCV_TEST_DNN_TIMVX)
+  if(TARGET opencv_test_dnn)
+    ocv_target_link_libraries(opencv_test_dnn ocv.3rdparty.timvx)
+  endif()
+endif()
+
 ocv_option(OPENCV_TEST_DNN_TFLITE "Build test with TFLite" (OPENCV_DNN_TFLITE))
 if(OPENCV_TEST_DNN_TFLITE)
   if(TARGET opencv_test_dnn)

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -298,7 +298,7 @@ endif()
 ocv_option(OPENCV_TEST_DNN_TIMVX "Build test with TIM-VX" (HAVE_TIMVX))
 if(OPENCV_TEST_DNN_TIMVX)
   if(TARGET opencv_test_dnn)
-  ocv_target_compile_definitions(opencv_test_dnn PRIVATE "HAVE_TIMVX=1")
+    ocv_target_compile_definitions(opencv_test_dnn PRIVATE "HAVE_TIMVX=1")
   endif()
 endif()
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
