### PR TITLE
imgcodecs: jpeg: (test) fix condition to compare rgb and cmyk jpeg

### DIFF
--- a/modules/imgcodecs/test/test_jpeg.cpp
+++ b/modules/imgcodecs/test/test_jpeg.cpp
@@ -207,7 +207,7 @@ TEST_P(Imgcodecs_Jpeg_decode_cmyk, regression25274)
     // Jpeg is lossy compression.
     // There may be small differences in decoding results by environments.
     // -> 255 * 1% = 2.55 .
-    EXPECT_EQ(3, cvtest::norm(rgb_img, cmyk_img, NORM_INF));
+    EXPECT_LE(cvtest::norm(rgb_img, cmyk_img, NORM_INF), 3); // norm() <= 3
 }
 
 INSTANTIATE_TEST_CASE_P( /* nothing */,


### PR DESCRIPTION
Comparing condition for rgb- and cmyk-jpeg is incorrect. When `norm()` returns less than 3, this may make false-positive error.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
