### PR TITLE
REPRODUCER: Reshape strange behavior

### DIFF
--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -62,6 +62,12 @@ public:
         const MatShape& inpShape = inputs[0];
         std::cout << "inpShape.size() = " << inpShape << std::endl;
         // std::cout << "paddings: " << paddings << std::endl;
+        if (inpShape.empty()){
+            std::cout << "in the new branch" << std::endl;
+            outputs.resize(1, MatShape(1, paddings.size() + 1));
+            std::cout << "outputs: " << outputs[0] << std::endl;
+            return false;
+        }
         CV_Assert(inpShape.size() >= paddings.size());
 
         CV_Assert(inputDims == -1 || inpShape.size() == inputDims || inpShape.size() > paddings.size());

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -40,6 +40,7 @@ public:
 
         CV_Assert(params.has("paddings"));
         const DictValue& paddingsParam = params.get("paddings");
+        std::cout << (paddingsParam.size() & 1) << std::endl;
         CV_Assert((paddingsParam.size() & 1) == 0);
 
         paddings.resize(paddingsParam.size() / 2);
@@ -57,8 +58,12 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size() == 1);
+        std::cout << "inputs.size() = " << inputs.size() << std::endl;
         const MatShape& inpShape = inputs[0];
+        std::cout << "inpShape.size() = " << inpShape << std::endl;
+        // std::cout << "paddings: " << paddings << std::endl;
         CV_Assert(inpShape.size() >= paddings.size());
+
         CV_Assert(inputDims == -1 || inpShape.size() == inputDims || inpShape.size() > paddings.size());
 
         outputs.resize(1, inpShape);

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -40,7 +40,6 @@ public:
 
         CV_Assert(params.has("paddings"));
         const DictValue& paddingsParam = params.get("paddings");
-        std::cout << (paddingsParam.size() & 1) << std::endl;
         CV_Assert((paddingsParam.size() & 1) == 0);
 
         paddings.resize(paddingsParam.size() / 2);
@@ -58,18 +57,8 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size() == 1);
-        std::cout << "inputs.size() = " << inputs.size() << std::endl;
         const MatShape& inpShape = inputs[0];
-        std::cout << "inpShape.size() = " << inpShape << std::endl;
-        // std::cout << "paddings: " << paddings << std::endl;
-        if (inpShape.empty()){
-            std::cout << "in the new branch" << std::endl;
-            outputs.resize(1, MatShape(1, paddings.size() + 1));
-            std::cout << "outputs: " << outputs[0] << std::endl;
-            return false;
-        }
         CV_Assert(inpShape.size() >= paddings.size());
-
         CV_Assert(inputDims == -1 || inpShape.size() == inputDims || inpShape.size() > paddings.size());
 
         outputs.resize(1, inpShape);

--- a/modules/dnn/test/test_common.impl.hpp
+++ b/modules/dnn/test/test_common.impl.hpp
@@ -79,6 +79,7 @@ void normAssert(
         cv::InputArray ref, cv::InputArray test, const char *comment /*= ""*/,
         double l1 /*= 0.00001*/, double lInf /*= 0.0001*/)
 {
+    std::cout << "ref size: " << ref.size() << std::endl;
     double normL1 = cvtest::norm(ref, test, cv::NORM_L1) / ref.getMat().total();
     EXPECT_LE(normL1, l1) << comment << "  |ref| = " << cvtest::norm(ref, cv::NORM_INF);
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -567,32 +567,53 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Slice_Test,
                 std::vector<int>({1, 4})
 ));
 
-TEST(Layer_Padding_Test, Accuracy){
+typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Padding_Test;
+TEST_P(Layer_Padding_Test, Accuracy_01D){
+
+    std::vector<int> input_shape = get<0>(GetParam());
+    float pad_value = 10;
+
     LayerParams lp;
     lp.type = "Padding";
     lp.name = "PaddingLayer";
-    // std::vector<int>paddings = {1};
-    // lp.set("paddings", DictValue::arrayInt(paddings.begin(), paddings.size()));
     std::vector<int> paddings = {1, 1}; // Pad before and pad after for one dimension
     lp.set("paddings", DictValue::arrayInt(paddings.data(), paddings.size()));
+    lp.set("value", pad_value);
+    lp.set("input_dims", (input_shape.size() == 1) ? -1 : 0);
     Ptr<PaddingLayer> layer = PaddingLayer::create(lp);
 
-    std::vector<int> input_shape = {0};
-    std::vector<int> output_shape = {1};
+    cv::Mat input(input_shape.size(), input_shape.data(), CV_32F);
+    cv::randn(input, 0.0, 1.0);
 
-    cv::Mat input(0, input_shape.data(), CV_32F, 1.0);
-    // cv::randn(input, 0.0, 1.0);
-
-    float data[] = {0, 1, 0};
-    cv::Mat output_ref(output_shape, CV_32F, data);
+    // create a refence
+    cv::Mat output_ref;
+    cv::copyMakeBorder(input, output_ref, 0, 0, 1, 1, 0, (Scalar) pad_value);
+    if (input_shape.size() == 0 || input_shape.size() == 1){
+        std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
+        std::cout << "total: " << output_ref.total() << std::endl;
+        // output_ref = output_ref.reshape(1, {3});
+        output_ref.dims = 1;
+    }
+    std::cout << "input: " << input << std::endl;
+    std::cout << "output_ref: " << output_ref << std::endl;
+    std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
+    std::cout << "output[0]: " << outputs[0] << std::endl;
+    std::cout << "output[0] shape: " << shape(outputs[0]) << std::endl;
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
-
+INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Padding_Test,
+/*input blob shape*/ testing::Values(
+            std::vector<int>{},
+            std::vector<int>{1},
+            std::vector<int>{1, 4},
+            std::vector<int>{4, 1}
+));
 
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -591,11 +591,11 @@ TEST_P(Layer_Padding_Test, Accuracy_01D){
     if (input_shape.size() == 0 || input_shape.size() == 1){
         std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
         std::cout << "total: " << output_ref.total() << std::endl;
-        // output_ref = output_ref.reshape(1, {3});
+        std::cout << "output_ref: " << output_ref.size() << std::endl;
+        output_ref = output_ref.reshape(1, (int)output_ref.total());
         output_ref.dims = 1;
+        std::cout << "output_ref: " << output_ref.size() << std::endl;
     }
-    std::cout << "input: " << input << std::endl;
-    std::cout << "output_ref: " << output_ref << std::endl;
     std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
 
     std::vector<Mat> inputs{input};
@@ -604,6 +604,8 @@ TEST_P(Layer_Padding_Test, Accuracy_01D){
     runLayer(layer, inputs, outputs);
     std::cout << "output[0]: " << outputs[0] << std::endl;
     std::cout << "output[0] shape: " << shape(outputs[0]) << std::endl;
+    std::cout << "output_ref: " << output_ref.size() << std::endl;
+    std::cout << "output[0]: " << outputs[0].size() << std::endl;
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -567,20 +567,11 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Slice_Test,
                 std::vector<int>({1, 4})
 ));
 
-typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_Padding_Test;
-TEST_P(Layer_Padding_Test, Accuracy_01D){
+typedef testing::TestWithParam<tuple<std::vector<int>>> Reproducer_test;
+TEST_P(Reproducer_test, Reshape){
 
     std::vector<int> input_shape = get<0>(GetParam());
     float pad_value = 10;
-
-    LayerParams lp;
-    lp.type = "Padding";
-    lp.name = "PaddingLayer";
-    std::vector<int> paddings = {1, 1}; // Pad before and pad after for one dimension
-    lp.set("paddings", DictValue::arrayInt(paddings.data(), paddings.size()));
-    lp.set("value", pad_value);
-    lp.set("input_dims", (input_shape.size() == 1) ? -1 : 0);
-    Ptr<PaddingLayer> layer = PaddingLayer::create(lp);
 
     cv::Mat input(input_shape.size(), input_shape.data(), CV_32F);
     cv::randn(input, 0.0, 1.0);
@@ -589,33 +580,24 @@ TEST_P(Layer_Padding_Test, Accuracy_01D){
     cv::Mat output_ref;
     cv::copyMakeBorder(input, output_ref, 0, 0, 1, 1, 0, (Scalar) pad_value);
     if (input_shape.size() == 0 || input_shape.size() == 1){
-        std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
-        std::cout << "total: " << output_ref.total() << std::endl;
-        std::cout << "output_ref: " << output_ref.size() << std::endl;
         output_ref = output_ref.reshape(1, (int)output_ref.total());
         output_ref.dims = 1;
-        std::cout << "output_ref: " << output_ref.size() << std::endl;
     }
-    std::cout << "shape output_ref: " << shape(output_ref) << std::endl;
-
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
+    std::vector<int> output_shape = {3};
+    outputs.push_back(cv::Mat(output_shape.size(), output_shape.data(), CV_32F));
 
-    runLayer(layer, inputs, outputs);
-    std::cout << "output[0]: " << outputs[0] << std::endl;
-    std::cout << "output[0] shape: " << shape(outputs[0]) << std::endl;
     std::cout << "output_ref: " << output_ref.size() << std::endl;
     std::cout << "output[0]: " << outputs[0].size() << std::endl;
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
-INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Padding_Test,
+INSTANTIATE_TEST_CASE_P(/*nothing*/,  Reproducer_test,
 /*input blob shape*/ testing::Values(
             std::vector<int>{},
-            std::vector<int>{1},
-            std::vector<int>{1, 4},
-            std::vector<int>{4, 1}
+            std::vector<int>{1}
 ));
 
 }}

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -567,4 +567,32 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Slice_Test,
                 std::vector<int>({1, 4})
 ));
 
+TEST(Layer_Padding_Test, Accuracy){
+    LayerParams lp;
+    lp.type = "Padding";
+    lp.name = "PaddingLayer";
+    // std::vector<int>paddings = {1};
+    // lp.set("paddings", DictValue::arrayInt(paddings.begin(), paddings.size()));
+    std::vector<int> paddings = {1, 1}; // Pad before and pad after for one dimension
+    lp.set("paddings", DictValue::arrayInt(paddings.data(), paddings.size()));
+    Ptr<PaddingLayer> layer = PaddingLayer::create(lp);
+
+    std::vector<int> input_shape = {0};
+    std::vector<int> output_shape = {1};
+
+    cv::Mat input(0, input_shape.data(), CV_32F, 1.0);
+    // cv::randn(input, 0.0, 1.0);
+
+    float data[] = {0, 1, 0};
+    cv::Mat output_ref(output_shape, CV_32F, data);
+
+    std::vector<Mat> inputs{input};
+    std::vector<Mat> outputs;
+
+    runLayer(layer, inputs, outputs);
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    normAssert(output_ref, outputs[0]);
+}
+
+
 }}

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1465,6 +1465,8 @@ double norm(InputArray _src, int normType, InputArray _mask)
 double norm(InputArray _src1, InputArray _src2, int normType, InputArray _mask)
 {
     Mat src1 = _src1.getMat(), src2 = _src2.getMat(), mask = _mask.getMat();
+    std::cout << "scr1 size: " << src1.size << std::endl;
+    std::cout << "scr2 size: " << src2.size << std::endl;
     if( src1.depth() == CV_16F || src1.depth() == CV_16BF )
     {
         Mat src1_32f, src2_32f;
@@ -1502,6 +1504,8 @@ double norm(InputArray _src1, InputArray _src2, int normType, InputArray _mask)
     normType = normType == NORM_L2SQR ? NORM_L2 : normType;
 
     CV_CheckTypeEQ(src1.type(), src2.type(), "");
+    std::cout << "scr1 size: " << src1.size << std::endl;
+    std::cout << "scr2 size: " << src2.size << std::endl;
     CV_Assert(src1.size == src2.size);
     CV_Assert( mask.empty() || (src1.size == mask.size && mask.type() == CV_8U) );
     CV_Assert( normType == NORM_INF || normType == NORM_L1 || normType == NORM_L2 );


### PR DESCRIPTION
This PR a small preproducer that show cases shtrange behavior in `cv::norm` funtion (not to be merged). Matrices with the same shape fail with error : 

```Bash 
 error: (-215:Assertion failed) src1.size == src2.size in function 'norm'
```



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
