### PR TITLE
Let call site know if decoding to a supplied memory buffer succeeded or not

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -307,6 +307,14 @@ reallocations when the function is called repeatedly for images of the same size
 */
 CV_EXPORTS Mat imdecode( InputArray buf, int flags, Mat* dst);
 
+/** @overload
+@param buf
+@param flags
+@param dst The output placeholder for the decoded matrix. It can save the image
+reallocations when the function is called repeatedly for images of the same size.
+*/
+CV_EXPORTS bool imdecode(InputArray buf, int flags, Mat& dst);
+
 /** @brief Reads a multi-page image from a buffer in memory.
 
 The function imdecodemulti reads a multi-page image from the specified buffer in the memory. If the buffer is too short or

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -929,6 +929,14 @@ Mat imdecode( InputArray _buf, int flags, Mat* dst )
     return *dst;
 }
 
+bool imdecode(InputArray _buf, int flags, Mat& dst)
+{
+    CV_TRACE_FUNCTION();
+
+    Mat buf = _buf.getMat();
+    return imdecode_(buf, flags, dst);
+}
+
 static bool
 imdecodemulti_(const Mat& buf, int flags, std::vector<Mat>& mats, int start, int count)
 {

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -218,6 +218,18 @@ void test_image_io(const Mat& image, const std::string& fname, const std::string
         waitKey();
     }
 #endif
+
+    buf_loaded.setTo(0);
+    const auto* data_before = buf_loaded.data;
+    bool success = imdecode(Mat(buf), imreadFlag, buf_loaded);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(buf_loaded.data, data_before);
+    EXPECT_EQ(0, cv::norm(loaded, buf_loaded, NORM_INF));
+
+    std::fill(buf.begin(), buf.end(), static_cast<uchar>(0));
+    success = imdecode(Mat(buf), imreadFlag, buf_loaded);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(buf_loaded.data, data_before);
 }
 
 TEST_P(Imgcodecs_Image, read_write_BGR)


### PR DESCRIPTION
Problem: when using the version of `imdecode` that caters for avoiding memory reallocations, there appears to be no (reliable) way to know if decoding succeeded, and the image data in the supplied memory buffer is valid.

Proposed solution: add a new wrapper around `imdecode_`: one that takes a _required_ (and not optional) placeholder for the decoded matrix, and returns a `bool` value indicating if the decoding succeeded, and the image data in the supplied memory buffer is usable to begin with.

Alternative solutions considered:
- Add a new optional output argument (e.g., having type `bool*` defaulting to `nullptr`) to the relevant existing version of `imdecode`, and set it to the return value of `imdecode_`. Doing so would however change the function's signature, possibly causing ABI compatibility issues.
- Change the existing version of `imdecode` to `return` an empty `Mat` (and not `*dst`) in case the call to `imdecode_` returns `false` (while keeping `dst` intact). However, doing so might conceivably break some existing applications out there, if they rely on the current behavior.
- Change `imdecode_` to `release()` its `mat` argument in _all_ error cases (in particular, when no decoder is found). However, doing so appears to be wasteful; remember that we wanted to avoid memory reallocations in the first place. (Although admittedly this is already happening in case a decoder is found, but it fails to decode the data.)

NB: If any of the above alternative solutions sounds more appealing to the maintainer(s), I am fine switching to one of them. Or if there is a better solution, please let me know.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
      – _it looks like 4.x is still the default branch, so it sounds appropriate to me – but if not, then feel free to advise_
- [ ] There is a reference to the original bug report and related work
      – _the problem is described in the PR itself_
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
      – _there are some tests, but no performance tests for example, because arguably not really applicable in this case_
- [ ] The feature is well documented and sample code can be built with the project CMake
      – _there is no sample code, but the feature is kind of trivial_
