### PR TITLE
Fixed problem with saving images in Android sample

### DIFF
--- a/platforms/android/gradle-wrapper/gradle.properties
+++ b/platforms/android/gradle-wrapper/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx2g
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true

--- a/samples/android/tutorial-3-cameracontrol/build.gradle.in
+++ b/samples/android/tutorial-3-cameracontrol/build.gradle.in
@@ -27,6 +27,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     //implementation fileTree(dir: 'libs', include: ['*.jar'])
     if (gradle.opencv_source == "sdk_path") {
         println 'Using OpenCV from SDK'

--- a/samples/android/tutorial-3-cameracontrol/src/org/opencv/samples/tutorial3/Tutorial3Activity.java
+++ b/samples/android/tutorial-3-cameracontrol/src/org/opencv/samples/tutorial3/Tutorial3Activity.java
@@ -28,6 +28,8 @@ import android.view.View.OnTouchListener;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import androidx.core.app.ActivityCompat;
+
 public class Tutorial3Activity extends CameraActivity implements CvCameraViewListener2, OnTouchListener {
     private static final String TAG = "OCVSample::Activity";
 
@@ -177,10 +179,17 @@ public class Tutorial3Activity extends CameraActivity implements CvCameraViewLis
     @Override
     public boolean onTouch(View v, MotionEvent event) {
         Log.i(TAG,"onTouch event");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+                String[] permissions = {Manifest.permission.WRITE_EXTERNAL_STORAGE};
+                ActivityCompat.requestPermissions(this, permissions, 1);
+                return false;
+            }
+        }
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
         String currentDateandTime = sdf.format(new Date());
-        String fileName = Environment.getExternalStorageDirectory().getPath() +
-                               "/sample_picture_" + currentDateandTime + ".jpg";
+        String fileName = "sample_picture_" + currentDateandTime + ".jpg";
         mOpenCvCameraView.takePicture(fileName);
         Toast.makeText(this, fileName + " saved", Toast.LENGTH_SHORT).show();
         return false;


### PR DESCRIPTION
Code for saving images in Android sample worked only on very old phones.
Added support for modern Android versions.
