### PR TITLE
Fix homepage of libspng

### DIFF
--- a/3rdparty/readme.txt
+++ b/3rdparty/readme.txt
@@ -31,7 +31,7 @@ libpng                Portable Network Graphics library.
                       
 libspng               Portable Network Graphics library.
                       The license and copyright notes can be found in libspng/LICENSE.
-                      See libspng home page https://www.libspng.org
+                      See libspng home page https://libspng.org
                       for details and links to the source code
                       
                       WITH_SPNG CMake option must be ON to add libspng support to imgcodecs


### PR DESCRIPTION
The current one cannot be reached. I replaced it with the one I found in official Github repository https://github.com/randy408/libspng

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
