### PR TITLE
Fix QNX build

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -120,11 +120,15 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
 #include <cstdlib>        // std::abort
 #endif
 
-#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __Fuchsia__
+#if defined __ANDROID__ || defined __unix__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __Fuchsia__ || defined __QNX__
 #  include <unistd.h>
 #  include <fcntl.h>
 #if defined __QNX__
 #  include <sys/elf.h>
+#  include <sys/auxv.h>
+using Elf64_auxv_t = auxv64_t;
+#  include <elfdefinitions.h>
+constexpr decltype(auto) AT_HWCAP = NT_GNU_HWCAP;
 #else
 #  include <elf.h>
 #endif
@@ -581,10 +585,12 @@ struct HWFeatures
                     have[CV_CPU_NEON_DOTPROD] = (auxv.a_un.a_val & (1 << 20)) != 0; // HWCAP_ASIMDDP
                     have[CV_CPU_NEON_FP16] = (auxv.a_un.a_val & (1 << 10)) != 0; // HWCAP_ASIMDHP
                 }
+#if defined(AT_HWCAP2)
                 else if (auxv.a_type == AT_HWCAP2)
                 {
                     have[CV_CPU_NEON_BF16] = (auxv.a_un.a_val & (1 << 14)) != 0; // HWCAP2_BF16
                 }
+#endif
             }
 
             close(cpufile);

--- a/modules/ts/CMakeLists.txt
+++ b/modules/ts/CMakeLists.txt
@@ -47,3 +47,7 @@ if(OPENCV_DISABLE_THREAD_SUPPORT)
   # described in `ts_gtest.h`.
   ocv_target_compile_definitions(${the_module} PUBLIC GTEST_HAS_PTHREAD=0)
 endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  ocv_target_link_libraries(${the_module} PUBLIC regex)
+endif()


### PR DESCRIPTION
Based on https://github.com/opencv/opencv/issues/24567

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

## Build locally

Passing `-D OPENCV_SKIP_CMAKE_CXX_STANDARD=ON` during cmake configure. 100% build success with commit of 2791bb7062:
```
2791bb7062 2024-01-12 | Merge pull request #24773 from tailsu:sd/pathlike (origin/master) [Stefan Dragnev]
```

QNX SDP version: 7.1.0, which uses a C++ compiler version 8.3.0:
> CMAKE_CXX_COMPILER_VERSION=8.3.0

Due to QNX SDP license, I'm not sure if I can provide its installer.

The latest version of QNX SDP can be obtained from its website https://www.qnx.com/account/login.html (a registered account is required. Not tested with its latest QNX SDP yet).

## What build errors this PR fixed?

### Compile error

This PR fixed several compile error. A minimal reproduce code, which can cause similar compile error when using QNX SDP as toolchain, is this:

```cpp
#include <iostream>

int main()
{
    std::cout << "hello world" << std::endl;
    return 0;
}
```

The errors are:

```
'pthread_mutexattr_settype' was not declared in this scope

'pthread_cond_timedwait' was not declared in this scope

'nanosleep' was not declared in this scope

'PTHREAD_MUTEX_RECURSIVE' was not declared in this scope

'pthread_mutexattr_settype' was not declared in this scope

'pthread_cond_timedwait' was not declared in this scope

'nanosleep' was not declared in this scope

'O_RDONLY' was not declared in this scope

'open' was not declared in this scope

'Elf64_auxv_t' was not declared in this scope

'auxv' was not declared in this scope

error: 'AT_HWCAP' was not declared in this scope

'AT_HWCAP2' was not declared in this scope

'close' was not declared in this scope
```

**The solution is: `-D OPENCV_SKIP_CMAKE_CXX_STANDARD=ON`**

### Link error
```
[ 52%] Linking CXX executable ../../bin/opencv_perf_core
/opt/qnx710/host/linux/x86_64/usr/bin/aarch64-unknown-nto-qnx7.1.0-ld: ../../lib/libopencv_ts.a(ts_gtest.cpp.o): in function `testing::internal::RE::PartialMatch(char const*, testing::internal::RE const&)':
ts_gtest.cpp:(.text._ZN7testing8internal2RE12PartialMatchEPKcRKS1_+0x38): undefined reference to `regexec'
collect2: error: ld returned 1 exit status
modules/core/CMakeFiles/opencv_perf_core.dir/build.make:599: recipe for target 'bin/opencv_perf_core' failed
make[2]: *** [bin/opencv_perf_core] Error 1
CMakeFiles/Makefile2:1955: recipe for target 'modules/core/CMakeFiles/opencv_perf_core.dir/all' failed
make[1]: *** [modules/core/CMakeFiles/opencv_perf_core.dir/all] Error 2
```

The solutions is:
```cmake
if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
  ocv_target_link_libraries(${the_module} PUBLIC regex)
endif()
```