### PR TITLE
Add test for YoloX Yolo v6 and Yolo v8

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2745,7 +2745,7 @@ TEST_P(Test_ONNX_nets, YOLOv8)
     float iou_threshold = 0.50;
 
     std::vector<int> refClassIds{16, 1, 2};
-    std::vector<float> refScores{0.9332, 0.8959, 0.6157};
+    std::vector<float> refScores{0.9332f, 0.8959f, 0.6157f};
     // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
@@ -2811,7 +2811,7 @@ TEST_P(Test_ONNX_nets, YOLOv6)
     float iou_threshold = 0.50;
 
     std::vector<int> refClassIds{1, 16, 7, 1};
-    std::vector<float> refScores{0.95031, 0.87123,  0.65453, 0.34142};
+    std::vector<float> refScores{0.95031f, 0.87123f,  0.65453f, 0.34142f};
     // [x1, y1, x2, y2] x 3
     std::vector<Rect2d> refBoxes{Rect2d(98.84, 177.91, 473.29, 431.19),
                                  Rect2d(109.80, 265.50, 258.86, 531.97),

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -13,12 +13,12 @@
 namespace opencv_test { namespace {
 
 void yoloPostProcessing(
-    std::vector<Mat>& outs, 
+    std::vector<Mat>& outs,
     std::vector<int>& keep_classIds,
     std::vector<float>& keep_confidences,
     std::vector<Rect2d>& keep_boxes,
-    float conf_threshold, 
-    float iou_threshold, 
+    float conf_threshold,
+    float iou_threshold,
     const std::string& test_name);
 
 template<typename TString>
@@ -2623,7 +2623,7 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
 
     Mat img = imread(imgPath);
 
-    Mat inp = blobFromImageWithParams(img, imgParams);  
+    Mat inp = blobFromImageWithParams(img, imgParams);
 
     Net net = readNet(weightPath);
 
@@ -2644,12 +2644,12 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
 }
 
 void yoloPostProcessing(
-    std::vector<Mat>& outs, 
-    std::vector<int>& keep_classIds, 
-    std::vector<float>& keep_confidences, 
-    std::vector<Rect2d>& keep_boxes, 
-    float conf_threshold, 
-    float iou_threshold, 
+    std::vector<Mat>& outs,
+    std::vector<int>& keep_classIds,
+    std::vector<float>& keep_confidences,
+    std::vector<Rect2d>& keep_boxes,
+    float conf_threshold,
+    float iou_threshold,
     const std::string& test_name
 ){
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2770,9 +2770,9 @@ TEST_P(Test_ONNX_nets, YOLOv8)
         1.0e-1, 1.0e-1, "yolov8");
 }
 
-TEST_P(Test_ONNX_layers, YOLOv8)
+TEST_P(Test_ONNX_nets, YOLOv8)
 {
-    std::string weightPath = _tf("/yolov8n.onnx", false);
+    std::string weightPath = _tf("models/yolov8n.onnx", false);
     std::string imgPath = _tf("../dog_orig_size.png");
 
     Size targetSize{640, 640};
@@ -2781,7 +2781,7 @@ TEST_P(Test_ONNX_layers, YOLOv8)
 
     std::vector<int> refClassIds{16, 1, 2};
     std::vector<float> refScores{0.9332, 0.8959, 0.6157};
-    // [x1, y1, x2, y2] 
+    // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
         Rect2d(110.4020, 192.9843, 473.4418, 429.5965),

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2732,9 +2732,9 @@ TEST_P(Test_ONNX_nets, YOLOx)
         1.0e-1, 1.0e-1);
 }
 
-TEST_P(Test_ONNX_layers, YOLOv8)
+TEST_P(Test_ONNX_nets, YOLOv8)
 {
-    std::string weightPath = _tf("/yolov8n.onnx", false);
+    std::string weightPath = _tf("models/yolov8n.onnx", false);
     std::string imgPath = _tf("../dog_orig_size.png");
 
     Size targetSize{640, 640};
@@ -2743,7 +2743,7 @@ TEST_P(Test_ONNX_layers, YOLOv8)
 
     std::vector<int> refClassIds{16, 1, 2};
     std::vector<float> refScores{0.9332, 0.8959, 0.6157};
-    // [x1, y1, x2, y2] 
+    // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
         Rect2d(110.4020, 192.9843, 473.4418, 429.5965),

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2823,6 +2823,97 @@ TEST_P(Test_ONNX_nets, YOLOv8)
     normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
 }
 
+TEST_P(Test_ONNX_layers, YOLOv8)
+{
+    std::string weightPath = _tf("/yolov8n.onnx", false);
+    std::string imgPath = _tf("../dog_orig_size.png");
+
+    Size targetSize{640, 640};
+    float conf_threshold = 0.25;
+    float iou_threshold = 0.50;
+
+    std::vector<int> refClassIds{16, 1, 2};
+    std::vector<float> refScores{0.9332, 0.8959, 0.6157};
+    // [x1, y1, x2, y2] 
+    std::vector<Rect2d> refBoxes{
+        Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
+        Rect2d(110.4020, 192.9843, 473.4418, 429.5965),
+        Rect2d(389.1603, 143.2506, 577.3542, 223.0615),
+        };
+
+    Mat img = imread(imgPath);
+
+    Image2BlobParams paramYolox(
+        Scalar::all(1/255.0),
+        targetSize,
+        Scalar::all(0),
+        true,
+        CV_32F,
+        DNN_LAYOUT_NCHW,
+        DNN_PMODE_LETTERBOX,
+        Scalar::all(144)
+        );
+
+    Mat inp = blobFromImageWithParams(img, paramYolox);
+    Net net = readNet(weightPath);
+
+    net.setInput(inp);
+    std::vector<Mat> outs;
+    net.forward(outs, net.getUnconnectedOutLayersNames());
+
+    // transpose to [1, 8400, 84] from [1, 84, 8400]
+    cv::transposeND(outs[0], {0, 2, 1}, outs[0]);
+
+    Mat preds = outs[0].reshape(1, outs[0].size[1]); // [1, 8400, 84]
+
+    // Retrieve
+    std::vector<int> classIds;
+    std::vector<float> confidences;
+    std::vector<Rect2d> boxes;
+
+    for (int i = 0; i < preds.rows; ++i)
+    {
+
+        Mat scores = preds.row(i).colRange(4, preds.cols);
+        double conf;
+        Point maxLoc;
+        minMaxLoc(scores, 0, &conf, 0, &maxLoc);
+
+        if (conf < conf_threshold)
+            continue;
+
+        // get bbox coords
+        float* det = preds.ptr<float>(i);
+        double cx = det[0];
+        double cy = det[1];
+        double w = det[2];
+        double h = det[3];
+
+        // [x1, y1, x2, y2]
+        boxes.push_back(Rect2d(cx - 0.5 * w, cy - 0.5 * h,
+                                cx + 0.5 * w, cy + 0.5 * h));
+        classIds.push_back(maxLoc.x);
+        confidences.push_back(conf);
+    }
+
+    // NMS
+    std::vector<int> keep_idx;
+    NMSBoxes(boxes, confidences, conf_threshold, iou_threshold, keep_idx);
+
+    std::vector<int> keep_classIds;
+    std::vector<float> keep_confidences;
+    std::vector<Rect2d> keep_boxes;
+
+    for (auto i : keep_idx)
+    {
+        keep_classIds.push_back(classIds[i]);
+        keep_confidences.push_back(confidences[i]);
+        keep_boxes.push_back(boxes[i]);
+    }
+
+    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
+}
+
 // This test is mainly to test:
 //  1. identity node with constant input
 //  2. limited support to range operator (all inputs are constant)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2661,7 +2661,7 @@ FilteredDetections yoloPostProcessing(std::vector<Mat>& outs, float conf_thresho
             float obj_conf = (test_name != "yolov8") ? preds.at<float>(i, 4) : 1.0f;
             if (obj_conf < conf_threshold)
                 continue;
-            
+
             Mat scores = preds.row(i).colRange((test_name != "yolov8") ? 5 : 4, preds.cols);
             double conf;
             Point maxLoc;
@@ -2712,7 +2712,7 @@ TEST_P(Test_ONNX_nets, YOLOx)
     std::vector<int> refClassIds{1, 16, 7};
     std::vector<float> refScores{0.96f, 0.91f, 0.66f};
 
-    // [x1, y1, x2, y2] 
+    // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(104.62, 181.28, 470.95, 428.22),
         Rect2d(112.32, 264.88, 258.11, 527.31),
@@ -2731,8 +2731,8 @@ TEST_P(Test_ONNX_nets, YOLOx)
         );
 
     testYOLO(
-        weightPath, refClassIds, refScores, refBoxes, 
-        imgParams, conf_threshold, iou_threshold, 
+        weightPath, refClassIds, refScores, refBoxes,
+        imgParams, conf_threshold, iou_threshold,
         1.0e-1, 1.0e-1);
 }
 
@@ -2765,8 +2765,8 @@ TEST_P(Test_ONNX_nets, YOLOv8)
         );
 
     testYOLO(
-        weightPath, refClassIds, refScores, refBoxes, 
-        imgParams, conf_threshold, iou_threshold, 
+        weightPath, refClassIds, refScores, refBoxes,
+        imgParams, conf_threshold, iou_threshold,
         1.0e-1, 1.0e-1, "yolov8");
 }
 
@@ -2785,7 +2785,7 @@ TEST_P(Test_ONNX_nets, YOLOv7)
     std::vector<Rect2d> refBoxes{Rect2d(105.973236f, 150.16716f,  472.59012f, 466.48834f),
                                  Rect2d(109.97953f,  246.17862f, 259.83676f, 600.76624f),
                                  Rect2d(385.96185f, 83.02809f,  576.07355f,  189.82793f)};
-                                 
+
     Size targetSize{640, 640};
 
     Image2BlobParams imgParams(
@@ -2831,8 +2831,8 @@ TEST_P(Test_ONNX_nets, YOLOv6)
         );
 
     testYOLO(
-        weightPath, refClassIds, refScores, refBoxes, 
-        imgParams, conf_threshold, iou_threshold, 
+        weightPath, refClassIds, refScores, refBoxes,
+        imgParams, conf_threshold, iou_threshold,
         1.0e-1, 1.0e-1);
 }
 
@@ -2847,7 +2847,7 @@ TEST_P(Test_ONNX_nets, YOLOv5n)
     std::vector<Rect2d> refBoxes{Rect2d(108.088f, 239.293f, 266.196f, 607.658f),
                                  Rect2d(392.028f, 89.9233f, 579.152f, 190.447f),
                                  Rect2d(120.278f, 159.76, 214.481f, 241.473f)};
-                                
+
     Size targetSize{640, 640};
 
     Image2BlobParams imgParams(

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2893,6 +2893,125 @@ TEST_P(Test_ONNX_nets, YOLOv7)
     testYOLO(weightPath, refClassIds, refScores, refBoxes, imgParams);
 }
 
+TEST_P(Test_ONNX_nets, YOLOv6)
+{
+    std::string weightPath = _tf("models/yolov6n.onnx", false);
+    std::string imgPath = _tf("../dog_orig_size.png");
+    // std::string imgPath = _tf("../yolov6_input_preprocessed.png");
+
+    Size targetSize{640, 640};
+    float conf_threshold = 0.30;
+    float iou_threshold = 0.50;
+
+    // Reference, which is collected with input size of 640x640
+    // std::vector<int> refClassIds{1, 16, 7, 2, 1};
+    // std::vector<float> refScores{0.95031, 0.87123,  0.65453, 0.55388, 0.34142};
+
+    std::vector<int> refClassIds{1, 16, 7, 1};
+    std::vector<float> refScores{0.95031, 0.87123,  0.65453, 0.34142};
+    // tensor([[   98.84711,   177.91743,   473.29028,   431.19647,     0.95031,     1.00000],
+    //     [  109.80331,   265.50464,   258.86099,   531.97986,     0.87123,    16.00000],
+    //     [  387.79333,   141.61865,   576.98975,   223.52478,     0.65453,     7.00000],
+    //     [  386.31982,   141.43988,   576.56836,   223.00580,     0.55388,     2.00000]])
+    //     [  105.62915,   199.24750,   218.37820,   389.84839,     0.34142,     1.00000]])
+    // [x1, y1, x2, y2] x 3
+    std::vector<Rect2d> refBoxes{Rect2d(98.84, 177.91, 473.29, 431.19),
+                                 Rect2d(109.80, 265.50, 258.86, 531.97),
+                                 Rect2d(387.79, 141.61, 576.98, 223.52),
+                                 Rect2d(105.62, 199.24, 218.37, 389.84),
+                                //  Rect2d(386.31, 141.43, 576.56, 223.00),
+                                 };
+    Mat img = imread(imgPath);
+
+    Image2BlobParams paramYolox(
+        Scalar::all(1/255.0),
+        targetSize,
+        Scalar::all(0),
+        true,
+        CV_32F,
+        DNN_LAYOUT_NCHW,
+        DNN_PMODE_LETTERBOX,
+        Scalar::all(114)
+        );
+    Mat inp = blobFromImageWithParams(img, paramYolox);
+
+    // Mat inp = blobFromImage(img, 1/255.0, targetSize, Scalar(0, 0, 0), true, false);
+
+    std::cout << "sum " << cv::sum(inp) << std::endl;
+    std::cout << "shape: " << inp.size << std::endl;
+
+
+    Net net = readNet(weightPath);
+
+
+    net.setInput(inp);
+    std::vector<Mat> outs;
+    net.forward(outs, net.getUnconnectedOutLayersNames());
+
+    // transpose to [1, 8400, 84] from [1, 84, 8400]
+    // cv::transposeND(outs[0], {0, 2, 1}, outs[0]);
+
+    Mat preds = outs[0].reshape(1, outs[0].size[1]); // [1, 8400, 85]
+
+    // Retrieve
+    std::vector<int> classIds;
+    std::vector<float> confidences;
+    std::vector<Rect2d> boxes;
+    // each row is [cx, cy, w, h, conf_obj, conf_class1, ..., conf_class80]
+    for (int i = 0; i < preds.rows; ++i)
+    {
+        // filter out non objects
+        float obj_conf = preds.row(i).at<float>(4);
+        if (obj_conf < conf_threshold)
+            continue;
+
+        // get class id and conf
+        Mat scores = preds.row(i).colRange(5, preds.cols);
+        double conf;
+        Point maxLoc;
+        minMaxLoc(scores, 0, &conf, 0, &maxLoc);
+        conf *= obj_conf;
+        if (conf < conf_threshold)
+            continue;
+
+        // get bbox coords
+        float* det = preds.ptr<float>(i);
+        double cx = det[0];
+        double cy = det[1];
+        double w = det[2];
+        double h = det[3];
+
+        // [x1, y1, x2, y2]
+        boxes.push_back(Rect2d(cx - 0.5 * w, cy - 0.5 * h,
+                                cx + 0.5 * w, cy + 0.5 * h));
+        classIds.push_back(maxLoc.x);
+        confidences.push_back(conf);
+
+    }
+
+    // NMS
+    std::vector<int> keep_idx;
+    NMSBoxes(boxes, confidences, conf_threshold, iou_threshold, keep_idx);
+
+    std::vector<int> keep_classIds;
+    std::vector<float> keep_confidences;
+    std::vector<Rect2d> keep_boxes;
+
+    for (auto i : keep_idx)
+    {
+        keep_classIds.push_back(classIds[i]);
+        keep_confidences.push_back(confidences[i]);
+        keep_boxes.push_back(boxes[i]);
+    }
+
+    for (int i = 0; i < keep_idx.size(); i++){
+        std::cout << keep_boxes[i].x  << " " << keep_boxes[i].y << " " << keep_boxes[i].width << " " << keep_boxes[i].height
+        << " " << keep_confidences[i] << " " << keep_classIds[i] << std::endl;
+    }
+
+    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
+}
+
 TEST_P(Test_ONNX_nets, YOLOv5n)
 {
     std::string weightPath = findDataFile("dnn/yolov5n.onnx", false);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -18,7 +18,7 @@ struct FilteredDetections{
     std::vector<Rect2d> keep_boxes;
 };
 
-FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, float iou_threshold);
+FilteredDetections yoloPostProcessing(const std::vector<Mat>& outs, float conf_threshold, float iou_threshold);
 
 template<typename TString>
 static std::string _tf(TString filename, bool required = true)
@@ -2631,7 +2631,7 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
     net.forward(outs, net.getUnconnectedOutLayersNames());
 
     FilteredDetections result;
-    result = postProcessing(outs, conf_threshold, iou_threshold);
+    result = yoloPostProcessing(outs, conf_threshold, iou_threshold);
 
     normAssertDetections(
         refClassIds, refScores, refBoxes,
@@ -2639,7 +2639,7 @@ static void testYOLO(const std::string& weightPath, const std::vector<int>& refC
         "", 0.0, scores_diff, boxes_iou_diff);
 }
 
-FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, float iou_threshold){
+FilteredDetections yoloPostProcessing(const std::vector<Mat>& outs, float conf_threshold, float iou_threshold){
 
     // Retrieve
     std::vector<int> classIds;
@@ -2656,7 +2656,7 @@ FilteredDetections postProcessing(std::vector<Mat> outs, float conf_threshold, f
             // filter out non objects
             float obj_conf = preds.row(i).at<float>(4);
             if (obj_conf < conf_threshold)
-            continue;
+                continue;
 
             // get class id and conf
             Mat scores = preds.row(i).colRange(5, preds.cols);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2823,9 +2823,9 @@ TEST_P(Test_ONNX_nets, YOLOv8)
     normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
 }
 
-TEST_P(Test_ONNX_layers, YOLOv8)
+TEST_P(Test_ONNX_nets, YOLOv8)
 {
-    std::string weightPath = _tf("/yolov8n.onnx", false);
+    std::string weightPath = _tf("models/yolov8n.onnx", false);
     std::string imgPath = _tf("../dog_orig_size.png");
 
     Size targetSize{640, 640};
@@ -2834,7 +2834,7 @@ TEST_P(Test_ONNX_layers, YOLOv8)
 
     std::vector<int> refClassIds{16, 1, 2};
     std::vector<float> refScores{0.9332, 0.8959, 0.6157};
-    // [x1, y1, x2, y2] 
+    // [x1, y1, x2, y2]
     std::vector<Rect2d> refBoxes{
         Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
         Rect2d(110.4020, 192.9843, 473.4418, 429.5965),

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2770,6 +2770,97 @@ TEST_P(Test_ONNX_nets, YOLOv8)
         1.0e-1, 1.0e-1, "yolov8");
 }
 
+TEST_P(Test_ONNX_layers, YOLOv8)
+{
+    std::string weightPath = _tf("/yolov8n.onnx", false);
+    std::string imgPath = _tf("../dog_orig_size.png");
+
+    Size targetSize{640, 640};
+    float conf_threshold = 0.25;
+    float iou_threshold = 0.50;
+
+    std::vector<int> refClassIds{16, 1, 2};
+    std::vector<float> refScores{0.9332, 0.8959, 0.6157};
+    // [x1, y1, x2, y2] 
+    std::vector<Rect2d> refBoxes{
+        Rect2d(108.8965, 261.9094, 257.1633, 530.3049),
+        Rect2d(110.4020, 192.9843, 473.4418, 429.5965),
+        Rect2d(389.1603, 143.2506, 577.3542, 223.0615),
+        };
+
+    Mat img = imread(imgPath);
+
+    Image2BlobParams paramYolox(
+        Scalar::all(1/255.0),
+        targetSize,
+        Scalar::all(0),
+        true,
+        CV_32F,
+        DNN_LAYOUT_NCHW,
+        DNN_PMODE_LETTERBOX,
+        Scalar::all(144)
+        );
+
+    Mat inp = blobFromImageWithParams(img, paramYolox);
+    Net net = readNet(weightPath);
+
+    net.setInput(inp);
+    std::vector<Mat> outs;
+    net.forward(outs, net.getUnconnectedOutLayersNames());
+
+    // transpose to [1, 8400, 84] from [1, 84, 8400]
+    cv::transposeND(outs[0], {0, 2, 1}, outs[0]);
+
+    Mat preds = outs[0].reshape(1, outs[0].size[1]); // [1, 8400, 84]
+
+    // Retrieve
+    std::vector<int> classIds;
+    std::vector<float> confidences;
+    std::vector<Rect2d> boxes;
+
+    for (int i = 0; i < preds.rows; ++i)
+    {
+
+        Mat scores = preds.row(i).colRange(4, preds.cols);
+        double conf;
+        Point maxLoc;
+        minMaxLoc(scores, 0, &conf, 0, &maxLoc);
+
+        if (conf < conf_threshold)
+            continue;
+
+        // get bbox coords
+        float* det = preds.ptr<float>(i);
+        double cx = det[0];
+        double cy = det[1];
+        double w = det[2];
+        double h = det[3];
+
+        // [x1, y1, x2, y2]
+        boxes.push_back(Rect2d(cx - 0.5 * w, cy - 0.5 * h,
+                                cx + 0.5 * w, cy + 0.5 * h));
+        classIds.push_back(maxLoc.x);
+        confidences.push_back(conf);
+    }
+
+    // NMS
+    std::vector<int> keep_idx;
+    NMSBoxes(boxes, confidences, conf_threshold, iou_threshold, keep_idx);
+
+    std::vector<int> keep_classIds;
+    std::vector<float> keep_confidences;
+    std::vector<Rect2d> keep_boxes;
+
+    for (auto i : keep_idx)
+    {
+        keep_classIds.push_back(classIds[i]);
+        keep_confidences.push_back(confidences[i]);
+        keep_boxes.push_back(boxes[i]);
+    }
+
+    normAssertDetections(refClassIds, refScores, refBoxes, keep_classIds, keep_confidences, keep_boxes, "", 0.0, 1.0e-1, 1.0e-1);
+}
+
 // This test is mainly to test:
 //  1. identity node with constant input
 //  2. limited support to range operator (all inputs are constant)


### PR DESCRIPTION
This PR adds test for YOLOv6 model (which was absent before)
The onnx weights for the test are located in this PR [ #1126](https://github.com/opencv/opencv_extra/pull/1126)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=ubuntu:22.04
buildworker:Custom=linux-4
```