### PR TITLE
Fixed regression in Android Tutorial2 initialization.

### DIFF
--- a/samples/android/tutorial-2-mixedprocessing/src/org/opencv/samples/tutorial2/Tutorial2Activity.java
+++ b/samples/android/tutorial-2-mixedprocessing/src/org/opencv/samples/tutorial2/Tutorial2Activity.java
@@ -57,6 +57,9 @@ public class Tutorial2Activity extends CameraActivity implements CvCameraViewLis
             return;
         }
 
+        // Load native library after(!) OpenCV initialization
+        System.loadLibrary("mixed_sample");
+
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         setContentView(R.layout.tutorial2_surface_view);


### PR DESCRIPTION
Regression was introduced in https://github.com/opencv/opencv/pull/24575

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
