### PR TITLE
1D Input Softmax test

### DIFF
--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -92,7 +92,8 @@ public:
         bool inplace = Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
         MatShape shape = inputs[0];
         int cAxis = normalize_axis(axisRaw, shape.size());
-        shape[cAxis] = 1;
+        if (!shape.empty())
+            shape[cAxis] = 1;
         internals.assign(1, shape);
         return inplace;
     }


### PR DESCRIPTION
This PR introduces parametrized 1D input support test for `softmax` layer. 


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
