### PR TITLE
imgproc: add 512mb tag for FindContours.accuracy test

### DIFF
--- a/modules/imgproc/test/test_contours.cpp
+++ b/modules/imgproc/test/test_contours.cpp
@@ -408,7 +408,12 @@ _exit_:
     return code;
 }
 
-TEST(Imgproc_FindContours, accuracy) { CV_FindContourTest test; test.safe_run(); }
+TEST(Imgproc_FindContours, accuracy)
+{
+    applyTestTag(CV_TEST_TAG_MEMORY_512MB);
+    CV_FindContourTest test;
+    test.safe_run();
+}
 
 //rotate/flip a quadrant appropriately
 static void rot(int n, int *x, int *y, int rx, int ry)


### PR DESCRIPTION
I've met issues when running `FindContours.accuracy` test (uses old C-API) on a machine with 512Mb memory (RISC-V CanMV K230). While test itself consumes ~400Mb, with the system and other tests' leftovers it often gets killed with OOM error. So I propose to mark this test with `512mb` tag to allow filtering it out on similar devices.

Below is memory consumption on x86_64 machine (GCC 11.4, Release build, with OCL):
![image](https://github.com/opencv/opencv/assets/3304494/637e8d71-84d0-4787-98cd-c09d8bf1411f)

Notes:
- Port to 5.x is not needed - this test will be removed with C-API there.
- Related CI PR: https://github.com/opencv/ci-gha-workflow/pull/165 (see failed checks)
- `free -h` shows `480Mi` _Total memory_ on this machine