### PR TITLE
dnn cann backend: add hardswish, layernorm and instasnce norm for cann and bug fix

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1891,8 +1891,8 @@ struct HardSwishFunctor : public BaseDefaultFunctor<HardSwishFunctor>
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV ||
-	       backendId == DNN_BACKEND_CUDA   ||
-	       backendId == DNN_BACKEND_CANN;
+               backendId == DNN_BACKEND_CUDA   ||
+               backendId == DNN_BACKEND_CANN;
     }
 
     inline float calculate(float x) const

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1890,7 +1890,9 @@ struct HardSwishFunctor : public BaseDefaultFunctor<HardSwishFunctor>
 
     bool supportBackend(int backendId, int)
     {
-        return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
+        return backendId == DNN_BACKEND_OPENCV ||
+	       backendId == DNN_BACKEND_CUDA   ||
+	       backendId == DNN_BACKEND_CANN;
     }
 
     inline float calculate(float x) const
@@ -1902,6 +1904,27 @@ struct HardSwishFunctor : public BaseDefaultFunctor<HardSwishFunctor>
     Ptr<BackendNode> initCUDA(int target, csl::Stream stream)
     {
         return make_cuda_node<cuda4dnn::HardSwishOp>(target, stream);
+    }
+#endif
+
+#ifdef HAVE_CANN
+    Ptr<BackendNode> initCannOp(const std::string& name,
+                                const std::vector<Ptr<BackendWrapper> > &inputs,
+                                const std::vector<Ptr<BackendNode> >& nodes)
+    {
+        auto x = inputs[0].dynamicCast<CannBackendWrapper>();
+
+        auto op = std::make_shared<ge::op::HardSwish>(name);
+
+        auto op_x = nodes[0].dynamicCast<CannBackendNode>()->getOp();
+        op->set_input_x_by_name(*op_x, x->name.c_str());
+        auto x_desc = x->getTensorDesc();
+        op->update_input_desc_x(*x_desc);
+
+        auto output_desc = std::make_shared<ge::TensorDesc>(ge::Shape(), ge::FORMAT_NCHW, ge::DT_FLOAT);
+        op->update_output_desc_y(*output_desc);
+
+        return Ptr<BackendNode>(new CannBackendNode(op));
     }
 #endif
 

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -274,6 +274,7 @@ public:
         op->update_input_desc_bias(*(op_const_C->getTensorDesc()));
 
         // set outputs
+        auto output_desc = std::make_shared<ge::TensorDesc>(ge::Shape(), ge::FORMAT_NCHW, ge::DT_FLOAT);
         op->update_output_desc_y(*output_desc);
         return Ptr<BackendNode>(new CannBackendNode(op));
     }

--- a/modules/dnn/src/layers/instance_norm_layer.cpp
+++ b/modules/dnn/src/layers/instance_norm_layer.cpp
@@ -43,8 +43,8 @@ public:
             return true;
 #endif
         return backendId == DNN_BACKEND_OPENCV ||
-               backendId == DNN_BACKEND_CUDA ||
-               backendId == DNN_BACKEND_CANN;
+               backendId == DNN_BACKEND_CUDA;
+            //    backendId == DNN_BACKEND_CANN; // not supported due to 1d mat shape issue
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/instance_norm_layer.cpp
+++ b/modules/dnn/src/layers/instance_norm_layer.cpp
@@ -186,15 +186,6 @@ public:
         auto bias_tensor_wrapper = inputs[2].dynamicCast<CannBackendWrapper>();
         auto bias_tensor_desc = bias_tensor_wrapper->getTensorDesc();
 
-        auto fn_build_1d_desc = [] (const ge::TensorDesc &desc) {
-            int64_t dim = desc.GetShape().GetDim(0);
-            return std::make_shared<ge::TensorDesc>(ge::Shape(std::vector<int64_t>{dim}),
-                                                    ge::FORMAT_NCHW,
-                                                    ge::DT_FLOAT);
-        };
-        scale_tensor_desc = fn_build_1d_desc(*scale_tensor_desc);
-        bias_tensor_desc = fn_build_1d_desc(*bias_tensor_desc);
-
         auto last_node = nodes[0].dynamicCast<CannBackendNode>()->getOp();
         auto scale_node = nodes[1].dynamicCast<CannBackendNode>()->getOp();
         auto bias_node = nodes[2].dynamicCast<CannBackendNode>()->getOp();

--- a/modules/dnn/src/layers/instance_norm_layer.cpp
+++ b/modules/dnn/src/layers/instance_norm_layer.cpp
@@ -43,7 +43,8 @@ public:
             return true;
 #endif
         return backendId == DNN_BACKEND_OPENCV ||
-               backendId == DNN_BACKEND_CUDA;
+               backendId == DNN_BACKEND_CUDA ||
+               backendId == DNN_BACKEND_CANN;
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/instance_norm_layer.cpp
+++ b/modules/dnn/src/layers/instance_norm_layer.cpp
@@ -6,6 +6,9 @@
 #include <opencv2/dnn/shape_utils.hpp>
 #include "./cpu_kernels/fast_norm.hpp"
 
+// CANN backend
+#include "../op_cann.hpp"
+
 // OpenVINO backend
 #include "../op_inf_engine.hpp"
 #include "../ie_ngraph.hpp"
@@ -168,6 +171,60 @@ public:
         return true;
     }
 #endif
+
+#ifdef HAVE_CANN
+    virtual Ptr<BackendNode> initCann(const std::vector<Ptr<BackendWrapper> > &inputs,
+                                      const std::vector<Ptr<BackendWrapper> > &outputs,
+                                      const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE {
+        auto input_tensor_wrapper = inputs[0].dynamicCast<CannBackendWrapper>();
+        auto input_tensor_desc = input_tensor_wrapper->getTensorDesc();
+
+        auto scale_tensor_wrapper = inputs[1].dynamicCast<CannBackendWrapper>();
+        auto scale_tensor_desc = scale_tensor_wrapper->getTensorDesc();
+
+        auto bias_tensor_wrapper = inputs[2].dynamicCast<CannBackendWrapper>();
+        auto bias_tensor_desc = bias_tensor_wrapper->getTensorDesc();
+
+        auto fn_build_1d_desc = [] (const ge::TensorDesc &desc) {
+            int64_t dim = desc.GetShape().GetDim(0);
+            return std::make_shared<ge::TensorDesc>(ge::Shape(std::vector<int64_t>{dim}),
+                                                    ge::FORMAT_NCHW,
+                                                    ge::DT_FLOAT);
+        };
+        scale_tensor_desc = fn_build_1d_desc(*scale_tensor_desc);
+        bias_tensor_desc = fn_build_1d_desc(*bias_tensor_desc);
+
+        auto last_node = nodes[0].dynamicCast<CannBackendNode>()->getOp();
+        auto scale_node = nodes[1].dynamicCast<CannBackendNode>()->getOp();
+        auto bias_node = nodes[2].dynamicCast<CannBackendNode>()->getOp();
+
+        auto op = std::make_shared<ge::op::InstanceNorm>(name);
+
+        // set attrs
+        op->set_attr_epsilon(epsilon);
+
+        // set inputs
+        // set inputs : x
+        op->set_input_x_by_name(*last_node, input_tensor_wrapper->name.c_str());
+        op->update_input_desc_x(*input_tensor_desc);
+        // set inputs : gamma
+        op->set_input_gamma_by_name((*scale_node), scale_tensor_wrapper->name.c_str());
+        op->update_input_desc_gamma(*scale_tensor_desc);
+        // set inputs : beta
+        op->set_input_beta_by_name(*bias_node, bias_tensor_wrapper->name.c_str());
+        op->update_input_desc_beta(*bias_tensor_desc);
+
+        // set outputs
+        auto output_desc_y = std::make_shared<ge::TensorDesc>(ge::Shape(), ge::FORMAT_NCHW, ge::DT_FLOAT);
+        op->update_output_desc_y(*output_desc_y);
+        auto output_desc_mean = std::make_shared<ge::TensorDesc>(ge::Shape(), ge::FORMAT_NCHW, ge::DT_FLOAT);
+        op->update_output_desc_mean(*output_desc_mean);
+        auto output_desc_var = std::make_shared<ge::TensorDesc>(ge::Shape(), ge::FORMAT_NCHW, ge::DT_FLOAT);
+        op->update_output_desc_variance(*output_desc_var);
+
+        return Ptr<BackendNode>(new CannBackendNode(op));
+    }
+#endif // HAVE_CANN
 
 #ifdef HAVE_DNN_NGRAPH
     virtual Ptr<BackendNode> initNgraph(const std::vector<Ptr<BackendWrapper> >& inputs,

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -26,7 +26,7 @@ public:
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
         return backendId == DNN_BACKEND_OPENCV ||
-               (backendId == DNN_BACKEND_CANN && axis != -1); // 
+               (backendId == DNN_BACKEND_CANN && axis != -1); // axis=-1 not supported due to 1d mat shape problem
     }
 
     virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -25,7 +25,8 @@ public:
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
-        return backendId == DNN_BACKEND_OPENCV;
+        return backendId == DNN_BACKEND_OPENCV ||
+               backendId == DNN_BACKEND_CANN;
     }
 
     virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24154
Resolves https://github.com/opencv/ci-gha-workflow/pull/120#issuecomment-1805226774

New CANN operator added in this PR:

- [x] HardSwish
- [x] LayerNorm (needs to be ported from https://github.com/opencv/opencv/pull/23550)
- [x] InstanceNorm

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
