### PR TITLE
core: persistence: use hfloat instead of float16_t

### DIFF
--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1967,13 +1967,13 @@ TEST_P(Core_InputOutput_regression_25073, my_float)
     fs.release();
 }
 
-TEST_P(Core_InputOutput_regression_25073, my_float16)
+TEST_P(Core_InputOutput_regression_25073, my_hfloat)
 {
     cv::String res = "";
-    cv::float16_t my_float16(0.5);
+    cv::hfloat my_hfloat(0.5);
 
     FileStorage fs( GetParam(), cv::FileStorage::WRITE | cv::FileStorage::MEMORY);
-    EXPECT_NO_THROW( fs << "my_float16" << my_float16 );
+    EXPECT_NO_THROW( fs << "my_hfloat" << my_hfloat );
     EXPECT_NO_THROW( fs << "my_int" << 5 );
     EXPECT_NO_THROW( res = fs.releaseAndGetString() );
     EXPECT_NE( res.find("0.5"), String::npos ) << res; // Found "0.5".


### PR DESCRIPTION
Related https://github.com/opencv/opencv/pull/25351
Related https://github.com/opencv/opencv/pull/25387

Use hfloat instead of float16_t.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
