### PR TITLE
dnn: fix to iteration variable scope

### DIFF
--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -260,12 +260,14 @@ void Layer::getTypes(const std::vector<MatType>&inputs,
 {
     CV_Assert(inputs.size());
     for (auto input : inputs)
+    {
         if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
             CV_CheckTypeEQ(input, CV_32F, "");
         else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
             CV_CheckType(input, input == CV_16F || input == CV_8S, "");
         else
             CV_CheckType(input, input == CV_32F || input == CV_8S, "");
+    }
 
     outputs.assign(requiredOutputs, inputs[0]);
     internals.assign(requiredInternals, inputs[0]);

--- a/modules/dnn/src/layers/permute_layer.cpp
+++ b/modules/dnn/src/layers/permute_layer.cpp
@@ -186,12 +186,14 @@ public:
     {
         CV_Assert(inputs.size());
         for (auto input : inputs)
+        {
             if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
                 CV_CheckTypeEQ(input, CV_32F, "Unsupported type");
             else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_32S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_32S, "");
+        }
 
         outputs.assign(requiredOutputs, inputs[0]);
     }

--- a/modules/dnn/src/layers/reorg_layer.cpp
+++ b/modules/dnn/src/layers/reorg_layer.cpp
@@ -109,12 +109,14 @@ public:
     {
         CV_Assert(inputs.size());
         for (auto input : inputs)
+        {
             if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
                 CV_CheckTypeEQ(input, CV_32F, "Unsupported type for CUDA");
             else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_32S || input == CV_64S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_32S || input == CV_64S, "");
+        }
 
         outputs.assign(requiredOutputs, inputs[0]);
     }

--- a/modules/dnn/src/layers/reshape_layer.cpp
+++ b/modules/dnn/src/layers/reshape_layer.cpp
@@ -267,12 +267,14 @@ public:
     {
         CV_Assert(inputs.size());
         for (auto input : inputs)
+        {
             if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
                 CV_CheckTypeEQ(input, CV_32F, "Unsupported type");
             else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_32S || input == CV_64S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_32S || input == CV_64S, "");
+        }
 
         outputs.assign(requiredOutputs, inputs[0]);
     }

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -286,12 +286,14 @@ public:
     {
         CV_CheckEQ(inputs.size(), (size_t)1, "");
         for (auto input : inputs)
+        {
             if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget  == DNN_TARGET_CUDA)
                 CV_CheckEQ(input, CV_32F, "Unsupported type");
             else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_32S || input == CV_64S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_32S || input == CV_64S, "");
+        }
 
         outputs.assign(requiredOutputs, inputs[0]);
     }
@@ -908,12 +910,14 @@ public:
     {
         CV_CheckEQ(inputs.size(), (size_t)2, "");
         for (auto input : inputs)
+        {
             if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget  == DNN_TARGET_CUDA)
                 CV_CheckTypeEQ(input, CV_32F, "Unsupported type");
             else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_32S || input == CV_64S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_32S || input == CV_64S, "");
+        }
 
         outputs.assign(requiredOutputs, inputs[0]);
     }


### PR DESCRIPTION
In Win64, 5.x branch makes build errors.

```
for ( auto input : inputs )
  if ( cond1 )
    statementA;
  else if (cond2)
    statementB;
  else
    statementC;
```

We expects `input` is available at stetementA, statementB and statementC.
However 'input' was undeclared identifier at statementB and statementC with Win64 build .
For fixing it, this patch adds `{ }` .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
