### PR TITLE
Concat Layer 0/1D test

### DIFF
--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -108,7 +108,10 @@ public:
                 }
             }
 
-            axisSum += curShape[cAxis];
+            axisSum += (!curShape.empty()) ? curShape[cAxis] : 1;
+        }
+        if (inputs[0].empty()){
+            outputs[0] = MatShape(1);
         }
         outputs[0][cAxis] = axisSum;
         return false;

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -378,7 +378,7 @@ TEST_P(Layer_Concat_Test, Accuracy_01D)
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Concat_Test,
 /*input blob shape*/    testing::Values(
-    make_tuple(std::vector<int>({})),
-    make_tuple(std::vector<int>({1}))
+    std::vector<int>({}),
+    std::vector<int>({1})
 ));
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -349,4 +349,36 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Expand_Test, Combine(
     )
 ));
 
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Concat_Test;
+TEST_P(Layer_Concat_Test, Accuracy_01D)
+{
+    LayerParams lp;
+    lp.type = "Concat";
+    lp.name = "ConcatLayer";
+    lp.set("axis", 0);
+
+    Ptr<ConcatLayer> layer = ConcatLayer::create(lp);
+
+    std::vector<int> input_shape = get<0>(GetParam());
+    std::vector<int> output_shape = {3};
+
+    Mat input1(input_shape.size(), input_shape.data(), CV_32F, 1.0);
+    Mat input2(input_shape.size(), input_shape.data(), CV_32F, 2.0);
+    Mat input3(input_shape.size(), input_shape.data(), CV_32F, 3.0);
+
+    float data[] = {1.0, 2.0, 3.0};
+    Mat output_ref(output_shape, CV_32F, data);
+
+    std::vector<Mat> inputs{input1, input2, input3};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Concat_Test,
+/*input blob shape*/    testing::Values(
+    make_tuple(std::vector<int>({})),
+    make_tuple(std::vector<int>({1}))
+));
 }}


### PR DESCRIPTION
This PR introduces parametrized `0/1D` input support test for `Concat` layer.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
