### PR TITLE
Support for boolean protoTensors

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1744,6 +1744,19 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
             Mat(sizes, depth, val).convertTo(blob, CV_8S, 1.0, offset);
         }
     }
+    else if (datatype == opencv_onnx::TensorProto_DataType_BOOL)
+    {
+        // Assuming ONNX boolean data is stored as raw bytes where each byte is either 0 or 1.
+        char* val = const_cast<char*>(tensor_proto.raw_data().c_str());
+        size_t totalElements = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<int>());
+        Mat temp(Size(sizes[1], sizes[0]), CV_8UC1, val); // Create a temporary Mat with raw boolean data.
+
+        blob.create(sizes, CV_8UC1); // Create the blob Mat with the appropriate size.
+        uchar* dst = blob.data;
+        for (size_t i = 0; i < totalElements; ++i) {
+            dst[i] = static_cast<uchar>(val[i] != 0); // Convert raw bytes to 0 or 1.
+        }
+    }
     else
     {
         std::string errorMsg = "Unsupported data type: " +

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4015,7 +4015,7 @@ void ONNXImporter::buildDispatchMap_ONNX_AI(int opset_version)
 
     dispatch["Equal"] = dispatch["Greater"] = dispatch["Less"] = dispatch["Pow"] = dispatch["Add"] =
             dispatch["Sub"] = dispatch["Mul"] = dispatch["Div"] = dispatch["GreaterOrEqual"] =
-            dispatch["LessOrEqual"] = dispatch["Mod"] = &ONNXImporter::parseElementWise;
+            dispatch["LessOrEqual"] = dispatch["Mod"] = dispatch["And"] = &ONNXImporter::parseElementWise;
 
     dispatch["Sum"] = dispatch["Min"] = dispatch["Max"] = &ONNXImporter::parseElementWise;
     dispatch["Where"] = &ONNXImporter::parseElementWise;


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/issues/19366

This PR resolves issue encountered while reading `protoTensors` with boolean values and is related to [conformance this conformance test.](https://github.com/opencv/opencv/blob/250cfe81c592e84dcb739ba51f6c499e214a89bf/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp#L10C16-L10C17) which make AND operation between booleans tensor. Before this PR onnx parser was not be able to parse graph with boolean values.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
