### PR TITLE
Add test for YOLOX 

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -18,7 +18,7 @@ struct FilteredDetections{
     std::vector<Rect2d> keep_boxes;
 };
 
-FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, float iou_threshold);
+FilteredDetections yoloPostProcessing(const std::vector<Mat>& outs, float conf_threshold, float iou_threshold);
 
 template<typename TString>
 static std::string _tf(TString filename, bool required = true)
@@ -2631,7 +2631,7 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
     net.forward(outs, net.getUnconnectedOutLayersNames());
 
     FilteredDetections result;
-    result = postProcessing(outs, conf_threshold, iou_threshold);
+    result = yoloPostProcessing(outs, conf_threshold, iou_threshold);
 
     normAssertDetections(
         refClassIds, refScores, refBoxes,
@@ -2639,7 +2639,7 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
         "", 0.0, scores_diff, boxes_iou_diff);
 }
 
-FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, float iou_threshold){
+FilteredDetections yoloPostProcessing(const std::vector<Mat>& outs, float conf_threshold, float iou_threshold){
 
     // Retrieve
     std::vector<int> classIds;
@@ -2656,7 +2656,7 @@ FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, f
             // filter out non objects
             float obj_conf = preds.row(i).at<float>(4);
             if (obj_conf < conf_threshold)
-            continue;
+                continue;
 
             // get class id and conf
             Mat scores = preds.row(i).colRange(5, preds.cols);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2708,7 +2708,7 @@ TEST_P(Test_ONNX_nets, YOLOx)
     std::vector<int> refClassIds{1, 16, 7};
     std::vector<float> refScores{0.96f, 0.91f, 0.66f};
 
-    // [x1, y1, x2, y2] 
+    // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(104.62, 181.28, 470.95, 428.22),
         Rect2d(112.32, 264.88, 258.11, 527.31),
@@ -2727,8 +2727,8 @@ TEST_P(Test_ONNX_nets, YOLOx)
         );
 
     testYOLO(
-        weightPath, refClassIds, refScores, refBoxes, 
-        imgParams, conf_threshold, iou_threshold, 
+        weightPath, refClassIds, refScores, refBoxes,
+        imgParams, conf_threshold, iou_threshold,
         1.0e-1, 1.0e-1);
 }
 


### PR DESCRIPTION
This PR adds test for YOLOX model (which was absent before) 
The onnx weights for the test are located in this PR  [#1126](https://github.com/opencv/opencv_extra/pull/1126)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
