### PR TITLE
Fix verify unsupported new mat depth for nonzero/minmax/lut

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -566,6 +566,7 @@ are taken from the input array. That is, the function processes each element of 
 \f[\texttt{dst} (I)  \leftarrow \texttt{lut(src(I) + d)}\f]
 where
 \f[d =  \fork{0}{if \(\texttt{src}\) has depth \(\texttt{CV_8U}\)}{128}{if \(\texttt{src}\) has depth \(\texttt{CV_8S}\)}\f]
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for lut.
 @param src input array of 8-bit elements.
 @param lut look-up table of 256 elements; in case of multi-channel input array, the table should
 either have a single channel (in this case the same table is used for all channels) or the same
@@ -596,6 +597,7 @@ CV_EXPORTS_W bool hasNonZero( InputArray src );
 
 The function returns the number of non-zero elements in src :
 \f[\sum _{I: \; \texttt{src} (I) \ne0 } 1\f]
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src single-channel array.
 @sa  mean, meanStdDev, norm, minMaxLoc, calcCovarMatrix
 */
@@ -624,6 +626,7 @@ or
     // access pixel coordinates
     Point pnt = locations[i];
 @endcode
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src single-channel array
 @param idx the output array, type of cv::Mat or std::vector<Point>, corresponding to non-zero indices in the input
 */
@@ -635,6 +638,7 @@ The function cv::mean calculates the mean value M of array elements,
 independently for each channel, and return it:
 \f[\begin{array}{l} N =  \sum _{I: \; \texttt{mask} (I) \ne 0} 1 \\ M_c =  \left ( \sum _{I: \; \texttt{mask} (I) \ne 0}{ \texttt{mtx} (I)_c} \right )/N \end{array}\f]
 When all the mask elements are 0's, the function returns Scalar::all(0)
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src input array that should have from 1 to 4 channels so that the result can be stored in
 Scalar_ .
 @param mask optional operation mask.
@@ -907,6 +911,7 @@ CV_EXPORTS void minMaxIdx(InputArray src, double* minVal, double* maxVal = 0,
                           int* minIdx = 0, int* maxIdx = 0, InputArray mask = noArray());
 
 /** @overload
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param a input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.
 @param maxVal pointer to the returned maximum value; NULL is used if not required.

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -588,6 +588,7 @@ CV_EXPORTS_AS(sumElems) Scalar sum(InputArray src);
 /** @brief Checks for the presence of at least one non-zero array element.
 
 The function returns whether there are non-zero elements in src
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src single-channel array.
 @sa  mean, meanStdDev, norm, minMaxLoc, calcCovarMatrix
 */
@@ -638,7 +639,6 @@ The function cv::mean calculates the mean value M of array elements,
 independently for each channel, and return it:
 \f[\begin{array}{l} N =  \sum _{I: \; \texttt{mask} (I) \ne 0} 1 \\ M_c =  \left ( \sum _{I: \; \texttt{mask} (I) \ne 0}{ \texttt{mtx} (I)_c} \right )/N \end{array}\f]
 When all the mask elements are 0's, the function returns Scalar::all(0)
-@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src input array that should have from 1 to 4 channels so that the result can be stored in
 Scalar_ .
 @param mask optional operation mask.
@@ -838,6 +838,7 @@ The function do not work with multi-channel arrays. If you need to find minimum 
 elements across all the channels, use Mat::reshape first to reinterpret the array as
 single-channel. Or you may extract the particular channel using either extractImageCOI , or
 mixChannels , or split .
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.
 @param maxVal pointer to the returned maximum value; NULL is used if not required.
@@ -898,6 +899,7 @@ a single-row or single-column matrix. In OpenCV (following MATLAB) each array ha
 dimensions, i.e. single-column matrix is Mx1 matrix (and therefore minIdx/maxIdx will be
 (i1,0)/(i2,0)) and single-row matrix is 1xN matrix (and therefore minIdx/maxIdx will be
 (0,j1)/(0,j2)).
+@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param src input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.
 @param maxVal pointer to the returned maximum value; NULL is used if not required.
@@ -911,7 +913,6 @@ CV_EXPORTS void minMaxIdx(InputArray src, double* minVal, double* maxVal = 0,
                           int* minIdx = 0, int* maxIdx = 0, InputArray mask = noArray());
 
 /** @overload
-@note CV_16F/CV_16BF/CV_Bool/CV_64U/CV_64S/CV_32U are not supported for src.
 @param a input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.
 @param maxVal pointer to the returned maximum value; NULL is used if not required.

--- a/modules/core/src/check.cpp
+++ b/modules/core/src/check.cpp
@@ -45,15 +45,16 @@ static const char* getTestOpMath(unsigned testOp)
 
 const char* depthToString_(int depth)
 {
-    static const char* depthNames[] = { "CV_8U", "CV_8S", "CV_16U", "CV_16S", "CV_32S", "CV_32F", "CV_64F", "CV_16F" };
-    return (depth <= CV_16F && depth >= 0) ? depthNames[depth] : NULL;
+    static const char* depthNames[] = { "CV_8U", "CV_8S", "CV_16U", "CV_16S", "CV_32S", "CV_32F", "CV_64F", "CV_16F",
+                                        "CV_16BF", "CV_Bool", "CV_64U", "CV_64S", "CV_32U" };
+    return (depth < CV_DEPTH_CURR_MAX && depth >= 0) ? depthNames[depth] : NULL;
 }
 
 cv::String typeToString_(int type)
 {
     int depth = CV_MAT_DEPTH(type);
     int cn = CV_MAT_CN(type);
-    if (depth >= 0 && depth <= CV_16F)
+    if (depth >= 0 && depth < CV_DEPTH_CURR_MAX)
         return cv::format("%sC%d", depthToString_(depth), cn);
     return cv::String();
 }

--- a/modules/core/src/count_non_zero.dispatch.cpp
+++ b/modules/core/src/count_non_zero.dispatch.cpp
@@ -161,6 +161,8 @@ void findNonZero(InputArray _src, OutputArray _idx)
     AutoBuffer<int> buf_(cols + 1);
     int* buf = buf_.data();
 
+    CV_Assert( depth < CV_16F );
+
     for( int i = 0; i < rows; i++ )
     {
         int j, k = 0;

--- a/modules/core/src/count_non_zero.simd.hpp
+++ b/modules/core/src/count_non_zero.simd.hpp
@@ -196,7 +196,7 @@ static int countNonZero64f( const double* src, int len )
 
 CountNonZeroFunc getCountNonZeroTab(int depth)
 {
-    static CountNonZeroFunc countNonZeroTab[] =
+    static CountNonZeroFunc countNonZeroTab[CV_DEPTH_MAX] =
     {
         (CountNonZeroFunc)GET_OPTIMIZED(countNonZero8u), (CountNonZeroFunc)GET_OPTIMIZED(countNonZero8u),
         (CountNonZeroFunc)GET_OPTIMIZED(countNonZero16u), (CountNonZeroFunc)GET_OPTIMIZED(countNonZero16u),

--- a/modules/core/src/has_non_zero.simd.hpp
+++ b/modules/core/src/has_non_zero.simd.hpp
@@ -310,7 +310,7 @@ static bool hasNonZero64f( const double* src, size_t len )
 
 HasNonZeroFunc getHasNonZeroTab(int depth)
 {
-    static HasNonZeroFunc hasNonZeroTab[] =
+    static HasNonZeroFunc hasNonZeroTab[CV_DEPTH_MAX] =
     {
         (HasNonZeroFunc)GET_OPTIMIZED(hasNonZero8u), (HasNonZeroFunc)GET_OPTIMIZED(hasNonZero8u),
         (HasNonZeroFunc)GET_OPTIMIZED(hasNonZero16u), (HasNonZeroFunc)GET_OPTIMIZED(hasNonZero16u),

--- a/modules/core/src/lut.cpp
+++ b/modules/core/src/lut.cpp
@@ -68,7 +68,7 @@ static void LUT8u_64f( const uchar* src, const double* lut, double* dst, int len
 
 typedef void (*LUTFunc)( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn );
 
-static LUTFunc lutTab[] =
+static LUTFunc lutTab[CV_DEPTH_MAX] =
 {
     (LUTFunc)LUT8u_8u, (LUTFunc)LUT8u_8s, (LUTFunc)LUT8u_16u, (LUTFunc)LUT8u_16s,
     (LUTFunc)LUT8u_32s, (LUTFunc)LUT8u_32f, (LUTFunc)LUT8u_64f, 0

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -834,7 +834,7 @@ typedef void (*MinMaxIdxFunc)(const uchar*, const uchar*, int*, int*, size_t*, s
 
 static MinMaxIdxFunc getMinmaxTab(int depth)
 {
-    static MinMaxIdxFunc minmaxTab[] =
+    static MinMaxIdxFunc minmaxTab[CV_DEPTH_MAX] =
     {
         (MinMaxIdxFunc)GET_OPTIMIZED(minMaxIdx_8u), (MinMaxIdxFunc)GET_OPTIMIZED(minMaxIdx_8s),
         (MinMaxIdxFunc)GET_OPTIMIZED(minMaxIdx_16u), (MinMaxIdxFunc)GET_OPTIMIZED(minMaxIdx_16s),

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -3032,4 +3032,75 @@ TEST_P(FiniteMaskFixture, flags)
 // Params are: depth, channels 1 to 4
 INSTANTIATE_TEST_CASE_P(Core_FiniteMask, FiniteMaskFixture, ::testing::Combine(::testing::Values(CV_32F, CV_64F), ::testing::Range(1, 5)));
 
+
+///////////////////////////////////////////////////////////////////////////////////
+typedef testing::TestWithParam<perf::MatDepth> NonZeroNotSupportedMatDepth;
+
+TEST_P(NonZeroNotSupportedMatDepth, findNonZero)
+{
+    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    vector<Point> pts;
+    EXPECT_THROW( findNonZero(src, pts), cv::Exception);
+}
+
+TEST_P(NonZeroNotSupportedMatDepth, countNonZero)
+{
+    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    EXPECT_THROW( countNonZero(src), cv::Exception);
+}
+
+TEST_P(NonZeroNotSupportedMatDepth, hasNonZero)
+{
+    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    EXPECT_THROW( hasNonZero(src), cv::Exception);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    NonZero,
+    NonZeroNotSupportedMatDepth,
+    testing::Values(perf::MatDepth(CV_16F), CV_16BF, CV_Bool, CV_64U, CV_64S, CV_32U)
+);
+
+///////////////////////////////////////////////////////////////////////////////////
+typedef testing::TestWithParam<perf::MatDepth> LutNotSupportedMatDepth;
+
+TEST_P(LutNotSupportedMatDepth, lut)
+{
+    cv::Mat src = cv::Mat::zeros(16,16, CV_8UC1);
+    cv::Mat lut = cv::Mat(1, 256, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat dst;
+    EXPECT_THROW( cv::LUT(src,lut,dst), cv::Exception);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    Lut,
+    LutNotSupportedMatDepth,
+    testing::Values(perf::MatDepth(CV_16F), CV_16BF, CV_Bool, CV_64U, CV_64S, CV_32U)
+);
+
+///////////////////////////////////////////////////////////////////////////////////
+typedef testing::TestWithParam<perf::MatDepth> MinMaxNotSupportedMatDepth;
+
+TEST_P(MinMaxNotSupportedMatDepth, minMaxLoc)
+{
+    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    double minV=0.0, maxV=0.0;
+    Point minLoc, maxLoc;
+    EXPECT_THROW( cv::minMaxLoc(src, &minV, &maxV, &minLoc, &maxLoc), cv::Exception);
+}
+
+TEST_P(MinMaxNotSupportedMatDepth, minMaxIdx)
+{
+    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    double minV=0.0, maxV=0.0;
+    int minIdx=0, maxIdx=0;
+    EXPECT_THROW( cv::minMaxIdx(src, &minV, &maxV, &minIdx, &maxIdx), cv::Exception);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    MinMaxLoc,
+    MinMaxNotSupportedMatDepth,
+    testing::Values(perf::MatDepth(CV_16F), CV_16BF, CV_Bool, CV_64U, CV_64S, CV_32U)
+);
+
 }} // namespace

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -160,7 +160,8 @@ private:
     };                                                                                  \
     static inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
 
-CV_ENUM(MatDepth, CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F, CV_16F)
+CV_ENUM(MatDepth, CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F, CV_16F, \
+                  CV_16BF, CV_Bool, CV_64U, CV_64S, CV_32U)
 
 /*****************************************************************************************\
 *                 Regression control utility for performance testing                      *


### PR DESCRIPTION
`cv::LUI()`, `cv::minMaxLoc()`, `cv::minMaxIdx()`, `cv::countNonZero()`, `cv::findNonZero()` and `cv::hasNonZero()` uses depth-based function table. However, it is too short for `CV_16BF`, `CV_Bool`, `CV_64U`, `CV_64S` and `CV_32U` and it may occur out-boundary-access. This patch fix it. And If necessary, when someone extends these functions to support, please relax this test.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
