### PR TITLE
Fixes #25056 : Optimising postProcess(const std::vector<Mat>& output_blobs)

### DIFF
--- a/modules/objdetect/src/face_detect.cpp
+++ b/modules/objdetect/src/face_detect.cpp
@@ -201,28 +201,28 @@ private:
                     face.at<float>(0, 14) = score;
 
                     // Checking if the score meets the threshold before adding the face
-                    if (score >= scoreThreshold) {
-                        // Add the detected face to the faces Mat
-                        float cx = ((c + bbox_v[idx * 4 + 0]) * strides[i]);
-                        float cy = ((r + bbox_v[idx * 4 + 1]) * strides[i]);
-                        float w = exp(bbox_v[idx * 4 + 2]) * strides[i];
-                        float h = exp(bbox_v[idx * 4 + 3]) * strides[i];
+                    if (score < scoreThreshold)
+                        continue;
+                    // Get bounding box
+                    float cx = ((c + bbox_v[idx * 4 + 0]) * strides[i]);
+                    float cy = ((r + bbox_v[idx * 4 + 1]) * strides[i]);
+                    float w = exp(bbox_v[idx * 4 + 2]) * strides[i];
+                    float h = exp(bbox_v[idx * 4 + 3]) * strides[i];
 
-                        float x1 = cx - w / 2.f;
-                        float y1 = cy - h / 2.f;
+                    float x1 = cx - w / 2.f;
+                    float y1 = cy - h / 2.f;
 
-                        face.at<float>(0, 0) = x1;
-                        face.at<float>(0, 1) = y1;
-                        face.at<float>(0, 2) = w;
-                        face.at<float>(0, 3) = h;
+                    face.at<float>(0, 0) = x1;
+                    face.at<float>(0, 1) = y1;
+                    face.at<float>(0, 2) = w;
+                    face.at<float>(0, 3) = h;
 
-                        // Get landmarks
-                        for(int n = 0; n < 5; ++n) {
-                            face.at<float>(0, 4 + 2 * n) = (kps_v[idx * 10 + 2 * n] + c) * strides[i];
-                            face.at<float>(0, 4 + 2 * n + 1) = (kps_v[idx * 10 + 2 * n + 1]+ r) * strides[i];
-                        }
-                        faces.push_back(face);
+                    // Get landmarks
+                    for(int n = 0; n < 5; ++n) {
+                        face.at<float>(0, 4 + 2 * n) = (kps_v[idx * 10 + 2 * n] + c) * strides[i];
+                        face.at<float>(0, 4 + 2 * n + 1) = (kps_v[idx * 10 + 2 * n + 1]+ r) * strides[i];
                     }
+                    faces.push_back(face);
                 }
             }
         }

--- a/modules/objdetect/src/face_detect.cpp
+++ b/modules/objdetect/src/face_detect.cpp
@@ -200,26 +200,29 @@ private:
                     float score = std::sqrt(cls_score * obj_score);
                     face.at<float>(0, 14) = score;
 
-                    // Get bounding box
-                    float cx = ((c + bbox_v[idx * 4 + 0]) * strides[i]);
-                    float cy = ((r + bbox_v[idx * 4 + 1]) * strides[i]);
-                    float w = exp(bbox_v[idx * 4 + 2]) * strides[i];
-                    float h = exp(bbox_v[idx * 4 + 3]) * strides[i];
+                    // Checking if the score meets the threshold before adding the face
+                    if (score >= scoreThreshold) {
+                        // Add the detected face to the faces Mat
+                        float cx = ((c + bbox_v[idx * 4 + 0]) * strides[i]);
+                        float cy = ((r + bbox_v[idx * 4 + 1]) * strides[i]);
+                        float w = exp(bbox_v[idx * 4 + 2]) * strides[i];
+                        float h = exp(bbox_v[idx * 4 + 3]) * strides[i];
 
-                    float x1 = cx - w / 2.f;
-                    float y1 = cy - h / 2.f;
+                        float x1 = cx - w / 2.f;
+                        float y1 = cy - h / 2.f;
 
-                    face.at<float>(0, 0) = x1;
-                    face.at<float>(0, 1) = y1;
-                    face.at<float>(0, 2) = w;
-                    face.at<float>(0, 3) = h;
+                        face.at<float>(0, 0) = x1;
+                        face.at<float>(0, 1) = y1;
+                        face.at<float>(0, 2) = w;
+                        face.at<float>(0, 3) = h;
 
-                    // Get landmarks
-                    for(int n = 0; n < 5; ++n) {
-                        face.at<float>(0, 4 + 2 * n) = (kps_v[idx * 10 + 2 * n] + c) * strides[i];
-                        face.at<float>(0, 4 + 2 * n + 1) = (kps_v[idx * 10 + 2 * n + 1]+ r) * strides[i];
+                        // Get landmarks
+                        for(int n = 0; n < 5; ++n) {
+                            face.at<float>(0, 4 + 2 * n) = (kps_v[idx * 10 + 2 * n] + c) * strides[i];
+                            face.at<float>(0, 4 + 2 * n + 1) = (kps_v[idx * 10 + 2 * n + 1]+ r) * strides[i];
+                        }
+                        faces.push_back(face);
                     }
-                    faces.push_back(face);
                 }
             }
         }


### PR DESCRIPTION
Like mentioned in the issue #25056 , I think checking the condition with `scoreThreshold` and then assigning the bounding boxes can optimize the function pretty well. By doing this, we prevent allocating boxes to faces with scores below the threshold. It also reduces the amount of data that needs to be processed during the subsequent NMS step. Builds and passed locally.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
