### PR TITLE
Fix proto and weights mess in dnn performance tests

### DIFF
--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -40,7 +40,7 @@ public:
             if (!halide_scheduler.empty())
                 halide_scheduler = findDataFile(std::string("dnn/halide_scheduler_") + (target == DNN_TARGET_OPENCL ? "opencl_" : "") + halide_scheduler, true);
         }
-        net = readNet(proto, weights);
+        net = readNet(weights, proto);
         // Set multiple inputs
         for(auto &inp: inputs){
             net.setInput(std::get<0>(inp), std::get<1>(inp));
@@ -283,7 +283,7 @@ PERF_TEST_P_(DNNTestNetwork, YOLOv5) {
     applyTestTag(CV_TEST_TAG_MEMORY_512MB);
     Mat sample = imread(findDataFile("dnn/dog416.png"));
     Mat inp = blobFromImage(sample, 1.0 / 255.0, Size(640, 640), Scalar(), true);
-    processNet("", "dnn/yolov5n.onnx", "", inp);
+    processNet("dnn/yolov5n.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, YOLOv8)
@@ -295,7 +295,7 @@ PERF_TEST_P_(DNNTestNetwork, YOLOv8)
 
     Mat sample = imread(findDataFile("dnn/dog416.png"));
     Mat inp = blobFromImage(sample, 1.0 / 255.0, Size(640, 640), Scalar(), true);
-    processNet("", "dnn/yolov8n.onnx", "", inp);
+    processNet("dnn/yolov8n.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, YOLOX) {
@@ -305,7 +305,7 @@ PERF_TEST_P_(DNNTestNetwork, YOLOX) {
     );
     Mat sample = imread(findDataFile("dnn/dog416.png"));
     Mat inp = blobFromImage(sample, 1.0 / 255.0, Size(640, 640), Scalar(), true);
-    processNet("", "dnn/yolox_s.onnx", "", inp);
+    processNet("dnn/yolox_s.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, EAST_text_detection)
@@ -365,15 +365,15 @@ PERF_TEST_P_(DNNTestNetwork, EfficientNet)
     Mat sample = imread(findDataFile("dnn/dog416.png"));
     Mat inp = blobFromImage(sample, 1.0 / 255.0, Size(224, 224), Scalar(), true);
     transposeND(inp, {0, 2, 3, 1}, inp);
-    processNet("", "dnn/efficientnet-lite4.onnx", "", inp);
+    processNet("dnn/efficientnet-lite4.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet) {
-    processNet("", "dnn/onnx/models/yunet-202303.onnx", "",  cv::Size(640, 640));
+    processNet("dnn/onnx/models/yunet-202303.onnx", "", "", cv::Size(640, 640));
 }
 
 PERF_TEST_P_(DNNTestNetwork, SFace) {
-    processNet("", "dnn/face_recognition_sface_2021dec.onnx", "",  cv::Size(112, 112));
+    processNet("dnn/face_recognition_sface_2021dec.onnx", "", "", cv::Size(112, 112));
 }
 
 PERF_TEST_P_(DNNTestNetwork, MPPalm) {
@@ -381,7 +381,7 @@ PERF_TEST_P_(DNNTestNetwork, MPPalm) {
     randu(inp, 0.0f, 1.0f);
     inp = blobFromImage(inp, 1.0, Size(), Scalar(), false);
     transposeND(inp, {0, 2, 3, 1}, inp);
-    processNet("", "dnn/palm_detection_mediapipe_2023feb.onnx", "", inp);
+    processNet("dnn/palm_detection_mediapipe_2023feb.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, MPHand) {
@@ -389,7 +389,7 @@ PERF_TEST_P_(DNNTestNetwork, MPHand) {
     randu(inp, 0.0f, 1.0f);
     inp = blobFromImage(inp, 1.0, Size(), Scalar(), false);
     transposeND(inp, {0, 2, 3, 1}, inp);
-    processNet("", "dnn/handpose_estimation_mediapipe_2023feb.onnx", "",  inp);
+    processNet("dnn/handpose_estimation_mediapipe_2023feb.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, MPPose) {
@@ -397,23 +397,23 @@ PERF_TEST_P_(DNNTestNetwork, MPPose) {
     randu(inp, 0.0f, 1.0f);
     inp = blobFromImage(inp, 1.0, Size(), Scalar(), false);
     transposeND(inp, {0, 2, 3, 1}, inp);
-    processNet("", "dnn/pose_estimation_mediapipe_2023mar.onnx", "",  inp);
+    processNet("dnn/pose_estimation_mediapipe_2023mar.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, PPOCRv3) {
     applyTestTag(CV_TEST_TAG_MEMORY_512MB);
-    processNet("", "dnn/onnx/models/PP_OCRv3_DB_text_det.onnx", "", cv::Size(736, 736));
+    processNet("dnn/onnx/models/PP_OCRv3_DB_text_det.onnx", "", "", cv::Size(736, 736));
 }
 
 PERF_TEST_P_(DNNTestNetwork, PPHumanSeg) {
-    processNet("", "dnn/human_segmentation_pphumanseg_2023mar.onnx", "", cv::Size(192, 192));
+    processNet("dnn/human_segmentation_pphumanseg_2023mar.onnx", "", "", cv::Size(192, 192));
 }
 
 PERF_TEST_P_(DNNTestNetwork, CRNN) {
     Mat inp(cv::Size(100, 32), CV_32FC1);
     randu(inp, 0.0f, 1.0f);
     inp = blobFromImage(inp, 1.0, Size(), Scalar(), false);
-    processNet("", "dnn/text_recognition_CRNN_EN_2021sep.onnx", "", inp);
+    processNet("dnn/text_recognition_CRNN_EN_2021sep.onnx", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, VitTrack) {
@@ -423,7 +423,8 @@ PERF_TEST_P_(DNNTestNetwork, VitTrack) {
     randu(inp2, 0.0f, 1.0f);
     inp1 = blobFromImage(inp1, 1.0, Size(), Scalar(), false);
     inp2 = blobFromImage(inp2, 1.0, Size(), Scalar(), false);
-    processNet("", "dnn/onnx/models/object_tracking_vittrack_2023sep.onnx", "",  {std::make_tuple(inp1, "template"), std::make_tuple(inp2, "search")});
+    processNet("dnn/onnx/models/object_tracking_vittrack_2023sep.onnx", "", "",
+               {std::make_tuple(inp1, "template"), std::make_tuple(inp2, "search")});
 }
 
 PERF_TEST_P_(DNNTestNetwork, EfficientDet_int8)
@@ -434,14 +435,14 @@ PERF_TEST_P_(DNNTestNetwork, EfficientDet_int8)
     }
     Mat inp = imread(findDataFile("dnn/dog416.png"));
     inp = blobFromImage(inp, 1.0 / 255.0, Size(320, 320), Scalar(), true);
-    processNet("", "dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", "", inp);
+    processNet("dnn/tflite/coco_efficientdet_lite0_v1_1.0_quant_2021_09_06.tflite", "", "", inp);
 }
 
 PERF_TEST_P_(DNNTestNetwork, VIT_B_32)
 {
     applyTestTag(CV_TEST_TAG_DEBUG_VERYLONG);
 
-    processNet("", "dnn/onnx/models/vit_b_32.onnx", "", cv::Size(224, 224));
+    processNet("dnn/onnx/models/vit_b_32.onnx", "", "", cv::Size(224, 224));
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, dnnBackendsAndTargets());


### PR DESCRIPTION
Proto and weights files are swapped in some tests. 
The fixed tests are marked with large memory tag and are not covered by buildbot
Need to force OPENCV_TEST_REQUIRE_DATA in CI: https://github.com/opencv/ci-gha-workflow/pull/133

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
