### PR TITLE
Fix QR code black/white balance computation

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3340,9 +3340,7 @@ bool QRDetectMulti::checkPoints(vector<Point2f> quadrangle)
         std::swap(quadrangle[1], quadrangle[2]);
     if ((quadrangle[0] - quadrangle[1]).dot(quadrangle[2] - quadrangle[3]) < 0.f)
         std::swap(quadrangle[0], quadrangle[1]);
-    BWCounter s;
-    s += BWCounter::checkOnePair(quadrangle[1], quadrangle[0], quadrangle[2], quadrangle[0], bin_barcode);
-    s += BWCounter::checkOnePair(quadrangle[1], quadrangle[3], quadrangle[2], quadrangle[3], bin_barcode);
+    BWCounter s = BWCounter::checkOnePair(quadrangle[0], quadrangle[1], quadrangle[2], quadrangle[3], bin_barcode);
     const double frac = s.getBWFraction();
     return frac > 0.76 && frac < 1.24;
 }

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3320,13 +3320,13 @@ void QRDetectMulti::fixationPoints(vector<Point2f> &local_point)
 
 class BWCounter
 {
-    size_t white;
-    size_t black;
+    uint64_t sum;
+    uint64_t cnt;
 public:
-    BWCounter(size_t b = 0, size_t w = 0) : white(w), black(b) {}
-    BWCounter& operator+=(const BWCounter& other) { black += other.black; white += other.white; return *this; }
-    void count1(uchar pixel) { if (pixel == 255) white++; else if (pixel == 0) black++; }
-    double getBWFraction() const { return white == 0 ? std::numeric_limits<double>::infinity() : double(black) / double(white); }
+    BWCounter(uint64_t s = 0, uint64_t c = 0) : sum(s), cnt(c) {}
+    BWCounter& operator+=(const BWCounter& other) { sum += other.sum; cnt += other.cnt; return *this; }
+    void count1(uchar pixel) { sum += pixel; cnt++; }
+    double getBWFraction() const { return sum == 0 ? std::numeric_limits<double>::infinity() : (double(255 * cnt - sum)) / double(sum); }
     static BWCounter checkCorners(const std::vector<Point2f> &points, const Mat& img)
     {
         BWCounter res;

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3047,13 +3047,6 @@ protected:
     vector<Point2f> not_resized_loc_points;
     vector<Point2f> resized_loc_points;
     vector< vector< Point2f > > localization_points, transformation_points;
-    struct compareDistanse_y
-    {
-        bool operator()(const Point2f& a, const Point2f& b) const
-        {
-            return a.y < b.y;
-        }
-    };
     struct compareSquare
     {
         const vector<Point2f>& points;
@@ -3343,7 +3336,10 @@ bool QRDetectMulti::checkPoints(vector<Point2f> quadrangle)
 {
     if (quadrangle.size() != 4)
         return false;
-    std::sort(quadrangle.begin(), quadrangle.end(), compareDistanse_y());
+    if (norm(quadrangle[0] - quadrangle[1]) > norm(quadrangle[0] - quadrangle[2]))
+        std::swap(quadrangle[1], quadrangle[2]);
+    if ((quadrangle[0] - quadrangle[1]).dot(quadrangle[2] - quadrangle[3]) < 0.f)
+        std::swap(quadrangle[0], quadrangle[1]);
     BWCounter s;
     s += BWCounter::checkOnePair(quadrangle[1], quadrangle[0], quadrangle[2], quadrangle[0], bin_barcode);
     s += BWCounter::checkOnePair(quadrangle[1], quadrangle[3], quadrangle[2], quadrangle[3], bin_barcode);

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -614,4 +614,21 @@ TEST(Objdetect_QRCode_detectAndDecode, utf8_output)
     EXPECT_NE(decoded_info.find("M\xc3\xbcllheimstrasse"), std::string::npos);
 }
 
+TEST_P(Objdetect_QRCode_detectAndDecodeMulti, detect_regression_24679)
+{
+    const std::string name_current_image = "issue_24679.png";
+    const std::string root = "qrcode/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat img = imread(image_path);
+    const std::string method = GetParam();
+    GraphicalCodeDetector qrcode = QRCodeDetector();
+    if (method == "aruco_based") {
+        qrcode = QRCodeDetectorAruco();
+    }
+    std::vector<cv::String> decoded_info;
+    ASSERT_TRUE(qrcode.detectAndDecodeMulti(img, decoded_info));
+    EXPECT_EQ(decoded_info.size(), 4U);
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

This fixes #24679. The issue seems to be that for the black/white balance computation, the corners of the QR code are not sorted properly in case the QR code is axis aligned. This leads to one QR code in the example image being rejected in a specific orientation.

Related PR for extra: https://github.com/opencv/opencv_extra/pull/1133

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
