### PR TITLE
1D test for Reduce layer

### DIFF
--- a/modules/dnn/src/layers/reduce_layer.cpp
+++ b/modules/dnn/src/layers/reduce_layer.cpp
@@ -76,7 +76,7 @@ public:
 
         bool do_nothing = true;
         for (auto axis : axes) {
-            if (shape_input[axis] != 1) {
+            if (shape_input[axis] != 1 || keepdims) {
                 do_nothing = false;
             }
         }

--- a/modules/dnn/src/layers/reduce_layer.cpp
+++ b/modules/dnn/src/layers/reduce_layer.cpp
@@ -92,6 +92,7 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         if (inputs[0].empty()){
+            CV_CheckEQ(axes[0], 0, "Axis must be 0 when input is empty.");
             outputs.assign(1, MatShape());
             return false;
         }
@@ -412,7 +413,7 @@ public:
         static void run(const Mat& src, Mat& dst, std::vector<int> axes, bool noop_with_empty_axes) {
             CV_Assert(src.isContinuous());
             CV_Assert(dst.isContinuous());
-            if (shape(src).empty() || (shape(src).size() == 1 && shape(src)[0] == 1)){
+            if (shape(src).empty() || (shape(src).size() == 1)){
                 // since there is only one element no need for parallel compute
                 // axis does not matter either (one element)
                 ReduceAllInvoker<Op> p(src, dst);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -581,12 +581,8 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
     cv::Mat output_ref = reduceOperation(input, reduce_operation, axis);
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
-    std::cout << "input: " << input << std::endl;
 
     runLayer(layer, inputs, outputs);
-    std::cout << "shape of output: " << shape(outputs[0]) << std::endl;
-    std::cout << "output: " << outputs[0] << std::endl;
-    std::cout << "ref: " << output_ref << std::endl;
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -516,11 +516,6 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
 
                 if (operation == "sum" || operation == "mean") res += value;
                 else if (operation == "sum_square") {
-                    if (shape(input).size() == 2 && shape(input)[0] == 1 && axis==0)
-                        res += value;
-                    else if (shape(input).size() == 2 && shape(input)[1] == 1 && axis==1)
-                        res += value;
-                    else
                         res += value * value;
                 } else if (operation == "l1") res += std::abs(value);
                 else if (operation == "l2") res += value * value;
@@ -586,8 +581,12 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
     cv::Mat output_ref = reduceOperation(input, reduce_operation, axis);
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
+    std::cout << "input: " << input << std::endl;
 
     runLayer(layer, inputs, outputs);
+    std::cout << "shape of output: " << shape(outputs[0]) << std::endl;
+    std::cout << "output: " << outputs[0] << std::endl;
+    std::cout << "ref: " << output_ref << std::endl;
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -488,9 +488,9 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
         cv::Mat result;
         if (shape(input).size() == 0 || shape(input).size() == 1){
             result = cv::Mat(shape(input).size(), shape(input).data(), CV_32F);
+            int sz[1] = {1};
             if (!shape(input).empty() && shape(input)[0] != 1){
                 result = cv::Mat(1, 1, CV_32F);
-                int sz[1];
                 result = result.reshape(1, 1, sz);
             }
         } else {

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -503,7 +503,9 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
                 res = is_first ? value : std::min(res, value);
             } else {
                 if (is_first) {
-                    if (operation == "sum" || operation == "l1" || operation == "l2" || operation == "sum_square" || operation == "mean") res = 0;
+                    if (operation == "sum" || operation == "l1" || operation == "l2"
+                        || operation == "sum_square" || operation == "mean" || operation == "log_sum"
+                        || operation == "log_sum_exp") res = 0;
                     else if (operation == "prod") res = 1;
                 }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -540,7 +540,7 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
 
     float out_value = reduceOperation(input, reduce_operation);
 
-    cv::Mat output_ref = cv::Mat(input_shape.size(), (input_shape.size() <= 1) ? input_shape.data() : std::vector<int>({1, 1}).data(), CV_32F, out_value);
+    cv::Mat output_ref(std::vector<int>(input_shape.size(), 1), CV_32F, out_value);
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -553,7 +553,8 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Reduce_Test, Combine(
 /*input blob shape*/    Values(
     std::vector<int>({}),
     std::vector<int>({1}),
-    std::vector<int>({1, 4})
+    std::vector<int>({1, 4}),
+    std::vector<int>({4, 1})
     ),
 /*reduce operation type*/
     Values("max", "min", "mean", "sum", "sum_square", "l1", "l2", "prod", "log_sum", "log_sum_exp"))

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -504,19 +504,16 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
                 result += value * value;
             } else if (operation == "prod") {
                 result = (i == 0) ? value : result * value;
+            } else if (operation == "log_sum" || operation == "log_sum_exp") {
+                result += (operation == "log_sum") ? std::log(input.at<float>(i)) : std::exp(input.at<float>(i));
             }
         }
         if (operation == "mean") {
             result = sum / input.total();
         } else if (operation == "l2") {
             result = std::sqrt(result);
-        } else if (operation == "log_sum" || operation == "log_sum_exp") {
-            for (int i = 0; i < input.total(); ++i) {
-                result += (operation == "log_sum") ? std::log(input.at<float>(i)) : std::exp(input.at<float>(i));
-            }
-            if (operation == "log_sum_exp") {
-                result = std::log(result);
-            }
+        } else if (operation == "log_sum_exp") {
+            result = std::log(result);
         }
         return result;
     };

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -551,7 +551,8 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Reduce_Test, Combine(
     std::vector<int>({}),
     std::vector<int>({1}),
     std::vector<int>({1, 4}),
-    std::vector<int>({4, 1})
+    std::vector<int>({4, 1}),
+    std::vector<int>({4, 4})
     ),
 /*reduce operation type*/
     Values("max", "min", "mean", "sum", "sum_square", "l1", "l2", "prod", "log_sum", "log_sum_exp"))

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -555,7 +555,8 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Reduce_Test, Combine(
     std::vector<int>({1}),
     std::vector<int>({1, 4})
     ),
-/*input blob shape*/    Values("max", "min", "mean", "sum", "sum_square", "l1", "l2", "prod", "log_sum", "log_sum_exp"))
+/*reduce operation type*/
+    Values("max", "min", "mean", "sum", "sum_square", "l1", "l2", "prod", "log_sum", "log_sum_exp"))
 );
 
 


### PR DESCRIPTION
This PR introduces test for `Reduce` layer to test its functionality for 1D arrays

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
