### PR TITLE
core: Add cgroupsv2 support to parallel.cpp

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -870,7 +870,22 @@ int getNumberOfCPUsImpl(const char *filename)
 
 #if defined CV_HAVE_CGROUPS
 static inline
-unsigned getNumberOfCPUsCFS()
+unsigned getNumberOfCPUsCFSv2()
+{
+    int cfs_quota = 0;
+    int cfs_period = 0;
+
+    std::ifstream ss_cpu_max("/sys/fs/cgroup/cpu.max", std::ios::in | std::ios::binary);
+    ss_cpu_max >> cfs_quota >> cfs_period;
+
+    if (ss_cpu_max.fail() || cfs_quota < 1 || cfs_period < 1) /* values must not be 0 or negative */
+        return 0;
+
+    return (unsigned)max(1, cfs_quota/cfs_period);
+}
+
+static inline
+unsigned getNumberOfCPUsCFSv1()
 {
     int cfs_quota = 0;
     {
@@ -966,8 +981,11 @@ int getNumberOfCPUs_()
     static unsigned ncpus_impl_cpuset = (unsigned)getNumberOfCPUsImpl("/sys/fs/cgroup/cpuset/cpuset.cpus");
     ncpus = minNonZero(ncpus, ncpus_impl_cpuset);
 
-    static unsigned ncpus_impl_cfs = getNumberOfCPUsCFS();
-    ncpus = minNonZero(ncpus, ncpus_impl_cfs);
+    static unsigned ncpus_impl_cfs_v1 = getNumberOfCPUsCFSv1();
+    ncpus = minNonZero(ncpus, ncpus_impl_cfs_v1);
+
+    static unsigned ncpus_impl_cfs_v2 = getNumberOfCPUsCFSv2();
+    ncpus = minNonZero(ncpus, ncpus_impl_cfs_v2);
 #endif
 
     static unsigned ncpus_impl_devices = (unsigned)getNumberOfCPUsImpl("/sys/devices/system/cpu/online");


### PR DESCRIPTION
The parallel code works out how many CPUs are on the system by checking the quota it has been assigned in the Linux cgroup. The existing code works under cgroups v1 but the file structure changed in cgroups v2. From [1]:

    "cpu.cfs_quota_us" and "cpu.cfs_period_us" are replaced by "cpu.max"
  which contains both quota and period.

This commit add support to parallel so it will read from the cgroups v2 location. v1 support is still retained.

Resolves #25284

[1] https://github.com/torvalds/linux/commit/0d5936344f30aba0f6ddb92b030cb6a05168efe6

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
