### PR TITLE
Added Java bindings for BOWImgDescriptorExtractor constructor

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1544,8 +1544,8 @@ public:
     @param dmatcher Descriptor matcher that is used to find the nearest word of the trained vocabulary
     for each keypoint descriptor of the image.
      */
-    CV_WRAP BOWImgDescriptorExtractor( const Ptr<DescriptorExtractor>& dextractor,
-                               const Ptr<DescriptorMatcher>& dmatcher );
+    CV_WRAP BOWImgDescriptorExtractor( const Ptr<Feature2D>& dextractor,
+                                       const Ptr<DescriptorMatcher>& dmatcher );
     /** @overload */
     BOWImgDescriptorExtractor( const Ptr<DescriptorMatcher>& dmatcher );
     virtual ~BOWImgDescriptorExtractor();

--- a/modules/features2d/misc/java/test/BOWImgDescriptorExtractorTest.java
+++ b/modules/features2d/misc/java/test/BOWImgDescriptorExtractorTest.java
@@ -1,0 +1,48 @@
+package org.opencv.test.features2d;
+
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfKeyPoint;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.core.KeyPoint;
+import org.opencv.features2d.ORB;
+import org.opencv.features2d.DescriptorMatcher;
+import org.opencv.features2d.BOWImgDescriptorExtractor;
+import org.opencv.test.OpenCVTestCase;
+import org.opencv.test.OpenCVTestRunner;
+import org.opencv.imgproc.Imgproc;
+
+public class BOWImgDescriptorExtractorTest extends OpenCVTestCase {
+
+    ORB extractor;
+    DescriptorMatcher matcher;
+    int matSize;
+
+    public static void assertDescriptorsClose(Mat expected, Mat actual, int allowedDistance) {
+        double distance = Core.norm(expected, actual, Core.NORM_HAMMING);
+        assertTrue("expected:<" + allowedDistance + "> but was:<" + distance + ">", distance <= allowedDistance);
+    }
+
+    private Mat getTestImg() {
+        Mat cross = new Mat(matSize, matSize, CvType.CV_8U, new Scalar(255));
+        Imgproc.line(cross, new Point(20, matSize / 2), new Point(matSize - 21, matSize / 2), new Scalar(100), 2);
+        Imgproc.line(cross, new Point(matSize / 2, 20), new Point(matSize / 2, matSize - 21), new Scalar(100), 2);
+
+        return cross;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        extractor = ORB.create();
+        matcher = DescriptorMatcher.create(DescriptorMatcher.BRUTEFORCE);
+        matSize = 100;
+    }
+
+    public void testCreate() {
+        BOWImgDescriptorExtractor bow = new BOWImgDescriptorExtractor(extractor, matcher);
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24094

Feature2D is synonym for DescriptorExtractor in C++.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
