### PR TITLE
fix for Eigen 3.4.1 unsupported Tensor/TensorMeta.h header issue

### DIFF
--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -61,8 +61,12 @@
 #if !defined(OPENCV_DISABLE_EIGEN_TENSOR_SUPPORT)
 #if EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3 \
     && defined(CV_CXX11) && defined(CV_CXX_STD_ARRAY)
+#if EIGEN_MAJOR_VERSION == 4 && EIGEN_MINOR_VERSION == 1
+// Deactivated Tensor support because of faulty header eigen-src/unsupported/Eigen/CXX11/src/Tensor/TensorMeta.h
+#else
 #include <unsupported/Eigen/CXX11/Tensor>
 #define OPENCV_EIGEN_TENSOR_SUPPORT 1
+#endif
 #endif  // EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
 #endif  // !defined(OPENCV_DISABLE_EIGEN_TENSOR_SUPPORT)
 


### PR DESCRIPTION
Fixing a build issue related to Eigen 3.4.1 unsupported headers.

The issue is related to the unsupported headers of Eigen, [which is included here](https://github.com/opencv/opencv/blob/bc54f76875aa040858e5e2274acd035d9c38055d/modules/core/include/opencv2/core/eigen.hpp#L66). Concerning these headers, this is [Eigen's disclaimer](https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/README.txt):

> This directory contains contributions from various users. They are provided "as is", without any support. Nevertheless,
most of them are subject to be included in Eigen in the future.

I can see that [unsupported/Eigen/CXX11/src/Tensor](https://gitlab.com/libeigen/eigen/-/tree/master/unsupported/Eigen/CXX11/src/Tensor?ref_type=heads) is in active development. 

The issue that we are facing has been fixed in Eigen Master branch [with this commit](https://gitlab.com/libeigen/eigen/-/commit/e4c40b092a209a52b882e2e46f32799582c2f430). 

So I suggest that we can exclude the problematic header (Tensor support) for Eigen when version == 3.4.1.
Note: It looks like Eigen branch 3.4 is currently the [3.4.1 release](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/Core/util/Macros.h?ref_type=heads#L20).