### PR TITLE
Fix contradiction on Mat dims >= 2

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2110,7 +2110,7 @@ public:
          - number of channels
      */
     int flags;
-    //! the matrix dimensionality, >= 2
+    //! the matrix dimensionality, >= 2 (can also be 0 when the array is empty)
     int dims;
     //! the number of rows and columns or (-1, -1) when the matrix has more than 2 dimensions
     int rows, cols;
@@ -2591,7 +2591,7 @@ public:
      */
     int flags;
 
-    //! the matrix dimensionality, >= 2
+    //! the matrix dimensionality, >= 2 (can also be 0 when the array is empty)
     int dims;
 
     //! number of rows in the matrix; -1 when the matrix has more than 2 dimensions


### PR DESCRIPTION
The docs of `dims` claimed `>= 2`, but another place in the page says `can also be 0 when the array is empty`, which is the case when `Mat m` is default-constructed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
* Comment-only change.