### PR TITLE
Relax test requirements for OpenCL in test DNNTestNetwork.FastNeuraStyle_eccv16

### DIFF
--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -456,7 +456,7 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
     Mat inp = blobFromImage(img, 1.0, Size(224, 224), Scalar(0.0, 0.0, 0.0), true, false);
     // Output image has values in range [0.0, 255.0].
     float l1 = 5e-4, lInf = 1e-2;
-    if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD)
+    if (target == DNN_TARGET_MYRIAD)
     {
         l1 = 0.4;
         lInf = 7.46;
@@ -480,6 +480,15 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
     {
         l1 = 0.4;
         lInf = 7.46;
+    }
+    else if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL)
+    {
+        l1 = 5.5e-4;
+    }
+    else if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
+    {
+        l1 = 0.86;
+        lInf = 16;
     }
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2022010000)


### PR DESCRIPTION
Closes sporadic test failures in GHA and Buildbot

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux OpenCL,Linux AVX2,Linux32,Win32
```