### PR TITLE
Release convolution weightsMat after usage

### DIFF
--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -6,6 +6,7 @@
 #define __OPENCV_TEST_COMMON_HPP__
 
 #ifdef _WIN32
+#include <windows.h>
 #include <psapi.h>
 #endif  // _WIN32
 

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -5,11 +5,6 @@
 #ifndef __OPENCV_TEST_COMMON_HPP__
 #define __OPENCV_TEST_COMMON_HPP__
 
-#ifdef _WIN32
-#include <windows.h>
-#include <psapi.h>
-#endif  // _WIN32
-
 #include "opencv2/dnn/utils/inference_engine.hpp"
 
 #ifdef HAVE_OPENCL
@@ -237,29 +232,7 @@ public:
             expectNoFallbacks(net);
     }
 
-    size_t getTopMemoryUsageMB()
-    {
-#ifdef _WIN32
-        PROCESS_MEMORY_COUNTERS proc;
-        GetProcessMemoryInfo(GetCurrentProcess(), &proc, sizeof(proc));
-        return proc.PeakWorkingSetSize / pow(1024, 2);  // bytes to megabytes
-#else
-        std::ifstream status("/proc/self/status");
-        std::string line, title;
-        while (std::getline(status, line))
-        {
-            std::istringstream iss(line);
-            iss >> title;
-            if (title == "VmHWM:")
-            {
-                size_t mem;
-                iss >> mem;
-                return mem / 1024;
-            }
-        }
-#endif
-        return 0l;
-    }
+    size_t getTopMemoryUsageMB();
 
 protected:
     void checkBackend(Mat* inp = 0, Mat* ref = 0)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2303,7 +2303,7 @@ TEST_P(Test_ONNX_nets, ResNet50v1)
     size_t hwm1 = getTopMemoryUsageMB();
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_CPU)
     {
-        EXPECT_LE(hwm1 - hwm0, 350);
+        EXPECT_LE(hwm1 - hwm0, 350) << "Top allocated memory";
     }
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2298,7 +2298,13 @@ TEST_P(Test_ONNX_nets, ResNet50v1)
     applyTestTag(CV_TEST_TAG_MEMORY_512MB);
 
     // output range: [-67; 75], after Softmax [0, 0.98]
+    size_t hwm0 = getTopMemoryUsageMB();
     testONNXModels("resnet50v1", pb, default_l1, default_lInf, true, target != DNN_TARGET_MYRIAD);
+    size_t hwm1 = getTopMemoryUsageMB();
+    if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_CPU)
+    {
+        EXPECT_LE(hwm1 - hwm0, 350);
+    }
 }
 
 TEST_P(Test_ONNX_nets, ResNet50_Int8)


### PR DESCRIPTION
### Pull Request Readiness Checklist

related (but not resolved): https://github.com/opencv/opencv/issues/24134

Minor memory footprint improvement. Also, adds a test for VmHWM.

RAM top memory usage (-230MB)

| YOLOv3 (237MB file) |   4.x   |    PR   |
|---------------------|---------|---------|
| no winograd         | 808 MB  | 581 MB  |
| winograd            | 1985 MB | 1750 MB |

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
