### PR TITLE
1D Einsum layer output mismatch. 

### DIFF
--- a/modules/dnn/test/test_onnx_conformance.cpp
+++ b/modules/dnn/test/test_onnx_conformance.cpp
@@ -1222,6 +1222,12 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
         {
             if (ref_outputs.size() == 1)
             {
+                if (ref_outputs[0].dims != outputs[0].dims) {
+                    if (ref_outputs[0].dims <= 1)
+                        ref_outputs[0] = ref_outputs[0].reshape(1, outputs[0].rows);
+                    if (outputs[0].dims <= 1)
+                        outputs[0] = outputs[0].reshape(1, ref_outputs[0].rows);
+                }
                 // probably we found random unconnected layers.
                 normAssert(ref_outputs[0], outputs[0], "", default_l1, default_lInf);
             }

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -103,7 +103,6 @@
 "test_dynamicquantizelinear_min_adjusted",
 "test_dynamicquantizelinear_min_adjusted_expanded",
 "test_edge_pad",
-"test_einsum_inner_prod",
 "test_equal",
 "test_equal_bcast",
 "test_expand_dim_changed",


### PR DESCRIPTION
This PR solves issue of output shape mismatch for 1d operations. The solution is borrowed from [`test_onnx_importer.cpp`](https://github.com/opencv/opencv/blob/f05ef64df87facaaee35e042c477b819e220e950/modules/dnn/test/test_onnx_importer.cpp#L118) in 5.x. The issue appears when [`test_einsum_inner_prod`](https://github.com/opencv/opencv/blob/f05ef64df87facaaee35e042c477b819e220e950/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp#L106) is commented in `test_onnx_conformance_layer_parser_denylist.inl.hpp`


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
