### PR TITLE
Fix qrcode bugs

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -481,7 +481,7 @@ bool QRDetect::localization()
         }
     }
 
-    if (list_lines_y.empty())
+    if (labels.empty())
     {
         localization_points.clear();
     }

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -1947,7 +1947,7 @@ vector<vector<float> > QRDecode::computeSpline(const vector<int> &x_arr, const v
     }
     for (int i = 0; i < n - 1; i++)
     {
-        h[i] = static_cast<float>(y_arr[i + 1] - y_arr[i]);
+        h[i] = static_cast<float>(y_arr[i + 1] - y_arr[i]) + std::numeric_limits<float>::epsilon();
     }
     for (int i = 1; i < n - 1; i++)
     {

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -481,6 +481,11 @@ bool QRDetect::localization()
         }
     }
 
+    if (list_lines_y.empty())
+    {
+        localization_points.clear();
+    }
+
     bool square_flag = false, local_points_flag = false;
     double triangle_sides[3];
     double triangle_perim, square_area, img_square_area;

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -1567,9 +1567,9 @@ Point QRDecode::findClosestZeroPoint(Point2f original_point)
     Point zero_point;
 
     const int step = 2;
-    for (int i = orig_x - step; i >= 0 && i <= orig_x + step; i++)
+    for (int i = std::max(orig_x - step, 0); i >= 0 && i <= std::min(orig_x + step, bin_barcode.cols - 1); i++)
     {
-        for (int j = orig_y - step; j >= 0 && j <= orig_y + step; j++)
+        for (int j = std::max(orig_y - step, 0); j >= 0 && j <= std::min(orig_y + step, bin_barcode.rows - 1); j++)
         {
             Point p(i, j);
             value = bin_barcode.at<uint8_t>(p);

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -466,16 +466,20 @@ bool QRDetect::localization()
     CV_TRACE_FUNCTION();
     Point2f begin, end;
     vector<Vec3d> list_lines_x = searchHorizontalLines();
-    if( list_lines_x.empty() ) { return false; }
-    vector<Point2f> list_lines_y = separateVerticalLines(list_lines_x);
-    if( list_lines_y.empty() ) { return false; }
-
+    vector<Point2f> list_lines_y;
     Mat labels;
-    kmeans(list_lines_y, 3, labels,
-           TermCriteria( TermCriteria::EPS + TermCriteria::COUNT, 10, 0.1),
-           3, KMEANS_PP_CENTERS, localization_points);
+    if (!list_lines_x.empty())
+    {
+        list_lines_y = separateVerticalLines(list_lines_x);
+        if (!list_lines_y.empty())
+        {
+            kmeans(list_lines_y, 3, labels,
+                TermCriteria( TermCriteria::EPS + TermCriteria::COUNT, 10, 0.1),
+                3, KMEANS_PP_CENTERS, localization_points);
 
-    fixationPoints(localization_points);
+            fixationPoints(localization_points);
+        }
+    }
 
     bool square_flag = false, local_points_flag = false;
     double triangle_sides[3];

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -631,4 +631,20 @@ TEST_P(Objdetect_QRCode_detectAndDecodeMulti, detect_regression_24679)
     EXPECT_EQ(decoded_info.size(), 4U);
 }
 
+TEST(Objdetect_QRCode_detect, detect_regression_24450)
+{
+    const std::string name_current_image = "issue_24450.png";
+    const std::string root = "qrcode/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat img = imread(image_path);
+    GraphicalCodeDetector qrcode = QRCodeDetector();
+    std::vector<Point2f> points;
+    ASSERT_TRUE(qrcode.detect(img, points));
+    EXPECT_EQ(points.size(), 4U);
+    img.at<Vec3b>(img.rows - 1, 296) = {};
+    ASSERT_TRUE(qrcode.detect(img, points));
+    EXPECT_EQ(points.size(), 4U);
+}
+
 }} // namespace

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -631,6 +631,23 @@ TEST_P(Objdetect_QRCode_detectAndDecodeMulti, detect_regression_24679)
     EXPECT_EQ(decoded_info.size(), 4U);
 }
 
+TEST_P(Objdetect_QRCode_detectAndDecodeMulti, detect_regression_24011)
+{
+    const std::string name_current_image = "issue_24011.jpg";
+    const std::string root = "qrcode/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat img = imread(image_path);
+    const std::string method = GetParam();
+    GraphicalCodeDetector qrcode = QRCodeDetector();
+    if (method == "aruco_based") {
+        qrcode = QRCodeDetectorAruco();
+    }
+    std::vector<cv::String> decoded_info;
+    ASSERT_TRUE(qrcode.detectAndDecodeMulti(img, decoded_info));
+    EXPECT_EQ(decoded_info.size(), 2U);
+}
+
 TEST(Objdetect_QRCode_detect, detect_regression_24450)
 {
     const std::string name_current_image = "issue_24450.png";

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -664,4 +664,19 @@ TEST(Objdetect_QRCode_detect, detect_regression_24450)
     EXPECT_EQ(points.size(), 4U);
 }
 
+TEST(Objdetect_QRCode_detect, detect_regression_22892)
+{
+    const std::string name_current_image = "issue_22892.png";
+    const std::string root = "qrcode/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat img = imread(image_path);
+
+    QRCodeDetector qrcode;
+    std::vector<Point> corners;
+    Mat straight_code;
+    qrcode.detectAndDecodeCurved(img, corners, straight_code);
+    EXPECT_EQ(corners.size(), 4U);
+}
+
 }} // namespace


### PR DESCRIPTION
This PR fixes #22892, #24011 and #24450 and adds regression tests using the images provided. I've also verified with the [benchmark](https://github.com/opencv/opencv_benchmarks/tree/develop/python_benchmarks/qr_codes) that this doesn't break anything there.

resolves #22892
resolves #24011
resolves #24450
Replaces https://github.com/opencv/opencv/pull/23802

Requires extra: https://github.com/opencv/opencv_extra/pull/1148

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
