### PR TITLE
Constant layer 0/1D test.

### DIFF
--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -603,4 +603,34 @@ INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
                             std::vector<int>({4})
 ));
 
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Const_Test;
+TEST_P(Layer_Const_Test, Accuracy_01D)
+{
+    std::vector<int> input_shape = get<0>(GetParam());
+
+    LayerParams lp;
+    lp.type = "Const";
+    lp.name = "ConstLayer";
+
+    Mat constBlob = Mat(input_shape.size(), input_shape.data(), CV_32F);
+    cv::randn(constBlob, 0.0, 1.0);
+    Mat output_ref = constBlob.clone();
+
+    lp.blobs.push_back(constBlob);
+    Ptr<Layer> layer = ConstLayer::create(lp);
+
+    std::vector<Mat> inputs; // No inputs are needed for a ConstLayer
+    std::vector<Mat> outputs;
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Const_Test, testing::Values(
+    std::vector<int>({}),
+    std::vector<int>({1}),
+    std::vector<int>({1, 4}),
+    std::vector<int>({4, 1})
+    ));
+
 }}


### PR DESCRIPTION
This PR introduces `0/1D` test for `Constant` layer

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
