### PR TITLE
Add definition "_USE_MATH_DEFINES" for the dnn plugin of Win32 build

### DIFF
--- a/modules/dnn/cmake/plugin.cmake
+++ b/modules/dnn/cmake/plugin.cmake
@@ -50,6 +50,7 @@ function(ocv_create_builtin_dnn_plugin name target)
   endforeach()
 
   if(WIN32)
+    add_definitions(-D_USE_MATH_DEFINES)
     set(OPENCV_PLUGIN_VERSION "${OPENCV_DLLVERSION}" CACHE STRING "")
     if(CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8)
       set(OPENCV_PLUGIN_ARCH "_64" CACHE STRING "")


### PR DESCRIPTION
Fixes #24392.
I'm not sure this is the best practice, but looks working well for me with rev.https://github.com/opencv/opencv/commit/2b1c8aa4db3cd74afec9a71b54765c7f57f053c5.
Any helps or advice are welcomed if this patch need to be modified.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
