### PR TITLE
Changed onnx weights of yolov7

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2797,7 +2797,7 @@ TEST_P(Test_ONNX_nets, YOLOv7)
         CV_TEST_TAG_DEBUG_VERYLONG
     );
 
-    std::string weightPath = _tf("models/yolov7_not_simplified.onnx", false);
+    std::string weightPath = _tf("models/yolov7.onnx", false);
     // Reference, which is collected with input size of 640x640
     std::vector<int> refClassIds{1, 16, 7};
     std::vector<float> refScores{0.9614331f, 0.9589417f, 0.8679074f};


### PR DESCRIPTION
This pull request changes weights of yolov7 model. This was required as the onnx graph of the previous yolov7 outputted detections and **as well as features maps of the model**. Having vector of 4 tensors would make [unification of API for YOLO models](https://github.com/opencv/opencv/pull/24691#discussion_r1435033606) problematic, thus change was required.

Weights are located in this PR [#1134](https://github.com/opencv/opencv_extra/pull/1134)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
