### PR TITLE
The AVVideoCodecJPEG symbol was deprecated in iOS 11.0. We may want to use AVVideoCodecTypeJPEG instead

### DIFF
--- a/modules/videoio/src/cap_ios_photo_camera.mm
+++ b/modules/videoio/src/cap_ios_photo_camera.mm
@@ -139,7 +139,7 @@
 {
     // setup still image output with jpeg codec
     self.stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
-    NSDictionary *outputSettings = [NSDictionary dictionaryWithObjectsAndKeys:AVVideoCodecJPEG, AVVideoCodecKey, nil];
+    NSDictionary *outputSettings = [NSDictionary dictionaryWithObjectsAndKeys:AVVideoCodecTypeJPEG, AVVideoCodecKey, nil];
     [self.stillImageOutput setOutputSettings:outputSettings];
     [self.captureSession addOutput:self.stillImageOutput];
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x] I agree to contribute to the project under Apache 2 License.
- [x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ x] The feature is well documented and sample code can be built with the project CMake
