### PR TITLE
feat: use numeric dtype for MatLike instead of generic

### DIFF
--- a/modules/core/misc/python/package/mat_wrapper/__init__.py
+++ b/modules/core/misc/python/package/mat_wrapper/__init__.py
@@ -4,15 +4,16 @@ import numpy as np
 import cv2 as cv
 from typing import TYPE_CHECKING, Any
 
-# Same as cv2.typing.NumPyArrayGeneric, but avoids circular dependencies
+# Same as cv2.typing.NumPyArrayNumeric, but avoids circular dependencies
 if TYPE_CHECKING:
-    _NumPyArrayGeneric = np.ndarray[Any, np.dtype[np.generic]]
+    _NumPyArrayNumeric = np.ndarray[Any, np.dtype[np.integer[Any] | np.floating[Any]]]
 else:
-    _NumPyArrayGeneric = np.ndarray
+    _NumPyArrayNumeric = np.ndarray
 
 # NumPy documentation: https://numpy.org/doc/stable/user/basics.subclassing.html
 
-class Mat(_NumPyArrayGeneric):
+
+class Mat(_NumPyArrayNumeric):
     '''
     cv.Mat wrapper for numpy array.
 

--- a/modules/python/src2/typing_stubs_generation/predefined_types.py
+++ b/modules/python/src2/typing_stubs_generation/predefined_types.py
@@ -34,7 +34,10 @@ _PREDEFINED_TYPES = (
     PrimitiveTypeNode.str_("char"),
     PrimitiveTypeNode.str_("String"),
     PrimitiveTypeNode.str_("c_string"),
-    ConditionalAliasTypeNode.numpy_array_("NumPyArrayGeneric"),
+    ConditionalAliasTypeNode.numpy_array_(
+        "NumPyArrayNumeric",
+        dtype="numpy.integer[_typing.Any] | numpy.floating[_typing.Any]"
+    ),
     ConditionalAliasTypeNode.numpy_array_("NumPyArrayFloat32", dtype="numpy.float32"),
     ConditionalAliasTypeNode.numpy_array_("NumPyArrayFloat64", dtype="numpy.float64"),
     NoneTypeNode("void"),
@@ -42,7 +45,7 @@ _PREDEFINED_TYPES = (
     AliasTypeNode.union_(
         "Mat",
         items=(ASTNodeTypeNode("Mat", module_name="cv2.mat_wrapper"),
-               AliasRefTypeNode("NumPyArrayGeneric")),
+               AliasRefTypeNode("NumPyArrayNumeric")),
         export_name="MatLike"
     ),
     AliasTypeNode.sequence_("MatShape", PrimitiveTypeNode.int_()),


### PR DESCRIPTION
closes #24803

`cv2/typing/__init__.py`:
```python
import typing as _typing

if _typing.TYPE_CHECKING:
    NumPyArrayNumeric = numpy.ndarray[_typing.Any, numpy.dtype[numpy.integer[_typing.Any] | numpy.floating[_typing.Any]]]
else:
    NumPyArrayNumeric = numpy.ndarray

MatLike = _typing.Union[cv2.mat_wrapper.Mat, NumPyArrayNumeric]
```

Test file (`test_numeric_ndarray.py`) content:

```python
import numpy as np
import cv2

mask = np.zeros((4, 4), dtype=np.uint8)
contours, hierarchy = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS)
contour = contours[0] * 2
```

`pyproject.toml` content
```toml
[tool.mypy]
strict = true
ignore_missing_imports = true
plugins = [
    "numpy.typing.mypy_plugin"
]
```

```shell
$ mypy test_numeric_ndarray.py
Success: no issues found in 1 source file
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
