### PR TITLE
Fixed build warnings introduced in #24938

### DIFF
--- a/modules/gapi/src/backends/ov/govbackend.cpp
+++ b/modules/gapi/src/backends/ov/govbackend.cpp
@@ -151,7 +151,7 @@ static void copyFromOV(const ov::Tensor &tensor, cv::Mat &mat) {
     }
 }
 
-cv::Mat wrapOV(const cv::MediaFrame::View& view,
+static cv::Mat wrapOV(const cv::MediaFrame::View& view,
                const cv::GFrameDesc& desc) {
     cv::Mat out;
     switch (desc.fmt) {
@@ -782,10 +782,10 @@ static cv::Mat preprocess(const cv::Mat     &in_mat,
 
 // NB: This function is used to preprocess input image
 // for InferROI, InferList, InferList2 kernels.
-cv::Mat preprocess(MediaFrame::View&     view,
-                   const cv::GFrameDesc& desc,
-                   const cv::Rect&       roi,
-                   const ::ov::Shape     &model_shape) {
+static cv::Mat preprocess(MediaFrame::View&     view,
+                          const cv::GFrameDesc& desc,
+                          const cv::Rect&       roi,
+                          const ::ov::Shape     &model_shape) {
     return preprocess(wrapOV(view, desc), roi, model_shape);
 }
 
@@ -805,6 +805,7 @@ static void preprocess_and_copy(std::shared_ptr<OVCallContext> ctx,
             auto view = cv::MediaFrame::View(currentFrame.access(cv::MediaFrame::Access::R));
             auto roi_mat = preprocess(view, currentFrame.desc(), roi, model_shape);
             copyToOV(roi_mat, tensor);
+            break;
         }
         default:
             GAPI_Assert("Unsupported input shape for OV backend");


### PR DESCRIPTION
Related patch: https://github.com/opencv/opencv/pull/24938

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
