### PR TITLE
Document read-only check in Python bindings

### DIFF
--- a/doc/py_tutorials/py_bindings/py_bindings_basics/py_bindings_basics.markdown
+++ b/doc/py_tutorials/py_bindings/py_bindings_basics/py_bindings_basics.markdown
@@ -79,9 +79,12 @@ Functions are extended using `CV_EXPORTS_W` macro. An example is shown below.
 @code{.cpp}
 CV_EXPORTS_W void equalizeHist( InputArray src, OutputArray dst );
 @endcode
-Header parser can understand the input and output arguments from keywords like
-InputArray, OutputArray etc. But sometimes, we may need to hardcode inputs and outputs. For that,
-macros like `CV_OUT`, `CV_IN_OUT` etc. are used.
+Header parser can understand the input and output arguments from keywords like InputArray,
+OutputArray etc. The arguments semantics are kept in Python: anything that is modified in C++
+will be modified in Python. And vice-versa read-only Python objects cannot be modified by OpenCV,
+if they are used as output. Such situation will cause Python exception. Sometimes, the parameters
+that are passed by reference in C++ may be used as input, output or both.
+Macros `CV_OUT`, `CV_IN_OUT` allow to solve ambiguity and generate correct bindings.
 @code{.cpp}
 CV_EXPORTS_W void minEnclosingCircle( InputArray points,
                                      CV_OUT Point2f& center, CV_OUT float& radius );


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24522
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
