### PR TITLE
Fix RANSAC RNG usage

### DIFF
--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -168,7 +168,7 @@ public:
         int d2 = m2.channels() > 1 ? m2.channels() : m2.cols;
         int count = m1.checkVector(d1), count2 = m2.checkVector(d2), maxGoodCount = 0;
 
-        RNG rng((uint64)-1);
+        RNG& rng = cv::theRNG();
 
         CV_Assert( cb );
         CV_Assert( confidence > 0 && confidence < 1 );
@@ -281,7 +281,7 @@ public:
         int count = m1.checkVector(d1), count2 = m2.checkVector(d2);
         double minMedian = DBL_MAX;
 
-        RNG rng((uint64)-1);
+        RNG& rng = cv::theRNG();
 
         CV_Assert( cb );
         CV_Assert( confidence > 0 && confidence < 1 );


### PR DESCRIPTION
The RANSAC implementation has a hard-coded RNG seed, which leads to unexpected behavior (see #24835). This patch switches to a reference to `cv::theRNG()`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] ~~The feature is well documented and sample code can be built with the project CMake~~ N/A
