### PR TITLE
Use initial quads corners in ChessBoardDetector::findQuadNeighbors

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1631,10 +1631,11 @@ void ChessBoardDetector::findQuadNeighbors()
                 continue;
 
             float min_dist = FLT_MAX;
+            int closest_neighbor_idx = -1;
             int closest_corner_idx = -1;
             ChessBoardQuad *closest_quad = 0;
 
-            cv::Point2f pt = cur_quad.corners[i]->pt;
+            cv::Point2f pt = all_quads_pts[(idx << 2) + i];
 
             // find the closest corner in all other quadrangles
             std::vector<float> query = Mat(pt);
@@ -1654,7 +1655,7 @@ void ChessBoardDetector::findQuadNeighbors()
                 if (q_k.neighbors[j])
                     continue;
 
-                const float dist = normL2Sqr<float>(pt - q_k.corners[j]->pt);
+                const float dist = normL2Sqr<float>(pt - all_quads_pts[neighbor_idx]);
                 if (dist < min_dist &&
                     dist <= cur_quad.edge_len * thresh_scale &&
                     dist <= q_k.edge_len * thresh_scale)
@@ -1669,6 +1670,7 @@ void ChessBoardDetector::findQuadNeighbors()
                         DPRINTF("Incompatible edge lengths");
                         continue;
                     }
+                    closest_neighbor_idx = neighbor_idx;
                     closest_corner_idx = j;
                     closest_quad = &q_k;
                     min_dist = dist;
@@ -1676,7 +1678,7 @@ void ChessBoardDetector::findQuadNeighbors()
             }
 
             // we found a matching corner point?
-            if (closest_corner_idx >= 0 && min_dist < FLT_MAX)
+            if (closest_neighbor_idx >= 0 && closest_corner_idx >= 0 && min_dist < FLT_MAX)
             {
                 CV_Assert(closest_quad);
 
@@ -1688,6 +1690,7 @@ void ChessBoardDetector::findQuadNeighbors()
                 // This is necessary to support small squares where otherwise the wrong
                 // corner will get matched to closest_quad;
                 ChessBoardCorner& closest_corner = *closest_quad->corners[closest_corner_idx];
+                cv::Point2f closest_corner_pt = all_quads_pts[closest_neighbor_idx];
 
                 int j = 0;
                 for (; j < 4; j++)
@@ -1695,7 +1698,7 @@ void ChessBoardDetector::findQuadNeighbors()
                     if (cur_quad.neighbors[j] == closest_quad)
                         break;
 
-                    if (normL2Sqr<float>(closest_corner.pt - cur_quad.corners[j]->pt) < min_dist)
+                    if (normL2Sqr<float>(closest_corner_pt - all_quads_pts[(idx << 2) + j]) < min_dist)
                         break;
                 }
                 if (j < 4)
@@ -1710,9 +1713,8 @@ void ChessBoardDetector::findQuadNeighbors()
                 if (j < 4)
                     continue;
 
-                // check whether the closest corner to closest_corner
-                // is different from cur_quad->corners[i]->pt
-                query = Mat(closest_corner.pt);
+                // check whether the closest corner to closest_corner is different from pt
+                query = Mat(closest_corner_pt);
                 radius = min_dist + 1;
                 neighbors_count = all_quads_pts_index.radiusSearch(query, neighbors_indices, neighbors_dists, radius, search_params);
 
@@ -1730,14 +1732,14 @@ void ChessBoardDetector::findQuadNeighbors()
                     CV_DbgAssert(q);
                     if (!q->neighbors[k])
                     {
-                        if (normL2Sqr<float>(closest_corner.pt - q->corners[k]->pt) < min_dist)
+                        if (normL2Sqr<float>(closest_corner_pt - all_quads_pts[neighbor_idx]) < min_dist)
                             break;
                     }
                 }
                 if (neighbor_idx_idx < neighbors_count)
                     continue;
 
-                closest_corner.pt = (pt + closest_corner.pt) * 0.5f;
+                closest_corner.pt = (pt + closest_corner_pt) * 0.5f;
 
                 // We've found one more corner - remember it
                 cur_quad.count++;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Idea is to make quad neighbors finding more simple (for understanding and debugging) and deterministic
And for that use initial quads corners, now they can be updated in
https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/calibinit.cpp#L1740
and then affect following finding, e.g. in
https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/calibinit.cpp#L1698

Before #24605 we also could use updated corners in nearest neighbors, but now we use k-d tree for it with copy of initial corners and what we use updated corners in following part of algorithm can be considered as something like logic divergence

I tested this PR with benchmark
```
python3 objdetect_benchmark.py --configuration=generate_run --board_x=7 --path=res_chessboard --synthetic_object=chessboard
```

There are no any changes in detected chessboards number:
```
cell_img_size = 100 (default)

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  109.607109 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  108.14007100000008 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 10

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  3.1171079999999995 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  2.982243999999999 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 9

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.516458                       7437             14400                           3.378223
Total detected time:  2.8566790000000015 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.516458                       7437             14400                           3.378223
Total detected time:  3.1788580000000017 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 8

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.474444                       6832             14400                           3.229681
Total detected time:  2.648073000000003 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.474444                       6832             14400                           3.229681
Total detected time:  2.5567910000000005 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 7

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.400972                       5774             14400                           3.422815
Total detected time:  2.461659 sec

after
                                      all             0.400972                       5774             14400                           3.422815
Total detected time:  2.3133559999999997 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 6

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.272708                       3927             14400                           3.236853
Total detected time:  1.9906030000000003 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.272708                       3927             14400                           3.236853
Total detected time:  2.080433999999999 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 5

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.137500                       1980             14400                           3.030068
Total detected time:  1.8522970000000019 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.137500                       1980             14400                           3.030068
Total detected time:  1.7436250000000018 sec
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
