### PR TITLE
Changed Gradle and AGP versions to 8.3

### DIFF
--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -1,5 +1,5 @@
 # https://developer.android.com/studio/releases/gradle-plugin
-set(ANDROID_GRADLE_PLUGIN_VERSION "3.2.1" CACHE STRING "Android Gradle Plugin version")
+set(ANDROID_GRADLE_PLUGIN_VERSION "8.3" CACHE STRING "Android Gradle Plugin version")
 message(STATUS "Android Gradle Plugin version: ${ANDROID_GRADLE_PLUGIN_VERSION}")
 
 set(KOTLIN_PLUGIN_VERSION "1.4.10" CACHE STRING "Kotlin Plugin version")
@@ -13,7 +13,7 @@ else()
   set(KOTLIN_STD_LIB "" CACHE STRING "Kotlin Standard Library dependency")
 endif()
 
-set(GRADLE_VERSION "5.6.4" CACHE STRING "Gradle version")
+set(GRADLE_VERSION "8.3" CACHE STRING "Gradle version")
 message(STATUS "Gradle version: ${GRADLE_VERSION}")
 
 set(ANDROID_COMPILE_SDK_VERSION "26" CACHE STRING "Android compileSdkVersion")


### PR DESCRIPTION
Changed Gradle and Android Gradle Plugin versions to 8.3. It is the version, that is used in the latest Android Studio.

Gradle and AGP versions is also defined here:
https://github.com/opencv/opencv/blob/4.x/platforms/android/ndk-22.config.py
https://github.com/opencv/opencv/blob/4.x/platforms/android/ndk-25.config.py
but looks like they are not used.

As I understand, this change affects only CI. It shouldn't affect SDK