### PR TITLE
Do not dilate binary images on first iteration in findChessboardCorners

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -531,14 +531,14 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     const int min_dilations = 0;
     const int max_dilations = is_plain ? 0 : 7;
 
-    // Try our standard "1" dilation, but if the pattern is not found, iterate the whole procedure with higher dilations.
-    // This is necessary because some squares simply do not separate properly with a single dilation.  However,
+    // Try our standard "0" and "1" dilations, but if the pattern is not found, iterate the whole procedure with higher dilations.
+    // This is necessary because some squares simply do not separate properly without and with a single dilations. However,
     // we want to use the minimum number of dilations possible since dilations cause the squares to become smaller,
     // making it difficult to detect smaller squares.
     for (int dilations = min_dilations; dilations <= max_dilations; dilations++)
     {
         //USE BINARY IMAGE COMPUTED USING icvBinarizationHistogramBased METHOD
-        if(!is_plain)
+        if(!is_plain && dilations > 0)
             dilate( thresh_img_new, thresh_img_new, Mat(), Point(-1, -1), 1 );
 
         // So we can find rectangles that go to the edge, we draw a white line around the image edge.
@@ -596,13 +596,13 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
                     block_size = block_size | 1;
                     // convert to binary
                     adaptiveThreshold( img, thresh_img, 255, ADAPTIVE_THRESH_MEAN_C, THRESH_BINARY, block_size, (k/2)*5 );
-                    if (dilations > 0)
-                        dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), dilations-1 );
+                    dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), dilations );
 
                 }
                 else
                 {
-                    dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), 1 );
+                    if (dilations > 0)
+                        dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), 1 );
                 }
                 SHOW("Old binarization", thresh_img);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

In some cases quadrangles can be separated already on first binary images and dilation is not needed on first iteration.

Following example was received on 3.2.0 code version with some modern patches. This is a histogram based binarization (first (new) part of algorithm).
![img_bgr](https://github.com/opencv/opencv/assets/25690822/a23a0cd2-8dc6-42cc-a849-547124ef0de9)
![thresh_img_new](https://github.com/opencv/opencv/assets/25690822/3c4905ac-4453-481a-b7b2-14bb9ec9a14f)

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
