### PR TITLE
Add a shape checker for tflite models

### DIFF
--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -58,7 +58,13 @@ void Test_TFLite::testModel(Net& net, const std::string& modelName, const Mat& i
     ASSERT_EQ(outs.size(), outNames.size());
     for (int i = 0; i < outNames.size(); ++i) {
         Mat ref = blobFromNPY(findDataFile(format("dnn/tflite/%s_out_%s.npy", modelName.c_str(), outNames[i].c_str())));
-        normAssert(ref.reshape(1, 1), outs[i].reshape(1, 1), outNames[i].c_str(), l1, lInf);
+        // A workaround solution for the following cases due to inconsistent shape definitions.
+        // The details please see: https://github.com/opencv/opencv/pull/25297#issuecomment-2039081369
+        if (modelName == "face_landmark" || modelName == "selfie_segmentation") {
+            ref = ref.reshape(1, 1);
+            outs[i] = outs[i].reshape(1, 1);
+        }
+        normAssert(ref, outs[i], outNames[i].c_str(), l1, lInf);
     }
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist
This is separate from #25297. The main purpose is to fix the shape checker in tflite tests.


See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
