### PR TITLE
Added kotlin classes to AAR

### DIFF
--- a/platforms/android/aar-template/OpenCV/build.gradle.template
+++ b/platforms/android/aar-template/OpenCV/build.gradle.template
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'maven-publish'
+    id 'kotlin-android'
 }
 
 android {

--- a/platforms/android/aar-template/build.gradle
+++ b/platforms/android/aar-template/build.gradle
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.library' version '7.3.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.5.20' apply false
 }

--- a/platforms/android/aar-template/build.gradle
+++ b/platforms/android/aar-template/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.library' version '7.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
 }


### PR DESCRIPTION
Added Kotlin classes to AAR

The resulting maven repo doesn't have kotlin-plugin dependency, and it works fine out of the box: Android Kotlin projects already have kotlin-plugin dependency, Android Java projects ignore kotlin classes.

Details on KGP versions: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
