### PR TITLE
cmake: use /INCREMENTAL:NO with MSVS 2015

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -22,6 +22,24 @@ if(NOT OPENCV_INITIAL_PASS)
   set(ENABLE_PRECOMPILED_HEADERS OFF CACHE INTERNAL "" FORCE)
   project(opencv_world)
 
+  # MSVS 2014 (vc14): LINK : fatal error LNK1210: exceeded internal ILK size limit; link with /INCREMENTAL:NO
+  if(MSVC AND MSVC_VERSION EQUAL 1900)
+    foreach(flag_var
+            CMAKE_EXE_LINKER_FLAGS_DEBUG
+            CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+            CMAKE_MODULE_LINKER_FLAGS_DEBUG
+            CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO
+            CMAKE_SHARED_LINKER_FLAGS_DEBUG
+            CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO
+    )
+      if(${flag_var} MATCHES "/INCREMENTAL")
+        string(REGEX REPLACE "/INCREMENTAL[^ ]*" "/INCREMENTAL:NO" ${flag_var} "${${flag_var}}")
+      else()
+        set(${flag_var} "${${flag_var}} /INCREMENTAL:NO*")
+      endif()
+    endforeach(flag_var)
+  endif()
+
   message(STATUS "Processing WORLD modules...")
   foreach(m ${OPENCV_MODULES_BUILD})
     set(the_module ${m})


### PR DESCRIPTION
Fixes: http://pullrequest.opencv.org/buildbot/builders/4_x_winpack-build-win64-vc14/builds/100340