### PR TITLE
Remove unnecessary floating point literal

### DIFF
--- a/modules/imgproc/src/phasecorr.cpp
+++ b/modules/imgproc/src/phasecorr.cpp
@@ -613,7 +613,7 @@ void cv::createHanningWindow(OutputArray _dst, cv::Size winSize, int type)
     AutoBuffer<double> _wc(cols);
     double* const wc = _wc.data();
 
-    double coeff0 = 2.0 * CV_PI / (double)(cols - 1), coeff1 = 2.0f * CV_PI / (double)(rows - 1);
+    double coeff0 = 2.0 * CV_PI / (double)(cols - 1), coeff1 = 2.0 * CV_PI / (double)(rows - 1);
     for(int j = 0; j < cols; j++)
         wc[j] = 0.5 * (1.0 - cos(coeff0 * j));
 


### PR DESCRIPTION
This pull request removes unnecessary floating point literal.
The "f" literal indicating float precision is unnecessary, because double precision is required in this line.
So, remove unnecessary literal from `coeff1` calculation to match `coeff0` calculation.
This change should not affect the calculation results.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
