### PR TITLE
Fix rectangle rounding in cvGetOptimalNewCameraMatrix.

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -2808,9 +2808,6 @@ void cvGetOptimalNewCameraMatrix( const CvMat* cameraMatrix, const CvMat* distCo
                                       (double)((inner.y - cy0)*s + cy),
                                       (double)(inner.width*s),
                                       (double)(inner.height*s));
-            cv::Rect r(cvCeil(inner.x), cvCeil(inner.y), cvFloor(inner.width), cvFloor(inner.height));
-            r &= cv::Rect(0, 0, newImgSize.width, newImgSize.height);
-            *validPixROI = cvRect(r);
         }
     }
     else
@@ -2840,10 +2837,14 @@ void cvGetOptimalNewCameraMatrix( const CvMat* cameraMatrix, const CvMat* distCo
         if( validPixROI )
         {
             icvGetRectangles( cameraMatrix, distCoeffs, 0, &matM, imgSize, inner, outer );
-            cv::Rect r = inner;
-            r &= cv::Rect(0, 0, newImgSize.width, newImgSize.height);
-            *validPixROI = cvRect(r);
         }
+    }
+    if( validPixROI )
+    {
+        cv::Rect r(cvFloor(inner.x), cvFloor(inner.y), cvCeil(inner.x+inner.width)-cvFloor(inner.x)+1,
+                   cvCeil(inner.y+inner.height)-cvFloor(inner.y)+1);
+        r &= cv::Rect(0, 0, newImgSize.width, newImgSize.height);
+        *validPixROI = cvRect(r);
     }
 
     cvConvert(&matM, newCameraMatrix);

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -2841,8 +2841,32 @@ void cvGetOptimalNewCameraMatrix( const CvMat* cameraMatrix, const CvMat* distCo
     }
     if( validPixROI )
     {
-        cv::Rect r(cvFloor(inner.x), cvFloor(inner.y), cvCeil(inner.x+inner.width)-cvFloor(inner.x)+1,
-                   cvCeil(inner.y+inner.height)-cvFloor(inner.y)+1);
+        // This tolerance defines how incomplete a pixel can be to still be considered complete.
+        // It has been chosen to get Calib3d_GetOptimalNewCameraMatrixNoDistortion.accuracy to pass.
+        constexpr double kTolerance = 1e-12;
+        Point p1, p2;
+        if( std::abs(inner.x-cvRound(inner.x))<kTolerance ) {
+            p1.x = cvRound(inner.x);
+        } else {
+            p1.x = cvCeil(inner.x);
+        }
+        if( std::abs(inner.y-cvRound(inner.y))<kTolerance ) {
+            p1.y = cvRound(inner.y);
+        } else {
+            p1.y = cvCeil(inner.y);
+        }
+        if( std::abs(inner.x+inner.width-cvRound(inner.x+inner.width))<kTolerance ) {
+            p2.x = cvRound(inner.x+inner.width);
+        } else {
+            p2.x = cvFloor(inner.x+inner.width);
+        }
+        if( std::abs(inner.y+inner.height-cvRound(inner.y+inner.height))<kTolerance ) {
+            p2.y = cvRound(inner.y+inner.height);
+        } else {
+            p2.y = cvCeil(inner.y+inner.height);
+        }
+        // +1 to make sure p2 is included.
+        cv::Rect r(p1, p2+cv::Point(1,1));
         r &= cv::Rect(0, 0, newImgSize.width, newImgSize.height);
         *validPixROI = cvRect(r);
     }


### PR DESCRIPTION
This fixes https://github.com/opencv/opencv/issues/24831

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
