### PR TITLE
Fix race condition in InternalFFMpegRegister initialization.

### DIFF
--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -223,7 +223,7 @@ cv::Ptr<cv::IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& fi
 
 } // namespace
 
-
+bool InternalFFMpegRegister::av_log_initialized = false;
 
 //==================================================================================================
 

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -223,7 +223,7 @@ cv::Ptr<cv::IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& fi
 
 } // namespace
 
-bool InternalFFMpegRegister::av_log_initialized = false;
+
 
 //==================================================================================================
 

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -926,11 +926,7 @@ public:
         std::unique_lock<cv::Mutex> lock(_mutex, std::defer_lock);
         if(!threadSafe)
             lock.lock();
-        if(av_log_initialized)
-            return;
         static InternalFFMpegRegister instance;
-        initLogger_();  // update logger setup unconditionally (GStreamer's libav plugin may override these settings)
-        av_log_initialized = true;
     }
     static void initLogger_()
     {
@@ -968,6 +964,7 @@ public:
         /* register a callback function for synchronization */
         av_lockmgr_register(&LockCallBack);
 #endif
+        initLogger_();  // update logger setup unconditionally (GStreamer's libav plugin may override these settings)
     }
     ~InternalFFMpegRegister()
     {
@@ -976,9 +973,6 @@ public:
 #endif
         av_log_set_callback(NULL);
     }
-
-private:
-    static bool av_log_initialized;
 };
 
 inline void fill_codec_context(AVCodecContext * enc, AVDictionary * dict)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -926,8 +926,11 @@ public:
         std::unique_lock<cv::Mutex> lock(_mutex, std::defer_lock);
         if(!threadSafe)
             lock.lock();
+        if(av_log_initialized)
+            return;
         static InternalFFMpegRegister instance;
         initLogger_();  // update logger setup unconditionally (GStreamer's libav plugin may override these settings)
+        av_log_initialized = true;
     }
     static void initLogger_()
     {
@@ -973,6 +976,9 @@ public:
 #endif
         av_log_set_callback(NULL);
     }
+
+private:
+    static bool av_log_initialized;
 };
 
 inline void fill_codec_context(AVCodecContext * enc, AVDictionary * dict)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -964,7 +964,7 @@ public:
         /* register a callback function for synchronization */
         av_lockmgr_register(&LockCallBack);
 #endif
-        initLogger_();  // update logger setup unconditionally (GStreamer's libav plugin may override these settings)
+        initLogger_();
     }
     ~InternalFFMpegRegister()
     {


### PR DESCRIPTION
initLogger_ does not check if the logger has been initizalized before and it might initialize it several times from different threads, racing with other threads that are logging.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work