### PR TITLE
Move (u)int64 typedefs from the global to the cv namespace in C++

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -380,6 +380,12 @@ enum CpuFeatures {
 #  define CV_FP16_TYPE 0
 #endif
 
+#ifdef __cplusplus
+using cv::int64;
+using cv::uint64;
+using cv::ushort;
+#endif
+
 typedef union Cv16suf
 {
     short i;

--- a/modules/core/include/opencv2/core/hal/interface.h
+++ b/modules/core/include/opencv2/core/hal/interface.h
@@ -32,13 +32,22 @@
 #if !defined _MSC_VER && !defined __BORLANDC__
 #  if defined __cplusplus && __cplusplus >= 201103L && !defined __APPLE__
 #    include <cstdint>
+#  else
+#    include <stdint.h>
+#  endif
+#endif
+
+#ifdef __cplusplus
+namespace cv {
+#endif
+#if !defined _MSC_VER && !defined __BORLANDC__
+#  if defined __cplusplus && __cplusplus >= 201103L && !defined __APPLE__
 #    ifdef __NEWLIB__
         typedef unsigned int uint;
 #    else
         typedef std::uint32_t uint;
 #    endif
 #  else
-#    include <stdint.h>
      typedef uint32_t uint;
 #  endif
 #else
@@ -62,6 +71,9 @@ typedef signed char schar;
    typedef uint64_t uint64;
 #  define CV_BIG_INT(n)   n##LL
 #  define CV_BIG_UINT(n)  n##ULL
+#endif
+#ifdef __cplusplus
+}  // namespace cv
 #endif
 
 #define CV_USRTYPE1 (void)"CV_USRTYPE1 support has been dropped in OpenCV 4.0"

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -53,7 +53,10 @@
 //#define CV__VALIDATE_UNUNITIALIZED_VARS 1  // C++11 & GCC only
 
 #ifdef __cplusplus
-
+using cv::schar;
+using cv::uchar;
+using cv::int64;
+using cv::uint64;
 #ifdef CV__VALIDATE_UNUNITIALIZED_VARS
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #define CV_STRUCT_INITIALIZER {0,}

--- a/modules/dnn/misc/objc/gen_dict.json
+++ b/modules/dnn/misc/objc/gen_dict.json
@@ -39,6 +39,15 @@
             "objc_type": "IntVector*",
             "v_type": "IntVector"
         },
+        "vector_uchar": {
+            "objc_type": "ByteVector*",
+            "to_cpp": "(std::vector<uchar>&)%(n)s.nativeRef",
+            "from_cpp": "[ByteVector fromNative:(std::vector<char>&)%(n)s]",
+            "cast_to": "std::vector<uchar>",
+            "primitive_vector": true,
+            "swift_type": "[UInt8]",
+            "unsigned": true
+        },
         "vector_vector_MatShape": {
             "objc_type": "IntVector*",
             "v_v_type": "IntVector"

--- a/modules/features2d/src/hal_replacement.hpp
+++ b/modules/features2d/src/hal_replacement.hpp
@@ -72,7 +72,7 @@
    @param height Source image height
    @param type FAST type
 */
-inline int hal_ni_FAST_dense(const unsigned char* src_data, size_t src_step, unsigned char* dst_data, size_t dst_step, int width, int height, cv::FastFeatureDetector::DetectorType type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST_dense(const uint8_t* src_data, size_t src_step, uint8_t* dst_data, size_t dst_step, int width, int height, cv::FastFeatureDetector::DetectorType type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST_dense hal_ni_FAST_dense
@@ -84,7 +84,7 @@ inline int hal_ni_FAST_dense(const unsigned char* src_data, size_t src_step, uns
    @param dst_data,dst_step Destination mask after NMS
    @param width,height Source mask dimensions
 */
-inline int hal_ni_FAST_NMS(const unsigned char* src_data, size_t src_step, unsigned char* dst_data, size_t dst_step, int width, int height) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST_NMS(const uint8_t* src_data, size_t src_step, uint8_t* dst_data, size_t dst_step, int width, int height) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST_NMS hal_ni_FAST_NMS
@@ -102,7 +102,7 @@ inline int hal_ni_FAST_NMS(const unsigned char* src_data, size_t src_step, unsig
    @param nonmax_suppression Indicates if make nonmaxima suppression or not.
    @param type FAST type
 */
-inline int hal_ni_FAST(const unsigned char* src_data, size_t src_step, int width, int height, unsigned char* keypoints_data, size_t* keypoints_count, int threshold, bool nonmax_suppression, int /*cv::FastFeatureDetector::DetectorType*/ type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST(const uint8_t* src_data, size_t src_step, int width, int height, uint8_t* keypoints_data, size_t* keypoints_count, int threshold, bool nonmax_suppression, int /*cv::FastFeatureDetector::DetectorType*/ type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST hal_ni_FAST

--- a/modules/features2d/src/hal_replacement.hpp
+++ b/modules/features2d/src/hal_replacement.hpp
@@ -72,7 +72,7 @@
    @param height Source image height
    @param type FAST type
 */
-inline int hal_ni_FAST_dense(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step, int width, int height, cv::FastFeatureDetector::DetectorType type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST_dense(const unsigned char* src_data, size_t src_step, unsigned char* dst_data, size_t dst_step, int width, int height, cv::FastFeatureDetector::DetectorType type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST_dense hal_ni_FAST_dense
@@ -84,7 +84,7 @@ inline int hal_ni_FAST_dense(const uchar* src_data, size_t src_step, uchar* dst_
    @param dst_data,dst_step Destination mask after NMS
    @param width,height Source mask dimensions
 */
-inline int hal_ni_FAST_NMS(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step, int width, int height) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST_NMS(const unsigned char* src_data, size_t src_step, unsigned char* dst_data, size_t dst_step, int width, int height) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST_NMS hal_ni_FAST_NMS
@@ -102,7 +102,7 @@ inline int hal_ni_FAST_NMS(const uchar* src_data, size_t src_step, uchar* dst_da
    @param nonmax_suppression Indicates if make nonmaxima suppression or not.
    @param type FAST type
 */
-inline int hal_ni_FAST(const uchar* src_data, size_t src_step, int width, int height, uchar* keypoints_data, size_t* keypoints_count, int threshold, bool nonmax_suppression, int /*cv::FastFeatureDetector::DetectorType*/ type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_FAST(const unsigned char* src_data, size_t src_step, int width, int height, unsigned char* keypoints_data, size_t* keypoints_count, int threshold, bool nonmax_suppression, int /*cv::FastFeatureDetector::DetectorType*/ type) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_FAST hal_ni_FAST

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -498,7 +498,7 @@ struct HammingLUT
     template<typename Iterator2>
     ResultType operator()(const unsigned char* a, const Iterator2 b, size_t size) const
     {
-        static const uchar popCountTable[] =
+        static const unsigned char popCountTable[] =
         {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -521,7 +521,7 @@ struct HammingLUT
     ResultType operator()(const unsigned char* a, const ZeroIterator<unsigned char> b, size_t size) const
     {
         (void)b;
-        static const uchar popCountTable[] =
+        static const unsigned char popCountTable[] =
         {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -762,7 +762,7 @@ struct DNAmmingLUT
     template<typename Iterator2>
     ResultType operator()(const unsigned char* a, const Iterator2 b, size_t size) const
     {
-        static const uchar popCountTable[] =
+        static const unsigned char popCountTable[] =
         {
             0, 1, 1, 1, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
             1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
@@ -785,7 +785,7 @@ struct DNAmmingLUT
     ResultType operator()(const unsigned char* a, const ZeroIterator<unsigned char> b, size_t size) const
     {
         (void)b;
-        static const uchar popCountTable[] =
+        static const unsigned char popCountTable[] =
         {
             0, 1, 1, 1, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
             1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -498,7 +498,7 @@ struct HammingLUT
     template<typename Iterator2>
     ResultType operator()(const unsigned char* a, const Iterator2 b, size_t size) const
     {
-        static const unsigned char popCountTable[] =
+        static const uint8_t popCountTable[] =
         {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -521,7 +521,7 @@ struct HammingLUT
     ResultType operator()(const unsigned char* a, const ZeroIterator<unsigned char> b, size_t size) const
     {
         (void)b;
-        static const unsigned char popCountTable[] =
+        static const uint8_t popCountTable[] =
         {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -762,7 +762,7 @@ struct DNAmmingLUT
     template<typename Iterator2>
     ResultType operator()(const unsigned char* a, const Iterator2 b, size_t size) const
     {
-        static const unsigned char popCountTable[] =
+        static const uint8_t popCountTable[] =
         {
             0, 1, 1, 1, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
             1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
@@ -785,7 +785,7 @@ struct DNAmmingLUT
     ResultType operator()(const unsigned char* a, const ZeroIterator<unsigned char> b, size_t size) const
     {
         (void)b;
-        static const unsigned char popCountTable[] =
+        static const uint8_t popCountTable[] =
         {
             0, 1, 1, 1, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,
             1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3, 1, 2, 2, 2, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3,

--- a/modules/flann/include/opencv2/flann/timer.h
+++ b/modules/flann/include/opencv2/flann/timer.h
@@ -47,7 +47,7 @@ namespace cvflann
  */
 class StartStopTimer
 {
-    int64 startTime;
+    int64_t startTime;
 
 public:
     /**
@@ -78,7 +78,7 @@ public:
      */
     void stop()
     {
-        int64 stopTime = cv::getTickCount();
+        int64_t stopTime = cv::getTickCount();
         value += ( (double)stopTime - startTime) / cv::getTickFrequency();
     }
 

--- a/modules/gapi/samples/text_detection.cpp
+++ b/modules/gapi/samples/text_detection.cpp
@@ -378,7 +378,7 @@ GAPI_OCV_KERNEL(OCVPostProcess, PostProcess) {
         const int h = cls_data_shape[1];
         const int w = cls_data_shape[2];
 
-        std::vector<uchar> pixel_mask(h * w, 0);
+        std::vector<uint8_t> pixel_mask(h * w, 0);
         std::unordered_map<int, int> group_mask;
         std::vector<cv::Point> points;
         for (int i = 0; i < static_cast<int>(pixel_mask.size()); i++) {
@@ -388,7 +388,7 @@ GAPI_OCV_KERNEL(OCVPostProcess, PostProcess) {
                 group_mask[i] = -1;
             }
         }
-        std::vector<uchar> link_mask(link_data.size(), 0);
+        std::vector<uint8_t> link_mask(link_data.size(), 0);
         for (size_t i = 0; i < link_mask.size(); i++) {
             link_mask[i] = link_data[i] >= link_conf_threshold;
         }
@@ -400,9 +400,9 @@ GAPI_OCV_KERNEL(OCVPostProcess, PostProcess) {
                     if (nx == point.x && ny == point.y)
                         continue;
                     if (nx >= 0 && nx < w && ny >= 0 && ny < h) {
-                        uchar pixel_value = pixel_mask[size_t(ny) * size_t(w) + size_t(nx)];
-                        uchar link_value = link_mask[(size_t(point.y) * size_t(w) + size_t(point.x))
-                                                     *neighbours + neighbour];
+                        uint8_t pixel_value = pixel_mask[size_t(ny) * size_t(w) + size_t(nx)];
+                        uint8_t link_value = link_mask[(size_t(point.y) * size_t(w) + size_t(point.x))
+                                                       *neighbours + neighbour];
                         if (pixel_value && link_value) {
                             join(point.x + point.y * w, nx + ny * w, group_mask);
                         }

--- a/modules/gapi/src/api/rmat.cpp
+++ b/modules/gapi/src/api/rmat.cpp
@@ -37,7 +37,7 @@ static View::stepsT defaultSteps(const cv::GMatDesc& desc) {
 }
 } // anonymous namespace
 
-View::View(const cv::GMatDesc& desc, uchar* data, size_t step, DestroyCallback&& cb)
+View::View(const cv::GMatDesc& desc, uint8_t* data, size_t step, DestroyCallback&& cb)
     : m_desc(checkDesc(desc))
     , m_data(data)
     , m_steps([this, step](){
@@ -51,7 +51,7 @@ View::View(const cv::GMatDesc& desc, uchar* data, size_t step, DestroyCallback&&
     , m_cb(std::move(cb)) {
 }
 
-View::View(const cv::GMatDesc& desc, uchar* data, const stepsT &steps, DestroyCallback&& cb)
+View::View(const cv::GMatDesc& desc, uint8_t* data, const stepsT &steps, DestroyCallback&& cb)
     : m_desc(checkDesc(desc))
     , m_data(data)
     , m_steps(steps == stepsT{} ? defaultSteps(m_desc): steps)

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -543,8 +543,8 @@ GAPI_OCV_KERNEL(GCPURGB2YUV422, cv::gapi::imgproc::GRGB2YUV422)
 
         for (int i = 0; i < in.rows; ++i)
         {
-            const uchar* in_line_p  = in.ptr<uchar>(i);
-            uchar* out_line_p = out.ptr<uchar>(i);
+            const unsigned char* in_line_p  = in.ptr<unsigned char>(i);
+            unsigned char* out_line_p = out.ptr<unsigned char>(i);
             cv::gapi::fluid::run_rgb2yuv422_impl(out_line_p, in_line_p, in.cols);
         }
     }

--- a/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuimgproc.cpp
@@ -543,8 +543,8 @@ GAPI_OCV_KERNEL(GCPURGB2YUV422, cv::gapi::imgproc::GRGB2YUV422)
 
         for (int i = 0; i < in.rows; ++i)
         {
-            const unsigned char* in_line_p  = in.ptr<unsigned char>(i);
-            unsigned char* out_line_p = out.ptr<unsigned char>(i);
+            const uint8_t* in_line_p  = in.ptr<uint8_t>(i);
+            uint8_t* out_line_p = out.ptr<uint8_t>(i);
             cv::gapi::fluid::run_rgb2yuv422_impl(out_line_p, in_line_p, in.cols);
         }
     }

--- a/modules/gapi/src/backends/cpu/gcpuvideo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuvideo.cpp
@@ -38,18 +38,18 @@ GAPI_OCV_KERNEL(GCPUBuildOptFlowPyramid, cv::gapi::video::GBuildOptFlowPyramid)
 
 GAPI_OCV_KERNEL(GCPUCalcOptFlowLK, cv::gapi::video::GCalcOptFlowLK)
 {
-    static void run(const cv::Mat                    &prevImg,
-                    const cv::Mat                    &nextImg,
-                    const std::vector<cv::Point2f>   &prevPts,
-                    const std::vector<cv::Point2f>   &predPts,
-                    const cv::Size                   &winSize,
-                    const cv::Scalar                 &maxLevel,
-                    const cv::TermCriteria           &criteria,
-                          int                         flags,
-                          double                      minEigThresh,
-                          std::vector<cv::Point2f>   &outPts,
-                          std::vector<unsigned char> &status,
-                          std::vector<float>         &err)
+    static void run(const cv::Mat                  &prevImg,
+                    const cv::Mat                  &nextImg,
+                    const std::vector<cv::Point2f> &prevPts,
+                    const std::vector<cv::Point2f> &predPts,
+                    const cv::Size                 &winSize,
+                    const cv::Scalar               &maxLevel,
+                    const cv::TermCriteria         &criteria,
+                          int                       flags,
+                          double                    minEigThresh,
+                          std::vector<cv::Point2f> &outPts,
+                          std::vector<uint8_t>     &status,
+                          std::vector<float>       &err)
     {
         if (flags & cv::OPTFLOW_USE_INITIAL_FLOW)
             outPts = predPts;
@@ -60,18 +60,18 @@ GAPI_OCV_KERNEL(GCPUCalcOptFlowLK, cv::gapi::video::GCalcOptFlowLK)
 
 GAPI_OCV_KERNEL(GCPUCalcOptFlowLKForPyr, cv::gapi::video::GCalcOptFlowLKForPyr)
 {
-    static void run(const std::vector<cv::Mat>       &prevPyr,
-                    const std::vector<cv::Mat>       &nextPyr,
-                    const std::vector<cv::Point2f>   &prevPts,
-                    const std::vector<cv::Point2f>   &predPts,
-                    const cv::Size                   &winSize,
-                    const cv::Scalar                 &maxLevel,
-                    const cv::TermCriteria           &criteria,
-                          int                         flags,
-                          double                      minEigThresh,
-                          std::vector<cv::Point2f>   &outPts,
-                          std::vector<unsigned char> &status,
-                          std::vector<float>         &err)
+    static void run(const std::vector<cv::Mat>     &prevPyr,
+                    const std::vector<cv::Mat>     &nextPyr,
+                    const std::vector<cv::Point2f> &prevPts,
+                    const std::vector<cv::Point2f> &predPts,
+                    const cv::Size                 &winSize,
+                    const cv::Scalar               &maxLevel,
+                    const cv::TermCriteria         &criteria,
+                          int                       flags,
+                          double                    minEigThresh,
+                          std::vector<cv::Point2f> &outPts,
+                          std::vector<uint8_t>     &status,
+                          std::vector<float>       &err)
     {
         if (flags & cv::OPTFLOW_USE_INITIAL_FLOW)
             outPts = predPts;

--- a/modules/gapi/src/backends/cpu/gcpuvideo.cpp
+++ b/modules/gapi/src/backends/cpu/gcpuvideo.cpp
@@ -38,18 +38,18 @@ GAPI_OCV_KERNEL(GCPUBuildOptFlowPyramid, cv::gapi::video::GBuildOptFlowPyramid)
 
 GAPI_OCV_KERNEL(GCPUCalcOptFlowLK, cv::gapi::video::GCalcOptFlowLK)
 {
-    static void run(const cv::Mat                  &prevImg,
-                    const cv::Mat                  &nextImg,
-                    const std::vector<cv::Point2f> &prevPts,
-                    const std::vector<cv::Point2f> &predPts,
-                    const cv::Size                 &winSize,
-                    const cv::Scalar               &maxLevel,
-                    const cv::TermCriteria         &criteria,
-                          int                       flags,
-                          double                    minEigThresh,
-                          std::vector<cv::Point2f> &outPts,
-                          std::vector<uchar>       &status,
-                          std::vector<float>       &err)
+    static void run(const cv::Mat                    &prevImg,
+                    const cv::Mat                    &nextImg,
+                    const std::vector<cv::Point2f>   &prevPts,
+                    const std::vector<cv::Point2f>   &predPts,
+                    const cv::Size                   &winSize,
+                    const cv::Scalar                 &maxLevel,
+                    const cv::TermCriteria           &criteria,
+                          int                         flags,
+                          double                      minEigThresh,
+                          std::vector<cv::Point2f>   &outPts,
+                          std::vector<unsigned char> &status,
+                          std::vector<float>         &err)
     {
         if (flags & cv::OPTFLOW_USE_INITIAL_FLOW)
             outPts = predPts;
@@ -60,18 +60,18 @@ GAPI_OCV_KERNEL(GCPUCalcOptFlowLK, cv::gapi::video::GCalcOptFlowLK)
 
 GAPI_OCV_KERNEL(GCPUCalcOptFlowLKForPyr, cv::gapi::video::GCalcOptFlowLKForPyr)
 {
-    static void run(const std::vector<cv::Mat>     &prevPyr,
-                    const std::vector<cv::Mat>     &nextPyr,
-                    const std::vector<cv::Point2f> &prevPts,
-                    const std::vector<cv::Point2f> &predPts,
-                    const cv::Size                 &winSize,
-                    const cv::Scalar               &maxLevel,
-                    const cv::TermCriteria         &criteria,
-                          int                       flags,
-                          double                    minEigThresh,
-                          std::vector<cv::Point2f> &outPts,
-                          std::vector<uchar>       &status,
-                          std::vector<float>       &err)
+    static void run(const std::vector<cv::Mat>       &prevPyr,
+                    const std::vector<cv::Mat>       &nextPyr,
+                    const std::vector<cv::Point2f>   &prevPts,
+                    const std::vector<cv::Point2f>   &predPts,
+                    const cv::Size                   &winSize,
+                    const cv::Scalar                 &maxLevel,
+                    const cv::TermCriteria           &criteria,
+                          int                         flags,
+                          double                      minEigThresh,
+                          std::vector<cv::Point2f>   &outPts,
+                          std::vector<unsigned char> &status,
+                          std::vector<float>         &err)
     {
         if (flags & cv::OPTFLOW_USE_INITIAL_FLOW)
             outPts = predPts;

--- a/modules/java/generator/src/cpp/converters.h
+++ b/modules/java/generator/src/cpp/converters.h
@@ -14,8 +14,8 @@ void vector_double_to_Mat(std::vector<double>& v_double, cv::Mat& mat);
 void Mat_to_vector_float(cv::Mat& mat, std::vector<float>& v_float);
 void vector_float_to_Mat(std::vector<float>& v_float, cv::Mat& mat);
 
-void Mat_to_vector_uchar(cv::Mat& mat, std::vector<unsigned char>& v_uchar);
-void vector_uchar_to_Mat(std::vector<unsigned char>& v_uchar, cv::Mat& mat);
+void Mat_to_vector_uchar(cv::Mat& mat, std::vector<uint8_t>& v_uchar);
+void vector_uchar_to_Mat(std::vector<uint8_t>& v_uchar, cv::Mat& mat);
 
 void Mat_to_vector_char(cv::Mat& mat, std::vector<char>& v_char);
 void vector_char_to_Mat(std::vector<char>& v_char, cv::Mat& mat);

--- a/modules/java/generator/src/cpp/converters.h
+++ b/modules/java/generator/src/cpp/converters.h
@@ -14,8 +14,8 @@ void vector_double_to_Mat(std::vector<double>& v_double, cv::Mat& mat);
 void Mat_to_vector_float(cv::Mat& mat, std::vector<float>& v_float);
 void vector_float_to_Mat(std::vector<float>& v_float, cv::Mat& mat);
 
-void Mat_to_vector_uchar(cv::Mat& mat, std::vector<uchar>& v_uchar);
-void vector_uchar_to_Mat(std::vector<uchar>& v_uchar, cv::Mat& mat);
+void Mat_to_vector_uchar(cv::Mat& mat, std::vector<unsigned char>& v_uchar);
+void vector_uchar_to_Mat(std::vector<unsigned char>& v_uchar, cv::Mat& mat);
 
 void Mat_to_vector_char(cv::Mat& mat, std::vector<char>& v_char);
 void vector_char_to_Mat(std::vector<char>& v_char, cv::Mat& mat);

--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -49,8 +49,7 @@
 
 using namespace cv::cuda;
 
-typedef unsigned char uchar;
-typedef unsigned short ushort;
+using cv::uchar;
 
 //////////////////////////////////////////////////////////////////////////////////
 //// Non Local Means Denosing

--- a/modules/python/src2/cv2_convert.hpp
+++ b/modules/python/src2/cv2_convert.hpp
@@ -127,8 +127,8 @@ template<> bool pyopencv_to(PyObject* obj, int& value, const ArgInfo& info);
 template<> PyObject* pyopencv_from(const int& value);
 
 // --- int64
-template<> bool pyopencv_to(PyObject* obj, int64& value, const ArgInfo& info);
-template<> PyObject* pyopencv_from(const int64& value);
+template<> bool pyopencv_to(PyObject* obj, int64_t& value, const ArgInfo& info);
+template<> PyObject* pyopencv_from(const int64_t& value);
 
 // There is conflict between "size_t" and "unsigned int".
 // They are the same type on some 32-bit platforms.
@@ -184,8 +184,8 @@ struct PyOpenCV_Converter
 
 
 // --- uchar
-template<> bool pyopencv_to(PyObject* obj, uchar& value, const ArgInfo& info);
-template<> PyObject* pyopencv_from(const uchar& value);
+template<> bool pyopencv_to(PyObject* obj, unsigned char& value, const ArgInfo& info);
+template<> PyObject* pyopencv_from(const unsigned char& value);
 
 // --- char
 template<> bool pyopencv_to(PyObject* obj, char& value, const ArgInfo& info);

--- a/modules/python/src2/cv2_convert.hpp
+++ b/modules/python/src2/cv2_convert.hpp
@@ -183,9 +183,9 @@ struct PyOpenCV_Converter
 };
 
 
-// --- uchar
-template<> bool pyopencv_to(PyObject* obj, unsigned char& value, const ArgInfo& info);
-template<> PyObject* pyopencv_from(const unsigned char& value);
+// --- uint8_t
+template<> bool pyopencv_to(PyObject* obj, uint8_t& value, const ArgInfo& info);
+template<> PyObject* pyopencv_from(const uint8_t& value);
 
 // --- char
 template<> bool pyopencv_to(PyObject* obj, char& value, const ArgInfo& info);

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -261,7 +261,7 @@ static inline void registerGlobalSkipTag(const std::string& tag1, const std::str
 
 class TS;
 
-int64 readSeed(const char* str);
+int64_t readSeed(const char* str);
 
 void randUni( RNG& rng, Mat& a, const Scalar& param1, const Scalar& param2 );
 
@@ -475,10 +475,10 @@ struct TestInfo
     int code;
 
     // seed value right before the data for the failed test case is prepared.
-    uint64 rng_seed;
+    uint64_t rng_seed;
 
     // seed value right before running the test
-    uint64 rng_seed0;
+    uint64_t rng_seed0;
 
     // index of test case, can be then passed to BaseTest::proceed_to_test_case()
     int test_case_idx;
@@ -494,7 +494,7 @@ struct TSParams
     TSParams();
 
     // RNG seed, passed to and updated by every test executed.
-    uint64 rng_seed;
+    uint64_t rng_seed;
 
     // whether to use IPP, MKL etc. or not
     bool use_optimized;
@@ -735,11 +735,11 @@ protected:
     }
 };
 
-extern uint64 param_seed;
+extern uint64_t param_seed;
 
 struct DefaultRngAuto
 {
-    const uint64 old_state;
+    const uint64_t old_state;
 
     DefaultRngAuto() : old_state(cv::theRNG().state) { cv::theRNG().state = cvtest::param_seed; }
     ~DefaultRngAuto() { cv::theRNG().state = old_state; }

--- a/samples/cpp/tutorial_code/imgcodecs/GDAL_IO/gdal-image.cpp
+++ b/samples/cpp/tutorial_code/imgcodecs/GDAL_IO/gdal-image.cpp
@@ -39,7 +39,7 @@ cv::Point2d world2dem( const cv::Point2d&, const cv::Size&);
 
 cv::Point2d pixel2world( const int&, const int&, const cv::Size& );
 
-void add_color( cv::Vec3b& pix, const uchar& b, const uchar& g, const uchar& r );
+void add_color( cv::Vec3b& pix, const uint8_t& b, const uint8_t& g, const uint8_t& r );
 
 
 
@@ -64,7 +64,7 @@ cv::Vec<DATATYPE,N> lerp( cv::Vec<DATATYPE,N> const& minColor,
 
     cv::Vec<DATATYPE,N> output;
     for( int i=0; i<N; i++ ){
-        output[i] = (uchar)(((1-t)*minColor[i]) + (t * maxColor[i]));
+        output[i] = (uint8_t)(((1-t)*minColor[i]) + (t * maxColor[i]));
     }
     return output;
 }
@@ -142,7 +142,7 @@ cv::Point2d pixel2world( const int& x, const int& y, const cv::Size& size ){
 /*
  * Add color to a specific pixel color value
 */
-void add_color( cv::Vec3b& pix, const uchar& b, const uchar& g, const uchar& r ){
+void add_color( cv::Vec3b& pix, const uint8_t& b, const uint8_t& g, const uint8_t& r ){
 
     if( pix[0] + b < 255 && pix[0] + b >= 0 ){ pix[0] += b; }
     if( pix[1] + g < 255 && pix[1] + g >= 0 ){ pix[1] += g; }

--- a/samples/tapi/camshift.cpp
+++ b/samples/tapi/camshift.cpp
@@ -142,7 +142,7 @@ int main(int argc, const char ** argv)
                     int binW = histimg.cols / hsize;
                     cv::Mat buf (1, hsize, CV_8UC3);
                     for (int i = 0; i < hsize; i++)
-                        buf.at<cv::Vec3b>(i) = cv::Vec3b(cv::saturate_cast<uchar>(i*180./hsize), 255, 255);
+                        buf.at<cv::Vec3b>(i) = cv::Vec3b(cv::saturate_cast<uint8_t>(i*180./hsize), 255, 255);
                     cv::cvtColor(buf, buf, cv::COLOR_HSV2BGR);
 
                     {

--- a/samples/tapi/pyrlk_optical_flow.cpp
+++ b/samples/tapi/pyrlk_optical_flow.cpp
@@ -12,7 +12,6 @@
 using namespace std;
 using namespace cv;
 
-typedef unsigned char uchar;
 #define LOOP_NUM 10
 int64 work_begin = 0;
 int64 work_end = 0;
@@ -30,7 +29,7 @@ static double getTime()
     return work_end * 1000. / getTickFrequency();
 }
 
-static void drawArrows(UMat& _frame, const vector<Point2f>& prevPts, const vector<Point2f>& nextPts, const vector<uchar>& status,
+static void drawArrows(UMat& _frame, const vector<Point2f>& prevPts, const vector<Point2f>& nextPts, const vector<uint8_t>& status,
                        Scalar line_color = Scalar(0, 0, 255))
 {
     Mat frame = _frame.getMat(ACCESS_WRITE);


### PR DESCRIPTION
This solves https://github.com/opencv/opencv/issues/7573
The only public API change are:
- typedefs in modules/core/include/opencv2/core/hal/interface.h are now in the `cv` namespace in C++
- in modules/flann/include/opencv2/flann/timer.h

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
