### PR TITLE
Build warning fix for Charuco tests

### DIFF
--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -814,7 +814,7 @@ TEST(CharucoBoardGenerate, issue_24806)
         Point2f chessCorner(pixInSquare*(p.x/squareLength),
                             pixInSquare*(p.y/squareLength));
         Mat winCorner = chessboardZoneImg(Rect(Point(cvRound(chessCorner.x) - 1, cvRound(chessCorner.y) - 1), Size(2, 2)));
-        bool eq = (cv::countNonZero(goldCorner1 != winCorner) == 0) | (cv::countNonZero(goldCorner2 != winCorner) == 0);
+        bool eq = (cv::countNonZero(goldCorner1 != winCorner) == 0) || (cv::countNonZero(goldCorner2 != winCorner) == 0);
         ASSERT_TRUE(eq);
     }
     // TODO: fix aruco generateImage and add test aruco corners for generated image


### PR DESCRIPTION
Fixes warning produced by default Android NDK compiler:
```
modules/objdetect/test/test_charucodetection.cpp:817:19: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
