### PR TITLE
build: suppress warning ARM64 + Visual Studio build

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -1642,7 +1642,7 @@ inline int v_signmask(const v_uint64x2& a)
 #if CV_NEON_AARCH64
     const int64x2_t signPosition = {0,1};
     uint64x2_t v0 = vshlq_u64(vshrq_n_u64(a.val, 63), signPosition);
-    uint64_t t0 = vaddvq_u64(v0);
+    int t0 = (int)vaddvq_u64(v0);
     return t0;
 #else // #if CV_NEON_AARCH64
     int64x1_t m0 = vdup_n_s64(0);


### PR DESCRIPTION
I see couple of warnings appear when building with Visual Studio + ARM64.
The full log is uploaded [here](https://gist.github.com/tomoaki0705/a0c690cd0747e1b63880998c5325460b)

Mainly they are from `carotene` module, so it's not really important, but I'd like to suppress them.
Most of them are implicit conversion from `double` to `float`, so I made them explicitly.

- summary
```
$ grep -i ' warning' log.txt  | sort | uniq -c
      1 C:\opencv\cross_build\carotene\tegra_hal.hpp(1030,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
     48 C:\opencv\modules\core\include\opencv2\core\hal\intrin_neon.hpp(1646,12): warning C4244: 'return': conversion from 'uint64_t' to 'int', possible loss of data
      1 C:\opencv\modules\core\src\arithm.simd.hpp(1559,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
      1 C:\opencv\modules\core\src\arithm.simd.hpp(1678,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
      1 C:\opencv\modules\core\src\arithm.simd.hpp(1826,1): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
      1 C:\opencv\modules\core\src\arithm.simd.hpp(1827,1): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
      1 C:\opencv\modules\core\src\arithm.simd.hpp(1927,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
      1 C:\opencv\modules\imgproc\src\resize.cpp(3784,5): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
```
- intrin_neon.hpp
```
C:\opencv\modules\core\include\opencv2\core\hal\intrin_neon.hpp(1646,12): warning C4244: 'return': conversion from 'uint64_t' to 'int', possible loss of data
(compiling source file 'matmul.neon_dotprod.cpp')
```
- arith.simd.hpp
```
C:\opencv\modules\core\src\arithm.simd.hpp(1559,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/arithm.dispatch.cpp')
C:\opencv\modules\core\src\arithm.simd.hpp(1678,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/arithm.dispatch.cpp')
C:\opencv\modules\core\src\arithm.simd.hpp(1826,1): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/arithm.dispatch.cpp')
C:\opencv\modules\core\src\arithm.simd.hpp(1827,1): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/arithm.dispatch.cpp')
C:\opencv\modules\core\src\arithm.simd.hpp(1927,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/arithm.dispatch.cpp')
```
- tegra_hal.hpp
```
C:\opencv\cross_build\carotene\tegra_hal.hpp(1030,1): warning C4244: 'argument': conversion from 'const double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/core/src/mathfuncs_core.dispatch.cpp')
C:\opencv\cross_build\carotene\tegra_hal.hpp(1030,1):
the template instantiation context (the oldest one first) is
	C:\opencv\modules\core\src\mathfuncs_core.dispatch.cpp(18,5):
	see reference to class template instantiation 'TegraRowOp_phase_Invoker<const carotene_o4t::f32,carotene_o4t::f32>' being compiled
	C:\opencv\cross_build\carotene\tegra_hal.hpp(1030,1):
	while compiling class template member function 'void TegraRowOp_phase_Invoker<const carotene_o4t::f32,carotene_o4t::f32>::operator ()(const cv::Range &) const'
```
- resize.cpp
```
C:\opencv\modules\imgproc\src\resize.cpp(3784,5): warning C4244: 'argument': conversion from 'double' to 'carotene_o4t::f32', possible loss of data
(compiling source file '../../../modules/imgproc/src/resize.cpp')
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
