### PR TITLE
G-API: Make test execution lighter (first attempt)

### DIFF
--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -454,6 +454,13 @@ namespace
 
 TEST(StatefulKernel, StateIsInitViaCompArgsInStreaming)
 {
+    // This test is long as it runs BG subtractor (a) twice
+    // (in G-API + for reference) over (b) two files. In fact
+    // it is one more BG Subtractor accuracy test, but not
+    // a stateful initialization test -- the latter must be
+    // done through a light-weight mock object. So for now:
+    applyTestTag(CV_TEST_TAG_VERYLONG);
+
     // G-API graph declaration
     cv::GMat in;
     cv::GMat out = GBackSub::on(in);

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -716,14 +716,16 @@ TEST_P(GAPI_Streaming, SmokeTest_AutoMeta_VideoScalar)
     EXPECT_EQ(165u, test_frames);
 }
 
+// Instantiate tests with different backends, but default queue capacity
 INSTANTIATE_TEST_CASE_P(TestStreaming, GAPI_Streaming,
-                        Combine(Values(  KernelPackage::OCV
-                                    //, KernelPackage::OCL // FIXME: Fails bit-exactness check, maybe relax it?
-                                      , KernelPackage::OCV_FLUID
-                                    //, KernelPackage::OCL // FIXME: Fails bit-exactness check, maybe relax it?
-                                ),
-                                Values(cv::optional<size_t>{}, 1u, 4u))
-                        );
+                        Combine(Values( KernelPackage::OCV
+                                      , KernelPackage::OCV_FLUID),
+                                Values(cv::optional<size_t>{})));
+
+// Instantiate tests with the same backend but various queue capacity
+INSTANTIATE_TEST_CASE_P(TestStreaming_QC, GAPI_Streaming,
+                        Combine(Values(KernelPackage::OCV_FLUID),
+                                Values(1u, 4u)));
 
 namespace TypesTest
 {

--- a/modules/gapi/test/streaming/gapi_streaming_utils_test.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_utils_test.cpp
@@ -245,6 +245,7 @@ TEST(OneVPL_ElasticBarrier, single_thread_visit)
 
 TEST(OneVPL_ElasticBarrier, multi_thread_visit)
 {
+    applyTestTag(CV_TEST_TAG_VERYLONG);
     TestBarrier tested_barrier;
 
     static const size_t max_visit_count = 10000000;


### PR DESCRIPTION
### Background

G-API tests look running longer than tests for the rest of modules (e.g., 5m), and the analysis show that there's several outliers in G-API test suite which take a lot of time but don't improve the testing quality much:
![image](https://github.com/opencv/opencv/assets/144187/e6df013f-e548-47ac-a418-285b3f78c9f8)

In this PR I will cut the execution time to something reasonable.

### Contents

- Marked some outliers as `verylong`:
  - OneVPL barrier test - pure brute force
  - Stateful test in stream - in fact BG Sub accuracy test clone
- Restructured parameters instantiation in Streaming tests to generate less test configurations (54 -> 36)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
