### PR TITLE
Compensate edge length in ChessBoardDetector::generateQuads

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -233,7 +233,7 @@ public:
         all_quads_count = 0;
     }
 
-    void generateQuads(const cv::Mat& image_, int flags);
+    void generateQuads(const cv::Mat& image_, int flags, int dilations);
 
     bool processQuads(std::vector<cv::Point2f>& out_corners, int &prev_sqr_size);
 
@@ -546,7 +546,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
         rectangle( thresh_img_new, Point(0,0), Point(thresh_img_new.cols-1, thresh_img_new.rows-1), Scalar(255,255,255), 3, LINE_8);
 
         detector.reset();
-        detector.generateQuads(thresh_img_new, flags);
+        detector.generateQuads(thresh_img_new, flags, dilations);
         DPRINTF("Quad count: %d/%d", detector.all_quads_count, (pattern_size.width/2+1)*(pattern_size.height/2+1));
         SHOW_QUADS("New quads", thresh_img_new, &detector.all_quads[0], detector.all_quads_count);
         if (detector.processQuads(out_corners, prev_sqr_size))
@@ -611,7 +611,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
                 rectangle( thresh_img, Point(0,0), Point(thresh_img.cols-1, thresh_img.rows-1), Scalar(255,255,255), 3, LINE_8);
 
                 detector.reset();
-                detector.generateQuads(thresh_img, flags);
+                detector.generateQuads(thresh_img, flags, dilations);
                 DPRINTF("Quad count: %d/%d", detector.all_quads_count, (pattern_size.width/2+1)*(pattern_size.height/2+1));
                 SHOW_QUADS("Old quads", thresh_img, &detector.all_quads[0], detector.all_quads_count);
                 if (detector.processQuads(out_corners, prev_sqr_size))
@@ -1754,7 +1754,7 @@ void ChessBoardDetector::findQuadNeighbors()
 // returns corners in clockwise order
 // corners don't necessarily start at same position on quad (e.g.,
 //   top left corner)
-void ChessBoardDetector::generateQuads(const cv::Mat& image_, int flags)
+void ChessBoardDetector::generateQuads(const cv::Mat& image_, int flags, int dilations)
 {
     binarized_image = image_;  // save for debug purposes
 
@@ -1879,6 +1879,9 @@ void ChessBoardDetector::generateQuads(const cv::Mat& image_, int flags)
             float d = normL2Sqr<float>(q.corners[i]->pt - q.corners[(i+1)&3]->pt);
             q.edge_len = std::min(q.edge_len, d);
         }
+
+        const int edge_len_compensation = 2 * dilations;
+        q.edge_len += 2 * sqrt(q.edge_len) * edge_len_compensation + edge_len_compensation * edge_len_compensation;
     }
 
     all_quads_count = quad_count;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Should be merged after #24710

Idea was mentioned in `Section III-C. Adaptive Quadrangle Linking Distance` of `Rufli, Martin & Scaramuzza, Davide & Siegwart, Roland. (2008). Automatic Detection of Checkerboards on Blurred and Distorted Images. 2008 IEEE/RSJ International Conference on Intelligent Robots and Systems, IROS. 3121-3126. 10.1109/IROS.2008.4650703` (https://rpg.ifi.uzh.ch/docs/IROS08_scaramuzza_b.pdf):
```
As mentioned in Section II­A.5, quadrangles only get linked if their corners are less than a certain distance apart. In the original implementation, inaccurately, the shortest edge length of the two involved quadrangles was chosen for this distance limit. If the checkers are large w.r.t erosion, the error introduced is small. But for low resolution images, erosion has a large effect on the overall size of the quadrangle, which may result in a drastic reduction of the smallest edge length. Therefore the distance measure was adapted to incorporate the effect of erosion:
d_limit = shortest_edge_length + 2 · erosion, (1)
where the factor two is due to the erosion acting on both quadrangles
```

I increased edge length by `2 * dilations` because each dilation with `3 x 3` rectangular structuring element as `kernel` in average case decrease edge length by one pixel but from each of two ends, so total edge length decrease is equal to `2 * dilations`

I tested this change (on 3.2.0 code version with some modern patches) on two private datasets and it increased number of found chessboards:
1. from `262` to `306` ~ `16.8%`
2. from `392` to `536` ~ `36.7%`

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
