### PR TITLE
Einsum OpenVINO backend

### DIFF
--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -597,7 +597,7 @@ CASE(test_dynamicquantizelinear_min_adjusted_expanded)
 CASE(test_edge_pad)
     // no filter
 CASE(test_einsum_batch_diagonal)
-    // no filter
+    SKIP;
 CASE(test_einsum_batch_matmul)
     // no filter
 CASE(test_einsum_inner_prod)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1471,6 +1471,8 @@ TEST_P(Test_ONNX_layers, Einsum_2D)
 
 TEST_P(Test_ONNX_layers, Einsum_2D_Ellipses)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("einsum_2d_ellipses", npy, 0, 0, false, false, 2);
 }
 
@@ -1501,6 +1503,8 @@ TEST_P(Test_ONNX_layers, DISABLED_Einsum_HadamardProduct)
 
 TEST_P(Test_ONNX_layers, Einsum_Batch_Diagonal)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("einsum_batch_diagonal", npy, 0, 0, false, false, 1);
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

On skipped tests:

```
[ RUN      ] Test_ONNX_layers.Einsum_2D_Ellipses/0, where GetParam() = NGRAPH/CPU
unknown file: Failure
C++ exception with description "Check 'input_rank >= labels.size()' failed at src/core/shape_inference/include/einsum_shape_inference.hpp:41:
While validating node 'opset7::Einsum Einsum_2190 (0.0[0]:f32[4,5], 1.1[0]:f32[5,8]) -> (dynamic[...])' with friendly_name 'Einsum_2190':
Input rank must be greater or equal to a number of labels in the corresponding input subscript.
" thrown in the test body.
[  FAILED  ] Test_ONNX_layers.Einsum_2D_Ellipses/0, where GetParam() = NGRAPH/CPU (0 ms)
```
```
[ RUN      ] Test_ONNX_layers.Einsum_Batch_Diagonal/0, where GetParam() = NGRAPH/CPU
unknown file: Failure
C++ exception with description "OpenCV(4.9.0-dev) /home/dkurtaev/opencv/modules/dnn/src/ie_ngraph.cpp:369: error: (-2:Unspecified error) in function 'initPlugin'
> Failed to initialize Inference Engine backend (device = CPU): Exception from src/inference/src/core.cpp:113:
> [ GENERAL_ERROR ] Unsupported operation of type: Einsum name: 1
> Details:
> Cannot fallback on ngraph reference implementation (Ngraph::Node::evaluate() is not implemented)
> " thrown in the test body.
[  FAILED  ] Test_ONNX_layers.Einsum_Batch_Diagonal/0, where GetParam() = NGRAPH/CPU (2 ms)
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
