### PR TITLE
Added int64 values support to scatter, scatterND and maxunpool layers

### DIFF
--- a/modules/dnn/src/layers/max_unpooling_layer.cpp
+++ b/modules/dnn/src/layers/max_unpooling_layer.cpp
@@ -94,14 +94,34 @@ public:
         Mat& input = inputs[0];
         Mat& indices = inputs[1];
 
-        if (input.type() == CV_32F && indices.type() == CV_32S)
-            run<float, int32_t>(input, indices, outputs);
-        else if (input.type() == CV_32F && indices.type() == CV_64S)
-            run<float, int64_t>(input, indices, outputs);
-        else if (input.type() == CV_16F && indices.type() == CV_32S)
-            run<int16_t, int32_t>(input, indices, outputs);
-        else if (input.type() == CV_16F && indices.type() == CV_64S)
-            run<int16_t, int64_t>(input, indices, outputs);
+        if (indices.depth() == CV_32S)
+            typeDispatch<int32_t>(input.type(), input, indices, outputs);
+        else if (indices.depth() == CV_64S)
+            typeDispatch<int64_t>(input.type(), input, indices, outputs);
+        else
+            CV_Error(cv::Error::BadDepth, "Unsupported type.");
+    }
+
+    template<typename T_INDEX, typename... Args>
+    inline void typeDispatch(const int type, Args&&... args)
+    {
+        switch (type)
+        {
+            case CV_32S:
+                run<int32_t, T_INDEX>(std::forward<Args>(args)...);
+                break;
+            case CV_64S:
+                run<int64_t, T_INDEX>(std::forward<Args>(args)...);
+                break;
+            case CV_32F:
+                run<float, T_INDEX>(std::forward<Args>(args)...);
+                break;
+            case CV_16F:
+                run<int16_t, T_INDEX>(std::forward<Args>(args)...);
+                break;
+            default:
+                CV_Error(cv::Error::BadDepth, "Unsupported type.");
+        };
     }
 
     template<typename T, typename INDEX_TYPE>

--- a/modules/dnn/src/layers/scatterND_layer.cpp
+++ b/modules/dnn/src/layers/scatterND_layer.cpp
@@ -190,6 +190,9 @@ public:
             case CV_32S:
                 reductionDispatch<int32_t, T_INDEX>(std::forward<Args>(args)...);
                 break;
+            case CV_64S:
+                reductionDispatch<int64_t, T_INDEX>(std::forward<Args>(args)...);
+                break;
             case CV_32F:
                 reductionDispatch<float, T_INDEX>(std::forward<Args>(args)...);
                 break;

--- a/modules/dnn/src/layers/scatter_layer.cpp
+++ b/modules/dnn/src/layers/scatter_layer.cpp
@@ -185,6 +185,9 @@ public:
             case CV_32S:
                 reductionDispatch<int32_t, T_INDEX>(std::forward<Args>(args)...);
                 break;
+            case CV_64S:
+                reductionDispatch<int64_t, T_INDEX>(std::forward<Args>(args)...);
+                break;
             case CV_32F:
                 reductionDispatch<float, T_INDEX>(std::forward<Args>(args)...);
                 break;


### PR DESCRIPTION
Added int64 values support to scatter, scatterND and maxunpool layers

The existing tests cover cases only with int indices and float values.
ONNX tests with int indices and int values will be added later in a separate PR.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
