### PR TITLE
Increate Vit_b test threshold a bit for CUDA FP16.

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2980,7 +2980,7 @@ TEST_P(Test_ONNX_nets, ViT_B_32) {
     if (target == DNN_TARGET_CUDA_FP16)
     {
         l1 = 0.01;
-        lInf = 0.05;
+        lInf = 0.06;
     }
     if (target == DNN_TARGET_OPENCL_FP16)
     {


### PR DESCRIPTION
Motivation: sporadic test failure like https://github.com/opencv/opencv/actions/runs/7297266682/job/19886377164?pr=24744

```
[ RUN      ] Test_ONNX_nets.ViT_B_32/1, where GetParam() = CUDA/CUDA_FP16
/home/ci/opencv/modules/dnn/test/test_common.impl.hpp:79: Failure
Expected: (normInf) <= (lInf), actual: 0.05369 vs 0.05
ViTB_32  |ref| = 2.8940291404724121
[  FAILED  ] Test_ONNX_nets.ViT_B_32/1, where GetParam() = CUDA/CUDA_FP16 (1352 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
