### PR TITLE
Fix bug in maskBoundingRect

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -1056,16 +1056,12 @@ static Rect maskBoundingRect( const Mat& img )
         for( ; j < offset; j++ )
             if( _ptr[j] )
             {
+                if( j < xmin )
+                    xmin = j;
+                if( j > xmax )
+                    xmax = j;
                 have_nz = 1;
-                break;
             }
-        if( j < offset )
-        {
-            if( j < xmin )
-                xmin = j;
-            if( j > xmax )
-                xmax = j;
-        }
         if( offset < size.width )
         {
             xmin -= offset;

--- a/modules/imgproc/test/test_boundingrect.cpp
+++ b/modules/imgproc/test/test_boundingrect.cpp
@@ -140,4 +140,20 @@ void CV_BoundingRectTest::run(int)
 
 TEST (Imgproc_BoundingRect, accuracy) { CV_BoundingRectTest test; test.safe_run(); }
 
+TEST (Imgproc_BoundingRect, bug_24217)
+{
+    for (int image_width = 3; image_width < 20; image_width++)
+    {
+        for (int image_height = 1; image_height < 15; image_height++)
+        {
+            cv::Rect rect(0, image_height - 1, 3, 1);
+
+            cv::Mat image(cv::Size(image_width, image_height), CV_8UC1, cv::Scalar(0));
+            image(rect) = 255;
+
+            ASSERT_EQ(boundingRect(image), rect);
+        }
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #24217 

Issue bug is reproduced when for filled row `offset == size.width`
We fully processed this row only in one loop and didn't go to branch `offset < size.width`
Problem was in that we were breaking out of loop after first non-zero value and thus couldn't update properly `xmax` value

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
