### PR TITLE
Add python bindings for Rect2f and Point3i

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -558,7 +558,7 @@ public:
     //! returns the minimal up-right integer rectangle containing the rotated rectangle
     CV_WRAP Rect boundingRect() const;
     //! returns the minimal (exact) floating point rectangle containing the rotated rectangle, not intended for use with images
-    Rect_<float> boundingRect2f() const;
+    CV_WRAP Rect2f boundingRect2f() const;
     //! returns the rectangle mass center
     CV_PROP_RW Point2f center;
     //! returns width and height of the rectangle

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -798,6 +798,21 @@ PyObject* pyopencv_from(const Rect& r)
 }
 
 template<>
+bool pyopencv_to(PyObject* obj, Rect2f& r, const ArgInfo& info)
+{
+    RefWrapper<float> values[] = {
+        RefWrapper<float>(r.x), RefWrapper<float>(r.y),
+        RefWrapper<float>(r.width), RefWrapper<float>(r.height)};
+    return parseSequence(obj, values, info);
+}
+
+template<>
+PyObject* pyopencv_from(const Rect2f& r)
+{
+    return Py_BuildValue("(ffff)", r.x, r.y, r.width, r.height);
+}
+
+template<>
 bool pyopencv_to(PyObject* obj, Rect2d& r, const ArgInfo& info)
 {
     RefWrapper<double> values[] = {
@@ -962,6 +977,21 @@ template<>
 PyObject* pyopencv_from(const Point2d& p)
 {
     return Py_BuildValue("(dd)", p.x, p.y);
+}
+
+template<>
+bool pyopencv_to(PyObject* obj, Point3i& p, const ArgInfo& info)
+{
+    RefWrapper<int> values[] = {RefWrapper<int>(p.x),
+                                RefWrapper<int>(p.y),
+                                RefWrapper<int>(p.z)};
+    return parseSequence(obj, values, info);
+}
+
+template<>
+PyObject* pyopencv_from(const Point3i& p)
+{
+    return Py_BuildValue("(iii)", p.x, p.y, p.z);
 }
 
 template<>

--- a/modules/python/src2/cv2_convert.hpp
+++ b/modules/python/src2/cv2_convert.hpp
@@ -214,6 +214,8 @@ template<> PyObject* pyopencv_from(const cv::Size_<float>& sz);
 // --- Rect
 template<> bool pyopencv_to(PyObject* obj, cv::Rect& r, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const cv::Rect& r);
+template<> bool pyopencv_to(PyObject* obj, cv::Rect2f& r, const ArgInfo& info);
+template<> PyObject* pyopencv_from(const cv::Rect2f& r);
 template<> bool pyopencv_to(PyObject* obj, cv::Rect2d& r, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const cv::Rect2d& r);
 
@@ -232,6 +234,8 @@ template<> bool pyopencv_to(PyObject* obj, cv::Point2f& p, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const cv::Point2f& p);
 template<> bool pyopencv_to(PyObject* obj, cv::Point2d& p, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const cv::Point2d& p);
+template<> bool pyopencv_to(PyObject* obj, cv::Point3i& p, const ArgInfo& info);
+template<> PyObject* pyopencv_from(const cv::Point3i& p);
 template<> bool pyopencv_to(PyObject* obj, cv::Point3f& p, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const cv::Point3f& p);
 template<> bool pyopencv_to(PyObject* obj, cv::Point3d& p, const ArgInfo& info);

--- a/modules/python/src2/typing_stubs_generation/predefined_types.py
+++ b/modules/python/src2/typing_stubs_generation/predefined_types.py
@@ -71,6 +71,8 @@ _PREDEFINED_TYPES = (
                             doc="Required length is 4"),
     AliasTypeNode.sequence_("Rect2i", PrimitiveTypeNode.int_(),
                             doc="Required length is 4"),
+    AliasTypeNode.sequence_("Rect2f", PrimitiveTypeNode.float_(),
+                            doc="Required length is 4"),
     AliasTypeNode.sequence_("Rect2d", PrimitiveTypeNode.float_(),
                             doc="Required length is 4"),
     AliasTypeNode.dict_("Moments", PrimitiveTypeNode.str_("Moments::key"),

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -608,6 +608,14 @@ class Arguments(NewOpenCVTests):
         _, inter_pts = cv.rotatedRectangleIntersection(rect1, rect2)
         self.assertLess(np.max(np.abs(inter_pts.reshape(-1, 2) - pts)), 1e-4)
 
+    def test_result_rotated_rect_boundingRect2f(self):
+        center = (0, 0)
+        size = (10, 10)
+        angle = 0
+        gold_box = (-5.0, -5.0, 10.0, 10.0)
+        rect1 = cv.RotatedRect(center, size, angle)
+        bbox = rect1.boundingRect2f()
+        self.assertEqual(gold_box, bbox)
 
     def test_parse_to_rotated_rect_not_convertible(self):
         for not_convertible in ([], (), np.array([]), (123, (45, 34), 1), {1: 2, 3: 4}, 123,


### PR DESCRIPTION
Replaces https://github.com/opencv/opencv/pull/24857/
Point3i is not used in OpenCV API
Type hints are already there for both types

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
