### PR TITLE
Scale layer 1d test

### DIFF
--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -618,6 +618,44 @@ TEST(Layer_LSTM_Test_Accuracy_with_, HiddenParams)
     normAssert(h_t_reference, outputs[0]);
 }
 
+typedef testing::TestWithParam<tuple<int>> Layer_Scale_1d_Test;
+TEST_P(Layer_Scale_1d_Test, Accuracy)
+{
+    int batch_size = get<0>(GetParam());
+
+    LayerParams lp;
+    lp.type = "Scale";
+    lp.name = "scaleLayer";
+    lp.set("axis", 0);
+    lp.set("mode", "scale");
+    lp.set("bias_term", false);
+    Ptr<ScaleLayer> layer = ScaleLayer::create(lp);
+
+    std::vector<int> input_shape = {batch_size, 3};
+    std::vector<int> output_shape = {batch_size, 3};
+
+    if (batch_size == 0){
+        input_shape.erase(input_shape.begin());
+        output_shape.erase(output_shape.begin());
+    }
+
+    cv::Mat input = cv::Mat(input_shape, CV_32F, 1.0);
+    cv::randn(input, 0.0, 1.0);
+    cv::Mat weight = cv::Mat(output_shape, CV_32F, 2.0);
+
+    std::vector<Mat> inputs{input, weight};
+    std::vector<Mat> outputs;
+
+    cv::Mat output_ref = input.mul(weight);
+    runLayer(layer, inputs, outputs);
+
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Scale_1d_Test,
+/*operation*/           Values(0, 1));
+
+
 typedef testing::TestWithParam<tuple<int, int>> Layer_Gather_1d_Test;
 TEST_P(Layer_Gather_1d_Test, Accuracy) {
 


### PR DESCRIPTION
This PR introduces 1D parametrized test for `scale` layer


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
