### PR TITLE
Removed old C API usage in new findContours implementation

### DIFF
--- a/modules/imgproc/src/contours_new.cpp
+++ b/modules/imgproc/src/contours_new.cpp
@@ -297,7 +297,7 @@ public:
     ~ContourScanner_() {}
     inline bool isInt() const
     {
-        return (this->mode == CV_RETR_FLOODFILL);
+        return (this->mode == RETR_FLOODFILL);
     }
     inline bool isSimple() const
     {
@@ -355,7 +355,7 @@ shared_ptr<ContourScanner_> ContourScanner_::create(Mat img, int mode, int metho
     root.body.brect = Rect(Point(0, 0), size);
     scanner->ctable.fill(-1);
     scanner->approx_method2 = scanner->approx_method1 = method;
-    if (method == CV_CHAIN_APPROX_TC89_L1 || method == CV_CHAIN_APPROX_TC89_KCOS)
+    if (method == CHAIN_APPROX_TC89_L1 || method == CHAIN_APPROX_TC89_KCOS)
         scanner->approx_method1 = CV_CHAIN_CODE;
     return scanner;
 }
@@ -454,7 +454,7 @@ bool ContourScanner_::contourScan(const int prev, int& p, Point& last_pos, const
 
     /* find contour parent */
     int main_parent = -1;
-    if (isSimple() || (!is_hole && (mode == CV_RETR_CCOMP || mode == CV_RETR_FLOODFILL)) ||
+    if (isSimple() || (!is_hole && (mode == RETR_CCOMP || mode == RETR_FLOODFILL)) ||
         last_pos.x <= 0)
     {
         main_parent = 0;

--- a/modules/imgproc/test/test_contours.cpp
+++ b/modules/imgproc/test/test_contours.cpp
@@ -39,7 +39,6 @@
 //
 //M*/
 
-#include "opencv2/imgproc/types_c.h"
 #include "test_precomp.hpp"
 #include <opencv2/highgui.hpp>
 

--- a/modules/imgproc/test/test_contours_new.cpp
+++ b/modules/imgproc/test/test_contours_new.cpp
@@ -2,7 +2,6 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
-#include "opencv2/imgproc/types_c.h"
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 #include "opencv2/imgproc/detail/legacy.hpp"


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/25146

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
