### PR TITLE
Optimize the Implementation of RVV Universal Intrinsic.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1390,23 +1390,23 @@ OPENCV_HAL_IMPL_RVV_REVERSE(v_float64, 64)
 #define OPENCV_HAL_IMPL_RVV_EXPAND(_Tp, _Tpwvec, _Tpwvec_m2, _Tpvec, width, suffix, suffix2, cvt) \
 inline void v_expand(const _Tpvec& a, _Tpwvec& b0, _Tpwvec& b1) \
 { \
-    _Tpwvec_m2 temp = cvt(a, vsetvlmax_e##width##m1()); \
+    _Tpwvec_m2 temp = cvt(a, VTraits<_Tpvec>::vlanes()); \
     b0 = vget_##suffix##m1(temp, 0); \
     b1 = vget_##suffix##m1(temp, 1); \
 } \
 inline _Tpwvec v_expand_low(const _Tpvec& a) \
 { \
-    _Tpwvec_m2 temp = cvt(a, vsetvlmax_e##width##m1()); \
+    _Tpwvec_m2 temp = cvt(a, VTraits<_Tpvec>::vlanes()); \
     return vget_##suffix##m1(temp, 0); \
 } \
 inline _Tpwvec v_expand_high(const _Tpvec& a) \
 { \
-    _Tpwvec_m2 temp = cvt(a, vsetvlmax_e##width##m1()); \
+    _Tpwvec_m2 temp = cvt(a, VTraits<_Tpvec>::vlanes()); \
     return vget_##suffix##m1(temp, 1); \
 } \
 inline _Tpwvec v_load_expand(const _Tp* ptr) \
 { \
-    return cvt(vle##width##_v_##suffix2##mf2(ptr, vsetvlmax_e##width##m1()), vsetvlmax_e##width##m1()); \
+    return cvt(vle##width##_v_##suffix2##mf2(ptr, VTraits<_Tpvec>::vlanes()), VTraits<_Tpvec>::vlanes()); \
 }
 
 OPENCV_HAL_IMPL_RVV_EXPAND(uchar, v_uint16, vuint16m2_t, v_uint8, 8, u16, u8, vwcvtu_x)
@@ -1759,8 +1759,8 @@ inline int v_scan_forward(const v_float64& a)
 // mask: {0,0,0,1, ...} -> {T,T,T,F, ...}
 #define OPENCV_HAL_IMPL_RVV_PACK_TRIPLETS(_Tpvec, v_trunc) \
 inline _Tpvec v_pack_triplets(const _Tpvec& vec) { \
-    size_t vl = vsetvlmax_e8m1(); \
-    vuint32m1_t one = vmv_v_x_u32m1(1, vl/4); \
+    size_t vl = __cv_rvv_e8m1_nlanes; \
+    vuint32m1_t one = vmv_v_x_u32m1(1, __cv_rvv_e32m1_nlanes); \
     vuint8m1_t zero = vmv_v_x_u8m1(0, vl); \
     vuint8m1_t mask = vreinterpret_u8m1(one); \
     return vcompress(vmseq(v_trunc(vslideup(zero, mask, 3, vl)), 0, vl), vec, vec, VTraits<_Tpvec>::vlanes()); \


### PR DESCRIPTION
I found that some of the functions in RVV Universal intrinsic call vsetvlmax instructions directly, that may create redundant vsetvl instructions. This patch optimizes those functions by using local variables. (`vsetvlmax` -> `VTraits<_Tpvec>::vlanes`)


The performance evaluation is [core.zip](https://github.com/opencv/opencv/files/13246313/core.zip)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
