### PR TITLE
Report correct open status from Bitstream

### DIFF
--- a/modules/videoio/src/container_avi.cpp
+++ b/modules/videoio/src/container_avi.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "opencv2/videoio/container_avi.private.hpp"
+#include <opencv2/core/utils/logger.hpp>
 #include <fstream>
 #include <limits>
 #include <typeinfo>
@@ -645,6 +646,11 @@ bool BitStream::open(const String& filename)
 {
     close();
     output.open(filename.c_str(), std::ios_base::binary);
+    if (!output.is_open())
+    {
+        CV_LOG_DEBUG(NULL, cv::format("Failed to open stream for writing to  \"%s\"", filename.c_str()));
+        return false;
+    }
     m_current = m_start;
     m_pos = 0;
     return true;


### PR DESCRIPTION
`Bitstream::open` did not check, if file was opened correctly.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
