### PR TITLE
video(test): filter very long debug tests

### DIFF
--- a/modules/video/test/test_trackers.cpp
+++ b/modules/video/test/test_trackers.cpp
@@ -21,25 +21,27 @@ const string FOLDER_OMIT_INIT = "initOmit";
 #include "test_trackers.impl.hpp"
 
 //[TESTDATA]
-PARAM_TEST_CASE(DistanceAndOverlap, string)
+PARAM_TEST_CASE(DistanceAndOverlap, string, int)
 {
     string dataset;
+    int numFramesLimit;
     virtual void SetUp()
     {
         dataset = GET_PARAM(0);
+        numFramesLimit = GET_PARAM(1);
     }
 };
 
 TEST_P(DistanceAndOverlap, MIL)
 {
     TrackerTest<Tracker, Rect> test(TrackerMIL::create(), dataset, 30, .65f, NoTransform);
-    test.run();
+    test.run(numFramesLimit);
 }
 
 TEST_P(DistanceAndOverlap, Shifted_Data_MIL)
 {
     TrackerTest<Tracker, Rect> test(TrackerMIL::create(), dataset, 30, .6f, CenterShiftLeft);
-    test.run();
+    test.run(numFramesLimit);
 }
 
 /***************************************************************************************/
@@ -48,7 +50,7 @@ TEST_P(DistanceAndOverlap, Shifted_Data_MIL)
 TEST_P(DistanceAndOverlap, Scaled_Data_MIL)
 {
     TrackerTest<Tracker, Rect> test(TrackerMIL::create(), dataset, 30, .7f, Scale_1_1);
-    test.run();
+    test.run(numFramesLimit);
 }
 
 TEST_P(DistanceAndOverlap, GOTURN)
@@ -59,10 +61,23 @@ TEST_P(DistanceAndOverlap, GOTURN)
     params.modelTxt = model;
     params.modelBin = weights;
     TrackerTest<Tracker, Rect> test(TrackerGOTURN::create(params), dataset, 35, .35f, NoTransform);
-    test.run();
+    test.run(numFramesLimit);
 }
 
-INSTANTIATE_TEST_CASE_P(Tracking, DistanceAndOverlap, TESTSET_NAMES);
+INSTANTIATE_TEST_CASE_P(Tracking, DistanceAndOverlap,
+    testing::Combine(
+        TESTSET_NAMES,
+        testing::Values(0)
+    )
+);
+
+INSTANTIATE_TEST_CASE_P(Tracking5Frames, DistanceAndOverlap,
+    testing::Combine(
+        TESTSET_NAMES,
+        testing::Values(5)
+    )
+);
+
 
 static bool checkIOU(const Rect& r0, const Rect& r1, double threshold)
 {

--- a/modules/video/test/test_trackers.impl.hpp
+++ b/modules/video/test/test_trackers.impl.hpp
@@ -65,7 +65,7 @@ public:
     TrackerTest(const Ptr<Tracker>& tracker, const string& video, float distanceThreshold,
             float overlapThreshold, int shift = NoTransform, int segmentIdx = 1, int numSegments = 10);
     ~TrackerTest() {}
-    void run();
+    void run(int numFramesLimit = 0);
 
 protected:
     void checkDataTest();
@@ -351,7 +351,7 @@ void TrackerTest<Tracker, ROI_t>::checkDataTest()
 }
 
 template <typename Tracker, typename ROI_t>
-void TrackerTest<Tracker, ROI_t>::run()
+void TrackerTest<Tracker, ROI_t>::run(int numFramesLimit)
 {
     srand(1);  // FIXIT remove that, ensure that there is no "rand()" in implementation
 
@@ -362,6 +362,21 @@ void TrackerTest<Tracker, ROI_t>::run()
     //check for failure
     if (::testing::Test::HasFatalFailure())
         return;
+
+    int numFrames = endFrame - startFrame;
+    std::cout << "Number of frames in test data: " << numFrames << std::endl;
+
+    if (numFramesLimit > 0)
+    {
+        numFrames = std::min(numFrames, numFramesLimit);
+        endFrame = startFrame + numFramesLimit;
+    }
+    else
+    {
+        applyTestTag(CV_TEST_TAG_DEBUG_VERYLONG);
+    }
+
+    std::cout << "Number of frames to test: " << numFrames << std::endl;
 
     distanceAndOverlapTest();
 }


### PR DESCRIPTION
Avoid very long test cases runs on CI by default.

Before:

```
[ RUN      ] Tracking/DistanceAndOverlap.GOTURN/1, where GetParam() = ("dudek")
startFrame = 1
frame size = [720 x 480]

command timed out: 600 seconds without output
```

After:

```
[ RUN      ] Tracking/DistanceAndOverlap.GOTURN/1, where GetParam() = ("dudek", 0)
Number of frames in test data: 106
[     SKIP ] Test with tag 'debug_verylong' is skipped ('debug_verylong' is in skip list)
[       OK ] Tracking/DistanceAndOverlap.GOTURN/1 (779 ms)

...

[ RUN      ] Tracking5Frames/DistanceAndOverlap.GOTURN/1, where GetParam() = ("dudek", 5)
Number of frames in test data: 106
Number of frames to test: 5
startFrame = 1
frame size = [720 x 480]
[       OK ] Tracking5Frames/DistanceAndOverlap.GOTURN/1 (11305 ms)
```