### PR TITLE
ocl: fix kernels compilation

### DIFF
--- a/modules/dnn/src/opencl/conv_layer_spatial.cl
+++ b/modules/dnn/src/opencl/conv_layer_spatial.cl
@@ -95,23 +95,23 @@
 #define __CAT(x, y) x##y
 #define CAT(x, y) __CAT(x, y)
 #define LOOP0(VAR, STMT)
-#define LOOP1(VAR, STMT) (STMT); (VAR)++;
-#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); (STMT); (VAR)++;
-#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); (STMT); (VAR)++;
-#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); (STMT); (VAR)++;
-#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); (STMT); (VAR)++;
-#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); (STMT); (VAR)++;
-#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); (STMT); (VAR)++;
-#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); (STMT); (VAR)++;
-#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); (STMT); (VAR)++;
-#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); (STMT); (VAR)++;
-#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); (STMT); (VAR)++;
-#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); (STMT); (VAR)++;
-#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); (STMT); (VAR)++;
-#define LOOP14(VAR, STMT) LOOP13(VAR, STMT); (STMT); (VAR)++;
-#define LOOP15(VAR, STMT) LOOP14(VAR, STMT); (STMT); (VAR)++;
-#define LOOP16(VAR, STMT) LOOP15(VAR, STMT); (STMT); (VAR)++;
-#define LOOP(N, VAR, STMT) CAT(LOOP, N)((VAR), (STMT))
+#define LOOP1(VAR, STMT) STMT; (VAR)++;
+#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); STMT; (VAR)++;
+#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); STMT; (VAR)++;
+#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); STMT; (VAR)++;
+#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); STMT; (VAR)++;
+#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); STMT; (VAR)++;
+#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); STMT; (VAR)++;
+#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); STMT; (VAR)++;
+#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); STMT; (VAR)++;
+#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); STMT; (VAR)++;
+#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); STMT; (VAR)++;
+#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); STMT; (VAR)++;
+#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); STMT; (VAR)++;
+#define LOOP14(VAR, STMT) LOOP13(VAR, STMT); STMT; (VAR)++;
+#define LOOP15(VAR, STMT) LOOP14(VAR, STMT); STMT; (VAR)++;
+#define LOOP16(VAR, STMT) LOOP15(VAR, STMT); STMT; (VAR)++;
+#define LOOP(N, VAR, STMT) CAT(LOOP, N)(VAR, STMT)
 
 #if defined(convolve_simd) || defined(Conv_Interleaved)
 #if TYPE == TYPE_HALF

--- a/modules/imgproc/src/opencl/filter2DSmall.cl
+++ b/modules/imgproc/src/opencl/filter2DSmall.cl
@@ -256,21 +256,21 @@ inline PX_LOAD_FLOAT_VEC_TYPE readSrcPixelGroup(int2 pos, __global const uchar* 
 }
 
 // Macros to ensure unrolled loops
-#define LOOP1(VAR, STMT) (STMT); (VAR)++;
-#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); (STMT); (VAR)++;
-#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); (STMT); (VAR)++;
-#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); (STMT); (VAR)++;
-#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); (STMT); (VAR)++;
-#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); (STMT); (VAR)++;
-#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); (STMT); (VAR)++;
-#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); (STMT); (VAR)++;
-#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); (STMT); (VAR)++;
-#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); (STMT); (VAR)++;
-#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); (STMT); (VAR)++;
-#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); (STMT); (VAR)++;
-#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); (STMT); (VAR)++;
+#define LOOP1(VAR, STMT) STMT; (VAR)++;
+#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); STMT; (VAR)++;
+#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); STMT; (VAR)++;
+#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); STMT; (VAR)++;
+#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); STMT; (VAR)++;
+#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); STMT; (VAR)++;
+#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); STMT; (VAR)++;
+#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); STMT; (VAR)++;
+#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); STMT; (VAR)++;
+#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); STMT; (VAR)++;
+#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); STMT; (VAR)++;
+#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); STMT; (VAR)++;
+#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); STMT; (VAR)++;
 
-#define LOOP(N, VAR, STMT) CAT(LOOP, N)((VAR), (STMT))
+#define LOOP(N, VAR, STMT) CAT(LOOP, N)(VAR, STMT)
 
 #define DIG(a) a,
 __constant WT1 kernelData[] = { COEFF };

--- a/modules/imgproc/src/opencl/filterSmall.cl
+++ b/modules/imgproc/src/opencl/filterSmall.cl
@@ -177,21 +177,21 @@ inline PX_LOAD_FLOAT_VEC_TYPE readSrcPixelGroup(int2 pos, __global const uchar *
 }
 
 // Macros to ensure unrolled loops
-#define LOOP1(VAR, STMT) (STMT); (VAR)++;
-#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); (STMT); (VAR)++;
-#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); (STMT); (VAR)++;
-#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); (STMT); (VAR)++;
-#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); (STMT); (VAR)++;
-#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); (STMT); (VAR)++;
-#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); (STMT); (VAR)++;
-#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); (STMT); (VAR)++;
-#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); (STMT); (VAR)++;
-#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); (STMT); (VAR)++;
-#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); (STMT); (VAR)++;
-#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); (STMT); (VAR)++;
-#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); (STMT); (VAR)++;
+#define LOOP1(VAR, STMT) STMT; (VAR)++;
+#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); STMT; (VAR)++;
+#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); STMT; (VAR)++;
+#define LOOP4(VAR, STMT) LOOP3(VAR, STMT); STMT; (VAR)++;
+#define LOOP5(VAR, STMT) LOOP4(VAR, STMT); STMT; (VAR)++;
+#define LOOP6(VAR, STMT) LOOP5(VAR, STMT); STMT; (VAR)++;
+#define LOOP7(VAR, STMT) LOOP6(VAR, STMT); STMT; (VAR)++;
+#define LOOP8(VAR, STMT) LOOP7(VAR, STMT); STMT; (VAR)++;
+#define LOOP9(VAR, STMT) LOOP8(VAR, STMT); STMT; (VAR)++;
+#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); STMT; (VAR)++;
+#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); STMT; (VAR)++;
+#define LOOP12(VAR, STMT) LOOP11(VAR, STMT); STMT; (VAR)++;
+#define LOOP13(VAR, STMT) LOOP12(VAR, STMT); STMT; (VAR)++;
 
-#define LOOP(N, VAR, STMT) CAT(LOOP, N)((VAR), (STMT))
+#define LOOP(N, VAR, STMT) CAT(LOOP, N)(VAR, STMT)
 
 #ifdef OP_BOX_FILTER
 #define PROCESS_ELEM \


### PR DESCRIPTION
Avoid verbose OpenCL compilation messages like:

relates #24734

```
[ RUN      ] DNNTestNetwork.AlexNet/0, where GetParam() = OCV/OCL
...
OpenCL program build log: dnn/conv_layer_spatial
Status 0: CL_SUCCESS
 -D TYPE=1 -D Dtype=float -D Dtype2=float2 -D Dtype4=float4 -D Dtype8=float8 -D Dtype16=float16 -D as_Dtype=as_float -D as_Dtype2=as_float2 -D as_Dtype4=as_float4 -D as_Dtype8=as_float8 -D KERNEL_WIDTH=11 -D KERNEL_HEIGHT=11 -D STRIDE_X=4 -D STRIDE_Y=4 -D DILATION_X=1 -D DILATION_Y=1 -D INPUT_PAD_W=0 -D INPUT_PAD_H=0 -D INPUT_PAD_RIGHT=0 -D INPUT_PAD_BOTTOM=0 -cl-fast-relaxed-math  -D GEMM_LIKE_CONV_32_1 -D Conv_Interleaved=U_GEMM_LIKE_CONV_k11x11_cn3_g1_s4x4_d1x1_b1_in240x240_p0x0_num1_M96_activ1_eltwise0_FP32_5_1_8_32_SIMD8 -cl-mad-enable -cl-no-subgroup-ifp  -D KERNEL_GEMM_LIKE -D INPUT_DEPTH=3 -D WIDTH1=96 -D OUT_PADDING_LEFT=0 -D OUT_PADDING_HEIGHT=0 -D OUT_DEPTH=96 -D NUM_BATCHES=1 -D DY=1 -D DX=32 -D KERNEL_WIDTH_DIV2=5 -D KERNEL_SLICE_DIV2=60 -D TILE_N_LAST=0 -D TILE_N_LAST_DIV8=0 -D APPLY_BIAS=1 -D FUSED_CONV_RELU=1 -D INTEL_DEVICE
3:406:1: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts
LOOP(KERNEL_WIDTH, pos,
^~~~~~~~~~~~~~~~~~~~~~~
3:67:48: note: expanded from macro 'LOOP'
#define LOOP(N, VAR, STMT) CAT(LOOP, N)((VAR), (STMT))
                                               ^
3:61:39: note: expanded from macro 'LOOP11'
#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); (STMT); (VAR)++;
                                      ^~~~
3:60:38: note: expanded from macro 'LOOP10'
#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); (STMT); (VAR)++;
                                     ^~~~
note: (skipping 6 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
3:53:37: note: expanded from macro 'LOOP3'
#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); (STMT); (VAR)++;
                                    ^~~~
3:52:37: note: expanded from macro 'LOOP2'
#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); (STMT); (VAR)++;
                                    ^~~~
3:51:27: note: expanded from macro 'LOOP1'
#define LOOP1(VAR, STMT) (STMT); (VAR)++;
                          ^~~~
3:407:1: note: '{' token is here
{
^
3:67:49: note: expanded from macro 'LOOP'
#define LOOP(N, VAR, STMT) CAT(LOOP, N)((VAR), (STMT))
                                                ^~~~
3:61:39: note: expanded from macro 'LOOP11'
#define LOOP11(VAR, STMT) LOOP10(VAR, STMT); (STMT); (VAR)++;
                                      ^~~~
3:60:38: note: expanded from macro 'LOOP10'
#define LOOP10(VAR, STMT) LOOP9(VAR, STMT); (STMT); (VAR)++;
                                     ^~~~
note: (skipping 6 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
3:53:37: note: expanded from macro 'LOOP3'
#define LOOP3(VAR, STMT) LOOP2(VAR, STMT); (STMT); (VAR)++;
                                    ^~~~
3:52:37: note: expanded from macro 'LOOP2'
#define LOOP2(VAR, STMT) LOOP1(VAR, STMT); (STMT); (VAR)++;
                                    ^~~~
3:51:27: note: expanded from macro 'LOOP1'
#define LOOP1(VAR, STMT) (STMT); (VAR)++;
                          ^~~~
```

Validate with:
- Intel OpenCL device (kernels are guarded by `dev.isIntel()`)
- disabled OpenCL cache in OpenCV: `OPENCV_OPENCL_CACHE_ENABLE=0`
- disable cache in runtime, e.g. `rm -f ~/.cache/neo_compiler_cache`
- enable `CV_OPENCL_ALWAYS_SHOW_BUILD_LOG` in ocl.cpp

relates https://reviews.llvm.org/D86751

```
force_builders=Linux OpenCL,Linux AVX2,Win64 OpenCL
```