### PR TITLE
build: fix warning in Clang 10

### DIFF
--- a/3rdparty/carotene/src/div.cpp
+++ b/3rdparty/carotene/src/div.cpp
@@ -157,8 +157,8 @@ void div(const Size2D &size,
 
     if (scale == 0.0f ||
         (std::numeric_limits<T>::is_integer &&
-         (scale * std::numeric_limits<T>::max()) <  1.0f &&
-         (scale * std::numeric_limits<T>::max()) > -1.0f))
+         (scale * static_cast<float>(std::numeric_limits<T>::max())) <  1.0f &&
+         (scale * static_cast<float>(std::numeric_limits<T>::max())) > -1.0f))
     {
         for (size_t y = 0; y < size.height; ++y)
         {

--- a/3rdparty/openexr/IlmImf/ImfConvert.cpp
+++ b/3rdparty/openexr/IlmImf/ImfConvert.cpp
@@ -107,7 +107,7 @@ floatToUint (float f)
     if (isNegative (f) || isNan (f))
 	return 0;
 
-    if (isInfinity (f) || f > UINT_MAX)
+    if (isInfinity (f) || f > (float)UINT_MAX)
 	return UINT_MAX;
 
     return (unsigned int) f;

--- a/3rdparty/openjpeg/openjp2/j2k.c
+++ b/3rdparty/openjpeg/openjp2/j2k.c
@@ -7796,7 +7796,7 @@ OPJ_BOOL opj_j2k_setup_encoder(opj_j2k_t *p_j2k,
                                        image->comps[0].h * image->comps[0].prec) /
                                       ((double)parameters->tcp_rates[parameters->tcp_numlayers - 1] * 8 *
                                        image->comps[0].dx * image->comps[0].dy));
-            if (temp_size > INT_MAX) {
+            if (temp_size > (OPJ_FLOAT32)INT_MAX) {
                 parameters->max_cs_size = INT_MAX;
             } else {
                 parameters->max_cs_size = (int) floor(temp_size);

--- a/3rdparty/openjpeg/openjp2/tcd.c
+++ b/3rdparty/openjpeg/openjp2/tcd.c
@@ -2262,7 +2262,7 @@ static OPJ_BOOL opj_tcd_dc_level_shift_decode(opj_tcd_t *p_tcd)
             for (j = 0; j < l_height; ++j) {
                 for (i = 0; i < l_width; ++i) {
                     OPJ_FLOAT32 l_value = *((OPJ_FLOAT32 *) l_current_ptr);
-                    if (l_value > INT_MAX) {
+                    if (l_value > (OPJ_FLOAT32)INT_MAX) {
                         *l_current_ptr = l_max;
                     } else if (l_value < INT_MIN) {
                         *l_current_ptr = l_min;


### PR DESCRIPTION
I had a chance to build OpenCV with clang 10.
I found 5 lines of warnings and I think it's worth to prevent it.

```
/opencv/3rdparty/carotene/src/div.cpp:160:19: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wi[0/1875]int-float-conversion]
         (scale * std::numeric_limits<T>::max()) <  1.0f &&
                ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opencv/3rdparty/carotene/src/div.cpp:453:5: note: in instantiation of function template specialization 'carotene_o4t::(anonymous namespace)::div<int>' requested here
    div<s32>(size, src0Base, src0Stride, src1Base, src1Stride, dstBase, dstStride, scale, cpolicy);
    ^
/opencv/3rdparty/carotene/src/div.cpp:161:19: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
         (scale * std::numeric_limits<T>::max()) > -1.0f))
                ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```

```
/opencv/3rdparty/openjpeg/openjp2/j2k.c:7799:29: warning: implicit conversion from 'int' to 'float' changes value from 21
47483647 to 2147483648 [-Wimplicit-int-float-conversion]
            if (temp_size > INT_MAX) {
                          ~ ^~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:46:19: note: expanded from macro 'INT_MAX'
#define INT_MAX   __INT_MAX__
                  ^~~~~~~~~~~
<built-in>:37:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^~~~~~~~~~
1 warning generated.
```

```
/opencv/3rdparty/openjpeg/openjp2/tcd.c:2265:35: warning: implicit conversion from 'int' to 'float' changes value from 21
47483647 to 2147483648 [-Wimplicit-int-float-conversion]
                    if (l_value > INT_MAX) {
                                ~ ^~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:46:19: note: expanded from macro 'INT_MAX'
#define INT_MAX   __INT_MAX__
                  ^~~~~~~~~~~
<built-in>:37:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^~~~~~~~~~
1 warning generated.
```

```
/opencv/3rdparty/openexr/IlmImf/ImfConvert.cpp:110:31: warning: implicit conversion from 'unsigned int' to 'float' change
s value from 4294967295 to 4294967296 [-Wimplicit-int-float-conversion]
    if (isInfinity (f) || f > UINT_MAX)
                            ~ ^~~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:56:37: note: expanded from macro 'UINT_MAX'
#define UINT_MAX  (__INT_MAX__  *2U +1U)
                   ~~~~~~~~~~~~~~~~~^~~
1 warning generated.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
