### PR TITLE
fix setArucoParameters in QRCodeDetectorAruco, add const to getArucoParameters 

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -854,7 +854,7 @@ public:
     CV_WRAP QRCodeDetectorAruco& setDetectorParameters(const QRCodeDetectorAruco::Params& params);
 
     /** @brief Aruco detector parameters are used to search for the finder patterns. */
-    CV_WRAP aruco::DetectorParameters getArucoParameters();
+    CV_WRAP const aruco::DetectorParameters& getArucoParameters() const;
 
     /** @brief Aruco detector parameters are used to search for the finder patterns. */
     CV_WRAP void setArucoParameters(const aruco::DetectorParameters& params);

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -4615,13 +4615,13 @@ vector<QRCode> analyzeFinderPatterns(const vector<vector<Point2f> > &corners, co
 struct PimplQRAruco : public ImplContour {
     QRCodeDetectorAruco::Params qrParams;
     aruco::ArucoDetector arucoDetector;
-    aruco::DetectorParameters arucoParams;
 
     PimplQRAruco() {
         Mat bits = Mat::ones(Size(5, 5), CV_8UC1);
         Mat(bits, Rect(1, 1, 3, 3)).setTo(Scalar(0));
         Mat byteList = aruco::Dictionary::getByteListFromBits(bits);
         aruco::Dictionary dictionary = aruco::Dictionary(byteList, 5, 4);
+        aruco::DetectorParameters arucoParams;
         arucoParams.minMarkerPerimeterRate = 0.02;
         arucoDetector = aruco::ArucoDetector(dictionary, arucoParams);
     }
@@ -4695,12 +4695,12 @@ QRCodeDetectorAruco& QRCodeDetectorAruco::setDetectorParameters(const QRCodeDete
     return *this;
 }
 
-aruco::DetectorParameters QRCodeDetectorAruco::getArucoParameters() {
-    return std::dynamic_pointer_cast<PimplQRAruco>(p)->arucoParams;
+const aruco::DetectorParameters& QRCodeDetectorAruco::getArucoParameters() const {
+    return std::dynamic_pointer_cast<PimplQRAruco>(p)->arucoDetector.getDetectorParameters();
 }
 
 void QRCodeDetectorAruco::setArucoParameters(const aruco::DetectorParameters& params) {
-    std::dynamic_pointer_cast<PimplQRAruco>(p)->arucoParams = params;
+    std::dynamic_pointer_cast<PimplQRAruco>(p)->arucoDetector.setDetectorParameters(params);
 }
 
 }  // namespace


### PR DESCRIPTION
Minor fix
fixed `setArucoParameters()`, added const ref to `getArucoParameters()` in QRCodeDetectorAruco
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
