### PR TITLE
Correction on OpenNI Property Handling to make KinectV2 compatible

### DIFF
--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -512,6 +512,8 @@ double CvCapture_OpenNI2::getCommonProperty( int propIdx ) const
         propValue = isMirroring ? 1.0 : 0.0;
         break;
     }
+    case CAP_PROP_ORIENTATION_META:
+    	break;
     default :
         CV_Error( CV_StsBadArg, cv::format("Such parameter (propIdx=%d) isn't supported for getting.", propIdx) );
     }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X ] I agree to contribute to the project under Apache 2 License.
- [X ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X ] The PR is proposed to the proper branch
- [X ] There is a reference to the original bug report and related work
- [X ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X ] The feature is well documented and sample code can be built with the project CMake
