### PR TITLE
remove bypass for ABI check in warpPointBackward

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
@@ -74,12 +74,12 @@ public:
 
     @param pt Projected point
     @param K Camera intrinsic parameters
-            @param R Camera rotation matrix
-            @return Backward-projected point
-            */
-            virtual Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R) = 0;
+    @param R Camera rotation matrix
+    @return Backward-projected point
+    */
+    virtual Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R) = 0;
 
-            /** @brief Builds the projection maps according to the given camera data.
+    /** @brief Builds the projection maps according to the given camera data.
 
     @param src_size Source image size
     @param K Camera intrinsic parameters

--- a/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/warpers.hpp
@@ -74,20 +74,12 @@ public:
 
     @param pt Projected point
     @param K Camera intrinsic parameters
-    @param R Camera rotation matrix
-    @return Backward-projected point
-    */
-#if CV_VERSION_MAJOR == 4
-    virtual Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R)
-    {
-        CV_UNUSED(pt); CV_UNUSED(K); CV_UNUSED(R);
-        CV_Error(Error::StsNotImplemented, "");
-    }
-#else
-    virtual Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R) = 0;
-#endif
+            @param R Camera rotation matrix
+            @return Backward-projected point
+            */
+            virtual Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R) = 0;
 
-    /** @brief Builds the projection maps according to the given camera data.
+            /** @brief Builds the projection maps according to the given camera data.
 
     @param src_size Source image size
     @param K Camera intrinsic parameters

--- a/modules/stitching/include/opencv2/stitching/warpers.hpp
+++ b/modules/stitching/include/opencv2/stitching/warpers.hpp
@@ -72,15 +72,8 @@ namespace cv {
         @param R Camera rotation matrix
         @return Backward-projected point
         */
-#if CV_VERSION_MAJOR == 4
-        CV_WRAP Point2f warpPointBackward(const Point2f& pt, InputArray K, InputArray R)
-        {
-            CV_UNUSED(pt); CV_UNUSED(K); CV_UNUSED(R);
-            CV_Error(Error::StsNotImplemented, "");
-        }
-#else
         CV_WRAP Point2f warpPointBackward(const Point2f &pt, InputArray K, InputArray R);
-#endif
+
         /** @brief Builds the projection maps according to the given camera data.
 
         @param src_size Source image size

--- a/modules/stitching/src/warpers.cpp
+++ b/modules/stitching/src/warpers.cpp
@@ -93,12 +93,10 @@ Point2f PyRotationWarper::warpPoint(const Point2f &pt, InputArray K, InputArray 
     return rw.get()->warpPoint(pt, K, R);
 }
 
-#if CV_VERSION_MAJOR != 4
 Point2f PyRotationWarper::warpPointBackward(const Point2f& pt, InputArray K, InputArray R)
 {
     return rw.get()->warpPointBackward(pt, K, R);
 }
-#endif
 
 Rect PyRotationWarper::buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] ~~There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.~~
- [x] The feature is well documented and sample code can be built with the project CMake

### What? 
In my [PR](https://github.com/opencv/opencv/commit/d31b6c3480c601305fa1e153a819aad0bd247fe2) regarding `warpPointBackward`, I was asked by alalek to [add a bypass](https://github.com/opencv/opencv/pull/18607/files#r508423486) to python wrapper class, presumably to ship the changes in the newest patch release (4.5.1).

The bypass was not removed in 4.6.0 release, so please remove it in either 4.10.0 or 4.11.0. Thanks!