### PR TITLE
Fully connected 0D test. 

### DIFF
--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -167,10 +167,11 @@ public:
             cAxis = normalize_axis(axis, inputsTmp[0]);
         }
 
-        MatShape outShape(cAxis + 1);
+        MatShape outShape((!inputs[0].empty()) ? cAxis + 1 : cAxis);
         for (int i = 0; i < cAxis; ++i)
             outShape[i] = inputsTmp[0][i];
-        outShape.back() = numOutput;
+        if (!inputs[0].empty())
+            outShape.back() = numOutput;
 
         outputs.resize(1, outShape);
         return false;

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -577,7 +577,10 @@ TEST_P(Layer_FullyConnected_Test, Accuracy)
     lp.set("bias_term", false);
     lp.set("axis", 0);
 
-    Mat weights(1, 1, CV_32F, 1.0);
+    RNG& rng = TS::ptr()->get_rng();
+    float inp_value = rng.uniform(0.0, 10.0); // random uniform value
+
+    Mat weights(1, 1, CV_32F, inp_value);
     lp.blobs.push_back(weights);
 
     Ptr<Layer> layer = LayerFactory::createLayerInstance("InnerProduct", lp);
@@ -585,7 +588,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy)
     std::vector<int> input_shape = get<0>(GetParam());
 
     Mat input(input_shape.size(), input_shape.data(), CV_32F, 3.0);
-    Mat output_ref(input_shape.size(), input_shape.data(), CV_32F, 3.0);
+    Mat output_ref(input_shape.size(), input_shape.data(), CV_32F, inp_value * 3.0);
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -567,4 +567,35 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Slice_Test,
                 std::vector<int>({1, 4})
 ));
 
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_FullyConnected_Test;
+TEST_P(Layer_FullyConnected_Test, Accuracy)
+{
+    LayerParams lp;
+    lp.type = "InnerProduct";
+    lp.name = "InnerProductLayer";
+    lp.set("num_output", 1);
+    lp.set("bias_term", false);
+    lp.set("axis", 0);
+
+    Mat weights(1, 1, CV_32F, 1.0);
+    lp.blobs.push_back(weights);
+
+    Ptr<Layer> layer = LayerFactory::createLayerInstance("InnerProduct", lp);
+
+    std::vector<int> input_shape = get<0>(GetParam());
+
+    Mat input(input_shape.size(), input_shape.data(), CV_32F, 3.0);
+    Mat output_ref(input_shape.size(), input_shape.data(), CV_32F, 3.0);
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+    runLayer(layer, inputs, outputs);
+    normAssert(output_ref, outputs[0]);
+}
+INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
+                        testing::Values(
+                            std::vector<int>({}),
+                            std::vector<int>({1}),
+));
+
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -568,7 +568,7 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Slice_Test,
 ));
 
 typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_FullyConnected_Test;
-TEST_P(Layer_FullyConnected_Test, Accuracy)
+TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
 {
     LayerParams lp;
     lp.type = "InnerProduct";

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -577,18 +577,19 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     lp.set("bias_term", false);
     lp.set("axis", 0);
 
-    RNG& rng = TS::ptr()->get_rng();
-    float inp_value = rng.uniform(0.0, 10.0); // random uniform value
+    std::vector<int> input_shape = get<0>(GetParam());
 
-    Mat weights(1, 1, CV_32F, inp_value);
+    RNG& rng = TS::ptr()->get_rng();
+    float inp_value = rng.uniform(0.0, 10.0);
+    Mat weights(std::vector<int>{total(input_shape), 1}, CV_32F, inp_value);
     lp.blobs.push_back(weights);
 
     Ptr<Layer> layer = LayerFactory::createLayerInstance("InnerProduct", lp);
 
-    std::vector<int> input_shape = get<0>(GetParam());
-
-    Mat input(input_shape.size(), input_shape.data(), CV_32F, 3.0);
-    Mat output_ref(input_shape.size(), input_shape.data(), CV_32F, inp_value * 3.0);
+    Mat input(input_shape.size(), input_shape.data(), CV_32F);
+    randn(input, 0, 1);
+    Mat output_ref = input.reshape(1, 1) * weights;
+    output_ref.dims = 1;
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
@@ -598,7 +599,8 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
                         testing::Values(
                             std::vector<int>({}),
-                            std::vector<int>({1})
+                            std::vector<int>({1}),
+                            std::vector<int>({4})
 ));
 
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -595,7 +595,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy)
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
                         testing::Values(
                             std::vector<int>({}),
-                            std::vector<int>({1}),
+                            std::vector<int>({1})
 ));
 
 }}


### PR DESCRIPTION
This PR introduces parametrized `0/1D` input support test for `Fullyconnected` layer.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
