### PR TITLE
Modified AAR script: added javadoc to Android Maven

### DIFF
--- a/platforms/android/aar-template/OpenCV/build.gradle.template
+++ b/platforms/android/aar-template/OpenCV/build.gradle.template
@@ -81,6 +81,28 @@ publishing {
             artifactId = '${PACKAGE_NAME}'
             version = '${OPENCV_VERSION}'
             artifact("opencv-release.aar")
+            pom {
+                name = "OpenCV"
+                description = "Open Source Computer Vision Library"
+                url = "https://opencv.org/"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "https://github.com/opencv/opencv/blob/master/LICENSE"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "admin"
+                        name = "OpenCV Team"
+                        email = "admin@opencv.org"
+                    }
+                }
+                scm {
+                    connection = "scm:git:https://github.com/opencv/opencv.git"
+                    url = "https://github.com/opencv/opencv"
+                }
+            }
         }
     }
     repositories {

--- a/platforms/android/aar-template/OpenCV/build.gradle.template
+++ b/platforms/android/aar-template/OpenCV/build.gradle.template
@@ -59,6 +59,7 @@ android {
     publishing {
         singleVariant('release') {
             withSourcesJar()
+            withJavadocJar()
         }
     }
 }
@@ -66,14 +67,20 @@ android {
 publishing {
     publications {
         release(MavenPublication) {
+            // Builds aar, sources jar and javadoc jar from project sources and creates maven
+            groupId = 'org.opencv'
+            artifactId = '${PACKAGE_NAME}'
+            version = '${OPENCV_VERSION}'
+            afterEvaluate {
+                from components.release
+            }
+        }
+        modified(MavenPublication) {
+            // Creates maven from opencv-release.aar
             groupId = 'org.opencv'
             artifactId = '${PACKAGE_NAME}'
             version = '${OPENCV_VERSION}'
             artifact("opencv-release.aar")
-
-//            afterEvaluate {
-//                from components.release
-//            }
         }
     }
     repositories {

--- a/platforms/android/build_java_shared_aar.py
+++ b/platforms/android/build_java_shared_aar.py
@@ -12,6 +12,7 @@ import subprocess
 COPY_FROM_SDK_TO_ANDROID_PROJECT = [
     ["sdk/native/jni/include", "OpenCV/src/main/cpp/include"],
     ["sdk/java/src/org", "OpenCV/src/main/java/org"],
+    ["sdk/java/javadoc", "OpenCV/src/main/java/javadoc"],
     ["sdk/java/res", "OpenCV/src/main/res"]
 ]
 
@@ -144,6 +145,8 @@ def main(args):
     print("Creating local maven repo...")
 
     shutil.copy(final_aar_path, path.join(ANDROID_PROJECT_DIR, "OpenCV/opencv-release.aar"))
+
+    print("Creating a maven repo from project sources (with sources jar and javadoc jar)...")
     subprocess.run(["./gradlew", "publishReleasePublicationToMyrepoRepository"],
             shell=False,
             cwd=ANDROID_PROJECT_DIR,
@@ -152,6 +155,17 @@ def main(args):
     os.makedirs(path.join(FINAL_REPO_PATH, "org/opencv"), exist_ok=True)
     shutil.move(path.join(ANDROID_PROJECT_DIR, "OpenCV/build/repo/org/opencv", MAVEN_PACKAGE_NAME),
                 path.join(FINAL_REPO_PATH, "org/opencv", MAVEN_PACKAGE_NAME))
+
+    print("Creating a maven repo from modified AAR (with cpp libraries)...")
+    subprocess.run(["./gradlew", "publishModifiedPublicationToMyrepoRepository"],
+            shell=False,
+            cwd=ANDROID_PROJECT_DIR,
+            check=True)
+
+    # Replacing AAR from the first maven repo with modified AAR from the second maven repo
+    shutil.copytree(path.join(ANDROID_PROJECT_DIR, "OpenCV/build/repo/org/opencv", MAVEN_PACKAGE_NAME),
+                    path.join(FINAL_REPO_PATH, "org/opencv", MAVEN_PACKAGE_NAME),
+                    dirs_exist_ok=True)
 
 
 if __name__ == "__main__":

--- a/platforms/android/build_java_shared_aar.py
+++ b/platforms/android/build_java_shared_aar.py
@@ -12,7 +12,6 @@ import subprocess
 COPY_FROM_SDK_TO_ANDROID_PROJECT = [
     ["sdk/native/jni/include", "OpenCV/src/main/cpp/include"],
     ["sdk/java/src/org", "OpenCV/src/main/java/org"],
-    ["sdk/java/javadoc", "OpenCV/src/main/java/javadoc"],
     ["sdk/java/res", "OpenCV/src/main/res"]
 ]
 

--- a/platforms/android/build_static_aar.py
+++ b/platforms/android/build_static_aar.py
@@ -216,6 +216,7 @@ def main(args):
 
     shutil.copy(final_aar_path, path.join(ANDROID_PROJECT_DIR, "OpenCV/opencv-release.aar"))
 
+    print("Creating a maven repo from project sources (with sources jar and javadoc jar)...")
     subprocess.run(["./gradlew", "publishReleasePublicationToMyrepoRepository"],
             shell=False,
             cwd=ANDROID_PROJECT_DIR,
@@ -224,6 +225,18 @@ def main(args):
     os.makedirs(path.join(FINAL_REPO_PATH, "org/opencv"), exist_ok=True)
     shutil.move(path.join(ANDROID_PROJECT_DIR, "OpenCV/build/repo/org/opencv", MAVEN_PACKAGE_NAME),
                 path.join(FINAL_REPO_PATH, "org/opencv", MAVEN_PACKAGE_NAME))
+
+    print("Creating a maven repo from modified AAR (with cpp libraries)...")
+    subprocess.run(["./gradlew", "publishModifiedPublicationToMyrepoRepository"],
+            shell=False,
+            cwd=ANDROID_PROJECT_DIR,
+            check=True)
+
+    # Replacing AAR from the first maven repo with modified AAR from the second maven repo
+    shutil.copytree(path.join(ANDROID_PROJECT_DIR, "OpenCV/build/repo/org/opencv", MAVEN_PACKAGE_NAME),
+                    path.join(FINAL_REPO_PATH, "org/opencv", MAVEN_PACKAGE_NAME),
+                    dirs_exist_ok=True)
+
     print("Done")
 
 


### PR DESCRIPTION
Modified AAR script.
Now the script creates 2 maven repos. The first repo contains sources jar, javadoc jar and AAR without cpp libraries. The second repo contains modified AAR with cpp libraries. The script merges two repos into one.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
