### PR TITLE
doc: removed duplicated markdown file

### DIFF
--- a/doc/tutorials/others/_old/table_of_content_objdetect.markdown
+++ b/doc/tutorials/others/_old/table_of_content_objdetect.markdown
@@ -1,4 +1,0 @@
-Object Detection (objdetect module) {#tutorial_table_of_content_objdetect}
-===================================
-
-Content has been moved to this page: @ref tutorial_table_of_content_other

--- a/modules/gapi/doc/00-root.markdown
+++ b/modules/gapi/doc/00-root.markdown
@@ -17,7 +17,7 @@ is volatile at the moment and there may be minor but
 compatibility-breaking changes in the future.
 
 # Contents
-gapi
+
 G-API documentation is organized into the following chapters:
 
 - @subpage gapi_purposes


### PR DESCRIPTION
There are two files with same id after adding Aruco tutorials - old stub file and new one. We can remove old stub file now.

Related warning: `/opencv/doc/tutorials/others/_old/table_of_content_objdetect.markdown:1: warning: An automatically generated id already has the name 'tutorial_table_of_content_objdetect'!`

```
force_builders_only=docs-js
buildworker:Docs=linux-4
```