### PR TITLE
Add support for custom padding in DNN preprocessing

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1221,7 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
-        CV_PROP_RW Scalar paddingmodeborderValue;   //!< Value used in padding mode for padding.
+        CV_PROP_RW Scalar borderValue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1212,7 +1212,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_WRAP Image2BlobParams();
         CV_WRAP Image2BlobParams(const Scalar& scalefactor, const Size& size = Size(), const Scalar& mean = Scalar(),
                             bool swapRB = false, int ddepth = CV_32F, DataLayout datalayout = DNN_LAYOUT_NCHW,
-                            ImagePaddingMode mode = DNN_PMODE_NULL);
+                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar fillvalue = 0.0);
 
         CV_PROP_RW Scalar scalefactor; //!< scalefactor multiplier for input image values.
         CV_PROP_RW Size size;    //!< Spatial size for output image.
@@ -1221,6 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
+        CV_PROP_RW Scalar paddingmodefillvalue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1212,7 +1212,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_WRAP Image2BlobParams();
         CV_WRAP Image2BlobParams(const Scalar& scalefactor, const Size& size = Size(), const Scalar& mean = Scalar(),
                             bool swapRB = false, int ddepth = CV_32F, DataLayout datalayout = DNN_LAYOUT_NCHW,
-                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar fillvalue = 0.0);
+                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar borderValue = 0.0);
 
         CV_PROP_RW Scalar scalefactor; //!< scalefactor multiplier for input image values.
         CV_PROP_RW Size size;    //!< Spatial size for output image.
@@ -1221,7 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
-        CV_PROP_RW Scalar paddingmodefillvalue;   //!< Value used in padding mode for padding.
+        CV_PROP_RW Scalar paddingmodeborderValue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -17,9 +17,9 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 {}
 
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
-                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_):
+                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar fillvalue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_)
+        datalayout(datalayout_), paddingmode(mode_), paddingmodefillvalue(fillvalue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodefillvalue);
             }
             else
             {

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -17,9 +17,9 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 {}
 
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
-                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar fillvalue_):
+                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar borderValue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_), paddingmodefillvalue(fillvalue_)
+        datalayout(datalayout_), paddingmode(mode_), paddingmodeborderValue(borderValue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodefillvalue);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodeborderValue);
             }
             else
             {

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -19,7 +19,7 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
                          int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar borderValue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_), paddingmodeborderValue(borderValue_)
+        datalayout(datalayout_), paddingmode(mode_), borderValue(borderValue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodeborderValue);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.borderValue);
             }
             else
             {

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -118,7 +118,7 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Image2BlobParams param;
     param.size = targetSize;
     param.paddingmode = DNN_PMODE_LETTERBOX;
-    param.paddingmodefillvalue = customPaddingValue; // Use your new feature here
+    param.paddingmodeborderValue = customPaddingValue; // Use your new feature here
 
     // Create blob with custom padding
     Mat blob = dnn::blobFromImageWithParams(img, param);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -97,8 +97,9 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
 {
     Mat img(40, 20, CV_8UC4, Scalar(0, 1, 2, 3));
 
-    // Custom padding value that you have added
-    Scalar customPaddingValue(0, 1, 2, 3); // Example padding value
+    // Custom padding values
+    int values[] = {5, 6, 7, 8};
+    Scalar customPaddingValue(values[0], values[1], values[2], values[3]);
 
     // Construct target mat with the expected padding value
     Mat targetCh[4];
@@ -108,6 +109,12 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Mat rowM(1, 20, CV_8UC1, valVec.data());
     for (int i = 0; i < 4; i++) {
         targetCh[i] = rowM * i;
+        // Modify specific values in targetCh[i]
+        for (int col = 0; col < targetCh[i].cols; col++) {
+            if (col < 5 || col > 14) {
+                targetCh[i].at<uint8_t>(0, col) = values[i];
+            }
+        }
     }
 
     Mat targetImg;

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -95,19 +95,19 @@ TEST(blobFromImageWithParams_4ch, NHWC_scalar_scale)
 
 TEST(blobFromImageWithParams_CustomPadding, letter_box)
 {
-    Mat img(40, 20, CV_8UC4, Scalar(2, 2, 2, 2));
+    Mat img(40, 20, CV_8UC4, Scalar(0, 1, 2, 3));
 
     // Custom padding value that you have added
-    Scalar customPaddingValue(1, 1, 1, 1); // Example padding value
+    Scalar customPaddingValue(0, 1, 2, 3); // Example padding value
 
     // Construct target mat with the expected padding value
     Mat targetCh[4];
 
-    std::vector<uint8_t> valVec = {1,1,1,1,1, 2,2,2,2,2,2,2,2,2,2, 1,1,1,1,1};
+    std::vector<uint8_t> valVec = {1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1};
 
     Mat rowM(1, 20, CV_8UC1, valVec.data());
     for (int i = 0; i < 4; i++) {
-        targetCh[i] = rowM;
+        targetCh[i] = rowM * i;
     }
 
     Mat targetImg;
@@ -118,7 +118,7 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Image2BlobParams param;
     param.size = targetSize;
     param.paddingmode = DNN_PMODE_LETTERBOX;
-    param.paddingmodeborderValue = customPaddingValue; // Use your new feature here
+    param.borderValue = customPaddingValue; // Use your new feature here
 
     // Create blob with custom padding
     Mat blob = dnn::blobFromImageWithParams(img, param);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -105,12 +105,11 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Mat targetImg = img.clone();
 
     cv::copyMakeBorder(
-        targetImg, targetImg, 0, 0, 
-        targetSize.width / 2, 
-        targetSize.width / 2, 
-        BORDER_CONSTANT, 
-        customPaddingValue
-        );
+        targetImg, targetImg, 0, 0,
+        targetSize.width / 2,
+        targetSize.width / 2,
+        BORDER_CONSTANT,
+        customPaddingValue);
 
     // Set up Image2BlobParams with your new functionality
     Image2BlobParams param;

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -97,29 +97,20 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
 {
     Mat img(40, 20, CV_8UC4, Scalar(0, 1, 2, 3));
 
-    // Custom padding values
-    int values[] = {5, 6, 7, 8};
-    Scalar customPaddingValue(values[0], values[1], values[2], values[3]);
+    // Custom padding value that you have added
+    Scalar customPaddingValue(5, 6, 7, 8); // Example padding value
 
-    // Construct target mat with the expected padding value
-    Mat targetCh[4];
-
-    std::vector<uint8_t> valVec = {1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1};
-
-    Mat rowM(1, 20, CV_8UC1, valVec.data());
-    for (int i = 0; i < 4; i++) {
-        targetCh[i] = rowM * i;
-        // Modify specific values in targetCh[i]
-        for (int col = 0; col < targetCh[i].cols; col++) {
-            if (col < 5 || col > 14) {
-                targetCh[i].at<uint8_t>(0, col) = values[i];
-            }
-        }
-    }
-
-    Mat targetImg;
-    merge(targetCh, 4, targetImg);
     Size targetSize(20, 20);
+
+    Mat targetImg = img.clone();
+
+    cv::copyMakeBorder(
+        targetImg, targetImg, 0, 0, 
+        targetSize.width / 2, 
+        targetSize.width / 2, 
+        BORDER_CONSTANT, 
+        customPaddingValue
+        );
 
     // Set up Image2BlobParams with your new functionality
     Image2BlobParams param;

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -93,6 +93,42 @@ TEST(blobFromImageWithParams_4ch, NHWC_scalar_scale)
     }
 }
 
+TEST(blobFromImageWithParams_CustomPadding, letter_box)
+{
+    Mat img(40, 20, CV_8UC4, Scalar(2, 2, 2, 2));
+
+    // Custom padding value that you have added
+    Scalar customPaddingValue(1, 1, 1, 1); // Example padding value
+
+    // Construct target mat with the expected padding value
+    Mat targetCh[4];
+
+    std::vector<uint8_t> valVec = {1,1,1,1,1, 2,2,2,2,2,2,2,2,2,2, 1,1,1,1,1};
+
+    Mat rowM(1, 20, CV_8UC1, valVec.data());
+    for (int i = 0; i < 4; i++) {
+        targetCh[i] = rowM;
+    }
+
+    Mat targetImg;
+    merge(targetCh, 4, targetImg);
+    Size targetSize(20, 20);
+
+    // Set up Image2BlobParams with your new functionality
+    Image2BlobParams param;
+    param.size = targetSize;
+    param.paddingmode = DNN_PMODE_LETTERBOX;
+    param.paddingmodefillvalue = customPaddingValue; // Use your new feature here
+
+    // Create blob with custom padding
+    Mat blob = dnn::blobFromImageWithParams(img, param);
+
+    // Create target blob for comparison
+    Mat targetBlob = dnn::blobFromImage(targetImg, 1.0, targetSize);
+
+    EXPECT_EQ(0, cvtest::norm(targetBlob, blob, NORM_INF));
+}
+
 TEST(blobFromImageWithParams_4ch, letter_box)
 {
     Mat img(40, 20, CV_8UC4, cv::Scalar(0,1,2,3));


### PR DESCRIPTION
This PR add functionality for specifying value in padding.
 It is required in many preprocessing pipelines in DNNs such as Yolox object detection model


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
