### PR TITLE
Update 3rdparty libspng to 0.7.4

### DIFF
--- a/3rdparty/libspng/CMakeLists.txt
+++ b/3rdparty/libspng/CMakeLists.txt
@@ -23,7 +23,6 @@ if(MSVC)
 endif(MSVC)
 
 add_library(${SPNG_LIBRARY} STATIC ${OPENCV_3RDPARTY_EXCLUDE_FROM_ALL} ${spng_headers} ${spng_sources})
-ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-variable)
 target_link_libraries(${SPNG_LIBRARY} ${ZLIB_LIBRARIES})
 
 set_target_properties(${SPNG_LIBRARY}

--- a/3rdparty/libspng/LICENSE
+++ b/3rdparty/libspng/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018-2022, Randy <randy408@protonmail.com>
+Copyright (c) 2018-2023, Randy <randy408@protonmail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/3rdparty/libspng/spng.h
+++ b/3rdparty/libspng/spng.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: (BSD-2-Clause AND libpng-2.0) */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #ifndef SPNG_H
 #define SPNG_H
 
@@ -28,7 +28,7 @@ extern "C" {
 
 #define SPNG_VERSION_MAJOR 0
 #define SPNG_VERSION_MINOR 7
-#define SPNG_VERSION_PATCH 3
+#define SPNG_VERSION_PATCH 4
 
 enum spng_errno
 {


### PR DESCRIPTION
Include three fixes:
https://github.com/randy408/libspng/commit/e68ba5df571726bf001d9ea150980463ea395a75 https://github.com/randy408/libspng/commit/6c7c8ce3729bb866eec9e94e426c3221abf402b0 https://github.com/randy408/libspng/commit/c9451cab664794dc909c4580dd1e6e013f3db512

and three chores:
https://github.com/randy408/libspng/commit/d86a11d3ab8f37e7772d52490d3b086d0e0f9bc7 https://github.com/randy408/libspng/commit/bab9f94a1186f8fda234b4e1cb65e1b9a77049cc https://github.com/randy408/libspng/commit/fb768002d4288590083a476af628e51c3f1d47cd

I have reviewed CMakeLists.txt and I think disabling unused-variable warning is not needed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
