### PR TITLE
tutorial_py_fourier_transform wrong division operator fix

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
+++ b/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
@@ -80,7 +80,7 @@ using **np.ifft2()** function. The result, again, will be a complex number. You 
 absolute value.
 @code{.py}
 rows, cols = img.shape
-crow,ccol = rows//2 , cols//2
+crow, ccol = rows//2, cols//2
 fshift[crow-30:crow+31, ccol-30:ccol+31] = 0
 f_ishift = np.fft.ifftshift(fshift)
 img_back = np.fft.ifft2(f_ishift)
@@ -146,7 +146,7 @@ content, and 0 at HF region.
 
 @code{.py}
 rows, cols = img.shape
-crow,ccol = rows/2 , cols/2
+crow, ccol = rows//2, cols//2
 
 # create a mask first, center square is 1, remaining all zeros
 mask = np.zeros((rows,cols,2),np.uint8)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Truediv (floating point division) operators on line 149 of [the tutorial](https://github.com/opencv/opencv/blob/4.x/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown) produce floating point result:
``` python
crow,ccol = rows/2 , cols/2
```

Hence, indexing operation on line 153:
``` python
mask[crow-30:crow+30, ccol-30:ccol+30] = 1
```

Fails with an error:
``` python
TypeError: slice indices must be integers or None or have an __index__ method
```

This PR fixes the error by replacing the operators with floordiv (integer division) ones.