### PR TITLE
Fix barcode detectAndDecode

### DIFF
--- a/modules/objdetect/perf/perf_barcode.cpp
+++ b/modules/objdetect/perf/perf_barcode.cpp
@@ -30,6 +30,7 @@ PERF_TEST_P_(Perf_Barcode_multi, detect)
     }
     SANITY_CHECK_NOTHING();
     ASSERT_TRUE(res);
+    ASSERT_EQ(16ull, corners.size());
 }
 
 PERF_TEST_P_(Perf_Barcode_multi, detect_decode)
@@ -54,6 +55,8 @@ PERF_TEST_P_(Perf_Barcode_multi, detect_decode)
     }
     SANITY_CHECK_NOTHING();
     ASSERT_TRUE(res);
+    ASSERT_EQ(16ull, corners.size());
+    ASSERT_EQ(4ull, decoded_info.size());
 }
 
 PERF_TEST_P_(Perf_Barcode_single, detect)
@@ -76,6 +79,7 @@ PERF_TEST_P_(Perf_Barcode_single, detect)
     }
     SANITY_CHECK_NOTHING();
     ASSERT_TRUE(res);
+    ASSERT_EQ(4ull, corners.size());
 }
 
 PERF_TEST_P_(Perf_Barcode_single, detect_decode)
@@ -100,6 +104,8 @@ PERF_TEST_P_(Perf_Barcode_single, detect_decode)
     }
     SANITY_CHECK_NOTHING();
     ASSERT_TRUE(res);
+    ASSERT_EQ(4ull, corners.size());
+    ASSERT_EQ(1ull, decoded_info.size());
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Perf_Barcode_multi,

--- a/modules/objdetect/src/barcode.cpp
+++ b/modules/objdetect/src/barcode.cpp
@@ -302,13 +302,13 @@ string BarcodeImpl::detectAndDecode(InputArray img, OutputArray points, OutputAr
     CV_UNUSED(straight_code);
     vector<string> decoded_info;
     vector<string> decoded_type;
-    vector<Point> points_;
+    vector<Point2f> points_;
     if (!detectAndDecodeWithType(img, decoded_info, decoded_type, points_))
         return string();
     if (points_.size() < 4 || decoded_info.size() < 1)
         return string();
     points_.resize(4);
-    points.setTo(points_);
+    updatePointsResult(points, points_);
     return decoded_info[0];
 }
 

--- a/modules/objdetect/test/test_barcode.cpp
+++ b/modules/objdetect/test/test_barcode.cpp
@@ -95,6 +95,13 @@ TEST_P(BarcodeDetector_main, interface)
         EXPECT_EQ(1u, expected_lines.count(res));
     }
 
+    {
+        string res = det.detectAndDecode(img, points);
+        ASSERT_FALSE(res.empty());
+        EXPECT_EQ(1u, expected_lines.count(res));
+        EXPECT_EQ(4u, points.size());
+    }
+
     // common interface (multi)
     {
         bool res = det.detectMulti(img, points);


### PR DESCRIPTION
The method `detectAndDecode()` in the `BarcodeDetector` class doesn't return the barcode corners.
This PR fixes the and add test for `detectAndDecode`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
