### PR TITLE
Enable Android samples with native part with AAR package

### DIFF
--- a/cmake/android/android_gradle_projects.cmake
+++ b/cmake/android/android_gradle_projects.cmake
@@ -221,20 +221,9 @@ include ':${__dir}'
   configure_file("${path}/build.gradle.in" "${ANDROID_TMP_INSTALL_BASE_DIR}/${__dir}/build.gradle" @ONLY)
   install(FILES "${ANDROID_TMP_INSTALL_BASE_DIR}/${__dir}/build.gradle" DESTINATION "${ANDROID_INSTALL_SAMPLES_DIR}/${__dir}" COMPONENT samples)
 
-  # HACK: AAR packages generated from current OpenCV project has incomple prefab part
-  # and cannot be used for native linkage against OpenCV.
-  # Alternative way to build AAR: https://github.com/opencv/opencv/blob/4.x/platforms/android/build_java_shared_aar.py
-  if("${__dir}" STREQUAL "tutorial-2-mixedprocessing" OR "${__dir}" STREQUAL "tutorial-4-opencl")
-    file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
-if (gradle.opencv_source == 'sdk_path') {
-    include ':${__dir}'
-}
-")
-  else()
-    file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
+  file(APPEND "${ANDROID_TMP_INSTALL_BASE_DIR}/settings.gradle" "
 include ':${__dir}'
 ")
-  endif()
 
 endmacro()
 


### PR DESCRIPTION
Removed hack introduced in https://github.com/opencv/opencv/pull/24752
The released AAR for 4.9.0 contains prefab part. The proposed hack is not relevant any more.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
