### PR TITLE
core: try to solve warnings caused by Apple's new LAPACK interface

### DIFF
--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -106,14 +106,25 @@ macro(ocv_lapack_check)
       list(APPEND __link_directories ${LAPACK_LINK_LIBRARIES})
     endif()
 
+    set(LAPACK_TRY_COMPILE_DEF "")
+    if(LAPACK_IMPL STREQUAL "LAPACK/Apple") # https://github.com/opencv/opencv/issues/24660
+      set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
+      # TODO: Need to find a way detecting macOS / iOS versions
+      #       enbale if macOS >= 13.3 or iOS >= 16.4
+      # add_compile_definitions(ACCELERATE_NEW_LAPACK)
+      # add_compile_definitions(ACCELERATE_LAPACK_ILP64)
+    endif()
+
     try_compile(__VALID_LAPACK
         "${OpenCV_BINARY_DIR}"
         "${OpenCV_SOURCE_DIR}/cmake/checks/lapack_check.cpp"
         CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${LAPACK_INCLUDE_DIR}\;${CMAKE_BINARY_DIR}"
                     "-DLINK_DIRECTORIES:STRING=${__link_directories}"
+        COMPILE_DEFINITIONS ${LAPACK_TRY_COMPILE_DEF}
         LINK_LIBRARIES ${LAPACK_LIBRARIES}
         OUTPUT_VARIABLE TRY_OUT
     )
+    message(STATUS "-------------LAPACK valid check: ${TRY_OUT}")
     if(NOT __VALID_LAPACK)
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
           "\nLAPACK(${LAPACK_IMPL}) check FAILED:\n"

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -140,7 +140,6 @@ macro(ocv_lapack_check)
         LINK_LIBRARIES ${LAPACK_LIBRARIES}
         OUTPUT_VARIABLE TRY_OUT
     )
-    message(STATUS "-------------LAPACK valid check: ${TRY_OUT}")
     if(NOT __VALID_LAPACK)
       file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
           "\nLAPACK(${LAPACK_IMPL}) check FAILED:\n"

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -108,11 +108,27 @@ macro(ocv_lapack_check)
 
     set(LAPACK_TRY_COMPILE_DEF "")
     if(LAPACK_IMPL STREQUAL "LAPACK/Apple") # https://github.com/opencv/opencv/issues/24660
-      set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
       # TODO: Need to find a way detecting macOS / iOS versions
       #       enbale if macOS >= 13.3 or iOS >= 16.4
-      # add_compile_definitions(ACCELERATE_NEW_LAPACK)
-      # add_compile_definitions(ACCELERATE_LAPACK_ILP64)
+
+      # Get macOS version
+      execute_process(COMMAND sw_vers -productVersion
+                      OUTPUT_VARIABLE MACOS_VERSION
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+      # Extract major and minor versions
+      string(REGEX MATCHALL "[0-9]+" MACOS_VERSION_NUMBER_LIST ${MACOS_VERSION})
+      list(LENGTH MACOS_VERSION_NUMBER_LIST MACOS_VERSION_NUMBER_LIST_LENGTH)
+      if(MACOS_VERSION_NUMBER_LIST_LENGTH GREATER_EQUAL 2)
+        list(GET MACOS_VERSION_NUMBER_LIST 0 MACOS_MAJOR_VERSION)
+        list(GET MACOS_VERSION_NUMBER_LIST 1 MACOS_MINOR_VERSION)
+      endif()
+      # Enable Accelerate New LAPACK if macOS >= 13.3
+      if(MACOS_MAJOR_VERSION GREATER_EQUAL 13 AND MACOS_MINOR_VERSION GREATER_EQUAL 3)
+        set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
+        add_compile_definitions(ACCELERATE_NEW_LAPACK)
+        add_compile_definitions(ACCELERATE_LAPACK_ILP64)
+      endif()
     endif()
 
     try_compile(__VALID_LAPACK

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -107,24 +107,13 @@ macro(ocv_lapack_check)
     endif()
 
     set(LAPACK_TRY_COMPILE_DEF "")
-    if(LAPACK_IMPL STREQUAL "LAPACK/Apple") # https://github.com/opencv/opencv/issues/24660
-      # TODO: Need to find a way detecting macOS / iOS versions
-      #       enbale if macOS >= 13.3 or iOS >= 16.4
-
+    if(LAPACK_IMPL STREQUAL "LAPACK/Apple" AND NOT IOS) # https://github.com/opencv/opencv/issues/24660
       # Get macOS version
       execute_process(COMMAND sw_vers -productVersion
                       OUTPUT_VARIABLE MACOS_VERSION
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-      # Extract major and minor versions
-      string(REGEX MATCHALL "[0-9]+" MACOS_VERSION_NUMBER_LIST ${MACOS_VERSION})
-      list(LENGTH MACOS_VERSION_NUMBER_LIST MACOS_VERSION_NUMBER_LIST_LENGTH)
-      if(MACOS_VERSION_NUMBER_LIST_LENGTH GREATER_EQUAL 2)
-        list(GET MACOS_VERSION_NUMBER_LIST 0 MACOS_MAJOR_VERSION)
-        list(GET MACOS_VERSION_NUMBER_LIST 1 MACOS_MINOR_VERSION)
-      endif()
       # Enable Accelerate New LAPACK if macOS >= 13.3
-      if(MACOS_MAJOR_VERSION GREATER_EQUAL 13 AND MACOS_MINOR_VERSION GREATER_EQUAL 3)
+      if (MACOS_VERSION VERSION_GREATER_EQUAL "13.3")
         set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
         add_compile_definitions(ACCELERATE_NEW_LAPACK)
         add_compile_definitions(ACCELERATE_LAPACK_ILP64)

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -113,7 +113,7 @@ macro(ocv_lapack_check)
                       OUTPUT_VARIABLE MACOS_VERSION
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
       # Enable Accelerate New LAPACK if macOS >= 13.3
-      if (MACOS_VERSION VERSION_GREATER_EQUAL "13.3")
+      if (MACOS_VERSION VERSION_GREATER "13.3" OR MACOS_VERSION VERSION_EQUAL "13.3")
         set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
         add_compile_definitions(ACCELERATE_NEW_LAPACK)
         add_compile_definitions(ACCELERATE_LAPACK_ILP64)

--- a/cmake/checks/lapack_check.cpp
+++ b/cmake/checks/lapack_check.cpp
@@ -9,9 +9,6 @@ static char* check_fn4 = (char*)sgesdd_;
 int main(int argc, char* argv[])
 {
     (void)argv;
-#if ACCELERATE_NEW_LAPACK
-    printf("ACCELERATE_NEW_LAPACK=1");
-#endif
     if(argc > 1000)
         return check_fn1[0] + check_fn2[0] + check_fn3[0] + check_fn4[0];
     return 0;

--- a/cmake/checks/lapack_check.cpp
+++ b/cmake/checks/lapack_check.cpp
@@ -9,6 +9,9 @@ static char* check_fn4 = (char*)sgesdd_;
 int main(int argc, char* argv[])
 {
     (void)argv;
+#if ACCELERATE_NEW_LAPACK
+    printf("ACCELERATE_NEW_LAPACK=1");
+#endif
     if(argc > 1000)
         return check_fn1[0] + check_fn2[0] + check_fn3[0] + check_fn4[0];
     return 0;

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -521,6 +521,8 @@ lapack_gemm_c(const fptype *src1, size_t src1_step, const fptype *src2, size_t s
     int lddst = (int)(dst_step / sizeof(std::complex<fptype>));
     int c_m, c_n, d_m;
     CBLAS_TRANSPOSE transA, transB;
+    std::complex<fptype> cAlpha(alpha, 0.0);
+    std::complex<fptype> cBeta(beta, 0.0);
 
     if(flags & CV_HAL_GEMM_2_T)
     {
@@ -582,8 +584,6 @@ lapack_gemm_c(const fptype *src1, size_t src1_step, const fptype *src2, size_t s
     // FIXME: this is a workaround. Support ILP64 in HAL API.
 #if defined (ACCELERATE_NEW_LAPACK) && defined (ACCELERATE_LAPACK_ILP64)
     int M = a_m, N = d_n, K = a_n;
-    std::complex<fptype> cAlpha(alpha, 0.0);
-    std::complex<fptype> cBeta(beta, 0.0);
     if(typeid(fptype) == typeid(float)) {
         auto src1_cast = (std::complex<float>*)(src1);
         auto src2_cast = (std::complex<float>*)(src2);

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -119,7 +119,7 @@ lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int*
     long _info[1];
 #else
     int* piv = new int[m];
-    int lda = (int)(a_step / sizeof(fptype)); 
+    int lda = (int)(a_step / sizeof(fptype));
     int _m = m, _n = n;
     int* _info = info;
 #endif
@@ -342,7 +342,7 @@ lapack_QR(fptype* a, size_t a_step, int m, int n, int k, fptype* b, size_t b_ste
 
     std::vector<fptype> tmpAMemHolder;
     fptype* tmpA;
-    
+
     if (m == n)
     {
         transpose_square_inplace(a, lda, m);

--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -112,16 +112,17 @@ template <typename fptype> static inline int
 lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int* info)
 {
 #if defined (ACCELERATE_NEW_LAPACK) && defined (ACCELERATE_LAPACK_ILP64)
-    long* piv = new long[m];
+    cv::AutoBuffer<long> piv_buff(m);
     long lda = (long)(a_step / sizeof(fptype));
     long _m = static_cast<long>(m), _n = static_cast<long>(n);
     long _info[1];
 #else
-    int* piv = new int[m];
+    cv::AutoBuffer<int> piv_buff(m);
     int lda = (int)(a_step / sizeof(fptype));
     int _m = m, _n = n;
     int* _info = info;
 #endif
+    auto piv = piv_buff.data();
 
     transpose_square_inplace(a, lda, m);
 
@@ -172,7 +173,6 @@ lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int*
     else
         *info = 0; //in opencv LU function zero means error
 
-    delete[] piv;
     return CV_HAL_ERROR_OK;
 }
 
@@ -238,7 +238,7 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
     long ldv = (long)(v_step / sizeof(fptype));
     long ldu = (long)(u_step / sizeof(fptype));
     long lwork = -1;
-    long* iworkBuf = new long[8*std::min(m, n)];
+    cv::AutoBuffer<long> iworkBuf_(8 * std::min(m, n));
 #else
     int _m = m, _n = n;
     int* _info = info;
@@ -246,8 +246,9 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
     int ldv = (int)(v_step / sizeof(fptype));
     int ldu = (int)(u_step / sizeof(fptype));
     int lwork = -1;
-    int* iworkBuf = new int[8*std::min(m, n)];
+    cv::AutoBuffer<int> iworkBuf_(8 * std::min(m, n));
 #endif
+    auto iworkBuf = iworkBuf_.data();
     fptype work1 = 0;
 
     //A already transposed and m>=n
@@ -313,7 +314,6 @@ lapack_SVD(fptype* a, size_t a_step, fptype *w, fptype* u, size_t u_step, fptype
         delete[] u;
     }
 
-    delete[] iworkBuf;
     delete[] buffer;
     return CV_HAL_ERROR_OK;
 }


### PR DESCRIPTION
Resolves https://github.com/opencv/opencv/issues/24660

Apple's BLAS documentation: https://developer.apple.com/documentation/accelerate/blas?language=objc

New interface since macOS >= 13.3, iOS >= 16.4.

Todo:

- [x] Detect macOS version.
- [x] ~Detect iOS versions (major and minor version).~ No calling of Accelerate New LAPACK on iOS.
- [x] Solve calling `cblas_cgemm` and `cblas_zgemm`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
