### PR TITLE
add component disable flag to android build

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -161,6 +161,7 @@ class Builder:
         self.opencl = True if config.opencl else False
         self.no_kotlin = True if config.no_kotlin else False
         self.shared = True if config.shared else False
+        self.disable = args.disable
 
     def get_cmake(self):
         if not self.config.use_android_buildtools and check_executable(['cmake', '--version']):
@@ -263,6 +264,9 @@ class Builder:
 
         if no_media_ndk:
             cmake_vars['WITH_ANDROID_MEDIANDK'] = "OFF"
+
+        if len(self.disable) > 0:
+            cmd.extend(["-DWITH_%s=OFF" % f for f in self.disable])
 
         cmake_vars.update(abi.cmake_vars)
         cmd += [ "-D%s='%s'" % (k, v) for (k, v) in cmake_vars.items() if v is not None]
@@ -375,6 +379,7 @@ if __name__ == "__main__":
     parser.add_argument('--no_kotlin', action="store_true", help="Disable Kotlin extensions")
     parser.add_argument('--shared', action="store_true", help="Build shared libraries")
     parser.add_argument('--no_media_ndk', action="store_true", help="Do not link Media NDK (required for video I/O support)")
+    parser.add_argument('--disable', metavar='FEATURE', default=[], action='append', help='OpenCV features to disable (add WITH_*=OFF). To disable multiple, specify this flag again, e.g. "--disable tbb --disable openmp"')
     args = parser.parse_args()
 
     log.basicConfig(format='%(message)s', level=log.DEBUG)

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -265,10 +265,11 @@ class Builder:
         if no_media_ndk:
             cmake_vars['WITH_ANDROID_MEDIANDK'] = "OFF"
 
-        if len(self.disable) > 0:
-            cmd.extend(["-DWITH_%s=OFF" % f for f in self.disable])
-
         cmake_vars.update(abi.cmake_vars)
+
+        if len(self.disable) > 0:
+            cmake_vars.update({'WITH_%s' % f : "OFF" for f in self.disable})
+
         cmd += [ "-D%s='%s'" % (k, v) for (k, v) in cmake_vars.items() if v is not None]
         cmd.append(self.opencvdir)
         execute(cmd)
@@ -379,7 +380,7 @@ if __name__ == "__main__":
     parser.add_argument('--no_kotlin', action="store_true", help="Disable Kotlin extensions")
     parser.add_argument('--shared', action="store_true", help="Build shared libraries")
     parser.add_argument('--no_media_ndk', action="store_true", help="Do not link Media NDK (required for video I/O support)")
-    parser.add_argument('--disable', metavar='FEATURE', default=[], action='append', help='OpenCV features to disable (add WITH_*=OFF). To disable multiple, specify this flag again, e.g. "--disable tbb --disable openmp"')
+    parser.add_argument('--disable', metavar='FEATURE', default=[], action='append', help='OpenCV features to disable (add WITH_*=OFF). To disable multiple, specify this flag again, e.g. "--disable TBB --disable OPENMP"')
     args = parser.parse_args()
 
     log.basicConfig(format='%(message)s', level=log.DEBUG)


### PR DESCRIPTION
Adding --disable flag to android sdk build script. The flag allows to exclude components from build by concatting -DWITH_XXX cmake flag to the build command. Example : --disable OPENEXR (uppercase).

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
