### PR TITLE
dnn: try improving performance of Attention layer

### DIFF
--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -10,59 +10,18 @@
 
 namespace cv { namespace dnn {
 
-// buffer_shape: [B, S, Dq+Dk+Dv] = [B, S, NH_q + NH_k + NH_v]
-// bias_shape:   [Dq+Dk+Dv]
-// q/k/v_shape:  [B, N, S, H] x 3
-static void SplitQKVBuffer(const float *buffer, const float *bias, float *q, float *k, float *v,
-                           size_t batch_size, size_t seq_len, size_t num_heads, size_t qk_head_size, size_t v_head_size) {
-    size_t head_size = qk_head_size + qk_head_size + v_head_size,
-           outer_size = batch_size * num_heads * seq_len;
-    // std::cout << "batch_size=" << batch_size << ", seq_len=" << seq_len << ", num_heads=" << num_heads << ", qk_head_size=" << qk_head_size << ", v_head_size=" << v_head_size << std::endl;
-
-    /*
-    auto *output = gemm_buffer.ptr<float>();
-    const auto *bias = blobs.empty() ? inputs[2].ptr<const float>() : blobs.back().ptr<const float>();
-    size_t output_offset = 0;
-    for (size_t i = 0; i < batch_size * seq_len; i++) {
-        output_offset = i * hidden_size;
-        for (size_t j = 0; j < hidden_size; j++) {
-            output[output_offset + j] += bias[j];
-        }
+static void packWeight(size_t num_heads, size_t head_size, size_t input_hidden_size,
+                       const float *weight_data, size_t hidden_size, std::vector<float> &packed_weight, const FastGemmOpt &opt) {
+    // num_heads * pack(head_size, input_hidden_size)
+    size_t pack_size = fastGemmPackBSize(head_size, input_hidden_size, opt);
+    size_t packed_weight_size = num_heads * pack_size;
+    packed_weight.resize(packed_weight_size, 0.f);
+    auto *packed_weight_data = packed_weight.data();
+    for (size_t i = 0; i < num_heads; i++) {
+        fastGemmPackB(false, head_size, input_hidden_size, weight_data, hidden_size, packed_weight_data, opt);
+        packed_weight_data += pack_size;
+        weight_data += head_size;
     }
-    */
-
-    auto worker = [&](const Range &r) {
-        for (int i = r.start; i < r.end; i++) {
-            const size_t dst_batch_index = i / (num_heads * seq_len);
-            const size_t dst_head_index = (i - dst_batch_index * seq_len * num_heads) / seq_len;
-            const size_t dst_seq_index = i % seq_len;
-            size_t buffer_offset = dst_batch_index * (seq_len * num_heads * head_size) + dst_seq_index * (num_heads * head_size);
-
-            // Split for Q and add bias
-            std::memcpy(q, buffer + buffer_offset + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
-            for (size_t j = 0; j < qk_head_size; j++) {
-                q[j] += bias[dst_head_index * qk_head_size + j];
-            }
-            q += qk_head_size;
-
-            // Split for K
-            std::memcpy(k, buffer + buffer_offset + num_heads * qk_head_size + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
-            for (size_t j = 0; j < qk_head_size; j++) {
-                k[j] += bias[num_heads * qk_head_size + dst_head_index * qk_head_size + j];
-            }
-            k += qk_head_size;
-
-            // Split for V
-            std::memcpy(v, buffer + buffer_offset + 2 * num_heads * qk_head_size + dst_head_index * v_head_size, v_head_size * sizeof(float));
-            for (size_t j = 0; j < qk_head_size; j++) {
-                v[j] += bias[2 * num_heads * qk_head_size + dst_head_index * v_head_size + j];
-            }
-            v += v_head_size;
-        }
-        
-    };
-    double nstripes = outer_size * (1 / 1024.0);
-    parallel_for_(Range(0, outer_size), worker, nstripes);
 }
 
 // Operator spec: https://github.com/microsoft/onnxruntime/blob/v1.16.1/docs/ContribOperators.md#com.microsoft.Attention
@@ -92,6 +51,8 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         scale = 1.f / params.get<float>("scale", sqrt(qkv_head_sizes[0]));
 
         output_ndims = params.get<int>("output_ndims", 3);
+
+        is_prepacked = false;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE {
@@ -102,12 +63,10 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
                                  const int requiredOutputs,
                                  std::vector<MatShape> &outputs,
                                  std::vector<MatShape> &internals) const CV_OVERRIDE {
-        const int total_inputs = static_cast<int>(inputs.size() + blobs.size());
-        CV_CheckGE(total_inputs, 1, "DNN/Attention: one input at least");
-        CV_CheckLE(total_inputs, 3, "DNN/Attention: three inputs at most");
+        CV_CheckEQ(inputs.size(), static_cast<size_t>(3), "DNN/Attention: three inputs are required");
         const auto &input_shape = inputs[0];
-        const auto &weight_shape = inputs.size() >= 2 ? inputs[1] : shape(blobs.front());
-        const auto &bias_shape = inputs.size() >= 3 ? inputs[2] : shape(blobs.back());
+        const auto &weight_shape = inputs[1];
+        const auto &bias_shape = inputs[2];
 
         CV_CheckEQ(input_shape.size(), static_cast<size_t>(3), "DNN/Attention: invalid input dimension");
         CV_CheckEQ(weight_shape.size(), static_cast<size_t>(2), "DNN/Attention: invalid weight dimension");
@@ -150,17 +109,10 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         seq_len = static_cast<size_t>(input_shape[1]);
         input_hidden_size = static_cast<size_t>(input_shape[2]);
 
-        const auto weight_shape = inputs.size() >= 2 ? shape(inputs[1]) : shape(blobs.front());
+        const auto weight_shape = shape(inputs[1]);
         hidden_size = weight_shape[1];
         qkv_hidden_sizes[2] = hidden_size - qkv_hidden_sizes[0] - qkv_hidden_sizes[1];
         qkv_head_sizes[2] = static_cast<size_t>(qkv_hidden_sizes[2] / num_heads);
-
-        // Prepack weight
-        matmulHelper.compute(false, false, input_shape, weight_shape, std::vector<int>{int(batch_size), int(seq_len), int(hidden_size)});
-        if (inputs.size() < 2) {
-            fastGemmPackB(blobs[0], packed_weight, false, opt);
-            matmulHelper.updatePackedBOffsets(packed_weight.size());
-        }
     }
 
     void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE {
@@ -178,31 +130,70 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         outputs_arr.getMatVector(outputs);
         internals_arr.getMatVector(internals);
 
-        // Compute Add(MatMul(Input, Weight), Bias)
-        auto &gemm_buffer = internals[0];
-        if (blobs.empty()) {
-            const auto *input = inputs[0].ptr<const float>();
-            const auto *weight = inputs[1].ptr<const float>();
-            fastGemmBatch(matmulHelper.batch, matmulHelper.A_offsets.data(), matmulHelper.B_offsets.data(), matmulHelper.C_offsets.data(),
-                          matmulHelper.M, matmulHelper.N, matmulHelper.K, 1.0f, input, matmulHelper.lda0, matmulHelper.lda1,
-                          weight, matmulHelper.ldb0, matmulHelper.ldb1, 0.f, gemm_buffer.ptr<float>(), matmulHelper.ldc, opt);
-        } else {
-            const auto *input = inputs[0].ptr<const float>();
-            fastGemmBatch(matmulHelper.batch, matmulHelper.A_offsets.data(), matmulHelper.B_offsets.data(), matmulHelper.C_offsets.data(),
-                          matmulHelper.M, matmulHelper.N, matmulHelper.K, 1.0f, input, matmulHelper.lda0, matmulHelper.lda1,
-                          packed_weight.data(), 0.f, gemm_buffer.ptr<float>(), matmulHelper.ldc, opt);
+        // prepack weights
+        if (!is_prepacked) {
+            // prepack
+            const auto &weight = inputs[1];
+            const auto *weight_data = weight.ptr<const float>();
+            packWeight(num_heads, qkv_head_sizes[0], input_hidden_size, weight_data,                                             hidden_size, packed_weight_q, opt);
+            packWeight(num_heads, qkv_head_sizes[1], input_hidden_size, weight_data + qkv_hidden_sizes[0],                       hidden_size, packed_weight_k, opt);
+            packWeight(num_heads, qkv_head_sizes[2], input_hidden_size, weight_data + qkv_hidden_sizes[0] + qkv_hidden_sizes[1], hidden_size, packed_weight_v, opt);
+
+            is_prepacked = true;
         }
-        // Split and get Q, K, V
-        Mat QMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[0])}, CV_32F),
-            KMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[1])}, CV_32F),
-            VMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[2])}, CV_32F);
-        const auto &bias = blobs.empty() ? inputs[2] : blobs.back();
-        SplitQKVBuffer(gemm_buffer.ptr<const float>(), bias.ptr<const float>(), QMat.ptr<float>(), KMat.ptr<float>(), VMat.ptr<float>(), batch_size, seq_len, num_heads, qkv_head_sizes[0], qkv_head_sizes[2]);
-        auto *Q = QMat.ptr<const float>(),
-             *K = KMat.ptr<const float>(),
-             *V = VMat.ptr<const float>();
+
+        float *packed_weights[3] = {packed_weight_q.data(), packed_weight_k.data(), packed_weight_v.data()};
+        size_t packed_weights_size[3] = {packed_weight_q.size() / num_heads, packed_weight_k.size() / num_heads, packed_weight_v.size() / num_heads};
+
+        // Mat gemm_buffer(std::vector<int>{int(batch_size), int(seq_len), int(hidden_size)}, CV_32F);
+        auto &gemm_buffer = internals[0];
+        auto *Q = gemm_buffer.ptr<float>();
+        auto *K = Q + batch_size * seq_len * qkv_hidden_sizes[0];
+        auto *V = K + batch_size * seq_len * qkv_hidden_sizes[1];
+        float *QKV[3] = {Q, K, V}; // Q, K, V: [B, N, S, H]
+        {
+            const auto &input = inputs[0];
+            const auto &bias = inputs[2];
+            const auto *input_data = input.ptr<const float>();
+            const auto *bias_data = bias.ptr<const float>();
+
+            opt.multi_thread = false;
+            auto fn = [&](const Range &r) {
+                for (int i = r.start; i < r.end; i++) {
+                    const int batch_index = static_cast<int>((i / 3) / num_heads);
+                    const int head_index = static_cast<int>((i / 3) % num_heads);
+                    const int qkv_index = static_cast<int>(i % 3);
+
+                    auto *dst = QKV[qkv_index];
+                    size_t head_size = qkv_head_sizes[qkv_index];
+
+                    int input_offset = batch_index * seq_len * input_hidden_size;
+                    int bias_offset = qkv_index * qkv_hidden_sizes[0] + head_index * head_size;
+                    int dst_offset = (batch_index * num_heads + head_index) * (seq_len * head_size);
+
+                    // broadcast bias ([NH] -> [BN, SH]) and make copy to dst
+                    const auto *bias_data_src = bias_data + bias_offset;
+                    auto *dst_data = dst + dst_offset;
+                    for (size_t seq_len_idx = 0; seq_len_idx < seq_len; seq_len_idx++) {
+                        std::memcpy(dst_data, bias_data_src, head_size * sizeof(float));
+                        dst_data += head_size;
+                    }
+
+                    auto *packed_weight = packed_weights[qkv_index] + packed_weights_size[qkv_index] * head_index;
+                    // single-thread gemm kernel
+                    fastGemm(false, seq_len, head_size, input_hidden_size,
+                            1.f, input_data + input_offset, input_hidden_size,
+                            packed_weight, 1.f, dst + dst_offset, head_size, opt);
+                }
+            };
+
+            size_t loops = 3 * batch_size * num_heads;
+            double nstripes = loops * seq_len * qkv_head_sizes[0] * input_hidden_size * (1 / 1024.0);
+            parallel_for_(Range(0, loops), fn, nstripes);
+        }
 
         // Compute softmax(scale * matmul(Q, K))
+        // Mat attention_prob(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(seq_len)}, CV_32F);
         auto &attention_prob = internals[1];
         {
             auto *output = attention_prob.ptr<float>();
@@ -231,6 +222,7 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         }
 
         // Compute np.matmul(attention_prob, V)
+        // Mat output_buffer(std::vector<int>{int(batch_size), int(num_heads), int(seq_len), int(qkv_head_sizes[2])}, CV_32F);
         auto &output_buffer = internals[2];
         {
             auto *output = outputs[0].ptr<float>();
@@ -281,10 +273,12 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
     size_t input_hidden_size;
     size_t hidden_size;
 
-    std::vector<float> packed_weight;
+    bool is_prepacked;
+    std::vector<float> packed_weight_q;
+    std::vector<float> packed_weight_k;
+    std::vector<float> packed_weight_v;
 
     FastGemmOpt opt;
-    MatMulHelper matmulHelper;
 };
 
 Ptr<AttentionLayer> AttentionLayer::create(const LayerParams &params) {

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -13,30 +13,19 @@ namespace cv { namespace dnn {
 // buffer_shape: [B, S, Dq+Dk+Dv] = [B, S, NH_q + NH_k + NH_v]
 // bias_shape:   [Dq+Dk+Dv]
 // q/k/v_shape:  [B, N, S, H] x 3
-static void SplitQKVBuffer(const float *buffer, const float *bias, float *q, float *k, float *v,
-                           size_t batch_size, size_t seq_len, size_t num_heads, size_t qk_head_size, size_t v_head_size) {
+static void SplitQKVBufferWithBias(const float *buffer, const float *bias, float *q, float *k, float *v,
+                                   size_t batch_size, size_t seq_len, size_t num_heads, size_t qk_head_size, size_t v_head_size) {
     size_t head_size = qk_head_size + qk_head_size + v_head_size,
-           outer_size = batch_size * num_heads * seq_len;
-    // std::cout << "batch_size=" << batch_size << ", seq_len=" << seq_len << ", num_heads=" << num_heads << ", qk_head_size=" << qk_head_size << ", v_head_size=" << v_head_size << std::endl;
-
-    /*
-    auto *output = gemm_buffer.ptr<float>();
-    const auto *bias = blobs.empty() ? inputs[2].ptr<const float>() : blobs.back().ptr<const float>();
-    size_t output_offset = 0;
-    for (size_t i = 0; i < batch_size * seq_len; i++) {
-        output_offset = i * hidden_size;
-        for (size_t j = 0; j < hidden_size; j++) {
-            output[output_offset + j] += bias[j];
-        }
-    }
-    */
+           NS = num_heads * seq_len, NSH = num_heads * seq_len * head_size,
+           NHqk = num_heads * qk_head_size, NH = num_heads * head_size,
+           outer_size = batch_size * NS;
 
     auto worker = [&](const Range &r) {
         for (int i = r.start; i < r.end; i++) {
-            const size_t dst_batch_index = i / (num_heads * seq_len);
-            const size_t dst_head_index = (i - dst_batch_index * seq_len * num_heads) / seq_len;
+            const size_t dst_batch_index = i / NS;
+            const size_t dst_head_index = (i - dst_batch_index * NS) / seq_len;
             const size_t dst_seq_index = i % seq_len;
-            size_t buffer_offset = dst_batch_index * (seq_len * num_heads * head_size) + dst_seq_index * (num_heads * head_size);
+            size_t buffer_offset = dst_batch_index * NSH + dst_seq_index * NH;
 
             // Split for Q and add bias
             std::memcpy(q, buffer + buffer_offset + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
@@ -45,21 +34,20 @@ static void SplitQKVBuffer(const float *buffer, const float *bias, float *q, flo
             }
             q += qk_head_size;
 
-            // Split for K
-            std::memcpy(k, buffer + buffer_offset + num_heads * qk_head_size + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
+            // Split for K and add bias
+            std::memcpy(k, buffer + buffer_offset + NHqk + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
             for (size_t j = 0; j < qk_head_size; j++) {
-                k[j] += bias[num_heads * qk_head_size + dst_head_index * qk_head_size + j];
+                k[j] += bias[NHqk + dst_head_index * qk_head_size + j];
             }
             k += qk_head_size;
 
-            // Split for V
-            std::memcpy(v, buffer + buffer_offset + 2 * num_heads * qk_head_size + dst_head_index * v_head_size, v_head_size * sizeof(float));
-            for (size_t j = 0; j < qk_head_size; j++) {
-                v[j] += bias[2 * num_heads * qk_head_size + dst_head_index * v_head_size + j];
+            // Split for V and add bias
+            std::memcpy(v, buffer + buffer_offset + 2 * NHqk + dst_head_index * v_head_size, v_head_size * sizeof(float));
+            for (size_t j = 0; j < v_head_size; j++) {
+                v[j] += bias[2 * NHqk + dst_head_index * v_head_size + j];
             }
             v += v_head_size;
         }
-        
     };
     double nstripes = outer_size * (1 / 1024.0);
     parallel_for_(Range(0, outer_size), worker, nstripes);
@@ -134,6 +122,7 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
                  attention_prob_shape{batch_size_ * num_heads_, seq_len_, seq_len_},
                  output_buffer_shape{batch_size_ * num_heads_, seq_len_, v_head_size_};
         internals.assign(1, gemm_buffer_shape);
+        internals.push_back(gemm_buffer_shape);
         internals.push_back(attention_prob_shape);
         internals.push_back(output_buffer_shape);
 
@@ -193,17 +182,14 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
                           packed_weight.data(), 0.f, gemm_buffer.ptr<float>(), matmulHelper.ldc, opt);
         }
         // Split and get Q, K, V
-        Mat QMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[0])}, CV_32F),
-            KMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[1])}, CV_32F),
-            VMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[2])}, CV_32F);
+        auto *Q = internals[1].ptr<float>(),
+             *K = Q + batch_size * num_heads * seq_len * qkv_head_sizes[0],
+             *V = K + batch_size * num_heads * seq_len * qkv_head_sizes[1];
         const auto &bias = blobs.empty() ? inputs[2] : blobs.back();
-        SplitQKVBuffer(gemm_buffer.ptr<const float>(), bias.ptr<const float>(), QMat.ptr<float>(), KMat.ptr<float>(), VMat.ptr<float>(), batch_size, seq_len, num_heads, qkv_head_sizes[0], qkv_head_sizes[2]);
-        auto *Q = QMat.ptr<const float>(),
-             *K = KMat.ptr<const float>(),
-             *V = VMat.ptr<const float>();
+        SplitQKVBufferWithBias(gemm_buffer.ptr<const float>(), bias.ptr<const float>(), Q, K, V, batch_size, seq_len, num_heads, qkv_head_sizes[0], qkv_head_sizes[2]);
 
         // Compute softmax(scale * matmul(Q, K))
-        auto &attention_prob = internals[1];
+        auto &attention_prob = internals[2];
         {
             auto *output = attention_prob.ptr<float>();
 
@@ -212,26 +198,25 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
             auto qk_head_size = qkv_head_sizes[0];
             auto qk_inner_size = seq_len * qk_head_size;
 
-            // Compute scale * matmul(Q, K)
-            opt.multi_thread = false;
-            parallel_for_(Range(0, loops), [&] (const Range r) {
-                for (int i = r.start; i < r.end; i++) {
-                    const int output_offset = i * seq_len_square;
-
-                    const auto *q = Q + qk_inner_size * i, *k = K + qk_inner_size * i;
-                    fastGemm(false, true, seq_len, qk_head_size, seq_len, qk_head_size,
-                             scale, q, qk_head_size, 1,
-                             k, qk_head_size, 1, 0.f,
-                             output + output_offset, seq_len, opt);
-                }
-            }, loops * seq_len * qk_head_size * seq_len * (1 / 1024.0));
+            // Compute: attention_prob = scale * MatMul(Q, K)
+            // Q: [B, N, S, H]
+            // K: [B, N, S, H] // transB=true
+            // P: [B, N, S, S]
+            std::vector<size_t> AB_offsets(loops), C_offsets(loops);
+            for (size_t i = 0; i < loops; i++) {
+                AB_offsets[i] = i * qk_inner_size;
+                C_offsets[i] = i * seq_len_square;
+            }
+            fastGemmBatch(loops, AB_offsets.data(), AB_offsets.data(), C_offsets.data(),
+                          seq_len, seq_len, qk_head_size, scale, Q, qk_head_size, 1,
+                          K, 1, qk_head_size, 0.f, output, seq_len, opt);
 
             // Compute softmax on the last dimension
             softmax(attention_prob, attention_prob, shape(attention_prob).size() - 1);
         }
 
         // Compute np.matmul(attention_prob, V)
-        auto &output_buffer = internals[2];
+        auto &output_buffer = internals[3];
         {
             auto *output = outputs[0].ptr<float>();
             auto *output_buff = output_buffer.ptr<float>();

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -10,18 +10,59 @@
 
 namespace cv { namespace dnn {
 
-static void packWeight(size_t num_heads, size_t head_size, size_t input_hidden_size,
-                       const float *weight_data, size_t hidden_size, std::vector<float> &packed_weight, const FastGemmOpt &opt) {
-    // num_heads * pack(head_size, input_hidden_size)
-    size_t pack_size = fastGemmPackBSize(head_size, input_hidden_size, opt);
-    size_t packed_weight_size = num_heads * pack_size;
-    packed_weight.resize(packed_weight_size, 0.f);
-    auto *packed_weight_data = packed_weight.data();
-    for (size_t i = 0; i < num_heads; i++) {
-        fastGemmPackB(false, head_size, input_hidden_size, weight_data, hidden_size, packed_weight_data, opt);
-        packed_weight_data += pack_size;
-        weight_data += head_size;
+// buffer_shape: [B, S, Dq+Dk+Dv] = [B, S, NH_q + NH_k + NH_v]
+// bias_shape:   [Dq+Dk+Dv]
+// q/k/v_shape:  [B, N, S, H] x 3
+static void SplitQKVBuffer(const float *buffer, const float *bias, float *q, float *k, float *v,
+                           size_t batch_size, size_t seq_len, size_t num_heads, size_t qk_head_size, size_t v_head_size) {
+    size_t head_size = qk_head_size + qk_head_size + v_head_size,
+           outer_size = batch_size * num_heads * seq_len;
+    // std::cout << "batch_size=" << batch_size << ", seq_len=" << seq_len << ", num_heads=" << num_heads << ", qk_head_size=" << qk_head_size << ", v_head_size=" << v_head_size << std::endl;
+
+    /*
+    auto *output = gemm_buffer.ptr<float>();
+    const auto *bias = blobs.empty() ? inputs[2].ptr<const float>() : blobs.back().ptr<const float>();
+    size_t output_offset = 0;
+    for (size_t i = 0; i < batch_size * seq_len; i++) {
+        output_offset = i * hidden_size;
+        for (size_t j = 0; j < hidden_size; j++) {
+            output[output_offset + j] += bias[j];
+        }
     }
+    */
+
+    auto worker = [&](const Range &r) {
+        for (int i = r.start; i < r.end; i++) {
+            const size_t dst_batch_index = i / (num_heads * seq_len);
+            const size_t dst_head_index = (i - dst_batch_index * seq_len * num_heads) / seq_len;
+            const size_t dst_seq_index = i % seq_len;
+            size_t buffer_offset = dst_batch_index * (seq_len * num_heads * head_size) + dst_seq_index * (num_heads * head_size);
+
+            // Split for Q and add bias
+            std::memcpy(q, buffer + buffer_offset + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
+            for (size_t j = 0; j < qk_head_size; j++) {
+                q[j] += bias[dst_head_index * qk_head_size + j];
+            }
+            q += qk_head_size;
+
+            // Split for K
+            std::memcpy(k, buffer + buffer_offset + num_heads * qk_head_size + dst_head_index * qk_head_size, qk_head_size * sizeof(float));
+            for (size_t j = 0; j < qk_head_size; j++) {
+                k[j] += bias[num_heads * qk_head_size + dst_head_index * qk_head_size + j];
+            }
+            k += qk_head_size;
+
+            // Split for V
+            std::memcpy(v, buffer + buffer_offset + 2 * num_heads * qk_head_size + dst_head_index * v_head_size, v_head_size * sizeof(float));
+            for (size_t j = 0; j < qk_head_size; j++) {
+                v[j] += bias[2 * num_heads * qk_head_size + dst_head_index * v_head_size + j];
+            }
+            v += v_head_size;
+        }
+        
+    };
+    double nstripes = outer_size * (1 / 1024.0);
+    parallel_for_(Range(0, outer_size), worker, nstripes);
 }
 
 // Operator spec: https://github.com/microsoft/onnxruntime/blob/v1.16.1/docs/ContribOperators.md#com.microsoft.Attention
@@ -51,8 +92,6 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         scale = 1.f / params.get<float>("scale", sqrt(qkv_head_sizes[0]));
 
         output_ndims = params.get<int>("output_ndims", 3);
-
-        is_prepacked = false;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE {
@@ -63,10 +102,12 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
                                  const int requiredOutputs,
                                  std::vector<MatShape> &outputs,
                                  std::vector<MatShape> &internals) const CV_OVERRIDE {
-        CV_CheckEQ(inputs.size(), static_cast<size_t>(3), "DNN/Attention: three inputs are required");
+        const int total_inputs = static_cast<int>(inputs.size() + blobs.size());
+        CV_CheckGE(total_inputs, 1, "DNN/Attention: one input at least");
+        CV_CheckLE(total_inputs, 3, "DNN/Attention: three inputs at most");
         const auto &input_shape = inputs[0];
-        const auto &weight_shape = inputs[1];
-        const auto &bias_shape = inputs[2];
+        const auto &weight_shape = inputs.size() >= 2 ? inputs[1] : shape(blobs.front());
+        const auto &bias_shape = inputs.size() >= 3 ? inputs[2] : shape(blobs.back());
 
         CV_CheckEQ(input_shape.size(), static_cast<size_t>(3), "DNN/Attention: invalid input dimension");
         CV_CheckEQ(weight_shape.size(), static_cast<size_t>(2), "DNN/Attention: invalid weight dimension");
@@ -109,10 +150,17 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         seq_len = static_cast<size_t>(input_shape[1]);
         input_hidden_size = static_cast<size_t>(input_shape[2]);
 
-        const auto weight_shape = shape(inputs[1]);
+        const auto weight_shape = inputs.size() >= 2 ? shape(inputs[1]) : shape(blobs.front());
         hidden_size = weight_shape[1];
         qkv_hidden_sizes[2] = hidden_size - qkv_hidden_sizes[0] - qkv_hidden_sizes[1];
         qkv_head_sizes[2] = static_cast<size_t>(qkv_hidden_sizes[2] / num_heads);
+
+        // Prepack weight
+        matmulHelper.compute(false, false, input_shape, weight_shape, std::vector<int>{int(batch_size), int(seq_len), int(hidden_size)});
+        if (inputs.size() < 2) {
+            fastGemmPackB(blobs[0], packed_weight, false, opt);
+            matmulHelper.updatePackedBOffsets(packed_weight.size());
+        }
     }
 
     void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE {
@@ -130,70 +178,31 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         outputs_arr.getMatVector(outputs);
         internals_arr.getMatVector(internals);
 
-        // prepack weights
-        if (!is_prepacked) {
-            // prepack
-            const auto &weight = inputs[1];
-            const auto *weight_data = weight.ptr<const float>();
-            packWeight(num_heads, qkv_head_sizes[0], input_hidden_size, weight_data,                                             hidden_size, packed_weight_q, opt);
-            packWeight(num_heads, qkv_head_sizes[1], input_hidden_size, weight_data + qkv_hidden_sizes[0],                       hidden_size, packed_weight_k, opt);
-            packWeight(num_heads, qkv_head_sizes[2], input_hidden_size, weight_data + qkv_hidden_sizes[0] + qkv_hidden_sizes[1], hidden_size, packed_weight_v, opt);
-
-            is_prepacked = true;
-        }
-
-        float *packed_weights[3] = {packed_weight_q.data(), packed_weight_k.data(), packed_weight_v.data()};
-        size_t packed_weights_size[3] = {packed_weight_q.size() / num_heads, packed_weight_k.size() / num_heads, packed_weight_v.size() / num_heads};
-
-        // Mat gemm_buffer(std::vector<int>{int(batch_size), int(seq_len), int(hidden_size)}, CV_32F);
+        // Compute Add(MatMul(Input, Weight), Bias)
         auto &gemm_buffer = internals[0];
-        auto *Q = gemm_buffer.ptr<float>();
-        auto *K = Q + batch_size * seq_len * qkv_hidden_sizes[0];
-        auto *V = K + batch_size * seq_len * qkv_hidden_sizes[1];
-        float *QKV[3] = {Q, K, V}; // Q, K, V: [B, N, S, H]
-        {
-            const auto &input = inputs[0];
-            const auto &bias = inputs[2];
-            const auto *input_data = input.ptr<const float>();
-            const auto *bias_data = bias.ptr<const float>();
-
-            opt.multi_thread = false;
-            auto fn = [&](const Range &r) {
-                for (int i = r.start; i < r.end; i++) {
-                    const int batch_index = static_cast<int>((i / 3) / num_heads);
-                    const int head_index = static_cast<int>((i / 3) % num_heads);
-                    const int qkv_index = static_cast<int>(i % 3);
-
-                    auto *dst = QKV[qkv_index];
-                    size_t head_size = qkv_head_sizes[qkv_index];
-
-                    int input_offset = batch_index * seq_len * input_hidden_size;
-                    int bias_offset = qkv_index * qkv_hidden_sizes[0] + head_index * head_size;
-                    int dst_offset = (batch_index * num_heads + head_index) * (seq_len * head_size);
-
-                    // broadcast bias ([NH] -> [BN, SH]) and make copy to dst
-                    const auto *bias_data_src = bias_data + bias_offset;
-                    auto *dst_data = dst + dst_offset;
-                    for (size_t seq_len_idx = 0; seq_len_idx < seq_len; seq_len_idx++) {
-                        std::memcpy(dst_data, bias_data_src, head_size * sizeof(float));
-                        dst_data += head_size;
-                    }
-
-                    auto *packed_weight = packed_weights[qkv_index] + packed_weights_size[qkv_index] * head_index;
-                    // single-thread gemm kernel
-                    fastGemm(false, seq_len, head_size, input_hidden_size,
-                            1.f, input_data + input_offset, input_hidden_size,
-                            packed_weight, 1.f, dst + dst_offset, head_size, opt);
-                }
-            };
-
-            size_t loops = 3 * batch_size * num_heads;
-            double nstripes = loops * seq_len * qkv_head_sizes[0] * input_hidden_size * (1 / 1024.0);
-            parallel_for_(Range(0, loops), fn, nstripes);
+        if (blobs.empty()) {
+            const auto *input = inputs[0].ptr<const float>();
+            const auto *weight = inputs[1].ptr<const float>();
+            fastGemmBatch(matmulHelper.batch, matmulHelper.A_offsets.data(), matmulHelper.B_offsets.data(), matmulHelper.C_offsets.data(),
+                          matmulHelper.M, matmulHelper.N, matmulHelper.K, 1.0f, input, matmulHelper.lda0, matmulHelper.lda1,
+                          weight, matmulHelper.ldb0, matmulHelper.ldb1, 0.f, gemm_buffer.ptr<float>(), matmulHelper.ldc, opt);
+        } else {
+            const auto *input = inputs[0].ptr<const float>();
+            fastGemmBatch(matmulHelper.batch, matmulHelper.A_offsets.data(), matmulHelper.B_offsets.data(), matmulHelper.C_offsets.data(),
+                          matmulHelper.M, matmulHelper.N, matmulHelper.K, 1.0f, input, matmulHelper.lda0, matmulHelper.lda1,
+                          packed_weight.data(), 0.f, gemm_buffer.ptr<float>(), matmulHelper.ldc, opt);
         }
+        // Split and get Q, K, V
+        Mat QMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[0])}, CV_32F),
+            KMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[1])}, CV_32F),
+            VMat(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(qkv_head_sizes[2])}, CV_32F);
+        const auto &bias = blobs.empty() ? inputs[2] : blobs.back();
+        SplitQKVBuffer(gemm_buffer.ptr<const float>(), bias.ptr<const float>(), QMat.ptr<float>(), KMat.ptr<float>(), VMat.ptr<float>(), batch_size, seq_len, num_heads, qkv_head_sizes[0], qkv_head_sizes[2]);
+        auto *Q = QMat.ptr<const float>(),
+             *K = KMat.ptr<const float>(),
+             *V = VMat.ptr<const float>();
 
         // Compute softmax(scale * matmul(Q, K))
-        // Mat attention_prob(std::vector<int>{int(batch_size * num_heads), int(seq_len), int(seq_len)}, CV_32F);
         auto &attention_prob = internals[1];
         {
             auto *output = attention_prob.ptr<float>();
@@ -222,7 +231,6 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
         }
 
         // Compute np.matmul(attention_prob, V)
-        // Mat output_buffer(std::vector<int>{int(batch_size), int(num_heads), int(seq_len), int(qkv_head_sizes[2])}, CV_32F);
         auto &output_buffer = internals[2];
         {
             auto *output = outputs[0].ptr<float>();
@@ -273,12 +281,10 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
     size_t input_hidden_size;
     size_t hidden_size;
 
-    bool is_prepacked;
-    std::vector<float> packed_weight_q;
-    std::vector<float> packed_weight_k;
-    std::vector<float> packed_weight_v;
+    std::vector<float> packed_weight;
 
     FastGemmOpt opt;
+    MatMulHelper matmulHelper;
 };
 
 Ptr<AttentionLayer> AttentionLayer::create(const LayerParams &params) {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3935,17 +3935,21 @@ void ONNXImporter::parseAttention(LayerParams& params, const opencv_onnx::NodePr
     CV_CheckEQ(param_qkv_hidden_sizes.size(), 3, "ONNXImporter/parseAttention: qkv_hidden_sizes is must and only have three elements");
 
     for (size_t i = 1; i < node_proto.input_size(); i++) {
-        if (layer_id.find(node_proto.input(i)) == layer_id.end()) {
+        if (constBlobs.find(node_proto.input(i)) != constBlobs.end()) {
             Mat tensor = getBlob(node_proto, i);
 
-            LayerParams const_params;
-            const_params.name = node_proto.input(i);
-            const_params.type = "Const";
-            const_params.blobs.push_back(tensor);
+            if (i == 0) {
+                LayerParams const_params;
+                const_params.name = node_proto.input(i);
+                const_params.type = "Const";
+                const_params.blobs.push_back(tensor);
 
-            opencv_onnx::NodeProto proto;
-            proto.add_output(const_params.name);
-            addLayer(const_params, proto);
+                opencv_onnx::NodeProto proto;
+                proto.add_output(const_params.name);
+                addLayer(const_params, proto);
+            } else {
+                params.blobs.push_back(tensor);
+            }
         }
     }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3935,21 +3935,17 @@ void ONNXImporter::parseAttention(LayerParams& params, const opencv_onnx::NodePr
     CV_CheckEQ(param_qkv_hidden_sizes.size(), 3, "ONNXImporter/parseAttention: qkv_hidden_sizes is must and only have three elements");
 
     for (size_t i = 1; i < node_proto.input_size(); i++) {
-        if (constBlobs.find(node_proto.input(i)) != constBlobs.end()) {
+        if (layer_id.find(node_proto.input(i)) == layer_id.end()) {
             Mat tensor = getBlob(node_proto, i);
 
-            if (i == 0) {
-                LayerParams const_params;
-                const_params.name = node_proto.input(i);
-                const_params.type = "Const";
-                const_params.blobs.push_back(tensor);
+            LayerParams const_params;
+            const_params.name = node_proto.input(i);
+            const_params.type = "Const";
+            const_params.blobs.push_back(tensor);
 
-                opencv_onnx::NodeProto proto;
-                proto.add_output(const_params.name);
-                addLayer(const_params, proto);
-            } else {
-                params.blobs.push_back(tensor);
-            }
+            opencv_onnx::NodeProto proto;
+            proto.add_output(const_params.name);
+            addLayer(const_params, proto);
         }
     }
 


### PR DESCRIPTION
Checklist:

- [x] Use `Mat` over `Mat::zeros` for temporary buffer in forward
- [x] Use layer internal buffer over temporary Mat buffer
- [x] Try a single fastGemmBatch on the Q/K/V calculation

Performance:

Performance test case is `Layer_Attention.VisionTransformer/0`, which has input of shape {1, 197, 768}, weight of shape {768, 2304} and bias {2304}.

Data is in millisecond.

| | macOS 14.2.1, Apple M1 | Ubuntu 22.04.2, Intel i7 12700K |
| - | - | - |
| Current | 10.96 | 1.58 |
| w/ Mat | 6.27 | 1.41 |
| w/ Internals | 5.87 | 1.38 |
| w/ fastGemmBatch | 6.12 | 2.14 |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
