### PR TITLE
Added int support to padding layer

### DIFF
--- a/modules/dnn/src/cuda/padding.cu
+++ b/modules/dnn/src/cuda/padding.cu
@@ -197,5 +197,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void copy_with_reflection101(const Stream&, TensorSpan<__half>, TensorView<__half>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
 #endif
     template void copy_with_reflection101(const Stream&, TensorSpan<float>, TensorView<float>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
+    template void copy_with_reflection101(const Stream&, TensorSpan<int32_t>, TensorView<int32_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
+    template void copy_with_reflection101(const Stream&, TensorSpan<int64_t>, TensorView<int64_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
 
 }}}} /* namespace namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda4dnn/primitives/padding.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/padding.hpp
@@ -34,7 +34,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
         /* `ranges` is indexed by axis and contains the range in the output where the input is copied to */
-        PaddingOp(csl::Stream stream_, PaddingType type_, T value_, std::vector<cv::Range> ranges)
+        PaddingOp(csl::Stream stream_, PaddingType type_, T value_, const std::vector<cv::Range>& ranges)
             : stream(std::move(stream_)),  type{ type_ }, value{ value_ }, dstRanges(std::move(ranges))
         {
         }

--- a/modules/dnn/src/cuda4dnn/primitives/padding.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/padding.hpp
@@ -34,7 +34,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
         /* `ranges` is indexed by axis and contains the range in the output where the input is copied to */
-        PaddingOp(csl::Stream stream_, PaddingType type_, T value_, std::vector<cv::Range> ranges)
+        PaddingOp(csl::Stream stream_, PaddingType type_, Mat value_, std::vector<cv::Range> ranges)
             : stream(std::move(stream_)),  type{ type_ }, value{ value_ }, dstRanges(std::move(ranges))
         {
         }
@@ -77,7 +77,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             if (type == PaddingType::CONSTANT)
             {
-                kernels::fill<T>(stream, output, value);
+                kernels::fill<T>(stream, output, value.at<T>(0));
 
                 std::vector<std::size_t> offsets(effective_rank, 0);
                 for (int i = 0; i < dstRanges.size(); i++)
@@ -108,7 +108,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
     private:
         csl::Stream stream;
         PaddingType type;
-        T value;
+        Mat value;
 
         std::vector<cv::Range> dstRanges;
     };

--- a/modules/dnn/src/cuda4dnn/primitives/padding.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/padding.hpp
@@ -34,7 +34,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
         /* `ranges` is indexed by axis and contains the range in the output where the input is copied to */
-        PaddingOp(csl::Stream stream_, PaddingType type_, Mat value_, std::vector<cv::Range> ranges)
+        PaddingOp(csl::Stream stream_, PaddingType type_, T value_, std::vector<cv::Range> ranges)
             : stream(std::move(stream_)),  type{ type_ }, value{ value_ }, dstRanges(std::move(ranges))
         {
         }
@@ -77,7 +77,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             if (type == PaddingType::CONSTANT)
             {
-                kernels::fill<T>(stream, output, value.at<T>(0));
+                kernels::fill<T>(stream, output, value);
 
                 std::vector<std::size_t> offsets(effective_rank, 0);
                 for (int i = 0; i < dstRanges.size(); i++)
@@ -108,7 +108,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
     private:
         csl::Stream stream;
         PaddingType type;
-        Mat value;
+        T value;
 
         std::vector<cv::Range> dstRanges;
     };

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -34,11 +34,11 @@ public:
     PaddingLayerImpl(const LayerParams &params)
     {
         setParamsFrom(params);
-        if (params.blobs.size() == 1)
-            // ONNX parser supports any type
+        if (params.get<bool>("valueAsBlob", false))
+            // ONNX parser supports any type and stores "value" as blob
             paddingValue = params.blobs[0];
         else
-            // Other parsers support only float
+            // Other parsers support only float type
             paddingValue = Mat(1, 1, CV_32F, params.get<float>("value", 0));
         inputDims = params.get<int>("input_dims", -1);
         paddingType = params.get<String>("type", "constant");

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -34,7 +34,12 @@ public:
     PaddingLayerImpl(const LayerParams &params)
     {
         setParamsFrom(params);
-        paddingValue = params.get<float>("value", 0);
+        if (params.blobs.size() == 1)
+            // ONNX parser supports any type
+            paddingValue = params.blobs[0];
+        else
+            // Other parsers support only float
+            paddingValue = Mat(1, 1, CV_32F, params.get<float>("value", 0));
         inputDims = params.get<int>("input_dims", -1);
         paddingType = params.get<String>("type", "constant");
 
@@ -68,6 +73,23 @@ public:
             outputs[0][offset + i] = inpShape[offset + i] + paddings[i].first + paddings[i].second;
         }
         return false;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_CheckEQ(inputs.size(), 1u, "");
+        if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
+            CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_32S || inputs[0] == CV_64S, "");
+        else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
+            CV_CheckType(inputs[0], inputs[0] == CV_16F || inputs[0] == CV_8S || inputs[0] == CV_32S || inputs[0] == CV_64S, "");
+        else
+            CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_8S || inputs[0] == CV_32S || inputs[0] == CV_64S, "");
+
+        outputs.assign(requiredOutputs, inputs[0]);
     }
 
     void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays) CV_OVERRIDE
@@ -184,7 +206,13 @@ public:
         else
             CV_Error(Error::StsNotImplemented, "Unsupported padding mode");
 
-        return make_cuda_node<cuda4dnn::PaddingOp>(preferableTarget, std::move(context->stream), ptype, paddingValue, dstRanges);
+        Mat padValue;
+        if (preferableTarget == DNN_TARGET_CUDA_FP16)
+            paddingValue.convertTo(padValue, CV_16F);
+        else
+            padValue = paddingValue;
+
+        return make_cuda_node_with_type<cuda4dnn::PaddingOp>(preferableTarget, inputs[0]->getHostMatDepth(), std::move(context->stream), ptype, padValue, dstRanges);
     }
 #endif
 
@@ -221,8 +249,7 @@ public:
         op->update_input_desc_paddings(*(op_const_paddings->getTensorDesc()));
         // set inputs : constant_values
         std::vector<int> constant_values_shape{1};
-        Mat constant_values_mat(1, 1, CV_32F, Scalar(paddingValue));
-        auto op_const_constant_values = std::make_shared<CannConstOp>(constant_values_mat.data, constant_values_mat.type(), constant_values_shape, cv::format("%s_constant_values", name.c_str()));
+        auto op_const_constant_values = std::make_shared<CannConstOp>(paddingValue.data, paddingValue.type(), constant_values_shape, cv::format("%s_constant_values", name.c_str()));
         op->set_input_constant_values(*(op_const_constant_values->getOp()));
         op->update_input_desc_constant_values(*(op_const_constant_values->getTensorDesc()));
 
@@ -248,7 +275,7 @@ public:
         auto padding_below = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{begins.size()}, begins.data());
         auto padding_above = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{ends.size()}, ends.data());
         auto pad_mode = paddingType == "constant" ? ov::op::PadMode::CONSTANT : ov::op::PadMode::REFLECT; // SYMMETRIC
-        auto arg_pad_value = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, &paddingValue);;
+        auto arg_pad_value = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, paddingValue.ptr<float>());;
 
         auto pad = paddingType == "constant" ?
              std::make_shared<ov::op::v1::Pad>(ieInpNode, padding_below, padding_above, arg_pad_value, pad_mode) :
@@ -261,7 +288,7 @@ private:
     std::vector<std::pair<int, int> > paddings;  // Pairs pad before, pad after.
     std::vector<Range> dstRanges;
     int inputDims;
-    float paddingValue;
+    Mat paddingValue;
     std::string paddingType;
 };
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2403,6 +2403,7 @@ void ONNXImporter::parsePad(LayerParams& layerParams, const opencv_onnx::NodePro
         paddings = paddings.t();
         layerParams.set("paddings", DictValue::arrayInt(paddings.ptr<int>(), paddings.total()));
 
+        layerParams.set("valueAsBlob", true);
         // check for non-null constant_value
         if (node_proto.input_size() == 3 && !node_proto.input(2).empty())
             layerParams.blobs.push_back(getBlob(node_proto, 2));
@@ -3398,6 +3399,7 @@ void ONNXImporter::parseQConv(LayerParams& layerParams, const opencv_onnx::NodeP
             padLp.type = "PaddingInt8";
             padLp.set("paddings", DictValue::arrayInt(&paddings[0], paddings.size()));
             padLp.set("depth", CV_8S);
+            padLp.set("valueAsBlob", true);
             padLp.blobs.push_back(getBlob(node_proto, 2));
 
             opencv_onnx::NodeProto proto;

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2416,7 +2416,7 @@ void ONNXImporter::parsePad(LayerParams& layerParams, const opencv_onnx::NodePro
                 case CV_8S:  padValue = value.ptr<int8_t>()[0];  break;
                 default: CV_Error(Error::BadDepth, "Unsupported type");
             }
-            layerParams.set<double>("value", padValue);
+            layerParams.set<double>("value", (double)padValue);
         }
     }
     addLayer(layerParams, node_proto);

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2405,11 +2405,9 @@ void ONNXImporter::parsePad(LayerParams& layerParams, const opencv_onnx::NodePro
 
         // check for non-null constant_value
         if (node_proto.input_size() == 3 && !node_proto.input(2).empty())
-        {
-            Mat value = getBlob(node_proto, 2);
-            float padValue = (depth == CV_8S) ? (float)value.ptr<int8_t>()[0] : value.ptr<float>()[0];
-            layerParams.set("value", padValue);
-        }
+            layerParams.blobs.push_back(getBlob(node_proto, 2));
+        else
+            layerParams.blobs.push_back(Mat::zeros(1, 1, depth));
     }
     addLayer(layerParams, node_proto);
 }
@@ -3400,7 +3398,7 @@ void ONNXImporter::parseQConv(LayerParams& layerParams, const opencv_onnx::NodeP
             padLp.type = "PaddingInt8";
             padLp.set("paddings", DictValue::arrayInt(&paddings[0], paddings.size()));
             padLp.set("depth", CV_8S);
-            padLp.set("value", inp_zp);
+            padLp.blobs.push_back(getBlob(node_proto, 2));
 
             opencv_onnx::NodeProto proto;
             proto.add_input(node_proto.input(0));

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -617,7 +617,7 @@ void TFImporter::setPadding(LayerParams &layerParams, const tensorflow::NodeDef 
     padLp.name = layer.name() + "/pad";
     padLp.type = "Padding";
     padLp.set("paddings", DictValue::arrayInt(pads, sizeof(pads) / sizeof(pads[0])));
-    padLp.set("value", value);
+    padLp.set<double>("value", (double)value);
 
     int id = dstNet.addLayer(padLp.name, padLp.type, padLp);
     layer_id[padLp.name] = id;


### PR DESCRIPTION
Added int32 and int64 support to padding layer (CPU and CUDA).
ONNX parser doesn't convert non-zero padding value to float now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
