### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2023.12

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/4.x_20230622
-# Binaries were created for OpenCV: 61d48dd0f8d1cc1a115d26998705a61478f64a3c
-ocv_update(FFMPEG_BINARIES_COMMIT "7da61f0695eabf8972a2c302bf1632a3d99fb0d5")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "4aaef1456e282e5ef665d65555f47f56")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "38a638851e064c591ce812e27ed43f1f")
+# Binaries branch name: ffmpeg/4.x_20231225
+# Binaries were created for OpenCV: 62f1a7410d5e5e03d6cee5c95549bf61d5ee98db
+ocv_update(FFMPEG_BINARIES_COMMIT "fbac408a47977ee4265f39e7659d33f1dfef5216")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "9b755ecbbade0a5b78332e9b4ef2dd1b")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "cb4db51ee9a423e6168b9d08bee61efc")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -240,9 +240,6 @@ typedef testing::TestWithParam< videoio_encapsulate_params_t > videoio_encapsula
 
 TEST_P(videoio_encapsulate, write)
 {
-#ifdef _WIN32
-    throw SkipTestException("Test disabled until PR for raw video encapsulation is merged and windows dll is updated");
-#else
     const VideoCaptureAPIs api = CAP_FFMPEG;
     if (!videoio_registry::hasBackend(api))
         throw SkipTestException("FFmpeg backend was not found");
@@ -316,7 +313,6 @@ TEST_P(videoio_encapsulate, write)
     }
 
     ASSERT_EQ(0, remove(fileNameOut.c_str()));
-#endif
 }
 
 const videoio_encapsulate_params_t videoio_encapsulate_params[] =
@@ -351,9 +347,6 @@ INSTANTIATE_TEST_CASE_P(/**/, videoio_encapsulate, testing::ValuesIn(videoio_enc
 
 TEST(videoio_encapsulate_set_idr, write)
 {
-#ifdef _WIN32
-    throw SkipTestException("Test disabled until PR for raw video encapsulation is merged and windows dll is updated");
-#else
     const VideoCaptureAPIs api = CAP_FFMPEG;
     if (!videoio_registry::hasBackend(api))
         throw SkipTestException("FFmpeg backend was not found");
@@ -390,7 +383,7 @@ TEST(videoio_encapsulate_set_idr, write)
                 memcpy(rawFrame.data, extraData.data, extraData.total());
                 memcpy(rawFrame.data + extraData.total(), tmp.data, tmp.total());
             }
-            if (static_cast<bool>(capRaw.get(CAP_PROP_LRF_HAS_KEY_FRAME)))
+            if (capRaw.get(CAP_PROP_LRF_HAS_KEY_FRAME) != 0)
                 container.set(VideoWriterProperties::VIDEOWRITER_PROP_KEY_FLAG, 1);
             else
                 container.set(VideoWriterProperties::VIDEOWRITER_PROP_KEY_FLAG, 0);
@@ -432,7 +425,6 @@ TEST(videoio_encapsulate_set_idr, write)
     }
 
     ASSERT_EQ(0, remove(fileNameOut.c_str()));
-#endif
 }
 
 typedef tuple<string, string, int> videoio_skip_params_t;
@@ -677,7 +669,6 @@ static void ffmpeg_check_read_raw(VideoCapture& cap)
     EXPECT_TRUE(data.rows == 1 || data.cols == 1) << data.size;
     EXPECT_EQ((size_t)37118, data.total());
 
-#ifndef WIN32
     // 12 is the nearset key frame to frame 18
     EXPECT_TRUE(cap.set(CAP_PROP_POS_FRAMES, 18.));
     EXPECT_EQ(cap.get(CAP_PROP_POS_FRAMES), 12.);
@@ -685,7 +676,6 @@ static void ffmpeg_check_read_raw(VideoCapture& cap)
     EXPECT_EQ(CV_8UC1, data.type()) << "CV_8UC1 != " << typeToString(data.type());
     EXPECT_TRUE(data.rows == 1 || data.cols == 1) << data.size;
     EXPECT_EQ((size_t)8726, data.total());
-#endif
 }
 
 TEST(videoio_ffmpeg, ffmpeg_check_extra_data)
@@ -719,9 +709,7 @@ TEST(videoio_ffmpeg, open_with_property)
     // confirm properties are returned without initializing AVCodecContext
     EXPECT_EQ(cap.get(CAP_PROP_FORMAT), -1);
     EXPECT_EQ(static_cast<int>(cap.get(CAP_PROP_FOURCC)), fourccFromString("FMP4"));
-#ifndef WIN32
     EXPECT_EQ(cap.get(CAP_PROP_N_THREADS), 0.0);
-#endif
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_HEIGHT), 384.0);
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_WIDTH), 672.0);
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_COUNT), 125);
@@ -742,9 +730,7 @@ TEST(videoio_ffmpeg, create_with_property)
     // confirm properties are returned without initializing AVCodecContext
     EXPECT_TRUE(cap.get(CAP_PROP_FORMAT) == -1);
     EXPECT_EQ(static_cast<int>(cap.get(CAP_PROP_FOURCC)), fourccFromString("FMP4"));
-#ifndef WIN32
     EXPECT_EQ(cap.get(CAP_PROP_N_THREADS), 0.0);
-#endif
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_HEIGHT), 384.0);
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_WIDTH), 672.0);
     EXPECT_EQ(cap.get(CAP_PROP_FRAME_COUNT), 125);


### PR DESCRIPTION
**Merge with 3rdparty**: https://github.com/opencv/opencv_3rdparty/pull/80

- FFmpeg 4.4.4
- OpenH264 version 1.8.0
- libVPX version 1.13.1
- libAOM version 3.8.0

previous update: #23846

```
force_builders=Win64,Win32
```