### PR TITLE
fix: supress GCC13 warnings

### DIFF
--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -601,7 +601,7 @@ static void setValue(SparseMat& M, const int* idx, double value, RNG& rng)
         CV_Error(CV_StsUnsupportedFormat, "");
 }
 
-#if defined(__GNUC__) && (__GNUC__ == 11 || __GNUC__ == 12)
+#if defined(__GNUC__) && (__GNUC__ == 11 || __GNUC__ == 12 || __GNUC__ == 13)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -149,7 +149,7 @@ void getPoolingKernelParams(const LayerParams &params, std::vector<size_t>& kern
                             std::vector<size_t>& strides, cv::String &padMode)
 {
     bool is_global = params.get<bool>("global_pooling", false);
-    globalPooling.resize(3);
+    globalPooling.reserve(3);
     globalPooling[0] = params.get<bool>("global_pooling_d", is_global);
     globalPooling[1] = params.get<bool>("global_pooling_h", is_global);
     globalPooling[2] = params.get<bool>("global_pooling_w", is_global);

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -149,10 +149,11 @@ void getPoolingKernelParams(const LayerParams &params, std::vector<size_t>& kern
                             std::vector<size_t>& strides, cv::String &padMode)
 {
     bool is_global = params.get<bool>("global_pooling", false);
-    globalPooling.reserve(3);
-    globalPooling[0] = params.get<bool>("global_pooling_d", is_global);
-    globalPooling[1] = params.get<bool>("global_pooling_h", is_global);
-    globalPooling[2] = params.get<bool>("global_pooling_w", is_global);
+    globalPooling.assign({
+        params.get<bool>("global_pooling_d", is_global),
+        params.get<bool>("global_pooling_h", is_global),
+        params.get<bool>("global_pooling_w", is_global)
+    });
 
     if (globalPooling[0] || globalPooling[1] || globalPooling[2])
     {

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -260,6 +260,11 @@ const tensorflow::AttrValue& getLayerAttr(const tensorflow::NodeDef &layer, cons
     return layer.attr().at(name);
 }
 
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
+
 static DataLayout getDataLayout(const tensorflow::NodeDef& layer)
 {
     if (hasLayerAttr(layer, "data_format"))
@@ -2977,6 +2982,10 @@ static void addConstNodes(tensorflow::GraphDef& net, std::map<String, int>& cons
     }
     CV_LOG_DEBUG(NULL, "DNN/TF: layers_to_ignore.size() = " << layers_to_ignore.size());
 }
+
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic pop
+#endif
 
 // If all inputs of specific layer have the same data layout we can say that
 // this layer's output has this data layout too. Returns DNN_LAYOUT_UNKNOWN otherwise.

--- a/modules/gapi/src/compiler/passes/exec.cpp
+++ b/modules/gapi/src/compiler/passes/exec.cpp
@@ -142,6 +142,11 @@ namespace
         std::unordered_set<CycleCausers, CycleHasher> cycle_causers;
     };
 
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
+
     bool canMerge(const GIslandModel::Graph &g,
                   const ade::NodeHandle &a_nh,
                   const ade::NodeHandle &slot_nh,
@@ -190,6 +195,10 @@ namespace
         }
         return true;
     }
+
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic pop
+#endif
 
     inline bool isProducedBy(const ade::NodeHandle &slot,
                              const ade::NodeHandle &island)

--- a/modules/gapi/src/streaming/onevpl/file_data_provider.hpp
+++ b/modules/gapi/src/streaming/onevpl/file_data_provider.hpp
@@ -18,6 +18,14 @@ namespace cv {
 namespace gapi {
 namespace wip {
 namespace onevpl {
+
+// With gcc13, std::unique_ptr(FILE, decltype(&fclose)> causes ignored-attributes warning.
+// See https://stackoverflow.com/questions/76849365/can-we-add-attributes-to-standard-function-declarations-without-breaking-standar
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 struct GAPI_EXPORTS FileDataProvider : public IDataProvider {
 
     using file_ptr = std::unique_ptr<FILE, decltype(&fclose)>;
@@ -34,6 +42,11 @@ private:
     mfx_codec_id_type codec;
     const uint32_t bitstream_data_size;
 };
+
+#if defined(__GNUC__) && (__GNUC__ == 13)
+#pragma GCC diagnostic pop
+#endif
+
 } // namespace onevpl
 } // namespace wip
 } // namespace gapi

--- a/modules/stitching/src/camera.cpp
+++ b/modules/stitching/src/camera.cpp
@@ -66,7 +66,7 @@ Mat CameraParams::K() const
     Mat_<double> k = Mat::eye(3, 3, CV_64F);
     k(0,0) = focal; k(0,2) = ppx;
     k(1,1) = focal * aspect; k(1,2) = ppy;
-    return k;
+    return Mat(k);
 }
 
 } // namespace detail

--- a/modules/stitching/src/camera.cpp
+++ b/modules/stitching/src/camera.cpp
@@ -66,7 +66,7 @@ Mat CameraParams::K() const
     Mat_<double> k = Mat::eye(3, 3, CV_64F);
     k(0,0) = focal; k(0,2) = ppx;
     k(1,1) = focal * aspect; k(1,2) = ppy;
-    return std::move(k);
+    return k;
 }
 
 } // namespace detail

--- a/modules/video/src/optical_flow_io.cpp
+++ b/modules/video/src/optical_flow_io.cpp
@@ -52,12 +52,12 @@ CV_EXPORTS_W Mat readOpticalFlow( const String& path )
     Mat_<Point2f> flow;
     std::ifstream file(path.c_str(), std::ios_base::binary);
     if ( !file.good() )
-        return std::move(flow); // no file - return empty matrix
+        return Mat(); // no file - return empty matrix
 
     float tag;
     file.read((char*) &tag, sizeof(float));
     if ( tag != FLOW_TAG_FLOAT )
-        return std::move(flow);
+        return Mat();
 
     int width, height;
 
@@ -76,14 +76,14 @@ CV_EXPORTS_W Mat readOpticalFlow( const String& path )
             if ( !file.good() )
             {
                 flow.release();
-                return std::move(flow);
+                return Mat();
             }
 
             flow(i, j) = u;
         }
     }
     file.close();
-    return std::move(flow);
+    return flow;
 }
 
 CV_EXPORTS_W bool writeOpticalFlow( const String& path, InputArray flow )

--- a/modules/video/src/optical_flow_io.cpp
+++ b/modules/video/src/optical_flow_io.cpp
@@ -83,7 +83,7 @@ CV_EXPORTS_W Mat readOpticalFlow( const String& path )
         }
     }
     file.close();
-    return flow;
+    return Mat(flow);
 }
 
 CV_EXPORTS_W bool writeOpticalFlow( const String& path, InputArray flow )


### PR DESCRIPTION
For ubuntu 23.10, supress GCC13 warnings.

OpenCV version: 4.x
Operating System / Platform: Ubuntu 23.10
Compiler & compiler version: GCC 13.2.0

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
