### PR TITLE
Enable Android AAR package build with SDK project itself without Python

### DIFF
--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -225,9 +225,20 @@ include ':${__dir}'
   configure_file("${path}/build.gradle.in" "${ANDROID_TMP_INSTALL_BASE_DIR}/${__dir}/build.gradle" @ONLY)
   install(FILES "${ANDROID_TMP_INSTALL_BASE_DIR}/${__dir}/build.gradle" DESTINATION "${ANDROID_INSTALL_SAMPLES_DIR}/${__dir}" COMPONENT samples)
 
-  file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
+  # HACK: AAR packages generated from current OpenCV project has incomple prefab part
+  # and cannot be used for native linkage against OpenCV.
+  # Alternative way to build AAR: https://github.com/opencv/opencv/blob/4.x/platforms/android/build_java_shared_aar.py
+  if("${__dir}" STREQUAL "tutorial-2-mixedprocessing" OR "${__dir}" STREQUAL "tutorial-4-opencl")
+    file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
+if (gradle.opencv_source == 'sdk_path') {
+    include ':${__dir}'
+}
+")
+  else()
+    file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
 include ':${__dir}'
 ")
+  endif()
 
 endmacro()
 

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -89,6 +89,7 @@
 //
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 @KOTLIN_PLUGIN_DECLARATION@
 
 def openCVersionName = "@OPENCV_VERSION@"
@@ -137,6 +138,17 @@ android {
         }
     }
 
+    buildFeatures {
+        aidl true
+        prefabPublishing true
+        buildConfig true
+    }
+    prefab {
+        opencv_jni_shared {
+            headers "native/jni/include"
+        }
+    }
+
     sourceSets {
         main {
             jniLibs.srcDirs = ['native/libs']
@@ -147,9 +159,36 @@ android {
         }
     }
 
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path (project.projectDir.toString() + '/libcxx_helper/CMakeLists.txt')
+        }
+    }
+}
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId = 'org.opencv'
+            artifactId = 'opencv'
+            version = '@OPENCV_VERSION_PLAIN@'
+
+            afterEvaluate {
+               from components.release
+           }
+        }
+    }
+    repositories {
+        maven {
+            name = 'myrepo'
+            url = "${project.buildDir}/repo"
         }
     }
 }

--- a/modules/java/android_sdk/libcxx_helper/CMakeLists.txt
+++ b/modules/java/android_sdk/libcxx_helper/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
+project(opencv_jni_shared)
+
 # dummy target to bring libc++_shared.so into packages
 add_library(opencv_jni_shared STATIC dummy.cpp)

--- a/platforms/android/build_aar.sh
+++ b/platforms/android/build_aar.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+SDK_DIR=$1
+
+echo "OpenCV Android SDK path: ${SDK_DIR}"
+
+ANDROID_HOME=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-${ANDROID_SDK?Required ANDROID_HOME/ANDROID_SDK/ANDROID_SDK_ROOT}}}
+ANDROID_NDK=${ANDROID_NDK_HOME-${ANDROID_NDK:-${NDKROOT?Required ANDROID_NDK_HOME/ANDROID_NDK/NDKROOT}}}
+
+echo "Android SDK: ${ANDROID_HOME}"
+echo "Android NDK: ${ANDROID_NDK}"
+
+if [ ! -d "${ANDROID_HOME}" ]; then
+  echo "FATAL: Missing Android SDK directory"
+  exit 1
+fi
+if [ ! -d "${ANDROID_NDK}" ]; then
+  echo "FATAL: Missing Android NDK directory"
+  exit 1
+fi
+
+export ANDROID_HOME=${ANDROID_HOME}
+export ANDROID_SDK=${ANDROID_HOME}
+export ANDROID_SDK_ROOT=${ANDROID_HOME}
+
+export ANDROID_NDK=${ANDROID_NDK}
+export ANDROID_NDK_HOME=${ANDROID_NDK}
+
+echo "Cloning OpenCV Android SDK ..."
+rm -rf "aar-build"
+cp -rp "${SDK_DIR}" "aar-build"
+echo "Cloning OpenCV Android SDK ... Done!"
+
+# drop cmake bin name and "bin" folder from path
+echo "ndk.dir=${ANDROID_NDK}" > "aar-build/samples/local.properties"
+echo "cmake.dir=$(dirname $(dirname $(which cmake)))" >> "aar-build/samples/local.properties"
+
+echo "Run gradle ..."
+(cd "aar-build/samples"; ./gradlew ${OPENCV_GRADLE_VERBOSE_OPTIONS:--i} opencv:publishReleasePublicationToMyrepoRepository)
+
+mkdir "maven_repo"
+cp -r aar-build/sdk/build/repo/* ./maven_repo/
+
+echo "#"
+echo "# Done!"
+echo "#"


### PR DESCRIPTION
- Added JavaDoc package build and publishing
- Added Source package build and publishing
- More metadata for publishing
- Disable native samples build with aar, because prefab is not complete yet

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
