### PR TITLE
Resolve out of bound write in RNG::fill

### DIFF
--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -544,7 +544,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
 
     if( disttype == UNIFORM )
     {
-        _parambuf.allocate((sizeof(DivStruct)+sizeof(double)-1)/sizeof(double) + cn*2 + n1 + n2);
+        _parambuf.allocate((sizeof(DivStruct)+sizeof(double)-1)/sizeof(double) + cn*2 + max(cn, n1) + max(cn, n2));
         double* parambuf = _parambuf.data();
         double* p1 = _param1.ptr<double>();
         double* p2 = _param2.ptr<double>();
@@ -584,6 +584,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
                                  depth == CV_8S ? 128. : depth == CV_16S ? 32768. : depth == CV_32U ? (double)UINT_MAX :
                                  depth == CV_32S ? (double)INT_MAX : (double)INT64_MAX);
                 }
+                CV_DbgCheckLT((size_t)(cn*2 + j*2 + 1), _parambuf.size(), "");
                 ip[j][1] = (int64_t)ceil(a);
                 int64_t idiff = ip[j][0] = (int64_t)floor(b) - ip[j][1] - 1;
                 if (idiff < 0)
@@ -650,6 +651,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
                 Vec2f* fp = (Vec2f*)(parambuf + cn*2);
                 for( j = 0; j < cn; j++ )
                 {
+                    CV_DbgCheckLT((size_t)(cn*2 + j*2 + 1), _parambuf.size(), "");
                     fp[j][0] = (float)(std::min(maxdiff, p2[j] - p1[j])*scale);
                     fp[j][1] = (float)((p2[j] + p1[j])*0.5);
                 }
@@ -660,6 +662,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
                 Vec2d* dp = (Vec2d*)(parambuf + cn*2);
                 for( j = 0; j < cn; j++ )
                 {
+                    CV_DbgCheckLT((size_t)(cn*2 + j*2 + 1), _parambuf.size(), "");
                     dp[j][0] = std::min(DBL_MAX, p2[j] - p1[j])*scale;
                     dp[j][1] = ((p2[j] + p1[j])*0.5);
                 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

problem is on 5.x only: https://pullrequest.opencv.org/buildbot/builders/5_x_valgrind-lin64-debug/builds/100059/steps/test_core/logs/valgrind%20summary

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
