### PR TITLE
Primitive 1D Tests

### DIFF
--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -209,6 +209,7 @@ public:
 
             if (channelsModeInput == ELTWISE_CHANNNELS_SAME)
             {
+                std::cout << "numChannels: " << numChannels << " input_channels: " << input_channels << std::endl;
                 CV_Assert(numChannels == input_channels);
             }
             else if (channelsModeInput == ELTWISE_CHANNNELS_INPUT_0)

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -198,12 +198,12 @@ public:
         int dims = inputs[0].size();
         // Number of channels in output shape is determined by the first input tensor.
         bool variableChannels = false;
-        int numChannels = inputs[0][1];
+        int numChannels = (dims == 1) ? inputs[0][0] : inputs[0][1];
         for (size_t i = 1; i < inputs.size(); i++)
         {
             CV_Assert(inputs[0][0] == inputs[i][0]);  // batch sizes are equal
 
-            int input_channels = inputs[i][1];
+            int input_channels = (dims == 1) ? inputs[i][0] : inputs[i][1];
             if (numChannels != input_channels)
                 variableChannels = true;
 

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -191,7 +191,7 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size() >= 2);
-        CV_Assert(inputs[0].size() >= 2);
+        CV_Assert(inputs[0].size() >= 1);
         CV_Assert(coeffs.size() == 0 || coeffs.size() == inputs.size());
         CV_Assert(op == SUM || coeffs.size() == 0);
 
@@ -235,13 +235,13 @@ public:
         outputs.assign(1, inputs[0]);
         outputs[0][1] = numChannels;
 
-        if (dims > 2)
+        if (dims >= 1)
         {
             size_t vecIdx = 0;
             bool isVecFound = false;
             for (size_t i = 0; i < inputs.size(); i++)
             {
-                bool allOnes = isAllOnes(inputs[i], 2, dims);
+                bool allOnes = isAllOnes(inputs[i], (dims != 1) ? 2 : 1, dims);
                 if (!allOnes && !isVecFound)
                 {
                     vecIdx = i;
@@ -277,7 +277,7 @@ public:
         for (size_t i = 0; i < inputs.size(); i++)
         {
             MatShape inpShape = shape(inputs[i].size);
-            if (isAllOnes(inpShape, 2, inputs[i].dims))
+            if (isAllOnes(inpShape, 0, inputs[i].dims))
             {
                 hasVecInput = true;
                 return;
@@ -310,11 +310,14 @@ public:
                         int nstripes)
         {
             const EltwiseOp op = self.op;
-            CV_Check(dst.dims, 1 < dst.dims && dst.dims <= 5, ""); CV_CheckTypeEQ(dst.type(), CV_32FC1, ""); CV_Assert(dst.isContinuous());
+            CV_Check(dst.dims, 1 <= dst.dims && dst.dims <= 5, "");
+            CV_CheckTypeEQ(dst.type(), CV_32FC1, "");
+            CV_Assert(dst.isContinuous());
             CV_Assert(self.coeffs.empty() || self.coeffs.size() == (size_t)nsrcs);
             CV_CheckGE(nsrcs, 2, "");
 
-            CV_Assert(self.outputChannels == dst.size[1]);
+            if (dst.dims != 1)
+                CV_Assert(self.outputChannels == dst.size[1]);
 
             EltwiseInvoker p(self);
             p.srcs.resize(nsrcs);

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -209,7 +209,6 @@ public:
 
             if (channelsModeInput == ELTWISE_CHANNNELS_SAME)
             {
-                std::cout << "numChannels: " << numChannels << " input_channels: " << input_channels << std::endl;
                 CV_Assert(numChannels == input_channels);
             }
             else if (channelsModeInput == ELTWISE_CHANNNELS_INPUT_0)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -618,7 +618,76 @@ TEST(Layer_LSTM_Test_Accuracy_with_, HiddenParams)
     normAssert(h_t_reference, outputs[0]);
 }
 
-TEST(Layer_MAX_1d_Test_Accuracy_, Accuracy) {
+
+TEST(Layer_GATHER_1d_Test, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Gather";
+    lp.name = "gatherLayer";
+    lp.set("axis", 1);
+    lp.set("real_ndims", 1);
+
+    Ptr<GatherLayer> layer = GatherLayer::create(lp);
+
+    cv::Mat input = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat indices = cv::Mat::ones(1, 1, CV_32F) * 0;
+    cv::Mat output_ref = cv::Mat::ones(1, 1, CV_32F);
+
+    std::vector<Mat> inputs{input, indices};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_ARGMIN_1d_Test, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Arg";
+    lp.name = "argLayer";
+    lp.set("op", "min");
+    lp.set("axis", 1);
+    lp.set("keepdims", 1);
+    lp.set("select_last_index", 0);
+
+    Ptr<ArgLayer> layer = ArgLayer::create(lp);
+
+    cv::Mat input = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat output_ref = cv::Mat::ones(1, 1, CV_32F) * 0;
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_ARGMAX_1d_Test, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Arg";
+    lp.name = "argLayer";
+    lp.set("op", "max");
+    lp.set("axis", 1);
+    lp.set("keepdims", 1);
+    lp.set("select_last_index", 0);
+
+    Ptr<ArgLayer> layer = ArgLayer::create(lp);
+
+    cv::Mat input = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat output_ref = cv::Mat::ones(1, 1, CV_32F) * 0;
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_MAX_1d_Test, Accuracy) {
 
     LayerParams lp;
     lp.type = "Eltwise";
@@ -634,10 +703,11 @@ TEST(Layer_MAX_1d_Test_Accuracy_, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
-TEST(Layer_MIN_1d_Test_Accuracy_, Accuracy) {
+TEST(Layer_MIN_1d_Test, Accuracy) {
 
     LayerParams lp;
     lp.type = "Eltwise";
@@ -653,10 +723,11 @@ TEST(Layer_MIN_1d_Test_Accuracy_, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
-TEST(Layer_PROD_1d_Test_Accuracy_, Accuracy) {
+TEST(Layer_PROD_1d_Test, Accuracy) {
 
     LayerParams lp;
     lp.type = "Eltwise";
@@ -672,10 +743,11 @@ TEST(Layer_PROD_1d_Test_Accuracy_, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
-TEST(Layer_DIV_1d_Test_Accuracy_, Accuracy) {
+TEST(Layer_DIV_1d_Test, Accuracy) {
 
     LayerParams lp;
     lp.type = "Eltwise";
@@ -691,10 +763,11 @@ TEST(Layer_DIV_1d_Test_Accuracy_, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
-TEST(Layer_ADD_1d_Test_Accuracy_, Accuracy) {
+TEST(Layer_ADD_1d_Test, Accuracy) {
 
     LayerParams lp;
     lp.type = "Eltwise";
@@ -710,6 +783,7 @@ TEST(Layer_ADD_1d_Test_Accuracy_, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -738,23 +738,25 @@ TEST_P(Layer_ELEMWISE_1d_Test, Accuracy) {
     lp.set("operation", operation);
     Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
 
-    std::vector<int> input_shape = {batch_size, 1, 1};
+    std::vector<int> input_shape = {batch_size, 1};
     if (batch_size == 0)
         input_shape.erase(input_shape.begin());
 
     cv::Mat input1 = cv::Mat(input_shape, CV_32F, 1.0);
     cv::Mat input2 = cv::Mat(input_shape, CV_32F, 1.0);
 
-    for (int i = 0; i < batch_size; ++i) {
-        input1.at<float>(i, 0, 0) = static_cast<float>(i + 1);
-        input2.at<float>(i, 0, 0) = static_cast<float>(2 * (i + 1));
+    // fill in the input matrices with different values
+    for (int i = 0; i < batch_size; ++i)
+    {
+        input1.at<float>(i, 0) = static_cast<float>(i);
+        input2.at<float>(i, 0) = static_cast<float>(i + 1);
     }
 
     // dynamicly select the operation
-    cv::Mat output_ref = (operation == "sum") ? input1 + input2 : (operation == "max") \
-                                            ? cv::max(input1, input2) : (operation == "min") \
-                                            ? cv::min(input1, input2) : (operation == "prod") \
-                                            ? input1.mul(input2) : input1 / input2;
+    cv::Mat output_ref = (operation == "sum") ? input1 + input2 :
+                         (operation == "max") ? cv::max(input1, input2) :
+                         (operation == "min") ? cv::min(input1, input2) :
+                         (operation == "prod")  ? input1.mul(input2) : input1 / input2;
 
     std::vector<Mat> inputs{input1, input2};
     std::vector<Mat> outputs;

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -657,8 +657,8 @@ TEST_P(Layer_ARG_1d_Test, Accuracy) {
 
     Ptr<ArgLayer> layer = ArgLayer::create(lp);
 
-    std::vector<int> input_shape = {batch_size, 1, 1};
-    std::vector<int> output_shape = {1, 1, 1};
+    std::vector<int> input_shape = {batch_size, 1};
+    std::vector<int> output_shape = {1, 1};
 
     if (batch_size == 0){
         input_shape.erase(input_shape.begin());
@@ -673,7 +673,7 @@ TEST_P(Layer_ARG_1d_Test, Accuracy) {
     cv::Mat output_ref = cv::Mat(output_shape,  CV_32F, 0);
 
     for (int i = 0; i < batch_size; ++i)
-        input.at<float>(i, 0, 0) = static_cast<float>(i + 1);
+        input.at<float>(i, 0) = static_cast<float>(i + 1);
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -618,6 +618,101 @@ TEST(Layer_LSTM_Test_Accuracy_with_, HiddenParams)
     normAssert(h_t_reference, outputs[0]);
 }
 
+TEST(Layer_MAX_1d_Test_Accuracy_, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Eltwise";
+    lp.name = "addLayer";
+    lp.set("operation", "max");
+    Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
+
+    cv::Mat input1 = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat input2 = cv::Mat::ones(1, 1, CV_32F) + 1;
+    cv::Mat output_ref = input2;
+
+    std::vector<Mat> inputs{input1, input2};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_MIN_1d_Test_Accuracy_, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Eltwise";
+    lp.name = "addLayer";
+    lp.set("operation", "min");
+    Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
+
+    cv::Mat input1 = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat input2 = cv::Mat::ones(1, 1, CV_32F) * 2;
+    cv::Mat output_ref = input1;
+
+    std::vector<Mat> inputs{input1, input2};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_PROD_1d_Test_Accuracy_, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Eltwise";
+    lp.name = "addLayer";
+    lp.set("operation", "prod");
+    Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
+
+    cv::Mat input1 = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat input2 = cv::Mat::ones(1, 1, CV_32F) * 2;
+    cv::Mat output_ref = input1 * input2;
+
+    std::vector<Mat> inputs{input1, input2};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_DIV_1d_Test_Accuracy_, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Eltwise";
+    lp.name = "addLayer";
+    lp.set("operation", "div");
+    Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
+
+    cv::Mat input1 = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat input2 = cv::Mat::ones(1, 1, CV_32F) * 2;
+    cv::Mat output_ref = input1 / input2;
+
+    std::vector<Mat> inputs{input1, input2};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+
+TEST(Layer_ADD_1d_Test_Accuracy_, Accuracy) {
+
+    LayerParams lp;
+    lp.type = "Eltwise";
+    lp.name = "addLayer";
+    lp.set("operation", "sum");
+    Ptr<EltwiseLayer> layer = EltwiseLayer::create(lp);
+
+    cv::Mat input1 = cv::Mat::ones(1, 1, CV_32F);
+    cv::Mat input2 = cv::Mat::ones(1, 1, CV_32F) * 2;
+    cv::Mat output_ref = input1 + input2;
+
+    std::vector<Mat> inputs{input1, input2};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+
 TEST(Layer_GRU_Test_Accuracy_with_, Pytorch)
 {
     Mat Wx = blobFromNPY(_tf("gru.W.npy"));


### PR DESCRIPTION
This PR is designed to add tests for 1D inputs for layer, which is required after introducing 1d support in 5.x. Currently tests are written for following layers: 

- [x] `Add`, `Sub`
- [x]  `Product`, `Div`
- [x]  `Min`, `Max`
- [x] `Argmin`, `Argmax`
- [x] `Gather` 

This list is to be extended for more layer such `gemm`, `conv` etc.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
