### PR TITLE
Link libacl_dvpp_mpi library when building with CANN backend

### DIFF
--- a/cmake/OpenCVFindCANN.cmake
+++ b/cmake/OpenCVFindCANN.cmake
@@ -57,6 +57,18 @@ if(CANN_INSTALL_DIR)
         set(HAVE_CANN OFF)
         return()
     endif()
+
+    #  * libacl_dvpp_mpi.so
+    set(libacl_dvpp_mpi "${CANN_INSTALL_DIR}/lib64")
+    find_library(found_libacldvppmpi NAMES acl_dvpp_mpi PATHS ${libacl_dvpp_mpi} NO_DEFAULT_PATH)
+    if(found_libacldvppmpi)
+        set(libacl_dvpp_mpi ${found_libacldvppmpi})
+        message(STATUS "CANN: libacl_dvpp_mpi.so is found at ${libacl_dvpp_mpi}")
+    else()
+        message(STATUS "CANN: Missing libacl_dvpp_mpi.so. Turning off HAVE_CANN")
+        set(HAVE_CANN OFF)
+        return()
+    endif()
     #  * libgraph.so
     set(lib_graph "${CANN_INSTALL_DIR}/compiler/lib64")
     find_library(found_lib_graph NAMES graph PATHS ${lib_graph} NO_DEFAULT_PATH)
@@ -105,6 +117,7 @@ if(CANN_INSTALL_DIR)
     list(APPEND libs_cann ${lib_opsproto})
     list(APPEND libs_cann ${lib_graph})
     list(APPEND libs_cann ${lib_ge_compiler})
+    list(APPEND libs_cann ${libacl_dvpp_mpi})
 
     #  * lib_graph_base.so
     if(NOT CANN_VERSION_BELOW_6_3_ALPHA002)


### PR DESCRIPTION
Ascend NPU is a series of AI processors. [hiascend](https://www.hiascend.com/). And Compute Architecture for Neural Network (CANN) is a set of computing architectures that serves NPU and programming.

This commit links the libacl_dvpp_mpi library when building with CANN backend. For implementation, please refer to https://github.com/opencv/opencv_contrib/pull/3608.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [N/A] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
