### PR TITLE
Use std::priority_queue in inpaint function for performance improvement

### DIFF
--- a/modules/photo/perf/perf_inpaint.cpp
+++ b/modules/photo/perf/perf_inpaint.cpp
@@ -6,6 +6,7 @@ namespace opencv_test
 CV_ENUM(InpaintingMethod, INPAINT_NS, INPAINT_TELEA)
 typedef tuple<Size, InpaintingMethod> InpaintArea_InpaintingMethod_t;
 typedef perf::TestBaseWithParam<InpaintArea_InpaintingMethod_t> InpaintArea_InpaintingMethod;
+typedef perf::TestBaseWithParam<InpaintingMethod> Perf_InpaintingMethod;
 
 
 PERF_TEST_P(InpaintArea_InpaintingMethod, inpaint,
@@ -32,6 +33,28 @@ PERF_TEST_P(InpaintArea_InpaintingMethod, inpaint,
 
     Mat inpaintedArea = result(inpaintArea);
     SANITY_CHECK(inpaintedArea);
+}
+
+PERF_TEST_P(Perf_InpaintingMethod, inpaintDots, InpaintingMethod::all())
+{
+    Mat src = imread(getDataPath("gpu/hog/road.png"));
+
+    int inpaintingMethod = GetParam();
+
+    Mat mask(src.size(), CV_8UC1, Scalar(0));
+    Mat result(src.size(), src.type());
+
+    for (int i = 0; i < src.size().height; i += 16) {
+        for (int j = 0; j < src.size().width; j += 16) {
+            mask.at<unsigned char>(i, j) = 255;
+        }
+    }
+
+    declare.in(src, mask).out(result).time(120);
+
+    TEST_CYCLE() inpaint(src, mask, result, 10.0, inpaintingMethod);
+
+    SANITY_CHECK_NOTHING();
 }
 
 } // namespace

--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -76,7 +76,7 @@ typedef struct CvHeapElem
 
     bool operator > (const CvHeapElem& rhs) const {
         if (T > rhs.T) {
-          return true;
+            return true;
         } else if (T < rhs.T) {
             return false;
         }
@@ -98,7 +98,7 @@ private:
     CvPriorityQueueFloat& operator=(const CvPriorityQueueFloat &); // assign disabled
 
 protected:
-  std::priority_queue<CvHeapElem, std::vector<CvHeapElem>,std::greater<CvHeapElem> > queue;
+    std::priority_queue<CvHeapElem, std::vector<CvHeapElem>,std::greater<CvHeapElem> > queue;
 
 public:
     bool Add(const CvMat* f) {

--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -73,6 +73,7 @@ typedef struct CvHeapElem
 {
     float T;
     int i,j;
+    int order;  // to keep insertion order
 
     bool operator > (const CvHeapElem& rhs) const {
         if (T > rhs.T) {
@@ -80,12 +81,7 @@ typedef struct CvHeapElem
         } else if (T < rhs.T) {
             return false;
         }
-        if (i > rhs.i) {
-            return true;
-        } else if (i < rhs.i) {
-            return false;
-        }
-        return j > rhs.j;
+        return order > rhs.order;
     }
 }
 CvHeapElem;
@@ -99,6 +95,7 @@ private:
 
 protected:
     std::priority_queue<CvHeapElem, std::vector<CvHeapElem>,std::greater<CvHeapElem> > queue;
+    int next_order;
 
 public:
     bool Add(const CvMat* f) {
@@ -114,7 +111,8 @@ public:
     }
 
     bool Push(int i, int j, float T) {
-        queue.push({T, i, j});
+        queue.push({T, i, j, next_order});
+        ++next_order;
         return true;
     }
 
@@ -139,7 +137,7 @@ public:
         return true;
     }
 
-    CvPriorityQueueFloat(void) {
+    CvPriorityQueueFloat(void) : queue(), next_order() {
     }
 };
 

--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -45,6 +45,8 @@
 //
 // */
 
+#include <queue>
+
 #include "precomp.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/photo/legacy/constants_c.h"
@@ -71,8 +73,20 @@ typedef struct CvHeapElem
 {
     float T;
     int i,j;
-    struct CvHeapElem* prev;
-    struct CvHeapElem* next;
+
+    bool operator > (const CvHeapElem& rhs) const {
+        if (T > rhs.T) {
+          return true;
+        } else if (T < rhs.T) {
+            return false;
+        }
+        if (i > rhs.i) {
+            return true;
+        } else if (i < rhs.i) {
+            return false;
+        }
+        return j > rhs.j;
+    }
 }
 CvHeapElem;
 
@@ -84,42 +98,9 @@ private:
     CvPriorityQueueFloat& operator=(const CvPriorityQueueFloat &); // assign disabled
 
 protected:
-    CvHeapElem *mem,*empty,*head,*tail;
-    int num,in;
+  std::priority_queue<CvHeapElem, std::vector<CvHeapElem>,std::greater<CvHeapElem> > queue;
 
 public:
-    bool Init( const CvMat* f )
-    {
-        int i,j;
-        for( i = num = 0; i < f->rows; i++ )
-        {
-            for( j = 0; j < f->cols; j++ )
-                num += CV_MAT_ELEM(*f,uchar,i,j)!=0;
-        }
-        if (num<=0) return false;
-        mem = (CvHeapElem*)cvAlloc((num+2)*sizeof(CvHeapElem));
-        if (mem==NULL) return false;
-
-        head       = mem;
-        head->i    = head->j = -1;
-        head->prev = NULL;
-        head->next = mem+1;
-        head->T    = -FLT_MAX;
-        empty      = mem+1;
-        for (i=1; i<=num; i++) {
-            mem[i].prev   = mem+i-1;
-            mem[i].next   = mem+i+1;
-            mem[i].i      = -1;
-            mem[i].T      = FLT_MAX;
-        }
-        tail       = mem+i;
-        tail->i    = tail->j = -1;
-        tail->prev = mem+i-1;
-        tail->next = NULL;
-        tail->T    = FLT_MAX;
-        return true;
-    }
-
     bool Add(const CvMat* f) {
         int i,j;
         for (i=0; i<f->rows; i++) {
@@ -133,71 +114,32 @@ public:
     }
 
     bool Push(int i, int j, float T) {
-        CvHeapElem *tmp=empty,*add=empty;
-        if (empty==tail) return false;
-        while (tmp->prev->T>T) tmp = tmp->prev;
-        if (tmp!=empty) {
-            add->prev->next = add->next;
-            add->next->prev = add->prev;
-            empty = add->next;
-            add->prev = tmp->prev;
-            add->next = tmp;
-            add->prev->next = add;
-            add->next->prev = add;
-        } else {
-            empty = empty->next;
-        }
-        add->i = i;
-        add->j = j;
-        add->T = T;
-        in++;
-        //      printf("push i %3d  j %3d  T %12.4e  in %4d\n",i,j,T,in);
+        queue.push({T, i, j});
         return true;
     }
 
     bool Pop(int *i, int *j) {
-        CvHeapElem *tmp=head->next;
-        if (empty==tmp) return false;
-        *i = tmp->i;
-        *j = tmp->j;
-        tmp->prev->next = tmp->next;
-        tmp->next->prev = tmp->prev;
-        tmp->prev = empty->prev;
-        tmp->next = empty;
-        tmp->prev->next = tmp;
-        tmp->next->prev = tmp;
-        empty = tmp;
-        in--;
-        //      printf("pop  i %3d  j %3d  T %12.4e  in %4d\n",tmp->i,tmp->j,tmp->T,in);
+        if (queue.empty()) {
+            return false;
+        }
+        *i = queue.top().i;
+        *j = queue.top().j;
+        queue.pop();
         return true;
     }
 
     bool Pop(int *i, int *j, float *T) {
-        CvHeapElem *tmp=head->next;
-        if (empty==tmp) return false;
-        *i = tmp->i;
-        *j = tmp->j;
-        *T = tmp->T;
-        tmp->prev->next = tmp->next;
-        tmp->next->prev = tmp->prev;
-        tmp->prev = empty->prev;
-        tmp->next = empty;
-        tmp->prev->next = tmp;
-        tmp->next->prev = tmp;
-        empty = tmp;
-        in--;
-        //      printf("pop  i %3d  j %3d  T %12.4e  in %4d\n",tmp->i,tmp->j,tmp->T,in);
+        if (queue.empty()) {
+            return false;
+        }
+        *i = queue.top().i;
+        *j = queue.top().j;
+        *T = queue.top().T;
+        queue.pop();
         return true;
     }
 
     CvPriorityQueueFloat(void) {
-        num=in=0;
-        mem=empty=head=tail=NULL;
-    }
-
-    ~CvPriorityQueueFloat(void)
-    {
-        cvFree( &mem );
     }
 };
 
@@ -786,8 +728,6 @@ icvInpaint( const CvArr* _input_img, const CvArr* _inpaint_mask, CvArr* _output_
     cvSet(t,cvScalar(1.0e6f,0,0,0));
     cv::dilate(cv::cvarrToMat(mask), cv::cvarrToMat(band), el_cross, cv::Point(1, 1));
     Heap=cv::makePtr<CvPriorityQueueFloat>();
-    if (!Heap->Init(band))
-        return;
     cvSub(band,mask,band,NULL);
     SET_BORDER1_C1(band,uchar,0);
     if (!Heap->Add(band))
@@ -803,8 +743,6 @@ icvInpaint( const CvArr* _input_img, const CvArr* _inpaint_mask, CvArr* _output_
         cv::dilate(cv::cvarrToMat(mask), cv::cvarrToMat(out), el_range);
         cvSub(out,mask,out,NULL);
         Out=cv::makePtr<CvPriorityQueueFloat>();
-        if (!Out->Init(out))
-            return;
         if (!Out->Add(band))
             return;
         cvSub(out,band,out,NULL);


### PR DESCRIPTION
In `cv::inpaint` implementation, it uses a priority queue with O(n) time linear search. For large images it is very slow.
I replaced it with C++'s standard library `std::priority_queue`, that uses O(log(n)) algorithm.
In my use case, it is x10 faster than the original.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
