### PR TITLE
doc: fix formulas in JavaDoc broken after Doxygen upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,10 @@ if(OPENCV_DISABLE_FILESYSTEM_SUPPORT)
   add_definitions(-DOPENCV_HAVE_FILESYSTEM_SUPPORT=0)
 endif()
 
+# MathJax is used for math rendering by both Doxygen HTML and JavaDoc, so
+# this var have to be defined before "modules" AND "doc" are processed
+set(OPENCV_MATHJAX_RELPATH "https://cdn.jsdelivr.net/npm/mathjax@3.0.1" CACHE STRING "URI to a MathJax installation")
+
 # ----------------------------------------------------------------------------
 #  Get actual OpenCV version number from sources
 # ----------------------------------------------------------------------------

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -195,9 +195,6 @@ if(DOXYGEN_FOUND)
   list(APPEND CMAKE_DOXYGEN_HTML_FILES "${CMAKE_CURRENT_SOURCE_DIR}/tutorial-utils.js")
   string(REPLACE ";" " \\\n" CMAKE_DOXYGEN_HTML_FILES "${CMAKE_DOXYGEN_HTML_FILES}")
 
-  set(OPENCV_MATHJAX_RELPATH "https://cdn.jsdelivr.net/npm/mathjax@3.0.1" CACHE STRING "URI to a MathJax installation")
-
-
   if (DOXYGEN_DOT_EXECUTABLE)
     message(STATUS "Found DOT executable: ${DOXYGEN_DOT_EXECUTABLE}")
     set(init_dot_path "${DOXYGEN_DOT_EXECUTABLE}")

--- a/doc/mymath.js
+++ b/doc/mymath.js
@@ -1,6 +1,8 @@
 //<![CDATA[
 window.MathJax = {
+    loader: {load: ['[tex]/ams']},
     tex: {
+        packages: {'[+]': ['ams']},
         macros: {
             matTT: [ "\\[ \\left|\\begin{array}{ccc} #1 & #2 & #3\\\\ #4 & #5 & #6\\\\ #7 & #8 & #9 \\end{array}\\right| \\]", 9],
             fork: ["\\left\\{ \\begin{array}{l l} #1 & \\mbox{#2}\\\\ #3 & \\mbox{#4}\\\\ \\end{array} \\right.", 4],
@@ -14,7 +16,8 @@ window.MathJax = {
             hdotsfor: ["\\dots", 1],
             mathbbm: ["\\mathbb{#1}", 1],
             bordermatrix: ["\\matrix{#1}", 1]
-        }
+        },
+        processEscapes: false
     }
 };
 //]]>

--- a/modules/java/jar/build.xml.in
+++ b/modules/java/jar/build.xml.in
@@ -45,18 +45,23 @@
       @CMAKE_CONFIG_OPENCV_JAVADOC_LINK@
       additionalparam="--allow-script-in-comments"
       >
-      <Header>
+      <bottom>
          <![CDATA[
             <script>
               var url = window.location.href;
               var pos = url.lastIndexOf('/javadoc/');
               url = pos >= 0 ? (url.substring(0, pos) + '/javadoc/mymath.js') : (window.location.origin + '/mymath.js');
               var script = document.createElement('script');
-              script.src = '@OPENCV_MATHJAX_RELPATH@/es5/tex-chtml.js,' + url;
-              document.getElementsByTagName('head')[0].appendChild(script);
+              script.setAttribute("src", url);
+              script.setAttribute("defer", "")
+              document.head.appendChild(script);
+              script = document.createElement('script');
+              script.setAttribute("src", '@OPENCV_MATHJAX_RELPATH@/es5/tex-chtml.js');
+              script.setAttribute("defer", "")
+              document.head.appendChild(script);
             </script>
          ]]>
-      </Header>
+      </bottom>
     </javadoc>
   </target>
 


### PR DESCRIPTION
Restored variable defining MathJax path.

https://github.com/opencv/opencv/pull/25042/files#r1515290130

```
force_builders_only=docs
```