### PR TITLE
Dnn_ Net_ A bug occurred when compiling getUnconnectedOutLayersNames into JavaScript

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -482,7 +482,7 @@ class JSWrapperGenerator(object):
                     ret_type = type_dict[ptr_type]
             for key in type_dict:
                 if key in ret_type:
-                    ret_type = re.sub('(^|[^\w])' + key + '($|[^\w])', type_dict[key], ret_type)
+	    ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
             arg_types = []
             unwrapped_arg_types = []
             for arg in variant.args:
@@ -670,7 +670,7 @@ class JSWrapperGenerator(object):
                     # Replace types. Instead of ret_type.replace we use regular
                     # expression to exclude false matches.
                     # See https://github.com/opencv/opencv/issues/15514
-                    ret_type = re.sub('(^|[^\w])' + key + '($|[^\w])', type_dict[key], ret_type)
+                    ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
             if variant.constret and ret_type.startswith('const') == False:
                 ret_type = 'const ' + ret_type
             if variant.refret and ret_type.endswith('&') == False:

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -80,20 +80,18 @@ else:
 func_table = {}
 
 # Ignore these functions due to Embind limitations for now
-ignore_list = [
-    "locate",  # int&
-    "minEnclosingCircle",  # float&
-    "checkRange",
-    "minMaxLoc",  # double*
-    "floodFill",  # special case, implemented in core_bindings.cpp
-    "phaseCorrelate",
-    "randShuffle",
-    "calibrationMatrixValues",  # double&
-    "undistortPoints",  # global redefinition
-    "CamShift",  # Rect&
-    "meanShift",  # Rect&
-]
-
+ignore_list = ['locate',  #int&
+               'minEnclosingCircle',  #float&
+               'checkRange',
+               'minMaxLoc',   #double*
+               'floodFill', # special case, implemented in core_bindings.cpp
+               'phaseCorrelate',
+               'randShuffle',
+               'calibrationMatrixValues', #double&
+               'undistortPoints', # global redefinition
+               'CamShift', #Rect&
+               'meanShift' #Rect&
+               ]
 
 def makeWhiteList(module_list):
     wl = {}
@@ -105,11 +103,10 @@ def makeWhiteList(module_list):
                 wl[k] = m[k]
     return wl
 
-
 white_list = None
 namespace_prefix_override = {
-    "dnn": "",
-    "aruco": "",
+    'dnn' : '',
+    'aruco' : '',
 }
 
 # Features to be exported
@@ -121,16 +118,15 @@ with_vec_from_js_array = True
 
 wrapper_namespace = "Wrappers"
 type_dict = {
-    "InputArray": "const cv::Mat&",
-    "OutputArray": "cv::Mat&",
-    "InputOutputArray": "cv::Mat&",
-    "InputArrayOfArrays": "const std::vector<cv::Mat>&",
-    "OutputArrayOfArrays": "std::vector<cv::Mat>&",
-    "string": "std::string",
-    "String": "std::string",
-    "const String&": "const std::string&",
+    'InputArray': 'const cv::Mat&',
+    'OutputArray': 'cv::Mat&',
+    'InputOutputArray': 'cv::Mat&',
+    'InputArrayOfArrays': 'const std::vector<cv::Mat>&',
+    'OutputArrayOfArrays': 'std::vector<cv::Mat>&',
+    'string': 'std::string',
+    'String': 'std::string',
+    'const String&':'const std::string&'
 }
-
 
 def normalize_class_name(name):
     return re.sub(r"^cv\.", "", name).replace(".", "_")
@@ -187,15 +183,14 @@ class ClassInfo(object):
 
 
 def handle_ptr(tp):
-    if tp.startswith("Ptr_"):
-        tp = "Ptr<" + "::".join(tp.split("_")[1:]) + ">"
+    if tp.startswith('Ptr_'):
+        tp = 'Ptr<' + "::".join(tp.split('_')[1:]) + '>'
     return tp
 
-
 def handle_vector(tp):
-    if tp.startswith("vector_"):
-        tp = handle_vector(tp[tp.find("_") + 1 :])
-        tp = "std::vector<" + "::".join(tp.split("_")) + ">"
+    if tp.startswith('vector_'):
+        tp = handle_vector(tp[tp.find('_') + 1:])
+        tp = 'std::vector<' + "::".join(tp.split('_')) + '>'
     return tp
 
 
@@ -249,21 +244,8 @@ class ArgInfo(object):
         self.py_inputarg = False
         self.py_outputarg = False
 
-
 class FuncVariant(object):
-    def __init__(
-        self,
-        class_name,
-        name,
-        decl,
-        is_constructor,
-        is_class_method,
-        is_const,
-        is_virtual,
-        is_pure_virtual,
-        ref_return,
-        const_return,
-    ):
+    def __init__(self, class_name, name, decl, is_constructor, is_class_method, is_const, is_virtual, is_pure_virtual, ref_return, const_return):
         self.class_name = class_name
         self.name = self.wname = name
         self.is_constructor = is_constructor
@@ -293,9 +275,7 @@ class FuncVariant(object):
 
 class FuncInfo(object):
     def __init__(self, class_name, name, cname, namespace, isconstructor):
-        self.name_id = "_".join(
-            [namespace] + ([class_name] if class_name else []) + [name]
-        )  # unique id for dict key
+        self.name_id = '_'.join([namespace] + ([class_name] if class_name else []) + [name])  # unique id for dict key
 
         self.class_name = class_name
         self.name = name
@@ -317,6 +297,7 @@ class Namespace(object):
 
 class JSWrapperGenerator(object):
     def __init__(self):
+
         self.bindings = []
         self.wrapper_funcs = []
 
@@ -333,31 +314,28 @@ class JSWrapperGenerator(object):
         self.class_idx += 1
 
         if class_info.name in self.classes:
-            print(
-                "Generator error: class %s (cpp_name=%s) already exists"
-                % (class_info.name, class_info.cname)
-            )
+            print("Generator error: class %s (cpp_name=%s) already exists" \
+                  % (class_info.name, class_info.cname))
             sys.exit(-1)
         self.classes[class_info.name] = class_info
 
     def resolve_class_inheritance(self):
         new_classes = {}
         for name, class_info in self.classes.items():
-            if not hasattr(class_info, "bases"):
+
+            if not hasattr(class_info, 'bases'):
                 new_classes[name] = class_info
-                continue  # not class
+                continue # not class
 
             if class_info.bases:
-                chunks = class_info.bases[0].split("::")
-                base = "_".join(chunks)
+                chunks = class_info.bases[0].split('::')
+                base = '_'.join(chunks)
                 while base not in self.classes and len(chunks) > 1:
                     del chunks[-2]
-                    base = "_".join(chunks)
+                    base = '_'.join(chunks)
                 if base not in self.classes:
-                    print(
-                        "Generator error: unable to resolve base %s for %s"
-                        % (class_info.bases[0], class_info.name)
-                    )
+                    print("Generator error: unable to resolve base %s for %s"
+                        % (class_info.bases[0], class_info.name))
                     sys.exit(-1)
                 else:
                     class_info.bases[0] = "::".join(chunks)
@@ -368,20 +346,19 @@ class JSWrapperGenerator(object):
         self.classes = new_classes
 
     def split_decl_name(self, name):
-        chunks = name.split(".")
+        chunks = name.split('.')
         namespace = chunks[:-1]
         classes = []
-        while namespace and ".".join(namespace) not in self.parser.namespaces:
+        while namespace and '.'.join(namespace) not in self.parser.namespaces:
             classes.insert(0, namespace.pop())
         return namespace, classes, chunks[-1]
 
     def add_enum(self, decl):
         name = decl[0].rsplit(" ", 1)[1]
         namespace, classes, val = self.split_decl_name(name)
-        namespace = ".".join(namespace)
+        namespace = '.'.join(namespace)
         ns = self.namespaces.setdefault(namespace, Namespace())
-        if len(name) == 0:
-            name = "<unnamed>"
+        if len(name) == 0: name = "<unnamed>"
         if name.endswith("<unnamed>"):
             i = 0
             while True:
@@ -389,13 +366,12 @@ class JSWrapperGenerator(object):
                 candidate_name = name.replace("<unnamed>", "unnamed_%u" % i)
                 if candidate_name not in ns.enums:
                     name = candidate_name
-                    break
-        cname = name.replace(".", "::")
+                    break;
+        cname = name.replace('.', '::')
         type_dict[normalize_class_name(name)] = cname
         if name in ns.enums:
-            print(
-                "Generator warning: enum %s (cname=%s) already exists" % (name, cname)
-            )
+            print("Generator warning: enum %s (cname=%s) already exists" \
+                  % (name, cname))
             # sys.exit(-1)
         else:
             ns.enums[name] = []
@@ -409,15 +385,14 @@ class JSWrapperGenerator(object):
             self.add_const(name.replace("const ", "").strip(), decl)
 
     def add_const(self, name, decl):
-        cname = name.replace(".", "::")
+        cname = name.replace('.','::')
         namespace, classes, name = self.split_decl_name(name)
-        namespace = ".".join(namespace)
-        name = "_".join(classes + [name])
+        namespace = '.'.join(namespace)
+        name = '_'.join(classes+[name])
         ns = self.namespaces.setdefault(namespace, Namespace())
         if name in ns.consts:
-            print(
-                "Generator error: constant %s (cname=%s) already exists" % (name, cname)
-            )
+            print("Generator error: constant %s (cname=%s) already exists" \
+                % (name, cname))
             sys.exit(-1)
         ns.consts[name] = cname
 
@@ -425,12 +400,12 @@ class JSWrapperGenerator(object):
         namespace, classes, barename = self.split_decl_name(decl[0])
         cpp_name = "::".join(namespace + classes + [barename])
         name = barename
-        class_name = ""
-        bare_class_name = ""
+        class_name = ''
+        bare_class_name = ''
         if classes:
-            class_name = normalize_class_name(".".join(namespace + classes))
+            class_name = normalize_class_name('.'.join(namespace + classes))
             bare_class_name = classes[-1]
-        namespace = ".".join(namespace)
+        namespace = '.'.join(namespace)
 
         is_constructor = name == bare_class_name
         is_class_method = False
@@ -465,18 +440,8 @@ class JSWrapperGenerator(object):
         fi = FuncInfo(class_name, name, cpp_name, namespace, is_constructor)
         func = func_map.setdefault(fi.name_id, fi)
 
-        variant = FuncVariant(
-            class_name,
-            name,
-            decl,
-            is_constructor,
-            is_class_method,
-            is_const_method,
-            is_virtual_method,
-            is_pure_virtual_method,
-            ref_return,
-            const_return,
-        )
+        variant = FuncVariant(class_name, name, decl, is_constructor, is_class_method, is_const_method,
+                        is_virtual_method, is_pure_virtual_method, ref_return, const_return)
         func.add_variant(variant)
 
     def save(self, path, name, buf):
@@ -485,6 +450,7 @@ class JSWrapperGenerator(object):
         f.close()
 
     def gen_function_binding_with_wrapper(self, func, ns_name, class_info):
+
         binding_text = None
         wrapper_func_text = None
 
@@ -492,37 +458,31 @@ class JSWrapperGenerator(object):
         wrappers = []
 
         for index, variant in enumerate(func.variants):
+
             factory = False
-            if class_info and "Ptr<" in variant.rettype:
+            if class_info and 'Ptr<' in variant.rettype:
+
                 factory = True
                 base_class_name = variant.rettype
-                base_class_name = (
-                    base_class_name.replace("Ptr<", "").replace(">", "").strip()
-                )
+                base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
                 if base_class_name in self.classes:
                     self.classes[base_class_name].has_smart_ptr = True
                 else:
-                    print(
-                        base_class_name,
-                        " not found in classes for registering smart pointer using ",
-                        class_info.name,
-                        "instead",
-                    )
+                    print(base_class_name, ' not found in classes for registering smart pointer using ', class_info.name, 'instead')
                     self.classes[class_info.name].has_smart_ptr = True
 
             def_args = []
             has_def_param = False
 
             # Return type
-            ret_type = "void" if variant.rettype.strip() == "" else variant.rettype
-            if ret_type.startswith("Ptr"):  # smart pointer
-                ptr_type = ret_type.replace("Ptr<", "").replace(">", "")
+            ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
+            if ret_type.startswith('Ptr'): #smart pointer
+                ptr_type = ret_type.replace('Ptr<', '').replace('>', '')
                 if ptr_type in type_dict:
                     ret_type = type_dict[ptr_type]
             for key in type_dict:
                 if key in ret_type:
                     ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
-
             arg_types = []
             unwrapped_arg_types = []
             for arg in variant.args:
@@ -532,18 +492,19 @@ class JSWrapperGenerator(object):
                 else:
                     arg_type = arg.tp
                 # Add default value
-                if with_default_params and arg.defval != "":
-                    def_args.append(arg.defval)
+                if with_default_params and arg.defval != '':
+                    def_args.append(arg.defval);
                 arg_types.append(arg_type)
                 unwrapped_arg_types.append(arg_type)
 
             # Function attribute
-            func_attribs = ""
-            if "*" in "".join(arg_types):
-                func_attribs += ", allow_raw_pointers()"
+            func_attribs = ''
+            if '*' in ''.join(arg_types):
+                func_attribs += ', allow_raw_pointers()'
 
             if variant.is_pure_virtual:
-                func_attribs += ", pure_virtual()"
+                func_attribs += ', pure_virtual()'
+
 
             # Wrapper function
             if ns_name != None and ns_name != "cv":
@@ -551,19 +512,17 @@ class JSWrapperGenerator(object):
                 if ns_parts[0] == "cv":
                     ns_parts = ns_parts[1:]
                 ns_part = "_".join(ns_parts) + "_"
-                ns_id = "_".join(ns_parts)
+                ns_id = '_'.join(ns_parts)
                 ns_prefix = namespace_prefix_override.get(ns_id, ns_id)
                 if ns_prefix:
-                    ns_prefix = ns_prefix + "_"
+                    ns_prefix = ns_prefix + '_'
             else:
-                ns_prefix = ""
+                ns_prefix = ''
             if class_info == None:
                 js_func_name = ns_prefix + func.name
                 wrap_func_name = js_func_name + "_wrapper"
             else:
-                wrap_func_name = (
-                    ns_prefix + func.class_name + "_" + func.name + "_wrapper"
-                )
+                wrap_func_name = ns_prefix + func.class_name + "_" + func.name + "_wrapper"
                 js_func_name = func.name
 
             # TODO: Name functions based wrap directives or based on arguments list
@@ -571,10 +530,10 @@ class JSWrapperGenerator(object):
                 wrap_func_name += str(index)
                 js_func_name += str(index)
 
-            c_func_name = "Wrappers::" + wrap_func_name
+            c_func_name = 'Wrappers::' + wrap_func_name
 
             # Binding template-
-            raw_arg_names = ["arg" + str(i + 1) for i in range(0, len(variant.args))]
+            raw_arg_names = ['arg' + str(i + 1) for i in range(0, len(variant.args))]
             arg_names = []
             w_signature = []
             casted_arg_types = []
@@ -582,77 +541,53 @@ class JSWrapperGenerator(object):
                 casted_arg_name = arg_name
                 if with_vec_from_js_array:
                     # Only support const vector reference as input parameter
-                    match = re.search(r"const std::vector<(.*)>&", arg_type)
+                    match = re.search(r'const std::vector<(.*)>&', arg_type)
                     if match:
                         type_in_vect = match.group(1)
-                        if type_in_vect in [
-                            "int",
-                            "float",
-                            "double",
-                            "char",
-                            "uchar",
-                            "String",
-                            "std::string",
-                        ]:
-                            casted_arg_name = (
-                                "emscripten::vecFromJSArray<"
-                                + type_in_vect
-                                + ">("
-                                + arg_name
-                                + ")"
-                            )
-                            arg_type = re.sub(
-                                r"std::vector<(.*)>", "emscripten::val", arg_type
-                            )
-                w_signature.append(arg_type + " " + arg_name)
+                        if type_in_vect in ['int', 'float', 'double', 'char', 'uchar', 'String', 'std::string']:
+                            casted_arg_name = 'emscripten::vecFromJSArray<' + type_in_vect + '>(' + arg_name + ')'
+                            arg_type = re.sub(r'std::vector<(.*)>', 'emscripten::val', arg_type)
+                w_signature.append(arg_type + ' ' + arg_name)
                 arg_names.append(casted_arg_name)
                 casted_arg_types.append(arg_type)
 
             arg_types = casted_arg_types
 
             # Argument list, signature
-            arg_names_casted = [
-                c if a == b else c + ".as<" + a + ">()"
-                for a, b, c in zip(unwrapped_arg_types, arg_types, arg_names)
-            ]
+            arg_names_casted = [c if a == b else c + '.as<' + a + '>()' for a, b, c in
+                                zip(unwrapped_arg_types, arg_types, arg_names)]
 
             # Add self object to the parameters
-            if class_info and not factory:
-                arg_types = [class_info.cname + "&"] + arg_types
-                w_signature = [class_info.cname + "& arg0 "] + w_signature
+            if class_info and not  factory:
+                arg_types = [class_info.cname + '&'] + arg_types
+                w_signature = [class_info.cname + '& arg0 '] + w_signature
 
             for j in range(0, len(def_args) + 1):
-                postfix = ""
+                postfix = ''
                 if j > 0:
-                    postfix = "_" + str(j)
+                    postfix = '_' + str(j);
 
                 ###################################
                 # Wrapper
-                if factory:  # TODO or static
-                    name = class_info.cname + "::" if variant.class_name else ""
-                    cpp_call_text = static_class_call_template.substitute(
-                        scope=name,
-                        func=func.cname,
-                        args=", ".join(arg_names[: len(arg_names) - j]),
-                    )
+                if factory: # TODO or static
+                    name = class_info.cname+'::' if variant.class_name else ""
+                    cpp_call_text = static_class_call_template.substitute(scope=name,
+                                                                   func=func.cname,
+                                                                   args=', '.join(arg_names[:len(arg_names)-j]))
                 elif class_info:
-                    cpp_call_text = class_call_template.substitute(
-                        obj="arg0",
-                        func=func.cname,
-                        args=", ".join(arg_names[: len(arg_names) - j]),
-                    )
+                    cpp_call_text = class_call_template.substitute(obj='arg0',
+                                                                   func=func.cname,
+                                                                   args=', '.join(arg_names[:len(arg_names)-j]))
                 else:
-                    cpp_call_text = call_template.substitute(
-                        func=func.cname, args=", ".join(arg_names[: len(arg_names) - j])
-                    )
+                    cpp_call_text = call_template.substitute(func=func.cname,
+                                                             args=', '.join(arg_names[:len(arg_names)-j]))
 
-                wrapper_func_text = wrapper_function_template.substitute(
-                    ret_val=ret_type,
-                    func=wrap_func_name + postfix,
-                    signature=", ".join(w_signature[: len(w_signature) - j]),
-                    cpp_call=cpp_call_text,
-                    const="" if variant.is_const else "",
-                )
+
+                wrapper_func_text = wrapper_function_template.substitute(ret_val=ret_type,
+                                                                             func=wrap_func_name+postfix,
+                                                                             signature=', '.join(w_signature[:len(w_signature)-j]),
+                                                                             cpp_call=cpp_call_text,
+                                                                             const='' if variant.is_const else '')
 
                 ###################################
                 # Binding
@@ -670,46 +605,39 @@ class JSWrapperGenerator(object):
                             # e.g. DescriptorMatcher
                             continue
                         class_info.constructor_arg_num.add(args_num)
-                        binding_text = ctr_template.substitute(
-                            const="const" if variant.is_const else "",
-                            cpp_name=c_func_name + postfix,
-                            ret=ret_type,
-                            args=",".join(arg_types[: len(arg_types) - j]),
-                            optional=func_attribs,
-                        )
+                        binding_text = ctr_template.substitute(const='const' if variant.is_const else '',
+                                                           cpp_name=c_func_name+postfix,
+                                                           ret=ret_type,
+                                                           args=','.join(arg_types[:len(arg_types)-j]),
+                                                           optional=func_attribs)
                     else:
-                        binding_template = (
-                            overload_class_static_function_template
-                            if variant.is_class_method
-                            else overload_class_function_template
-                        )
-                        binding_text = binding_template.substitute(
-                            js_name=js_func_name,
-                            const="" if variant.is_const else "",
-                            cpp_name=c_func_name + postfix,
-                            ret=ret_type,
-                            args=",".join(arg_types[: len(arg_types) - j]),
-                            optional=func_attribs,
-                        )
+                        binding_template = overload_class_static_function_template if variant.is_class_method else \
+                            overload_class_function_template
+                        binding_text = binding_template.substitute(js_name=js_func_name,
+                                                           const='' if variant.is_const else '',
+                                                           cpp_name=c_func_name+postfix,
+                                                           ret=ret_type,
+                                                           args=','.join(arg_types[:len(arg_types)-j]),
+                                                           optional=func_attribs)
                 else:
-                    binding_text = overload_function_template.substitute(
-                        js_name=js_func_name,
-                        cpp_name=c_func_name + postfix,
-                        const="const" if variant.is_const else "",
-                        ret=ret_type,
-                        args=", ".join(arg_types[: len(arg_types) - j]),
-                        optional=func_attribs,
-                    )
+                    binding_text = overload_function_template.substitute(js_name=js_func_name,
+                                                       cpp_name=c_func_name+postfix,
+                                                       const='const' if variant.is_const else '',
+                                                       ret=ret_type,
+                                                       args=', '.join(arg_types[:len(arg_types)-j]),
+                                                       optional=func_attribs)
 
                 bindings.append(binding_text)
                 wrappers.append(wrapper_func_text)
 
         return [bindings, wrappers]
 
+
     def gen_function_binding(self, func, class_info):
-        if not class_info == None:
-            func_name = class_info.cname + "::" + func.cname
-        else:
+
+        if not class_info == None :
+            func_name = class_info.cname+'::'+func.cname
+        else :
             func_name = func.cname
 
         binding_text = None
@@ -717,34 +645,24 @@ class JSWrapperGenerator(object):
 
         for index, variant in enumerate(func.variants):
             factory = False
-            # TODO if variant.is_class_method and variant.rettype == ('Ptr<' + class_info.name + '>'):
-            if (
-                (not class_info == None)
-                and variant.rettype == ("Ptr<" + class_info.name + ">")
-                or (func.name.startswith("create") and variant.rettype)
-            ):
+            #TODO if variant.is_class_method and variant.rettype == ('Ptr<' + class_info.name + '>'):
+            if (not class_info == None) and variant.rettype == ('Ptr<' + class_info.name + '>') or (func.name.startswith("create") and variant.rettype):
                 factory = True
                 base_class_name = variant.rettype
-                base_class_name = (
-                    base_class_name.replace("Ptr<", "").replace(">", "").strip()
-                )
+                base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
                 if base_class_name in self.classes:
                     self.classes[base_class_name].has_smart_ptr = True
                 else:
-                    print(
-                        base_class_name,
-                        " not found in classes for registering smart pointer using ",
-                        class_info.name,
-                        "instead",
-                    )
+                    print(base_class_name, ' not found in classes for registering smart pointer using ', class_info.name, 'instead')
                     self.classes[class_info.name].has_smart_ptr = True
 
+
             # Return type
-            ret_type = "void" if variant.rettype.strip() == "" else variant.rettype
+            ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
 
             ret_type = ret_type.strip()
-            if ret_type.startswith("Ptr"):  # smart pointer
-                ptr_type = ret_type.replace("Ptr<", "").replace(">", "")
+            if ret_type.startswith('Ptr'): #smart pointer
+                ptr_type = ret_type.replace('Ptr<', '').replace('>', '')
                 if ptr_type in type_dict:
                     ret_type = type_dict[ptr_type]
             for key in type_dict:
@@ -753,10 +671,10 @@ class JSWrapperGenerator(object):
                     # expression to exclude false matches.
                     # See https://github.com/opencv/opencv/issues/15514
                     ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
-            if variant.constret and ret_type.startswith("const") == False:
-                ret_type = "const " + ret_type
-            if variant.refret and ret_type.endswith("&") == False:
-                ret_type += "&"
+            if variant.constret and ret_type.startswith('const') == False:
+                ret_type = 'const ' + ret_type
+            if variant.refret and ret_type.endswith('&') == False:
+                ret_type += '&'
 
             arg_types = []
             orig_arg_types = []
@@ -767,61 +685,50 @@ class JSWrapperGenerator(object):
                 else:
                     arg_type = arg.tp
 
-                # if arg.outputarg:
+                #if arg.outputarg:
                 #    arg_type += '&'
                 orig_arg_types.append(arg_type)
-                if with_default_params and arg.defval != "":
+                if with_default_params and arg.defval != '':
                     def_args.append(arg.defval)
                 arg_types.append(orig_arg_types[-1])
 
             # Function attribute
-            func_attribs = ""
-            if "*" in "".join(orig_arg_types):
-                func_attribs += ", allow_raw_pointers()"
+            func_attribs = ''
+            if '*' in ''.join(orig_arg_types):
+                func_attribs += ', allow_raw_pointers()'
 
             if variant.is_pure_virtual:
-                func_attribs += ", pure_virtual()"
+                func_attribs += ', pure_virtual()'
 
-            # TODO better naming
-            # if variant.name in self.jsfunctions:
-            # else
+            #TODO better naming
+            #if variant.name in self.jsfunctions:
+            #else
             js_func_name = variant.name
 
-            c_func_name = (
-                func.cname
-                if (factory and variant.is_class_method == False)
-                else func_name
-            )
+
+            c_func_name = func.cname if (factory and variant.is_class_method == False) else func_name
+
 
             ################################### Binding
             for j in range(0, len(def_args) + 1):
-                postfix = ""
+                postfix = ''
                 if j > 0:
-                    postfix = "_" + str(j)
+                    postfix = '_' + str(j);
                 if factory:
-                    binding_text = ctr_template.substitute(
-                        const="const" if variant.is_const else "",
-                        cpp_name=c_func_name + postfix,
-                        ret=ret_type,
-                        args=",".join(arg_types[: len(arg_types) - j]),
-                        optional=func_attribs,
-                    )
+                    binding_text = ctr_template.substitute(const='const' if variant.is_const else '',
+                                                           cpp_name=c_func_name+postfix,
+                                                           ret=ret_type,
+                                                           args=','.join(arg_types[:len(arg_types)-j]),
+                                                           optional=func_attribs)
                 else:
-                    binding_template = (
-                        overload_class_static_function_template
-                        if variant.is_class_method
-                        else overload_function_template
-                        if class_info == None
-                        else overload_class_function_template
-                    )
-                    binding_text = binding_template.substitute(
-                        js_name=js_func_name,
-                        const="const" if variant.is_const else "",
-                        cpp_name=c_func_name + postfix,
-                        ret=ret_type,
-                        args=",".join(arg_types[: len(arg_types) - 1]),
-                        optional=func_attribs,
-                    )
+                    binding_template = overload_class_static_function_template if variant.is_class_method else \
+                            overload_function_template if class_info == None else overload_class_function_template
+                    binding_text = binding_template.substitute(js_name=js_func_name,
+                                                               const='const' if variant.is_const else '',
+                                                               cpp_name=c_func_name+postfix,
+                                                               ret=ret_type,
+                                                               args=','.join(arg_types[:len(arg_types)-1]),
+                                                               optional=func_attribs)
 
                 binding_text_list.append(binding_text)
 
@@ -849,12 +756,12 @@ class JSWrapperGenerator(object):
             # self.print_decls(decls);
             if len(decls) == 0:
                 continue
-            headers.append(hdr[hdr.rindex("opencv2/") :])
+            headers.append(hdr[hdr.rindex('opencv2/'):])
             for decl in decls:
                 name = decl[0]
-                type = name[: name.find(" ")]
+                type = name[:name.find(" ")]
                 if type == "struct" or type == "class":  # class/structure case
-                    name = name[name.find(" ") + 1 :].strip()
+                    name = name[name.find(" ") + 1:].strip()
                     self.add_class(type, name, decl)
                 elif name.startswith("enum"):  # enumerations
                     self.add_enum(decl)
@@ -869,33 +776,32 @@ class JSWrapperGenerator(object):
         # step 2: generate bindings
         # Global functions
         for ns_name, ns in sorted(self.namespaces.items()):
-            ns_parts = ns_name.split(".")
-            if ns_parts[0] != "cv":
-                print("Ignore namespace: {}".format(ns_name))
+            ns_parts = ns_name.split('.')
+            if ns_parts[0] != 'cv':
+                print('Ignore namespace: {}'.format(ns_name))
                 continue
             else:
                 ns_parts = ns_parts[1:]
-            ns_id = "_".join(ns_parts)
+            ns_id = '_'.join(ns_parts)
             ns_prefix = namespace_prefix_override.get(ns_id, ns_id)
             for name_id, func in sorted(ns.funcs.items()):
                 name = func.name
                 if ns_prefix:
-                    name = ns_prefix + "_" + name
+                    name = ns_prefix + '_' + name
                 if name in ignore_list:
                     continue
-                if not name in white_list[""]:
-                    # print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
+                if not name in white_list['']:
+                    #print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
                     continue
 
                 ext_cnst = False
                 # Check if the method is an external constructor
                 for variant in func.variants:
                     if "Ptr<" in variant.rettype:
+
                         # Register the smart pointer
                         base_class_name = variant.rettype
-                        base_class_name = (
-                            base_class_name.replace("Ptr<", "").replace(">", "").strip()
-                        )
+                        base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
                         self.classes[base_class_name].has_smart_ptr = True
 
                         # Adds the external constructor
@@ -909,20 +815,18 @@ class JSWrapperGenerator(object):
                     continue
 
                 if with_wrapped_functions:
-                    binding, wrapper = self.gen_function_binding_with_wrapper(
-                        func, ns_name, class_info=None
-                    )
+                    binding, wrapper = self.gen_function_binding_with_wrapper(func, ns_name, class_info=None)
                     self.bindings += binding
                     self.wrapper_funcs += wrapper
                 else:
                     binding = self.gen_function_binding(func, class_info=None)
-                    self.bindings += binding
+                    self.bindings+=binding
 
         # generate code for the classes and their methods
         for name, class_info in sorted(self.classes.items()):
             class_bindings = []
             if not name in white_list:
-                # print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
+                #print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
                 continue
 
             # Generate bindings for methods
@@ -935,131 +839,94 @@ class JSWrapperGenerator(object):
                     for variant in method.variants:
                         args = []
                         for arg in variant.args:
-                            arg_type = (
-                                type_dict[arg.tp] if arg.tp in type_dict else arg.tp
-                            )
+                            arg_type = type_dict[arg.tp] if arg.tp in type_dict else arg.tp
                             args.append(arg_type)
                         # print('Constructor: ', class_info.name, len(variant.args))
                         args_num = len(variant.args)
                         if args_num in class_info.constructor_arg_num:
                             continue
                         class_info.constructor_arg_num.add(args_num)
-                        class_bindings.append(
-                            constructor_template.substitute(signature=", ".join(args))
-                        )
+                        class_bindings.append(constructor_template.substitute(signature=', '.join(args)))
                 else:
-                    if with_wrapped_functions and (
-                        len(method.variants) > 1
-                        or len(method.variants[0].args) > 0
-                        or "String" in method.variants[0].rettype
-                    ):
-                        binding, wrapper = self.gen_function_binding_with_wrapper(
-                            method, None, class_info=class_info
-                        )
+                    if with_wrapped_functions and (len(method.variants) > 1 or len(method.variants[0].args)>0 or "String" in method.variants[0].rettype):
+                        binding, wrapper = self.gen_function_binding_with_wrapper(method, None, class_info=class_info)
                         self.wrapper_funcs = self.wrapper_funcs + wrapper
                         class_bindings = class_bindings + binding
                     else:
-                        binding = self.gen_function_binding(
-                            method, class_info=class_info
-                        )
+                        binding = self.gen_function_binding(method, class_info=class_info)
                         class_bindings = class_bindings + binding
 
             # Regiseter Smart pointer
             if class_info.has_smart_ptr:
-                class_bindings.append(
-                    smart_ptr_reg_template.substitute(
-                        cname=class_info.cname, name=class_info.name
-                    )
-                )
+                class_bindings.append(smart_ptr_reg_template.substitute(cname=class_info.cname, name=class_info.name))
 
             # Attach external constructors
             # for method_name, method in class_info.ext_constructors.items():
-            # print("ext constructor", method_name)
-            # if class_info.ext_constructors:
+                # print("ext constructor", method_name)
+            #if class_info.ext_constructors:
+
+
 
             # Generate bindings for properties
             for property in class_info.props:
-                _class_property = (
-                    class_property_enum_template
-                    if property.tp in type_dict
-                    else class_property_template
-                )
-                class_bindings.append(
-                    _class_property.substitute(
-                        js_name=property.name,
-                        cpp_name="::".join([class_info.cname, property.name]),
-                    )
-                )
+                _class_property = class_property_enum_template if property.tp in type_dict else class_property_template
+                class_bindings.append(_class_property.substitute(js_name=property.name, cpp_name='::'.join(
+                    [class_info.cname, property.name])))
 
-            dv = ""
+            dv = ''
             base = Template("""base<$base>""")
 
-            assert len(class_info.bases) <= 1, "multiple inheritance not supported"
+            assert len(class_info.bases) <= 1 , "multiple inheritance not supported"
 
             if len(class_info.bases) == 1:
-                dv = "," + base.substitute(base=", ".join(class_info.bases))
+                dv = "," + base.substitute(base=', '.join(class_info.bases))
 
-            self.bindings.append(
-                class_template.substitute(
-                    cpp_name=class_info.cname,
-                    js_name=name,
-                    class_templates="".join(class_bindings),
-                    derivation=dv,
-                )
-            )
+            self.bindings.append(class_template.substitute(cpp_name=class_info.cname,
+                                                           js_name=name,
+                                                           class_templates=''.join(class_bindings),
+                                                           derivation=dv))
 
         if export_enums:
             # step 4: generate bindings for enums
             # TODO anonymous enums are ignored for now.
             for ns_name, ns in sorted(self.namespaces.items()):
-                if ns_name.split(".")[0] != "cv":
+                if ns_name.split('.')[0] != 'cv':
                     continue
                 for name, enum in sorted(ns.enums.items()):
-                    if not name.endswith(".anonymous"):
+                    if not name.endswith('.anonymous'):
                         name = name.replace("cv.", "")
                         enum_values = []
                         for enum_val in enum:
-                            value = enum_val[0][enum_val[0].rfind(".") + 1 :]
-                            enum_values.append(
-                                enum_item_template.substitute(
-                                    val=value,
-                                    cpp_val=name.replace(".", "::") + "::" + value,
-                                )
-                            )
+                            value = enum_val[0][enum_val[0].rfind(".")+1:]
+                            enum_values.append(enum_item_template.substitute(val=value,
+                                                                             cpp_val=name.replace('.', '::')+'::'+value))
 
-                        self.bindings.append(
-                            enum_template.substitute(
-                                cpp_name=name.replace(".", "::"),
-                                js_name=name.replace(".", "_"),
-                                enum_items="".join(enum_values),
-                            )
-                        )
+                        self.bindings.append(enum_template.substitute(cpp_name=name.replace(".", "::"),
+                                                                      js_name=name.replace(".", "_"),
+                                                                      enum_items=''.join(enum_values)))
                     else:
                         print(name)
-                        # TODO: represent anonymous enums with constants
+                        #TODO: represent anonymous enums with constants
 
         if export_consts:
             # step 5: generate bindings for consts
             for ns_name, ns in sorted(self.namespaces.items()):
-                if ns_name.split(".")[0] != "cv":
+                if ns_name.split('.')[0] != 'cv':
                     continue
                 for name, const in sorted(ns.consts.items()):
                     # print("Gen consts: ", name, const)
-                    self.bindings.append(
-                        const_template.substitute(js_name=name, value=const)
-                    )
+                    self.bindings.append(const_template.substitute(js_name=name, value=const))
 
         with open(core_bindings) as f:
             ret = f.read()
 
-        header_includes = "\n".join(['#include "{}"'.format(hdr) for hdr in headers])
-        ret = ret.replace("@INCLUDES@", header_includes)
+        header_includes = '\n'.join(['#include "{}"'.format(hdr) for hdr in headers])
+        ret = ret.replace('@INCLUDES@', header_includes)
 
-        defis = "\n".join(self.wrapper_funcs)
+        defis = '\n'.join(self.wrapper_funcs)
         ret += wrapper_codes_template.substitute(ns=wrapper_namespace, defs=defis)
-        ret += emscripten_binding_template.substitute(
-            binding_name="testBinding", bindings="".join(self.bindings)
-        )
+        ret += emscripten_binding_template.substitute(binding_name='testBinding', bindings=''.join(self.bindings))
+
 
         # print(ret)
         text_file = open(dst_file, "w")
@@ -1069,12 +936,10 @@ class JSWrapperGenerator(object):
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:
-        print(
-            "Usage:\n",
-            os.path.basename(sys.argv[0]),
-            "<full path to hdr_parser.py> <bindings.cpp> <headers.txt> <core_bindings.cpp> <opencv_js.config.py>",
-        )
-        print("Current args are: ", ", ".join(["'" + a + "'" for a in sys.argv]))
+        print("Usage:\n", \
+            os.path.basename(sys.argv[0]), \
+            "<full path to hdr_parser.py> <bindings.cpp> <headers.txt> <core_bindings.cpp> <opencv_js.config.py>")
+        print("Current args are: ", ", ".join(["'"+a+"'" for a in sys.argv]))
         exit(0)
 
     dstdir = "."
@@ -1085,11 +950,11 @@ if __name__ == "__main__":
     import hdr_parser
 
     bindingsCpp = sys.argv[2]
-    headers = open(sys.argv[3], "r").read().split(";")
+    headers = open(sys.argv[3], 'r').read().split(';')
     coreBindings = sys.argv[4]
     whiteListFile = sys.argv[5]
     exec(open(whiteListFile).read())
-    assert white_list
+    assert(white_list)
 
     generator = JSWrapperGenerator()
     generator.gen(bindingsCpp, headers, coreBindings)

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -80,18 +80,20 @@ else:
 func_table = {}
 
 # Ignore these functions due to Embind limitations for now
-ignore_list = ['locate',  #int&
-               'minEnclosingCircle',  #float&
-               'checkRange',
-               'minMaxLoc',   #double*
-               'floodFill', # special case, implemented in core_bindings.cpp
-               'phaseCorrelate',
-               'randShuffle',
-               'calibrationMatrixValues', #double&
-               'undistortPoints', # global redefinition
-               'CamShift', #Rect&
-               'meanShift' #Rect&
-               ]
+ignore_list = [
+    "locate",  # int&
+    "minEnclosingCircle",  # float&
+    "checkRange",
+    "minMaxLoc",  # double*
+    "floodFill",  # special case, implemented in core_bindings.cpp
+    "phaseCorrelate",
+    "randShuffle",
+    "calibrationMatrixValues",  # double&
+    "undistortPoints",  # global redefinition
+    "CamShift",  # Rect&
+    "meanShift",  # Rect&
+]
+
 
 def makeWhiteList(module_list):
     wl = {}
@@ -103,10 +105,11 @@ def makeWhiteList(module_list):
                 wl[k] = m[k]
     return wl
 
+
 white_list = None
 namespace_prefix_override = {
-    'dnn' : '',
-    'aruco' : '',
+    "dnn": "",
+    "aruco": "",
 }
 
 # Features to be exported
@@ -118,15 +121,16 @@ with_vec_from_js_array = True
 
 wrapper_namespace = "Wrappers"
 type_dict = {
-    'InputArray': 'const cv::Mat&',
-    'OutputArray': 'cv::Mat&',
-    'InputOutputArray': 'cv::Mat&',
-    'InputArrayOfArrays': 'const std::vector<cv::Mat>&',
-    'OutputArrayOfArrays': 'std::vector<cv::Mat>&',
-    'string': 'std::string',
-    'String': 'std::string',
-    'const String&':'const std::string&'
+    "InputArray": "const cv::Mat&",
+    "OutputArray": "cv::Mat&",
+    "InputOutputArray": "cv::Mat&",
+    "InputArrayOfArrays": "const std::vector<cv::Mat>&",
+    "OutputArrayOfArrays": "std::vector<cv::Mat>&",
+    "string": "std::string",
+    "String": "std::string",
+    "const String&": "const std::string&",
 }
+
 
 def normalize_class_name(name):
     return re.sub(r"^cv\.", "", name).replace(".", "_")
@@ -183,14 +187,15 @@ class ClassInfo(object):
 
 
 def handle_ptr(tp):
-    if tp.startswith('Ptr_'):
-        tp = 'Ptr<' + "::".join(tp.split('_')[1:]) + '>'
+    if tp.startswith("Ptr_"):
+        tp = "Ptr<" + "::".join(tp.split("_")[1:]) + ">"
     return tp
 
+
 def handle_vector(tp):
-    if tp.startswith('vector_'):
-        tp = handle_vector(tp[tp.find('_') + 1:])
-        tp = 'std::vector<' + "::".join(tp.split('_')) + '>'
+    if tp.startswith("vector_"):
+        tp = handle_vector(tp[tp.find("_") + 1 :])
+        tp = "std::vector<" + "::".join(tp.split("_")) + ">"
     return tp
 
 
@@ -244,8 +249,21 @@ class ArgInfo(object):
         self.py_inputarg = False
         self.py_outputarg = False
 
+
 class FuncVariant(object):
-    def __init__(self, class_name, name, decl, is_constructor, is_class_method, is_const, is_virtual, is_pure_virtual, ref_return, const_return):
+    def __init__(
+        self,
+        class_name,
+        name,
+        decl,
+        is_constructor,
+        is_class_method,
+        is_const,
+        is_virtual,
+        is_pure_virtual,
+        ref_return,
+        const_return,
+    ):
         self.class_name = class_name
         self.name = self.wname = name
         self.is_constructor = is_constructor
@@ -275,7 +293,9 @@ class FuncVariant(object):
 
 class FuncInfo(object):
     def __init__(self, class_name, name, cname, namespace, isconstructor):
-        self.name_id = '_'.join([namespace] + ([class_name] if class_name else []) + [name])  # unique id for dict key
+        self.name_id = "_".join(
+            [namespace] + ([class_name] if class_name else []) + [name]
+        )  # unique id for dict key
 
         self.class_name = class_name
         self.name = name
@@ -297,7 +317,6 @@ class Namespace(object):
 
 class JSWrapperGenerator(object):
     def __init__(self):
-
         self.bindings = []
         self.wrapper_funcs = []
 
@@ -314,28 +333,31 @@ class JSWrapperGenerator(object):
         self.class_idx += 1
 
         if class_info.name in self.classes:
-            print("Generator error: class %s (cpp_name=%s) already exists" \
-                  % (class_info.name, class_info.cname))
+            print(
+                "Generator error: class %s (cpp_name=%s) already exists"
+                % (class_info.name, class_info.cname)
+            )
             sys.exit(-1)
         self.classes[class_info.name] = class_info
 
     def resolve_class_inheritance(self):
         new_classes = {}
         for name, class_info in self.classes.items():
-
-            if not hasattr(class_info, 'bases'):
+            if not hasattr(class_info, "bases"):
                 new_classes[name] = class_info
-                continue # not class
+                continue  # not class
 
             if class_info.bases:
-                chunks = class_info.bases[0].split('::')
-                base = '_'.join(chunks)
+                chunks = class_info.bases[0].split("::")
+                base = "_".join(chunks)
                 while base not in self.classes and len(chunks) > 1:
                     del chunks[-2]
-                    base = '_'.join(chunks)
+                    base = "_".join(chunks)
                 if base not in self.classes:
-                    print("Generator error: unable to resolve base %s for %s"
-                        % (class_info.bases[0], class_info.name))
+                    print(
+                        "Generator error: unable to resolve base %s for %s"
+                        % (class_info.bases[0], class_info.name)
+                    )
                     sys.exit(-1)
                 else:
                     class_info.bases[0] = "::".join(chunks)
@@ -346,19 +368,20 @@ class JSWrapperGenerator(object):
         self.classes = new_classes
 
     def split_decl_name(self, name):
-        chunks = name.split('.')
+        chunks = name.split(".")
         namespace = chunks[:-1]
         classes = []
-        while namespace and '.'.join(namespace) not in self.parser.namespaces:
+        while namespace and ".".join(namespace) not in self.parser.namespaces:
             classes.insert(0, namespace.pop())
         return namespace, classes, chunks[-1]
 
     def add_enum(self, decl):
         name = decl[0].rsplit(" ", 1)[1]
         namespace, classes, val = self.split_decl_name(name)
-        namespace = '.'.join(namespace)
+        namespace = ".".join(namespace)
         ns = self.namespaces.setdefault(namespace, Namespace())
-        if len(name) == 0: name = "<unnamed>"
+        if len(name) == 0:
+            name = "<unnamed>"
         if name.endswith("<unnamed>"):
             i = 0
             while True:
@@ -366,12 +389,13 @@ class JSWrapperGenerator(object):
                 candidate_name = name.replace("<unnamed>", "unnamed_%u" % i)
                 if candidate_name not in ns.enums:
                     name = candidate_name
-                    break;
-        cname = name.replace('.', '::')
+                    break
+        cname = name.replace(".", "::")
         type_dict[normalize_class_name(name)] = cname
         if name in ns.enums:
-            print("Generator warning: enum %s (cname=%s) already exists" \
-                  % (name, cname))
+            print(
+                "Generator warning: enum %s (cname=%s) already exists" % (name, cname)
+            )
             # sys.exit(-1)
         else:
             ns.enums[name] = []
@@ -385,14 +409,15 @@ class JSWrapperGenerator(object):
             self.add_const(name.replace("const ", "").strip(), decl)
 
     def add_const(self, name, decl):
-        cname = name.replace('.','::')
+        cname = name.replace(".", "::")
         namespace, classes, name = self.split_decl_name(name)
-        namespace = '.'.join(namespace)
-        name = '_'.join(classes+[name])
+        namespace = ".".join(namespace)
+        name = "_".join(classes + [name])
         ns = self.namespaces.setdefault(namespace, Namespace())
         if name in ns.consts:
-            print("Generator error: constant %s (cname=%s) already exists" \
-                % (name, cname))
+            print(
+                "Generator error: constant %s (cname=%s) already exists" % (name, cname)
+            )
             sys.exit(-1)
         ns.consts[name] = cname
 
@@ -400,12 +425,12 @@ class JSWrapperGenerator(object):
         namespace, classes, barename = self.split_decl_name(decl[0])
         cpp_name = "::".join(namespace + classes + [barename])
         name = barename
-        class_name = ''
-        bare_class_name = ''
+        class_name = ""
+        bare_class_name = ""
         if classes:
-            class_name = normalize_class_name('.'.join(namespace + classes))
+            class_name = normalize_class_name(".".join(namespace + classes))
             bare_class_name = classes[-1]
-        namespace = '.'.join(namespace)
+        namespace = ".".join(namespace)
 
         is_constructor = name == bare_class_name
         is_class_method = False
@@ -440,8 +465,18 @@ class JSWrapperGenerator(object):
         fi = FuncInfo(class_name, name, cpp_name, namespace, is_constructor)
         func = func_map.setdefault(fi.name_id, fi)
 
-        variant = FuncVariant(class_name, name, decl, is_constructor, is_class_method, is_const_method,
-                        is_virtual_method, is_pure_virtual_method, ref_return, const_return)
+        variant = FuncVariant(
+            class_name,
+            name,
+            decl,
+            is_constructor,
+            is_class_method,
+            is_const_method,
+            is_virtual_method,
+            is_pure_virtual_method,
+            ref_return,
+            const_return,
+        )
         func.add_variant(variant)
 
     def save(self, path, name, buf):
@@ -450,7 +485,6 @@ class JSWrapperGenerator(object):
         f.close()
 
     def gen_function_binding_with_wrapper(self, func, ns_name, class_info):
-
         binding_text = None
         wrapper_func_text = None
 
@@ -458,31 +492,37 @@ class JSWrapperGenerator(object):
         wrappers = []
 
         for index, variant in enumerate(func.variants):
-
             factory = False
-            if class_info and 'Ptr<' in variant.rettype:
-
+            if class_info and "Ptr<" in variant.rettype:
                 factory = True
                 base_class_name = variant.rettype
-                base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
+                base_class_name = (
+                    base_class_name.replace("Ptr<", "").replace(">", "").strip()
+                )
                 if base_class_name in self.classes:
                     self.classes[base_class_name].has_smart_ptr = True
                 else:
-                    print(base_class_name, ' not found in classes for registering smart pointer using ', class_info.name, 'instead')
+                    print(
+                        base_class_name,
+                        " not found in classes for registering smart pointer using ",
+                        class_info.name,
+                        "instead",
+                    )
                     self.classes[class_info.name].has_smart_ptr = True
 
             def_args = []
             has_def_param = False
 
             # Return type
-            ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
-            if ret_type.startswith('Ptr'): #smart pointer
-                ptr_type = ret_type.replace('Ptr<', '').replace('>', '')
+            ret_type = "void" if variant.rettype.strip() == "" else variant.rettype
+            if ret_type.startswith("Ptr"):  # smart pointer
+                ptr_type = ret_type.replace("Ptr<", "").replace(">", "")
                 if ptr_type in type_dict:
                     ret_type = type_dict[ptr_type]
             for key in type_dict:
                 if key in ret_type:
-	    ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
+                    ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
+
             arg_types = []
             unwrapped_arg_types = []
             for arg in variant.args:
@@ -492,19 +532,18 @@ class JSWrapperGenerator(object):
                 else:
                     arg_type = arg.tp
                 # Add default value
-                if with_default_params and arg.defval != '':
-                    def_args.append(arg.defval);
+                if with_default_params and arg.defval != "":
+                    def_args.append(arg.defval)
                 arg_types.append(arg_type)
                 unwrapped_arg_types.append(arg_type)
 
             # Function attribute
-            func_attribs = ''
-            if '*' in ''.join(arg_types):
-                func_attribs += ', allow_raw_pointers()'
+            func_attribs = ""
+            if "*" in "".join(arg_types):
+                func_attribs += ", allow_raw_pointers()"
 
             if variant.is_pure_virtual:
-                func_attribs += ', pure_virtual()'
-
+                func_attribs += ", pure_virtual()"
 
             # Wrapper function
             if ns_name != None and ns_name != "cv":
@@ -512,17 +551,19 @@ class JSWrapperGenerator(object):
                 if ns_parts[0] == "cv":
                     ns_parts = ns_parts[1:]
                 ns_part = "_".join(ns_parts) + "_"
-                ns_id = '_'.join(ns_parts)
+                ns_id = "_".join(ns_parts)
                 ns_prefix = namespace_prefix_override.get(ns_id, ns_id)
                 if ns_prefix:
-                    ns_prefix = ns_prefix + '_'
+                    ns_prefix = ns_prefix + "_"
             else:
-                ns_prefix = ''
+                ns_prefix = ""
             if class_info == None:
                 js_func_name = ns_prefix + func.name
                 wrap_func_name = js_func_name + "_wrapper"
             else:
-                wrap_func_name = ns_prefix + func.class_name + "_" + func.name + "_wrapper"
+                wrap_func_name = (
+                    ns_prefix + func.class_name + "_" + func.name + "_wrapper"
+                )
                 js_func_name = func.name
 
             # TODO: Name functions based wrap directives or based on arguments list
@@ -530,10 +571,10 @@ class JSWrapperGenerator(object):
                 wrap_func_name += str(index)
                 js_func_name += str(index)
 
-            c_func_name = 'Wrappers::' + wrap_func_name
+            c_func_name = "Wrappers::" + wrap_func_name
 
             # Binding template-
-            raw_arg_names = ['arg' + str(i + 1) for i in range(0, len(variant.args))]
+            raw_arg_names = ["arg" + str(i + 1) for i in range(0, len(variant.args))]
             arg_names = []
             w_signature = []
             casted_arg_types = []
@@ -541,53 +582,77 @@ class JSWrapperGenerator(object):
                 casted_arg_name = arg_name
                 if with_vec_from_js_array:
                     # Only support const vector reference as input parameter
-                    match = re.search(r'const std::vector<(.*)>&', arg_type)
+                    match = re.search(r"const std::vector<(.*)>&", arg_type)
                     if match:
                         type_in_vect = match.group(1)
-                        if type_in_vect in ['int', 'float', 'double', 'char', 'uchar', 'String', 'std::string']:
-                            casted_arg_name = 'emscripten::vecFromJSArray<' + type_in_vect + '>(' + arg_name + ')'
-                            arg_type = re.sub(r'std::vector<(.*)>', 'emscripten::val', arg_type)
-                w_signature.append(arg_type + ' ' + arg_name)
+                        if type_in_vect in [
+                            "int",
+                            "float",
+                            "double",
+                            "char",
+                            "uchar",
+                            "String",
+                            "std::string",
+                        ]:
+                            casted_arg_name = (
+                                "emscripten::vecFromJSArray<"
+                                + type_in_vect
+                                + ">("
+                                + arg_name
+                                + ")"
+                            )
+                            arg_type = re.sub(
+                                r"std::vector<(.*)>", "emscripten::val", arg_type
+                            )
+                w_signature.append(arg_type + " " + arg_name)
                 arg_names.append(casted_arg_name)
                 casted_arg_types.append(arg_type)
 
             arg_types = casted_arg_types
 
             # Argument list, signature
-            arg_names_casted = [c if a == b else c + '.as<' + a + '>()' for a, b, c in
-                                zip(unwrapped_arg_types, arg_types, arg_names)]
+            arg_names_casted = [
+                c if a == b else c + ".as<" + a + ">()"
+                for a, b, c in zip(unwrapped_arg_types, arg_types, arg_names)
+            ]
 
             # Add self object to the parameters
-            if class_info and not  factory:
-                arg_types = [class_info.cname + '&'] + arg_types
-                w_signature = [class_info.cname + '& arg0 '] + w_signature
+            if class_info and not factory:
+                arg_types = [class_info.cname + "&"] + arg_types
+                w_signature = [class_info.cname + "& arg0 "] + w_signature
 
             for j in range(0, len(def_args) + 1):
-                postfix = ''
+                postfix = ""
                 if j > 0:
-                    postfix = '_' + str(j);
+                    postfix = "_" + str(j)
 
                 ###################################
                 # Wrapper
-                if factory: # TODO or static
-                    name = class_info.cname+'::' if variant.class_name else ""
-                    cpp_call_text = static_class_call_template.substitute(scope=name,
-                                                                   func=func.cname,
-                                                                   args=', '.join(arg_names[:len(arg_names)-j]))
+                if factory:  # TODO or static
+                    name = class_info.cname + "::" if variant.class_name else ""
+                    cpp_call_text = static_class_call_template.substitute(
+                        scope=name,
+                        func=func.cname,
+                        args=", ".join(arg_names[: len(arg_names) - j]),
+                    )
                 elif class_info:
-                    cpp_call_text = class_call_template.substitute(obj='arg0',
-                                                                   func=func.cname,
-                                                                   args=', '.join(arg_names[:len(arg_names)-j]))
+                    cpp_call_text = class_call_template.substitute(
+                        obj="arg0",
+                        func=func.cname,
+                        args=", ".join(arg_names[: len(arg_names) - j]),
+                    )
                 else:
-                    cpp_call_text = call_template.substitute(func=func.cname,
-                                                             args=', '.join(arg_names[:len(arg_names)-j]))
+                    cpp_call_text = call_template.substitute(
+                        func=func.cname, args=", ".join(arg_names[: len(arg_names) - j])
+                    )
 
-
-                wrapper_func_text = wrapper_function_template.substitute(ret_val=ret_type,
-                                                                             func=wrap_func_name+postfix,
-                                                                             signature=', '.join(w_signature[:len(w_signature)-j]),
-                                                                             cpp_call=cpp_call_text,
-                                                                             const='' if variant.is_const else '')
+                wrapper_func_text = wrapper_function_template.substitute(
+                    ret_val=ret_type,
+                    func=wrap_func_name + postfix,
+                    signature=", ".join(w_signature[: len(w_signature) - j]),
+                    cpp_call=cpp_call_text,
+                    const="" if variant.is_const else "",
+                )
 
                 ###################################
                 # Binding
@@ -605,39 +670,46 @@ class JSWrapperGenerator(object):
                             # e.g. DescriptorMatcher
                             continue
                         class_info.constructor_arg_num.add(args_num)
-                        binding_text = ctr_template.substitute(const='const' if variant.is_const else '',
-                                                           cpp_name=c_func_name+postfix,
-                                                           ret=ret_type,
-                                                           args=','.join(arg_types[:len(arg_types)-j]),
-                                                           optional=func_attribs)
+                        binding_text = ctr_template.substitute(
+                            const="const" if variant.is_const else "",
+                            cpp_name=c_func_name + postfix,
+                            ret=ret_type,
+                            args=",".join(arg_types[: len(arg_types) - j]),
+                            optional=func_attribs,
+                        )
                     else:
-                        binding_template = overload_class_static_function_template if variant.is_class_method else \
-                            overload_class_function_template
-                        binding_text = binding_template.substitute(js_name=js_func_name,
-                                                           const='' if variant.is_const else '',
-                                                           cpp_name=c_func_name+postfix,
-                                                           ret=ret_type,
-                                                           args=','.join(arg_types[:len(arg_types)-j]),
-                                                           optional=func_attribs)
+                        binding_template = (
+                            overload_class_static_function_template
+                            if variant.is_class_method
+                            else overload_class_function_template
+                        )
+                        binding_text = binding_template.substitute(
+                            js_name=js_func_name,
+                            const="" if variant.is_const else "",
+                            cpp_name=c_func_name + postfix,
+                            ret=ret_type,
+                            args=",".join(arg_types[: len(arg_types) - j]),
+                            optional=func_attribs,
+                        )
                 else:
-                    binding_text = overload_function_template.substitute(js_name=js_func_name,
-                                                       cpp_name=c_func_name+postfix,
-                                                       const='const' if variant.is_const else '',
-                                                       ret=ret_type,
-                                                       args=', '.join(arg_types[:len(arg_types)-j]),
-                                                       optional=func_attribs)
+                    binding_text = overload_function_template.substitute(
+                        js_name=js_func_name,
+                        cpp_name=c_func_name + postfix,
+                        const="const" if variant.is_const else "",
+                        ret=ret_type,
+                        args=", ".join(arg_types[: len(arg_types) - j]),
+                        optional=func_attribs,
+                    )
 
                 bindings.append(binding_text)
                 wrappers.append(wrapper_func_text)
 
         return [bindings, wrappers]
 
-
     def gen_function_binding(self, func, class_info):
-
-        if not class_info == None :
-            func_name = class_info.cname+'::'+func.cname
-        else :
+        if not class_info == None:
+            func_name = class_info.cname + "::" + func.cname
+        else:
             func_name = func.cname
 
         binding_text = None
@@ -645,24 +717,34 @@ class JSWrapperGenerator(object):
 
         for index, variant in enumerate(func.variants):
             factory = False
-            #TODO if variant.is_class_method and variant.rettype == ('Ptr<' + class_info.name + '>'):
-            if (not class_info == None) and variant.rettype == ('Ptr<' + class_info.name + '>') or (func.name.startswith("create") and variant.rettype):
+            # TODO if variant.is_class_method and variant.rettype == ('Ptr<' + class_info.name + '>'):
+            if (
+                (not class_info == None)
+                and variant.rettype == ("Ptr<" + class_info.name + ">")
+                or (func.name.startswith("create") and variant.rettype)
+            ):
                 factory = True
                 base_class_name = variant.rettype
-                base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
+                base_class_name = (
+                    base_class_name.replace("Ptr<", "").replace(">", "").strip()
+                )
                 if base_class_name in self.classes:
                     self.classes[base_class_name].has_smart_ptr = True
                 else:
-                    print(base_class_name, ' not found in classes for registering smart pointer using ', class_info.name, 'instead')
+                    print(
+                        base_class_name,
+                        " not found in classes for registering smart pointer using ",
+                        class_info.name,
+                        "instead",
+                    )
                     self.classes[class_info.name].has_smart_ptr = True
 
-
             # Return type
-            ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
+            ret_type = "void" if variant.rettype.strip() == "" else variant.rettype
 
             ret_type = ret_type.strip()
-            if ret_type.startswith('Ptr'): #smart pointer
-                ptr_type = ret_type.replace('Ptr<', '').replace('>', '')
+            if ret_type.startswith("Ptr"):  # smart pointer
+                ptr_type = ret_type.replace("Ptr<", "").replace(">", "")
                 if ptr_type in type_dict:
                     ret_type = type_dict[ptr_type]
             for key in type_dict:
@@ -671,10 +753,10 @@ class JSWrapperGenerator(object):
                     # expression to exclude false matches.
                     # See https://github.com/opencv/opencv/issues/15514
                     ret_type = re.sub(r"\b" + key + r"\b", type_dict[key], ret_type)
-            if variant.constret and ret_type.startswith('const') == False:
-                ret_type = 'const ' + ret_type
-            if variant.refret and ret_type.endswith('&') == False:
-                ret_type += '&'
+            if variant.constret and ret_type.startswith("const") == False:
+                ret_type = "const " + ret_type
+            if variant.refret and ret_type.endswith("&") == False:
+                ret_type += "&"
 
             arg_types = []
             orig_arg_types = []
@@ -685,50 +767,61 @@ class JSWrapperGenerator(object):
                 else:
                     arg_type = arg.tp
 
-                #if arg.outputarg:
+                # if arg.outputarg:
                 #    arg_type += '&'
                 orig_arg_types.append(arg_type)
-                if with_default_params and arg.defval != '':
+                if with_default_params and arg.defval != "":
                     def_args.append(arg.defval)
                 arg_types.append(orig_arg_types[-1])
 
             # Function attribute
-            func_attribs = ''
-            if '*' in ''.join(orig_arg_types):
-                func_attribs += ', allow_raw_pointers()'
+            func_attribs = ""
+            if "*" in "".join(orig_arg_types):
+                func_attribs += ", allow_raw_pointers()"
 
             if variant.is_pure_virtual:
-                func_attribs += ', pure_virtual()'
+                func_attribs += ", pure_virtual()"
 
-            #TODO better naming
-            #if variant.name in self.jsfunctions:
-            #else
+            # TODO better naming
+            # if variant.name in self.jsfunctions:
+            # else
             js_func_name = variant.name
 
-
-            c_func_name = func.cname if (factory and variant.is_class_method == False) else func_name
-
+            c_func_name = (
+                func.cname
+                if (factory and variant.is_class_method == False)
+                else func_name
+            )
 
             ################################### Binding
             for j in range(0, len(def_args) + 1):
-                postfix = ''
+                postfix = ""
                 if j > 0:
-                    postfix = '_' + str(j);
+                    postfix = "_" + str(j)
                 if factory:
-                    binding_text = ctr_template.substitute(const='const' if variant.is_const else '',
-                                                           cpp_name=c_func_name+postfix,
-                                                           ret=ret_type,
-                                                           args=','.join(arg_types[:len(arg_types)-j]),
-                                                           optional=func_attribs)
+                    binding_text = ctr_template.substitute(
+                        const="const" if variant.is_const else "",
+                        cpp_name=c_func_name + postfix,
+                        ret=ret_type,
+                        args=",".join(arg_types[: len(arg_types) - j]),
+                        optional=func_attribs,
+                    )
                 else:
-                    binding_template = overload_class_static_function_template if variant.is_class_method else \
-                            overload_function_template if class_info == None else overload_class_function_template
-                    binding_text = binding_template.substitute(js_name=js_func_name,
-                                                               const='const' if variant.is_const else '',
-                                                               cpp_name=c_func_name+postfix,
-                                                               ret=ret_type,
-                                                               args=','.join(arg_types[:len(arg_types)-1]),
-                                                               optional=func_attribs)
+                    binding_template = (
+                        overload_class_static_function_template
+                        if variant.is_class_method
+                        else overload_function_template
+                        if class_info == None
+                        else overload_class_function_template
+                    )
+                    binding_text = binding_template.substitute(
+                        js_name=js_func_name,
+                        const="const" if variant.is_const else "",
+                        cpp_name=c_func_name + postfix,
+                        ret=ret_type,
+                        args=",".join(arg_types[: len(arg_types) - 1]),
+                        optional=func_attribs,
+                    )
 
                 binding_text_list.append(binding_text)
 
@@ -756,12 +849,12 @@ class JSWrapperGenerator(object):
             # self.print_decls(decls);
             if len(decls) == 0:
                 continue
-            headers.append(hdr[hdr.rindex('opencv2/'):])
+            headers.append(hdr[hdr.rindex("opencv2/") :])
             for decl in decls:
                 name = decl[0]
-                type = name[:name.find(" ")]
+                type = name[: name.find(" ")]
                 if type == "struct" or type == "class":  # class/structure case
-                    name = name[name.find(" ") + 1:].strip()
+                    name = name[name.find(" ") + 1 :].strip()
                     self.add_class(type, name, decl)
                 elif name.startswith("enum"):  # enumerations
                     self.add_enum(decl)
@@ -776,32 +869,33 @@ class JSWrapperGenerator(object):
         # step 2: generate bindings
         # Global functions
         for ns_name, ns in sorted(self.namespaces.items()):
-            ns_parts = ns_name.split('.')
-            if ns_parts[0] != 'cv':
-                print('Ignore namespace: {}'.format(ns_name))
+            ns_parts = ns_name.split(".")
+            if ns_parts[0] != "cv":
+                print("Ignore namespace: {}".format(ns_name))
                 continue
             else:
                 ns_parts = ns_parts[1:]
-            ns_id = '_'.join(ns_parts)
+            ns_id = "_".join(ns_parts)
             ns_prefix = namespace_prefix_override.get(ns_id, ns_id)
             for name_id, func in sorted(ns.funcs.items()):
                 name = func.name
                 if ns_prefix:
-                    name = ns_prefix + '_' + name
+                    name = ns_prefix + "_" + name
                 if name in ignore_list:
                     continue
-                if not name in white_list['']:
-                    #print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
+                if not name in white_list[""]:
+                    # print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
                     continue
 
                 ext_cnst = False
                 # Check if the method is an external constructor
                 for variant in func.variants:
                     if "Ptr<" in variant.rettype:
-
                         # Register the smart pointer
                         base_class_name = variant.rettype
-                        base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
+                        base_class_name = (
+                            base_class_name.replace("Ptr<", "").replace(">", "").strip()
+                        )
                         self.classes[base_class_name].has_smart_ptr = True
 
                         # Adds the external constructor
@@ -815,18 +909,20 @@ class JSWrapperGenerator(object):
                     continue
 
                 if with_wrapped_functions:
-                    binding, wrapper = self.gen_function_binding_with_wrapper(func, ns_name, class_info=None)
+                    binding, wrapper = self.gen_function_binding_with_wrapper(
+                        func, ns_name, class_info=None
+                    )
                     self.bindings += binding
                     self.wrapper_funcs += wrapper
                 else:
                     binding = self.gen_function_binding(func, class_info=None)
-                    self.bindings+=binding
+                    self.bindings += binding
 
         # generate code for the classes and their methods
         for name, class_info in sorted(self.classes.items()):
             class_bindings = []
             if not name in white_list:
-                #print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
+                # print('Not in whitelist: "{}" from ns={}'.format(name, ns_name))
                 continue
 
             # Generate bindings for methods
@@ -839,94 +935,131 @@ class JSWrapperGenerator(object):
                     for variant in method.variants:
                         args = []
                         for arg in variant.args:
-                            arg_type = type_dict[arg.tp] if arg.tp in type_dict else arg.tp
+                            arg_type = (
+                                type_dict[arg.tp] if arg.tp in type_dict else arg.tp
+                            )
                             args.append(arg_type)
                         # print('Constructor: ', class_info.name, len(variant.args))
                         args_num = len(variant.args)
                         if args_num in class_info.constructor_arg_num:
                             continue
                         class_info.constructor_arg_num.add(args_num)
-                        class_bindings.append(constructor_template.substitute(signature=', '.join(args)))
+                        class_bindings.append(
+                            constructor_template.substitute(signature=", ".join(args))
+                        )
                 else:
-                    if with_wrapped_functions and (len(method.variants) > 1 or len(method.variants[0].args)>0 or "String" in method.variants[0].rettype):
-                        binding, wrapper = self.gen_function_binding_with_wrapper(method, None, class_info=class_info)
+                    if with_wrapped_functions and (
+                        len(method.variants) > 1
+                        or len(method.variants[0].args) > 0
+                        or "String" in method.variants[0].rettype
+                    ):
+                        binding, wrapper = self.gen_function_binding_with_wrapper(
+                            method, None, class_info=class_info
+                        )
                         self.wrapper_funcs = self.wrapper_funcs + wrapper
                         class_bindings = class_bindings + binding
                     else:
-                        binding = self.gen_function_binding(method, class_info=class_info)
+                        binding = self.gen_function_binding(
+                            method, class_info=class_info
+                        )
                         class_bindings = class_bindings + binding
 
             # Regiseter Smart pointer
             if class_info.has_smart_ptr:
-                class_bindings.append(smart_ptr_reg_template.substitute(cname=class_info.cname, name=class_info.name))
+                class_bindings.append(
+                    smart_ptr_reg_template.substitute(
+                        cname=class_info.cname, name=class_info.name
+                    )
+                )
 
             # Attach external constructors
             # for method_name, method in class_info.ext_constructors.items():
-                # print("ext constructor", method_name)
-            #if class_info.ext_constructors:
-
-
+            # print("ext constructor", method_name)
+            # if class_info.ext_constructors:
 
             # Generate bindings for properties
             for property in class_info.props:
-                _class_property = class_property_enum_template if property.tp in type_dict else class_property_template
-                class_bindings.append(_class_property.substitute(js_name=property.name, cpp_name='::'.join(
-                    [class_info.cname, property.name])))
+                _class_property = (
+                    class_property_enum_template
+                    if property.tp in type_dict
+                    else class_property_template
+                )
+                class_bindings.append(
+                    _class_property.substitute(
+                        js_name=property.name,
+                        cpp_name="::".join([class_info.cname, property.name]),
+                    )
+                )
 
-            dv = ''
+            dv = ""
             base = Template("""base<$base>""")
 
-            assert len(class_info.bases) <= 1 , "multiple inheritance not supported"
+            assert len(class_info.bases) <= 1, "multiple inheritance not supported"
 
             if len(class_info.bases) == 1:
-                dv = "," + base.substitute(base=', '.join(class_info.bases))
+                dv = "," + base.substitute(base=", ".join(class_info.bases))
 
-            self.bindings.append(class_template.substitute(cpp_name=class_info.cname,
-                                                           js_name=name,
-                                                           class_templates=''.join(class_bindings),
-                                                           derivation=dv))
+            self.bindings.append(
+                class_template.substitute(
+                    cpp_name=class_info.cname,
+                    js_name=name,
+                    class_templates="".join(class_bindings),
+                    derivation=dv,
+                )
+            )
 
         if export_enums:
             # step 4: generate bindings for enums
             # TODO anonymous enums are ignored for now.
             for ns_name, ns in sorted(self.namespaces.items()):
-                if ns_name.split('.')[0] != 'cv':
+                if ns_name.split(".")[0] != "cv":
                     continue
                 for name, enum in sorted(ns.enums.items()):
-                    if not name.endswith('.anonymous'):
+                    if not name.endswith(".anonymous"):
                         name = name.replace("cv.", "")
                         enum_values = []
                         for enum_val in enum:
-                            value = enum_val[0][enum_val[0].rfind(".")+1:]
-                            enum_values.append(enum_item_template.substitute(val=value,
-                                                                             cpp_val=name.replace('.', '::')+'::'+value))
+                            value = enum_val[0][enum_val[0].rfind(".") + 1 :]
+                            enum_values.append(
+                                enum_item_template.substitute(
+                                    val=value,
+                                    cpp_val=name.replace(".", "::") + "::" + value,
+                                )
+                            )
 
-                        self.bindings.append(enum_template.substitute(cpp_name=name.replace(".", "::"),
-                                                                      js_name=name.replace(".", "_"),
-                                                                      enum_items=''.join(enum_values)))
+                        self.bindings.append(
+                            enum_template.substitute(
+                                cpp_name=name.replace(".", "::"),
+                                js_name=name.replace(".", "_"),
+                                enum_items="".join(enum_values),
+                            )
+                        )
                     else:
                         print(name)
-                        #TODO: represent anonymous enums with constants
+                        # TODO: represent anonymous enums with constants
 
         if export_consts:
             # step 5: generate bindings for consts
             for ns_name, ns in sorted(self.namespaces.items()):
-                if ns_name.split('.')[0] != 'cv':
+                if ns_name.split(".")[0] != "cv":
                     continue
                 for name, const in sorted(ns.consts.items()):
                     # print("Gen consts: ", name, const)
-                    self.bindings.append(const_template.substitute(js_name=name, value=const))
+                    self.bindings.append(
+                        const_template.substitute(js_name=name, value=const)
+                    )
 
         with open(core_bindings) as f:
             ret = f.read()
 
-        header_includes = '\n'.join(['#include "{}"'.format(hdr) for hdr in headers])
-        ret = ret.replace('@INCLUDES@', header_includes)
+        header_includes = "\n".join(['#include "{}"'.format(hdr) for hdr in headers])
+        ret = ret.replace("@INCLUDES@", header_includes)
 
-        defis = '\n'.join(self.wrapper_funcs)
+        defis = "\n".join(self.wrapper_funcs)
         ret += wrapper_codes_template.substitute(ns=wrapper_namespace, defs=defis)
-        ret += emscripten_binding_template.substitute(binding_name='testBinding', bindings=''.join(self.bindings))
-
+        ret += emscripten_binding_template.substitute(
+            binding_name="testBinding", bindings="".join(self.bindings)
+        )
 
         # print(ret)
         text_file = open(dst_file, "w")
@@ -936,10 +1069,12 @@ class JSWrapperGenerator(object):
 
 if __name__ == "__main__":
     if len(sys.argv) < 5:
-        print("Usage:\n", \
-            os.path.basename(sys.argv[0]), \
-            "<full path to hdr_parser.py> <bindings.cpp> <headers.txt> <core_bindings.cpp> <opencv_js.config.py>")
-        print("Current args are: ", ", ".join(["'"+a+"'" for a in sys.argv]))
+        print(
+            "Usage:\n",
+            os.path.basename(sys.argv[0]),
+            "<full path to hdr_parser.py> <bindings.cpp> <headers.txt> <core_bindings.cpp> <opencv_js.config.py>",
+        )
+        print("Current args are: ", ", ".join(["'" + a + "'" for a in sys.argv]))
         exit(0)
 
     dstdir = "."
@@ -950,11 +1085,11 @@ if __name__ == "__main__":
     import hdr_parser
 
     bindingsCpp = sys.argv[2]
-    headers = open(sys.argv[3], 'r').read().split(';')
+    headers = open(sys.argv[3], "r").read().split(";")
     coreBindings = sys.argv[4]
     whiteListFile = sys.argv[5]
     exec(open(whiteListFile).read())
-    assert(white_list)
+    assert white_list
 
     generator = JSWrapperGenerator()
     generator.gen(bindingsCpp, headers, coreBindings)

--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -70,24 +70,26 @@
 
 #include <emscripten/bind.h>
 
-@INCLUDES@
+@INCLUDES @
 #include "../../../modules/core/src/parallel_impl.hpp"
 
 #ifdef TEST_WASM_INTRIN
 #include "../../../modules/core/include/opencv2/core/hal/intrin.hpp"
 #include "../../../modules/core/include/opencv2/core/utils/trace.hpp"
 #include "../../../modules/ts/include/opencv2/ts/ts_gtest.h"
-namespace cv {
-namespace hal {
+    namespace cv
+{
+    namespace hal
+    {
 #include "../../../modules/core/test/test_intrin_utils.hpp"
-}
+    }
 }
 #endif
 
 using namespace emscripten;
 using namespace cv;
 
-using namespace cv::segmentation;  // FIXIT
+using namespace cv::segmentation; // FIXIT
 
 #ifdef HAVE_OPENCV_OBJDETECT
 using namespace cv::aruco;
@@ -108,49 +110,51 @@ typedef std::string string;
 
 namespace binding_utils
 {
-    template<typename classT, typename enumT>
-    static inline typename std::underlying_type<enumT>::type classT::* underlying_ptr(enumT classT::* enum_ptr)
+    template <typename classT, typename enumT>
+    static inline typename std::underlying_type<enumT>::type classT::*underlying_ptr(enumT classT::*enum_ptr)
     {
         return reinterpret_cast<typename std::underlying_type<enumT>::type classT::*>(enum_ptr);
     }
 
-    template<typename T>
-    emscripten::val matData(const cv::Mat& mat)
+    template <typename T>
+    emscripten::val matData(const cv::Mat &mat)
     {
-        return emscripten::val(emscripten::memory_view<T>((mat.total()*mat.elemSize())/sizeof(T),
-                               (T*)mat.data));
+        return emscripten::val(emscripten::memory_view<T>((mat.total() * mat.elemSize()) / sizeof(T),
+                                                          (T *)mat.data));
     }
 
-    template<typename T>
-    emscripten::val matPtr(const cv::Mat& mat, int i)
+    template <typename T>
+    emscripten::val matPtr(const cv::Mat &mat, int i)
     {
         return emscripten::val(emscripten::memory_view<T>(mat.step1(0), mat.ptr<T>(i)));
     }
 
-    template<typename T>
-    emscripten::val matPtr(const cv::Mat& mat, int i, int j)
+    template <typename T>
+    emscripten::val matPtr(const cv::Mat &mat, int i, int j)
     {
-        return emscripten::val(emscripten::memory_view<T>(mat.step1(1), mat.ptr<T>(i,j)));
+        return emscripten::val(emscripten::memory_view<T>(mat.step1(1), mat.ptr<T>(i, j)));
     }
 
-    cv::Mat* createMat(int rows, int cols, int type, intptr_t data, size_t step)
+    cv::Mat *createMat(int rows, int cols, int type, intptr_t data, size_t step)
     {
-        return new cv::Mat(rows, cols, type, reinterpret_cast<void*>(data), step);
+        return new cv::Mat(rows, cols, type, reinterpret_cast<void *>(data), step);
     }
 
-    static emscripten::val getMatSize(const cv::Mat& mat)
+    static emscripten::val getMatSize(const cv::Mat &mat)
     {
         emscripten::val size = emscripten::val::array();
-        for (int i = 0; i < mat.dims; i++) {
+        for (int i = 0; i < mat.dims; i++)
+        {
             size.call<void>("push", mat.size[i]);
         }
         return size;
     }
 
-    static emscripten::val getMatStep(const cv::Mat& mat)
+    static emscripten::val getMatStep(const cv::Mat &mat)
     {
         emscripten::val step = emscripten::val::array();
-        for (int i = 0; i < mat.dims; i++) {
+        for (int i = 0; i < mat.dims; i++)
+        {
             step.call<void>("push", mat.step[i]);
         }
         return step;
@@ -166,22 +170,22 @@ namespace binding_utils
         return Mat(cv::Mat::eye(size, type));
     }
 
-    void convertTo(const Mat& obj, Mat& m, int rtype, double alpha, double beta)
+    void convertTo(const Mat &obj, Mat &m, int rtype, double alpha, double beta)
     {
         obj.convertTo(m, rtype, alpha, beta);
     }
 
-    void convertTo(const Mat& obj, Mat& m, int rtype)
+    void convertTo(const Mat &obj, Mat &m, int rtype)
     {
         obj.convertTo(m, rtype);
     }
 
-    void convertTo(const Mat& obj, Mat& m, int rtype, double alpha)
+    void convertTo(const Mat &obj, Mat &m, int rtype, double alpha)
     {
         obj.convertTo(m, rtype, alpha);
     }
 
-    Size matSize(const cv::Mat& mat)
+    Size matSize(const cv::Mat &mat)
     {
         return mat.size();
     }
@@ -193,7 +197,7 @@ namespace binding_utils
 
     cv::Mat matZeros(cv::Size arg0, int arg1)
     {
-        return cv::Mat::zeros(arg0,arg1);
+        return cv::Mat::zeros(arg0, arg1);
     }
 
     cv::Mat matOnes(int arg0, int arg1, int arg2)
@@ -206,73 +210,74 @@ namespace binding_utils
         return cv::Mat::ones(arg0, arg1);
     }
 
-    double matDot(const cv::Mat& obj, const Mat& mat)
+    double matDot(const cv::Mat &obj, const Mat &mat)
     {
-        return  obj.dot(mat);
+        return obj.dot(mat);
     }
 
-    Mat matMul(const cv::Mat& obj, const Mat& mat, double scale)
+    Mat matMul(const cv::Mat &obj, const Mat &mat, double scale)
     {
-        return  Mat(obj.mul(mat, scale));
+        return Mat(obj.mul(mat, scale));
     }
 
-    Mat matT(const cv::Mat& obj)
+    Mat matT(const cv::Mat &obj)
     {
-        return  Mat(obj.t());
+        return Mat(obj.t());
     }
 
-    Mat matInv(const cv::Mat& obj, int type)
+    Mat matInv(const cv::Mat &obj, int type)
     {
-        return  Mat(obj.inv(type));
+        return Mat(obj.inv(type));
     }
 
-    void matCopyTo(const cv::Mat& obj, cv::Mat& mat)
+    void matCopyTo(const cv::Mat &obj, cv::Mat &mat)
     {
         return obj.copyTo(mat);
     }
 
-    void matCopyTo(const cv::Mat& obj, cv::Mat& mat, const cv::Mat& mask)
+    void matCopyTo(const cv::Mat &obj, cv::Mat &mat, const cv::Mat &mask)
     {
         return obj.copyTo(mat, mask);
     }
 
-    Mat matDiag(const cv::Mat& obj, int d)
+    Mat matDiag(const cv::Mat &obj, int d)
     {
         return obj.diag(d);
     }
 
-    Mat matDiag(const cv::Mat& obj)
+    Mat matDiag(const cv::Mat &obj)
     {
         return obj.diag();
     }
 
-    void matSetTo(cv::Mat& obj, const cv::Scalar& s)
+    void matSetTo(cv::Mat &obj, const cv::Scalar &s)
     {
         obj.setTo(s);
     }
 
-    void matSetTo(cv::Mat& obj, const cv::Scalar& s, const cv::Mat& mask)
+    void matSetTo(cv::Mat &obj, const cv::Scalar &s, const cv::Mat &mask)
     {
         obj.setTo(s, mask);
     }
 
-    emscripten::val rotatedRectPoints(const cv::RotatedRect& obj)
+    emscripten::val rotatedRectPoints(const cv::RotatedRect &obj)
     {
         cv::Point2f points[4];
         obj.points(points);
         emscripten::val pointsArray = emscripten::val::array();
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++)
+        {
             pointsArray.call<void>("push", points[i]);
         }
         return pointsArray;
     }
 
-    Rect rotatedRectBoundingRect(const cv::RotatedRect& obj)
+    Rect rotatedRectBoundingRect(const cv::RotatedRect &obj)
     {
         return obj.boundingRect();
     }
 
-    Rect2f rotatedRectBoundingRect2f(const cv::RotatedRect& obj)
+    Rect2f rotatedRectBoundingRect2f(const cv::RotatedRect &obj)
     {
         return obj.boundingRect2f();
     }
@@ -291,14 +296,14 @@ namespace binding_utils
         Point maxLoc;
     };
 
-    MinMaxLoc minMaxLoc(const cv::Mat& src, const cv::Mat& mask)
+    MinMaxLoc minMaxLoc(const cv::Mat &src, const cv::Mat &mask)
     {
         MinMaxLoc result;
         cv::minMaxLoc(src, &result.minVal, &result.maxVal, &result.minLoc, &result.maxLoc, mask);
         return result;
     }
 
-    MinMaxLoc minMaxLoc_1(const cv::Mat& src)
+    MinMaxLoc minMaxLoc_1(const cv::Mat &src)
     {
         MinMaxLoc result;
         cv::minMaxLoc(src, &result.minVal, &result.maxVal, &result.minLoc, &result.maxLoc);
@@ -313,14 +318,14 @@ namespace binding_utils
     };
 
 #ifdef HAVE_OPENCV_IMGPROC
-    Circle minEnclosingCircle(const cv::Mat& points)
+    Circle minEnclosingCircle(const cv::Mat &points)
     {
         Circle circle;
         cv::minEnclosingCircle(points, circle.center, circle.radius);
         return circle;
     }
 
-    int floodFill_withRect_helper(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6 = Scalar(), Scalar arg7 = Scalar(), int arg8 = 4)
+    int floodFill_withRect_helper(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6 = Scalar(), Scalar arg7 = Scalar(), int arg8 = 4)
     {
         cv::Rect rect;
 
@@ -334,29 +339,34 @@ namespace binding_utils
         return rc;
     }
 
-    int floodFill_wrapper(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7, int arg8) {
+    int floodFill_wrapper(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7, int arg8)
+    {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
-    int floodFill_wrapper_1(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7) {
+    int floodFill_wrapper_1(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7)
+    {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
-    int floodFill_wrapper_2(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6) {
+    int floodFill_wrapper_2(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6)
+    {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
-    int floodFill_wrapper_3(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5) {
+    int floodFill_wrapper_3(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5)
+    {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5);
     }
 
-    int floodFill_wrapper_4(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4) {
+    int floodFill_wrapper_4(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4)
+    {
         return cv::floodFill(arg1, arg2, arg3, arg4);
     }
 #endif
 
 #ifdef HAVE_OPENCV_VIDEO
-    emscripten::val CamShiftWrapper(const cv::Mat& arg1, Rect& arg2, TermCriteria arg3)
+    emscripten::val CamShiftWrapper(const cv::Mat &arg1, Rect &arg2, TermCriteria arg3)
     {
         RotatedRect rotatedRect = cv::CamShift(arg1, arg2, arg3);
         emscripten::val result = emscripten::val::array();
@@ -365,7 +375,7 @@ namespace binding_utils
         return result;
     }
 
-    emscripten::val meanShiftWrapper(const cv::Mat& arg1, Rect& arg2, TermCriteria arg3)
+    emscripten::val meanShiftWrapper(const cv::Mat &arg1, Rect &arg2, TermCriteria arg3)
     {
         int n = cv::meanShift(arg1, arg2, arg3);
         emscripten::val result = emscripten::val::array();
@@ -374,13 +384,12 @@ namespace binding_utils
         return result;
     }
 
-
-    void Tracker_init_wrapper(cv::Tracker& arg0, const cv::Mat& arg1, const Rect& arg2)
+    void Tracker_init_wrapper(cv::Tracker &arg0, const cv::Mat &arg1, const Rect &arg2)
     {
         return arg0.init(arg1, arg2);
     }
 
-    emscripten::val Tracker_update_wrapper(cv::Tracker& arg0, const cv::Mat& arg1)
+    emscripten::val Tracker_update_wrapper(cv::Tracker &arg0, const cv::Mat &arg1)
     {
         Rect rect;
         bool update = arg0.update(arg1, rect);
@@ -390,57 +399,72 @@ namespace binding_utils
         result.call<void>("push", rect);
         return result;
     }
-#endif  // HAVE_OPENCV_VIDEO
+#endif // HAVE_OPENCV_VIDEO
 
-    std::string getExceptionMsg(const cv::Exception& e) {
+    std::string getExceptionMsg(const cv::Exception &e)
+    {
         return e.msg;
     }
 
-    void setExceptionMsg(cv::Exception& e, std::string msg) {
+    void setExceptionMsg(cv::Exception &e, std::string msg)
+    {
         e.msg = msg;
         return;
     }
 
-    cv::Exception exceptionFromPtr(intptr_t ptr) {
-        return *reinterpret_cast<cv::Exception*>(ptr);
+    cv::Exception exceptionFromPtr(intptr_t ptr)
+    {
+        return *reinterpret_cast<cv::Exception *>(ptr);
     }
 
-    std::string getBuildInformation() {
+    std::string getBuildInformation()
+    {
         return cv::getBuildInformation();
     }
 
 #ifdef TEST_WASM_INTRIN
-    void test_hal_intrin_uint8() {
+    void test_hal_intrin_uint8()
+    {
         cv::hal::test_hal_intrin_uint8();
     }
-    void test_hal_intrin_int8() {
+    void test_hal_intrin_int8()
+    {
         cv::hal::test_hal_intrin_int8();
     }
-    void test_hal_intrin_uint16() {
+    void test_hal_intrin_uint16()
+    {
         cv::hal::test_hal_intrin_uint16();
     }
-    void test_hal_intrin_int16() {
+    void test_hal_intrin_int16()
+    {
         cv::hal::test_hal_intrin_int16();
     }
-    void test_hal_intrin_uint32() {
+    void test_hal_intrin_uint32()
+    {
         cv::hal::test_hal_intrin_uint32();
     }
-    void test_hal_intrin_int32() {
+    void test_hal_intrin_int32()
+    {
         cv::hal::test_hal_intrin_int32();
     }
-    void test_hal_intrin_uint64() {
+    void test_hal_intrin_uint64()
+    {
         cv::hal::test_hal_intrin_uint64();
     }
-    void test_hal_intrin_int64() {
+    void test_hal_intrin_int64()
+    {
         cv::hal::test_hal_intrin_int64();
     }
-    void test_hal_intrin_float32() {
+    void test_hal_intrin_float32()
+    {
         cv::hal::test_hal_intrin_float32();
     }
-    void test_hal_intrin_float64() {
+    void test_hal_intrin_float64()
+    {
         cv::hal::test_hal_intrin_float64();
     }
-    void test_hal_intrin_all() {
+    void test_hal_intrin_all()
+    {
         cv::hal::test_hal_intrin_uint8();
         cv::hal::test_hal_intrin_int8();
         cv::hal::test_hal_intrin_uint16();
@@ -460,7 +484,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<int>("IntVector");
     register_vector<char>("CharVector");
     register_vector<float>("FloatVector");
-    register_vector<double>("DoubleVector"); 
+    register_vector<double>("DoubleVector");
     register_vector<std::string>("StringVector");
     register_vector<cv::Point>("PointVector");
     register_vector<cv::Mat>("MatVector");
@@ -469,13 +493,12 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<cv::DMatch>("DMatchVector");
     register_vector<std::vector<cv::DMatch>>("DMatchVectorVector");
 
-
     emscripten::class_<cv::Mat>("Mat")
         .constructor<>()
-        .constructor<const Mat&>()
+        .constructor<const Mat &>()
         .constructor<Size, int>()
         .constructor<int, int, int>()
-        .constructor<int, int, int, const Scalar&>()
+        .constructor<int, int, int, const Scalar &>()
         .constructor(&binding_utils::createMat, allow_raw_pointers())
 
         .class_function("eye", select_overload<Mat(Size, int)>(&binding_utils::matEye))
@@ -497,78 +520,78 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .property("data32F", &binding_utils::matData<float>)
         .property("data64F", &binding_utils::matData<double>)
 
-        .function("elemSize", select_overload<size_t()const>(&cv::Mat::elemSize))
-        .function("elemSize1", select_overload<size_t()const>(&cv::Mat::elemSize1))
-        .function("channels", select_overload<int()const>(&cv::Mat::channels))
-        .function("convertTo", select_overload<void(const Mat&, Mat&, int, double, double)>(&binding_utils::convertTo))
-        .function("convertTo", select_overload<void(const Mat&, Mat&, int)>(&binding_utils::convertTo))
-        .function("convertTo", select_overload<void(const Mat&, Mat&, int, double)>(&binding_utils::convertTo))
-        .function("total", select_overload<size_t()const>(&cv::Mat::total))
-        .function("row", select_overload<Mat(int)const>(&cv::Mat::row))
+        .function("elemSize", select_overload<size_t() const>(&cv::Mat::elemSize))
+        .function("elemSize1", select_overload<size_t() const>(&cv::Mat::elemSize1))
+        .function("channels", select_overload<int() const>(&cv::Mat::channels))
+        .function("convertTo", select_overload<void(const Mat &, Mat &, int, double, double)>(&binding_utils::convertTo))
+        .function("convertTo", select_overload<void(const Mat &, Mat &, int)>(&binding_utils::convertTo))
+        .function("convertTo", select_overload<void(const Mat &, Mat &, int, double)>(&binding_utils::convertTo))
+        .function("total", select_overload<size_t() const>(&cv::Mat::total))
+        .function("row", select_overload<Mat(int) const>(&cv::Mat::row))
         .function("create", select_overload<void(int, int, int)>(&cv::Mat::create))
         .function("create", select_overload<void(Size, int)>(&cv::Mat::create))
-        .function("rowRange", select_overload<Mat(int, int)const>(&cv::Mat::rowRange))
-        .function("rowRange", select_overload<Mat(const Range&)const>(&cv::Mat::rowRange))
-        .function("copyTo", select_overload<void(const Mat&, Mat&)>(&binding_utils::matCopyTo))
-        .function("copyTo", select_overload<void(const Mat&, Mat&, const Mat&)>(&binding_utils::matCopyTo))
-        .function("type", select_overload<int()const>(&cv::Mat::type))
-        .function("empty", select_overload<bool()const>(&cv::Mat::empty))
-        .function("colRange", select_overload<Mat(int, int)const>(&cv::Mat::colRange))
-        .function("colRange", select_overload<Mat(const Range&)const>(&cv::Mat::colRange))
-        .function("step1", select_overload<size_t(int)const>(&cv::Mat::step1))
-        .function("clone", select_overload<Mat()const>(&cv::Mat::clone))
-        .function("depth", select_overload<int()const>(&cv::Mat::depth))
-        .function("col", select_overload<Mat(int)const>(&cv::Mat::col))
-        .function("dot", select_overload<double(const Mat&, const Mat&)>(&binding_utils::matDot))
-        .function("mul", select_overload<Mat(const Mat&, const Mat&, double)>(&binding_utils::matMul))
-        .function("inv", select_overload<Mat(const Mat&, int)>(&binding_utils::matInv))
-        .function("t", select_overload<Mat(const Mat&)>(&binding_utils::matT))
-        .function("roi", select_overload<Mat(const Rect&)const>(&cv::Mat::operator()))
-        .function("diag", select_overload<Mat(const Mat&, int)>(&binding_utils::matDiag))
-        .function("diag", select_overload<Mat(const Mat&)>(&binding_utils::matDiag))
-        .function("isContinuous", select_overload<bool()const>(&cv::Mat::isContinuous))
-        .function("setTo", select_overload<void(Mat&, const Scalar&)>(&binding_utils::matSetTo))
-        .function("setTo", select_overload<void(Mat&, const Scalar&, const Mat&)>(&binding_utils::matSetTo))
-        .function("size", select_overload<Size(const Mat&)>(&binding_utils::matSize))
+        .function("rowRange", select_overload<Mat(int, int) const>(&cv::Mat::rowRange))
+        .function("rowRange", select_overload<Mat(const Range &) const>(&cv::Mat::rowRange))
+        .function("copyTo", select_overload<void(const Mat &, Mat &)>(&binding_utils::matCopyTo))
+        .function("copyTo", select_overload<void(const Mat &, Mat &, const Mat &)>(&binding_utils::matCopyTo))
+        .function("type", select_overload<int() const>(&cv::Mat::type))
+        .function("empty", select_overload<bool() const>(&cv::Mat::empty))
+        .function("colRange", select_overload<Mat(int, int) const>(&cv::Mat::colRange))
+        .function("colRange", select_overload<Mat(const Range &) const>(&cv::Mat::colRange))
+        .function("step1", select_overload<size_t(int) const>(&cv::Mat::step1))
+        .function("clone", select_overload<Mat() const>(&cv::Mat::clone))
+        .function("depth", select_overload<int() const>(&cv::Mat::depth))
+        .function("col", select_overload<Mat(int) const>(&cv::Mat::col))
+        .function("dot", select_overload<double(const Mat &, const Mat &)>(&binding_utils::matDot))
+        .function("mul", select_overload<Mat(const Mat &, const Mat &, double)>(&binding_utils::matMul))
+        .function("inv", select_overload<Mat(const Mat &, int)>(&binding_utils::matInv))
+        .function("t", select_overload<Mat(const Mat &)>(&binding_utils::matT))
+        .function("roi", select_overload<Mat(const Rect &) const>(&cv::Mat::operator()))
+        .function("diag", select_overload<Mat(const Mat &, int)>(&binding_utils::matDiag))
+        .function("diag", select_overload<Mat(const Mat &)>(&binding_utils::matDiag))
+        .function("isContinuous", select_overload<bool() const>(&cv::Mat::isContinuous))
+        .function("setTo", select_overload<void(Mat &, const Scalar &)>(&binding_utils::matSetTo))
+        .function("setTo", select_overload<void(Mat &, const Scalar &, const Mat &)>(&binding_utils::matSetTo))
+        .function("size", select_overload<Size(const Mat &)>(&binding_utils::matSize))
 
-        .function("ptr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ptr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ucharPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ucharPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("charPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<char>))
-        .function("charPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<char>))
-        .function("shortPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<short>))
-        .function("shortPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<short>))
-        .function("ushortPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned short>))
-        .function("ushortPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned short>))
-        .function("intPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<int>))
-        .function("intPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<int>))
-        .function("floatPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<float>))
-        .function("floatPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<float>))
-        .function("doublePtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<double>))
-        .function("doublePtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<double>))
+        .function("ptr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ptr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ucharPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ucharPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("charPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<char>))
+        .function("charPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<char>))
+        .function("shortPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<short>))
+        .function("shortPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<short>))
+        .function("ushortPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned short>))
+        .function("ushortPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned short>))
+        .function("intPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<int>))
+        .function("intPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<int>))
+        .function("floatPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<float>))
+        .function("floatPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<float>))
+        .function("doublePtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<double>))
+        .function("doublePtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<double>))
 
-        .function("charAt", select_overload<char&(int)>(&cv::Mat::at<char>))
-        .function("charAt", select_overload<char&(int, int)>(&cv::Mat::at<char>))
-        .function("charAt", select_overload<char&(int, int, int)>(&cv::Mat::at<char>))
-        .function("ucharAt", select_overload<unsigned char&(int)>(&cv::Mat::at<unsigned char>))
-        .function("ucharAt", select_overload<unsigned char&(int, int)>(&cv::Mat::at<unsigned char>))
-        .function("ucharAt", select_overload<unsigned char&(int, int, int)>(&cv::Mat::at<unsigned char>))
-        .function("shortAt", select_overload<short&(int)>(&cv::Mat::at<short>))
-        .function("shortAt", select_overload<short&(int, int)>(&cv::Mat::at<short>))
-        .function("shortAt", select_overload<short&(int, int, int)>(&cv::Mat::at<short>))
-        .function("ushortAt", select_overload<unsigned short&(int)>(&cv::Mat::at<unsigned short>))
-        .function("ushortAt", select_overload<unsigned short&(int, int)>(&cv::Mat::at<unsigned short>))
-        .function("ushortAt", select_overload<unsigned short&(int, int, int)>(&cv::Mat::at<unsigned short>))
-        .function("intAt", select_overload<int&(int)>(&cv::Mat::at<int>) )
-        .function("intAt", select_overload<int&(int, int)>(&cv::Mat::at<int>) )
-        .function("intAt", select_overload<int&(int, int, int)>(&cv::Mat::at<int>) )
-        .function("floatAt", select_overload<float&(int)>(&cv::Mat::at<float>))
-        .function("floatAt", select_overload<float&(int, int)>(&cv::Mat::at<float>))
-        .function("floatAt", select_overload<float&(int, int, int)>(&cv::Mat::at<float>))
-        .function("doubleAt", select_overload<double&(int, int, int)>(&cv::Mat::at<double>))
-        .function("doubleAt", select_overload<double&(int)>(&cv::Mat::at<double>))
-        .function("doubleAt", select_overload<double&(int, int)>(&cv::Mat::at<double>));
+        .function("charAt", select_overload<char &(int)>(&cv::Mat::at<char>))
+        .function("charAt", select_overload<char &(int, int)>(&cv::Mat::at<char>))
+        .function("charAt", select_overload<char &(int, int, int)>(&cv::Mat::at<char>))
+        .function("ucharAt", select_overload<unsigned char &(int)>(&cv::Mat::at<unsigned char>))
+        .function("ucharAt", select_overload<unsigned char &(int, int)>(&cv::Mat::at<unsigned char>))
+        .function("ucharAt", select_overload<unsigned char &(int, int, int)>(&cv::Mat::at<unsigned char>))
+        .function("shortAt", select_overload<short &(int)>(&cv::Mat::at<short>))
+        .function("shortAt", select_overload<short &(int, int)>(&cv::Mat::at<short>))
+        .function("shortAt", select_overload<short &(int, int, int)>(&cv::Mat::at<short>))
+        .function("ushortAt", select_overload<unsigned short &(int)>(&cv::Mat::at<unsigned short>))
+        .function("ushortAt", select_overload<unsigned short &(int, int)>(&cv::Mat::at<unsigned short>))
+        .function("ushortAt", select_overload<unsigned short &(int, int, int)>(&cv::Mat::at<unsigned short>))
+        .function("intAt", select_overload<int &(int)>(&cv::Mat::at<int>))
+        .function("intAt", select_overload<int &(int, int)>(&cv::Mat::at<int>))
+        .function("intAt", select_overload<int &(int, int, int)>(&cv::Mat::at<int>))
+        .function("floatAt", select_overload<float &(int)>(&cv::Mat::at<float>))
+        .function("floatAt", select_overload<float &(int, int)>(&cv::Mat::at<float>))
+        .function("floatAt", select_overload<float &(int, int, int)>(&cv::Mat::at<float>))
+        .function("doubleAt", select_overload<double &(int, int, int)>(&cv::Mat::at<double>))
+        .function("doubleAt", select_overload<double &(int)>(&cv::Mat::at<double>))
+        .function("doubleAt", select_overload<double &(int, int)>(&cv::Mat::at<double>));
 
     emscripten::value_object<cv::Range>("Range")
         .field("start", &cv::Range::start)
@@ -579,27 +602,27 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("maxCount", &cv::TermCriteria::maxCount)
         .field("epsilon", &cv::TermCriteria::epsilon);
 
-#define EMSCRIPTEN_CV_SIZE(type) \
+#define EMSCRIPTEN_CV_SIZE(type)            \
     emscripten::value_object<type>("#type") \
-        .field("width", &type::width) \
+        .field("width", &type::width)       \
         .field("height", &type::height);
 
     EMSCRIPTEN_CV_SIZE(Size)
     EMSCRIPTEN_CV_SIZE(Size2f)
 
-#define EMSCRIPTEN_CV_POINT(type) \
+#define EMSCRIPTEN_CV_POINT(type)           \
     emscripten::value_object<type>("#type") \
-        .field("x", &type::x) \
-        .field("y", &type::y); \
+        .field("x", &type::x)               \
+        .field("y", &type::y);
 
     EMSCRIPTEN_CV_POINT(Point)
     EMSCRIPTEN_CV_POINT(Point2f)
 
-#define EMSCRIPTEN_CV_RECT(type, name) \
-    emscripten::value_object<cv::Rect_<type>> (name) \
-        .field("x", &cv::Rect_<type>::x) \
-        .field("y", &cv::Rect_<type>::y) \
-        .field("width", &cv::Rect_<type>::width) \
+#define EMSCRIPTEN_CV_RECT(type, name)              \
+    emscripten::value_object<cv::Rect_<type>>(name) \
+        .field("x", &cv::Rect_<type>::x)            \
+        .field("y", &cv::Rect_<type>::y)            \
+        .field("width", &cv::Rect_<type>::width)    \
         .field("height", &cv::Rect_<type>::height);
 
     EMSCRIPTEN_CV_RECT(int, "Rect")
@@ -610,9 +633,9 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("size", &cv::RotatedRect::size)
         .field("angle", &cv::RotatedRect::angle);
 
-    function("rotatedRectPoints", select_overload<emscripten::val(const cv::RotatedRect&)>(&binding_utils::rotatedRectPoints));
-    function("rotatedRectBoundingRect", select_overload<Rect(const cv::RotatedRect&)>(&binding_utils::rotatedRectBoundingRect));
-    function("rotatedRectBoundingRect2f", select_overload<Rect2f(const cv::RotatedRect&)>(&binding_utils::rotatedRectBoundingRect2f));
+    function("rotatedRectPoints", select_overload<emscripten::val(const cv::RotatedRect &)>(&binding_utils::rotatedRectPoints));
+    function("rotatedRectBoundingRect", select_overload<Rect(const cv::RotatedRect &)>(&binding_utils::rotatedRectBoundingRect));
+    function("rotatedRectBoundingRect2f", select_overload<Rect2f(const cv::RotatedRect &)>(&binding_utils::rotatedRectBoundingRect2f));
 
     emscripten::value_object<cv::KeyPoint>("KeyPoint")
         .field("angle", &cv::KeyPoint::angle)
@@ -628,7 +651,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("imgIdx", &cv::DMatch::imgIdx)
         .field("distance", &cv::DMatch::distance);
 
-    emscripten::value_array<cv::Scalar_<double>> ("Scalar")
+    emscripten::value_array<cv::Scalar_<double>>("Scalar")
         .element(emscripten::index<0>())
         .element(emscripten::index<1>())
         .element(emscripten::index<2>())
@@ -644,7 +667,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("center", &binding_utils::Circle::center)
         .field("radius", &binding_utils::Circle::radius);
 
-    emscripten::value_object<cv::Moments >("Moments")
+    emscripten::value_object<cv::Moments>("Moments")
         .field("m00", &cv::Moments::m00)
         .field("m10", &cv::Moments::m10)
         .field("m01", &cv::Moments::m01)
@@ -677,22 +700,22 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     function("exceptionFromPtr", &binding_utils::exceptionFromPtr, allow_raw_pointers());
 
 #ifdef HAVE_OPENCV_IMGPROC
-    function("minEnclosingCircle", select_overload<binding_utils::Circle(const cv::Mat&)>(&binding_utils::minEnclosingCircle));
+    function("minEnclosingCircle", select_overload<binding_utils::Circle(const cv::Mat &)>(&binding_utils::minEnclosingCircle));
 
-    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar, Scalar, int)>(&binding_utils::floodFill_wrapper));
+    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar, Scalar, int)>(&binding_utils::floodFill_wrapper));
 
-    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar, Scalar)>(&binding_utils::floodFill_wrapper_1));
+    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar, Scalar)>(&binding_utils::floodFill_wrapper_1));
 
-    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar)>(&binding_utils::floodFill_wrapper_2));
+    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar)>(&binding_utils::floodFill_wrapper_2));
 
-    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val)>(&binding_utils::floodFill_wrapper_3));
+    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val)>(&binding_utils::floodFill_wrapper_3));
 
-    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar)>(&binding_utils::floodFill_wrapper_4));
+    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar)>(&binding_utils::floodFill_wrapper_4));
 #endif
 
-    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat&, const cv::Mat&)>(&binding_utils::minMaxLoc));
+    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat &, const cv::Mat &)>(&binding_utils::minMaxLoc));
 
-    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat&)>(&binding_utils::minMaxLoc_1));
+    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat &)>(&binding_utils::minMaxLoc_1));
 
 #ifdef HAVE_OPENCV_IMGPROC
     function("morphologyDefaultBorderValue", &cv::morphologyDefaultBorderValue);
@@ -701,13 +724,13 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     function("CV_MAT_DEPTH", &binding_utils::cvMatDepth);
 
 #ifdef HAVE_OPENCV_VIDEO
-    function("CamShift", select_overload<emscripten::val(const cv::Mat&, Rect&, TermCriteria)>(&binding_utils::CamShiftWrapper));
+    function("CamShift", select_overload<emscripten::val(const cv::Mat &, Rect &, TermCriteria)>(&binding_utils::CamShiftWrapper));
 
-    function("meanShift", select_overload<emscripten::val(const cv::Mat&, Rect&, TermCriteria)>(&binding_utils::meanShiftWrapper));
+    function("meanShift", select_overload<emscripten::val(const cv::Mat &, Rect &, TermCriteria)>(&binding_utils::meanShiftWrapper));
 
-    emscripten::class_<cv::Tracker >("Tracker")
-        .function("init", select_overload<void(cv::Tracker&,const cv::Mat&,const Rect&)>(&binding_utils::Tracker_init_wrapper), pure_virtual())
-        .function("update", select_overload<emscripten::val(cv::Tracker&,const cv::Mat&)>(&binding_utils::Tracker_update_wrapper), pure_virtual());
+    emscripten::class_<cv::Tracker>("Tracker")
+        .function("init", select_overload<void(cv::Tracker &, const cv::Mat &, const Rect &)>(&binding_utils::Tracker_init_wrapper), pure_virtual())
+        .function("update", select_overload<emscripten::val(cv::Tracker &, const cv::Mat &)>(&binding_utils::Tracker_update_wrapper), pure_virtual());
 
 #endif
 
@@ -771,7 +794,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     constant("CV_8S", CV_8S);
     constant("CV_16U", CV_16U);
     constant("CV_16S", CV_16S);
-    constant("CV_32S",  CV_32S);
+    constant("CV_32S", CV_32S);
     constant("CV_32F", CV_32F);
     constant("CV_64F", CV_64F);
 

--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -460,7 +460,8 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<int>("IntVector");
     register_vector<char>("CharVector");
     register_vector<float>("FloatVector");
-    register_vector<double>("DoubleVector");
+    register_vector<double>("DoubleVector"); 
+    register_vector<std::string>("StringVector");
     register_vector<cv::Point>("PointVector");
     register_vector<cv::Mat>("MatVector");
     register_vector<cv::Rect>("RectVector");

--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -70,26 +70,24 @@
 
 #include <emscripten/bind.h>
 
-@INCLUDES @
+@INCLUDES@
 #include "../../../modules/core/src/parallel_impl.hpp"
 
 #ifdef TEST_WASM_INTRIN
 #include "../../../modules/core/include/opencv2/core/hal/intrin.hpp"
 #include "../../../modules/core/include/opencv2/core/utils/trace.hpp"
 #include "../../../modules/ts/include/opencv2/ts/ts_gtest.h"
-    namespace cv
-{
-    namespace hal
-    {
+namespace cv {
+namespace hal {
 #include "../../../modules/core/test/test_intrin_utils.hpp"
-    }
+}
 }
 #endif
 
 using namespace emscripten;
 using namespace cv;
 
-using namespace cv::segmentation; // FIXIT
+using namespace cv::segmentation;  // FIXIT
 
 #ifdef HAVE_OPENCV_OBJDETECT
 using namespace cv::aruco;
@@ -110,51 +108,49 @@ typedef std::string string;
 
 namespace binding_utils
 {
-    template <typename classT, typename enumT>
-    static inline typename std::underlying_type<enumT>::type classT::*underlying_ptr(enumT classT::*enum_ptr)
+    template<typename classT, typename enumT>
+    static inline typename std::underlying_type<enumT>::type classT::* underlying_ptr(enumT classT::* enum_ptr)
     {
         return reinterpret_cast<typename std::underlying_type<enumT>::type classT::*>(enum_ptr);
     }
 
-    template <typename T>
-    emscripten::val matData(const cv::Mat &mat)
+    template<typename T>
+    emscripten::val matData(const cv::Mat& mat)
     {
-        return emscripten::val(emscripten::memory_view<T>((mat.total() * mat.elemSize()) / sizeof(T),
-                                                          (T *)mat.data));
+        return emscripten::val(emscripten::memory_view<T>((mat.total()*mat.elemSize())/sizeof(T),
+                               (T*)mat.data));
     }
 
-    template <typename T>
-    emscripten::val matPtr(const cv::Mat &mat, int i)
+    template<typename T>
+    emscripten::val matPtr(const cv::Mat& mat, int i)
     {
         return emscripten::val(emscripten::memory_view<T>(mat.step1(0), mat.ptr<T>(i)));
     }
 
-    template <typename T>
-    emscripten::val matPtr(const cv::Mat &mat, int i, int j)
+    template<typename T>
+    emscripten::val matPtr(const cv::Mat& mat, int i, int j)
     {
-        return emscripten::val(emscripten::memory_view<T>(mat.step1(1), mat.ptr<T>(i, j)));
+        return emscripten::val(emscripten::memory_view<T>(mat.step1(1), mat.ptr<T>(i,j)));
     }
 
-    cv::Mat *createMat(int rows, int cols, int type, intptr_t data, size_t step)
+    cv::Mat* createMat(int rows, int cols, int type, intptr_t data, size_t step)
     {
-        return new cv::Mat(rows, cols, type, reinterpret_cast<void *>(data), step);
+        return new cv::Mat(rows, cols, type, reinterpret_cast<void*>(data), step);
     }
 
-    static emscripten::val getMatSize(const cv::Mat &mat)
+    static emscripten::val getMatSize(const cv::Mat& mat)
     {
         emscripten::val size = emscripten::val::array();
-        for (int i = 0; i < mat.dims; i++)
-        {
+        for (int i = 0; i < mat.dims; i++) {
             size.call<void>("push", mat.size[i]);
         }
         return size;
     }
 
-    static emscripten::val getMatStep(const cv::Mat &mat)
+    static emscripten::val getMatStep(const cv::Mat& mat)
     {
         emscripten::val step = emscripten::val::array();
-        for (int i = 0; i < mat.dims; i++)
-        {
+        for (int i = 0; i < mat.dims; i++) {
             step.call<void>("push", mat.step[i]);
         }
         return step;
@@ -170,22 +166,22 @@ namespace binding_utils
         return Mat(cv::Mat::eye(size, type));
     }
 
-    void convertTo(const Mat &obj, Mat &m, int rtype, double alpha, double beta)
+    void convertTo(const Mat& obj, Mat& m, int rtype, double alpha, double beta)
     {
         obj.convertTo(m, rtype, alpha, beta);
     }
 
-    void convertTo(const Mat &obj, Mat &m, int rtype)
+    void convertTo(const Mat& obj, Mat& m, int rtype)
     {
         obj.convertTo(m, rtype);
     }
 
-    void convertTo(const Mat &obj, Mat &m, int rtype, double alpha)
+    void convertTo(const Mat& obj, Mat& m, int rtype, double alpha)
     {
         obj.convertTo(m, rtype, alpha);
     }
 
-    Size matSize(const cv::Mat &mat)
+    Size matSize(const cv::Mat& mat)
     {
         return mat.size();
     }
@@ -197,7 +193,7 @@ namespace binding_utils
 
     cv::Mat matZeros(cv::Size arg0, int arg1)
     {
-        return cv::Mat::zeros(arg0, arg1);
+        return cv::Mat::zeros(arg0,arg1);
     }
 
     cv::Mat matOnes(int arg0, int arg1, int arg2)
@@ -210,74 +206,73 @@ namespace binding_utils
         return cv::Mat::ones(arg0, arg1);
     }
 
-    double matDot(const cv::Mat &obj, const Mat &mat)
+    double matDot(const cv::Mat& obj, const Mat& mat)
     {
-        return obj.dot(mat);
+        return  obj.dot(mat);
     }
 
-    Mat matMul(const cv::Mat &obj, const Mat &mat, double scale)
+    Mat matMul(const cv::Mat& obj, const Mat& mat, double scale)
     {
-        return Mat(obj.mul(mat, scale));
+        return  Mat(obj.mul(mat, scale));
     }
 
-    Mat matT(const cv::Mat &obj)
+    Mat matT(const cv::Mat& obj)
     {
-        return Mat(obj.t());
+        return  Mat(obj.t());
     }
 
-    Mat matInv(const cv::Mat &obj, int type)
+    Mat matInv(const cv::Mat& obj, int type)
     {
-        return Mat(obj.inv(type));
+        return  Mat(obj.inv(type));
     }
 
-    void matCopyTo(const cv::Mat &obj, cv::Mat &mat)
+    void matCopyTo(const cv::Mat& obj, cv::Mat& mat)
     {
         return obj.copyTo(mat);
     }
 
-    void matCopyTo(const cv::Mat &obj, cv::Mat &mat, const cv::Mat &mask)
+    void matCopyTo(const cv::Mat& obj, cv::Mat& mat, const cv::Mat& mask)
     {
         return obj.copyTo(mat, mask);
     }
 
-    Mat matDiag(const cv::Mat &obj, int d)
+    Mat matDiag(const cv::Mat& obj, int d)
     {
         return obj.diag(d);
     }
 
-    Mat matDiag(const cv::Mat &obj)
+    Mat matDiag(const cv::Mat& obj)
     {
         return obj.diag();
     }
 
-    void matSetTo(cv::Mat &obj, const cv::Scalar &s)
+    void matSetTo(cv::Mat& obj, const cv::Scalar& s)
     {
         obj.setTo(s);
     }
 
-    void matSetTo(cv::Mat &obj, const cv::Scalar &s, const cv::Mat &mask)
+    void matSetTo(cv::Mat& obj, const cv::Scalar& s, const cv::Mat& mask)
     {
         obj.setTo(s, mask);
     }
 
-    emscripten::val rotatedRectPoints(const cv::RotatedRect &obj)
+    emscripten::val rotatedRectPoints(const cv::RotatedRect& obj)
     {
         cv::Point2f points[4];
         obj.points(points);
         emscripten::val pointsArray = emscripten::val::array();
-        for (int i = 0; i < 4; i++)
-        {
+        for (int i = 0; i < 4; i++) {
             pointsArray.call<void>("push", points[i]);
         }
         return pointsArray;
     }
 
-    Rect rotatedRectBoundingRect(const cv::RotatedRect &obj)
+    Rect rotatedRectBoundingRect(const cv::RotatedRect& obj)
     {
         return obj.boundingRect();
     }
 
-    Rect2f rotatedRectBoundingRect2f(const cv::RotatedRect &obj)
+    Rect2f rotatedRectBoundingRect2f(const cv::RotatedRect& obj)
     {
         return obj.boundingRect2f();
     }
@@ -296,14 +291,14 @@ namespace binding_utils
         Point maxLoc;
     };
 
-    MinMaxLoc minMaxLoc(const cv::Mat &src, const cv::Mat &mask)
+    MinMaxLoc minMaxLoc(const cv::Mat& src, const cv::Mat& mask)
     {
         MinMaxLoc result;
         cv::minMaxLoc(src, &result.minVal, &result.maxVal, &result.minLoc, &result.maxLoc, mask);
         return result;
     }
 
-    MinMaxLoc minMaxLoc_1(const cv::Mat &src)
+    MinMaxLoc minMaxLoc_1(const cv::Mat& src)
     {
         MinMaxLoc result;
         cv::minMaxLoc(src, &result.minVal, &result.maxVal, &result.minLoc, &result.maxLoc);
@@ -318,14 +313,14 @@ namespace binding_utils
     };
 
 #ifdef HAVE_OPENCV_IMGPROC
-    Circle minEnclosingCircle(const cv::Mat &points)
+    Circle minEnclosingCircle(const cv::Mat& points)
     {
         Circle circle;
         cv::minEnclosingCircle(points, circle.center, circle.radius);
         return circle;
     }
 
-    int floodFill_withRect_helper(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6 = Scalar(), Scalar arg7 = Scalar(), int arg8 = 4)
+    int floodFill_withRect_helper(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6 = Scalar(), Scalar arg7 = Scalar(), int arg8 = 4)
     {
         cv::Rect rect;
 
@@ -339,34 +334,29 @@ namespace binding_utils
         return rc;
     }
 
-    int floodFill_wrapper(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7, int arg8)
-    {
+    int floodFill_wrapper(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7, int arg8) {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
-    int floodFill_wrapper_1(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7)
-    {
+    int floodFill_wrapper_1(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6, Scalar arg7) {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
-    int floodFill_wrapper_2(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6)
-    {
+    int floodFill_wrapper_2(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5, Scalar arg6) {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
-    int floodFill_wrapper_3(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4, emscripten::val arg5)
-    {
+    int floodFill_wrapper_3(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4, emscripten::val arg5) {
         return floodFill_withRect_helper(arg1, arg2, arg3, arg4, arg5);
     }
 
-    int floodFill_wrapper_4(cv::Mat &arg1, cv::Mat &arg2, Point arg3, Scalar arg4)
-    {
+    int floodFill_wrapper_4(cv::Mat& arg1, cv::Mat& arg2, Point arg3, Scalar arg4) {
         return cv::floodFill(arg1, arg2, arg3, arg4);
     }
 #endif
 
 #ifdef HAVE_OPENCV_VIDEO
-    emscripten::val CamShiftWrapper(const cv::Mat &arg1, Rect &arg2, TermCriteria arg3)
+    emscripten::val CamShiftWrapper(const cv::Mat& arg1, Rect& arg2, TermCriteria arg3)
     {
         RotatedRect rotatedRect = cv::CamShift(arg1, arg2, arg3);
         emscripten::val result = emscripten::val::array();
@@ -375,7 +365,7 @@ namespace binding_utils
         return result;
     }
 
-    emscripten::val meanShiftWrapper(const cv::Mat &arg1, Rect &arg2, TermCriteria arg3)
+    emscripten::val meanShiftWrapper(const cv::Mat& arg1, Rect& arg2, TermCriteria arg3)
     {
         int n = cv::meanShift(arg1, arg2, arg3);
         emscripten::val result = emscripten::val::array();
@@ -384,12 +374,13 @@ namespace binding_utils
         return result;
     }
 
-    void Tracker_init_wrapper(cv::Tracker &arg0, const cv::Mat &arg1, const Rect &arg2)
+
+    void Tracker_init_wrapper(cv::Tracker& arg0, const cv::Mat& arg1, const Rect& arg2)
     {
         return arg0.init(arg1, arg2);
     }
 
-    emscripten::val Tracker_update_wrapper(cv::Tracker &arg0, const cv::Mat &arg1)
+    emscripten::val Tracker_update_wrapper(cv::Tracker& arg0, const cv::Mat& arg1)
     {
         Rect rect;
         bool update = arg0.update(arg1, rect);
@@ -399,72 +390,57 @@ namespace binding_utils
         result.call<void>("push", rect);
         return result;
     }
-#endif // HAVE_OPENCV_VIDEO
+#endif  // HAVE_OPENCV_VIDEO
 
-    std::string getExceptionMsg(const cv::Exception &e)
-    {
+    std::string getExceptionMsg(const cv::Exception& e) {
         return e.msg;
     }
 
-    void setExceptionMsg(cv::Exception &e, std::string msg)
-    {
+    void setExceptionMsg(cv::Exception& e, std::string msg) {
         e.msg = msg;
         return;
     }
 
-    cv::Exception exceptionFromPtr(intptr_t ptr)
-    {
-        return *reinterpret_cast<cv::Exception *>(ptr);
+    cv::Exception exceptionFromPtr(intptr_t ptr) {
+        return *reinterpret_cast<cv::Exception*>(ptr);
     }
 
-    std::string getBuildInformation()
-    {
+    std::string getBuildInformation() {
         return cv::getBuildInformation();
     }
 
 #ifdef TEST_WASM_INTRIN
-    void test_hal_intrin_uint8()
-    {
+    void test_hal_intrin_uint8() {
         cv::hal::test_hal_intrin_uint8();
     }
-    void test_hal_intrin_int8()
-    {
+    void test_hal_intrin_int8() {
         cv::hal::test_hal_intrin_int8();
     }
-    void test_hal_intrin_uint16()
-    {
+    void test_hal_intrin_uint16() {
         cv::hal::test_hal_intrin_uint16();
     }
-    void test_hal_intrin_int16()
-    {
+    void test_hal_intrin_int16() {
         cv::hal::test_hal_intrin_int16();
     }
-    void test_hal_intrin_uint32()
-    {
+    void test_hal_intrin_uint32() {
         cv::hal::test_hal_intrin_uint32();
     }
-    void test_hal_intrin_int32()
-    {
+    void test_hal_intrin_int32() {
         cv::hal::test_hal_intrin_int32();
     }
-    void test_hal_intrin_uint64()
-    {
+    void test_hal_intrin_uint64() {
         cv::hal::test_hal_intrin_uint64();
     }
-    void test_hal_intrin_int64()
-    {
+    void test_hal_intrin_int64() {
         cv::hal::test_hal_intrin_int64();
     }
-    void test_hal_intrin_float32()
-    {
+    void test_hal_intrin_float32() {
         cv::hal::test_hal_intrin_float32();
     }
-    void test_hal_intrin_float64()
-    {
+    void test_hal_intrin_float64() {
         cv::hal::test_hal_intrin_float64();
     }
-    void test_hal_intrin_all()
-    {
+    void test_hal_intrin_all() {
         cv::hal::test_hal_intrin_uint8();
         cv::hal::test_hal_intrin_int8();
         cv::hal::test_hal_intrin_uint16();
@@ -493,12 +469,13 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<cv::DMatch>("DMatchVector");
     register_vector<std::vector<cv::DMatch>>("DMatchVectorVector");
 
+
     emscripten::class_<cv::Mat>("Mat")
         .constructor<>()
-        .constructor<const Mat &>()
+        .constructor<const Mat&>()
         .constructor<Size, int>()
         .constructor<int, int, int>()
-        .constructor<int, int, int, const Scalar &>()
+        .constructor<int, int, int, const Scalar&>()
         .constructor(&binding_utils::createMat, allow_raw_pointers())
 
         .class_function("eye", select_overload<Mat(Size, int)>(&binding_utils::matEye))
@@ -520,78 +497,78 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .property("data32F", &binding_utils::matData<float>)
         .property("data64F", &binding_utils::matData<double>)
 
-        .function("elemSize", select_overload<size_t() const>(&cv::Mat::elemSize))
-        .function("elemSize1", select_overload<size_t() const>(&cv::Mat::elemSize1))
-        .function("channels", select_overload<int() const>(&cv::Mat::channels))
-        .function("convertTo", select_overload<void(const Mat &, Mat &, int, double, double)>(&binding_utils::convertTo))
-        .function("convertTo", select_overload<void(const Mat &, Mat &, int)>(&binding_utils::convertTo))
-        .function("convertTo", select_overload<void(const Mat &, Mat &, int, double)>(&binding_utils::convertTo))
-        .function("total", select_overload<size_t() const>(&cv::Mat::total))
-        .function("row", select_overload<Mat(int) const>(&cv::Mat::row))
+        .function("elemSize", select_overload<size_t()const>(&cv::Mat::elemSize))
+        .function("elemSize1", select_overload<size_t()const>(&cv::Mat::elemSize1))
+        .function("channels", select_overload<int()const>(&cv::Mat::channels))
+        .function("convertTo", select_overload<void(const Mat&, Mat&, int, double, double)>(&binding_utils::convertTo))
+        .function("convertTo", select_overload<void(const Mat&, Mat&, int)>(&binding_utils::convertTo))
+        .function("convertTo", select_overload<void(const Mat&, Mat&, int, double)>(&binding_utils::convertTo))
+        .function("total", select_overload<size_t()const>(&cv::Mat::total))
+        .function("row", select_overload<Mat(int)const>(&cv::Mat::row))
         .function("create", select_overload<void(int, int, int)>(&cv::Mat::create))
         .function("create", select_overload<void(Size, int)>(&cv::Mat::create))
-        .function("rowRange", select_overload<Mat(int, int) const>(&cv::Mat::rowRange))
-        .function("rowRange", select_overload<Mat(const Range &) const>(&cv::Mat::rowRange))
-        .function("copyTo", select_overload<void(const Mat &, Mat &)>(&binding_utils::matCopyTo))
-        .function("copyTo", select_overload<void(const Mat &, Mat &, const Mat &)>(&binding_utils::matCopyTo))
-        .function("type", select_overload<int() const>(&cv::Mat::type))
-        .function("empty", select_overload<bool() const>(&cv::Mat::empty))
-        .function("colRange", select_overload<Mat(int, int) const>(&cv::Mat::colRange))
-        .function("colRange", select_overload<Mat(const Range &) const>(&cv::Mat::colRange))
-        .function("step1", select_overload<size_t(int) const>(&cv::Mat::step1))
-        .function("clone", select_overload<Mat() const>(&cv::Mat::clone))
-        .function("depth", select_overload<int() const>(&cv::Mat::depth))
-        .function("col", select_overload<Mat(int) const>(&cv::Mat::col))
-        .function("dot", select_overload<double(const Mat &, const Mat &)>(&binding_utils::matDot))
-        .function("mul", select_overload<Mat(const Mat &, const Mat &, double)>(&binding_utils::matMul))
-        .function("inv", select_overload<Mat(const Mat &, int)>(&binding_utils::matInv))
-        .function("t", select_overload<Mat(const Mat &)>(&binding_utils::matT))
-        .function("roi", select_overload<Mat(const Rect &) const>(&cv::Mat::operator()))
-        .function("diag", select_overload<Mat(const Mat &, int)>(&binding_utils::matDiag))
-        .function("diag", select_overload<Mat(const Mat &)>(&binding_utils::matDiag))
-        .function("isContinuous", select_overload<bool() const>(&cv::Mat::isContinuous))
-        .function("setTo", select_overload<void(Mat &, const Scalar &)>(&binding_utils::matSetTo))
-        .function("setTo", select_overload<void(Mat &, const Scalar &, const Mat &)>(&binding_utils::matSetTo))
-        .function("size", select_overload<Size(const Mat &)>(&binding_utils::matSize))
+        .function("rowRange", select_overload<Mat(int, int)const>(&cv::Mat::rowRange))
+        .function("rowRange", select_overload<Mat(const Range&)const>(&cv::Mat::rowRange))
+        .function("copyTo", select_overload<void(const Mat&, Mat&)>(&binding_utils::matCopyTo))
+        .function("copyTo", select_overload<void(const Mat&, Mat&, const Mat&)>(&binding_utils::matCopyTo))
+        .function("type", select_overload<int()const>(&cv::Mat::type))
+        .function("empty", select_overload<bool()const>(&cv::Mat::empty))
+        .function("colRange", select_overload<Mat(int, int)const>(&cv::Mat::colRange))
+        .function("colRange", select_overload<Mat(const Range&)const>(&cv::Mat::colRange))
+        .function("step1", select_overload<size_t(int)const>(&cv::Mat::step1))
+        .function("clone", select_overload<Mat()const>(&cv::Mat::clone))
+        .function("depth", select_overload<int()const>(&cv::Mat::depth))
+        .function("col", select_overload<Mat(int)const>(&cv::Mat::col))
+        .function("dot", select_overload<double(const Mat&, const Mat&)>(&binding_utils::matDot))
+        .function("mul", select_overload<Mat(const Mat&, const Mat&, double)>(&binding_utils::matMul))
+        .function("inv", select_overload<Mat(const Mat&, int)>(&binding_utils::matInv))
+        .function("t", select_overload<Mat(const Mat&)>(&binding_utils::matT))
+        .function("roi", select_overload<Mat(const Rect&)const>(&cv::Mat::operator()))
+        .function("diag", select_overload<Mat(const Mat&, int)>(&binding_utils::matDiag))
+        .function("diag", select_overload<Mat(const Mat&)>(&binding_utils::matDiag))
+        .function("isContinuous", select_overload<bool()const>(&cv::Mat::isContinuous))
+        .function("setTo", select_overload<void(Mat&, const Scalar&)>(&binding_utils::matSetTo))
+        .function("setTo", select_overload<void(Mat&, const Scalar&, const Mat&)>(&binding_utils::matSetTo))
+        .function("size", select_overload<Size(const Mat&)>(&binding_utils::matSize))
 
-        .function("ptr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ptr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ucharPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("ucharPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned char>))
-        .function("charPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<char>))
-        .function("charPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<char>))
-        .function("shortPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<short>))
-        .function("shortPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<short>))
-        .function("ushortPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<unsigned short>))
-        .function("ushortPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<unsigned short>))
-        .function("intPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<int>))
-        .function("intPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<int>))
-        .function("floatPtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<float>))
-        .function("floatPtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<float>))
-        .function("doublePtr", select_overload<val(const Mat &, int)>(&binding_utils::matPtr<double>))
-        .function("doublePtr", select_overload<val(const Mat &, int, int)>(&binding_utils::matPtr<double>))
+        .function("ptr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ptr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ucharPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("ucharPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned char>))
+        .function("charPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<char>))
+        .function("charPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<char>))
+        .function("shortPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<short>))
+        .function("shortPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<short>))
+        .function("ushortPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<unsigned short>))
+        .function("ushortPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<unsigned short>))
+        .function("intPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<int>))
+        .function("intPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<int>))
+        .function("floatPtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<float>))
+        .function("floatPtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<float>))
+        .function("doublePtr", select_overload<val(const Mat&, int)>(&binding_utils::matPtr<double>))
+        .function("doublePtr", select_overload<val(const Mat&, int, int)>(&binding_utils::matPtr<double>))
 
-        .function("charAt", select_overload<char &(int)>(&cv::Mat::at<char>))
-        .function("charAt", select_overload<char &(int, int)>(&cv::Mat::at<char>))
-        .function("charAt", select_overload<char &(int, int, int)>(&cv::Mat::at<char>))
-        .function("ucharAt", select_overload<unsigned char &(int)>(&cv::Mat::at<unsigned char>))
-        .function("ucharAt", select_overload<unsigned char &(int, int)>(&cv::Mat::at<unsigned char>))
-        .function("ucharAt", select_overload<unsigned char &(int, int, int)>(&cv::Mat::at<unsigned char>))
-        .function("shortAt", select_overload<short &(int)>(&cv::Mat::at<short>))
-        .function("shortAt", select_overload<short &(int, int)>(&cv::Mat::at<short>))
-        .function("shortAt", select_overload<short &(int, int, int)>(&cv::Mat::at<short>))
-        .function("ushortAt", select_overload<unsigned short &(int)>(&cv::Mat::at<unsigned short>))
-        .function("ushortAt", select_overload<unsigned short &(int, int)>(&cv::Mat::at<unsigned short>))
-        .function("ushortAt", select_overload<unsigned short &(int, int, int)>(&cv::Mat::at<unsigned short>))
-        .function("intAt", select_overload<int &(int)>(&cv::Mat::at<int>))
-        .function("intAt", select_overload<int &(int, int)>(&cv::Mat::at<int>))
-        .function("intAt", select_overload<int &(int, int, int)>(&cv::Mat::at<int>))
-        .function("floatAt", select_overload<float &(int)>(&cv::Mat::at<float>))
-        .function("floatAt", select_overload<float &(int, int)>(&cv::Mat::at<float>))
-        .function("floatAt", select_overload<float &(int, int, int)>(&cv::Mat::at<float>))
-        .function("doubleAt", select_overload<double &(int, int, int)>(&cv::Mat::at<double>))
-        .function("doubleAt", select_overload<double &(int)>(&cv::Mat::at<double>))
-        .function("doubleAt", select_overload<double &(int, int)>(&cv::Mat::at<double>));
+        .function("charAt", select_overload<char&(int)>(&cv::Mat::at<char>))
+        .function("charAt", select_overload<char&(int, int)>(&cv::Mat::at<char>))
+        .function("charAt", select_overload<char&(int, int, int)>(&cv::Mat::at<char>))
+        .function("ucharAt", select_overload<unsigned char&(int)>(&cv::Mat::at<unsigned char>))
+        .function("ucharAt", select_overload<unsigned char&(int, int)>(&cv::Mat::at<unsigned char>))
+        .function("ucharAt", select_overload<unsigned char&(int, int, int)>(&cv::Mat::at<unsigned char>))
+        .function("shortAt", select_overload<short&(int)>(&cv::Mat::at<short>))
+        .function("shortAt", select_overload<short&(int, int)>(&cv::Mat::at<short>))
+        .function("shortAt", select_overload<short&(int, int, int)>(&cv::Mat::at<short>))
+        .function("ushortAt", select_overload<unsigned short&(int)>(&cv::Mat::at<unsigned short>))
+        .function("ushortAt", select_overload<unsigned short&(int, int)>(&cv::Mat::at<unsigned short>))
+        .function("ushortAt", select_overload<unsigned short&(int, int, int)>(&cv::Mat::at<unsigned short>))
+        .function("intAt", select_overload<int&(int)>(&cv::Mat::at<int>) )
+        .function("intAt", select_overload<int&(int, int)>(&cv::Mat::at<int>) )
+        .function("intAt", select_overload<int&(int, int, int)>(&cv::Mat::at<int>) )
+        .function("floatAt", select_overload<float&(int)>(&cv::Mat::at<float>))
+        .function("floatAt", select_overload<float&(int, int)>(&cv::Mat::at<float>))
+        .function("floatAt", select_overload<float&(int, int, int)>(&cv::Mat::at<float>))
+        .function("doubleAt", select_overload<double&(int, int, int)>(&cv::Mat::at<double>))
+        .function("doubleAt", select_overload<double&(int)>(&cv::Mat::at<double>))
+        .function("doubleAt", select_overload<double&(int, int)>(&cv::Mat::at<double>));
 
     emscripten::value_object<cv::Range>("Range")
         .field("start", &cv::Range::start)
@@ -602,27 +579,27 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("maxCount", &cv::TermCriteria::maxCount)
         .field("epsilon", &cv::TermCriteria::epsilon);
 
-#define EMSCRIPTEN_CV_SIZE(type)            \
+#define EMSCRIPTEN_CV_SIZE(type) \
     emscripten::value_object<type>("#type") \
-        .field("width", &type::width)       \
+        .field("width", &type::width) \
         .field("height", &type::height);
 
     EMSCRIPTEN_CV_SIZE(Size)
     EMSCRIPTEN_CV_SIZE(Size2f)
 
-#define EMSCRIPTEN_CV_POINT(type)           \
+#define EMSCRIPTEN_CV_POINT(type) \
     emscripten::value_object<type>("#type") \
-        .field("x", &type::x)               \
-        .field("y", &type::y);
+        .field("x", &type::x) \
+        .field("y", &type::y); \
 
     EMSCRIPTEN_CV_POINT(Point)
     EMSCRIPTEN_CV_POINT(Point2f)
 
-#define EMSCRIPTEN_CV_RECT(type, name)              \
-    emscripten::value_object<cv::Rect_<type>>(name) \
-        .field("x", &cv::Rect_<type>::x)            \
-        .field("y", &cv::Rect_<type>::y)            \
-        .field("width", &cv::Rect_<type>::width)    \
+#define EMSCRIPTEN_CV_RECT(type, name) \
+    emscripten::value_object<cv::Rect_<type>> (name) \
+        .field("x", &cv::Rect_<type>::x) \
+        .field("y", &cv::Rect_<type>::y) \
+        .field("width", &cv::Rect_<type>::width) \
         .field("height", &cv::Rect_<type>::height);
 
     EMSCRIPTEN_CV_RECT(int, "Rect")
@@ -633,9 +610,9 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("size", &cv::RotatedRect::size)
         .field("angle", &cv::RotatedRect::angle);
 
-    function("rotatedRectPoints", select_overload<emscripten::val(const cv::RotatedRect &)>(&binding_utils::rotatedRectPoints));
-    function("rotatedRectBoundingRect", select_overload<Rect(const cv::RotatedRect &)>(&binding_utils::rotatedRectBoundingRect));
-    function("rotatedRectBoundingRect2f", select_overload<Rect2f(const cv::RotatedRect &)>(&binding_utils::rotatedRectBoundingRect2f));
+    function("rotatedRectPoints", select_overload<emscripten::val(const cv::RotatedRect&)>(&binding_utils::rotatedRectPoints));
+    function("rotatedRectBoundingRect", select_overload<Rect(const cv::RotatedRect&)>(&binding_utils::rotatedRectBoundingRect));
+    function("rotatedRectBoundingRect2f", select_overload<Rect2f(const cv::RotatedRect&)>(&binding_utils::rotatedRectBoundingRect2f));
 
     emscripten::value_object<cv::KeyPoint>("KeyPoint")
         .field("angle", &cv::KeyPoint::angle)
@@ -651,7 +628,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("imgIdx", &cv::DMatch::imgIdx)
         .field("distance", &cv::DMatch::distance);
 
-    emscripten::value_array<cv::Scalar_<double>>("Scalar")
+    emscripten::value_array<cv::Scalar_<double>> ("Scalar")
         .element(emscripten::index<0>())
         .element(emscripten::index<1>())
         .element(emscripten::index<2>())
@@ -667,7 +644,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("center", &binding_utils::Circle::center)
         .field("radius", &binding_utils::Circle::radius);
 
-    emscripten::value_object<cv::Moments>("Moments")
+    emscripten::value_object<cv::Moments >("Moments")
         .field("m00", &cv::Moments::m00)
         .field("m10", &cv::Moments::m10)
         .field("m01", &cv::Moments::m01)
@@ -700,22 +677,22 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     function("exceptionFromPtr", &binding_utils::exceptionFromPtr, allow_raw_pointers());
 
 #ifdef HAVE_OPENCV_IMGPROC
-    function("minEnclosingCircle", select_overload<binding_utils::Circle(const cv::Mat &)>(&binding_utils::minEnclosingCircle));
+    function("minEnclosingCircle", select_overload<binding_utils::Circle(const cv::Mat&)>(&binding_utils::minEnclosingCircle));
 
-    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar, Scalar, int)>(&binding_utils::floodFill_wrapper));
+    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar, Scalar, int)>(&binding_utils::floodFill_wrapper));
 
-    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar, Scalar)>(&binding_utils::floodFill_wrapper_1));
+    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar, Scalar)>(&binding_utils::floodFill_wrapper_1));
 
-    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val, Scalar)>(&binding_utils::floodFill_wrapper_2));
+    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val, Scalar)>(&binding_utils::floodFill_wrapper_2));
 
-    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar, emscripten::val)>(&binding_utils::floodFill_wrapper_3));
+    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar, emscripten::val)>(&binding_utils::floodFill_wrapper_3));
 
-    function("floodFill", select_overload<int(cv::Mat &, cv::Mat &, Point, Scalar)>(&binding_utils::floodFill_wrapper_4));
+    function("floodFill", select_overload<int(cv::Mat&, cv::Mat&, Point, Scalar)>(&binding_utils::floodFill_wrapper_4));
 #endif
 
-    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat &, const cv::Mat &)>(&binding_utils::minMaxLoc));
+    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat&, const cv::Mat&)>(&binding_utils::minMaxLoc));
 
-    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat &)>(&binding_utils::minMaxLoc_1));
+    function("minMaxLoc", select_overload<binding_utils::MinMaxLoc(const cv::Mat&)>(&binding_utils::minMaxLoc_1));
 
 #ifdef HAVE_OPENCV_IMGPROC
     function("morphologyDefaultBorderValue", &cv::morphologyDefaultBorderValue);
@@ -724,13 +701,13 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     function("CV_MAT_DEPTH", &binding_utils::cvMatDepth);
 
 #ifdef HAVE_OPENCV_VIDEO
-    function("CamShift", select_overload<emscripten::val(const cv::Mat &, Rect &, TermCriteria)>(&binding_utils::CamShiftWrapper));
+    function("CamShift", select_overload<emscripten::val(const cv::Mat&, Rect&, TermCriteria)>(&binding_utils::CamShiftWrapper));
 
-    function("meanShift", select_overload<emscripten::val(const cv::Mat &, Rect &, TermCriteria)>(&binding_utils::meanShiftWrapper));
+    function("meanShift", select_overload<emscripten::val(const cv::Mat&, Rect&, TermCriteria)>(&binding_utils::meanShiftWrapper));
 
-    emscripten::class_<cv::Tracker>("Tracker")
-        .function("init", select_overload<void(cv::Tracker &, const cv::Mat &, const Rect &)>(&binding_utils::Tracker_init_wrapper), pure_virtual())
-        .function("update", select_overload<emscripten::val(cv::Tracker &, const cv::Mat &)>(&binding_utils::Tracker_update_wrapper), pure_virtual());
+    emscripten::class_<cv::Tracker >("Tracker")
+        .function("init", select_overload<void(cv::Tracker&,const cv::Mat&,const Rect&)>(&binding_utils::Tracker_init_wrapper), pure_virtual())
+        .function("update", select_overload<emscripten::val(cv::Tracker&,const cv::Mat&)>(&binding_utils::Tracker_update_wrapper), pure_virtual());
 
 #endif
 
@@ -794,7 +771,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     constant("CV_8S", CV_8S);
     constant("CV_16U", CV_16U);
     constant("CV_16S", CV_16S);
-    constant("CV_32S", CV_32S);
+    constant("CV_32S",  CV_32S);
     constant("CV_32F", CV_32F);
     constant("CV_64F", CV_64F);
 

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -255,7 +255,8 @@ if __name__ == "__main__":
     parser.add_argument('--config', default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'opencv_js.config.py'),
                         help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
-
+    parser.add_argument("-DCMAKE_TOOLCHAIN_FILE", default="", help="DCMAKE_TOOLCHAIN_FILE")
+    parser.add_argument("-DCMAKE_CROSSCOMPILING_EMULATOR",default="",help="DCMAKE_CROSSCOMPILING_EMULATOR")
     args = parser.parse_args()
 
     log.debug("Args: %s", args)

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -256,9 +256,6 @@ if __name__ == "__main__":
                         help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
 
-    parser.add_argument("-DCMAKE_TOOLCHAIN_FILE", default="", help="DCMAKE_TOOLCHAIN_FILE")
-    parser.add_argument("-DCMAKE_CROSSCOMPILING_EMULATOR",default="",help="DCMAKE_CROSSCOMPILING_EMULATOR")
-
     args = parser.parse_args()
 
     log.debug("Args: %s", args)

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -255,8 +255,10 @@ if __name__ == "__main__":
     parser.add_argument('--config', default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'opencv_js.config.py'),
                         help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
+
     parser.add_argument("-DCMAKE_TOOLCHAIN_FILE", default="", help="DCMAKE_TOOLCHAIN_FILE")
     parser.add_argument("-DCMAKE_CROSSCOMPILING_EMULATOR",default="",help="DCMAKE_CROSSCOMPILING_EMULATOR")
+
     args = parser.parse_args()
 
     log.debug("Args: %s", args)

--- a/platforms/js/opencv_js.config.py
+++ b/platforms/js/opencv_js.config.py
@@ -147,7 +147,7 @@ video = {
     'TrackerMIL_Params': [],
 }
 
-dnn = {'dnn_Net': ['setInput', 'forward', 'setPreferableBackend'],
+dnn = {'dnn_Net': ['setInput', 'forward', 'setPreferableBackend','getUnconnectedOutLayersNames'],
        '': ['readNetFromCaffe', 'readNetFromTensorflow', 'readNetFromTorch', 'readNetFromDarknet',
             'readNetFromONNX', 'readNetFromTFLite', 'readNet', 'blobFromImage']}
 


### PR DESCRIPTION
ret_type = re.sub('(^|[^\w])' + key + '($|[^\w])', type_dict[key], ret_type)
When compiling JavaScript, this code converts vector<std:: string>to vector std:: string
Details: https://laolaolulu.github.io/posts/emscripten-opencv/#opencvjs%E7%BC%96%E8%AF%91getunconnectedoutlayersnames%E8%BF%87%E7%A8%8B%E4%B8%AD%E9%94%99%E8%AF%AF%E5%A4%84%E7%90%86

```
force_builders=Custom
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```