### PR TITLE
remove filter fix in aruco qr code detector

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -4476,25 +4476,14 @@ static
 vector<QRCode> analyzeFinderPatterns(const vector<vector<Point2f> > &corners, const Mat& img,
                                      const QRCodeDetectorAruco::Params& qrDetectorParameters) {
     vector<QRCode> qrCodes;
-    vector<FinderPatternInfo> patterns;
+    vector<FinderPatternInfo> patterns(corners.size());
     if (img.empty())
         return qrCodes;
     float maxModuleSize = 0.f;
     for (size_t i = 0ull; i < corners.size(); i++) {
         FinderPatternInfo pattern = FinderPatternInfo(corners[i]);
-        // TODO: improve thinning Aruco markers
-        bool isUniq = true;
-        for (const FinderPatternInfo& tmp : patterns) {
-            Point2f dist = pattern.center - tmp.center;
-            if (max(abs(dist.x), abs(dist.y)) < 3.f * tmp.moduleSize) {
-                isUniq = false;
-                break;
-            }
-        }
-        if (isUniq) {
-            patterns.push_back(pattern);
-            maxModuleSize = max(maxModuleSize, patterns.back().moduleSize);
-        }
+        patterns[i] = pattern;
+        maxModuleSize = max(maxModuleSize, pattern.moduleSize);
     }
     const int threshold = cvRound(qrDetectorParameters.minModuleSizeInPyramid * 12.5f) +
                           (cvRound(qrDetectorParameters.minModuleSizeInPyramid * 12.5f) % 2 ? 0 : 1);


### PR DESCRIPTION
Remove filter fix in ArUco-based qr code detector after PR Fix contour filtering in ArUco #24479

there are no changes in accuracy in the [benchmark](https://github.com/opencv/opencv_benchmarks/tree/develop/python_benchmarks/qr_codes)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
