### PR TITLE
Fixed possible out-of-bound access in cv::Mat output formatter

### DIFF
--- a/modules/core/src/out.cpp
+++ b/modules/core/src/out.cpp
@@ -342,9 +342,10 @@ namespace cv
 
         Ptr<Formatted> format(const Mat& mtx) const CV_OVERRIDE
         {
-            static const char* numpyTypes[] =
+            static const char* numpyTypes[CV_DEPTH_MAX] =
             {
-                "uint8", "int8", "uint16", "int16", "int32", "float32", "float64", "float16"
+                "uint8", "int8", "uint16", "int16", "int32", "float32", "float64",
+                "float16", "bfloat16", "bool", "uint64", "int64", "uint32"
             };
             char braces[5] = {'[', ']', ',', '[', ']'};
             if (mtx.cols == 1)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
