### PR TITLE
Make finding corner neighbor symmetrical in ChessBoardDetector::findQuadNeighbors

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -227,7 +227,7 @@ public:
         std::vector<int> neighbors_indices;
         std::vector<float> neighbors_dists;
         std::vector<Point2f> all_quads_pts;
-        Ptr<flann::GenericIndex<flann::L2_Simple<float>>> p_all_quads_pts_index;
+        flann::GenericIndex<flann::L2_Simple<float>> all_quads_pts_index;
 
         NeighborsFinder(ChessBoardDetector& detector);
 
@@ -491,20 +491,27 @@ static void icvBinarizationHistogramBased(Mat & img)
     }
 }
 
-ChessBoardDetector::NeighborsFinder::NeighborsFinder(ChessBoardDetector& _detector): detector(_detector) {
-    const int all_corners_count = detector.all_quads_count * 4;
-    neighbors_indices.resize(all_corners_count);
-    neighbors_dists.resize(all_corners_count);
-    all_quads_pts.reserve(all_corners_count);
-    for (int idx = 0; idx < detector.all_quads_count; idx++)
+static std::vector<Point2f> getCornersFromQuads(ChessBoardQuad* p_all_quads, const int all_quads_count)
+{
+    std::vector<Point2f> all_quads_pts;
+    all_quads_pts.reserve(all_quads_count * 4);
+    for (int idx = 0; idx < all_quads_count; idx++)
     {
-        const ChessBoardQuad& cur_quad = (const ChessBoardQuad&)detector.all_quads[idx];
+        const ChessBoardQuad& cur_quad = (const ChessBoardQuad&)p_all_quads[idx];
         for (int i = 0; i < 4; i++)
             all_quads_pts.push_back(cur_quad.corners[i]->pt);
     }
-    const cvflann::KDTreeSingleIndexParams index_params;
-    p_all_quads_pts_index = makePtr<flann::GenericIndex<flann::L2_Simple<float>>>
-                            (Mat(all_quads_pts).reshape(1, all_corners_count), index_params);
+    return all_quads_pts;
+}
+
+ChessBoardDetector::NeighborsFinder::NeighborsFinder(ChessBoardDetector& _detector) :
+    detector(_detector),
+    all_quads_pts(getCornersFromQuads(detector.all_quads.data(), detector.all_quads_count)),
+    all_quads_pts_index(Mat(all_quads_pts).reshape(1, detector.all_quads_count * 4), cvflann::KDTreeSingleIndexParams())
+{
+    const int all_corners_count = detector.all_quads_count * 4;
+    neighbors_indices.resize(all_corners_count);
+    neighbors_dists.resize(all_corners_count);
 }
 
 bool ChessBoardDetector::NeighborsFinder::findCornerNeighbor(
@@ -517,14 +524,13 @@ bool ChessBoardDetector::NeighborsFinder::findCornerNeighbor(
     cv::Point2f& closest_corner_pt)
 {
     ChessBoardQuad* p_all_quads = detector.all_quads.data();
-    flann::GenericIndex<flann::L2_Simple<float>>& all_quads_pts_index = *p_all_quads_pts_index;
 
     const ChessBoardQuad& cur_quad = (const ChessBoardQuad&)p_all_quads[idx];
     int closest_neighbor_idx = -1;
     ChessBoardQuad *closest_quad = 0;
 
     // find the closest corner in all other quadrangles
-    const std::vector<float> query = Mat(pt);
+    const std::vector<float> query = { pt.x, pt.y };
     const cvflann::SearchParams search_params(-1);
     const int neighbors_count = all_quads_pts_index.radiusSearch(query, neighbors_indices, neighbors_dists, radius, search_params);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

The basic idea of finding pair of corners neighbors is to find best candidate for first corner and check if first corner quite good candidate for its best candidate. And we test first corner for its best candidate less than best candidate for first corner.

Idea of changes is to make finding corner neighbor symmetrical - find best candidate for first corner, find best candidate for second corner and match them as pair iff they are both best candidates for each other.

Additional advantage - it simplifies code and removes some code duplication.

I tested this PR with benchmark
```
python3 objdetect_benchmark.py --configuration=generate_run --board_x=7 --path=res_chessboard --synthetic_object=chessboard
```

There are minor changes in results
```
cell_img_size = 100 (default)

before

                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                          _none_none_blur             1.000000                        360               360                           0.630345
                    _none_none_gaussNoise             0.833333                        300               360                           0.623405
                          _none_none_none             1.000000                        360               360                           0.631517
                    _none_none_strongBlur             1.000000                        360               360                           0.630316
                   _none_undistorted_blur             1.000000                        360               360                           0.671232
             _none_undistorted_gaussNoise             1.000000                        360               360                           0.672619
                   _none_undistorted_none             1.000000                        360               360                           0.673669
             _none_undistorted_strongBlur             1.000000                        360               360                           0.671257
                   _perspective_none_blur             1.000000                       1080              1080                           0.588694
             _perspective_none_gaussNoise             0.805556                        870              1080                           0.599312
                   _perspective_none_none             1.000000                       1080              1080                           0.591063
             _perspective_none_strongBlur             1.000000                       1080              1080                           0.588604
            _perspective_undistorted_blur             1.000000                       1080              1080                           0.622081
      _perspective_undistorted_gaussNoise             1.000000                       1080              1080                           0.625704
            _perspective_undistorted_none             1.000000                       1080              1080                           0.624191
      _perspective_undistorted_strongBlur             1.000000                       1080              1080                           0.621618
             _strongPerspective_none_blur             1.000000                        360               360                           0.482934
       _strongPerspective_none_gaussNoise             0.166667                         60               360                           0.391551
             _strongPerspective_none_none             1.000000                        360               360                           0.480290
       _strongPerspective_none_strongBlur             0.333333                        120               360                           0.469080
      _strongPerspective_undistorted_blur             1.000000                        360               360                           0.503458
_strongPerspective_undistorted_gaussNoise             0.250000                         90               360                           0.448713
      _strongPerspective_undistorted_none             1.000000                        360               360                           0.504412
_strongPerspective_undistorted_strongBlur             0.166667                         60               360                           0.473791
                                      all             0.904167                      13020             14400                           0.600512
Total detected time:  139.65614900000008 sec

after

                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                          _none_none_blur             1.000000                        360               360                           0.630345
                    _none_none_gaussNoise             0.750000                        270               360                           0.636279
                          _none_none_none             1.000000                        360               360                           0.631517
                    _none_none_strongBlur             1.000000                        360               360                           0.630316
                   _none_undistorted_blur             1.000000                        360               360                           0.671232
             _none_undistorted_gaussNoise             1.000000                        360               360                           0.672619
                   _none_undistorted_none             1.000000                        360               360                           0.673669
             _none_undistorted_strongBlur             1.000000                        360               360                           0.671257
                   _perspective_none_blur             1.000000                       1080              1080                           0.588694
             _perspective_none_gaussNoise             0.888889                        960              1080                           0.594106
                   _perspective_none_none             1.000000                       1080              1080                           0.591064
             _perspective_none_strongBlur             1.000000                       1080              1080                           0.588604
            _perspective_undistorted_blur             1.000000                       1080              1080                           0.622081
      _perspective_undistorted_gaussNoise             1.000000                       1080              1080                           0.625703
            _perspective_undistorted_none             1.000000                       1080              1080                           0.624191
      _perspective_undistorted_strongBlur             1.000000                       1080              1080                           0.621618
             _strongPerspective_none_blur             1.000000                        360               360                           0.482934
       _strongPerspective_none_gaussNoise             0.166667                         60               360                           0.391551
             _strongPerspective_none_none             1.000000                        360               360                           0.480290
       _strongPerspective_none_strongBlur             0.333333                        120               360                           0.469080
      _strongPerspective_undistorted_blur             1.000000                        360               360                           0.503458
_strongPerspective_undistorted_gaussNoise             0.333333                        120               360                           0.422259
      _strongPerspective_undistorted_none             1.000000                        360               360                           0.504412
_strongPerspective_undistorted_strongBlur             0.166667                         60               360                           0.473791
                                      all             0.910417                      13110             14400                           0.599746
Total detected time:  142.40333700000005 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 10

before

                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                          _none_none_blur             0.991667                        357               360                           4.905091
                    _none_none_gaussNoise             0.750000                        270               360                           5.215633
                          _none_none_none             1.000000                        360               360                           4.943304
                    _none_none_strongBlur             0.916667                        330               360                           3.806217
                   _none_undistorted_blur             0.994444                        358               360                           5.220915
             _none_undistorted_gaussNoise             0.997222                        359               360                           4.542443
                   _none_undistorted_none             0.997222                        359               360                           4.340208
             _none_undistorted_strongBlur             0.161111                         58               360                           5.024331
                   _perspective_none_blur             0.629630                        680              1080                           4.825401
             _perspective_none_gaussNoise             0.966667                       1044              1080                           3.895425
                   _perspective_none_none             0.971296                       1049              1080                           3.920378
             _perspective_none_strongBlur             0.000000                          0              1080                                NaN
            _perspective_undistorted_blur             0.583333                        630              1080                           4.594335
      _perspective_undistorted_gaussNoise             0.999074                       1079              1080                           3.553195
            _perspective_undistorted_none             0.750000                        810              1080                           3.604110
      _perspective_undistorted_strongBlur             0.000000                          0              1080                                NaN
             _strongPerspective_none_blur             0.000000                          0               360                                NaN
       _strongPerspective_none_gaussNoise             0.000000                          0               360                                NaN
             _strongPerspective_none_none             0.083333                         30               360                           2.382460
       _strongPerspective_none_strongBlur             0.000000                          0               360                                NaN
      _strongPerspective_undistorted_blur             0.000000                          0               360                                NaN
_strongPerspective_undistorted_gaussNoise             0.000000                          0               360                                NaN
      _strongPerspective_undistorted_none             0.000000                          0               360                                NaN
_strongPerspective_undistorted_strongBlur             0.000000                          0               360                                NaN
                                      all             0.539792                       7773             14400                           4.209964
Total detected time:  2.6968930000000015 sec

after

                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                          _none_none_blur             0.991667                        357               360                           4.905091
                    _none_none_gaussNoise             0.750000                        270               360                           5.215633
                          _none_none_none             1.000000                        360               360                           4.943304
                    _none_none_strongBlur             0.916667                        330               360                           3.806217
                   _none_undistorted_blur             0.994444                        358               360                           5.220915
             _none_undistorted_gaussNoise             0.997222                        359               360                           4.542443
                   _none_undistorted_none             0.997222                        359               360                           4.340208
             _none_undistorted_strongBlur             0.161111                         58               360                           5.024331
                   _perspective_none_blur             0.629630                        680              1080                           4.825401
             _perspective_none_gaussNoise             0.966667                       1044              1080                           3.895425
                   _perspective_none_none             0.999074                       1079              1080                           3.865684
             _perspective_none_strongBlur             0.000000                          0              1080                                NaN
            _perspective_undistorted_blur             0.583333                        630              1080                           4.594335
      _perspective_undistorted_gaussNoise             0.999074                       1079              1080                           3.553195
            _perspective_undistorted_none             0.750000                        810              1080                           3.604110
      _perspective_undistorted_strongBlur             0.000000                          0              1080                                NaN
             _strongPerspective_none_blur             0.000000                          0               360                                NaN
       _strongPerspective_none_gaussNoise             0.000000                          0               360                                NaN
             _strongPerspective_none_none             0.000000                          0               360                                NaN
       _strongPerspective_none_strongBlur             0.000000                          0               360                                NaN
      _strongPerspective_undistorted_blur             0.000000                          0               360                                NaN
_strongPerspective_undistorted_gaussNoise             0.000000                          0               360                                NaN
      _strongPerspective_undistorted_none             0.000000                          0               360                                NaN
_strongPerspective_undistorted_strongBlur             0.000000                          0               360                                NaN
                                      all             0.539792                       7773             14400                           4.208308
Total detected time:  2.7706419999999983 sec
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
