### PR TITLE
doc: auto-enabling DOT support (5.x)

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -17,8 +17,8 @@ endif()
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
   if (DOXYGEN_VERSION VERSION_LESS 1.9.8)
-    message(WARNING "Found doxygen ${DOXYGEN_VERSION}, version 1.9.8 is used for testing, there is
-                     a chance your documentation will look different or have some limitations.")
+    message(WARNING "Found doxygen ${DOXYGEN_VERSION}, version 1.9.8 is used for testing, there is "
+                    "a chance your documentation will look different or have some limitations.")
   endif()
   add_custom_target(doxygen)
 
@@ -202,10 +202,18 @@ if(DOXYGEN_FOUND)
 
   set(OPENCV_MATHJAX_RELPATH "https://cdn.jsdelivr.net/npm/mathjax@3.0.1" CACHE STRING "URI to a MathJax installation")
 
-  set(OPENCV_DOCS_DOT_PATH "" CACHE PATH "Doxygen/DOT_PATH value")
-  set(CMAKECONFIG_DOT_PATH "${OPENCV_DOCS_DOT_PATH}")
 
-  set(OPENCV_DOCS_HAVE_DOT "NO" CACHE BOOL "Doxygen: build extra diagrams")
+  if (DOXYGEN_DOT_EXECUTABLE)
+    message(STATUS "Found DOT executable: ${DOXYGEN_DOT_EXECUTABLE}")
+    set(init_dot_path "${DOXYGEN_DOT_EXECUTABLE}")
+    set(init_dot_mode "YES")
+  else()
+    set(init_dot_path "")
+    set(init_dot_mode "NO")
+  endif()
+  set(OPENCV_DOCS_DOT_PATH "${init_dot_path}" CACHE PATH "Doxygen/DOT_PATH value")
+  set(OPENCV_DOCS_HAVE_DOT "${init_dot_mode}" CACHE BOOL "Doxygen: build extra diagrams")
+  set(CMAKECONFIG_DOT_PATH "${OPENCV_DOCS_DOT_PATH}")
   set(CMAKECONFIG_HAVE_DOT "${OPENCV_DOCS_HAVE_DOT}")
 
   # 'png' is good enough for compatibility (but requires +50% storage space)


### PR DESCRIPTION
Port of #25171

Fixes documentation issue on BuildBot CI:
```
warning: ignoring \dot command because HAVE_DOT is not set
...
```