### PR TITLE
Resolve valgrind issue in 3d module

### DIFF
--- a/modules/3d/src/rgbd/volume_impl.cpp
+++ b/modules/3d/src/rgbd/volume_impl.cpp
@@ -563,6 +563,7 @@ void ColorTsdfVolume::reset()
         {
             RGBTsdfVoxel& v = reinterpret_cast<RGBTsdfVoxel&>(vv);
             v.tsdf = floatToTsdf(0.0f); v.weight = 0;
+            v.r = v.g = v.b = 0;
         });
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

https://pullrequest.opencv.org/buildbot/builders/5_x_valgrind-lin64-debug/builds/100059/steps/test_3d/logs/stdio

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
