### PR TITLE
5.x core: sync changes that drop some member functions in class hfloat

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -822,26 +822,6 @@ public:
     hfloat() : h(0) {}
     explicit hfloat(float x) { h = (__fp16)x; }
     operator float() const { return (float)h; }
-    static hfloat fromBits(ushort w)
-    {
-        Cv16suf u;
-        u.u = w;
-        hfloat result;
-        result.h = u.h;
-        return result;
-    }
-    static hfloat zero()
-    {
-        hfloat result;
-        result.h = (__fp16)0;
-        return result;
-    }
-    ushort bits() const
-    {
-        Cv16suf u;
-        u.h = h;
-        return u.u;
-    }
 protected:
     __fp16 h;
 
@@ -898,14 +878,6 @@ protected:
     #endif
     }
 
-    static hfloat zero()
-    {
-        hfloat result;
-        result.w = (ushort)0;
-        return result;
-    }
-
-    ushort bits() const { return w; }
 protected:
     ushort w;
 


### PR DESCRIPTION
Sync changes that are missed in the last 4.x->5.x merge.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
