### PR TITLE
dnn: improve fp16 code style

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/conv_block.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv_block.simd.hpp
@@ -489,7 +489,7 @@ void convBlockMR1_F32(int np, const float * a, const float * b, float *c, const 
 }
 #endif
 
-#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_FP16
 
 void convBlock_F16(int np, const char * _a, const char * _b, char * _c, int ldc, bool init_c, int width,
                     const int convMR_fp16, const int convNR_fp16)

--- a/modules/dnn/src/layers/cpu_kernels/conv_winograd_f63.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv_winograd_f63.simd.hpp
@@ -420,7 +420,7 @@ void winofunc_AtXA_8x8_F32(const float* inptr, int inpstep,
 #endif // CV_AVX
 
 // FP16, currently, only ARMv8 may support it
-#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_FP16
 
 #undef T4x4
 #define T4x4(a, b, c, d, tr0, tr1) \


### PR DESCRIPTION
This pr only changes the macro `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` to `CV_FP16` and will not affect the dnn speed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
