### PR TITLE
0D test for Reshape layer 

### DIFF
--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -245,4 +245,32 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Elemwise_1d_Test, Combine(
 /*operation*/           Values("div", "prod", "max", "min", "sum")
 ));
 
+// WORKING FOR 1D
+TEST(Layer_Reshape_Test, Accuracy)
+{
+    LayerParams lp;
+    lp.type = "Reshape";
+    lp.name = "ReshapeLayer";
+    lp.set("axis", 0); // Set axis to 0 to start reshaping from the first dimension
+    lp.set("num_axes", -1); // Set num_axes to -1 to indicate all following axes are included in the reshape
+    int newShape[] = {1};
+    lp.set("dim", DictValue::arrayInt(newShape, 1));
+
+    Ptr<ReshapeLayer> layer = ReshapeLayer::create(lp);
+
+    std::vector<int> input_shape = {0};
+    std::vector<int> output_shape = {1};
+
+    Mat input(0, input_shape.data(), CV_32F);
+    randn(input, 0.0, 1.0);
+    Mat output_ref(1, output_shape.data(), CV_32F, input.data);
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -245,7 +245,6 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Elemwise_1d_Test, Combine(
 /*operation*/           Values("div", "prod", "max", "min", "sum")
 ));
 
-// WORKING FOR 1D
 TEST(Layer_Reshape_Test, Accuracy)
 {
     LayerParams lp;
@@ -259,11 +258,10 @@ TEST(Layer_Reshape_Test, Accuracy)
     Ptr<ReshapeLayer> layer = ReshapeLayer::create(lp);
 
     std::vector<int> input_shape = {0};
-    std::vector<int> output_shape = {1};
 
     Mat input(0, input_shape.data(), CV_32F);
     randn(input, 0.0, 1.0);
-    Mat output_ref(1, output_shape.data(), CV_32F, input.data);
+    Mat output_ref(1, newShape, CV_32F, input.data);
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;


### PR DESCRIPTION
This PR introduces parametrized `0/1D` input support test for `Reshape` layer.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
