### PR TITLE
Test for YOLOX

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1221,7 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
-        CV_PROP_RW Scalar paddingmodeborderValue;   //!< Value used in padding mode for padding.
+        CV_PROP_RW Scalar borderValue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1212,7 +1212,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_WRAP Image2BlobParams();
         CV_WRAP Image2BlobParams(const Scalar& scalefactor, const Size& size = Size(), const Scalar& mean = Scalar(),
                             bool swapRB = false, int ddepth = CV_32F, DataLayout datalayout = DNN_LAYOUT_NCHW,
-                            ImagePaddingMode mode = DNN_PMODE_NULL);
+                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar fillvalue = 0.0);
 
         CV_PROP_RW Scalar scalefactor; //!< scalefactor multiplier for input image values.
         CV_PROP_RW Size size;    //!< Spatial size for output image.
@@ -1221,6 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
+        CV_PROP_RW Scalar paddingmodefillvalue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1212,7 +1212,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_WRAP Image2BlobParams();
         CV_WRAP Image2BlobParams(const Scalar& scalefactor, const Size& size = Size(), const Scalar& mean = Scalar(),
                             bool swapRB = false, int ddepth = CV_32F, DataLayout datalayout = DNN_LAYOUT_NCHW,
-                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar fillvalue = 0.0);
+                            ImagePaddingMode mode = DNN_PMODE_NULL, Scalar borderValue = 0.0);
 
         CV_PROP_RW Scalar scalefactor; //!< scalefactor multiplier for input image values.
         CV_PROP_RW Size size;    //!< Spatial size for output image.
@@ -1221,7 +1221,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP_RW int ddepth;   //!< Depth of output blob. Choose CV_32F or CV_8U.
         CV_PROP_RW DataLayout datalayout; //!< Order of output dimensions. Choose DNN_LAYOUT_NCHW or DNN_LAYOUT_NHWC.
         CV_PROP_RW ImagePaddingMode paddingmode;   //!< Image padding mode. @see ImagePaddingMode.
-        CV_PROP_RW Scalar paddingmodefillvalue;   //!< Value used in padding mode for padding.
+        CV_PROP_RW Scalar paddingmodeborderValue;   //!< Value used in padding mode for padding.
     };
 
     /** @brief Creates 4-dimensional blob from image with given params.

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -17,9 +17,9 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 {}
 
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
-                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_):
+                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar fillvalue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_)
+        datalayout(datalayout_), paddingmode(mode_), paddingmodefillvalue(fillvalue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodefillvalue);
             }
             else
             {

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -17,9 +17,9 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 {}
 
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
-                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar fillvalue_):
+                         int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar borderValue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_), paddingmodefillvalue(fillvalue_)
+        datalayout(datalayout_), paddingmode(mode_), paddingmodeborderValue(borderValue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodefillvalue);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodeborderValue);
             }
             else
             {

--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -19,7 +19,7 @@ Image2BlobParams::Image2BlobParams():scalefactor(Scalar::all(1.0)), size(Size())
 Image2BlobParams::Image2BlobParams(const Scalar& scalefactor_, const Size& size_, const Scalar& mean_, bool swapRB_,
                          int ddepth_, DataLayout datalayout_, ImagePaddingMode mode_, Scalar borderValue_):
         scalefactor(scalefactor_), size(size_), mean(mean_), swapRB(swapRB_), ddepth(ddepth_),
-        datalayout(datalayout_), paddingmode(mode_), paddingmodeborderValue(borderValue_)
+        datalayout(datalayout_), paddingmode(mode_), borderValue(borderValue_)
 {}
 
 void getVector(InputArrayOfArrays images_, std::vector<Mat>& images) {
@@ -196,7 +196,7 @@ void blobFromImagesWithParamsImpl(InputArrayOfArrays images_, Tmat& blob_, const
                 int bottom = size.height - top - rh;
                 int left = (size.width - rw)/2;
                 int right = size.width - left - rw;
-                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.paddingmodeborderValue);
+                copyMakeBorder(images[i], images[i], top, bottom, left, right, BORDER_CONSTANT, param.borderValue);
             }
             else
             {

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -118,7 +118,7 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Image2BlobParams param;
     param.size = targetSize;
     param.paddingmode = DNN_PMODE_LETTERBOX;
-    param.paddingmodefillvalue = customPaddingValue; // Use your new feature here
+    param.paddingmodeborderValue = customPaddingValue; // Use your new feature here
 
     // Create blob with custom padding
     Mat blob = dnn::blobFromImageWithParams(img, param);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -95,19 +95,19 @@ TEST(blobFromImageWithParams_4ch, NHWC_scalar_scale)
 
 TEST(blobFromImageWithParams_CustomPadding, letter_box)
 {
-    Mat img(40, 20, CV_8UC4, Scalar(2, 2, 2, 2));
+    Mat img(40, 20, CV_8UC4, Scalar(0, 1, 2, 3));
 
     // Custom padding value that you have added
-    Scalar customPaddingValue(1, 1, 1, 1); // Example padding value
+    Scalar customPaddingValue(0, 1, 2, 3); // Example padding value
 
     // Construct target mat with the expected padding value
     Mat targetCh[4];
 
-    std::vector<uint8_t> valVec = {1,1,1,1,1, 2,2,2,2,2,2,2,2,2,2, 1,1,1,1,1};
+    std::vector<uint8_t> valVec = {1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1};
 
     Mat rowM(1, 20, CV_8UC1, valVec.data());
     for (int i = 0; i < 4; i++) {
-        targetCh[i] = rowM;
+        targetCh[i] = rowM * i;
     }
 
     Mat targetImg;
@@ -118,7 +118,7 @@ TEST(blobFromImageWithParams_CustomPadding, letter_box)
     Image2BlobParams param;
     param.size = targetSize;
     param.paddingmode = DNN_PMODE_LETTERBOX;
-    param.paddingmodeborderValue = customPaddingValue; // Use your new feature here
+    param.borderValue = customPaddingValue; // Use your new feature here
 
     // Create blob with custom padding
     Mat blob = dnn::blobFromImageWithParams(img, param);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -93,6 +93,42 @@ TEST(blobFromImageWithParams_4ch, NHWC_scalar_scale)
     }
 }
 
+TEST(blobFromImageWithParams_CustomPadding, letter_box)
+{
+    Mat img(40, 20, CV_8UC4, Scalar(2, 2, 2, 2));
+
+    // Custom padding value that you have added
+    Scalar customPaddingValue(1, 1, 1, 1); // Example padding value
+
+    // Construct target mat with the expected padding value
+    Mat targetCh[4];
+
+    std::vector<uint8_t> valVec = {1,1,1,1,1, 2,2,2,2,2,2,2,2,2,2, 1,1,1,1,1};
+
+    Mat rowM(1, 20, CV_8UC1, valVec.data());
+    for (int i = 0; i < 4; i++) {
+        targetCh[i] = rowM;
+    }
+
+    Mat targetImg;
+    merge(targetCh, 4, targetImg);
+    Size targetSize(20, 20);
+
+    // Set up Image2BlobParams with your new functionality
+    Image2BlobParams param;
+    param.size = targetSize;
+    param.paddingmode = DNN_PMODE_LETTERBOX;
+    param.paddingmodefillvalue = customPaddingValue; // Use your new feature here
+
+    // Create blob with custom padding
+    Mat blob = dnn::blobFromImageWithParams(img, param);
+
+    // Create target blob for comparison
+    Mat targetBlob = dnn::blobFromImage(targetImg, 1.0, targetSize);
+
+    EXPECT_EQ(0, cvtest::norm(targetBlob, blob, NORM_INF));
+}
+
 TEST(blobFromImageWithParams_4ch, letter_box)
 {
     Mat img(40, 20, CV_8UC4, cv::Scalar(0,1,2,3));

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2594,22 +2594,32 @@ TEST_P(Test_ONNX_layers, YOLOx)
     std::string imgPath = _tf("../dog_orig_size.png");
 
     Size targetSize{640, 640};
-    float conf_threshold = 0.25;
-    float iou_threshold = 0.45;
+    float conf_threshold = 0.50;
+    float iou_threshold = 0.50;
 
-    // Reference, which is collected with input size of 640x640
     std::vector<int> refClassIds{1, 16, 7};
-    std::vector<float> refScores{0.9642f, 0.9205f, 0.7558f};
+    std::vector<float> refScores{0.96f, 0.91f, 0.66f};
     // [x1, y1, x2, y2] x 3
     std::vector<Rect2d> refBoxes{
-        Rect2d(101.8698, 143.0301, 472.6174, 465.4247),
-        Rect2d(110.7208, 247.7161, 257.6797, 604.0322),
-        Rect2d(384.4736,  82.4499, 579.6175, 190.9493)};
-
+        Rect2d(104.62, 181.28, 470.95, 428.22),
+        Rect2d(112.32, 264.88, 258.11, 527.31),
+        Rect2d(389.63, 144.63, 576.66, 223.18),
+        };
 
     Mat img = imread(imgPath);
-    // Note: this image tranformation is not the same as in YOLOX repo.
-    Mat inp = blobFromImage(img, 1.0, targetSize, Scalar(0, 0, 0), true, false);
+
+    Image2BlobParams paramYolox(
+        Scalar::all(1),
+        targetSize,
+        Scalar::all(0),
+        true,
+        CV_32F,
+        DNN_LAYOUT_NCHW,
+        DNN_PMODE_LETTERBOX,
+        Scalar::all(144)
+        );
+
+    Mat inp = blobFromImageWithParams(img, paramYolox);
 
     Net net = readNet(weightPath);
 
@@ -2662,6 +2672,7 @@ TEST_P(Test_ONNX_layers, YOLOx)
     std::vector<int> keep_classIds;
     std::vector<float> keep_confidences;
     std::vector<Rect2d> keep_boxes;
+
     for (auto i : keep_idx)
     {
         keep_classIds.push_back(classIds[i]);
@@ -2669,7 +2680,7 @@ TEST_P(Test_ONNX_layers, YOLOx)
         keep_boxes.push_back(boxes[i]);
     }
 
-    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 3.0e+0);
+    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
 }
 
 // This test is mainly to test:

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2588,6 +2588,90 @@ TEST_P(Test_ONNX_layers, CumSum)
     testONNXModels("cumsum_3d_dim_2");
 }
 
+TEST_P(Test_ONNX_layers, YOLOx)
+{
+    std::string weightPath = _tf("models/yolox_s_inf_decoder.onnx", false);
+    std::string imgPath = _tf("../dog_orig_size.png");
+
+    Size targetSize{640, 640};
+    float conf_threshold = 0.25;
+    float iou_threshold = 0.45;
+
+    // Reference, which is collected with input size of 640x640
+    std::vector<int> refClassIds{1, 16, 7};
+    std::vector<float> refScores{0.9642f, 0.9205f, 0.7558f};
+    // [x1, y1, x2, y2] x 3
+    std::vector<Rect2d> refBoxes{
+        Rect2d(101.8698, 143.0301, 472.6174, 465.4247),
+        Rect2d(110.7208, 247.7161, 257.6797, 604.0322),
+        Rect2d(384.4736,  82.4499, 579.6175, 190.9493)};
+
+
+    Mat img = imread(imgPath);
+    // Note: this image tranformation is not the same as in YOLOX repo.
+    Mat inp = blobFromImage(img, 1.0, targetSize, Scalar(0, 0, 0), true, false);
+
+    Net net = readNet(weightPath);
+
+    net.setInput(inp);
+    std::vector<Mat> outs;
+    net.forward(outs, net.getUnconnectedOutLayersNames());
+
+    Mat preds = outs[0].reshape(1, outs[0].size[1]); // [1, 8400, 85]
+
+    // Retrieve
+    std::vector<int> classIds;
+    std::vector<float> confidences;
+    std::vector<Rect2d> boxes;
+    // each row is [cx, cy, w, h, conf_obj, conf_class1, ..., conf_class80]
+    for (int i = 0; i < preds.rows; ++i)
+    {
+        // filter out non objects
+        float obj_conf = preds.row(i).at<float>(4);
+        if (obj_conf < conf_threshold)
+            continue;
+
+        // get class id and conf
+        Mat scores = preds.row(i).colRange(5, preds.cols);
+        double conf;
+        Point maxLoc;
+        minMaxLoc(scores, 0, &conf, 0, &maxLoc);
+        conf *= obj_conf;
+        if (conf < conf_threshold)
+            continue;
+
+        // get bbox coords
+        float* det = preds.ptr<float>(i);
+        double cx = det[0];
+        double cy = det[1];
+        double w = det[2];
+        double h = det[3];
+
+        // [x1, y1, x2, y2]
+        boxes.push_back(Rect2d(cx - 0.5 * w, cy - 0.5 * h,
+                                cx + 0.5 * w, cy + 0.5 * h));
+        classIds.push_back(maxLoc.x);
+        confidences.push_back(conf);
+
+    }
+
+    // NMS
+    std::vector<int> keep_idx;
+    NMSBoxes(boxes, confidences, conf_threshold, iou_threshold, keep_idx);
+
+    std::vector<int> keep_classIds;
+    std::vector<float> keep_confidences;
+    std::vector<Rect2d> keep_boxes;
+    for (auto i : keep_idx)
+    {
+        keep_classIds.push_back(classIds[i]);
+        keep_confidences.push_back(confidences[i]);
+        keep_boxes.push_back(boxes[i]);
+    }
+
+    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 3.0e+0);
+}
+
 // This test is mainly to test:
 //  1. identity node with constant input
 //  2. limited support to range operator (all inputs are constant)


### PR DESCRIPTION
This PR adds test for YOLOX model (which was absent before) 
The onnx weights for the test are located in this PR  [#1126](https://github.com/opencv/opencv_extra/pull/1126)

**Note:** 
This PR needs to be merge `only after PR` [#24569](https://github.com/opencv/opencv/pull/24569) is merged, since it depends on padding functionally.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
