### PR TITLE
Fix bias in HoughLines with even number of rho discretization steps #25038

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Please read the [contribution guidelines](https://github.com/opencv/opencv/wiki/
 * [Follow OpenCV on Mastodon](http://mastodon.social/@opencv) in the Fediverse
 * [Follow OpenCV on Twitter](https://twitter.com/opencvlive)
 * [OpenCV.ai](https://opencv.ai): Computer Vision and AI development services from the OpenCV team.
+

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -214,7 +214,7 @@ HoughLinesStandard( InputArray src, OutputArray lines, int type,
         int idx = _sort_buf[i];
         int n = cvFloor(idx*scale) - 1;
         int r = idx - (n+1)*(numrho+2) - 1;
-        line.rho = (r - (numrho - 1)*0.5f) * rho;
+        line.rho = (r - (numrho - 1)/2) * rho;
         line.angle = static_cast<float>(min_theta) + n * theta;
         if (type == CV_32FC2)
         {


### PR DESCRIPTION
#25038

Description:
Replace the multiplication by 0.5f with a division by int(2) in the calculation of rho value to address potential bias in Hough Line Transform.

Changes Made:
Modified the calculation of the rho value in Hough Line Transform by changing the expression from `(r - (numrho - 1)*0.5f) * rho` to `(r - (numrho - 1)/2) * rho`.

Purpose:
To fix a potential bias issue in the calculated rho values of detected lines in the Hough Line Transform.

Related Issue:
No specific issue tracked. This change addresses a potential issue identified in the codebase.

Additional Information:
This change has been tested locally and verified to resolve the bias issue in rho values without affecting the functionality of the Hough Line Transform.


