### PR TITLE
fix highgui qt's statusbar text got cropped

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -1725,14 +1725,14 @@ CvWindow::CvWindow(QString name, int arg2)
 
     //Now attach everything
     if (myToolBar)
-        myGlobalLayout->addWidget(myToolBar, Qt::AlignCenter);
+        myGlobalLayout->addWidget(myToolBar, 0, Qt::AlignLeft);
 
-    myGlobalLayout->addWidget(myView->getWidget(), Qt::AlignCenter);
+    myGlobalLayout->addWidget(myView->getWidget(), 0, Qt::AlignCenter);
 
-    myGlobalLayout->addLayout(myBarLayout, Qt::AlignCenter);
+    myGlobalLayout->addLayout(myBarLayout);
 
     if (myStatusBar)
-        myGlobalLayout->addWidget(myStatusBar, Qt::AlignCenter);
+        myGlobalLayout->addWidget(myStatusBar, 0, Qt::AlignLeft);
 
     setLayout(myGlobalLayout);
     show();
@@ -2142,7 +2142,6 @@ void CvWindow::createStatusBar()
 {
     myStatusBar = new QStatusBar(this);
     myStatusBar->setSizeGripEnabled(false);
-    myStatusBar->setFixedHeight(20);
     myStatusBar->setMinimumWidth(1);
     myStatusBar_msg = new QLabel;
 


### PR DESCRIPTION
I was trying to fix highgui's statusbar got cropped.

![image](https://github.com/opencv/opencv/assets/20123683/9e7562a3-edd2-4319-9de4-8d896c4a7a62)

However, none of my fixes by adjusting heights take any effect, and it reveals a deeper and actual problem.

The `QBoxLayout myGlobalLayout -> addWidget`'s 2nd parameter is `stretch` rather than `alignment`, so the old code does nothing, and the layout does not work.

https://doc.qt.io/qt-6/qboxlayout.html#addWidget

`myStatusBar->setFixedHeight(20);` is a ad-hoc fix becuase when adding the statusbar, the author did not realize that the layout was not working.;

Since the layout is fixed, setting a fixed height is no longer needed (both statusbar & qlabel's default height is reasonably small, roughly text height).

After:

![image](https://github.com/opencv/opencv/assets/20123683/541ef9e8-20ae-414a-bfb1-cfd86d3ef550)

The statusbar text looks perfect now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
