### PR TITLE
fix Issue 23558

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1273,6 +1273,28 @@ Use gen_pattern.py (@ref tutorial_camera_calibration_pattern) to create checkerb
 CV_EXPORTS_W bool findChessboardCorners( InputArray image, Size patternSize, OutputArray corners,
                                          int flags = CALIB_CB_ADAPTIVE_THRESH + CALIB_CB_NORMALIZE_IMAGE );
 
+
+/** @brief Finds the positions of internal corners of the chessboard.
+
+@param image Source chessboard view. It must be an 8-bit black and white image
+@param patternSize Number of inner corners per a chessboard row and column
+( patternSize = cv::Size(points_per_row,points_per_colum) = cv::Size(columns,rows) ).
+@param corners Output array of detected corners.
+@param flags Various operation flags that can be zero or a combination of the following values:
+-   @ref CALIB_CB_FILTER_QUADS Use additional criteria (like contour area, perimeter,
+square-like shape) to filter out false quads extracted at the contour retrieval stage.
+
+The function similarly to #findChessboardCorners attempts to determine whether the input image is a view of the chessboard pattern and
+locate the internal chessboard corners. The main difference with #findChessboardCorners is that the function does not perform any kind of processing of the input image,
+which rather must be preprocessed before calling the function i.e. the image must be a B&W image.
+The function returns a non-zero value if all of the corners are found and they are placed in a certain order (row by row, left to right in every row).
+Otherwise, if the function fails to find all the corners or reorder them, it returns 0.
+The detected coordinates are approximate, and to determine their positions more accurately the function #cornerSubPix can be used.
+ */
+CV_EXPORTS_W bool checkChessboardCorners(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
+
+
+
 /*
    Checks whether the image contains chessboard of the specific size or not.
    If yes, nonzero value is returned.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1291,7 +1291,7 @@ The function returns a non-zero value if all of the corners are found and they a
 Otherwise, if the function fails to find all the corners or reorder them, it returns 0.
 The detected coordinates are approximate, and to determine their positions more accurately the function #cornerSubPix can be used.
  */
-CV_EXPORTS_W bool checkChessboardCorners(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
+CV_EXPORTS_W bool findChessboardCornersSimple(InputArray image, Size patternSize, OutputArray corners, int flags = 0);
 
 
 

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,6 +662,74 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
+{
+    CV_INSTRUMENT_REGION();
+    
+    int type = image_.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    
+    Mat img = image_.getMat();
+    
+    CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale image are supported");
+    
+    if (pattern_size.width <= 2 || pattern_size.height <= 2)
+      CV_Error(Error::StsOutOfRange, "Both width and height of the pattern should have bigger than 2");
+    
+    if (!corners_.needed())
+      CV_Error(Error::StsNullPtr, "Null pointer to corners");
+    
+    std::vector<cv::Point2f> out_corners;
+    
+    ChessBoardDetector detector(pattern_size);
+    
+    // So we can find rectangles that go to the edge, we draw a white line around the image edge.
+    // Otherwise FindContours will miss those clipped rectangle contours.
+    // The border color will be the image mean, because otherwise we risk screwing up filters like cvSmooth()...
+    rectangle(img, Point(0,0), Point(img.cols-1, img.rows-1), Scalar(255,255,255), 3, LINE_8);
+    
+    detector.reset();
+  
+    detector.generateQuads(img, flags);
+    
+    int prev_sqr_size = 0;
+  
+    if(!detector.processQuads(out_corners, prev_sqr_size))
+    {
+      return false;
+    }
+    
+    if(!detector.checkBoardMonotony(out_corners))
+    {
+      return false;
+    }
+    
+    // check that none of the found corners is too close to the image boundary
+    const int BORDER = 8;
+    for (int k = 0; k < pattern_size.width*pattern_size.height; ++k)
+    {
+      if( out_corners[k].x <= BORDER || out_corners[k].x > img.cols - BORDER ||
+         out_corners[k].y <= BORDER || out_corners[k].y > img.rows - BORDER )
+      {
+        return false;
+      }
+    }
+    
+    if ((pattern_size.height & 1) == 0 && (pattern_size.width & 1) == 0 )
+    {
+      int last_row = (pattern_size.height-1)*pattern_size.width;
+      double dy0 = out_corners[last_row].y - out_corners[0].y;
+      if (dy0 < 0)
+      {
+        int n = pattern_size.width*pattern_size.height;
+        for(int i = 0; i < n/2; i++ )
+        {
+          std::swap(out_corners[i], out_corners[n-i-1]);
+        }
+      }
+    }
+        
+    Mat(out_corners).copyTo(corners_);
+    return true;
+}
 
 //
 // Checks that each board row and column is pretty much monotonous curve:

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,6 +662,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
+bool checkChessboardCorners(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
 {
     CV_INSTRUMENT_REGION();
     

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -662,7 +662,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     return found;
 }
 
-bool checkChessboardCorners(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
+bool findChessboardCornersSimple(InputArray image_, Size pattern_size, OutputArray corners_, int flags)
 {
     CV_INSTRUMENT_REGION();
     

--- a/modules/calib3d/src/checkchessboard.cpp
+++ b/modules/calib3d/src/checkchessboard.cpp
@@ -51,9 +51,9 @@ using namespace std;
 
 static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point > > & contours, const std::vector< cv::Vec4i > & hierarchy, std::vector<std::pair<float, int> >& quads, int class_id)
 {
-    const float min_aspect_ratio = 0.3f;
-    const float max_aspect_ratio = 3.0f;
-    const float min_box_size = 10.0f;
+    const float min_aspect_ratio = 0.5f;
+    const float max_aspect_ratio = 1.5f;
+    const float min_box_size = 25.0f;
 
     for (size_t i = 0; i < contours.size(); ++i)
     {
@@ -63,7 +63,7 @@ static void icvGetQuadrangleHypotheses(const std::vector<std::vector< cv::Point 
         const std::vector< cv::Point > & c = contours[i];
         cv::RotatedRect box = cv::minAreaRect(c);
 
-        float box_size = MAX(box.size.width, box.size.height);
+        float box_size = MIN(box.size.width, box.size.height);
         if(box_size < min_box_size)
         {
             continue;


### PR DESCRIPTION
this pull request resolves issue #23558.

in the issue #23558 an empty image was passed to the findChessboardCorners() function with the CALIB_CB_FAST_CHECK flag. The fast check failed and findChessboardCorners() wasted 15minutes finding a checkerboard that was not there in the image.

The reason is that the checkChessboardBinary() function returned true because the checkQuads() function was convinced that among all the contours found by fillQuads() were those of the checkerboard.

The problem was icvGetQuadrangleHypotheses() that incorrectly filtering the contours found. 
It was passing too many contours to checkQuads(), and by the law of large numbers, checkQuads() was able to find contours that "looked" like a checkerboard between them.

What I did is to shrink the parameters in the icvGetQuadrangleHypotheses() function.
I changed the range of the ratio between the sides of the contour found to 0.5 and 1.5.
More reasonable values than the previous 0.3 and 3.0
In addition, I raised the minimum side length of the hypothetical square from 10 to 25 pixels.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
