### PR TITLE
Improve contours approximations in ChessBoardDetector::generateQuads

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1796,22 +1796,12 @@ void ChessBoardDetector::generateQuads(const cv::Mat& image_, int flags, int dil
         if (contour_rect.area() < min_area)
             continue;
 
-        std::vector<Point> approx_contour;
+        std::vector<Point> approx_contour = contour;
 
         const int min_approx_level = 1, max_approx_level = MAX_CONTOUR_APPROX;
-        for (int approx_level = min_approx_level; approx_level <= max_approx_level; approx_level++ )
+        for (int approx_level = min_approx_level; approx_contour.size() > 4 && approx_level <= max_approx_level; approx_level++ )
         {
-            approxPolyDP(contour, approx_contour, (float)approx_level, true);
-            if (approx_contour.size() == 4)
-                break;
-
-            // we call this again on its own output, because sometimes
-            // approxPoly() does not simplify as much as it should.
-            std::vector<Point> approx_contour_tmp;
-            std::swap(approx_contour, approx_contour_tmp);
-            approxPolyDP(approx_contour_tmp, approx_contour, (float)approx_level, true);
-            if (approx_contour.size() == 4)
-                break;
+            approxPolyDP(approx_contour, approx_contour, (float)approx_level, true);
         }
 
         // reject non-quadrangles


### PR DESCRIPTION
### Pull Request Readiness Checklist

Firstly, there were bugs/problems:
1) we always approximated contour at least once even if it was originally quadrangle
2) we broke loop only if `approx_contour.size() == 4`, which was wrong, `approx_contour.size() <= 4` - is correct

Secondly, approximation can be sped up. Before we approximated source contour twice on each loop iteration. But we can approximate source contour sequentially (on current iteration approximate output from previous iteration). The previous idea that for getting quadrangle we may need several approximations of source contour is taken into account here. And it will be much faster - because current countour size will decrease quite quickly with iterations.

I tested this PR (on `3.2.0` code version with some modern patches) on two private datasets and it sped up chessboards detection by `24%` with minor changes in detected chessboards number:
1. from `58` seconds to `44` seconds (without changes in detected chessboards number)
2. from `142` seconds to `108` seconds (from `536` detected chessboards to `532` detected chessboards)

And with benchmark
```
python3 objdetect_benchmark.py --configuration=generate_run --board_x=7 --path=res_chessboard --synthetic_object=chessboard
```
PR sped up chessboards detection by `12-16%` with minor changes in detected chessboards number (majority is in favor of PR):
```
cell_img_size = 100 (default)

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  127.96504 sec

after

                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  109.11559199999988 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 10

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.541875                       7803             14400                           4.199676
Total detected time:  3.6333469999999997 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  3.0567529999999987 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 9

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.512292                       7377             14400                           3.375697
Total detected time:  3.4287690000000013 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.516458                       7437             14400                           3.378223
Total detected time:  2.9598780000000016 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 8

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.474444                       6832             14400                           3.246657
Total detected time:  3.0795969999999997 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.474444                       6832             14400                           3.229681
Total detected time:  2.6868730000000016 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 7

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.398889                       5744             14400                           3.421867
Total detected time:  2.7457670000000003 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.400972                       5774             14400                           3.422815
Total detected time:  2.4135210000000034 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 6

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.268472                       3866             14400                           3.240348
Total detected time:  2.388680000000001 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.272708                       3927             14400                           3.236853
Total detected time:  2.0548080000000017 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 5

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.137500                       1980             14400                           3.028695
Total detected time:  1.9060430000000004 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.137500                       1980             14400                           3.030068
Total detected time:  1.6219549999999998 sec
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
