### PR TITLE
Remove exception for NaryEltwise

### DIFF
--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -737,7 +737,7 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
                           inp_i_data->layerInstance->type != "Permute" &&
                           inp_i_data->layerInstance->type != "Reorg" &&
                           inp_i_data->layerInstance->type != "Eltwise" &&
-                          inp_i_data->layerInstance->type != "NaryEltwise" &&
+                        //   inp_i_data->layerInstance->type != "NaryEltwise" &&
                           inp_i_data->layerInstance.dynamicCast<ActivationLayer>().empty())))
                     {
                         break;

--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -737,7 +737,7 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
                           inp_i_data->layerInstance->type != "Permute" &&
                           inp_i_data->layerInstance->type != "Reorg" &&
                           inp_i_data->layerInstance->type != "Eltwise" &&
-                        //   inp_i_data->layerInstance->type != "NaryEltwise" &&
+                        //   inp_i_data->layerInstance->type != "NaryEltwise" && // link to the issue: https://github.com/opencv/opencv/issues/24721
                           inp_i_data->layerInstance.dynamicCast<ActivationLayer>().empty())))
                     {
                         break;

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1520,7 +1520,6 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
 
 TEST_P(Test_ONNX_layers, Cuda_concat)
 {
-    // testONNXModels("matmul_concat", npy, 0, 0, false, false, 1);
     String basename = "matmul_concat";
     Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
     Net net_cuda = readNetFromONNX(_tf("models/" + basename + ".onnx"));

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1518,6 +1518,32 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
     testONNXModels("einsum_const_inputs", npy, 0, 0, false, false, 1);
 }
 
+TEST_P(Test_ONNX_layers, Cuda_concat)
+{
+    // testONNXModels("matmul_concat", npy, 0, 0, false, false, 1);
+    String basename = "matmul_concat";
+    Net net = readNetFromONNX(_tf("models/" + basename + ".onnx"));
+    Net net_cuda = readNetFromONNX(_tf("models/" + basename + ".onnx"));
+
+    ASSERT_FALSE(net.empty());
+    ASSERT_FALSE(net_cuda.empty());
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    net_cuda.setPreferableBackend(backend);
+    net_cuda.setPreferableTarget(target);
+
+    Mat input = blobFromNPY(_tf("data/input_" + basename + ".npy"));
+
+    net.setInput(input);
+    net_cuda.setInput(input);
+
+    Mat out = net.forward();
+    Mat out_cuda = net.forward();
+    normAssert(out, out_cuda, "", default_l1, default_lInf);
+}
+
 TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 {
     testONNXModels("ReflectionPad2d");


### PR DESCRIPTION
This is **an experimental PR** to check what fails if exception for NaryEltwise is removed. This PR is based on suggestion made in #24721

Data for this PR is located in [1136](https://github.com/opencv/opencv_extra/pull/1136) 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
