### PR TITLE
Check Checkerboard Corners

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1273,6 +1273,28 @@ Use gen_pattern.py (@ref tutorial_camera_calibration_pattern) to create checkerb
 CV_EXPORTS_W bool findChessboardCorners( InputArray image, Size patternSize, OutputArray corners,
                                          int flags = CALIB_CB_ADAPTIVE_THRESH + CALIB_CB_NORMALIZE_IMAGE );
 
+
+/** @brief Finds the positions of internal corners of the chessboard.
+
+@param image Source chessboard view. It must be an 8-bit black and white image
+@param patternSize Number of inner corners per a chessboard row and column
+( patternSize = cv::Size(points_per_row,points_per_colum) = cv::Size(columns,rows) ).
+@param corners Output array of detected corners.
+@param flags Various operation flags that can be zero or a combination of the following values:
+-   @ref CALIB_CB_FILTER_QUADS Use additional criteria (like contour area, perimeter,
+square-like shape) to filter out false quads extracted at the contour retrieval stage.
+
+The function similarly to #findChessboardCorners attempts to determine whether the input image is a view of the chessboard pattern and
+locate the internal chessboard corners. The main difference with #findChessboardCorners is that the function does not perform any kind of processing of the input image,
+which rather must be preprocessed before calling the function i.e. the image must be a B&W image.
+The function returns a non-zero value if all of the corners are found and they are placed in a certain order (row by row, left to right in every row).
+Otherwise, if the function fails to find all the corners or reorder them, it returns 0.
+The detected coordinates are approximate, and to determine their positions more accurately the function #cornerSubPix can be used.
+ */
+CV_EXPORTS_W bool checkChessboardCorners(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
+
+
+
 /*
    Checks whether the image contains chessboard of the specific size or not.
    If yes, nonzero value is returned.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -490,7 +490,8 @@ enum { CALIB_CB_ADAPTIVE_THRESH = 1,
        CALIB_CB_EXHAUSTIVE      = 16,
        CALIB_CB_ACCURACY        = 32,
        CALIB_CB_LARGER          = 64,
-       CALIB_CB_MARKER          = 128
+       CALIB_CB_MARKER          = 128,
+       CALIB_CB_PLAIN           = 256
      };
 
 enum { CALIB_CB_SYMMETRIC_GRID  = 1,
@@ -1235,7 +1236,11 @@ square-like shape) to filter out false quads extracted at the contour retrieval 
 -   @ref CALIB_CB_FAST_CHECK Run a fast check on the image that looks for chessboard corners,
 and shortcut the call if none is found. This can drastically speed up the call in the
 degenerate condition when no chessboard is observed.
-
+ -   @ref CALIB_CB_PLAIN All other flags are ignored. The input image is taken as is.
+ No image processing is done to improve to find the checkerboard. This has the effect of speeding up the
+ execution of the function but could lead to not recognizing the checkerboard if the image
+ is not previously binarized in the appropriate manner.
+ 
 The function attempts to determine whether the input image is a view of the chessboard pattern and
 locate the internal chessboard corners. The function returns a non-zero value if all of the corners
 are found and they are placed in a certain order (row by row, left to right in every row).
@@ -1272,28 +1277,6 @@ Use gen_pattern.py (@ref tutorial_camera_calibration_pattern) to create checkerb
  */
 CV_EXPORTS_W bool findChessboardCorners( InputArray image, Size patternSize, OutputArray corners,
                                          int flags = CALIB_CB_ADAPTIVE_THRESH + CALIB_CB_NORMALIZE_IMAGE );
-
-
-/** @brief Finds the positions of internal corners of the chessboard.
-
-@param image Source chessboard view. It must be an 8-bit black and white image
-@param patternSize Number of inner corners per a chessboard row and column
-( patternSize = cv::Size(points_per_row,points_per_colum) = cv::Size(columns,rows) ).
-@param corners Output array of detected corners.
-@param flags Various operation flags that can be zero or a combination of the following values:
--   @ref CALIB_CB_FILTER_QUADS Use additional criteria (like contour area, perimeter,
-square-like shape) to filter out false quads extracted at the contour retrieval stage.
-
-The function similarly to #findChessboardCorners attempts to determine whether the input image is a view of the chessboard pattern and
-locate the internal chessboard corners. The main difference with #findChessboardCorners is that the function does not perform any kind of processing of the input image,
-which rather must be preprocessed before calling the function i.e. the image must be a B&W image.
-The function returns a non-zero value if all of the corners are found and they are placed in a certain order (row by row, left to right in every row).
-Otherwise, if the function fails to find all the corners or reorder them, it returns 0.
-The detected coordinates are approximate, and to determine their positions more accurately the function #cornerSubPix can be used.
- */
-CV_EXPORTS_W bool findChessboardCornersSimple(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
-
-
 
 /*
    Checks whether the image contains chessboard of the specific size or not.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1236,11 +1236,11 @@ square-like shape) to filter out false quads extracted at the contour retrieval 
 -   @ref CALIB_CB_FAST_CHECK Run a fast check on the image that looks for chessboard corners,
 and shortcut the call if none is found. This can drastically speed up the call in the
 degenerate condition when no chessboard is observed.
- -   @ref CALIB_CB_PLAIN All other flags are ignored. The input image is taken as is.
- No image processing is done to improve to find the checkerboard. This has the effect of speeding up the
- execution of the function but could lead to not recognizing the checkerboard if the image
- is not previously binarized in the appropriate manner.
- 
+-   @ref CALIB_CB_PLAIN All other flags are ignored. The input image is taken as is.
+No image processing is done to improve to find the checkerboard. This has the effect of speeding up the
+execution of the function but could lead to not recognizing the checkerboard if the image
+is not previously binarized in the appropriate manner.
+
 The function attempts to determine whether the input image is a view of the chessboard pattern and
 locate the internal chessboard corners. The function returns a non-zero value if all of the corners
 are found and they are placed in a certain order (row by row, left to right in every row).

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1291,7 +1291,7 @@ The function returns a non-zero value if all of the corners are found and they a
 Otherwise, if the function fails to find all the corners or reorder them, it returns 0.
 The detected coordinates are approximate, and to determine their positions more accurately the function #cornerSubPix can be used.
  */
-CV_EXPORTS_W bool checkChessboardCorners(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
+CV_EXPORTS_W bool findChessboardCornersSimple(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
 
 
 

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -525,7 +525,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
 
     if(flags & CALIB_CB_PLAIN)
       max_dilations = 0;
-      
+
     // Try our standard "1" dilation, but if the pattern is not found, iterate the whole procedure with higher dilations.
     // This is necessary because some squares simply do not separate properly with a single dilation.  However,
     // we want to use the minimum number of dilations possible since dilations cause the squares to become smaller,

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -479,7 +479,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
 
     bool found = false;
 
-    const bool is_plain = flags & CALIB_CB_PLAIN;
+    const bool is_plain = flags & (bool)CALIB_CB_PLAIN;
 
     int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     Mat img = image_.getMat();

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -496,7 +496,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     std::vector<cv::Point2f> out_corners;
 
     if (is_plain)
-      CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale images are supported whit CALIB_CB_PLAIN flag enable");
+      CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale images are supported whith CALIB_CB_PLAIN flag enable");
 
     if (img.channels() != 1)
     {
@@ -510,7 +510,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
         icvBinarizationHistogramBased(thresh_img_new); // process image in-place
     SHOW("New binarization", thresh_img_new);
 
-    if (flags & CALIB_CB_FAST_CHECK && !(flags & CALIB_CB_PLAIN))
+    if (flags & CALIB_CB_FAST_CHECK && !is_plain)
     {
         //perform new method for checking chessboard using a binary image.
         //image is binarised using a threshold dependent on the image histogram
@@ -558,7 +558,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     DPRINTF("Chessboard detection result 0: %d", (int)found);
 
     // revert to old, slower, method if detection failed
-    if (!found && !(flags & CALIB_CB_PLAIN))
+    if (!found && !is_plain)
     {
         if (flags & CALIB_CB_NORMALIZE_IMAGE)
         {

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,6 +662,74 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
+{
+    CV_INSTRUMENT_REGION();
+    
+    int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    
+    Mat img = image_.getMat();
+    
+    CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale image are supported");
+    
+    if (pattern_size.width <= 2 || pattern_size.height <= 2)
+      CV_Error(Error::StsOutOfRange, "Both width and height of the pattern should have bigger than 2");
+    
+    if (!corners_.needed())
+      CV_Error(Error::StsNullPtr, "Null pointer to corners");
+    
+    std::vector<cv::Point2f> out_corners;
+    
+    ChessBoardDetector detector(pattern_size);
+    
+    // So we can find rectangles that go to the edge, we draw a white line around the image edge.
+    // Otherwise FindContours will miss those clipped rectangle contours.
+    // The border color will be the image mean, because otherwise we risk screwing up filters like cvSmooth()...
+    rectangle(img, Point(0,0), Point(img.cols-1, img.rows-1), Scalar(255,255,255), 3, LINE_8);
+    
+    detector.reset();
+  
+    detector.generateQuads(img, flags);
+    
+    int prev_sqr_size = 0;
+  
+    if(!detector.processQuads(out_corners, prev_sqr_size))
+    {
+      return false;
+    }
+    
+    if(!detector.checkBoardMonotony(out_corners))
+    {
+      return false;
+    }
+    
+    // check that none of the found corners is too close to the image boundary
+    const int BORDER = 8;
+    for (int k = 0; k < pattern_size.width*pattern_size.height; ++k)
+    {
+      if( out_corners[k].x <= BORDER || out_corners[k].x > img.cols - BORDER ||
+         out_corners[k].y <= BORDER || out_corners[k].y > img.rows - BORDER )
+      {
+        return false;
+      }
+    }
+    
+    if ((pattern_size.height & 1) == 0 && (pattern_size.width & 1) == 0 )
+    {
+      int last_row = (pattern_size.height-1)*pattern_size.width;
+      double dy0 = out_corners[last_row].y - out_corners[0].y;
+      if (dy0 < 0)
+      {
+        int n = pattern_size.width*pattern_size.height;
+        for(int i = 0; i < n/2; i++ )
+        {
+          std::swap(out_corners[i], out_corners[n-i-1]);
+        }
+      }
+    }
+        
+    Mat(out_corners).copyTo(corners_);
+    return true;
+}
 
 //
 // Checks that each board row and column is pretty much monotonous curve:

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -479,7 +479,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
 
     bool found = false;
 
-    const bool is_plain = (flags & CALIB_CB_PLAIN) != 0;
+    const bool is_plain = (flags & CALIB_CB_PLAIN) != 0;
 
     int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     Mat img = image_.getMat();

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -479,7 +479,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
 
     bool found = false;
 
-    const bool is_plain = flags & (bool)CALIB_CB_PLAIN;
+    const bool is_plain = (flags & CALIB_CB_PLAIN == CALIB_CB_PLAIN);
 
     int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     Mat img = image_.getMat();

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -496,7 +496,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     std::vector<cv::Point2f> out_corners;
 
     if (is_plain)
-      CV_CheckType(type, depth == CV_8U && cn == 1 ), "Only 8-bit grayscale images are supported whit CALIB_CB_PLAIN flag enable");
+      CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale images are supported whit CALIB_CB_PLAIN flag enable");
 
     if (img.channels() != 1)
     {

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -479,7 +479,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
 
     bool found = false;
 
-    const bool is_plain = (flags & CALIB_CB_PLAIN == CALIB_CB_PLAIN);
+    const bool is_plain = (flags & CALIB_CB_PLAIN) != 0;
 
     int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     Mat img = image_.getMat();

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,6 +662,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
+bool checkChessboardCorners(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
 {
     CV_INSTRUMENT_REGION();
     

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,7 +662,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
-bool checkChessboardCorners(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
+bool findChessboardCornersSimple(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
 {
     CV_INSTRUMENT_REGION();
     

--- a/modules/calib3d/src/checkchessboard.cpp
+++ b/modules/calib3d/src/checkchessboard.cpp
@@ -51,9 +51,9 @@ using namespace std;
 
 static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point > > & contours, const std::vector< cv::Vec4i > & hierarchy, std::vector<std::pair<float, int> >& quads, int class_id)
 {
-    const float min_aspect_ratio = 0.5f;
-    const float max_aspect_ratio = 1.5f;
-    const float min_box_size = 25.0f;
+    const float min_aspect_ratio = 0.3f;
+    const float max_aspect_ratio = 3.0f;
+    const float min_box_size = 10.0f;
 
     for (size_t i = 0; i < contours.size(); ++i)
     {
@@ -63,7 +63,7 @@ static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point 
         const std::vector< cv::Point > & c = contours[i];
         cv::RotatedRect box = cv::minAreaRect(c);
 
-        float box_size = MIN(box.size.width, box.size.height);
+        float box_size = MAX(box.size.width, box.size.height);
         if(box_size < min_box_size)
         {
             continue;

--- a/modules/calib3d/src/checkchessboard.cpp
+++ b/modules/calib3d/src/checkchessboard.cpp
@@ -51,9 +51,9 @@ using namespace std;
 
 static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point > > & contours, const std::vector< cv::Vec4i > & hierarchy, std::vector<std::pair<float, int> >& quads, int class_id)
 {
-    const float min_aspect_ratio = 0.3f;
-    const float max_aspect_ratio = 3.0f;
-    const float min_box_size = 10.0f;
+    const float min_aspect_ratio = 0.5f;
+    const float max_aspect_ratio = 1.5f;
+    const float min_box_size = 25.0f;
 
     for (size_t i = 0; i < contours.size(); ++i)
     {
@@ -63,7 +63,7 @@ static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point 
         const std::vector< cv::Point > & c = contours[i];
         cv::RotatedRect box = cv::minAreaRect(c);
 
-        float box_size = MAX(box.size.width, box.size.height);
+        float box_size = MIN(box.size.width, box.size.height);
         if(box_size < min_box_size)
         {
             continue;

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -149,8 +149,26 @@ void CV_ChessboardDetectorTest::run( int /*start_from */)
         case CHESSBOARD_SB:
             checkByGeneratorHighAccuracy();      // not supported by CHESSBOARD
             /* fallthrough */
-        case CHESSBOARD:
         case CHESSBOARD_PLAIN:
+            checkByGenerator();
+            if (ts->get_err_code() != cvtest::TS::OK)
+            {
+                break;
+            }
+
+            run_batch("negative_list.dat");
+            if (ts->get_err_code() != cvtest::TS::OK)
+            {
+                break;
+            }
+
+            run_batch("chessboard_list.dat");
+            if (ts->get_err_code() != cvtest::TS::OK)
+            {
+                break;
+            }
+            break;
+        case CHESSBOARD:
             checkByGenerator();
             if (ts->get_err_code() != cvtest::TS::OK)
             {
@@ -219,8 +237,6 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
     int max_idx = (int)board_list.size()/2;
     if(filename.compare("chessboard_list.dat") == 0 & pattern == CHESSBOARD_PLAIN)
          max_idx = 7;
-    if(filename.compare("chessboard_list_subpixel.dat") == 0 & pattern == CHESSBOARD_PLAIN)
-      max_idx = 0;
 
     double sum_error = 0.0;
     int count = 0;

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -73,7 +73,7 @@ void show_points( const Mat& gray, const Mat& expected, const vector<Point2f>& a
 #define show_points(...)
 #endif
 
-enum Pattern { CHESSBOARD,CHESSBOARD_SB,CIRCLES_GRID, ASYMMETRIC_CIRCLES_GRID};
+enum Pattern { CHESSBOARD, CHESSBOARD_SB, CHESSBOARD_PLAIN, CIRCLES_GRID, ASYMMETRIC_CIRCLES_GRID};
 
 class CV_ChessboardDetectorTest : public cvtest::BaseTest
 {
@@ -150,6 +150,7 @@ void CV_ChessboardDetectorTest::run( int /*start_from */)
             checkByGeneratorHighAccuracy();      // not supported by CHESSBOARD
             /* fallthrough */
         case CHESSBOARD:
+        case CHESSBOARD_PLAIN:
             checkByGenerator();
             if (ts->get_err_code() != cvtest::TS::OK)
             {
@@ -191,6 +192,7 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
     {
         case CHESSBOARD:
         case CHESSBOARD_SB:
+        case CHESSBOARD_PLAIN:
             folder = string(ts->get_data_path()) + "cv/cameracalibration/";
             break;
         case CIRCLES_GRID:
@@ -215,6 +217,11 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
 
     int progress = 0;
     int max_idx = (int)board_list.size()/2;
+    if(filename.compare("chessboard_list.dat") == 0 & pattern == CHESSBOARD_PLAIN)
+         max_idx = 7;
+    if(filename.compare("chessboard_list_subpixel.dat") == 0 & pattern == CHESSBOARD_PLAIN)
+      max_idx = 0;
+
     double sum_error = 0.0;
     int count = 0;
 
@@ -247,6 +254,7 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
         size_t count_exp = static_cast<size_t>(expected.cols * expected.rows);
         Size pattern_size = expected.size();
 
+        Mat ori;
         vector<Point2f> v;
         int flags = 0;
         switch( pattern )
@@ -254,14 +262,30 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
             case CHESSBOARD:
                 flags = CALIB_CB_ADAPTIVE_THRESH | CALIB_CB_NORMALIZE_IMAGE;
                 break;
+            case CHESSBOARD_PLAIN: {
+                flags = CALIB_CB_PLAIN;
+                ori = gray.clone();
+                int min_size = cvRound((gray.cols * gray.rows * 0.05) / ((pattern_size.width+1) * (pattern_size.height+1)));
+                if(min_size%2==0) min_size += 1;
+                adaptiveThreshold(gray, gray, 255, ADAPTIVE_THRESH_MEAN_C, THRESH_BINARY, min_size, 0);
+                dilate(gray, gray, Mat(), Point(-1, -1), 1);
+                break;
+            }
             case CIRCLES_GRID:
             case CHESSBOARD_SB:
             case ASYMMETRIC_CIRCLES_GRID:
             default:
                 flags = 0;
         }
+
         bool result = findChessboardCornersWrapper(gray, pattern_size,v,flags);
-        if(result && sharpness && (pattern == CHESSBOARD_SB || pattern == CHESSBOARD))
+      
+        if(result && pattern == CHESSBOARD_PLAIN) {
+            gray = ori;
+            cornerSubPix(gray, v, Size(6,6), Size(-1,-1), TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 30, 0.1));
+        }
+      
+        if(result && sharpness && (pattern == CHESSBOARD_SB || pattern == CHESSBOARD || pattern == CHESSBOARD_PLAIN))
         {
             Scalar s= estimateChessboardSharpness(gray,pattern_size,v);
             if(fabs(s[0] - sharpness) > 0.1)
@@ -287,7 +311,7 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
             double err = calcError(v, expected);
             max_rough_error = MAX( max_rough_error, err );
 #endif
-            if( pattern == CHESSBOARD )
+            if( pattern == CHESSBOARD || pattern == CHESSBOARD_PLAIN )
                 cornerSubPix( gray, v, Size(5, 5), Size(-1,-1), TermCriteria(TermCriteria::EPS|TermCriteria::MAX_ITER, 30, 0.1));
             //find4QuadCornerSubpix(gray, v, Size(5, 5));
             show_points( gray, expected, v, result  );
@@ -381,6 +405,7 @@ bool CV_ChessboardDetectorTest::findChessboardCornersWrapper(InputArray image, S
     switch(pattern)
     {
     case CHESSBOARD:
+    case CHESSBOARD_PLAIN:
         return findChessboardCorners(image,patternSize,corners,flags);
     case CHESSBOARD_SB:
         // check default settings until flags have been specified
@@ -631,6 +656,7 @@ bool CV_ChessboardDetectorTest::checkByGeneratorHighAccuracy()
 
 TEST(Calib3d_ChessboardDetector, accuracy) {  CV_ChessboardDetectorTest test( CHESSBOARD ); test.safe_run(); }
 TEST(Calib3d_ChessboardDetector2, accuracy) {  CV_ChessboardDetectorTest test( CHESSBOARD_SB ); test.safe_run(); }
+TEST(Calib3d_ChessboardDetector3, accuracy) {  CV_ChessboardDetectorTest test( CHESSBOARD_PLAIN ); test.safe_run(); }
 TEST(Calib3d_CirclesPatternDetector, accuracy) { CV_ChessboardDetectorTest test( CIRCLES_GRID ); test.safe_run(); }
 TEST(Calib3d_AsymmetricCirclesPatternDetector, accuracy) { CV_ChessboardDetectorTest test( ASYMMETRIC_CIRCLES_GRID ); test.safe_run(); }
 #ifdef HAVE_OPENCV_FLANN

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -235,7 +235,7 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
 
     int progress = 0;
     int max_idx = (int)board_list.size()/2;
-    if(filename.compare("chessboard_list.dat") == 0 & pattern == CHESSBOARD_PLAIN)
+    if(filename.compare("chessboard_list.dat") == 0 && pattern == CHESSBOARD_PLAIN)
          max_idx = 7;
 
     double sum_error = 0.0;

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -295,12 +295,12 @@ void CV_ChessboardDetectorTest::run_batch( const string& filename )
         }
 
         bool result = findChessboardCornersWrapper(gray, pattern_size,v,flags);
-      
+
         if(result && pattern == CHESSBOARD_PLAIN) {
             gray = ori;
             cornerSubPix(gray, v, Size(6,6), Size(-1,-1), TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 30, 0.1));
         }
-      
+
         if(result && sharpness && (pattern == CHESSBOARD_SB || pattern == CHESSBOARD || pattern == CHESSBOARD_PLAIN))
         {
             Scalar s= estimateChessboardSharpness(gray,pattern_size,v);


### PR DESCRIPTION
What I did was get you to pull out of findChessboardCorners cornres the whole part that "checks" and sorts the corners of the checkerboard if present.
The main reason for this is that findChessboardCorners is often very slow to find the corners and this depends in that the size the contrast etc of the checkerboards can be very different from each other and writing a function that works on all kinds of images is complicated. 
So I find it very useful to have the ability to write your own code to process the image and then have a function that controls or orders the corners.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
