### PR TITLE
Resolve valgrind issue at QRCode detector

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2936,7 +2936,8 @@ QRDecode::QRDecode(bool _useAlignmentMarkers):
     useAlignmentMarkers(_useAlignmentMarkers),
     version(0),
     version_size(0),
-    test_perspective_size(0.f)
+    test_perspective_size(0.f),
+    mode(QRCodeEncoder::EncodeMode::MODE_AUTO)
     {}
 
 std::string ImplContour::decode(InputArray in, InputArray points, OutputArray straight_qrcode) const {


### PR DESCRIPTION
### Pull Request Readiness Checklist

https://pullrequest.opencv.org/buildbot/builders/4_x_valgrind-lin64-debug/builds/100068/steps/test_objdetect/logs/valgrind%20summary

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
