### PR TITLE
Add logs of test failure to `test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp`

### DIFF
--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -1005,9 +1005,7 @@ CASE(test_maxpool_3d_default)
     SKIP_NON_CPU;
 #endif
 CASE(test_maxpool_with_argmax_2d_precomputed_pads)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_maxpool_with_argmax_2d_precomputed_strides)
 #if SKIP_SET_1
     SKIP;

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -1,19 +1,19 @@
-"test_add_uint8",  // output type mismatch
-"test_averagepool_2d_pads_count_include_pad",
-"test_averagepool_2d_precomputed_pads_count_include_pad",
-"test_averagepool_2d_same_lower",
-"test_cast_FLOAT_to_STRING",
-"test_cast_STRING_to_FLOAT",
-"test_castlike_FLOAT_to_STRING_expanded",
-"test_castlike_STRING_to_FLOAT_expanded",
-"test_concat_1d_axis_negative_1", // 1d support is required
-"test_div_uint8",  // output type mismatch //FAILS
-"test_maxpool_2d_dilations", //FAILS
-"test_maxpool_2d_same_lower", //FAILS
-"test_maxpool_2d_uint8",  // output type mismatch //FAILS
-"test_maxpool_with_argmax_2d_precomputed_pads",
-"test_maxpool_with_argmax_2d_precomputed_strides",
-"test_maxunpool_export_with_output_shape",  // exception during net.forward() call
+"test_add_uint8", // output size mismatch in NORMASSERT
+"test_averagepool_2d_pads_count_include_pad",  // wrong output
+"test_averagepool_2d_precomputed_pads_count_include_pad", // wrong output
+"test_averagepool_2d_same_lower", // wrong output
+"test_cast_FLOAT_to_STRING", // Unsupported type in function 'parseCast'
+"test_cast_STRING_to_FLOAT", // unexception during net.forward() call
+"test_castlike_FLOAT_to_STRING_expanded", // Unsupported type in function 'parseCast'
+"test_castlike_STRING_to_FLOAT_expanded", // unexception during net.forward() call
+// "test_concat_1d_axis_negative_1",
+"test_div_uint8",  // output type mismatch
+"test_maxpool_2d_dilations", // output size mismatch in NORMASSERT
+"test_maxpool_2d_same_lower", // wrong output
+"test_maxpool_2d_uint8",  // output type mismatch
+// "test_maxpool_with_argmax_2d_precomputed_pads",
+"test_maxpool_with_argmax_2d_precomputed_strides", // wrong output
+"test_maxunpool_export_with_output_shape",  // unexception during net.forward() call
 "test_mul_uint8",  // output type mismatch
 "test_sub_uint8",  // output type mismatch
-"test_upsample_nearest",
+"test_upsample_nearest", // Dimension mismatch of input

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -6,12 +6,10 @@
 "test_cast_STRING_to_FLOAT", // unexception during net.forward() call
 "test_castlike_FLOAT_to_STRING_expanded", // Unsupported type in function 'parseCast'
 "test_castlike_STRING_to_FLOAT_expanded", // unexception during net.forward() call
-// "test_concat_1d_axis_negative_1",
 "test_div_uint8",  // output type mismatch
 "test_maxpool_2d_dilations", // output size mismatch in NORMASSERT
 "test_maxpool_2d_same_lower", // wrong output
 "test_maxpool_2d_uint8",  // output type mismatch
-// "test_maxpool_with_argmax_2d_precomputed_pads",
 "test_maxpool_with_argmax_2d_precomputed_strides", // wrong output
 "test_maxunpool_export_with_output_shape",  // unexception during net.forward() call
 "test_mul_uint8",  // output type mismatch

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -7,10 +7,10 @@
 "test_castlike_FLOAT_to_STRING_expanded",
 "test_castlike_STRING_to_FLOAT_expanded",
 "test_concat_1d_axis_negative_1", // 1d support is required
-"test_div_uint8",  // output type mismatch
-"test_maxpool_2d_dilations",
-"test_maxpool_2d_same_lower",
-"test_maxpool_2d_uint8",  // output type mismatch
+"test_div_uint8",  // output type mismatch //FAILS
+"test_maxpool_2d_dilations", //FAILS
+"test_maxpool_2d_same_lower", //FAILS
+"test_maxpool_2d_uint8",  // output type mismatch //FAILS
 "test_maxpool_with_argmax_2d_precomputed_pads",
 "test_maxpool_with_argmax_2d_precomputed_strides",
 "test_maxunpool_export_with_output_shape",  // exception during net.forward() call


### PR DESCRIPTION
### Pull Request Readiness Checklist

This PR add logs to test failures to  `test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp` and it continuation of #25442

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
