### PR TITLE
Fix testMahalanobis

### DIFF
--- a/modules/core/misc/java/test/CoreTest.java
+++ b/modules/core/misc/java/test/CoreTest.java
@@ -947,11 +947,11 @@ public class CoreTest extends OpenCVTestCase {
     }
 
     public void testMahalanobis() {
-        Mat src = new Mat(matSize, matSize, CvType.CV_32F);
+        Mat src = new Mat(matSize + 1, matSize, CvType.CV_32F);
         Core.randu(src, -128, 128);
 
         Mat covar = new Mat(matSize, matSize, CvType.CV_32F);
-        Mat mean = new Mat(1, matSize, CvType.CV_32F);
+        Mat mean = new Mat(1, matSize + 1, CvType.CV_32F);
         Core.calcCovarMatrix(src, covar, mean, Core.COVAR_ROWS | Core.COVAR_NORMAL, CvType.CV_32F);
         covar = covar.inv();
 
@@ -962,9 +962,8 @@ public class CoreTest extends OpenCVTestCase {
 
         assertEquals(0.0, d);
 
-        // Bug: https://github.com/opencv/opencv/issues/24348
-        // d = Core.Mahalanobis(line1, line2, covar);
-        // assertTrue(d > 0.0);
+        d = Core.Mahalanobis(line1, line2, covar);
+        assertTrue(d > 0.0);
     }
 
     public void testMax() {


### PR DESCRIPTION
The problem in `CoreTest.testMahalanobis` is that the generated covariance matrix is not invertible, because the random matrix has too few samples.

Consider 3 vectors in 3D space. They all lie on a plane, so they can be expressed as their mean + 2 linearly independent vectors. This makes their covariance matrix singular. The same applies to n ≠ 3. You can verify this by observing that in
```
import numpy as np
n = 10
a = np.random.uniform(-128, 128, (n, n))
print(np.linalg.eigvals(np.cov(a)))
```
you will for any `n` always get a zero eigenvalue (actually close to zero due to numerical errors).

The inverses in #24348 are different across platforms because, well, the inverse doesn't exist up to numerical errors. The fix is to add one more random sample to make the covariance matrix non-singular.

This PR resolves #24348

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
