### PR TITLE
Supress build warnings on Win32 for ARM

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -41,7 +41,7 @@ if(MSVC)
     # and IE deprecated code warning C4996
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4503 /wd4996)
   endif()
-  if(MSVC_VERSION LESS 1920)  # MSVS 2015/2017
+  if((MSVC_VERSION LESS 1920) OR ARM OR AARCH64) # MSVS 2015/2017 on x86 and ARM
     ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4702)  # 'unreachable code'
   endif()
 endif()


### PR DESCRIPTION
### Pull Request Readiness Checklist

<details>
```
2024-04-02T14:45:12.1775805Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbuffer.cpp(93): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1782145Z 
2024-04-02T14:45:12.1786856Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\api\s11n.cpp(144): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1791303Z 
2024-04-02T14:45:12.1796090Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\compiler\gcompiler.cpp(344): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1801287Z 
2024-04-02T14:45:12.1806289Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbackend.cpp(316): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1811120Z 
2024-04-02T14:45:12.1816044Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbackend.cpp(328): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1820876Z 
2024-04-02T14:45:12.1825817Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\executor\gstreamingexecutor.cpp(1833): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1830589Z 
2024-04-02T14:45:12.1835586Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(213): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1840368Z 
2024-04-02T14:45:12.1845351Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(224): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1850135Z 
2024-04-02T14:45:12.1855298Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(401): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1860178Z 
2024-04-02T14:45:12.1865157Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(406): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1869998Z 
2024-04-02T14:45:12.1879417Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(413): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1884363Z 
2024-04-02T14:45:12.1889582Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\test\streaming\gapi_streaming_tests.cpp(330): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_test_gapi.vcxproj]
2024-04-02T14:45:12.1894591Z 
2024-04-02T14:45:12.1899553Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbuffer.cpp(93): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1904378Z 
2024-04-02T14:45:12.1907601Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\api\s11n.cpp(144): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1909376Z 
2024-04-02T14:45:12.1911295Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\compiler\gcompiler.cpp(344): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1913169Z 
2024-04-02T14:45:12.1915181Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbackend.cpp(316): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1917113Z 
2024-04-02T14:45:12.1919120Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\fluid\gfluidbackend.cpp(328): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1921217Z 
2024-04-02T14:45:12.1923232Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\executor\gstreamingexecutor.cpp(1833): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1925176Z 
2024-04-02T14:45:12.1927191Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(213): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1929136Z 
2024-04-02T14:45:12.1931143Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(224): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1933107Z 
2024-04-02T14:45:12.1935104Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(401): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1937047Z 
2024-04-02T14:45:12.1939036Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(406): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1940970Z 
2024-04-02T14:45:12.1942973Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\src\backends\common\serialization.cpp(413): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_gapi.vcxproj]
2024-04-02T14:45:12.1944901Z 
2024-04-02T14:45:12.1946965Z   C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\gapi\test\streaming\gapi_streaming_tests.cpp(330): warning C4702: unreachable code [c:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\gapi\opencv_test_gapi.vcxproj]
```
</details>

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
