### PR TITLE
Fixed Python signatures in Doxygen documentation.

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -1059,7 +1059,7 @@ class FuncInfo(object):
             else:
                 py_name = classinfo.full_export_name + "." + self.variants[0].wname
 
-            if not self.is_static:
+            if not self.is_static and not self.isconstructor:
                 cname = classinfo.cname + '::' + cname
         else:
             py_name = '.'.join([self.namespace, self.variants[0].wname])


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/23133

Python bindings signatures are added to Doxygen documentation with `pyopencv_signatures.json`. The file is generated by python bindings generator. The constructors are there, but namespace is handled incorrectly, e.g.:
```
    "cv::aruco::Dictionary::cv::aruco::Dictionary::Dictionary": [
        {
            "name": "cv.aruco.Dictionary",
            "arg": "",
            "ret": "<aruco_Dictionary object>"
        },
        {
            "name": "cv.aruco.Dictionary",
            "arg": "bytesList, _markerSize[, maxcorr]",
            "ret": "<aruco_Dictionary object>"
        }
    ],
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
