### PR TITLE
Unconditionally create SuperScale in BarcodeDetector to avoid null deref

### DIFF
--- a/modules/objdetect/src/barcode.cpp
+++ b/modules/objdetect/src/barcode.cpp
@@ -343,11 +343,11 @@ BarcodeDetector::BarcodeDetector(const string &prototxt_path, const string &mode
 {
     Ptr<BarcodeImpl> p_ = new BarcodeImpl();
     p = p_;
+    p_->sr = make_shared<SuperScale>();
     if (!prototxt_path.empty() && !model_path.empty())
     {
         CV_Assert(utils::fs::exists(prototxt_path));
         CV_Assert(utils::fs::exists(model_path));
-        p_->sr = make_shared<SuperScale>();
         int res = p_->sr->init(prototxt_path, model_path);
         CV_Assert(res == 0);
         p_->use_nn_sr = true;


### PR DESCRIPTION
This pointer is called unconditionally in BarcodeImpl::initDecode assuming the size of the image is outside the specified bounds.  This seems to not cause problems on optimized builds, I assume because the optimizer sees through the processImageScale call to see that it can be reduced to a resize call.  Leaving it as is relies on undefined behavior.

This was the least invasive change I could make, however, it might be worthwhile to pull up the logic for a resize so that a SuperScale does not need to be allocated, which seems to be the most common case.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
