### PR TITLE
Speed up adaptive threshold in findChessboardCorners

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -601,13 +601,13 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
                     {
                         adaptiveThreshold( img, thresh_img, 255, ADAPTIVE_THRESH_MEAN_C, THRESH_BINARY, block_size, (k/2)*5 );
                         dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), dilations );
-                        prev_thresh_img = thresh_img.clone();
+                        thresh_img.copyTo(prev_thresh_img);
                     }
                     else
                     {
                         if (dilations > 0)
                             dilate( prev_thresh_img, prev_thresh_img, Mat(), Point(-1, -1), 1 );
-                        thresh_img = prev_thresh_img.clone();
+                        prev_thresh_img.copyTo(thresh_img);
                     }
                     prev_block_size = block_size;
                 }

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -583,10 +583,10 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
         }
         //if flag CALIB_CB_ADAPTIVE_THRESH is not set it doesn't make sense to iterate over k
         int max_k = useAdaptive ? 6 : 1;
+        Mat prev_thresh_img;
         for (int k = 0; k < max_k && !found; k++)
         {
             int prev_block_size = -1;
-            Mat prev_thresh_img;
             for (int dilations = min_dilations; dilations <= max_dilations; dilations++)
             {
                 // convert the input grayscale image to binary (black-n-white)
@@ -603,10 +603,9 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
                         dilate( thresh_img, thresh_img, Mat(), Point(-1, -1), dilations );
                         thresh_img.copyTo(prev_thresh_img);
                     }
-                    else
+                    else if (dilations > 0)
                     {
-                        if (dilations > 0)
-                            dilate( prev_thresh_img, prev_thresh_img, Mat(), Point(-1, -1), 1 );
+                        dilate( prev_thresh_img, prev_thresh_img, Mat(), Point(-1, -1), 1 );
                         prev_thresh_img.copyTo(thresh_img);
                     }
                     prev_block_size = block_size;


### PR DESCRIPTION
### Pull Request Readiness Checklist

If `block_size` hasn't been changed between iterations for same `k`, then all `adaptiveThreshold` arguments will be same and we can reuse result from previous iteration.

I tested this PR with benchmark
```
python3 objdetect_benchmark.py --configuration=generate_run --board_x=7 --path=res_chessboard --synthetic_object=chessboard
```
PR speed up chessboards detection by `7.5/17%` without any changes in detected chessboards number:
```
cell_img_size = 100 (default)

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  107.27875600000003 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  99.0223499999999 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 10

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  2.989205999999999 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  2.4802350000000013 sec
```


See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
