### PR TITLE
Serialize Android samples build in SDK script to prevent raise between gradle instances

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -270,7 +270,7 @@ class Builder:
         if self.no_samples_build:
             execute([self.ninja_path, "install" if (self.debug_info or self.debug) else "install/strip"])
         else:
-            execute([self.ninja_path, "-j1" if (self.debug_info or self.debug) else "-j3", "install" if (self.debug_info or self.debug) else "install/strip"])
+            execute([self.ninja_path, "-j1", "install" if (self.debug_info or self.debug) else "install/strip"])
 
     def build_javadoc(self):
         classpaths = []


### PR DESCRIPTION
Tries to fix build errors like this:
```
2023-11-27T14:14:56.4627503Z FAILURE: Build failed with an exception.
2023-11-27T14:14:56.4627530Z 
2023-11-27T14:14:56.4627946Z * What went wrong:
2023-11-27T14:14:56.4629021Z Execution failed for task ':tutorial-1-camerapreview:lintVitalAnalyzeRelease'.
2023-11-27T14:14:56.4630451Z > Could not resolve all files for configuration ':tutorial-1-camerapreview:releaseCompileClasspath'.
2023-11-27T14:14:56.4636192Z    > Failed to transform out.aar (project :opencv) to match attributes {artifactType=android-lint-exploded-aar, com.android.build.api.attributes.AgpVersionAttr=7.3.1, com.android.build.api.attributes.BuildTypeAttr=release, com.android.build.gradle.internal.attributes.VariantAttr=release, org.gradle.usage=java-api, org.jetbrains.kotlin.platform.type=androidJvm}.
2023-11-27T14:14:56.4638063Z       > Execution failed for ExtractAarTransform: /home/ci/build/o4a/opencv_android/opencv/build/intermediates/local_aar_for_lint/release/out.aar.
2023-11-27T14:14:56.4638630Z          > unexpected EOF
2023-11-27T14:14:56.4638644Z 
2023-11-27T14:14:56.4638837Z * Try:
2023-11-27T14:14:56.4639515Z > Run with --stacktrace option to get the stack trace.
2023-11-27T14:14:56.4640066Z > Run with --debug option to get more log output.
2023-11-27T14:14:56.4640492Z > Run with --scan to get full insights.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
