### PR TITLE
Relax test requirements for CUDA in DNNTestNetwork.FastNeuraStyle_eccv16

### DIFF
--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -469,7 +469,7 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
     }
     else if (target == DNN_TARGET_CUDA)
     {
-        l1 = 7e-4;
+        l1 = 8e-4;
         lInf = 2e-2;
     }
     else if (target == DNN_TARGET_CUDA_FP16)


### PR DESCRIPTION
Previous iteration with OpenCL: https://github.com/opencv/opencv/pull/24899
Related CI test failure: https://github.com/opencv/opencv/actions/runs/7869342400/job/21469344280?pr=24992

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
