### PR TITLE
Make default axis of softmax in onnx "-1" without opset option

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -499,6 +499,11 @@ public:
             {
                 type = "Convolution";
             }
+            else if (type == "Softmax"){
+                // set default axis to 1
+                if(!layerParams.has("axis"))
+                    layerParams.set("axis", 1);
+            }
 
             int id = dstNet.addLayer(name, type, layerParams);
 

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -314,6 +314,7 @@ namespace cv {
                     cv::dnn::LayerParams softmax_param;
                     softmax_param.name = "Softmax-name";
                     softmax_param.type = "Softmax";
+                    softmax_param.set("axis", 1);
                     darknet::LayerParameter lp;
 
                     std::string layer_name = cv::format("softmax_%d", layer_id);

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -314,7 +314,9 @@ namespace cv {
                     cv::dnn::LayerParams softmax_param;
                     softmax_param.name = "Softmax-name";
                     softmax_param.type = "Softmax";
-                    softmax_param.set("axis", 1);
+                    // set default axis to 1
+                    if(!softmax_param.has("axis"))
+                        softmax_param.set("axis", 1);
                     darknet::LayerParameter lp;
 
                     std::string layer_name = cv::format("softmax_%d", layer_id);

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -76,7 +76,7 @@ public:
 
     SoftMaxLayerImpl(const LayerParams& params)
     {
-        axisRaw = params.get<int>("axis", 1);
+        axisRaw = params.get<int>("axis", -1);
         logSoftMax = params.get<bool>("log_softmax", false);
         setParamsFrom(params);
     }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3962,7 +3962,7 @@ void ONNXImporter::buildDispatchMap_ONNX_AI(int opset_version)
     dispatch["Concat"] = &ONNXImporter::parseConcat;
     dispatch["Resize"] = &ONNXImporter::parseResize;
     dispatch["Upsample"] = &ONNXImporter::parseUpsample;
-    dispatch["SoftMax"] = dispatch["LogSoftmax"] = &ONNXImporter::parseSoftMax;
+    dispatch["SoftMax"] = dispatch["Softmax"] = dispatch["LogSoftmax"] = &ONNXImporter::parseSoftMax;
     dispatch["DetectionOutput"] = &ONNXImporter::parseDetectionOutput;
     dispatch["CumSum"] = &ONNXImporter::parseCumSum;
     dispatch["SpaceToDepth"] = dispatch["DepthToSpace"] = &ONNXImporter::parseDepthToSpace;
@@ -3981,7 +3981,7 @@ void ONNXImporter::buildDispatchMap_ONNX_AI(int opset_version)
 
     std::vector<std::string> simpleLayers{"Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",
                                           "Cosh", "Dropout", "Erf", "Exp", "Floor", "HardSigmoid", "HardSwish",
-                                          "Identity", "Log", "Round", "Reciprocal", "Selu", "Sign", "Sigmoid", "Sin", "Sinh", "Softmax",
+                                          "Identity", "Log", "Round", "Reciprocal", "Selu", "Sign", "Sigmoid", "Sin", "Sinh",
                                           "Softplus", "Softsign", "Shrink", "Sqrt", "Tan", "ThresholdedRelu", "Gelu",
                                           "GeluApproximation"};
     for (const auto& name : simpleLayers)

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2788,10 +2788,10 @@ void ONNXImporter::parseSoftMax(LayerParams& layerParams, const opencv_onnx::Nod
 {
     const std::string& layer_type = node_proto.op_type();
     int axis;
-    if (layerParams.has("opset") && layerParams.get<int>("opset") > 11) {
-        axis = layerParams.get<int>("axis", -1);
-    } else {
+    if (layerParams.has("opset") && layerParams.get<int>("opset") <= 11) {
         axis = layerParams.get<int>("axis", 1);
+    } else {
+        axis = layerParams.get<int>("axis", -1);
     }
     layerParams.set<int>("axis", axis);
     layerParams.type = "Softmax";

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2788,7 +2788,7 @@ void ONNXImporter::parseSoftMax(LayerParams& layerParams, const opencv_onnx::Nod
 {
     const std::string& layer_type = node_proto.op_type();
     int axis;
-    if (layerParams.has("opset") && layerParams.get<int>("opset") <= 11) {
+    if (onnx_opset != 0 && onnx_opset <= 11) {
         axis = layerParams.get<int>("axis", 1);
     } else {
         axis = layerParams.get<int>("axis", -1);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -2300,6 +2300,12 @@ void TFImporter::parseSoftmax(tensorflow::GraphDef& net, const tensorflow::NodeD
     CV_CheckGT(num_inputs, 0, "");
     if (hasLayerAttr(layer, "axis"))
         layerParams.set("axis", getLayerAttr(layer, "axis").i());
+    // if tf version is 2.x, use axis -1 as default
+    else if(netBin.has_versions() && (int)netBin.versions().producer() >= 2)
+        layerParams.set("axis", -1);
+    // else use axis 1 as default
+    else
+        layerParams.set("axis", 1);
 
     int id = dstNet.addLayer(name, "Softmax", layerParams);
     layer_id[name] = id;

--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -874,6 +874,9 @@ struct TorchImporter
             {
                 newModule->apiType = "Softmax";
                 layerParams.set("log_softmax", nnName == "LogSoftMax");
+                // set default axis to 1
+                if(!layerParams.has("axis"))
+                    layerParams.set("axis", 1);
                 curModule->modules.push_back(newModule);
             }
             else if (nnName == "SpatialCrossMapLRN")

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -716,15 +716,15 @@ INSTANTIATE_TEST_CASE_P(Test_Caffe, opencv_face_detector,
 
 TEST_P(Test_Caffe_nets, FasterRCNN_vgg16)
 {
-    applyTestTag(
-#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
-        CV_TEST_TAG_MEMORY_2GB,  // utilizes ~1Gb, but huge blobs may not be allocated on 32-bit systems due memory fragmentation
-#else
-        CV_TEST_TAG_MEMORY_2GB,
-#endif
-        CV_TEST_TAG_LONG,
-        CV_TEST_TAG_DEBUG_VERYLONG
-    );
+//    applyTestTag(
+//#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
+//        CV_TEST_TAG_MEMORY_2GB,  // utilizes ~1Gb, but huge blobs may not be allocated on 32-bit systems due memory fragmentation
+//#else
+//        CV_TEST_TAG_MEMORY_2GB,
+//#endif
+//        CV_TEST_TAG_LONG,
+//        CV_TEST_TAG_DEBUG_VERYLONG
+//    );
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2021040000)
     if ((backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -716,15 +716,15 @@ INSTANTIATE_TEST_CASE_P(Test_Caffe, opencv_face_detector,
 
 TEST_P(Test_Caffe_nets, FasterRCNN_vgg16)
 {
-//    applyTestTag(
-//#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
-//        CV_TEST_TAG_MEMORY_2GB,  // utilizes ~1Gb, but huge blobs may not be allocated on 32-bit systems due memory fragmentation
-//#else
-//        CV_TEST_TAG_MEMORY_2GB,
-//#endif
-//        CV_TEST_TAG_LONG,
-//        CV_TEST_TAG_DEBUG_VERYLONG
-//    );
+    applyTestTag(
+#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
+        CV_TEST_TAG_MEMORY_2GB,  // utilizes ~1Gb, but huge blobs may not be allocated on 32-bit systems due memory fragmentation
+#else
+        CV_TEST_TAG_MEMORY_2GB,
+#endif
+        CV_TEST_TAG_LONG,
+        CV_TEST_TAG_DEBUG_VERYLONG
+    );
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2021040000)
     if ((backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH) && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -43,7 +43,6 @@
 "test_castlike_STRING_to_FLOAT_expanded",
 "test_concat_1d_axis_negative_1",
 "test_div_uint8",  // output type mismatch
-"test_logsoftmax_default_axis",
 "test_maxpool_2d_dilations",
 "test_maxpool_2d_same_lower",
 "test_maxpool_2d_uint8",  // output type mismatch
@@ -51,7 +50,6 @@
 "test_maxpool_with_argmax_2d_precomputed_strides",
 "test_maxunpool_export_with_output_shape",  // exception during net.forward() call
 "test_mul_uint8",  // output type mismatch
-"test_softmax_default_axis",
 "test_sub_bcast",
 "test_sub_uint8",  // output type mismatch
 "test_upsample_nearest",


### PR DESCRIPTION
Try to solve problem: https://github.com/opencv/opencv/pull/24476#discussion_r1404821158

**ONNX**
`opset <= 11` use 1
`else` use -1

**TensorFlow**
`TF version = 2.x` use -1
`else` use 1

**Darknet, Caffe, Torch**
use 1 by definition