### PR TITLE
Refactor JavaCamera2View to add option to override Camera2 session request options

### DIFF
--- a/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
+++ b/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
@@ -45,6 +45,7 @@ public class JavaCamera2View extends CameraBridgeViewBase {
 
     protected ImageReader mImageReader;
     protected int mPreviewFormat = ImageFormat.YUV_420_888;
+    protected int mRequestTemplate = CameraDevice.TEMPLATE_PREVIEW;
 
     protected CameraDevice mCameraDevice;
     protected CameraCaptureSession mCaptureSession;
@@ -155,6 +156,35 @@ public class JavaCamera2View extends CameraBridgeViewBase {
 
     };
 
+    protected CameraCaptureSession.StateCallback allocateSessionStateCallback() {
+        return new CameraCaptureSession.StateCallback() {
+            @Override
+            public void onConfigured(CameraCaptureSession cameraCaptureSession) {
+                Log.i(LOGTAG, "createCaptureSession::onConfigured");
+                if (null == mCameraDevice) {
+                    return; // camera is already closed
+                }
+                mCaptureSession = cameraCaptureSession;
+                try {
+                    mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,
+                            CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+                    mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE,
+                            CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
+
+                    mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(), null, mBackgroundHandler);
+                    Log.i(LOGTAG, "CameraPreviewSession has been started");
+                } catch (Exception e) {
+                    Log.e(LOGTAG, "createCaptureSession failed", e);
+                }
+            }
+
+            @Override
+            public void onConfigureFailed(CameraCaptureSession cameraCaptureSession) {
+                Log.e(LOGTAG, "createCameraPreviewSession failed");
+            }
+        };
+    }
+
     private void createCameraPreviewSession() {
         final int w = mPreviewSize.getWidth(), h = mPreviewSize.getHeight();
         Log.i(LOGTAG, "createCameraPreviewSession(" + w + "x" + h + ")");
@@ -191,38 +221,11 @@ public class JavaCamera2View extends CameraBridgeViewBase {
             }, mBackgroundHandler);
             Surface surface = mImageReader.getSurface();
 
-            mPreviewRequestBuilder = mCameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+            mPreviewRequestBuilder = mCameraDevice.createCaptureRequest(mRequestTemplate);
             mPreviewRequestBuilder.addTarget(surface);
 
             mCameraDevice.createCaptureSession(Arrays.asList(surface),
-                new CameraCaptureSession.StateCallback() {
-                    @Override
-                    public void onConfigured(CameraCaptureSession cameraCaptureSession) {
-                        Log.i(LOGTAG, "createCaptureSession::onConfigured");
-                        if (null == mCameraDevice) {
-                            return; // camera is already closed
-                        }
-                        mCaptureSession = cameraCaptureSession;
-                        try {
-                            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,
-                                    CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
-                            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE,
-                                    CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
-
-                            mCaptureSession.setRepeatingRequest(mPreviewRequestBuilder.build(), null, mBackgroundHandler);
-                            Log.i(LOGTAG, "CameraPreviewSession has been started");
-                        } catch (Exception e) {
-                            Log.e(LOGTAG, "createCaptureSession failed", e);
-                        }
-                    }
-
-                    @Override
-                    public void onConfigureFailed(CameraCaptureSession cameraCaptureSession) {
-                        Log.e(LOGTAG, "createCameraPreviewSession failed");
-                    }
-                },
-                null
-            );
+                                               allocateSessionStateCallback(), null);
         } catch (CameraAccessException e) {
             Log.e(LOGTAG, "createCameraPreviewSession", e);
         }


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/15369

Use app may implement inherited class and set `CameraCaptureSession.StateCallback` with any camera options. `allocateSesstionStateCallback` should be overridden for this.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
