### PR TITLE
Revert 3rdparty files to their state before #25086

### DIFF
--- a/3rdparty/libjasper/jas_stream.c
+++ b/3rdparty/libjasper/jas_stream.c
@@ -889,7 +889,7 @@ int jas_stream_copy(jas_stream_t *out, jas_stream_t *in, int n)
     while (all || m > 0) {
         if ((c = jas_stream_getc_macro(in)) == EOF) {
             /* The next character of input could not be read. */
-            /* Return with an error if an I/O error occurred
+            /* Return with an error if an I/O error occured
               (not including EOF) or if an explicit copy count
               was specified. */
             return (!all || jas_stream_error(in)) ? (-1) : 0;

--- a/3rdparty/libjasper/jpc_bs.h
+++ b/3rdparty/libjasper/jpc_bs.h
@@ -100,7 +100,7 @@
 #define	JPC_BITSTREAM_NOCLOSE	0x01
 /* End of file has been reached while reading. */
 #define	JPC_BITSTREAM_EOF	0x02
-/* An I/O error has occurerd. */
+/* An I/O error has occured. */
 #define	JPC_BITSTREAM_ERR	0x04
 
 /******************************************************************************\


### PR DESCRIPTION
Related [opencv/opencv#25086 (comment)](https://github.com/opencv/opencv/pull/25086#discussion_r1501611243)
I created this PR because #25086 was merged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
