### PR TITLE
bild: reenable fp16 compile in old compiler (armv7)

### DIFF
--- a/cmake/checks/cpu_fp16.cpp
+++ b/cmake/checks/cpu_fp16.cpp
@@ -15,12 +15,12 @@ int test()
 #include "arm_neon.h"
 int test()
 {
-    const float src[] = { 0.0f, 1.0f, 2.0f, 3.0f };
-    short dst[4];
-    float32x4_t v_src = vld1q_f32(src);
+    const float src[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    short dst[8];
+    float32x4_t v_src = *(float32x4_t*)src;
     float16x4_t v_dst = vcvt_f16_f32(v_src);
-    vst1_f16((__fp16*)dst, v_dst);
-    return dst[0] + dst[1] + dst[2] + dst[3];
+    *(float16x4_t*)dst = v_dst;
+    return (int)dst[0];
 }
 #else
 #error "FP16 is not supported"


### PR DESCRIPTION
Based on discussion on #24588 

Armv7 GCC 4 and 5 series don't have `vst_f16` natively.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
