### PR TITLE
fix qnx-sdp-700 build

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -128,7 +128,7 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
 #  include <sys/auxv.h>
 using Elf64_auxv_t = auxv64_t;
 #  include <elfdefinitions.h>
-constexpr decltype(auto) AT_HWCAP = NT_GNU_HWCAP;
+const uint64_t AT_HWCAP = NT_GNU_HWCAP;
 #else
 #  include <elf.h>
 #endif


### PR DESCRIPTION
based on https://github.com/opencv/opencv/pull/24864

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### What build errors this PR solved

When building with qnx-sdp-700 with code in this PR: https://github.com/opencv/opencv/pull/24864, 
there is compile error:
```
[ 38%] Building CXX object modules/core/CMakeFiles/opencv_core.dir/src/trace.cpp.o
/builds/3rdparty/opencv-build/opencv/modules/core/src/system.cpp:131:20: error: expected primary-expression before 'auto'
 constexpr decltype(auto) AT_HWCAP = NT_GNU_HWCAP;
                    ^
```

`decltype(auto)` seems to be an C++14 introduced feature, intead of C++11.
`uint64_t` is OK when build locally.

[asmorkalov](https://github.com/asmorkalov)