### PR TITLE
Features to the GUI under QT

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -261,6 +261,15 @@ enum QtButtonTypes {
        QT_NEW_BUTTONBAR = 1024  //!< Button should create a new buttonbar
      };
 
+//! Qt "cursor" type
+enum QtCursorTypes {
+       QT_ARROW_CURSOR     = 0,  //!< Arrow Cursor
+       QT_CROSS_CURSOR     = 2,  //!< Cross Cursor
+       QT_WAIT_CURSOR      = 3,  //!< Wait Cursor
+       QT_OPENHAND_CURSOR  = 17, //!< Open Hand Cursor
+       QT_CLOSEHAND_CURSOR = 18  //!< Close Hand Cursor
+     };
+
 //! @} highgui_qt
 
 /** @brief Callback function for mouse events. see cv::setMouseCallback
@@ -472,6 +481,17 @@ CV_EXPORTS_W Rect getWindowImageRect(const String& winname);
 /** @example samples/cpp/create_mask.cpp
 This program demonstrates using mouse events and how to make and use a mask image (black and white) .
 */
+
+/** @brief Return the window handle
+
+The function getWindowHandle returns the handle of window
+
+@param winname Name of the window.
+
+@sa resizeWindow moveWindow
+ */
+CV_EXPORTS_W void * getWindowHandle(const String& winname);
+
 /** @brief Sets mouse handler for the specified window
 
 @param winname Name of the window.
@@ -838,6 +858,17 @@ value could be 0 or 1. (__Optional__)
 CV_EXPORTS int createButton( const String& bar_name, ButtonCallback on_change,
                              void* userdata = 0, int type = QT_PUSH_BUTTON,
                              bool initial_button_state = false);
+
+
+CV_EXPORTS void centerView(const String& windowName, float factor, Point coord);
+
+CV_EXPORTS void resetZoom(const String& windowName);
+
+CV_EXPORTS void hideNav(const String& windowName);
+
+CV_EXPORTS void showNav(const String& windowName);
+
+CV_EXPORTS void setDefaultCursor(const String& windowName, int shape);
 
 //! @} highgui_qt
 

--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -859,7 +859,6 @@ CV_EXPORTS int createButton( const String& bar_name, ButtonCallback on_change,
                              void* userdata = 0, int type = QT_PUSH_BUTTON,
                              bool initial_button_state = false);
 
-
 CV_EXPORTS void centerView(const String& windowName, float factor, Point coord);
 
 CV_EXPORTS void resetZoom(const String& windowName);

--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -89,6 +89,15 @@ CVAPI(void) cvStopLoop( void );
 typedef void (CV_CDECL *CvButtonCallback)(int state, void* userdata);
 enum {CV_PUSH_BUTTON = 0, CV_CHECKBOX = 1, CV_RADIOBOX = 2};
 CVAPI(int) cvCreateButton( const char* button_name CV_DEFAULT(NULL),CvButtonCallback on_change CV_DEFAULT(NULL), void* userdata CV_DEFAULT(NULL) , int button_type CV_DEFAULT(CV_PUSH_BUTTON), int initial_button_state CV_DEFAULT(0));
+
+CVAPI(void) cvCenterView(const char* name, float factor, CvPoint coord);
+CVAPI(void) cvResetZoom(const char* name);
+CVAPI(void) cvResetZoom(const char* name);
+CVAPI(void) cvHideNav(const char* name);
+CVAPI(void) cvShowNav(const char* name);
+
+CVAPI(void) cvSetDefaultCursor(const char* name, int shape);
+
 //----------------------
 
 

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -1260,27 +1260,27 @@ int cv::createButton(const String&, ButtonCallback, void*, int , bool )
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
 
-void cv::centerView(float, Point)
+void cv::centerView(const String&, float, Point)
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
 
-void cv::resetZoom()
+void cv::resetZoom(const String&)
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
 
-void cv::hideNav()
+void cv::hideNav(const String&)
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
 
-void cv::showNav()
+void cv::showNav(const String&)
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
 
-void cv::setDefaultCursor(int)
+void cv::setDefaultCursor(const String&, int)
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -443,6 +443,14 @@ cv::Rect cv::getWindowImageRect(const String& winname)
 #endif
 }
 
+void * cv::getWindowHandle(const String& winname){
+  
+  CV_TRACE_FUNCTION();
+  
+  return cvGetWindowHandle(winname.c_str());
+  
+}
+
 void cv::namedWindow( const String& winname, int flags )
 {
     CV_TRACE_FUNCTION();
@@ -1170,6 +1178,34 @@ int cv::createButton(const String& button_name, ButtonCallback on_change, void* 
     return cvCreateButton(button_name.c_str(), on_change, userdata, button_type , initial_button_state );
 }
 
+void cv::centerView(const String& windowName, float factor, Point coord)
+{
+  CvPoint _coord;
+  _coord.x = coord.x;
+  _coord.y = coord.y;
+  cvCenterView(windowName.c_str(), factor, _coord);
+}
+
+void cv::resetZoom(const String& windowName)
+{
+  cvResetZoom(windowName.c_str());
+}
+
+void cv::hideNav(const String& windowName)
+{
+  cvHideNav(windowName.c_str());
+}
+
+void cv::showNav(const String& windowName)
+{
+  cvShowNav(windowName.c_str());
+}
+
+void cv::setDefaultCursor(const String& windowName, int shape)
+{
+  cvSetDefaultCursor(windowName.c_str(), shape);
+}
+
 #else
 
 static const char* NO_QT_ERR_MSG = "The library is compiled without QT support";
@@ -1223,6 +1259,32 @@ int cv::createButton(const String&, ButtonCallback, void*, int , bool )
 {
     CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
 }
+
+void cv::centerView(float, Point)
+{
+    CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
+}
+
+void cv::resetZoom()
+{
+    CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
+}
+
+void cv::hideNav()
+{
+    CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
+}
+
+void cv::showNav()
+{
+    CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
+}
+
+void cv::setDefaultCursor(int)
+{
+    CV_Error(CV_StsNotImplemented, NO_QT_ERR_MSG);
+}
+
 
 #endif
 
@@ -1390,6 +1452,31 @@ CV_IMPL void cvSaveWindowParameters(const char* )
 CV_IMPL int cvCreateButton(const char*, void (*)(int, void*), void*, int, int)
 {
     CV_NO_GUI_ERROR("cvCreateButton");
+}
+
+CV_IMPL void cvCenterView(const char*, float , Point)
+{
+    CV_NO_GUI_ERROR("cvCenterView");
+}
+
+CV_IMPL void cvResetZoom(const char*)
+{
+    CV_NO_GUI_ERROR("cvResetZoom");
+}
+
+CV_IMPL void cvHideNav(const char*)
+{
+    CV_NO_GUI_ERROR("cvHideNav");
+}
+
+CV_IMPL void cvShowNav(const char*)
+{
+    CV_NO_GUI_ERROR("cvShowNav");
+}
+
+CV_IMPL void cvSetDefaultCursor(const char*, int)
+{
+    CV_NO_GUI_ERROR("cvSetDefaultCursor");
 }
 
 #endif

--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -339,6 +339,63 @@ CV_IMPL void cvDisplayStatusBar(const char* name, const char* text, int delayms)
         Q_ARG(int, delayms));
 }
 
+CV_IMPL void cvCenterView(const char* name, float factor, CvPoint coord)
+{
+    if (!guiMainThread)
+        CV_Error( CV_StsNullPtr, "NULL guiReceiver (please create a window)" );
+
+    QMetaObject::invokeMethod(guiMainThread,
+        "centerView",
+        autoBlockingConnection(),
+        Q_ARG(QString, QString(name)),
+        Q_ARG(qreal, factor),
+        Q_ARG(QPoint, QPoint(coord.x, coord.y)));
+}
+
+CV_IMPL void cvResetZoom(const char* name)
+{
+    if (!guiMainThread)
+        CV_Error( CV_StsNullPtr, "NULL guiReceiver (please create a window)" );
+
+    QMetaObject::invokeMethod(guiMainThread,
+        "resetZoom",
+        autoBlockingConnection(),
+        Q_ARG(QString, QString(name)));
+}
+
+CV_IMPL void cvHideNav(const char* name)
+{
+    if (!guiMainThread)
+        CV_Error( CV_StsNullPtr, "NULL guiReceiver (please create a window)" );
+
+    QMetaObject::invokeMethod(guiMainThread,
+        "hideNav",
+        autoBlockingConnection(),
+        Q_ARG(QString, QString(name)));
+}
+
+CV_IMPL void cvShowNav(const char* name)
+{
+    if (!guiMainThread)
+        CV_Error( CV_StsNullPtr, "NULL guiReceiver (please create a window)" );
+
+    QMetaObject::invokeMethod(guiMainThread,
+        "showNav",
+        autoBlockingConnection(),
+        Q_ARG(QString, QString(name)));
+}
+
+CV_IMPL void cvSetDefaultCursor(const char* name, int shape)
+{
+    if (!guiMainThread)
+        CV_Error( CV_StsNullPtr, "NULL guiReceiver (please create a window)" );
+
+    QMetaObject::invokeMethod(guiMainThread,
+        "setDefaultCursor",
+        autoBlockingConnection(),
+        Q_ARG(QString, QString(name)),
+        Q_ARG(Qt::CursorShape, Qt::CursorShape(shape)));
+}
 
 CV_IMPL int cvWaitKey(int delay)
 {
@@ -1073,6 +1130,45 @@ void GuiReceiver::displayStatusBar(QString name, QString text, int delayms)
         w->displayStatusBar(text, delayms);
 }
 
+void GuiReceiver::centerView(QString name, qreal factor, QPoint coord)
+{
+    QPointer<CvWindow> w = icvFindWindowByName(name);
+
+    if (w)
+        w->centerView(factor, coord);
+}
+              
+void GuiReceiver::resetZoom(QString name)
+{
+    QPointer<CvWindow> w = icvFindWindowByName(name);
+
+    if (w)
+        w->resetZoom();
+}
+
+void GuiReceiver::hideNav(QString name)
+{
+    QPointer<CvWindow> w = icvFindWindowByName(name);
+
+    if (w)
+        w->hideNav();
+}
+
+void GuiReceiver::showNav(QString name)
+{
+    QPointer<CvWindow> w = icvFindWindowByName(name);
+
+    if (w)
+        w->showNav();
+}
+
+void GuiReceiver::setDefaultCursor(QString name, Qt::CursorShape shape)
+{
+    QPointer<CvWindow> w = icvFindWindowByName(name);
+
+    if (w)
+        w->setDefaultCursor(shape);
+}
 
 void GuiReceiver::showImage(QString name, void* arr)
 {
@@ -2178,6 +2274,30 @@ void CvWindow::showTools()
         myStatusBar->show();
 }
 
+void CvWindow::centerView(qreal factor, QPoint coord)
+{
+  myView->centerView(factor, coord);
+}
+              
+void CvWindow::resetZoom()
+{
+  myView->resetZoom();
+}
+
+void CvWindow::hideNav()
+{
+  myView->hideNav();
+}
+
+void CvWindow::showNav()
+{
+  myView->showNav();
+}
+
+void CvWindow::setDefaultCursor(Qt::CursorShape shape)
+{
+  myView->setDefaultCursor(shape);
+}
 
 CvWinProperties* CvWindow::createParameterWindow()
 {
@@ -2548,6 +2668,8 @@ DefaultViewPort::DefaultViewPort(CvWindow* arg, int arg2) : QGraphicsView(arg), 
     // #13657 Tab key disables arrow keys
     // #20215 QT backend: cv::waitKey() and cv::waitKeyEx() do not capture arrow keys once you click on the image or press TAB
     setFocusPolicy(Qt::NoFocus);
+  
+    drawNav = true;
 }
 
 
@@ -2723,6 +2845,15 @@ void DefaultViewPort::resetZoom()
     controlImagePosition();
 }
 
+void DefaultViewPort::centerView(qreal factor, QPoint coord)
+{
+    resetZoom();
+  
+    float x = (coord.x() * size().width()) / (float)image2Draw_qt.width();
+    float y = (coord.y() * size().height()) / (float)image2Draw_qt.height();
+
+    scaleView(factor, QPointF(x, y));
+}
 
 void DefaultViewPort::ZoomIn()
 {
@@ -2735,6 +2866,21 @@ void DefaultViewPort::ZoomOut()
     scaleView(-0.5, QPointF(size().width() / 2, size().height() / 2));
 }
 
+void DefaultViewPort::hideNav()
+{
+  drawNav = false;
+}
+
+void DefaultViewPort::showNav()
+{
+  drawNav = true;
+}
+
+void DefaultViewPort::setDefaultCursor(Qt::CursorShape shape)
+{
+  setCursor(shape);
+  defaultCursorShape = shape;
+}
 
 //can save as JPG, JPEG, BMP, PNG
 void DefaultViewPort::saveView()
@@ -2877,7 +3023,7 @@ void DefaultViewPort::mouseReleaseEvent(QMouseEvent* evnt)
     icvmouseEvent(evnt, mouse_up);
 
     if (param_matrixWorld.m11()>1)
-        setCursor(Qt::OpenHandCursor);
+        setCursor(defaultCursorShape);
 
     QWidget::mouseReleaseEvent(evnt);
 }
@@ -2929,9 +3075,9 @@ void DefaultViewPort::paintEvent(QPaintEvent* evnt)
     }
 
     //in mode zoom/panning
-    if (param_matrixWorld.m11() > 1)
+    if (param_matrixWorld.m11() > 1 && drawNav)
     {
-        drawViewOverview(&myPainter);
+          drawViewOverview(&myPainter);
     }
 
     //for information overlay
@@ -3009,7 +3155,7 @@ void DefaultViewPort::moveView(QPointF delta)
 }
 
 //factor is -0.5 (zoom out) or 0.5 (zoom in)
-void DefaultViewPort::scaleView(qreal factor,QPointF center)
+void DefaultViewPort::scaleView(qreal factor, QPointF center)
 {
     factor/=5;//-0.1 <-> 0.1
     factor+=1;//0.9 <-> 1.1
@@ -3029,7 +3175,7 @@ void DefaultViewPort::scaleView(qreal factor,QPointF center)
     //inverse the transform
     int a, b;
     matrixWorld_inv.map(center.x(),center.y(),&a,&b);
-
+  
     param_matrixWorld.translate(a-factor*a,b-factor*b);
     param_matrixWorld.scale(factor,factor);
 
@@ -3040,7 +3186,7 @@ void DefaultViewPort::scaleView(qreal factor,QPointF center)
         centralWidget->displayStatusBar(tr("Zoom: %1%").arg(param_matrixWorld.m11()*100),1000);
 
     if (param_matrixWorld.m11()>1)
-        setCursor(Qt::OpenHandCursor);
+        setCursor(defaultCursorShape);
     else
         unsetCursor();
 }
@@ -3129,6 +3275,8 @@ void DefaultViewPort::drawStatusBar()
 //accept only CV_8UC1 and CV_8UC8 image for now
 void DefaultViewPort::drawImgRegion(QPainter *painter)
 {
+  
+  return;
     if (nbChannelOriginImage!=CV_8UC1 && nbChannelOriginImage!=CV_8UC3)
         return;
 
@@ -3231,21 +3379,21 @@ void DefaultViewPort::drawImgRegion(QPainter *painter)
 void DefaultViewPort::drawViewOverview(QPainter *painter)
 {
     QSize viewSize = size();
-    viewSize.scale ( 100, 100,Qt::KeepAspectRatio );
+    viewSize.scale(100, 100, Qt::KeepAspectRatio);
 
-    const int margin = 5;
+    const int margin = 10;
 
     //draw the image's location
     painter->setBrush(QColor(0, 0, 0, 127));
     painter->setPen(Qt::darkGreen);
-    painter->drawRect(QRect(width()-viewSize.width()-margin, 0,viewSize.width(),viewSize.height()));
+    painter->drawRect(QRect(width()-viewSize.width()-margin,margin,viewSize.width(),viewSize.height()));
 
     //daw the view's location inside the image
     qreal ratioSize = 1/param_matrixWorld.m11();
     qreal ratioWindow = (qreal)(viewSize.height())/(qreal)(size().height());
     painter->setPen(Qt::darkBlue);
     painter->drawRect(QRectF(width()-viewSize.width()-positionCorners.left()*ratioSize*ratioWindow-margin,
-        -positionCorners.top()*ratioSize*ratioWindow,
+        -positionCorners.top()*ratioSize*ratioWindow+margin,
         (viewSize.width()-1)*ratioSize,
         (viewSize.height()-1)*ratioSize)
         );
@@ -3407,6 +3555,31 @@ void OpenGlViewPort::setSize(QSize size_)
 {
     size = size_;
     updateGeometry();
+}
+
+void OpenGlViewPort::centerView(qreal factor, QPoint coord) override
+{
+    CV_Error("OpenGL Window doesn't support centerView()");
+}
+
+void OpenGlViewPort::resetZoom() override
+{
+    CV_Error("OpenGL Window doesn't support resetZoom()");
+}
+
+void OpenGlViewPort::hideNav() override
+{
+    CV_Error("OpenGL Window doesn't support hideNav()");
+}
+
+void OpenGlViewPort::showNav() override
+{
+    CV_Error("OpenGL Window doesn't support showNav()");
+}
+
+void OpenGlViewPort::setDefaultCursor((Qt::CursorShape shape) override
+{
+    CV_Error("OpenGL Window doesn't support setDefaultCursor()");
 }
 
 #endif //HAVE_QT_OPENGL

--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -2998,6 +2998,9 @@ void DefaultViewPort::wheelEvent(QWheelEvent* evnt)
     icvmouseEvent((QMouseEvent *)evnt, mouse_wheel);
 
     scaleView(wheelEventDelta(evnt) / 240.0, wheelEventPos(evnt));
+  
+    controlImagePosition();
+
     viewport()->update();
 
     QWidget::wheelEvent(evnt);
@@ -3012,6 +3015,9 @@ void DefaultViewPort::mousePressEvent(QMouseEvent* evnt)
     {
         setCursor(Qt::ClosedHandCursor);
         positionGrabbing = evnt->pos();
+        int x, y;
+        param_matrixWorld.map(positionGrabbing.x(), positionGrabbing.y(),&x,&y);
+        matrixWorld_inv.map(positionGrabbing.x(), positionGrabbing.y(),&x,&y);
     }
 
     QWidget::mousePressEvent(evnt);

--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -155,6 +155,13 @@ public slots:
     void addButton(QString button_name, int button_type, int initial_button_state , void* on_change, void* userdata);
     void enablePropertiesButtonEachWindow();
 
+    void centerView(QString name, qreal factor, QPoint coord);
+    void resetZoom(QString name);
+    void hideNav(QString name);
+    void showNav(QString name);
+  
+    void setDefaultCursor(QString name, Qt::CursorShape shape);
+
     void setOpenGlDrawCallback(QString name, void* callback, void* userdata);
     void setOpenGlContext(QString name);
     void updateWindow(QString name);
@@ -347,6 +354,13 @@ public:
     QPointer<QToolBar> myToolBar;
     QPointer<QLabel> myStatusBar_msg;
 
+    void centerView(qreal factor, QPoint coord);
+    void resetZoom();
+    void hideNav();
+    void showNav();
+  
+    void setDefaultCursor(Qt::CursorShape shape);
+  
 protected:
     virtual void keyPressEvent(QKeyEvent* event) CV_OVERRIDE;
 
@@ -375,6 +389,7 @@ private:
 
     void hideTools();
     void showTools();
+  
     QSize getAvailableSize();
 
 private slots:
@@ -416,6 +431,14 @@ public:
     virtual void updateGl() = 0;
 
     virtual void setSize(QSize size_) = 0;
+  
+    virtual void centerView(qreal factor, QPoint coord) = 0;
+    virtual void resetZoom() = 0;
+    virtual void hideNav() = 0;
+    virtual void showNav() = 0;
+  
+    virtual void setDefaultCursor(Qt::CursorShape shape) = 0;
+
 };
 
 
@@ -528,7 +551,14 @@ public slots:
     void siftWindowOnUp() ;
     void siftWindowOnDown();
 
-    void resetZoom();
+  
+    void centerView(qreal factor, QPoint coord) override;
+    void resetZoom() override;
+    void hideNav() override;
+    void showNav() override;
+  
+    void setDefaultCursor(Qt::CursorShape shape) override;
+
     void imgRegion();
     void ZoomIn();
     void ZoomOut();
@@ -557,7 +587,6 @@ private:
     QImage image2Draw_qt;
     int nbChannelOriginImage;
 
-
     void scaleView(qreal scaleFactor, QPointF center);
     void moveView(QPointF delta);
 
@@ -575,6 +604,10 @@ private:
     bool drawInfo;
     QString infoText;
     QRectF target;
+  
+    bool drawNav;
+  
+    Qt::CursorShape defaultCursorShape;
 
     void drawInstructions(QPainter *painter);
     void drawViewOverview(QPainter *painter);


### PR DESCRIPTION
Hello everyone,

I have added some features to the GUI under QT that I think can be very useful.
 - Resetting the zoom
- Hide/Display the Navigator
- Center the window in a part of the image with a given zoom
- Change the cursor 

I tested the whole thing under macOs and Ubuntu

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
