### PR TITLE
Take first suitable neighbor in ChessBoardDetector::findQuadNeighbors

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1667,8 +1667,7 @@ void ChessBoardDetector::findQuadNeighbors()
                     continue;
 
                 const float dist = normL2Sqr<float>(pt - all_quads_pts[neighbor_idx]);
-                if (dist < min_dist &&
-                    dist <= cur_quad.edge_len * thresh_scale &&
+                if (dist <= cur_quad.edge_len * thresh_scale &&
                     dist <= q_k.edge_len * thresh_scale)
                 {
                     // check edge lengths, make sure they're compatible
@@ -1685,6 +1684,7 @@ void ChessBoardDetector::findQuadNeighbors()
                     closest_corner_idx = j;
                     closest_quad = &q_k;
                     min_dist = dist;
+                    break;
                 }
             }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

Neighbors are sorted by distance in ascending order.
```
if (min_dist < FLT_MAX)
    CV_Assert(dist >= min_dist);
```
isn't triggered.

So, we always take first suitable neighbor and we can stop search after this.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
