### PR TITLE
Resolve valgrind warnings

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -3250,20 +3250,20 @@ typedef testing::TestWithParam<perf::MatDepth> NonZeroSupportedMatDepth;
 
 TEST_P(NonZeroSupportedMatDepth, findNonZero)
 {
-    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     vector<Point> pts;
     EXPECT_NO_THROW(findNonZero(src, pts));
 }
 
 TEST_P(NonZeroSupportedMatDepth, countNonZero)
 {
-    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     EXPECT_NO_THROW(countNonZero(src));
 }
 
 TEST_P(NonZeroSupportedMatDepth, hasNonZero)
 {
-    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     EXPECT_NO_THROW(hasNonZero(src));
 }
 
@@ -3295,7 +3295,7 @@ typedef testing::TestWithParam<perf::MatDepth> MinMaxSupportedMatDepth;
 
 TEST_P(MinMaxSupportedMatDepth, minMaxLoc)
 {
-    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     double minV=0.0, maxV=0.0;
     Point minLoc, maxLoc;
     EXPECT_NO_THROW(cv::minMaxLoc(src, &minV, &maxV, &minLoc, &maxLoc));
@@ -3303,7 +3303,7 @@ TEST_P(MinMaxSupportedMatDepth, minMaxLoc)
 
 TEST_P(MinMaxSupportedMatDepth, minMaxIdx)
 {
-    cv::Mat src = cv::Mat(16,16, CV_MAKETYPE(GetParam(), 1));
+    cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     double minV=0.0, maxV=0.0;
     int minIdx=0, maxIdx=0;
     EXPECT_NO_THROW(cv::minMaxIdx(src, &minV, &maxV, &minIdx, &maxIdx));

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -233,7 +233,7 @@ public:
         outputChannels = numChannels;
 
         outputs.assign(1, inputs[0]);
-        outputs[0][1] = numChannels;
+        outputs[0][(dims == 1) ? 0 : 1] = numChannels;
 
         if (dims >= 1)
         {


### PR DESCRIPTION
### Pull Request Readiness Checklist

5.x related only

1. https://pullrequest.opencv.org/buildbot/builders/5_x_valgrind-lin64-debug/builds/100060/steps/test_core/logs/valgrind%20summary
2. https://pullrequest.opencv.org/buildbot/builders/5_x_valgrind-lin64-debug/builds/100060/steps/test_dnn/logs/valgrind%20summary

Related PRs:
- https://github.com/opencv/opencv/pull/24578

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
