### PR TITLE
core: fix clang warnings

### DIFF
--- a/modules/core/include/opencv2/core/cuda/common.hpp
+++ b/modules/core/include/opencv2/core/cuda/common.hpp
@@ -99,7 +99,7 @@ namespace cv { namespace cuda
         }
 
 #if (CUDART_VERSION >= 12000)
-        template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {
+        template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t*, PtrStepSz<T>&, const cudaTextureDesc&) {
             CV_Error(cv::Error::GpuNotSupported, "Function removed in CUDA SDK 12"); }
 #else
         //TODO: remove from OpenCV 5.x


### PR DESCRIPTION
Currently building opencv_core with clang emits the following warnings

> 3 warnings generated.
> [3/109] Building CXX object modules/core/CMakeFiles/opencv_core.dir/src/bindings_utils.cpp.o
> In file included from /home/b/repos/opencv/opencv/modules/core/src/bindings_utils.cpp:5:
> In file included from /home/b/repos/opencv/opencv/modules/core/src/precomp.hpp:60:
> In file included from /home/b/repos/opencv/opencv/modules/core/include/opencv2/core/private.cuda.hpp:73:
> /home/b/repos/opencv/opencv/modules/core/include/opencv2/core/cuda/common.hpp:102:87: warning: unused parameter 'tex' [-Wunused-parameter]
>         template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {
>                                                                                       ^
> /home/b/repos/opencv/opencv/modules/core/include/opencv2/core/cuda/common.hpp:102:106: warning: unused parameter 'img' [-Wunused-parameter]
>         template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {
>                                                                                                          ^
> /home/b/repos/opencv/opencv/modules/core/include/opencv2/core/cuda/common.hpp:102:134: warning: unused parameter 'texDesc' [-Wunused-parameter]
>         template<class T> inline void createTextureObjectPitch2D(cudaTextureObject_t* tex, PtrStepSz<T>& img, const cudaTextureDesc& texDesc) {

which are removed with this PR.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
