### PR TITLE
[CUDA] Hotfix Scale with 1 parameter

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/scale_shift.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/scale_shift.hpp
@@ -128,6 +128,9 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             /* the scale shift operation might require broadcasting */
             const int end_axis = [&] {
+                if (num_parameters == 1) {
+                    return static_cast<int>(axis + 1);
+                }
                 for (int endAxis = axis + 1; endAxis <= input.rank(); endAxis++) {
                     if (input.size_range(axis, endAxis) == mid_size)
                         return endAxis;


### PR DESCRIPTION
### Pull Request Readiness Checklist

caused by https://github.com/opencv/opencv/pull/24384

```
[ RUN      ] Test_Darknet_layers.crop/0, where GetParam() = CUDA/CUDA
unknown file: Failure
C++ exception with description "OpenCV(4.8.0-dev) /home/ci/opencv/modules/dnn/src/layers/../cuda4dnn/primitives/scale_shift.hpp:135: error: (-215:Assertion failed) 0 in function 'operator()'
" thrown in the test body.
[  FAILED  ] Test_Darknet_layers.crop/0, where GetParam() = CUDA/CUDA (4 ms)
[ RUN      ] Test_Darknet_layers.crop/1, where GetParam() = CUDA/CUDA_FP16
unknown file: Failure
C++ exception with description "OpenCV(4.8.0-dev) /home/ci/opencv/modules/dnn/src/layers/../cuda4dnn/primitives/scale_shift.hpp:135: error: (-215:Assertion failed) 0 in function 'operator()'
" thrown in the test body.
[  FAILED  ] Test_Darknet_layers.crop/1, where GetParam() = CUDA/CUDA_FP16 (3 ms)
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
