### PR TITLE
Fix detect rotated SYMMETRIC_GRID

### DIFF
--- a/modules/calib3d/src/circlesgrid.hpp
+++ b/modules/calib3d/src/circlesgrid.hpp
@@ -186,6 +186,7 @@ private:
 
   const cv::Size_<size_t> patternSize;
   cv::CirclesGridFinderParameters parameters;
+  bool rotatedGrid = false;
 
   CirclesGridFinder& operator=(const CirclesGridFinder&);
   CirclesGridFinder(const CirclesGridFinder&);


### PR DESCRIPTION
Merge with https://github.com/opencv/opencv_extra/pull/1157
Fixes https://github.com/opencv/opencv/issues/24964

This PR fixes `isDetectionCorrect()` in `findCirclesGrid()` for SYMMETRIC_GRID.
To `isDetectionCorrect()` added check rotation of the grid and bool flag `rotatedGrid`. if `rotatedGrid` is true, `getHoles()` transpose the circle grid before return.

Detect pattern with Size(7, 6):
![image](https://github.com/opencv/opencv/assets/22337800/e5c0c538-9bd7-4a37-8226-c5f44c50a0db)

Detect pattern with Size(6, 7):
![image](https://github.com/opencv/opencv/assets/22337800/cbc76763-35f9-4933-92ea-fec334c3ec29)

Tests in [benchmark](https://github.com/opencv/opencv_benchmarks/tree/develop/python_benchmarks/objdetect_benchmark
) with params `--configuration=generate_run --board_x=7 --board_y=6 --path=res_circle --synthetic_object=circle_sym_grid`:
before fix:
![image](https://github.com/opencv/opencv/assets/22337800/76bf5bb5-f96a-44bd-afd8-48d5cf8dd8d1)
after fix:
![image](https://github.com/opencv/opencv/assets/22337800/eaceda8c-142c-404e-a620-0c0d488b073e)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
