### PR TITLE
DON'T MERGE, DNN: disable winograd as default

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -862,7 +862,7 @@ CV__DNN_INLINE_NS_BEGIN
 
         /** @brief Enables or disables the Winograd compute branch. The Winograd compute branch can speed up
          * 3x3 Convolution at a small loss of accuracy.
-        * @param useWinograd true to enable the Winograd compute branch. The default is true.
+        * @param useWinograd true to enable the Winograd compute branch. The default is false.
         */
         CV_WRAP void enableWinograd(bool useWinograd);
 

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -195,7 +195,7 @@ void getConvolutionKernelParams(const LayerParams &params, std::vector<size_t>& 
     util::getStrideAndPadding(params, pads_begin, pads_end, strides, padMode, kernel.size());
     util::getParameter(params, "dilation", "dilation", dilations, true, std::vector<size_t>(kernel.size(), 1));
     util::getParameter(params, "adj", "adj", adjust_pads, true, std::vector<size_t>(kernel.size(), 0));
-    useWinograd = params.get<bool>("use_winograd", true);
+    useWinograd = params.get<bool>("use_winograd", useWinograd);
 
     for (int i = 0; i < dilations.size(); i++)
         CV_Assert(dilations[i] > 0);


### PR DESCRIPTION
This PR tries to disable the Winograd compute branch as default, which will greatly affect dnn running performance.

Test at Apple M2 chip, multi-thread:
[m2_perf_test.zip](https://github.com/opencv/opencv/files/13453991/m2_perf_test.zip)

After turn off the Wingrad, 3x3s1 convolution performance drops a lot (4.x vs patch):
![image](https://github.com/opencv/opencv/assets/16487352/8abc8f1f-87c9-458f-b56e-dec1f3430ac2)




### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
