### PR TITLE
dnn (CANN): Fix incorrect shape of 1d bias in Gemm

### DIFF
--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -269,7 +269,12 @@ public:
         }
         // set inputs : bias
         auto mat_C = have_bias && const_C ? blobs.back() : Mat::zeros(1, 1, CV_32F);
-        auto op_const_C = std::make_shared<CannConstOp>(mat_C.data, mat_C.type(), shape(mat_C), cv::format("%s_b", name.c_str()));
+        auto &shape_C = shape(mat_C);
+        if (real_ndims_C == 1) {
+            int dim = shape_C.back();
+            shape_C.assign(1, std::vector<int>{dim});
+        }
+        auto op_const_C = std::make_shared<CannConstOp>(mat_C.data, mat_C.type(), shape_C, cv::format("%s_b", name.c_str()));
         op->set_input_bias(*(op_const_C->getOp()));
         op->update_input_desc_bias(*(op_const_C->getTensorDesc()));
 

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -269,10 +269,10 @@ public:
         }
         // set inputs : bias
         auto mat_C = have_bias && const_C ? blobs.back() : Mat::zeros(1, 1, CV_32F);
-        auto &shape_C = shape(mat_C);
+        auto shape_C = shape(mat_C);
         if (real_ndims_C == 1) {
-            int dim = shape_C.back();
-            shape_C.assign(1, std::vector<int>{dim});
+            int dim = static_cast<int>(mat_C.total());
+            shape_C = std::vector<int>{dim};
         }
         auto op_const_C = std::make_shared<CannConstOp>(mat_C.data, mat_C.type(), shape_C, cv::format("%s_b", name.c_str()));
         op->set_input_bias(*(op_const_C->getOp()));


### PR DESCRIPTION
Gemm layer was refactored some time ago. Users found that the mobilenet example in https://github.com/opencv/opencv/wiki/Huawei-CANN-Backend does not work because of incorrect shape set for 1d bias in Gemm. This PR resolves this issue.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
