### PR TITLE
Fix mismatch and simplify code in ChessBoardDetector::findQuadNeighbors

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1629,7 +1629,9 @@ void ChessBoardDetector::findQuadNeighbors()
                         dist <= q_k.edge_len*thresh_scale )
                     {
                         // check edge lengths, make sure they're compatible
-                        // edges that are different by more than 1:4 are rejected
+                        // edges that are different by more than 1:4 are rejected.
+                        // edge_len is squared edge length, so we compare them
+                        // with squared constant 16 = 4^2
                         if (q_k.edge_len > 16*cur_quad.edge_len ||
                             cur_quad.edge_len > 16*q_k.edge_len)
                         {

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1630,9 +1630,8 @@ void ChessBoardDetector::findQuadNeighbors()
                     {
                         // check edge lengths, make sure they're compatible
                         // edges that are different by more than 1:4 are rejected
-                        const float ediff = fabs(cur_quad.edge_len - q_k.edge_len);
-                        if (ediff > 32*cur_quad.edge_len ||
-                            ediff > 32*q_k.edge_len)
+                        if (q_k.edge_len > 16*cur_quad.edge_len ||
+                            cur_quad.edge_len > 16*q_k.edge_len)
                         {
                             DPRINTF("Incompatible edge lengths");
                             continue;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Сode doesn't match comment. 
If we want check `1:4` edges ratio and `edge_len` is squared edge length, then we should check
```
ediff > 15*edge_len
```
with constant `15`, not `32`, because
```
ediff > 15*edge_len2 <=> edge_len1 - edge_len2 > 15*edge_len2 <=> edge_len1 > 16*edge_len2 <=> 1:4 edges ratio
```

But for me it's better and simpler to directly check `edge_len1 > 16*edge_len2`

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
