### PR TITLE
Added option to dump v4l2 test frame from virtual camera

### DIFF
--- a/modules/videoio/test/test_v4l2.cpp
+++ b/modules/videoio/test/test_v4l2.cpp
@@ -17,6 +17,8 @@
 
 #ifdef HAVE_CAMV4L2
 
+// #define DUMP_CAMERA_FRAME
+
 #include "test_precomp.hpp"
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <linux/videodev2.h>
@@ -113,6 +115,13 @@ TEST_P(videoio_v4l2, formats)
             EXPECT_EQ(sz, img.size());
             EXPECT_EQ(3, img.channels());
             EXPECT_EQ(CV_8U, img.depth());
+#ifdef DUMP_CAMERA_FRAME
+            std::string img_name = "frame_" + fourccToString(params.pixel_format);
+            // V4L2 flag for big-endian formats
+            if(params.pixel_format & (1 << 31))
+                img_name += "-BE";
+            cv::imwrite(img_name + ".png", img);
+#endif
         }
     }
 }


### PR DESCRIPTION
I see RGB-BGR color issue with NV12 and NV21 on Ubuntu 18.04 (kernel 5.4.0-150). I'll re-check with newer Ubuntu and file another patch to fix it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
