### PR TITLE
Permute Layer Test 0D

### DIFF
--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -480,4 +480,37 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Scatter_Test, Combine(
 
 
 
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Permute_Test;
+TEST_P(Layer_Permute_Test, Accuracy_01D)
+{
+    LayerParams lp;
+    lp.type = "Permute";
+    lp.name = "PermuteLayer";
+
+    int order[] = {0}; // Since it's a 0D tensor, the order remains [0]
+    lp.set("order", DictValue::arrayInt(order, 1));
+    Ptr<PermuteLayer> layer = PermuteLayer::create(lp);
+
+    std::vector<int> input_shape = get<0>(GetParam());
+
+    Mat input = Mat(input_shape.size(), input_shape.data(), CV_32F);
+    cv::randn(input, 0.0, 1.0);
+    Mat output_ref = input.clone();
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Permute_Test,
+/*input blob shape*/ testing::Values(
+            std::vector<int>{},
+            std::vector<int>{1},
+            std::vector<int>{1, 4},
+            std::vector<int>{4, 1}
+));
+
 }}


### PR DESCRIPTION
This PR introduces parametrized `0/1D` input support test for `Permute` layer.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
