### PR TITLE
Fix aruco detector thread safety.

### DIFF
--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -780,7 +780,7 @@ struct ArucoDetector::ArucoDetectorImpl {
         vector<int> idsTmp(ncandidates, -1);
         vector<int> rotated(ncandidates, 0);
         vector<uint8_t> validCandidates(ncandidates, 0);
-        vector<bool> was(ncandidates, false);
+        vector<uint8_t> was(ncandidates, false);
         bool checkCloseContours = true;
 
         int maxDepth = 0;


### PR DESCRIPTION
Concurrently writing to a `vector<bool>` is not thread-safe.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch