### PR TITLE
Replace legacy __ARM_NEON__ by __ARM_NEON

### DIFF
--- a/cmake/checks/cpu_neon.cpp
+++ b/cmake/checks/cpu_neon.cpp
@@ -5,7 +5,7 @@
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
-#elif defined(__ARM_NEON__) || (defined (__ARM_NEON) && defined(__aarch64__))
+#elif defined(__ARM_NEON)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #endif

--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -141,7 +141,7 @@
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
-#elif defined(__ARM_NEON) || defined(__aarch64__)
+#elif defined(__ARM_NEON)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #endif
@@ -225,7 +225,7 @@ struct VZeroUpperGuard {
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
-#elif defined(__ARM_NEON) || defined(__aarch64__)
+#elif defined(__ARM_NEON)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #elif defined(__VSX__) && defined(__PPC64__) && defined(__LITTLE_ENDIAN__)

--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -141,7 +141,7 @@
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
-#elif defined(__ARM_NEON__) || (defined (__ARM_NEON) && defined(__aarch64__))
+#elif defined(__ARM_NEON) || defined(__aarch64__)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #endif
@@ -149,10 +149,6 @@
 #if defined(__riscv) && defined(__riscv_vector) && defined(__riscv_vector_071)
 # include<riscv_vector.h>
 # define CV_RVV071 1
-#endif
-
-#if defined(__ARM_NEON__) || defined(__aarch64__)
-#  include <arm_neon.h>
 #endif
 
 #ifdef CV_CPU_COMPILE_VSX
@@ -229,7 +225,7 @@ struct VZeroUpperGuard {
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
-#elif defined(__ARM_NEON__) || (defined (__ARM_NEON) && defined(__aarch64__))
+#elif defined(__ARM_NEON) || defined(__aarch64__)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #elif defined(__VSX__) && defined(__PPC64__) && defined(__LITTLE_ENDIAN__)

--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -84,7 +84,7 @@
   #if defined(CV_INLINE_ROUND_FLT)
     // user-specified version
     // CV_INLINE_ROUND_DBL should be defined too
-  #elif defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__ || defined __ARM_NEON__) && !defined __SOFTFP__
+  #elif defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__ || defined __ARM_NEON) && !defined __SOFTFP__
     // 1. general scheme
     #define ARM_ROUND(_value, _asm_string) \
         int res; \

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -637,10 +637,10 @@ struct HWFeatures
         }
     #endif
     #elif (defined __APPLE__)
-    #if (defined __ARM_NEON__ || (defined __ARM_NEON && defined __aarch64__))
+    #if (defined __ARM_NEON || defined __aarch64__)
         have[CV_CPU_NEON] = true;
     #endif
-    #if (defined __ARM_FP  && (((__ARM_FP & 0x2) != 0) && defined __ARM_NEON__))
+    #if (defined __ARM_FP  && (((__ARM_FP & 0x2) != 0) && defined __ARM_NEON))
         have[CV_CPU_FP16] = have[CV_CPU_NEON_FP16] = true;
     #endif
     // system.cpp may be compiled w/o special -march=armv8...+dotprod, -march=armv8...+bf16 etc.,
@@ -659,7 +659,7 @@ struct HWFeatures
         have[CV_CPU_NEON_BF16] = true;
     }
     #elif (defined __clang__)
-    #if (defined __ARM_NEON__ || (defined __ARM_NEON && defined __aarch64__))
+    #if (defined __ARM_NEON || defined __aarch64__)
         have[CV_CPU_NEON] = true;
         #if (defined __ARM_FP  && ((__ARM_FP & 0x2) != 0))
         have[CV_CPU_FP16] = true;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -637,7 +637,7 @@ struct HWFeatures
         }
     #endif
     #elif (defined __APPLE__)
-    #if (defined __ARM_NEON || defined __aarch64__)
+    #if defined __ARM_NEON
         have[CV_CPU_NEON] = true;
     #endif
     #if (defined __ARM_FP  && (((__ARM_FP & 0x2) != 0) && defined __ARM_NEON))
@@ -659,7 +659,7 @@ struct HWFeatures
         have[CV_CPU_NEON_BF16] = true;
     }
     #elif (defined __clang__)
-    #if (defined __ARM_NEON || defined __aarch64__)
+    #if defined __ARM_NEON
         have[CV_CPU_NEON] = true;
         #if (defined __ARM_FP  && ((__ARM_FP & 0x2) != 0))
         have[CV_CPU_FP16] = true;

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -49,7 +49,7 @@ typedef unsigned __int64 uint64_t;
 # include <Intrin.h>
 #endif
 
-#if defined(__ARM_NEON__) && !defined(__CUDACC__)
+#if defined(__ARM_NEON) && !defined(__CUDACC__)
 # include "arm_neon.h"
 #endif
 
@@ -559,7 +559,7 @@ struct Hamming
     ResultType operator()(const Iterator1 a, const Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
     {
         ResultType result = 0;
-#if defined(__ARM_NEON__) && !defined(__CUDACC__)
+#if defined(__ARM_NEON) && !defined(__CUDACC__)
         {
             const unsigned char* a2 = reinterpret_cast<const unsigned char*> (a);
             const unsigned char* b2 = reinterpret_cast<const unsigned char*> (b);
@@ -611,7 +611,7 @@ struct Hamming
     {
         (void)b;
         ResultType result = 0;
-#if defined(__ARM_NEON__) && !defined(__CUDACC__)
+#if defined(__ARM_NEON) && !defined(__CUDACC__)
         {
             const unsigned char* a2 = reinterpret_cast<const unsigned char*> (a);
             uint32x4_t bits = vmovq_n_u32(0);


### PR DESCRIPTION
Even ACLE 1.1 referes to __ARM_NEON
https://developer.arm.com/documentation/ihi0053/b/?lang=en

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
