### PR TITLE
Add compatibility with latest (3.1.54) emsdk version

### DIFF
--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -66,7 +66,7 @@ Module['imread'] = function(imageSource) {
     }
 
     var imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    return cv.matFromImageData(imgData);
+    return Module.matFromImageData(imgData);
 };
 
 Module['imshow'] = function(canvasSource, mat) {
@@ -80,27 +80,27 @@ Module['imshow'] = function(canvasSource, mat) {
         throw new Error('Please input the valid canvas element or id.');
         return;
     }
-    if (!(mat instanceof cv.Mat)) {
+    if (!(mat instanceof Module.Mat)) {
         throw new Error('Please input the valid cv.Mat instance.');
         return;
     }
 
     // convert the mat type to cv.CV_8U
-    var img = new cv.Mat();
+    var img = new Module.Mat();
     var depth = mat.type()%8;
-    var scale = depth <= cv.CV_8S? 1.0 : (depth <= cv.CV_32S? 1.0/256.0 : 255.0);
-    var shift = (depth === cv.CV_8S || depth === cv.CV_16S)? 128.0 : 0.0;
-    mat.convertTo(img, cv.CV_8U, scale, shift);
+    var scale = depth <= Module.CV_8S? 1.0 : (depth <= Module.CV_32S? 1.0/256.0 : 255.0);
+    var shift = (depth === Module.CV_8S || depth === Module.CV_16S)? 128.0 : 0.0;
+    mat.convertTo(img, Module.CV_8U, scale, shift);
 
     // convert the img type to cv.CV_8UC4
     switch (img.type()) {
-        case cv.CV_8UC1:
-            cv.cvtColor(img, img, cv.COLOR_GRAY2RGBA);
+        case Module.CV_8UC1:
+            Module.cvtColor(img, img, Module.COLOR_GRAY2RGBA);
             break;
-        case cv.CV_8UC3:
-            cv.cvtColor(img, img, cv.COLOR_RGB2RGBA);
+        case Module.CV_8UC3:
+            Module.cvtColor(img, img, Module.COLOR_RGB2RGBA);
             break;
-        case cv.CV_8UC4:
+        case Module.CV_8UC4:
             break;
         default:
             throw new Error('Bad number of channels (Source image must have 1, 3 or 4 channels)');
@@ -132,11 +132,11 @@ Module['VideoCapture'] = function(videoSource) {
     var ctx = canvas.getContext('2d');
     this.video = video;
     this.read = function(frame) {
-        if (!(frame instanceof cv.Mat)) {
+        if (!(frame instanceof Module.Mat)) {
             throw new Error('Please input the valid cv.Mat instance.');
             return;
         }
-        if (frame.type() !== cv.CV_8UC4) {
+        if (frame.type() !== Module.CV_8UC4) {
             throw new Error('Bad type of input mat: the type should be cv.CV_8UC4.');
             return;
         }
@@ -331,61 +331,61 @@ function TermCriteria() {
 Module['TermCriteria'] = TermCriteria;
 
 Module['matFromArray'] = function(rows, cols, type, array) {
-    var mat = new cv.Mat(rows, cols, type);
+    var mat = new Module.Mat(rows, cols, type);
     switch (type) {
-        case cv.CV_8U:
-        case cv.CV_8UC1:
-        case cv.CV_8UC2:
-        case cv.CV_8UC3:
-        case cv.CV_8UC4: {
+        case Module.CV_8U:
+        case Module.CV_8UC1:
+        case Module.CV_8UC2:
+        case Module.CV_8UC3:
+        case Module.CV_8UC4: {
             mat.data.set(array);
             break;
         }
-        case cv.CV_8S:
-        case cv.CV_8SC1:
-        case cv.CV_8SC2:
-        case cv.CV_8SC3:
-        case cv.CV_8SC4: {
+        case Module.CV_8S:
+        case Module.CV_8SC1:
+        case Module.CV_8SC2:
+        case Module.CV_8SC3:
+        case Module.CV_8SC4: {
             mat.data8S.set(array);
             break;
         }
-        case cv.CV_16U:
-        case cv.CV_16UC1:
-        case cv.CV_16UC2:
-        case cv.CV_16UC3:
-        case cv.CV_16UC4: {
+        case Module.CV_16U:
+        case Module.CV_16UC1:
+        case Module.CV_16UC2:
+        case Module.CV_16UC3:
+        case Module.CV_16UC4: {
             mat.data16U.set(array);
             break;
         }
-        case cv.CV_16S:
-        case cv.CV_16SC1:
-        case cv.CV_16SC2:
-        case cv.CV_16SC3:
-        case cv.CV_16SC4: {
+        case Module.CV_16S:
+        case Module.CV_16SC1:
+        case Module.CV_16SC2:
+        case Module.CV_16SC3:
+        case Module.CV_16SC4: {
             mat.data16S.set(array);
             break;
         }
-        case cv.CV_32S:
-        case cv.CV_32SC1:
-        case cv.CV_32SC2:
-        case cv.CV_32SC3:
-        case cv.CV_32SC4: {
+        case Module.CV_32S:
+        case Module.CV_32SC1:
+        case Module.CV_32SC2:
+        case Module.CV_32SC3:
+        case Module.CV_32SC4: {
             mat.data32S.set(array);
             break;
         }
-        case cv.CV_32F:
-        case cv.CV_32FC1:
-        case cv.CV_32FC2:
-        case cv.CV_32FC3:
-        case cv.CV_32FC4: {
+        case Module.CV_32F:
+        case Module.CV_32FC1:
+        case Module.CV_32FC2:
+        case Module.CV_32FC3:
+        case Module.CV_32FC4: {
             mat.data32F.set(array);
             break;
         }
-        case cv.CV_64F:
-        case cv.CV_64FC1:
-        case cv.CV_64FC2:
-        case cv.CV_64FC3:
-        case cv.CV_64FC4: {
+        case Module.CV_64F:
+        case Module.CV_64FC1:
+        case Module.CV_64FC2:
+        case Module.CV_64FC3:
+        case Module.CV_64FC4: {
             mat.data64F.set(array);
             break;
         }
@@ -397,7 +397,7 @@ Module['matFromArray'] = function(rows, cols, type, array) {
 };
 
 Module['matFromImageData'] = function(imageData) {
-    var mat = new cv.Mat(imageData.height, imageData.width, cv.CV_8UC4);
+    var mat = new Module.Mat(imageData.height, imageData.width, cv.CV_8UC4);
     mat.data.set(imageData.data);
     return mat;
 };

--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -42,6 +42,10 @@ if (typeof Module.FS === 'undefined' && typeof FS !== 'undefined') {
     Module.FS = FS;
 }
 
+if (typeof cv === 'undefined') {
+    var cv = Module;
+}
+
 Module['imread'] = function(imageSource) {
     var img = null;
     if (typeof imageSource === 'string') {
@@ -66,7 +70,7 @@ Module['imread'] = function(imageSource) {
     }
 
     var imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    return Module.matFromImageData(imgData);
+    return cv.matFromImageData(imgData);
 };
 
 Module['imshow'] = function(canvasSource, mat) {
@@ -80,27 +84,27 @@ Module['imshow'] = function(canvasSource, mat) {
         throw new Error('Please input the valid canvas element or id.');
         return;
     }
-    if (!(mat instanceof Module.Mat)) {
+    if (!(mat instanceof cv.Mat)) {
         throw new Error('Please input the valid cv.Mat instance.');
         return;
     }
 
     // convert the mat type to cv.CV_8U
-    var img = new Module.Mat();
+    var img = new cv.Mat();
     var depth = mat.type()%8;
-    var scale = depth <= Module.CV_8S? 1.0 : (depth <= Module.CV_32S? 1.0/256.0 : 255.0);
-    var shift = (depth === Module.CV_8S || depth === Module.CV_16S)? 128.0 : 0.0;
-    mat.convertTo(img, Module.CV_8U, scale, shift);
+    var scale = depth <= cv.CV_8S? 1.0 : (depth <= cv.CV_32S? 1.0/256.0 : 255.0);
+    var shift = (depth === cv.CV_8S || depth === cv.CV_16S)? 128.0 : 0.0;
+    mat.convertTo(img, cv.CV_8U, scale, shift);
 
     // convert the img type to cv.CV_8UC4
     switch (img.type()) {
-        case Module.CV_8UC1:
-            Module.cvtColor(img, img, Module.COLOR_GRAY2RGBA);
+        case cv.CV_8UC1:
+            cv.cvtColor(img, img, cv.COLOR_GRAY2RGBA);
             break;
-        case Module.CV_8UC3:
-            Module.cvtColor(img, img, Module.COLOR_RGB2RGBA);
+        case cv.CV_8UC3:
+            cv.cvtColor(img, img, cv.COLOR_RGB2RGBA);
             break;
-        case Module.CV_8UC4:
+        case cv.CV_8UC4:
             break;
         default:
             throw new Error('Bad number of channels (Source image must have 1, 3 or 4 channels)');
@@ -132,11 +136,11 @@ Module['VideoCapture'] = function(videoSource) {
     var ctx = canvas.getContext('2d');
     this.video = video;
     this.read = function(frame) {
-        if (!(frame instanceof Module.Mat)) {
+        if (!(frame instanceof cv.Mat)) {
             throw new Error('Please input the valid cv.Mat instance.');
             return;
         }
-        if (frame.type() !== Module.CV_8UC4) {
+        if (frame.type() !== cv.CV_8UC4) {
             throw new Error('Bad type of input mat: the type should be cv.CV_8UC4.');
             return;
         }
@@ -331,61 +335,61 @@ function TermCriteria() {
 Module['TermCriteria'] = TermCriteria;
 
 Module['matFromArray'] = function(rows, cols, type, array) {
-    var mat = new Module.Mat(rows, cols, type);
+    var mat = new cv.Mat(rows, cols, type);
     switch (type) {
-        case Module.CV_8U:
-        case Module.CV_8UC1:
-        case Module.CV_8UC2:
-        case Module.CV_8UC3:
-        case Module.CV_8UC4: {
+        case cv.CV_8U:
+        case cv.CV_8UC1:
+        case cv.CV_8UC2:
+        case cv.CV_8UC3:
+        case cv.CV_8UC4: {
             mat.data.set(array);
             break;
         }
-        case Module.CV_8S:
-        case Module.CV_8SC1:
-        case Module.CV_8SC2:
-        case Module.CV_8SC3:
-        case Module.CV_8SC4: {
+        case cv.CV_8S:
+        case cv.CV_8SC1:
+        case cv.CV_8SC2:
+        case cv.CV_8SC3:
+        case cv.CV_8SC4: {
             mat.data8S.set(array);
             break;
         }
-        case Module.CV_16U:
-        case Module.CV_16UC1:
-        case Module.CV_16UC2:
-        case Module.CV_16UC3:
-        case Module.CV_16UC4: {
+        case cv.CV_16U:
+        case cv.CV_16UC1:
+        case cv.CV_16UC2:
+        case cv.CV_16UC3:
+        case cv.CV_16UC4: {
             mat.data16U.set(array);
             break;
         }
-        case Module.CV_16S:
-        case Module.CV_16SC1:
-        case Module.CV_16SC2:
-        case Module.CV_16SC3:
-        case Module.CV_16SC4: {
+        case cv.CV_16S:
+        case cv.CV_16SC1:
+        case cv.CV_16SC2:
+        case cv.CV_16SC3:
+        case cv.CV_16SC4: {
             mat.data16S.set(array);
             break;
         }
-        case Module.CV_32S:
-        case Module.CV_32SC1:
-        case Module.CV_32SC2:
-        case Module.CV_32SC3:
-        case Module.CV_32SC4: {
+        case cv.CV_32S:
+        case cv.CV_32SC1:
+        case cv.CV_32SC2:
+        case cv.CV_32SC3:
+        case cv.CV_32SC4: {
             mat.data32S.set(array);
             break;
         }
-        case Module.CV_32F:
-        case Module.CV_32FC1:
-        case Module.CV_32FC2:
-        case Module.CV_32FC3:
-        case Module.CV_32FC4: {
+        case cv.CV_32F:
+        case cv.CV_32FC1:
+        case cv.CV_32FC2:
+        case cv.CV_32FC3:
+        case cv.CV_32FC4: {
             mat.data32F.set(array);
             break;
         }
-        case Module.CV_64F:
-        case Module.CV_64FC1:
-        case Module.CV_64FC2:
-        case Module.CV_64FC3:
-        case Module.CV_64FC4: {
+        case cv.CV_64F:
+        case cv.CV_64FC1:
+        case cv.CV_64FC2:
+        case cv.CV_64FC3:
+        case cv.CV_64FC4: {
             mat.data64F.set(array);
             break;
         }
@@ -397,7 +401,7 @@ Module['matFromArray'] = function(rows, cols, type, array) {
 };
 
 Module['matFromImageData'] = function(imageData) {
-    var mat = new Module.Mat(imageData.height, imageData.width, Module.CV_8UC4);
+    var mat = new cv.Mat(imageData.height, imageData.width, cv.CV_8UC4);
     mat.data.set(imageData.data);
     return mat;
 };

--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -397,7 +397,7 @@ Module['matFromArray'] = function(rows, cols, type, array) {
 };
 
 Module['matFromImageData'] = function(imageData) {
-    var mat = new Module.Mat(imageData.height, imageData.width, cv.CV_8UC4);
+    var mat = new Module.Mat(imageData.height, imageData.width, Module.CV_8UC4);
     mat.data.set(imageData.data);
     return mat;
 };

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
                         help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
 
-    transformed_args = [f'--cmake_option={arg}' if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
+    transformed_args = ["--cmake_option=%s".format(arg) if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
     args = parser.parse_args(transformed_args)
 
     log.debug("Args: %s", args)

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -84,7 +84,6 @@ class Builder:
             "-DPYTHON_DEFAULT_EXECUTABLE=%s" % sys.executable,
                "-DENABLE_PIC=FALSE", # To workaround emscripten upstream backend issue https://github.com/emscripten-core/emscripten/issues/8761
                "-DCMAKE_BUILD_TYPE=Release",
-               "-DCMAKE_TOOLCHAIN_FILE='%s'" % self.get_toolchain_file(),
                "-DCPU_BASELINE=''",
                "-DCMAKE_INSTALL_PREFIX=/usr/local",
                "-DCPU_DISPATCH=''",
@@ -145,6 +144,8 @@ class Builder:
                "-DBUILD_PERF_TESTS=ON"]
         if self.options.cmake_option:
             cmd += self.options.cmake_option
+        if not self.options.cmake_option or all(["-DCMAKE_TOOLCHAIN_FILE" not in opt for opt in self.options.cmake_option]):
+            cmd.append("-DCMAKE_TOOLCHAIN_FILE='%s'" % self.get_toolchain_file())
         if self.options.build_doc:
             cmd.append("-DBUILD_DOCS=ON")
         else:
@@ -194,6 +195,7 @@ class Builder:
             flags += self.options.build_flags
         if self.options.webnn:
             flags += "-s USE_WEBNN=1 "
+        flags += "-s EXPORTED_FUNCTIONS=\"['_malloc', '_free']\""
         return flags
 
     def config(self):
@@ -224,10 +226,12 @@ if __name__ == "__main__":
 
     opencv_dir = os.path.abspath(os.path.join(SCRIPT_DIR, '../..'))
     emscripten_dir = None
-    if "EMSCRIPTEN" in os.environ:
+    if "EMSDK" in os.environ:
+        emscripten_dir = os.path.join(os.environ["EMSDK"], "upstream", "emscripten")
+    elif "EMSCRIPTEN" in os.environ:
         emscripten_dir = os.environ["EMSCRIPTEN"]
     else:
-        log.warning("EMSCRIPTEN environment variable is not available. Please properly activate Emscripten SDK and consider using 'emcmake' launcher")
+        log.warning("EMSCRIPTEN/EMSDK environment variable is not available. Please properly activate Emscripten SDK and consider using 'emcmake' launcher")
 
     parser = argparse.ArgumentParser(description='Build OpenCV.js by Emscripten')
     parser.add_argument("build_dir", help="Building directory (and output)")
@@ -256,7 +260,8 @@ if __name__ == "__main__":
                         help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
 
-    args = parser.parse_args()
+    transformed_args = [f'--cmake_option={arg}' if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
+    args = parser.parse_args(transformed_args)
 
     log.debug("Args: %s", args)
 
@@ -266,7 +271,7 @@ if __name__ == "__main__":
         del os.environ['EMMAKEN_JUST_CONFIGURE']  # avoid linker errors with NODERAWFS message then using 'emcmake' launcher
 
     if args.emscripten_dir is None:
-        log.error("Cannot get Emscripten path, please use 'emcmake' launcher or specify it either by EMSCRIPTEN environment variable or --emscripten_dir option.")
+        log.error("Cannot get Emscripten path, please use 'emcmake' launcher or specify it either by EMSCRIPTEN/EMSDK environment variable or --emscripten_dir option.")
         sys.exit(-1)
 
     builder = Builder(args)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Details

I was following [this tutorial](https://docs.opencv.org/4.9.0/d4/da1/tutorial_js_setup.html) for building opencv with wasm target. The tutorial mentions that the last verified version of emscripten that is tested with opencv is 2.0.10, but I was curious if I could get it to work with more recent versions. I've run into a few issues with the latest version, for which fixes are included in this PR. I've found a few issues that have the same problems I encountered:

- https://github.com/opencv/opencv/issues/24620
- https://github.com/opencv/opencv/issues/20313
- https://stackoverflow.com/questions/77469603/custom-opencv-js-wasm-using-cv-matfromarray-results-in-cv-mat-is-not-a-co
- https://github.com/emscripten-core/emscripten/issues/14803
- https://github.com/opencv/opencv/issues/24572
- https://github.com/opencv/opencv/issues/19493#issuecomment-857167996

I used the docker image for building and comparing results with different emsdk versions. I tested by building with `--build_wasm` and `--build-test` flags and ran the tests in the browser. I addressed the following issues with newer versions of emscripten:

- In newer versions `EMSCRIPTEN` environemnt variable was stopped being set. I added support for deriving location based on the `EMSDK` environment variable, as suggested [here](https://github.com/emscripten-core/emscripten/issues/14803)
- In newer versions emcmake started passing `-DCMAKE...` arguments, however the opencv python script didn't know how to handle them. I added processing to the args that will forward all arguments to `cmake` that start with `-D`. I opted for this in hopes of being more futureproof, but another approach could be just ignoreing them, or explicitly forwarding them instead of matching anything starting with `-D`. These approches were suggested [here](https://github.com/opencv/opencv/issues/19493#issuecomment-855529448)
- With [version 3.1.31](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3131---012623) some previously exported functions stopped being automatically exported. Because of this, `_free` and `_malloc` were no longer available and had to be explicitly exported because of breaking tests.
- With [version 3.1.42](https://github.com/emscripten-core/emscripten/compare/3.1.41...3.1.42#diff-e505aa80b2764c0197acfc9afd8179b3600f0ab5dd00ff77db01879a84515cdbL3875) the `post-js` code doesn't receive the module named as `EXPORT_NAME` anymore, but only as `moduleArg`/`Module`. This broke existing code in `helpers.js`, which was referencing exported functions through `cv.Mat`, etc. I changed all of these references to use `Module.Mat`, etc. If it is preferred, alternatively the `cv` variable could be reintroduced in `helper.js` as suggested [here](https://github.com/opencv/opencv/issues/24620)

With the above changes in place, I can successfully build and run tests with the latest emscripten/emsdk docker image (also with 2.0.10 and most of the other older tags, except for a few that contain transient issues like [this](https://github.com/emscripten-core/emscripten/issues/17700)).

This is my first time contributing to opencv, so I hope I got everything correct in this PR, but please let me know if I should change anything!

```
force_builders=Custom
build_image:Docs=docs-js:18.04
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```