### PR TITLE
imgcodecs: tiff: to avoid using TIFFTAG_* directly for imwrite() params.

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -104,6 +104,8 @@ enum ImwriteFlags {
        IMWRITE_TIFF_XDPI           = 257,//!< For TIFF, use to specify the X direction DPI
        IMWRITE_TIFF_YDPI           = 258,//!< For TIFF, use to specify the Y direction DPI
        IMWRITE_TIFF_COMPRESSION    = 259,//!< For TIFF, use to specify the image compression scheme. See libtiff for integer constants corresponding to compression formats. Note, for images whose depth is CV_32F, only libtiff's SGILOG compression scheme is used. For other supported depths, the compression scheme can be specified by this flag; LZW compression is the default.
+       IMWRITE_TIFF_ROWSPERSTRIP   = 278,//!< For TIFF, use to specify the number of rows per strip.
+       IMWRITE_TIFF_PREDICTOR      = 317,//!< For TIFF, use to specify predictor.
        IMWRITE_JPEG2000_COMPRESSION_X1000 = 272,//!< For JPEG2000, use to specify the target compression rate (multiplied by 1000). The value can be from 0 to 1000. Default is 1000.
        IMWRITE_AVIF_QUALITY        = 512,//!< For AVIF, it can be a quality between 0 and 100 (the higher the better). Default is 95.
        IMWRITE_AVIF_DEPTH          = 513,//!< For AVIF, it can be 8, 10 or 12. If >8, it is stored/read as CV_32F. Default is 8.

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -1229,7 +1229,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
     int resUnit = -1, dpiX = -1, dpiY = -1;
 
     readParam(params, IMWRITE_TIFF_COMPRESSION, compression);
-    readParam(params, TIFFTAG_PREDICTOR, predictor);
+    readParam(params, IMWRITE_TIFF_PREDICTOR, predictor);
     readParam(params, IMWRITE_TIFF_RESUNIT, resUnit);
     readParam(params, IMWRITE_TIFF_XDPI, dpiX);
     readParam(params, IMWRITE_TIFF_YDPI, dpiY);
@@ -1318,7 +1318,7 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         CV_Assert(fileStep > 0);
 
         int rowsPerStrip = (int)((1 << 13) / fileStep);
-        readParam(params, TIFFTAG_ROWSPERSTRIP, rowsPerStrip);
+        readParam(params, IMWRITE_TIFF_ROWSPERSTRIP, rowsPerStrip);
         rowsPerStrip = std::max(1, std::min(height, rowsPerStrip));
 
         int colorspace = channels > 1 ? PHOTOMETRIC_RGB : PHOTOMETRIC_MINISBLACK;

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -28,7 +28,7 @@ TEST(Imgcodecs_Tiff, decode_tile16384x16384)
     string file4 = cv::tempfile(".tiff");
 
     std::vector<int> params;
-    params.push_back(TIFFTAG_ROWSPERSTRIP);
+    params.push_back(IMWRITE_TIFF_ROWSPERSTRIP);
     params.push_back(big.rows);
     EXPECT_NO_THROW(cv::imwrite(file4, big, params));
     EXPECT_NO_THROW(cv::imwrite(file3, big.colRange(0, big.cols - 1), params));
@@ -767,7 +767,7 @@ TEST(Imgcodecs_Tiff, readWrite_32FC3_RAW)
 
     std::vector<int> params;
     params.push_back(IMWRITE_TIFF_COMPRESSION);
-    params.push_back(1/*COMPRESSION_NONE*/);
+    params.push_back(COMPRESSION_NONE);
 
     ASSERT_TRUE(cv::imwrite(filenameOutput, img, params));
     const Mat img2 = cv::imread(filenameOutput, IMREAD_UNCHANGED);
@@ -824,9 +824,9 @@ TEST(Imgcodecs_Tiff, readWrite_predictor)
         string out = cv::tempfile(".tif");
 
         std::vector<int> params;
-        params.push_back(TIFFTAG_COMPRESSION);
+        params.push_back(IMWRITE_TIFF_COMPRESSION);
         params.push_back(methods[i]);
-        params.push_back(TIFFTAG_PREDICTOR);
+        params.push_back(IMWRITE_TIFF_PREDICTOR);
         params.push_back(PREDICTOR_HORIZONTAL);
 
         EXPECT_NO_THROW(cv::imwrite(out, mat, params));


### PR DESCRIPTION
Normaly, we set IMWRITE_* flags for imwrite() params. But imgcodecs expects to use some TIFFTAG_* directory. This patch introduce IMWRITE_TIFF_ROWSPERSTRIP and IMWRITE_TIFF_PREDICTOR instead of TIFFTAG_*.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
