### PR TITLE
Alternative solution for QR code black/white balance computation

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3070,7 +3070,10 @@ protected:
     {
         bool operator()(const Point2f& a, const Point2f& b) const
         {
-            return a.y < b.y;
+            if (a.y != b.y)
+                return a.y < b.y;
+            else
+                return a.x < b.x;
         }
     };
     struct compareSquare

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -614,4 +614,21 @@ TEST(Objdetect_QRCode_detectAndDecode, utf8_output)
     EXPECT_NE(decoded_info.find("M\xc3\xbcllheimstrasse"), std::string::npos);
 }
 
+TEST_P(Objdetect_QRCode_detectAndDecodeMulti, detect_regression_24679)
+{
+    const std::string name_current_image = "issue_24679.png";
+    const std::string root = "qrcode/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat img = imread(image_path);
+    const std::string method = GetParam();
+    GraphicalCodeDetector qrcode = QRCodeDetector();
+    if (method == "aruco_based") {
+        qrcode = QRCodeDetectorAruco();
+    }
+    std::vector<cv::String> decoded_info;
+    ASSERT_TRUE(qrcode.detectAndDecodeMulti(img, decoded_info));
+    EXPECT_EQ(decoded_info.size(), 4U);
+}
+
 }} // namespace


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24679
Related PR for extra: https://github.com/opencv/opencv_extra/pull/1133
Alternative to https://github.com/opencv/opencv/pull/24758/
No regressions in QR code benchmark

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
