### PR TITLE
CV_Assert that function exists in arithm_op

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -617,7 +617,9 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
 
         Mat src1 = psrc1->getMat(), src2 = psrc2->getMat(), dst = _dst.getMat();
         Size sz = getContinuousSize2D(src1, src2, dst, src1.channels());
-        tab[depth1](src1.ptr(), src1.step, src2.ptr(), src2.step, dst.ptr(), dst.step, sz.width, sz.height, usrdata);
+        BinaryFuncC func = tab[depth1];
+        CV_Assert(func);
+        func(src1.ptr(), src1.step, src2.ptr(), src2.step, dst.ptr(), dst.step, sz.width, sz.height, usrdata);
         return;
     }
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1676,6 +1676,13 @@ TEST(Core_Add, AddToColumnWhen4Rows)
     ASSERT_EQ(0, countNonZero(m1 - m2));
 }
 
+TEST(Core_Add, regression_CV_F16_add_sub_do_not_cash){
+    cv::Mat m1(2, 3, CV_16F, cv::Scalar(1));
+    cv::Mat m2(2, 3, CV_16F, cv::Scalar(2));
+    EXPECT_THROW(cv::Mat(m1 + m2), cv::Exception);
+    EXPECT_THROW(cv::Mat(m1 - m2), cv::Exception);
+}
+
 TEST(Core_round, CvRound)
 {
     ASSERT_EQ(2, cvRound(2.0));


### PR DESCRIPTION
Arithmetic like addition and subtraction on CV_16F matrices lead to SEGFAULT due to a call of NULL function, added CV_Assert to change it into an exception

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ✅ ] I agree to contribute to the project under Apache 2 License.
- [ ✅ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ✅ ] The PR is proposed to the proper branch
- [ ❌ ] There is a reference to the original bug report and related work 
  -  no bug report found
- [ ❌  ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name. 
   - added a regression test
- [ ❌  ] The feature is well documented and sample code can be built with the project CMake
   - probably not documented, perhaps the expected behavior is to perform the operation instead of raising an exception
