### PR TITLE
imgcodecs: jpeg: re-support to read CMYK Jpeg

### DIFF
--- a/modules/imgcodecs/test/test_jpeg.cpp
+++ b/modules/imgcodecs/test/test_jpeg.cpp
@@ -178,6 +178,40 @@ TEST(Imgcodecs_Jpeg, encode_decode_rst_jpeg)
     EXPECT_EQ(0, remove(output_normal.c_str()));
 }
 
+// See https://github.com/opencv/opencv/issues/25274
+TEST(Imgcodecs_Jpeg, regression25274_cmykjpeg)
+{
+    /*
+     * "test_1_c4.jpg" is CMYK-JPEG.
+     * $ convert test_1_c3.jpg -colorspace CMYK test_1_c4.jpg
+     * $ identify test_1_c4.jpg
+     * test_1_c4.jpg JPEG 480x640 480x640+0+0 8-bit CMYK 11240B 0.000u 0:00.000
+     */
+
+    cvtest::TS& ts = *cvtest::TS::ptr();
+    string input = string(ts.get_data_path()) + "readwrite/test_1_c4.jpg";
+    {
+        cv::Mat img = cv::imread(input);
+        ASSERT_FALSE(img.empty());
+        EXPECT_EQ(CV_8UC3, img.type()); // BGR
+    }
+    {
+        cv::Mat img = cv::imread(input, cv::IMREAD_GRAYSCALE);
+        ASSERT_FALSE(img.empty());
+        EXPECT_EQ(CV_8UC1, img.type()); // GRAY
+    }
+    {
+        cv::Mat img = cv::imread(input, cv::IMREAD_COLOR);
+        ASSERT_FALSE(img.empty());
+        EXPECT_EQ(CV_8UC3, img.type()); // BGR
+    }
+    {
+        cv::Mat img = cv::imread(input, cv::IMREAD_ANYCOLOR);
+        ASSERT_FALSE(img.empty());
+        EXPECT_EQ(CV_8UC3, img.type()); // BGR
+    }
+}
+
 //==================================================================================================
 
 static const uint32_t default_sampling_factor = static_cast<uint32_t>(0x221111);


### PR DESCRIPTION
Close #25274 
OpenCV Extra: https://github.com/opencv/opencv_extra/pull/1163

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
