### PR TITLE
fix [use hasattr("cv2", "name") ,but first param is 'character string',

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -33,7 +33,7 @@ def __load_extra_py_code_for_module(base, name, enable_debug_print=False):
         # Extension doesn't contain extra py code
         return False
 
-    if not hasattr(base, name):
+    if base in sys.modules and not hasattr(sys.modules[base], name):
         setattr(sys.modules[base], name, py_module)
     sys.modules[export_module_name] = py_module
     # If it is C extension module it is already loaded by cv2 package


### PR DESCRIPTION
resulting in an error in the judgment condition]

fixes #25078
relates #20611

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
