### PR TITLE
docs: move detail section of group to the top of the page

### DIFF
--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -139,6 +139,9 @@
     <groupgraph visible="$GROUP_GRAPHS"/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>
+    </memberdecl>
+    <detaileddescription title=""/>
+    <memberdecl>
       <dirs visible="yes" title=""/>
       <files visible="yes" title=""/>
       <namespaces visible="yes" title=""/>
@@ -158,7 +161,6 @@
       <friends title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <pagedocs/>
       <inlineclasses title=""/>


### PR DESCRIPTION
relates #25047 part 1

Test page:
- http://pullrequest.opencv.org/buildbot/export/pr/25048/docs/d9/d0c/group__calib3d.html

```
force_builders_only=docs
```