### PR TITLE
Fix link error caused by lack of moc in the cvv module during checked world

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -52,6 +52,23 @@ if(NOT OPENCV_INITIAL_PASS)
   endforeach()
   message(STATUS "Processing WORLD modules... DONE")
   set(CMAKE_CURRENT_SOURCE_DIR "${OPENCV_MODULE_opencv_world_LOCATION}")
+
+  if(BUILD_opencv_cvv AND OPENCV_MODULE_opencv_cvv_IS_PART_OF_WORLD)
+    # Qt
+    set(CVV_QT_MODULES Core Gui Widgets)
+    if(QT_VERSION_MAJOR EQUAL 6)
+      list(APPEND CVV_QT_MODULES Core5Compat)
+    endif()
+
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${CVV_QT_MODULES})
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+    set_property(GLOBAL PROPERTY AUTOGEN_TARGETS_FOLDER AutoMoc)
+    set_target_properties(Qt5::moc PROPERTIES IMPORTED_LOCATION "${QT_MOC_EXECUTABLE}")
+
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_INCLUDE_CURRENT_DIR ON)
+    cmake_policy(SET CMP0071 NEW)
+  endif()
 endif()
 
 ocv_add_module(world opencv_core)


### PR DESCRIPTION
issue:https://github.com/opencv/opencv_contrib/issues/3629

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
