### PR TITLE
0D test for split layer

### DIFF
--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -271,28 +271,25 @@ TEST(Layer_Reshape_Test, Accuracy)
     normAssert(output_ref, outputs[0]);
 }
 
-// WORKING FOR 1D
-typedef testing::TestWithParam<tuple<int>> Layer_Split_Test;
-TEST_P(Layer_Split_Test, Accuracy)
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Split_Test;
+TEST_P(Layer_Split_Test, Accuracy_01D)
 {
     LayerParams lp;
     lp.type = "Split";
     lp.name = "SplitLayer";
     int top_count = 2; // 2 is for simplicity
     lp.set("top_count", top_count);
-    int dims = get<0>(GetParam());
-
     Ptr<SplitLayer> layer = SplitLayer::create(lp);
-    std::vector<int> input_shape = {dims};
-    std::vector<int> output_shape = {dims};
 
-    Mat input(dims, input_shape.data(), CV_32F);
+    std::vector<int> input_shape = std::get<0>(GetParam());
+
+    Mat input(input_shape.size(), input_shape.data(), CV_32F);
     cv::randn(input, 0.0, 1.0);
-    cv::Mat output_ref = cv::Mat(dims, output_shape.data(), CV_32F, input.data);
+
+    Mat output_ref = Mat(input_shape.size(), input_shape.data(), CV_32F, input.data);
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
-
     runLayer(layer, inputs, outputs);
     for (int i = 0; i < top_count; i++)
     {
@@ -300,7 +297,14 @@ TEST_P(Layer_Split_Test, Accuracy)
         normAssert(output_ref, outputs[i]);
     }
 }
-INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Split_Test,
-/*input blob shape*/    Values(0, 1));
+INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_Split_Test,
+                        testing::Values(
+                            std::vector<int>({}),
+                            std::vector<int>({1}),
+                            std::vector<int>({1, 4}),
+                            std::vector<int>({1, 5}),
+                            std::vector<int>({4, 1}),
+                            std::vector<int>({4, 5})
+));
 
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -271,4 +271,36 @@ TEST(Layer_Reshape_Test, Accuracy)
     normAssert(output_ref, outputs[0]);
 }
 
+// WORKING FOR 1D
+typedef testing::TestWithParam<tuple<int>> Layer_Split_Test;
+TEST_P(Layer_Split_Test, Accuracy)
+{
+    LayerParams lp;
+    lp.type = "Split";
+    lp.name = "SplitLayer";
+    int top_count = 2; // 2 is for simplicity
+    lp.set("top_count", top_count);
+    int dims = get<0>(GetParam());
+
+    Ptr<SplitLayer> layer = SplitLayer::create(lp);
+    std::vector<int> input_shape = {dims};
+    std::vector<int> output_shape = {dims};
+
+    Mat input(dims, input_shape.data(), CV_32F);
+    cv::randn(input, 0.0, 1.0);
+    cv::Mat output_ref = cv::Mat(dims, output_shape.data(), CV_32F, input.data);
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    for (int i = 0; i < top_count; i++)
+    {
+        ASSERT_EQ(shape(output_ref), shape(outputs[i]));
+        normAssert(output_ref, outputs[i]);
+    }
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Split_Test,
+/*input blob shape*/    Values(0, 1));
+
 }}


### PR DESCRIPTION
This PR introduces parametrized `0/1D` input support test for `Split` layer.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
