### PR TITLE
imgproc: doc: fix arrow symbols in header

### DIFF
--- a/modules/imgproc/doc/colors.markdown
+++ b/modules/imgproc/doc/colors.markdown
@@ -6,8 +6,8 @@ See cv::cvtColor and cv::ColorConversionCodes
 @todo document other conversion modes
 
 @anchor color_convert_rgb_gray
-RGB \emoji arrow_right GRAY
-------------------------------
+RGB <-> GRAY
+------------
 Transformations within RGB space like adding/removing the alpha channel, reversing the channel
 order, conversion to/from 16-bit RGB color (R5:G6:B5 or R5:G5:B5), as well as conversion
 to/from grayscale using:
@@ -22,8 +22,8 @@ More advanced channel reordering can also be done with cv::mixChannels.
 @see cv::COLOR_BGR2GRAY, cv::COLOR_RGB2GRAY, cv::COLOR_GRAY2BGR, cv::COLOR_GRAY2RGB
 
 @anchor color_convert_rgb_xyz
-RGB \emoji arrow_right CIE XYZ.Rec 709 with D65 white point
---------------------------------------------------------------
+RGB <-> CIE XYZ.Rec 709 with D65 white point
+--------------------------------------------
 \f[\begin{bmatrix} X  \\ Y  \\ Z
   \end{bmatrix} \leftarrow \begin{bmatrix} 0.412453 & 0.357580 & 0.180423 \\ 0.212671 & 0.715160 & 0.072169 \\ 0.019334 & 0.119193 & 0.950227
   \end{bmatrix} \cdot \begin{bmatrix} R  \\ G  \\ B
@@ -37,8 +37,8 @@ RGB \emoji arrow_right CIE XYZ.Rec 709 with D65 white point
 @see cv::COLOR_BGR2XYZ, cv::COLOR_RGB2XYZ, cv::COLOR_XYZ2BGR, cv::COLOR_XYZ2RGB
 
 @anchor color_convert_rgb_ycrcb
-RGB \emoji arrow_right YCrCb JPEG (or YCC)
----------------------------------------------
+RGB <-> YCrCb JPEG (or YCC)
+---------------------------
 \f[Y  \leftarrow 0.299  \cdot R + 0.587  \cdot G + 0.114  \cdot B\f]
 \f[Cr  \leftarrow (R-Y)  \cdot 0.713 + delta\f]
 \f[Cb  \leftarrow (B-Y)  \cdot 0.564 + delta\f]
@@ -51,8 +51,8 @@ Y, Cr, and Cb cover the whole value range.
 @see cv::COLOR_BGR2YCrCb, cv::COLOR_RGB2YCrCb, cv::COLOR_YCrCb2BGR, cv::COLOR_YCrCb2RGB
 
 @anchor color_convert_rgb_hsv
-RGB \emoji arrow_right HSV
------------------------------
+RGB <-> HSV
+-----------
 In case of 8-bit and 16-bit images, R, G, and B are converted to the floating-point format and
 scaled to fit the 0 to 1 range.
 
@@ -73,8 +73,8 @@ The values are then converted to the destination data type:
 @see cv::COLOR_BGR2HSV, cv::COLOR_RGB2HSV, cv::COLOR_HSV2BGR, cv::COLOR_HSV2RGB
 
 @anchor color_convert_rgb_hls
-RGB \emoji arrow_right HLS
------------------------------
+RGB <-> HLS
+-----------
 In case of 8-bit and 16-bit images, R, G, and B are converted to the floating-point format and
 scaled to fit the 0 to 1 range.
 
@@ -98,8 +98,8 @@ The values are then converted to the destination data type:
 @see cv::COLOR_BGR2HLS, cv::COLOR_RGB2HLS, cv::COLOR_HLS2BGR, cv::COLOR_HLS2RGB
 
 @anchor color_convert_rgb_lab
-RGB \emoji arrow_right CIE L\*a\*b\*
----------------------------------------
+RGB <-> CIE L\*a\*b\*
+---------------------
 In case of 8-bit and 16-bit images, R, G, and B are converted to the floating-point format and
 scaled to fit the 0 to 1 range.
 
@@ -123,8 +123,8 @@ are then converted to the destination data type:
 @see cv::COLOR_BGR2Lab, cv::COLOR_RGB2Lab, cv::COLOR_Lab2BGR, cv::COLOR_Lab2RGB
 
 @anchor color_convert_rgb_luv
-RGB \emoji arrow_right CIE L\*u\*v\*
----------------------------------------
+RGB <-> CIE L\*u\*v\*
+---------------------
 In case of 8-bit and 16-bit images, R, G, and B are converted to the floating-point format and
 scaled to fit 0 to 1 range.
 
@@ -150,8 +150,8 @@ sources on the web, primarily from the Charles Poynton site <http://www.poynton.
 @see cv::COLOR_BGR2Luv, cv::COLOR_RGB2Luv, cv::COLOR_Luv2BGR, cv::COLOR_Luv2RGB
 
 @anchor color_convert_bayer
-Bayer \emoji arrow_right RGB
----------------------------
+Bayer -> RGB
+------------
 The Bayer pattern is widely used in CCD and CMOS cameras. It enables you to get color pictures
 from a single plane where R, G, and B pixels (sensors of a particular component) are interleaved
 as follows:


### PR DESCRIPTION
Close #25401 

emoji command doesn't work well in section header, so this patch remove it.
( There are no other files which has emoji commands )

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
