### PR TITLE
Build warning fix in Tutorial4-OpenCL.

### DIFF
--- a/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
@@ -4,10 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="21" />
-
     <uses-feature android:glEsVersion="0x00020000" android:required="true"/>
     <uses-feature android:name="android.hardware.camera"/>
     <uses-feature android:name="android.hardware.camera2" android:required="false"/>


### PR DESCRIPTION
Fixes warnings:

```
2024-01-31T09:16:51.4631930Z /Users/xperience/GHA-Actions-OpenCV/_work/opencv/opencv/opencv/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml:7:5-9:41 Warning:
2024-01-31T09:16:51.4632620Z 	uses-sdk:minSdkVersion value (14) specified in the manifest file is ignored. It is overridden by the value declared in the DSL or the variant API, or 1 if not declared/present. Current value is (21).
2024-01-31T09:16:51.4633130Z /Users/xperience/GHA-Actions-OpenCV/_work/opencv/opencv/opencv/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml:7:5-9:41 Warning:
2024-01-31T09:16:51.4633810Z 	uses-sdk:targetSdkVersion value (21) specified in the manifest file is ignored. It is overridden by the value declared in the DSL or the variant API, or 1 if not declared/present. Current value is (31).
```

As the parameters are defined in Gradle.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
