### PR TITLE
Fixing the formula in the documentation of reprojectImageTo3D

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2983,7 +2983,7 @@ W
 x \\
 y \\
 \texttt{disparity} (x,y) \\
-z
+1
 \end{bmatrix}.\f]
 
 @sa


### PR DESCRIPTION
Fixing the formula in the documentation of reprojectImageTo3D

fixes #25082

The documentation states correctly:

> Reprojects a disparity image to 3D space.

and

> The function transforms a single-channel disparity map to a 3-channel image representing a 3D surface. That is, for each pixel (x,y) and the corresponding disparity d=disparity(x,y) , it computes:

But then there is an error in the formula:
![image](https://github.com/opencv/opencv/assets/30472679/d60f8f4e-da54-4bfb-9bce-1aa5d5c74384)

This does not make sense since the function wants to calculate $Z$, it makes no sense to have $z$ on the right side of the equation. It does not have any meaning in a disparity image. The value should be one at that coordinate, to reflect that this is a normalized homogenous coordinate in 3 dimensions.

I fixed it to 
![image](https://github.com/opencv/opencv/assets/30472679/b1c07edf-9545-4f41-81a9-d84556f92dc7)

which corresponds to the implementation which is (click permalink to get to file):

[`Vec4d homg_pt = _Q*Vec4d(x, y, d, 1.0);`](https://github.com/opencv/opencv/blob/d792086ba66a76707e00ee7fffcec50289837fb4/modules/calib3d/src/calibration.cpp#L3124)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work

Do not apply since this is only a documentation fix:
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
