### PR TITLE
0/1D test for `BatchNorm` layer

### DIFF
--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -280,22 +280,11 @@ public:
         if (inputs[0].dims <= 1) { // Handling for 0D and 1D
             Mat &inpBlob = inputs[0];
             Mat &outBlob = outputs[0];
-
-            if (inputs[0].dims == 0) {  // Scalar input
-                float inpVal = inputs[0].at<float>();
-                float outVal = inpVal * weights_.at<float>(0) + bias_.at<float>(0);
-                outBlob.at<float>(0) = outVal;
-            } else {  // Vector input
-                for (int i = 0; i < inpBlob.size[0]; i++) {
-                    float inpVal = inpBlob.at<float>(i);
-                    float outVal = inpVal * weights_.at<float>(i) + bias_.at<float>(i);
-                    outBlob.at<float>(i) = outVal;
-                }
-            }
+            CV_Assert(inpBlob.total() == weights_.total());
+            cv::multiply(inpBlob, weights_, outBlob);
+            cv::add(outBlob, bias_, outBlob);
             return;
         }
-
-
 
         CV_Assert(blobs.size() >= 2);
         CV_Assert(inputs.size() == 1);

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -163,10 +163,18 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
+        if (inputs[0].empty()) { // Support for 0D input
+            outputs.push_back(MatShape()); // Output is also a scalar.
+            std::cout << "output shape: " << outputs[0] << std::endl;
+            return true;
+        }
+
         dims = inputs[0].size();
         if (!useGlobalStats && inputs[0][0] != 1)
             CV_Error(Error::StsNotImplemented, "Batch normalization in training mode with batch size > 1");
         Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        std::cout << "input shape: " << inputs[0] << std::endl;
+        std::cout << "output shape: " << outputs[0] << std::endl;
         return true;
     }
 
@@ -272,6 +280,40 @@ public:
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);
 
+        if (inputs[0].dims <= 1) { // Handling for 0D and 1D
+            Mat &inpBlob = inputs[0];
+            Mat &outBlob = outputs[0];
+
+            // float w = (hasWeights ? weights_.at<float>(0) : 1.0f);  // Use first weight or default to 1 if not present
+            // float b = (hasBias ? bias_.at<float>(0) : 0.0f);        // Use first bias or default to 0 if not present
+
+            // float w = weights_.at<float>(0);  // Use first weight or default to 1 if not present
+            // float b = bias_.at<float>(0);        // Use first bias or default to 0 if not present
+
+            // if (inpBlob.dims == 0) {  // Scalar input
+            //     float inpVal = inpBlob.at<float>();
+            //     float outVal = inpVal * w + b;
+            //     outBlob.create(1, &outVal, inpBlob.type());
+            // } else {  // Vector input
+            // inpBlob.convertTo(outBlob, inpBlob.type(), w, b);
+            // }
+
+            if (inputs[0].dims == 0) {  // Scalar input
+                float inpVal = inputs[0].at<float>();
+                float outVal = inpVal * weights_.at<float>(0) + bias_.at<float>(0);
+                outBlob.at<float>(0) = outVal;
+            } else {  // Vector input
+                for (int i = 0; i < inpBlob.size[0]; i++) {
+                    float inpVal = inpBlob.at<float>(i);
+                    float outVal = inpVal * weights_.at<float>(i) + bias_.at<float>(i);
+                    outBlob.at<float>(i) = outVal;
+                }
+            }
+            return;
+        }
+
+
+
         CV_Assert(blobs.size() >= 2);
         CV_Assert(inputs.size() == 1);
 
@@ -280,10 +322,14 @@ public:
         for (size_t i = 2; i < inpBlob.dims; i++) {
             planeSize *= inpBlob.size[i];
         }
+        std::cout << "planeSize: " << planeSize << std::endl;
+        std::cout << "outpus size: " << outputs.size() << std::endl;
 
         for (size_t ii = 0; ii < outputs.size(); ii++)
         {
             Mat &outBlob = outputs[ii];
+            std::cout << "outBlob shape: " << shape(outBlob) << std::endl;
+            std::cout << "outBlob size: " << outBlob.size << std::endl;
 
             for(int num = 0; num < outBlob.size[0]; num++)
             {

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -165,7 +165,6 @@ public:
     {
         if (inputs[0].empty()) { // Support for 0D input
             outputs.push_back(MatShape()); // Output is also a scalar.
-            std::cout << "output shape: " << outputs[0] << std::endl;
             return true;
         }
 
@@ -173,8 +172,6 @@ public:
         if (!useGlobalStats && inputs[0][0] != 1)
             CV_Error(Error::StsNotImplemented, "Batch normalization in training mode with batch size > 1");
         Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
-        std::cout << "input shape: " << inputs[0] << std::endl;
-        std::cout << "output shape: " << outputs[0] << std::endl;
         return true;
     }
 
@@ -284,20 +281,6 @@ public:
             Mat &inpBlob = inputs[0];
             Mat &outBlob = outputs[0];
 
-            // float w = (hasWeights ? weights_.at<float>(0) : 1.0f);  // Use first weight or default to 1 if not present
-            // float b = (hasBias ? bias_.at<float>(0) : 0.0f);        // Use first bias or default to 0 if not present
-
-            // float w = weights_.at<float>(0);  // Use first weight or default to 1 if not present
-            // float b = bias_.at<float>(0);        // Use first bias or default to 0 if not present
-
-            // if (inpBlob.dims == 0) {  // Scalar input
-            //     float inpVal = inpBlob.at<float>();
-            //     float outVal = inpVal * w + b;
-            //     outBlob.create(1, &outVal, inpBlob.type());
-            // } else {  // Vector input
-            // inpBlob.convertTo(outBlob, inpBlob.type(), w, b);
-            // }
-
             if (inputs[0].dims == 0) {  // Scalar input
                 float inpVal = inputs[0].at<float>();
                 float outVal = inpVal * weights_.at<float>(0) + bias_.at<float>(0);
@@ -322,15 +305,10 @@ public:
         for (size_t i = 2; i < inpBlob.dims; i++) {
             planeSize *= inpBlob.size[i];
         }
-        std::cout << "planeSize: " << planeSize << std::endl;
-        std::cout << "outpus size: " << outputs.size() << std::endl;
 
         for (size_t ii = 0; ii < outputs.size(); ii++)
         {
             Mat &outBlob = outputs[ii];
-            std::cout << "outBlob shape: " << shape(outBlob) << std::endl;
-            std::cout << "outBlob size: " << outBlob.size << std::endl;
-
             for(int num = 0; num < outBlob.size[0]; num++)
             {
                 for (int n = 0; n < outBlob.size[1]; n++)

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -617,59 +617,25 @@ TEST_P(Layer_BatchNorm_Test, Accuracy_01D)
     lp.set("has_weight", has_weight);
     lp.set("has_bias", has_bias);
 
-    // Set the mean and variance
-    // vector<float> mean = {0.5f};
-    // vector<float> variance = {0.5f};
-    // Mat meanMat(1, mean.size(), CV_32F, mean.data());
-    // Mat varMat(1, variance.size(), CV_32F, variance.data());
     Mat meanMat(input_shape.size(), input_shape.data(), CV_32F, 0.5);
     Mat varMat(input_shape.size(), input_shape.data(), CV_32F, 0.5);
     vector<Mat> blobs = {meanMat, varMat};
-    std::cout << "meanMat: " << meanMat << std::endl;
-    std::cout << "varMat: " << varMat << std::endl;
-
-    // Mat weights, bias;
-    // if (has_weight) {
-    //     weights = Mat(1, mean.size(), CV_32F, 1);
-    //     blobs.push_back(weights);
-    // }
-    // if (has_bias) {
-    //     bias = Mat(1, mean.size(), CV_32F, 0);
-    //     blobs.push_back(bias);
-    // }
     lp.blobs = blobs;
 
     // Create the layer
     Ptr<Layer> layer = BatchNormLayer::create(lp);
 
     Mat input(input_shape.size(), input_shape.data(), CV_32F, 1.0);
-    // cv::randn(input, 0, 1);
-    std::cout << "input: " << input << std::endl;
-    // Mat output_ref = input.reshape(1, 1) * weights;
-    // output_ref.dims = 1;
+    cv::randn(input, 0, 1);
 
-    std::cout << "here" << std::endl;
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-
-    std::cout << "+++++++++++++++" << std::endl;
-    std::cout << "outputs: " << outputs[0] << std::endl;
-    std::cout << "outputs[0] shape" << shape(outputs[0]) << std::endl;
-    std::cout << "outputs[0] size" << outputs[0].size() << std::endl;
-    std::cout << "outputs[0] type" << outputs[0].type() << std::endl;
 
     //create output_ref to compare with outputs
     Mat output_ref = input.clone();
     cv::sqrt(varMat + 1e-5, varMat);
     output_ref = (output_ref - meanMat) / varMat;
-
-    std::cout << "output_ref: " << output_ref << std::endl;
-    std::cout << "output_ref shape" << shape(output_ref) << std::endl;
-    std::cout << "output_ref size" << output_ref.size() << std::endl;
-    std::cout << "output_ref type" << output_ref.type() << std::endl;
-    std::cout << "+++++++++++++++" << std::endl;
-
 
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
@@ -682,7 +648,6 @@ INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_BatchNorm_Test,
                             std::vector<int>({4}),
                             std::vector<int>({1, 4}),
                             std::vector<int>({4, 1})
-
 ));
 
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -603,22 +603,23 @@ INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
                             std::vector<int>({4})
 ));
 
-typedef testing::TestWithParam<tuple<std::vector<int>>> Layer_BatchNorm_Test;
+typedef testing::TestWithParam<std::vector<int>> Layer_BatchNorm_Test;
 TEST_P(Layer_BatchNorm_Test, Accuracy_01D)
 {
-    std::vector<int> input_shape = get<0>(GetParam());
-    bool has_weight = false;
-    bool has_bias = false;
+    std::vector<int> input_shape = GetParam();
 
     // Layer parameters
     LayerParams lp;
     lp.type = "BatchNorm";
     lp.name = "BatchNormLayer";
-    lp.set("has_weight", has_weight);
-    lp.set("has_bias", has_bias);
+    lp.set("has_weight", false);
+    lp.set("has_bias", false);
 
-    Mat meanMat(input_shape.size(), input_shape.data(), CV_32F, 0.5);
-    Mat varMat(input_shape.size(), input_shape.data(), CV_32F, 0.5);
+    RNG& rng = TS::ptr()->get_rng();
+    float inp_value = rng.uniform(0.0, 10.0);
+
+    Mat meanMat(input_shape.size(), input_shape.data(), CV_32F, inp_value);
+    Mat varMat(input_shape.size(), input_shape.data(), CV_32F, inp_value);
     vector<Mat> blobs = {meanMat, varMat};
     lp.blobs = blobs;
 


### PR DESCRIPTION
This PR introduces support for 0/1D inputs in `BatchNorm` layer. 


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
