### PR TITLE
Check the return value of avifDecoderSetIOMemory.

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -147,18 +147,6 @@ AvifDecoder::~AvifDecoder() {
 
 size_t AvifDecoder::signatureLength() const { return kAvifSignatureSize; }
 
-bool AvifDecoder::checkSignature(const String &signature) const {
-  avifDecoder *decoder = avifDecoderCreate();
-  if (!decoder) return false;
-  avifDecoderSetIOMemory(decoder,
-                         reinterpret_cast<const uint8_t *>(signature.c_str()),
-                         signature.size());
-  decoder->io->sizeHint = 1e9;
-  const avifResult status = avifDecoderParse(decoder);
-  avifDecoderDestroy(decoder);
-  return (status == AVIF_RESULT_OK || status == AVIF_RESULT_TRUNCATED_DATA);
-}
-
 #define OPENCV_AVIF_CHECK_STATUS(X, ENCDEC)               \
   {                                                       \
     const avifResult status = (X);                        \
@@ -169,6 +157,20 @@ bool AvifDecoder::checkSignature(const String &signature) const {
       return false;                                       \
     }                                                     \
   }
+
+bool AvifDecoder::checkSignature(const String &signature) const {
+  avifDecoder *decoder = avifDecoderCreate();
+  if (!decoder) return false;
+  OPENCV_AVIF_CHECK_STATUS(
+      avifDecoderSetIOMemory(
+          decoder, reinterpret_cast<const uint8_t *>(signature.c_str()),
+          signature.size()),
+      decoder);
+  decoder->io->sizeHint = 1e9;
+  const avifResult status = avifDecoderParse(decoder);
+  avifDecoderDestroy(decoder);
+  return (status == AVIF_RESULT_OK || status == AVIF_RESULT_TRUNCATED_DATA);
+}
 
 ImageDecoder AvifDecoder::newDecoder() const { return makePtr<AvifDecoder>(); }
 


### PR DESCRIPTION
The API will soon be made no_discard.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
