### PR TITLE
Element-wise test for 1D

### DIFF
--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -460,7 +460,7 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
     axis = (axis + dims) % dims;
     CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
 
-    std::vector<int> sizes(dims);
+    std::vector<int> sizes(srcMat.dims);
     std::copy(srcMat.size.p, srcMat.size.p + srcMat.dims, sizes.begin());
     if(!sizes.empty())
         sizes[axis] = 1;

--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -459,10 +459,6 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
     int dims = std::max(1, srcMat.dims);
     axis = (axis + dims) % dims;
     CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
-
-    int dims = std::max(1, srcMat.dims);
-    axis = (axis + dims) % dims;
-    CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis < dims);
     std::vector<int> sizes(dims);
     std::copy(srcMat.size.p, srcMat.size.p + srcMat.dims, sizes.begin());
     if(!sizes.empty())

--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -459,6 +459,7 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
     int dims = std::max(1, srcMat.dims);
     axis = (axis + dims) % dims;
     CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
+
     std::vector<int> sizes(dims);
     std::copy(srcMat.size.p, srcMat.size.p + srcMat.dims, sizes.begin());
     if(!sizes.empty())

--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -460,7 +460,10 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
     axis = (axis + dims) % dims;
     CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
 
-    std::vector<int> sizes(srcMat.dims);
+    int dims = std::max(1, srcMat.dims);
+    axis = (axis + dims) % dims;
+    CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis < dims);
+    std::vector<int> sizes(dims);
     std::copy(srcMat.size.p, srcMat.size.p + srcMat.dims, sizes.begin());
     if(!sizes.empty())
         sizes[axis] = 1;

--- a/modules/dnn/src/layers/arg_layer.cpp
+++ b/modules/dnn/src/layers/arg_layer.cpp
@@ -64,8 +64,13 @@ public:
                                  std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         MatShape inpShape = inputs[0];
+        // no axis for scalar
+        if (inpShape.empty()){
+            CV_Assert(axis == 0);
+        }
 
         const int axis_ = normalize_axis(axis, inpShape);
+        // handle dims = 0 situation
         if (!inpShape.empty())
             handleKeepDims(inpShape, axis_);
         outputs.assign(1, inpShape);

--- a/modules/dnn/src/layers/gather_layer.cpp
+++ b/modules/dnn/src/layers/gather_layer.cpp
@@ -39,8 +39,8 @@ public:
         }
 
         const int axis = normalize_axis(m_axis, inpShape);
-
-        inpShape.erase(inpShape.begin() + axis);
+        if (!inpShape.empty())
+            inpShape.erase(inpShape.begin() + axis);
         auto end = m_real_ndims == -1 ? inputs[1].end() : inputs[1].begin() + m_real_ndims;
         inpShape.insert(inpShape.begin() + axis, inputs[1].begin(), end);
         outputs.assign(1, inpShape);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -12,10 +12,9 @@
 
 namespace opencv_test { namespace {
 
-class Layer_Test_01D: public testing::TestWithParam<tuple<int>>
+class Layer_Test_01D: public testing::TestWithParam<tuple<std::vector<int>>>
 {
 public:
-    int dims;
     std::vector<int> input_shape;
     std::vector<int> output_shape;
     float inp_value;
@@ -24,14 +23,13 @@ public:
 
     void SetUp()
     {
-        dims = get<0>(GetParam());
-        input_shape = {dims};
-        output_shape = {dims};
+        input_shape = get<0>(GetParam());
+        output_shape = input_shape;
 
         // generate random positeve value from 1 to 10
         RNG& rng = TS::ptr()->get_rng();
         inp_value = rng.uniform(1.0, 10.0); // random uniform value
-        input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+        input = Mat(input_shape.size(), input_shape.data(), CV_32F, inp_value);
     }
 
     void TestLayer(Ptr<Layer> layer, std::vector<Mat> &inputs, const Mat& output_ref){
@@ -53,7 +51,7 @@ TEST_P(Layer_Test_01D, Scale)
     lp.set("bias_term", false);
     Ptr<ScaleLayer> layer = ScaleLayer::create(lp);
 
-    Mat weight = Mat(dims, output_shape.data(), CV_32F, 2.0);
+    Mat weight = Mat(output_shape.size(), output_shape.data(), CV_32F, 2.0);
     std::vector<Mat> inputs{input, weight};
     Mat output_ref = input.mul(weight);
 
@@ -69,7 +67,7 @@ TEST_P(Layer_Test_01D, ReLU6)
     lp.set("max_value", 1.0);
     Ptr<ReLU6Layer> layer = ReLU6Layer::create(lp);
 
-    Mat output_ref(dims, output_shape.data(), CV_32F, 1.0);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, 1.0);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -84,7 +82,7 @@ TEST_P(Layer_Test_01D, Clip)
     lp.set("max_value", 1.0);
     Ptr<ReLU6Layer> layer = ReLU6Layer::create(lp);
 
-    Mat output_ref(dims, output_shape.data(), CV_32F, 1.0);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, 1.0);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -98,7 +96,7 @@ TEST_P(Layer_Test_01D, ReLU)
     lp.set("negative_slope", 0.0);
     Ptr<ReLULayer> layer = ReLULayer::create(lp);
 
-    Mat output_ref(dims, output_shape.data(), CV_32F, inp_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, inp_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -112,7 +110,7 @@ TEST_P(Layer_Test_01D, Gelu)
     Ptr<GeluLayer> layer = GeluLayer::create(lp);
 
     float value = inp_value * 0.5 * (std::erf(inp_value * 1 / std::sqrt(2.0)) + 1.0);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -126,7 +124,7 @@ TEST_P(Layer_Test_01D, GeluApprox)
     Ptr<GeluApproximationLayer> layer = GeluApproximationLayer::create(lp);
 
     float value = inp_value * 0.5 * (1.0 + std::tanh(std::sqrt(2.0 / M_PI) * (inp_value + 0.044715 * std::pow(inp_value, 3))));
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -140,7 +138,7 @@ TEST_P(Layer_Test_01D, Sigmoid)
     Ptr<SigmoidLayer> layer = SigmoidLayer::create(lp);
 
     float value = 1.0 / (1.0 + std::exp(-inp_value));
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -155,7 +153,7 @@ TEST_P(Layer_Test_01D, Tanh)
 
 
     float value = std::tanh(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -169,7 +167,7 @@ TEST_P(Layer_Test_01D, Swish)
     Ptr<Layer> layer = SwishLayer::create(lp);
 
     float value = inp_value / (1 + std::exp(-inp_value));
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -183,7 +181,7 @@ TEST_P(Layer_Test_01D, Mish)
     Ptr<Layer> layer = MishLayer::create(lp);
 
     float value = inp_value * std::tanh(std::log(1 + std::exp(inp_value)));
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -198,7 +196,7 @@ TEST_P(Layer_Test_01D, ELU)
     Ptr<Layer> layer = ELULayer::create(lp);
 
     float value = inp_value > 0 ? inp_value : std::exp(inp_value) - 1;
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -212,7 +210,7 @@ TEST_P(Layer_Test_01D, Abs)
     Ptr<Layer> layer = AbsLayer::create(lp);
 
     float value = std::abs(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -226,7 +224,7 @@ TEST_P(Layer_Test_01D, BNLL)
     Ptr<Layer> layer = BNLLLayer::create(lp);
 
     float value = std::log(1 + std::exp(inp_value));
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -240,7 +238,7 @@ TEST_P(Layer_Test_01D, Ceil)
     Ptr<Layer> layer = CeilLayer::create(lp);
 
     float value = std::ceil(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -254,7 +252,7 @@ TEST_P(Layer_Test_01D, Floor)
     Ptr<Layer> layer = FloorLayer::create(lp);
 
     float value = std::floor(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -268,7 +266,7 @@ TEST_P(Layer_Test_01D, Log)
     Ptr<Layer> layer = LogLayer::create(lp);
 
     float value = std::log(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -282,7 +280,7 @@ TEST_P(Layer_Test_01D, Round)
     Ptr<Layer> layer = RoundLayer::create(lp);
 
     float value = std::round(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -296,7 +294,7 @@ TEST_P(Layer_Test_01D, Sqrt)
     Ptr<Layer> layer = SqrtLayer::create(lp);
 
     float value = std::sqrt(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -310,10 +308,10 @@ TEST_P(Layer_Test_01D, Acos)
     Ptr<Layer> layer = AcosLayer::create(lp);
 
     inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
-    input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+    input = Mat(input_shape.size(), input_shape.data(), CV_32F, inp_value);
 
     float value = std::acos(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -327,7 +325,7 @@ TEST_P(Layer_Test_01D, Acosh)
     Ptr<Layer> layer = AcoshLayer::create(lp);
 
     float value = std::acosh(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -341,10 +339,10 @@ TEST_P(Layer_Test_01D, Asin)
     Ptr<Layer> layer = AsinLayer::create(lp);
 
     inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
-    input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+    input = Mat(input_shape.size(), input_shape.data(), CV_32F, inp_value);
 
     float value = std::asin(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -358,7 +356,7 @@ TEST_P(Layer_Test_01D, Asinh)
     Ptr<Layer> layer = AsinhLayer::create(lp);
 
     float value = std::asinh(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -372,7 +370,7 @@ TEST_P(Layer_Test_01D, Atan)
     Ptr<Layer> layer = AtanLayer::create(lp);
 
     float value = std::atan(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -386,7 +384,7 @@ TEST_P(Layer_Test_01D, Cos)
     Ptr<Layer> layer = CosLayer::create(lp);
 
     float value = std::cos(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -400,7 +398,7 @@ TEST_P(Layer_Test_01D, Cosh)
     Ptr<Layer> layer = CoshLayer::create(lp);
 
     float value = std::cosh(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -414,7 +412,7 @@ TEST_P(Layer_Test_01D, Sin)
     Ptr<Layer> layer = SinLayer::create(lp);
 
     float value = std::sin(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -428,7 +426,7 @@ TEST_P(Layer_Test_01D, Sinh)
     Ptr<Layer> layer = SinhLayer::create(lp);
 
     float value = std::sinh(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -442,7 +440,7 @@ TEST_P(Layer_Test_01D, Tan)
     Ptr<Layer> layer = TanLayer::create(lp);
 
     float value = std::tan(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -456,7 +454,7 @@ TEST_P(Layer_Test_01D, Erf)
     Ptr<Layer> layer = ErfLayer::create(lp);
 
     float out_value = std::erf(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -470,7 +468,7 @@ TEST_P(Layer_Test_01D, Reciprocal)
     Ptr<Layer> layer = ReciprocalLayer::create(lp);
 
     float out_value = 1/inp_value;
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -484,7 +482,7 @@ TEST_P(Layer_Test_01D, HardSwish)
     Ptr<Layer> layer = HardSwishLayer::create(lp);
 
     float out_value = inp_value * std::max(0.0f, std::min(6.0f, inp_value + 3.0f)) / 6.0f;
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -498,7 +496,7 @@ TEST_P(Layer_Test_01D, Softplus)
     Ptr<Layer> layer = SoftplusLayer::create(lp);
 
     float out_value = std::log(1 + std::exp(inp_value));
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -512,7 +510,7 @@ TEST_P(Layer_Test_01D, SoftSign)
     Ptr<Layer> layer = SoftsignLayer::create(lp);
 
     float out_value = inp_value / (1 + std::abs(inp_value));
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -527,7 +525,7 @@ TEST_P(Layer_Test_01D, CELU)
     Ptr<Layer> layer = CeluLayer::create(lp);
 
     float out_value = inp_value < 0 ? std::exp(inp_value) - 1 : inp_value;
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -541,7 +539,7 @@ TEST_P(Layer_Test_01D, HardSigmoid)
     Ptr<Layer> layer = HardSigmoidLayer::create(lp);
 
     float out_value = std::max(0.0f, std::min(1.0f, 0.2f * inp_value + 0.5f));
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -563,7 +561,7 @@ TEST_P(Layer_Test_01D, SELU)
 
     float value = static_cast<float>(value_double);
 
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -578,7 +576,7 @@ TEST_P(Layer_Test_01D, ThresholdedReLU)
     Ptr<Layer> layer = ThresholdedReluLayer::create(lp);
 
     float value = inp_value > 1.0 ? inp_value : 0.0;
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -595,7 +593,7 @@ TEST_P(Layer_Test_01D, Power)
     Ptr<Layer> layer = PowerLayer::create(lp);
 
     float value = std::pow(inp_value, 2.0);
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -609,7 +607,7 @@ TEST_P(Layer_Test_01D, Exp)
     Ptr<Layer> layer = ExpLayer::create(lp);
 
     float out_value = std::exp(inp_value);
-    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, out_value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -623,7 +621,7 @@ TEST_P(Layer_Test_01D, Sign)
     Ptr<Layer> layer = SignLayer::create(lp);
 
     float value = inp_value > 0 ? 1.0 : 0.0;
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -639,7 +637,7 @@ TEST_P(Layer_Test_01D, Shrink)
     Ptr<Layer> layer = ShrinkLayer::create(lp);
 
     float value = inp_value > 0.5 ? inp_value - 0.5 : 0.0;
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
@@ -655,12 +653,16 @@ TEST_P(Layer_Test_01D, ChannelsPReLU)
     Ptr<Layer> layer = ChannelsPReLULayer::create(lp);
 
     float value = inp_value > 0 ? inp_value : 0.5 * inp_value;
-    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    Mat output_ref(output_shape.size(), output_shape.data(), CV_32F, value);
     std::vector<Mat> inputs{input};
 
     TestLayer(layer, inputs, output_ref);
 }
-INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Test_01D, Values(0, 1));
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Test_01D,
+        testing::Values(
+            std::vector<int>{},
+            std::vector<int>{1}
+        ));
 
 typedef testing::TestWithParam<tuple<std::vector<int>, int>> Layer_Gather_Test;
 TEST_P(Layer_Gather_Test, Accuracy_01D) {

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -724,8 +724,8 @@ int arg_op(const std::vector<T>& vec, const std::string& operation) {
     }
 }
 // Test for ArgLayer is disabled because there problem in runLayer function related to type assignment
-typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_Arg_1d_Test;
-TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
+typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_Arg_Test;
+TEST_P(Layer_Arg_Test, Accuracy_01D) {
     std::vector<int> input_shape = get<0>(GetParam());
     std::string operation = get<1>(GetParam());
 
@@ -734,8 +734,8 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     lp.name = "arg" + operation + "_Layer";
     int axis = (input_shape.size() == 0 || input_shape.size() == 1 ) ? 0 : 1;
     lp.set("op", operation);
-    lp.set("axis", 0);
-    lp.set("keepdims", 0);
+    lp.set("axis", axis);
+    lp.set("keepdims", 1);
     lp.set("select_last_index", 0);
 
     Ptr<ArgLayer> layer = ArgLayer::create(lp);
@@ -768,6 +768,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
+
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
@@ -776,7 +777,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     normAssert(output_ref, outputs[0]);
 }
 
-INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Arg_1d_Test, Combine(
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Arg_Test, Combine(
 /*input blob shape*/    testing::Values(
                                 std::vector<int>({}),
                                 std::vector<int>({1}),
@@ -803,7 +804,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     cv::randu(input1, 0.0, 1.0);
     cv::randu(input2, 0.0, 1.0);
 
-    Mat output_ref;
+    cv::Mat output_ref;
     if (operation == "sum") {
         output_ref = input1 + input2;
     } else if (operation == "mul") {
@@ -813,7 +814,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     } else if (operation == "sub") {
         output_ref = input1 - input2;
     } else {
-        output_ref = Mat();
+        output_ref = cv::Mat();
     }
     std::vector<Mat> inputs{input1, input2};
     std::vector<Mat> outputs;
@@ -854,7 +855,7 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy_01D) {
     cv::randu(input2, 0.0, 1.0);
 
     // Dynamically select the operation
-    Mat output_ref;
+    cv::Mat output_ref;
     if (operation == "sum") {
         output_ref = input1 + input2;
     } else if (operation == "max") {
@@ -866,7 +867,7 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy_01D) {
     } else if (operation == "div") {
         output_ref = input1 / input2;
     } else {
-        output_ref = Mat();
+        output_ref = cv::Mat();
     }
 
     std::vector<Mat> inputs{input1, input2};

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -662,7 +662,7 @@ TEST_P(Layer_Test_01D, ChannelsPReLU)
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Test_01D, Values(0, 1));
 
-typedef testing::TestWithParam<tuple<std::vector<int>, int>> Layer_Gather_1d_Test;
+typedef testing::TestWithParam<tuple<std::vector<int>, int>> Layer_Gather_Test;
 TEST_P(Layer_Gather_Test, Accuracy_01D) {
 
     std::vector<int> input_shape = get<0>(GetParam());
@@ -702,7 +702,7 @@ TEST_P(Layer_Gather_Test, Accuracy_01D) {
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
-INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_1d_Test, Combine(
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_Test, Combine(
 /*input blob shape*/    testing::Values(
                                 std::vector<int>({}),
                                 std::vector<int>({1}),

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -45,7 +45,7 @@ TEST_P(Layer_Test_01D, Scale)
 {
 
     lp.type = "Scale";
-    lp.name = "scaleLayer";
+    lp.name = "ScaleLayer";
     lp.set("axis", 0);
     lp.set("mode", "scale");
     lp.set("bias_term", false);
@@ -77,7 +77,7 @@ TEST_P(Layer_Test_01D, Clip)
 {
 
     lp.type = "Clip";
-    lp.name = "clipLayer";
+    lp.name = "ClipLayer";
     lp.set("min_value", 0.0);
     lp.set("max_value", 1.0);
     Ptr<ReLU6Layer> layer = ReLU6Layer::create(lp);
@@ -92,7 +92,7 @@ TEST_P(Layer_Test_01D, ReLU)
 {
 
     lp.type = "ReLU";
-    lp.name = "reluLayer";
+    lp.name = "ReluLayer";
     lp.set("negative_slope", 0.0);
     Ptr<ReLULayer> layer = ReLULayer::create(lp);
 
@@ -106,7 +106,7 @@ TEST_P(Layer_Test_01D, Gelu)
 {
 
     lp.type = "Gelu";
-    lp.name = "geluLayer";
+    lp.name = "GeluLayer";
     Ptr<GeluLayer> layer = GeluLayer::create(lp);
 
     float value = inp_value * 0.5 * (std::erf(inp_value * 1 / std::sqrt(2.0)) + 1.0);
@@ -120,7 +120,7 @@ TEST_P(Layer_Test_01D, GeluApprox)
 {
 
     lp.type = "GeluApprox";
-    lp.name = "geluApproxLayer";
+    lp.name = "GeluApproxLayer";
     Ptr<GeluApproximationLayer> layer = GeluApproximationLayer::create(lp);
 
     float value = inp_value * 0.5 * (1.0 + std::tanh(std::sqrt(2.0 / M_PI) * (inp_value + 0.044715 * std::pow(inp_value, 3))));
@@ -134,7 +134,7 @@ TEST_P(Layer_Test_01D, Sigmoid)
 {
 
     lp.type = "Sigmoid";
-    lp.name = "sigmoidLayer";
+    lp.name = "SigmoidLayer";
     Ptr<SigmoidLayer> layer = SigmoidLayer::create(lp);
 
     float value = 1.0 / (1.0 + std::exp(-inp_value));
@@ -191,7 +191,7 @@ TEST_P(Layer_Test_01D, ELU)
 {
 
     lp.type = "ELU";
-    lp.name = "eluLayer";
+    lp.name = "EluLayer";
     lp.set("alpha", 1.0);
     Ptr<Layer> layer = ELULayer::create(lp);
 
@@ -206,7 +206,7 @@ TEST_P(Layer_Test_01D, Abs)
 {
 
     lp.type = "Abs";
-    lp.name = "absLayer";
+    lp.name = "AbsLayer";
     Ptr<Layer> layer = AbsLayer::create(lp);
 
     float value = std::abs(inp_value);
@@ -220,7 +220,7 @@ TEST_P(Layer_Test_01D, BNLL)
 {
 
     lp.type = "BNLL";
-    lp.name = "bnllLayer";
+    lp.name = "BNLLLayer";
     Ptr<Layer> layer = BNLLLayer::create(lp);
 
     float value = std::log(1 + std::exp(inp_value));
@@ -234,7 +234,7 @@ TEST_P(Layer_Test_01D, Ceil)
 {
 
     lp.type = "Ceil";
-    lp.name = "ceilLayer";
+    lp.name = "CeilLayer";
     Ptr<Layer> layer = CeilLayer::create(lp);
 
     float value = std::ceil(inp_value);
@@ -248,7 +248,7 @@ TEST_P(Layer_Test_01D, Floor)
 {
 
     lp.type = "Floor";
-    lp.name = "floorLayer";
+    lp.name = "FloorLayer";
     Ptr<Layer> layer = FloorLayer::create(lp);
 
     float value = std::floor(inp_value);
@@ -262,7 +262,7 @@ TEST_P(Layer_Test_01D, Log)
 {
 
     lp.type = "Log";
-    lp.name = "logLayer";
+    lp.name = "LogLayer";
     Ptr<Layer> layer = LogLayer::create(lp);
 
     float value = std::log(inp_value);
@@ -276,7 +276,7 @@ TEST_P(Layer_Test_01D, Round)
 {
 
     lp.type = "Round";
-    lp.name = "roundLayer";
+    lp.name = "RoundLayer";
     Ptr<Layer> layer = RoundLayer::create(lp);
 
     float value = std::round(inp_value);
@@ -290,7 +290,7 @@ TEST_P(Layer_Test_01D, Sqrt)
 {
 
     lp.type = "Sqrt";
-    lp.name = "sqrtLayer";
+    lp.name = "SqrtLayer";
     Ptr<Layer> layer = SqrtLayer::create(lp);
 
     float value = std::sqrt(inp_value);
@@ -304,7 +304,7 @@ TEST_P(Layer_Test_01D, Acos)
 {
 
     lp.type = "Acos";
-    lp.name = "acosLayer";
+    lp.name = "AcosLayer";
     Ptr<Layer> layer = AcosLayer::create(lp);
 
     inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
@@ -321,7 +321,7 @@ TEST_P(Layer_Test_01D, Acosh)
 {
 
     lp.type = "Acosh";
-    lp.name = "acoshLayer";
+    lp.name = "AcoshLayer";
     Ptr<Layer> layer = AcoshLayer::create(lp);
 
     float value = std::acosh(inp_value);
@@ -335,7 +335,7 @@ TEST_P(Layer_Test_01D, Asin)
 {
 
     lp.type = "Asin";
-    lp.name = "asinLayer";
+    lp.name = "AsinLayer";
     Ptr<Layer> layer = AsinLayer::create(lp);
 
     inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
@@ -352,7 +352,7 @@ TEST_P(Layer_Test_01D, Asinh)
 {
 
     lp.type = "Asinh";
-    lp.name = "asinhLayer";
+    lp.name = "AsinhLayer";
     Ptr<Layer> layer = AsinhLayer::create(lp);
 
     float value = std::asinh(inp_value);
@@ -366,7 +366,7 @@ TEST_P(Layer_Test_01D, Atan)
 {
 
     lp.type = "Atan";
-    lp.name = "atanLayer";
+    lp.name = "AtanLayer";
     Ptr<Layer> layer = AtanLayer::create(lp);
 
     float value = std::atan(inp_value);
@@ -380,7 +380,7 @@ TEST_P(Layer_Test_01D, Cos)
 {
 
     lp.type = "Cos";
-    lp.name = "cosLayer";
+    lp.name = "CosLayer";
     Ptr<Layer> layer = CosLayer::create(lp);
 
     float value = std::cos(inp_value);
@@ -394,7 +394,7 @@ TEST_P(Layer_Test_01D, Cosh)
 {
 
     lp.type = "Cosh";
-    lp.name = "coshLayer";
+    lp.name = "CoshLayer";
     Ptr<Layer> layer = CoshLayer::create(lp);
 
     float value = std::cosh(inp_value);
@@ -408,7 +408,7 @@ TEST_P(Layer_Test_01D, Sin)
 {
 
     lp.type = "Sin";
-    lp.name = "sinLayer";
+    lp.name = "SinLayer";
     Ptr<Layer> layer = SinLayer::create(lp);
 
     float value = std::sin(inp_value);
@@ -422,7 +422,7 @@ TEST_P(Layer_Test_01D, Sinh)
 {
 
     lp.type = "Sinh";
-    lp.name = "sinhLayer";
+    lp.name = "SinhLayer";
     Ptr<Layer> layer = SinhLayer::create(lp);
 
     float value = std::sinh(inp_value);
@@ -436,7 +436,7 @@ TEST_P(Layer_Test_01D, Tan)
 {
 
     lp.type = "Tan";
-    lp.name = "tanLayer";
+    lp.name = "TanLayer";
     Ptr<Layer> layer = TanLayer::create(lp);
 
     float value = std::tan(inp_value);
@@ -450,7 +450,7 @@ TEST_P(Layer_Test_01D, Erf)
 {
 
     lp.type = "Erf";
-    lp.name = "erfLayer";
+    lp.name = "ErfLayer";
     Ptr<Layer> layer = ErfLayer::create(lp);
 
     float out_value = std::erf(inp_value);
@@ -464,7 +464,7 @@ TEST_P(Layer_Test_01D, Reciprocal)
 {
 
     lp.type = "Reciprocal";
-    lp.name = "reciprocalLayer";
+    lp.name = "ReciprocalLayer";
     Ptr<Layer> layer = ReciprocalLayer::create(lp);
 
     float out_value = 1/inp_value;
@@ -478,7 +478,7 @@ TEST_P(Layer_Test_01D, HardSwish)
 {
 
     lp.type = "HardSwish";
-    lp.name = "hardSwishLayer";
+    lp.name = "HardSwishLayer";
     Ptr<Layer> layer = HardSwishLayer::create(lp);
 
     float out_value = inp_value * std::max(0.0f, std::min(6.0f, inp_value + 3.0f)) / 6.0f;
@@ -492,7 +492,7 @@ TEST_P(Layer_Test_01D, Softplus)
 {
 
     lp.type = "Softplus";
-    lp.name = "softplusLayer";
+    lp.name = "SoftplusLayer";
     Ptr<Layer> layer = SoftplusLayer::create(lp);
 
     float out_value = std::log(1 + std::exp(inp_value));
@@ -506,7 +506,7 @@ TEST_P(Layer_Test_01D, SoftSign)
 {
 
     lp.type = "Softsign";
-    lp.name = "softsignLayer";
+    lp.name = "SoftsignLayer";
     Ptr<Layer> layer = SoftsignLayer::create(lp);
 
     float out_value = inp_value / (1 + std::abs(inp_value));
@@ -520,7 +520,7 @@ TEST_P(Layer_Test_01D, CELU)
 {
 
     lp.type = "CELU";
-    lp.name = "celuLayer";
+    lp.name = "CeluLayer";
     lp.set("alpha", 1.0);
     Ptr<Layer> layer = CeluLayer::create(lp);
 
@@ -535,7 +535,7 @@ TEST_P(Layer_Test_01D, HardSigmoid)
 {
 
     lp.type = "HardSigmoid";
-    lp.name = "hardSigmoidLayer";
+    lp.name = "HardSigmoidLayer";
     Ptr<Layer> layer = HardSigmoidLayer::create(lp);
 
     float out_value = std::max(0.0f, std::min(1.0f, 0.2f * inp_value + 0.5f));
@@ -549,7 +549,7 @@ TEST_P(Layer_Test_01D, SELU)
 {
 
     lp.type = "SELU";
-    lp.name = "seluLayer";
+    lp.name = "SeluLayer";
     lp.set("alpha", 1.6732631921768188);
     lp.set("gamma", 1.0507009873554805);
     Ptr<Layer> layer = SeluLayer::create(lp);
@@ -570,8 +570,8 @@ TEST_P(Layer_Test_01D, SELU)
 TEST_P(Layer_Test_01D, ThresholdedReLU)
 {
 
-    lp.type = "ThresholdedReLU";
-    lp.name = "thresholdedReluLayer";
+    lp.type = "ThresholdedRelu";
+    lp.name = "ThresholdedReluLayer";
     lp.set("alpha", 1.0);
     Ptr<Layer> layer = ThresholdedReluLayer::create(lp);
 
@@ -586,7 +586,7 @@ TEST_P(Layer_Test_01D, Power)
 {
 
     lp.type = "Power";
-    lp.name = "powerLayer";
+    lp.name = "PowerLayer";
     lp.set("power", 2.0);
     lp.set("scale", 1.0);
     lp.set("shift", 0.0);
@@ -603,7 +603,7 @@ TEST_P(Layer_Test_01D, Exp)
 {
 
     lp.type = "Exp";
-    lp.name = "expLayer";
+    lp.name = "ExpLayer";
     Ptr<Layer> layer = ExpLayer::create(lp);
 
     float out_value = std::exp(inp_value);
@@ -617,7 +617,7 @@ TEST_P(Layer_Test_01D, Sign)
 {
 
     lp.type = "Sign";
-    lp.name = "signLayer";
+    lp.name = "SignLayer";
     Ptr<Layer> layer = SignLayer::create(lp);
 
     float value = inp_value > 0 ? 1.0 : 0.0;
@@ -631,7 +631,7 @@ TEST_P(Layer_Test_01D, Shrink)
 {
 
     lp.type = "Shrink";
-    lp.name = "shrinkLayer";
+    lp.name = "ShrinkLayer";
     lp.set("lambda", 0.5);
     lp.set("bias", 0.5);
     Ptr<Layer> layer = ShrinkLayer::create(lp);
@@ -733,7 +733,7 @@ TEST_P(Layer_Arg_Test, Accuracy_01D) {
 
     LayerParams lp;
     lp.type = "Arg";
-    lp.name = "arg" + operation + "_Layer";
+    lp.name = "Arg" + operation + "_Layer";
     int axis = (input_shape.size() == 0 || input_shape.size() == 1 ) ? 0 : 1;
     lp.set("op", operation);
     lp.set("axis", axis);
@@ -796,7 +796,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     std::string operation = get<1>(GetParam());
 
     LayerParams lp;
-    lp.type = "Eltwise";
+    lp.type = "NaryEltwise";
     lp.name = operation + "_Layer";
     lp.set("operation", operation);
     Ptr<NaryEltwiseLayer> layer = NaryEltwiseLayer::create(lp);
@@ -1091,7 +1091,7 @@ TEST_P(Layer_Scatter_Test, Accuracy1D) {
 
     LayerParams lp;
     lp.type = "Scatter";
-    lp.name = "addLayer";
+    lp.name = "ScatterLayer";
     lp.set("axis", axis);
     lp.set("reduction", opr);
     Ptr<ScatterLayer> layer = ScatterLayer::create(lp);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -12,12 +12,40 @@
 
 namespace opencv_test { namespace {
 
-typedef testing::TestWithParam<tuple<int>> Layer_1d_Test;
-TEST_P(Layer_1d_Test, Scale)
+class Layer_Test_01D: public testing::TestWithParam<tuple<int>>
 {
-    int batch_size = get<0>(GetParam());
-
+public:
+    int dims;
+    std::vector<int> input_shape;
+    std::vector<int> output_shape;
+    float inp_value;
+    Mat input;
     LayerParams lp;
+
+    void SetUp()
+    {
+        dims = get<0>(GetParam());
+        input_shape = {dims};
+        output_shape = {dims};
+
+        // generate random positeve value from 1 to 10
+        RNG& rng = TS::ptr()->get_rng();
+        inp_value = rng.uniform(1.0, 10.0); // random uniform value
+        input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+    }
+
+    void TestLayer(Ptr<Layer> layer, std::vector<Mat> &inputs, const Mat& output_ref){
+        std::vector<Mat> outputs;
+        runLayer(layer, inputs, outputs);
+        ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+        normAssert(output_ref, outputs[0]);
+    }
+
+};
+
+TEST_P(Layer_Test_01D, Scale)
+{
+
     lp.type = "Scale";
     lp.name = "scaleLayer";
     lp.set("axis", 0);
@@ -25,30 +53,617 @@ TEST_P(Layer_1d_Test, Scale)
     lp.set("bias_term", false);
     Ptr<ScaleLayer> layer = ScaleLayer::create(lp);
 
-    std::vector<int> input_shape = {batch_size, 3};
-    std::vector<int> output_shape = {batch_size, 3};
-
-    if (batch_size == 0){
-        input_shape.erase(input_shape.begin());
-        output_shape.erase(output_shape.begin());
-    }
-
-    cv::Mat input = cv::Mat(input_shape, CV_32F, 1.0);
-    cv::randn(input, 0.0, 1.0);
-    cv::Mat weight = cv::Mat(output_shape, CV_32F, 2.0);
-
+    Mat weight = Mat(dims, output_shape.data(), CV_32F, 2.0);
     std::vector<Mat> inputs{input, weight};
-    std::vector<Mat> outputs;
+    Mat output_ref = input.mul(weight);
 
-    cv::Mat output_ref = input.mul(weight);
-    runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
-    normAssert(output_ref, outputs[0]);
+    TestLayer(layer, inputs, output_ref);
 }
 
+TEST_P(Layer_Test_01D, ReLU6)
+{
+
+    lp.type = "ReLU6";
+    lp.name = "ReLU6Layer";
+    lp.set("min_value", 0.0);
+    lp.set("max_value", 1.0);
+    Ptr<ReLU6Layer> layer = ReLU6Layer::create(lp);
+
+    Mat output_ref(dims, output_shape.data(), CV_32F, 1.0);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Clip)
+{
+
+    lp.type = "Clip";
+    lp.name = "clipLayer";
+    lp.set("min_value", 0.0);
+    lp.set("max_value", 1.0);
+    Ptr<ReLU6Layer> layer = ReLU6Layer::create(lp);
+
+    Mat output_ref(dims, output_shape.data(), CV_32F, 1.0);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, ReLU)
+{
+
+    lp.type = "ReLU";
+    lp.name = "reluLayer";
+    lp.set("negative_slope", 0.0);
+    Ptr<ReLULayer> layer = ReLULayer::create(lp);
+
+    Mat output_ref(dims, output_shape.data(), CV_32F, inp_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Gelu)
+{
+
+    lp.type = "Gelu";
+    lp.name = "geluLayer";
+    Ptr<GeluLayer> layer = GeluLayer::create(lp);
+
+    float value = inp_value * 0.5 * (std::erf(inp_value * 1 / std::sqrt(2.0)) + 1.0);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, GeluApprox)
+{
+
+    lp.type = "GeluApprox";
+    lp.name = "geluApproxLayer";
+    Ptr<GeluApproximationLayer> layer = GeluApproximationLayer::create(lp);
+
+    float value = inp_value * 0.5 * (1.0 + std::tanh(std::sqrt(2.0 / M_PI) * (inp_value + 0.044715 * std::pow(inp_value, 3))));
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Sigmoid)
+{
+
+    lp.type = "Sigmoid";
+    lp.name = "sigmoidLayer";
+    Ptr<SigmoidLayer> layer = SigmoidLayer::create(lp);
+
+    float value = 1.0 / (1.0 + std::exp(-inp_value));
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Tanh)
+{
+
+    lp.type = "TanH";
+    lp.name = "TanHLayer";
+    Ptr<Layer> layer = TanHLayer::create(lp);
+
+
+    float value = std::tanh(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Swish)
+{
+
+    lp.type = "Swish";
+    lp.name = "SwishLayer";
+    Ptr<Layer> layer = SwishLayer::create(lp);
+
+    float value = inp_value / (1 + std::exp(-inp_value));
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Mish)
+{
+
+    lp.type = "Mish";
+    lp.name = "MishLayer";
+    Ptr<Layer> layer = MishLayer::create(lp);
+
+    float value = inp_value * std::tanh(std::log(1 + std::exp(inp_value)));
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, ELU)
+{
+
+    lp.type = "ELU";
+    lp.name = "eluLayer";
+    lp.set("alpha", 1.0);
+    Ptr<Layer> layer = ELULayer::create(lp);
+
+    float value = inp_value > 0 ? inp_value : std::exp(inp_value) - 1;
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Abs)
+{
+
+    lp.type = "Abs";
+    lp.name = "absLayer";
+    Ptr<Layer> layer = AbsLayer::create(lp);
+
+    float value = std::abs(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, BNLL)
+{
+
+    lp.type = "BNLL";
+    lp.name = "bnllLayer";
+    Ptr<Layer> layer = BNLLLayer::create(lp);
+
+    float value = std::log(1 + std::exp(inp_value));
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Ceil)
+{
+
+    lp.type = "Ceil";
+    lp.name = "ceilLayer";
+    Ptr<Layer> layer = CeilLayer::create(lp);
+
+    float value = std::ceil(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Floor)
+{
+
+    lp.type = "Floor";
+    lp.name = "floorLayer";
+    Ptr<Layer> layer = FloorLayer::create(lp);
+
+    float value = std::floor(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Log)
+{
+
+    lp.type = "Log";
+    lp.name = "logLayer";
+    Ptr<Layer> layer = LogLayer::create(lp);
+
+    float value = std::log(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Round)
+{
+
+    lp.type = "Round";
+    lp.name = "roundLayer";
+    Ptr<Layer> layer = RoundLayer::create(lp);
+
+    float value = std::round(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Sqrt)
+{
+
+    lp.type = "Sqrt";
+    lp.name = "sqrtLayer";
+    Ptr<Layer> layer = SqrtLayer::create(lp);
+
+    float value = std::sqrt(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Acos)
+{
+
+    lp.type = "Acos";
+    lp.name = "acosLayer";
+    Ptr<Layer> layer = AcosLayer::create(lp);
+
+    inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
+    input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+
+    float value = std::acos(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Acosh)
+{
+
+    lp.type = "Acosh";
+    lp.name = "acoshLayer";
+    Ptr<Layer> layer = AcoshLayer::create(lp);
+
+    float value = std::acosh(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Asin)
+{
+
+    lp.type = "Asin";
+    lp.name = "asinLayer";
+    Ptr<Layer> layer = AsinLayer::create(lp);
+
+    inp_value = 0.5 + static_cast <float> (inp_value) / (static_cast <float> (RAND_MAX/(1-0.5)));
+    input = Mat(dims, input_shape.data(), CV_32F, inp_value);
+
+    float value = std::asin(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Asinh)
+{
+
+    lp.type = "Asinh";
+    lp.name = "asinhLayer";
+    Ptr<Layer> layer = AsinhLayer::create(lp);
+
+    float value = std::asinh(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Atan)
+{
+
+    lp.type = "Atan";
+    lp.name = "atanLayer";
+    Ptr<Layer> layer = AtanLayer::create(lp);
+
+    float value = std::atan(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Cos)
+{
+
+    lp.type = "Cos";
+    lp.name = "cosLayer";
+    Ptr<Layer> layer = CosLayer::create(lp);
+
+    float value = std::cos(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Cosh)
+{
+
+    lp.type = "Cosh";
+    lp.name = "coshLayer";
+    Ptr<Layer> layer = CoshLayer::create(lp);
+
+    float value = std::cosh(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Sin)
+{
+
+    lp.type = "Sin";
+    lp.name = "sinLayer";
+    Ptr<Layer> layer = SinLayer::create(lp);
+
+    float value = std::sin(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Sinh)
+{
+
+    lp.type = "Sinh";
+    lp.name = "sinhLayer";
+    Ptr<Layer> layer = SinhLayer::create(lp);
+
+    float value = std::sinh(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Tan)
+{
+
+    lp.type = "Tan";
+    lp.name = "tanLayer";
+    Ptr<Layer> layer = TanLayer::create(lp);
+
+    float value = std::tan(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Erf)
+{
+
+    lp.type = "Erf";
+    lp.name = "erfLayer";
+    Ptr<Layer> layer = ErfLayer::create(lp);
+
+    float out_value = std::erf(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Reciprocal)
+{
+
+    lp.type = "Reciprocal";
+    lp.name = "reciprocalLayer";
+    Ptr<Layer> layer = ReciprocalLayer::create(lp);
+
+    float out_value = 1/inp_value;
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, HardSwish)
+{
+
+    lp.type = "HardSwish";
+    lp.name = "hardSwishLayer";
+    Ptr<Layer> layer = HardSwishLayer::create(lp);
+
+    float out_value = inp_value * std::max(0.0f, std::min(6.0f, inp_value + 3.0f)) / 6.0f;
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Softplus)
+{
+
+    lp.type = "Softplus";
+    lp.name = "softplusLayer";
+    Ptr<Layer> layer = SoftplusLayer::create(lp);
+
+    float out_value = std::log(1 + std::exp(inp_value));
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, SoftSign)
+{
+
+    lp.type = "Softsign";
+    lp.name = "softsignLayer";
+    Ptr<Layer> layer = SoftsignLayer::create(lp);
+
+    float out_value = inp_value / (1 + std::abs(inp_value));
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, CELU)
+{
+
+    lp.type = "CELU";
+    lp.name = "celuLayer";
+    lp.set("alpha", 1.0);
+    Ptr<Layer> layer = CeluLayer::create(lp);
+
+    float out_value = inp_value < 0 ? std::exp(inp_value) - 1 : inp_value;
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, HardSigmoid)
+{
+
+    lp.type = "HardSigmoid";
+    lp.name = "hardSigmoidLayer";
+    Ptr<Layer> layer = HardSigmoidLayer::create(lp);
+
+    float out_value = std::max(0.0f, std::min(1.0f, 0.2f * inp_value + 0.5f));
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, SELU)
+{
+
+    lp.type = "SELU";
+    lp.name = "seluLayer";
+    lp.set("alpha", 1.6732631921768188);
+    lp.set("gamma", 1.0507009873554805);
+    Ptr<Layer> layer = SeluLayer::create(lp);
+
+
+    double inp_value_double = static_cast<double>(inp_value); // Ensure the input is treated as double for the computation
+
+    double value_double = 1.0507009873554805 * (inp_value_double > 0 ? inp_value_double : 1.6732631921768188 * (std::exp(inp_value_double / 1.0) - 1));
+
+    float value = static_cast<float>(value_double);
+
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, ThresholdedReLU)
+{
+
+    lp.type = "ThresholdedReLU";
+    lp.name = "thresholdedReluLayer";
+    lp.set("alpha", 1.0);
+    Ptr<Layer> layer = ThresholdedReluLayer::create(lp);
+
+    float value = inp_value > 1.0 ? inp_value : 0.0;
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Power)
+{
+
+    lp.type = "Power";
+    lp.name = "powerLayer";
+    lp.set("power", 2.0);
+    lp.set("scale", 1.0);
+    lp.set("shift", 0.0);
+    Ptr<Layer> layer = PowerLayer::create(lp);
+
+    float value = std::pow(inp_value, 2.0);
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Exp)
+{
+
+    lp.type = "Exp";
+    lp.name = "expLayer";
+    Ptr<Layer> layer = ExpLayer::create(lp);
+
+    float out_value = std::exp(inp_value);
+    Mat output_ref(dims, output_shape.data(), CV_32F, out_value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Sign)
+{
+
+    lp.type = "Sign";
+    lp.name = "signLayer";
+    Ptr<Layer> layer = SignLayer::create(lp);
+
+    float value = inp_value > 0 ? 1.0 : 0.0;
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, Shrink)
+{
+
+    lp.type = "Shrink";
+    lp.name = "shrinkLayer";
+    lp.set("lambda", 0.5);
+    lp.set("bias", 0.5);
+    Ptr<Layer> layer = ShrinkLayer::create(lp);
+
+    float value = inp_value > 0.5 ? inp_value - 0.5 : 0.0;
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+
+TEST_P(Layer_Test_01D, ChannelsPReLU)
+{
+
+    lp.type = "ChannelsPReLU";
+    lp.name = "ChannelsPReLULayer";
+    Mat alpha = Mat(1, 3, CV_32F, 0.5);
+    lp.blobs.push_back(alpha);
+    Ptr<Layer> layer = ChannelsPReLULayer::create(lp);
+
+    float value = inp_value > 0 ? inp_value : 0.5 * inp_value;
+    Mat output_ref(dims, output_shape.data(), CV_32F, value);
+    std::vector<Mat> inputs{input};
+
+    TestLayer(layer, inputs, output_ref);
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Test_01D, Values(0, 1));
+
 typedef testing::TestWithParam<tuple<std::vector<int>, int>> Layer_Gather_1d_Test;
-TEST_P(Layer_Gather_1d_Test, Accuracy) {
+TEST_P(Layer_Gather_Test, Accuracy_01D) {
 
     std::vector<int> input_shape = get<0>(GetParam());
     int axis = get<1>(GetParam());
@@ -119,8 +734,8 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     lp.name = "arg" + operation + "_Layer";
     int axis = (input_shape.size() == 0 || input_shape.size() == 1 ) ? 0 : 1;
     lp.set("op", operation);
-    lp.set("axis", axis);
-    lp.set("keepdims", 1);
+    lp.set("axis", 0);
+    lp.set("keepdims", 0);
     lp.set("select_last_index", 0);
 
     Ptr<ArgLayer> layer = ArgLayer::create(lp);
@@ -153,7 +768,6 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
-
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
@@ -189,7 +803,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     cv::randu(input1, 0.0, 1.0);
     cv::randu(input2, 0.0, 1.0);
 
-    cv::Mat output_ref;
+    Mat output_ref;
     if (operation == "sum") {
         output_ref = input1 + input2;
     } else if (operation == "mul") {
@@ -199,7 +813,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     } else if (operation == "sub") {
         output_ref = input1 - input2;
     } else {
-        output_ref = cv::Mat();
+        output_ref = Mat();
     }
     std::vector<Mat> inputs{input1, input2};
     std::vector<Mat> outputs;
@@ -240,7 +854,7 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy_01D) {
     cv::randu(input2, 0.0, 1.0);
 
     // Dynamically select the operation
-    cv::Mat output_ref;
+    Mat output_ref;
     if (operation == "sum") {
         output_ref = input1 + input2;
     } else if (operation == "max") {
@@ -252,7 +866,7 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy_01D) {
     } else if (operation == "div") {
         output_ref = input1 / input2;
     } else {
-        output_ref = cv::Mat();
+        output_ref = Mat();
     }
 
     std::vector<Mat> inputs{input1, input2};


### PR DESCRIPTION
This PR introduces 1D parametrized test for element wise layer. The means that the tests covers following layer: 

`Clip`, `ReLU6`, `ReLU`,
                        `GeLU`, `GeluApprox`, `TanH`,
                        `Swish`, `Mish`, `Sigmoid`,
                        `ELULayer`, `Abs`, `BNLL`,
                        `Ceil`, `Floor`, `LogLayer`,
                        `Round`, `Sqrt`, `Acos`,
                        `Acosh`, `Asin`, `Asinh`,
                        `Atan`, `Atanh`, `Cos`,
                        `Sin`, `Sinh`, `Tan`, `Erf`,
                        `Reciprocal`, `Cosh`, `HardSwish`,
                        `Softplus`, `Softsign`, `Celu`,
                        `HardSigmid`, `Selu`, `ThresholdedRelu`,
                        `Power`, `Exp`, `Sign`, `Shrink`,
                        `ChannelsPReLU`
                       
Not sure if this is best way to implement this test.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
