### PR TITLE
cmake: brush up the cmake part of merging option

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -484,21 +484,19 @@ macro(ocv_check_compiler_optimization OPT)
 endmacro()
 
 macro(ocv_cpu_aarch64_baseline_merge_feature_options FEATURE_NAME_LIST FLAG_STRING COMMON_OPTION)
-  if(NOT MSVC)
-    unset(_POSTFIX)
-    # Check each feature option
-    foreach(OPT IN LISTS ${FEATURE_NAME_LIST})
-      string(FIND "${${FLAG_STRING}}" "${CPU_${OPT}_FLAGS_ON}" OPT_FOUND)
-      if(NOT ${OPT_FOUND} EQUAL -1)
-        string(REPLACE "${COMMON_OPTION}" "" TRAILING_PART "${CPU_${OPT}_FLAGS_ON}")
-        string(APPEND _POSTFIX "${TRAILING_PART}")
-        string(REPLACE " ${CPU_${OPT}_FLAGS_ON}" "" ${FLAG_STRING} ${${FLAG_STRING}})
-      endif()
-    endforeach()
-    # If more than one option found, merge them
-    if(NOT "x${_POSTFIX}" STREQUAL "x")
-      set(${FLAG_STRING} "${${FLAG_STRING}} ${COMMON_OPTION}${_POSTFIX}")
+  unset(_POSTFIX)
+  # Check each feature option
+  foreach(OPT IN LISTS ${FEATURE_NAME_LIST})
+    string(FIND "${${FLAG_STRING}}" "${CPU_${OPT}_FLAGS_ON}" OPT_FOUND)
+    if(NOT ${OPT_FOUND} EQUAL -1)
+      string(REPLACE "${COMMON_OPTION}" "" TRAILING_PART "${CPU_${OPT}_FLAGS_ON}")
+      string(APPEND _POSTFIX "${TRAILING_PART}")
+      string(REPLACE " ${CPU_${OPT}_FLAGS_ON}" "" ${FLAG_STRING} ${${FLAG_STRING}})
     endif()
+  endforeach()
+  # If more than one option found, merge them
+  if(NOT "x${_POSTFIX}" STREQUAL "x")
+    set(${FLAG_STRING} "${${FLAG_STRING}} ${COMMON_OPTION}${_POSTFIX}")
   endif()
 endmacro()
 
@@ -596,10 +594,12 @@ foreach(OPT ${CPU_KNOWN_OPTIMIZATIONS})
 endforeach()
 
 if(AARCH64)
+  if(NOT MSVC)
     # Define the list of NEON options to check
     set(NEON_OPTIONS_LIST NEON_DOTPROD NEON_FP16 NEON_BF16)
     set(BASE_ARCHITECTURE "-march=armv8.2-a")
     ocv_cpu_aarch64_baseline_merge_feature_options(NEON_OPTIONS_LIST CPU_BASELINE_FLAGS ${BASE_ARCHITECTURE})
+  endif()
 endif()
 
 foreach(OPT ${CPU_BASELINE_REQUIRE})


### PR DESCRIPTION
Sorry for submitting multiple PRs.
This is a follow-up of #24642 and #24698 

I just concluded that `if` section of each compiler should correspond where defining the option and calling the `ocv_cpu_aarch64_baseline_merge_feature_options`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
