### PR TITLE
Fix compilation on some 32-bit windows

### DIFF
--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -865,7 +865,7 @@ static void cmp_loop_nosimd(const double* src1, size_t step1, const double* src2
     }
 
 // todo: try to avoid define dispatcher functions using macros with these such cases
-DEFINE_SIMD_ALL(cmp)
+DEFINE_SIMD_ALL(cmp, void)
 
 //=========================================================================
 // scaling helpers for single and dual source


### PR DESCRIPTION
I do not have more info on the platform as it is internal.

Without this fix, the error is:
```
core/src/arithm.simd.hpp:868:1: error: too few arguments provided to function-like macro invocation
  868 | DEFINE_SIMD_ALL(cmp)
      | ^
./third_party/OpenCV/public/modules/./core/src/arithm.simd.hpp:93:5: note: expanded from macro 'DEFINE_SIMD_ALL'
   93 |     DEFINE_SIMD_NSAT(fun, __VA_ARGS__)
      |     ^
./third_party/OpenCV/public/modules/./core/src/arithm.simd.hpp:89:5: note: expanded from macro 'DEFINE_SIMD_NSAT'
   89 |     DEFINE_SIMD_F64(fun, __VA_ARGS__)
      |     ^
./third_party/OpenCV/public/modules/./core/src/arithm.simd.hpp:77:9: note: expanded from macro 'DEFINE_SIMD_F64'
   77 |         DEFINE_NOSIMD(__CV_CAT(fun, 64f), double, __VA_ARGS__)
      |         ^
./third_party/OpenCV/public/modules/./core/src/arithm.simd.hpp:47:56: note: expanded from macro 'DEFINE_NOSIMD'
   47 |         DEFINE_NOSIMD_FUN(fun_name, c_type, __VA_ARGS__)
      |                                                        ^
./third_party/OpenCV/public/modules/./core/src/arithm.simd.hpp:860:9: note: macro 'DEFINE_NOSIMD_FUN' defined here
  860 | #define DEFINE_NOSIMD_FUN(fun, _T1, _Tvec, ...)     \
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
