### PR TITLE
Optimize findTransformECC() by removing redundant computations

### DIFF
--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -119,7 +119,7 @@ bool CV_ECC_Test_Translation::testTranslation(int from)
         return false;
     }
     Mat testImg;
-    resize(img, testImg, Size(216, 216), 0, 0, INTER_LINEAR_EXACT);
+    resize(img, testImg, Size(432, 432), 0, 0, INTER_LINEAR_EXACT);
 
     cv::RNG rng = ts->get_rng();
 


### PR DESCRIPTION
This PR removed two redundant computations in findTransformECC().
- Removed "errorProjection" jacobian computation. "errorProjection" can be obtained just by calculating weighed sum of precomputed projections.
- Removed warp functions for "gradient[X|Y]Warped" generation. Just applying first-order differential operator to warped image is more efficient.

The performance gains obtained from conventional tests were as follows:

| Name of Test  | 4.x | PR | PR vs. 4.x |
| ------------- | ------------- | ------------- | ------------- |
| Video_ECC_Translation.accuracy | 176 ms | 116 ms | 1.52 |
| Video_ECC_Euclidean.accuracy | 202 ms | 132 ms | 1.53 |
| Video_ECC_Affine.accuracy | 234 ms | 174 ms | 1.34 |
| Video_ECC_Homography.accuracy | 454 ms | 347 ms | 1.31 |
| Video_ECC_Mask.accuracy | 323 ms | 208 ms | 1.55 |

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
