### PR TITLE
added in-place support for cartToPolar and polarToCart

### DIFF
--- a/modules/core/include/opencv2/core/hal/hal.hpp
+++ b/modules/core/include/opencv2/core/hal/hal.hpp
@@ -91,10 +91,14 @@ CV_EXPORTS void exp64f(const double* src, double* dst, int n);
 CV_EXPORTS void log32f(const float* src, float* dst, int n);
 CV_EXPORTS void log64f(const double* src, double* dst, int n);
 
+CV_EXPORTS void cartToPolar32f(const float* x, const float* y, float* mag, float* angle, int n, bool angleInDegrees);
+CV_EXPORTS void cartToPolar64f(const double* x, const double* y, double* mag, double* angle, int n, bool angleInDegrees);
 CV_EXPORTS void fastAtan32f(const float* y, const float* x, float* dst, int n, bool angleInDegrees);
 CV_EXPORTS void fastAtan64f(const double* y, const double* x, double* dst, int n, bool angleInDegrees);
 CV_EXPORTS void magnitude32f(const float* x, const float* y, float* dst, int n);
 CV_EXPORTS void magnitude64f(const double* x, const double* y, double* dst, int n);
+CV_EXPORTS void polarToCart32f(const float* mag, const float* angle, float* x, float* y, int n, bool angleInDegrees);
+CV_EXPORTS void polarToCart64f(const double* mag, const double* angle, double* x, double* y, int n, bool angleInDegrees);
 CV_EXPORTS void sqrt32f(const float* src, float* dst, int len);
 CV_EXPORTS void sqrt64f(const double* src, double* dst, int len);
 CV_EXPORTS void invSqrt32f(const float* src, float* dst, int len);

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -413,6 +413,24 @@ inline int hal_ni_merge64s(const int64 **src_data, int64 *dst_data, int len, int
 #define cv_hal_merge64s hal_ni_merge64s
 //! @endcond
 
+/**
+@param x source X arrays
+@param y source Y arrays
+@param mag destination magnitude array
+@param angle destination angle array
+@param len length of arrays
+@param angleInDegrees if set to true return angles in degrees, otherwise in radians
+*/
+//! @addtogroup core_hal_interface_fastAtan Atan calculation
+//! @{
+inline int hal_ni_cartToPolar32f(const float* x, const float* y, float* mag, float* angle, int len, bool angleInDegrees) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_cartToPolar64f(const double* x, const double* y, double* mag, double* angle, int len, bool angleInDegrees) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+//! @}
+
+//! @cond IGNORED
+#define cv_hal_cartToPolar32f hal_ni_cartToPolar32f
+#define cv_hal_cartToPolar64f hal_ni_cartToPolar64f
+//! @endcond
 
 /**
 @param y source Y arrays
@@ -450,6 +468,24 @@ inline int hal_ni_magnitude64f(const double *x, const double  *y, double *dst, i
 #define cv_hal_magnitude64f hal_ni_magnitude64f
 //! @endcond
 
+/**
+@param mag source magnitude arrays
+@param mag source angle arrays
+@param x destination X array
+@param y destination Y array
+@param len length of arrays
+@param angleInDegrees if set to true interpret angles from degrees, otherwise from radians
+*/
+//! @addtogroup core_hal_interface_fastAtan Atan calculation
+//! @{
+inline int hal_ni_polarToCart32f(const float* mag, const float* angle, float* x, float* y, int len, bool angleInDegrees) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_polarToCart64f(const double* mag, const double* angle, double* x, double* y, int len, bool angleInDegrees) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+//! @}
+
+//! @cond IGNORED
+#define cv_hal_polarToCart32f hal_ni_polarToCart32f
+#define cv_hal_polarToCart64f hal_ni_polarToCart64f
+//! @endcond
 
 /**
 @param src source array

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -244,7 +244,7 @@ static bool ocl_cartToPolar( InputArray _src1, InputArray _src2,
         return false;
 
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc,
-                  format("-D BINARY_OP -D dstT=%s -D DEPTH_dst=%d -D rowsPerWI=%d -D OP_CTP_%s%s",
+                  format("-D BINARY_OP -D dstT=%s -D DEPTH_dst=%d -D rowsPerWI=%d -D OP_CTP_%s%s%s%s%s%s",
                          ocl::typeToStr(CV_MAKE_TYPE(depth, 1)), depth,
                          rowsPerWI, angleInDegrees ? "AD" : "AR",
                          doubleSupport ? " -D DOUBLE_SUPPORT" : "",
@@ -490,7 +490,7 @@ static bool ocl_polarToCart( InputArray _mag, InputArray _angle,
         return false;
 
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc,
-                  format("-D dstT=%s -D DEPTH_dst=%d -D rowsPerWI=%d -D BINARY_OP -D OP_PTC_%s%s",
+                  format("-D dstT=%s -D DEPTH_dst=%d -D rowsPerWI=%d -D BINARY_OP -D OP_PTC_%s%s%s%s%s%s",
                          ocl::typeToStr(CV_MAKE_TYPE(depth, 1)), depth,
                          rowsPerWI,
                          angleInDegrees ? "AD" : "AR",

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -693,8 +693,11 @@ void polarToCart( InputArray src1, InputArray src2,
                     }
                 else
                 {
-                    std::memcpy(x, buf[0], sizeof(float) * len);
-                    std::memcpy(y, buf[1], sizeof(float) * len);
+                    for( k = 0; k < len; k++ )
+                    {
+                        x[k] = buf[0][k];
+                        y[k] = buf[1][k];
+                    }
                 }
             }
 

--- a/modules/core/src/mathfuncs_core.dispatch.cpp
+++ b/modules/core/src/mathfuncs_core.dispatch.cpp
@@ -9,7 +9,25 @@
 
 namespace cv { namespace hal {
 
-///////////////////////////////////// ATAN2 ////////////////////////////////////
+void cartToPolar32f(const float* x, const float* y, float* mag, float* angle, int len, bool angleInDegrees)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(cartToPolar32f, cv_hal_cartToPolar32f, x, y, mag, angle, len, angleInDegrees);
+
+    CV_CPU_DISPATCH(cartToPolar32f, (x, y, mag, angle, len, angleInDegrees),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
+
+void cartToPolar64f(const double* x, const double* y, double* mag, double* angle, int len, bool angleInDegrees)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(cartToPolar64f, cv_hal_cartToPolar64f, x, y, mag, angle, len, angleInDegrees);
+
+    CV_CPU_DISPATCH(cartToPolar64f, (x, y, mag, angle, len, angleInDegrees),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
 
 void fastAtan32f(const float *Y, const float *X, float *angle, int len, bool angleInDegrees )
 {

--- a/modules/core/src/opencl/arithm.cl
+++ b/modules/core/src/opencl/arithm.cl
@@ -382,14 +382,18 @@
 #define TO_DEGREE
 #endif
 #ifdef SRC1_IS_DST_MAG
-dstptr = srcptr1
+#define ADAPT_SRC1 dstptr = srcptr1;
 #elif SRC1_IS_DST_ANGLE
-dstptr2 = srcptr1
+#define ADAPT_SRC1 dstptr2 = srcptr1;
+#else
+#define ADAPT_SRC1
 #endif
 #ifdef SRC2_IS_DST_MAG
-dstptr = srcptr2
+#define ADAPT_SRC2 dstptr = srcptr2;
 #elif SRC2_IS_DST_ANGLE
-dstptr2 = srcptr2
+#define ADAPT_SRC2 dstptr2 = srcptr2;
+#else
+#define ADAPT_SRC2
 #endif
 #define PROCESS_ELEM \
     dstT x = srcelem1, y = srcelem2; \
@@ -400,6 +404,8 @@ dstptr2 = srcptr2
     dstT tmp1 = y >= 0 ? CV_PI * 0.5f : CV_PI * 1.5f; \
     dstT cartToPolar = y2 <= x2 ? x * y / mad((dstT)(0.28f), y2, x2 + CV_EPSILON) + tmp : (tmp1 - x * y / mad((dstT)(0.28f), x2, y2 + CV_EPSILON)); \
     TO_DEGREE \
+    ADAPT_SRC1 \
+    ADAPT_SRC2 \
     storedst(magnitude); \
     storedst2(cartToPolar)
 
@@ -410,18 +416,24 @@ dstptr2 = srcptr2
 #define FROM_DEGREE
 #endif
 #ifdef SRC1_IS_DST_X
-dstptr = srcptr1
+#define ADAPT_SRC1 dstptr = srcptr1;
 #elif SRC1_IS_DST_Y
-dstptr2 = srcptr1
+#define ADAPT_SRC1 dstptr2 = srcptr1;
+#else
+#define ADAPT_SRC1
 #endif
 #ifdef SRC2_IS_DST_X
-dstptr = srcptr2
+#define ADAPT_SRC2 dstptr = srcptr2;
 #elif SRC2_IS_DST_Y
-dstptr2 = srcptr2
+#define ADAPT_SRC2 dstptr2 = srcptr2;
+#else
+#define ADAPT_SRC2
 #endif
 #define PROCESS_ELEM \
     dstT x = srcelem1, y = srcelem2, cosval; \
     FROM_DEGREE; \
+    ADAPT_SRC1; \
+    ADAPT_SRC2; \
     storedst2(sincos(y, &cosval) * x); \
     storedst(cosval * x);
 

--- a/modules/core/src/opencl/arithm.cl
+++ b/modules/core/src/opencl/arithm.cl
@@ -381,6 +381,16 @@
 #elif defined OP_CTP_AR
 #define TO_DEGREE
 #endif
+#ifdef SRC1_IS_DST_MAG
+dstptr = srcptr1
+#elif SRC1_IS_DST_ANGLE
+dstptr2 = srcptr1
+#endif
+#ifdef SRC2_IS_DST_MAG
+dstptr = srcptr2
+#elif SRC2_IS_DST_ANGLE
+dstptr2 = srcptr2
+#endif
 #define PROCESS_ELEM \
     dstT x = srcelem1, y = srcelem2; \
     dstT x2 = x * x, y2 = y * y; \
@@ -398,6 +408,16 @@
 #define FROM_DEGREE y = radians(y)
 #else
 #define FROM_DEGREE
+#endif
+#ifdef SRC1_IS_DST_X
+dstptr = srcptr1
+#elif SRC1_IS_DST_Y
+dstptr2 = srcptr1
+#endif
+#ifdef SRC2_IS_DST_X
+dstptr = srcptr2
+#elif SRC2_IS_DST_Y
+dstptr2 = srcptr2
 #endif
 #define PROCESS_ELEM \
     dstT x = srcelem1, y = srcelem2, cosval; \

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2834,8 +2834,8 @@ PARAM_TEST_CASE(Core_CartPolar_reverse, int, bool)
 TEST_P(Core_CartPolar_reverse, reverse)
 {
     const int type = CV_MAKETYPE(depth, 1);
-    cv::Mat1d A[2] = {cv::Mat(10, 10, type), cv::Mat1d(10, 10, type)};
-    cv::Mat1d B[2], C[2];
+    cv::Mat A[2] = {cv::Mat(10, 10, type), cv::Mat(10, 10, type)};
+    cv::Mat B[2], C[2];
     cv::UMat uA[2];
     cv::UMat uB[2];
     cv::UMat uC[2];
@@ -2875,8 +2875,8 @@ PARAM_TEST_CASE(Core_CartToPolar_inplace, int, bool)
 TEST_P(Core_CartToPolar_inplace, inplace)
 {
     const int type = CV_MAKETYPE(depth, 1);
-    cv::Mat1d A[2] = {cv::Mat(10, 10, type), cv::Mat(10, 10, type)};
-    cv::Mat1d B[2], C[2];
+    cv::Mat A[2] = {cv::Mat(10, 10, type), cv::Mat(10, 10, type)};
+    cv::Mat B[2], C[2];
     cv::UMat uA[2];
     cv::UMat uB[2];
     cv::UMat uC[2];
@@ -2944,8 +2944,8 @@ PARAM_TEST_CASE(Core_PolarToCart_inplace, int, bool, bool)
 TEST_P(Core_PolarToCart_inplace, inplace)
 {
     const int type = CV_MAKETYPE(depth, 1);
-    cv::Mat1d A[2] = {cv::Mat(10, 10, type), cv::Mat(10, 10, type)};
-    cv::Mat1d B[2], C[2];
+    cv::Mat A[2] = {cv::Mat(10, 10, type), cv::Mat(10, 10, type)};
+    cv::Mat B[2], C[2];
     cv::UMat uA[2];
     cv::UMat uB[2];
     cv::UMat uC[2];

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2855,7 +2855,7 @@ TEST(Core_CartPolar, inplace)
     EXPECT_MAT_NEAR(C[0], B[0], 2);
     EXPECT_MAT_NEAR(C[1], B[1], 2);
 
-    // Inplace OCL
+    // Inplace OCL x<->mag y<->angle
     for(int i = 0; i < 2; ++i)
         uA[i].copyTo(uB[i]);
     cv::cartToPolar(uA[0], uA[1], uC[0], uC[1], false);
@@ -2869,6 +2869,21 @@ TEST(Core_CartPolar, inplace)
     cv::polarToCart(uB[0], uB[1], uB[0], uB[1], false);
     EXPECT_MAT_NEAR(uC[0], uB[0], 2);
     EXPECT_MAT_NEAR(uC[1], uB[1], 2);
+
+    // Inplace OCL x<->angle y<->mag
+    for(int i = 0; i < 2; ++i)
+        uA[i].copyTo(uB[i]);
+    cv::cartToPolar(uA[0], uA[1], uC[0], uC[1], false);
+    cv::cartToPolar(uB[0], uB[1], uB[1], uB[0], false);
+    EXPECT_MAT_NEAR(uC[0], uB[1], 2);
+    EXPECT_MAT_NEAR(uC[1], uB[0], 2);
+
+    for(int i = 0; i < 2; ++i)
+        uA[i].copyTo(uB[i]);
+    cv::polarToCart(uA[0], uA[1], uC[0], uC[1], false);
+    cv::polarToCart(uB[0], uB[1], uB[1], uB[0], false);
+    EXPECT_MAT_NEAR(uC[0], uB[1], 2);
+    EXPECT_MAT_NEAR(uC[1], uB[0], 2);
 }
 
 }} // namespace

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2825,6 +2825,8 @@ TEST(Core_CartPolar, inplace)
     cv::Mat1d A[2] = {cv::Mat1d(10, 10), cv::Mat1d(10, 10)};
     cv::Mat1d B[2], C[2];
     cv::UMat uA[2];
+    cv::UMat uB[2];
+    cv::UMat uC[2];
 
     for(int i = 0; i < 2; ++i)
     {
@@ -2839,16 +2841,34 @@ TEST(Core_CartPolar, inplace)
     EXPECT_MAT_NEAR(A[1], C[1], 2);
 
     // Inplace
-    EXPECT_THROW(cv::polarToCart(B[0], B[1], B[0], B[1], false), cv::Exception);
-    EXPECT_THROW(cv::polarToCart(B[0], B[1], B[1], B[0], false), cv::Exception);
-    EXPECT_THROW(cv::cartToPolar(A[0], A[1], A[0], A[1], false), cv::Exception);
-    EXPECT_THROW(cv::cartToPolar(A[0], A[1], A[1], A[0], false), cv::Exception);
-    // Inplace OCL
-    EXPECT_THROW(cv::polarToCart(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
-    EXPECT_THROW(cv::polarToCart(uA[0], uA[1], uA[1], uA[0]), cv::Exception);
-    EXPECT_THROW(cv::cartToPolar(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
-    EXPECT_THROW(cv::cartToPolar(uA[0], uA[1], uA[0], uA[1]), cv::Exception);
+    for(int i = 0; i < 2; ++i)
+        A[i].copyTo(B[i]);
+    cv::cartToPolar(A[0], A[1], C[0], C[1], false);
+    cv::cartToPolar(B[0], B[1], B[0], B[1], false);
+    EXPECT_MAT_NEAR(C[0], B[0], 2);
+    EXPECT_MAT_NEAR(C[1], B[1], 2);
 
+    for(int i = 0; i < 2; ++i)
+        A[i].copyTo(B[i]);
+    cv::polarToCart(A[0], A[1], C[0], C[1], false);
+    cv::polarToCart(B[0], B[1], B[0], B[1], false);
+    EXPECT_MAT_NEAR(C[0], B[0], 2);
+    EXPECT_MAT_NEAR(C[1], B[1], 2);
+
+    // Inplace OCL
+    for(int i = 0; i < 2; ++i)
+        uA[i].copyTo(uB[i]);
+    cv::cartToPolar(uA[0], uA[1], uC[0], uC[1], false);
+    cv::cartToPolar(uB[0], uB[1], uB[0], uB[1], false);
+    EXPECT_MAT_NEAR(uC[0], uB[0], 2);
+    EXPECT_MAT_NEAR(uC[1], uB[1], 2);
+
+    for(int i = 0; i < 2; ++i)
+        uA[i].copyTo(uB[i]);
+    cv::polarToCart(uA[0], uA[1], uC[0], uC[1], false);
+    cv::polarToCart(uB[0], uB[1], uB[0], uB[1], false);
+    EXPECT_MAT_NEAR(uC[0], uB[0], 2);
+    EXPECT_MAT_NEAR(uC[1], uB[1], 2);
 }
 
 }} // namespace


### PR DESCRIPTION
- a fused hal::cartToPolar[32|64]f() is used instead of sequential hal::magnitude[32|64]f/hal::fastAtan[32|64]f
- ipp_polarToCart is skipped for in-place processing (it seems not to support it correctly)

relates to #24891
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
