### PR TITLE
Fixed build warning introduced in #24243

### DIFF
--- a/modules/videoio/test/test_gstreamer.cpp
+++ b/modules/videoio/test/test_gstreamer.cpp
@@ -190,7 +190,7 @@ TEST_P(gstreamer_bunny, manual_seek)
     const string video_file = BunnyParameters::getFilename("." + GetParam());
     const string pipeline = "filesrc location=" + video_file + " ! decodebin ! videoconvert ! video/x-raw, format=BGR ! appsink drop=1";
     const double target_pos = 3000.0;
-    const float ms_per_frame = 1000 / BunnyParameters::getFps();
+    const double ms_per_frame = 1000.0 / BunnyParameters::getFps();
     VideoCapture cap;
     cap.open(pipeline, CAP_GSTREAMER);
     ASSERT_TRUE(cap.isOpened());


### PR DESCRIPTION
Issue: https://pullrequest.opencv.org/buildbot/builders/precommit_windows64/builds/103335/steps/compile%20release/logs/warnings%20%282%29
Related PR: https://github.com/opencv/opencv/pull/24243

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
