### PR TITLE
Einsum Layer Inner Product Issue Solution 

### DIFF
--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -1367,7 +1367,7 @@ Mat LayerEinsumImpl::batchwiseMatMul(
 
         // input1 should of size MxK
         // check if input1 needs reshape, if need reshape
-        if (input1.dims > 2 || input1.size[0] != M || input1.size[1] != K)
+        if (input1.dims > 2 || input1.size[0] != M || (input1.dims > 1 && input1.size[1] != K) || input1.dims == 1)
         {
             int shape[] = {M, K};
             reshapedInput1 = input1.reshape(1, 2, shape);
@@ -1375,7 +1375,7 @@ Mat LayerEinsumImpl::batchwiseMatMul(
 
         // input2 should be of size KxN
         // check if input2 needs reshape, if needs reshape
-        if (input2.dims > 2 || input2.size[0] != K || input2.size[1] != N)
+        if (input2.dims > 2 || input2.size[0] != K || (input2.dims > 1 &&  input2.size[1] != N) || input2.dims == 1)
         {
             int shape2[] = {K, N};
             reshapedInput2 = input2.reshape(1, 2, shape2);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1496,7 +1496,7 @@ TEST_P(Test_ONNX_layers, Einsum_5D)
 }
 
 // https://github.com/opencv/opencv/issues/24883
-TEST_P(Test_ONNX_layers, DISABLED_Einsum_InnerProduct)
+TEST_P(Test_ONNX_layers, Einsum_InnerProduct)
 {
     testONNXModels("einsum_inner", npy, 0, 0, false, false, 2);
 }


### PR DESCRIPTION
This PR resolves the issue #24883 related in Einsum layer inner product operation with 1D vectors. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
