### PR TITLE
ios build fixes

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -824,7 +824,7 @@ CvCaptureFile::CvCaptureFile(const char* filename) {
 
 // Available since iOS 15
 #if TARGET_OS_VISION || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 150000)
-    if (@available(iOS 15, visionOS 1, *)) {
+    if (@available(iOS 15, *)) {
         [mAsset loadTracksWithMediaType:AVMediaTypeVideo completionHandler:^(NSArray<AVAssetTrack *>* tracks, NSError* err) {
             if (err != nil) {
                 handleTracks(tracks, filename);
@@ -1311,7 +1311,7 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const char* filename, int
 #if TARGET_OS_VISION || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 110000)
     }else if(fourcc == CV_FOURCC('H','2','6','5') || fourcc == CV_FOURCC('h','v','c','1') ||
             fourcc == CV_FOURCC('H','E','V','C') || fourcc == CV_FOURCC('h','e','v','c')){
-        if (@available(iOS 11, visionOS 1, *)) {
+        if (@available(iOS 11, *)) {
             codec = [AVVideoCodecTypeHEVC copy];
         } else {
             codec = [AVVideoCodecTypeH264 copy];

--- a/platforms/ios/Info.Dynamic.plist.in
+++ b/platforms/ios/Info.Dynamic.plist.in
@@ -23,7 +23,7 @@
         <string>iPhoneOS</string>
     </array>
     <key>MinimumOSVersion</key>
-    <string>8.0</string>
+    <string>${IPHONEOS_DEPLOYMENT_TARGET}</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>1</integer>


### PR DESCRIPTION
A couple of small fixes:
1. remove visionos 1 from @available list as it is behind #if TARGET_OS_VISION check and 1 is the base version.
2. use IPHONEOS_DEPLOYMENT_TARGET env var to generate info.plist for dynamic library with correct properties.

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
