### PR TITLE
Additional fixes to 0/1D tests

### DIFF
--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -457,11 +457,12 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
 
     cv::Mat srcMat = src.getMat();
     axis = (axis + srcMat.dims) % srcMat.dims;
-    CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis < srcMat.dims);
+    CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
 
     std::vector<int> sizes(srcMat.dims);
     std::copy(srcMat.size.p, srcMat.size.p + srcMat.dims, sizes.begin());
-    sizes[axis] = 1;
+    if(!sizes.empty())
+        sizes[axis] = 1;
 
     dst.create(srcMat.dims, sizes.data(), CV_32SC1); // indices
     cv::Mat dstMat = dst.getMat();

--- a/modules/core/src/minmax.dispatch.cpp
+++ b/modules/core/src/minmax.dispatch.cpp
@@ -456,7 +456,8 @@ static void reduceMinMax(cv::InputArray src, cv::OutputArray dst, ReduceMode mod
     CV_INSTRUMENT_REGION();
 
     cv::Mat srcMat = src.getMat();
-    axis = (axis + srcMat.dims) % srcMat.dims;
+    int dims = std::max(1, srcMat.dims);
+    axis = (axis + dims) % dims;
     CV_Assert(srcMat.channels() == 1 && axis >= 0 && axis <= srcMat.dims);
 
     std::vector<int> sizes(srcMat.dims);

--- a/modules/dnn/src/layers/arg_layer.cpp
+++ b/modules/dnn/src/layers/arg_layer.cpp
@@ -66,7 +66,8 @@ public:
         MatShape inpShape = inputs[0];
 
         const int axis_ = normalize_axis(axis, inpShape);
-        handleKeepDims(inpShape, axis_);
+        if (!inpShape.empty())
+            handleKeepDims(inpShape, axis_);
         outputs.assign(1, inpShape);
 
         return false;

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -191,6 +191,10 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size() >= 2);
+        if (inputs[0].size() == 0){
+            outputs.assign(1, inputs[0]);
+            return false;
+        }
         CV_Assert(inputs[0].size() >= 1);
         CV_Assert(coeffs.size() == 0 || coeffs.size() == inputs.size());
         CV_Assert(op == SUM || coeffs.size() == 0);
@@ -310,13 +314,13 @@ public:
                         int nstripes)
         {
             const EltwiseOp op = self.op;
-            CV_Check(dst.dims, 1 <= dst.dims && dst.dims <= 5, "");
+            CV_Check(dst.dims, 0 <= dst.dims && dst.dims <= 5, "");
             CV_CheckTypeEQ(dst.type(), CV_32FC1, "");
             CV_Assert(dst.isContinuous());
             CV_Assert(self.coeffs.empty() || self.coeffs.size() == (size_t)nsrcs);
             CV_CheckGE(nsrcs, 2, "");
 
-            if (dst.dims != 1)
+            if (dst.dims > 1)
                 CV_Assert(self.outputChannels == dst.size[1]);
 
             EltwiseInvoker p(self);

--- a/modules/dnn/src/layers/gather_layer.cpp
+++ b/modules/dnn/src/layers/gather_layer.cpp
@@ -30,12 +30,16 @@ public:
     {
         CV_CheckEQ(inputs.size(), 2ull, "");
         MatShape inpShape = inputs[0];
+        if (inpShape.size() == 0  || inpShape.size() == 1){
+            outputs.assign(1, inpShape);
+            return false;
+        }
+
         const int axis = normalize_axis(m_axis, inpShape);
 
         inpShape.erase(inpShape.begin() + axis);
         auto end = m_real_ndims == -1 ? inputs[1].end() : inputs[1].begin() + m_real_ndims;
         inpShape.insert(inpShape.begin() + axis, inputs[1].begin(), end);
-
         outputs.assign(1, inpShape);
         return false;
     }

--- a/modules/dnn/src/layers/gather_layer.cpp
+++ b/modules/dnn/src/layers/gather_layer.cpp
@@ -30,7 +30,7 @@ public:
     {
         CV_CheckEQ(inputs.size(), 2ull, "");
         MatShape inpShape = inputs[0];
-        if (inpShape.size() == 0  || inpShape.size() == 1){
+        if (inpShape.size() == 0 ){
             outputs.assign(1, inpShape);
             return false;
         }

--- a/modules/dnn/test/test_common.cpp
+++ b/modules/dnn/test/test_common.cpp
@@ -12,21 +12,24 @@ void runLayer(cv::Ptr<cv::dnn::Layer> layer, std::vector<cv::Mat> &inpBlobs, std
     size_t ninputs = inpBlobs.size();
     std::vector<cv::Mat> inp(ninputs), outp, intp;
     std::vector<cv::dnn::MatShape> inputs, outputs, internals;
+    std::vector<cv::dnn::MatType> inputs_types, outputs_types, internals_types;
 
     for (size_t i = 0; i < ninputs; i++)
     {
         inp[i] = inpBlobs[i].clone();
         inputs.push_back(cv::dnn::shape(inp[i]));
+        inputs_types.push_back(cv::dnn::MatType(inp[i].type()));
     }
 
     layer->getMemoryShapes(inputs, 0, outputs, internals);
+    layer->getTypes(inputs_types, outputs.size(), internals.size(), outputs_types, internals_types);
     for (size_t i = 0; i < outputs.size(); i++)
     {
-        outp.push_back(cv::Mat(outputs[i], CV_32F));
+        outp.push_back(cv::Mat(outputs[i], outputs_types[i]));
     }
     for (size_t i = 0; i < internals.size(); i++)
     {
-        intp.push_back(cv::Mat(internals[i], CV_32F));
+        intp.push_back(cv::Mat(internals[i], internals_types[i]));
     }
 
     layer->finalize(inp, outp);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -42,8 +42,8 @@ TEST_P(Layer_1d_Test, Scale)
 
     cv::Mat output_ref = input.mul(weight);
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -83,8 +83,8 @@ TEST_P(Layer_Gather_1d_Test, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_1d_Test, Combine(
@@ -154,7 +154,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
 
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -202,8 +202,8 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
 
     runLayer(layer, inputs, outputs);
     if (!output_ref.empty()) {
-        ASSERT_EQ(outputs.size(), 1);
-        ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(shape(output_ref), shape(outputs[0]));
         normAssert(output_ref, outputs[0]);
     } else {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
@@ -256,8 +256,8 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy_01D) {
 
     runLayer(layer, inputs, outputs);
     if (!output_ref.empty()) {
-        ASSERT_EQ(outputs.size(), 1);
-        ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(shape(output_ref), shape(outputs[0]));
         normAssert(output_ref, outputs[0]);
     } else {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
@@ -295,8 +295,8 @@ TEST(Layer_Reshape_Test, Accuracy_1D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -360,8 +360,8 @@ TEST_P(Layer_Expand_Test, Accuracy_ND) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Expand_Test, Combine(
@@ -403,8 +403,8 @@ TEST_P(Layer_Concat_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Concat_Test,
@@ -443,8 +443,8 @@ TEST_P(Layer_Softmax_Test, Accuracy_01D) {
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -501,8 +501,8 @@ TEST_P(Layer_Scatter_Test, Accuracy1D) {
     std::vector<Mat> inputs{output, indices_mat, input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Scatter_Test, Combine(
@@ -534,8 +534,8 @@ TEST_P(Layer_Permute_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Permute_Test,
@@ -627,8 +627,8 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
@@ -673,8 +673,8 @@ TEST_P(Layer_BatchNorm_Test, Accuracy_01D)
     cv::sqrt(varMat + 1e-5, varMat);
     output_ref = (output_ref - meanMat) / varMat;
 
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 
 }
@@ -706,8 +706,8 @@ TEST_P(Layer_Const_Test, Accuracy_01D)
     std::vector<Mat> inputs; // No inputs are needed for a ConstLayer
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Const_Test, testing::Values(

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -42,8 +42,8 @@ TEST_P(Layer_1d_Test, Scale)
 
     cv::Mat output_ref = input.mul(weight);
     runLayer(layer, inputs, outputs);
-
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -82,7 +82,8 @@ TEST_P(Layer_Gather_1d_Test, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_1d_Test, Combine(
@@ -129,7 +130,8 @@ TEST_P(Layer_Arg_1d_Test, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -177,7 +179,8 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
 
     runLayer(layer, inputs, outputs);
     if (!output_ref.empty()) {
-        ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(shape(outputs[0]), shape(output_ref));
         normAssert(output_ref, outputs[0]);
     } else {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
@@ -233,7 +236,8 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy) {
     runLayer(layer, inputs, outputs);
 
     if (!output_ref.empty()) {
-        ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(shape(outputs[0]), shape(output_ref));
         normAssert(output_ref, outputs[0]);
     } else {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
@@ -245,7 +249,7 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Elemwise_1d_Test, Combine(
 /*operation*/           Values("div", "prod", "max", "min", "sum")
 ));
 
-TEST(Layer_Reshape_Test, Accuracy)
+TEST(Layer_Reshape_Test, Accuracy_1D)
 {
     LayerParams lp;
     lp.type = "Reshape";
@@ -267,7 +271,8 @@ TEST(Layer_Reshape_Test, Accuracy)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -291,6 +296,7 @@ TEST_P(Layer_Split_Test, Accuracy_01D)
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(top_count, outputs.size());
     for (int i = 0; i < top_count; i++)
     {
         ASSERT_EQ(shape(output_ref), shape(outputs[i]));
@@ -330,8 +336,8 @@ TEST_P(Layer_Expand_Test, Accuracy_ND) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Expand_Test, Combine(
@@ -373,7 +379,8 @@ TEST_P(Layer_Concat_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Concat_Test,
@@ -412,8 +419,8 @@ TEST_P(Layer_Softmax_Test, Accuracy_01D) {
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 
@@ -469,8 +476,8 @@ TEST_P(Layer_Scatter_Test, Accuracy1D) {
     std::vector<Mat> inputs{output, indices_mat, input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Scatter_Test, Combine(
 /*input blob shape*/    testing::Values(std::vector<int>{4},
@@ -501,8 +508,8 @@ TEST_P(Layer_Permute_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Permute_Test,
@@ -555,7 +562,7 @@ TEST_P(Layer_Slice_Test, Accuracy_1D){
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-
+    ASSERT_EQ(splits, outputs.size());
     for (int i = 0; i < splits; ++i){
         ASSERT_EQ(shape(output_refs[i]), shape(outputs[i]));
         normAssert(output_refs[i], outputs[i]);
@@ -594,6 +601,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
+    ASSERT_EQ(1, outputs.size());
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
@@ -638,8 +646,8 @@ TEST_P(Layer_BatchNorm_Test, Accuracy_01D)
     cv::sqrt(varMat + 1e-5, varMat);
     output_ref = (output_ref - meanMat) / varMat;
 
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 
 }
@@ -671,8 +679,8 @@ TEST_P(Layer_Const_Test, Accuracy_01D)
     std::vector<Mat> inputs; // No inputs are needed for a ConstLayer
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Const_Test, testing::Values(

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -108,8 +108,9 @@ int arg_op(const std::vector<T>& vec, const std::string& operation) {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
     }
 }
+// Test for ArgLayer is disabled because there problem in runLayer function related to type assignment
 typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_Arg_1d_Test;
-TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
+TEST_P(Layer_Arg_1d_Test, DISABLED_Accuracy_01D) {
     std::vector<int> input_shape = get<0>(GetParam());
     std::string operation = get<1>(GetParam());
 
@@ -143,9 +144,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
             }
             ref_output[i] = (int) arg_op(row_vec, operation);
         }
-        std::cout << "ref_output :" << ref_output << std::endl;
         output_ref = cv::Mat(rows, (axis == 1) ? 1 : cols, CV_32S, ref_output.data());
-        std::cout << "output_ref :" << output_ref << std::endl;
     } else if (input_shape.size() <= 1) {
         int index = arg_op(std::vector<float>(input.begin<float>(), input.end<float>()), operation);
         output_ref = cv::Mat(input_shape.size(), input_shape.data(), CV_32FC1, &index);
@@ -159,10 +158,6 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     // convert output_ref to float to match the output type
     output_ref.convertTo(output_ref, CV_32FC1);
-
-
-    std::cout << "output_ref: " << output_ref << std::endl;
-    std::cout << "outputs[0]: " << outputs[0] << std::endl;
     normAssert(output_ref, outputs[0]);
 }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -131,6 +131,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     }
 
     // create reference output with required shape and values
+    int index;
     cv::Mat output_ref;
     std::vector<int> ref_output;
     if (input_shape.size() == 2 ){
@@ -146,7 +147,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
         }
         output_ref = cv::Mat(rows, (axis == 1) ? 1 : cols, CV_32S, ref_output.data());
     } else if (input_shape.size() <= 1) {
-        int index = arg_op(std::vector<float>(input.begin<float>(), input.end<float>()), operation);
+        index = arg_op(std::vector<float>(input.begin<float>(), input.end<float>()), operation);
         output_ref = cv::Mat(input_shape.size(), input_shape.data(), CV_32FC1, &index);
     }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -141,9 +141,11 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
             for (int j = 0; j < cols; j++) {
                 row_vec[j] = input.at<float>(i, j);
             }
-            ref_output[i] = arg_op(row_vec, operation);
+            ref_output[i] = (int) arg_op(row_vec, operation);
         }
-        output_ref = cv::Mat(rows, (axis == 1) ? 1 : cols, CV_32FC1, ref_output.data());
+        std::cout << "ref_output :" << ref_output << std::endl;
+        output_ref = cv::Mat(rows, (axis == 1) ? 1 : cols, CV_32S, ref_output.data());
+        std::cout << "output_ref :" << output_ref << std::endl;
     } else if (input_shape.size() <= 1) {
         int index = arg_op(std::vector<float>(input.begin<float>(), input.end<float>()), operation);
         output_ref = cv::Mat(input_shape.size(), input_shape.data(), CV_32FC1, &index);
@@ -155,6 +157,12 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    // convert output_ref to float to match the output type
+    output_ref.convertTo(output_ref, CV_32FC1);
+
+
+    std::cout << "output_ref: " << output_ref << std::endl;
+    std::cout << "outputs[0]: " << outputs[0] << std::endl;
     normAssert(output_ref, outputs[0]);
 }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -110,7 +110,7 @@ int arg_op(const std::vector<T>& vec, const std::string& operation) {
 }
 // Test for ArgLayer is disabled because there problem in runLayer function related to type assignment
 typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_Arg_1d_Test;
-TEST_P(Layer_Arg_1d_Test, DISABLED_Accuracy_01D) {
+TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     std::vector<int> input_shape = get<0>(GetParam());
     std::string operation = get<1>(GetParam());
 
@@ -157,7 +157,7 @@ TEST_P(Layer_Arg_1d_Test, DISABLED_Accuracy_01D) {
     ASSERT_EQ(1, outputs.size());
     ASSERT_EQ(shape(output_ref), shape(outputs[0]));
     // convert output_ref to float to match the output type
-    output_ref.convertTo(output_ref, CV_32FC1);
+    output_ref.convertTo(output_ref, CV_64SC1);
     normAssert(output_ref, outputs[0]);
 }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -453,7 +453,7 @@ TEST_P(Layer_Scatter_Test, Accuracy1D) {
 
     cv::Mat input = cv::Mat(input_shape.size(), input_shape.data(), CV_32F);
     cv::randn(input, 0.0, 1.0);
-    
+
     int indices[] = {3, 2, 1, 0};
     cv::Mat indices_mat(input_shape.size(), input_shape.data(), CV_32S, indices);
     cv::Mat output(input_shape.size(), input_shape.data(), CV_32F, 0.0);
@@ -598,12 +598,13 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     Mat input(input_shape.size(), input_shape.data(), CV_32F);
     randn(input, 0, 1);
     Mat output_ref = input.reshape(1, 1) * weights;
-    output_ref.dims = 1;
+    output_ref.dims = input_shape.size();
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -94,7 +94,7 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_1d_Test, Combine(
                                 std::vector<int>({1, 4}),
                                 std::vector<int>({4, 4})
                                 ),
-/*operation*/           testing::Values(0, 1)
+/*axis*/           testing::Values(0, 1)
 ));
 
 template <typename T>

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -42,7 +42,7 @@ TEST_P(Layer_1d_Test, Scale)
 
     cv::Mat output_ref = input.mul(weight);
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -82,7 +82,7 @@ TEST_P(Layer_Gather_1d_Test, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -130,7 +130,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -179,7 +179,7 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
 
     runLayer(layer, inputs, outputs);
     if (!output_ref.empty()) {
-        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(outputs.size(), 1);
         ASSERT_EQ(shape(outputs[0]), shape(output_ref));
         normAssert(output_ref, outputs[0]);
     } else {
@@ -236,7 +236,7 @@ TEST_P(Layer_Elemwise_1d_Test, Accuracy) {
     runLayer(layer, inputs, outputs);
 
     if (!output_ref.empty()) {
-        ASSERT_EQ(1, outputs.size());
+        ASSERT_EQ(outputs.size(), 1);
         ASSERT_EQ(shape(outputs[0]), shape(output_ref));
         normAssert(output_ref, outputs[0]);
     } else {
@@ -271,7 +271,7 @@ TEST(Layer_Reshape_Test, Accuracy_1D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -296,10 +296,10 @@ TEST_P(Layer_Split_Test, Accuracy_01D)
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(top_count, outputs.size());
+    ASSERT_EQ(outputs.size(), top_count);
     for (int i = 0; i < top_count; i++)
     {
-        ASSERT_EQ(shape(output_ref), shape(outputs[i]));
+        ASSERT_EQ(shape(outputs[i]), shape(output_ref));
         normAssert(output_ref, outputs[i]);
     }
 }
@@ -336,7 +336,7 @@ TEST_P(Layer_Expand_Test, Accuracy_ND) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -379,7 +379,7 @@ TEST_P(Layer_Concat_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -419,7 +419,7 @@ TEST_P(Layer_Softmax_Test, Accuracy_01D) {
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -477,7 +477,7 @@ TEST_P(Layer_Scatter_Test, Accuracy1D) {
     std::vector<Mat> inputs{output, indices_mat, input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -510,7 +510,7 @@ TEST_P(Layer_Permute_Test, Accuracy_01D)
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -564,9 +564,9 @@ TEST_P(Layer_Slice_Test, Accuracy_1D){
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(splits, outputs.size());
+    ASSERT_EQ(outputs.size(), splits);
     for (int i = 0; i < splits; ++i){
-        ASSERT_EQ(shape(output_refs[i]), shape(outputs[i]));
+        ASSERT_EQ(shape(outputs[i]), shape(output_refs[i]));
         normAssert(output_refs[i], outputs[i]);
     }
 }
@@ -603,7 +603,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }
@@ -649,7 +649,7 @@ TEST_P(Layer_BatchNorm_Test, Accuracy_01D)
     cv::sqrt(varMat + 1e-5, varMat);
     output_ref = (output_ref - meanMat) / varMat;
 
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 
@@ -682,7 +682,7 @@ TEST_P(Layer_Const_Test, Accuracy_01D)
     std::vector<Mat> inputs; // No inputs are needed for a ConstLayer
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(1, outputs.size());
+    ASSERT_EQ(outputs.size(), 1);
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -141,10 +141,10 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Arg_1d_Test, Combine(
 /*operation*/           Values( "max", "min")
 ));
 
-typedef testing::TestWithParam<tuple<int, std::string>> Layer_NaryElemwise_1d_Test;
+typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_NaryElemwise_1d_Test;
 TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
 
-    int batch_size = get<0>(GetParam());
+    std::vector<int> input_shape = get<0>(GetParam());
     std::string operation = get<1>(GetParam());
 
     LayerParams lp;
@@ -153,12 +153,8 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
     lp.set("operation", operation);
     Ptr<NaryEltwiseLayer> layer = NaryEltwiseLayer::create(lp);
 
-    std::vector<int> input_shape = {batch_size, 1};
-    if (batch_size == 0)
-        input_shape.erase(input_shape.begin());
-
-    cv::Mat input1 = cv::Mat(input_shape, CV_32F, 0.0);
-    cv::Mat input2 = cv::Mat(input_shape, CV_32F, 0.0);
+    cv::Mat input1 = cv::Mat(input_shape.size(), input_shape.data(), CV_32F);
+    cv::Mat input2 = cv::Mat(input_shape.size(), input_shape.data(), CV_32F);
     cv::randu(input1, 0.0, 1.0);
     cv::randu(input2, 0.0, 1.0);
 
@@ -186,10 +182,13 @@ TEST_P(Layer_NaryElemwise_1d_Test, Accuracy) {
         CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
     }
 }
-
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_NaryElemwise_1d_Test, Combine(
-/*input blob shape*/    Values(0, 1),
-/*operation*/           Values("div", "mul", "sum", "sub")
+/*input blob shape*/    testing::Values(
+                            std::vector<int>({}),
+                            std::vector<int>({1}),
+                            std::vector<int>({1, 4}),
+                            std::vector<int>({4, 1})),
+/*operation*/           testing::Values("div", "mul", "sum", "sub")
 ));
 
 typedef testing::TestWithParam<tuple<int, std::string>> Layer_Elemwise_1d_Test;

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -93,10 +93,13 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Gather_1d_Test, Combine(
 
 template <typename T>
 int arg_op(const std::vector<T>& vec, const std::string& operation) {
+    CV_Assert(!vec.empty());
     if (operation == "max") {
         return static_cast<int>(std::distance(vec.begin(), std::max_element(vec.begin(), vec.end())));
-    } else {
+    } else if (operation == "min") {
         return static_cast<int>(std::distance(vec.begin(), std::min_element(vec.begin(), vec.end())));
+    } else {
+        CV_Error(Error::StsAssert, "Provided operation: " + operation + " is not supported. Please check the test instantiation.");
     }
 }
 typedef testing::TestWithParam<tuple<std::vector<int>, std::string>> Layer_Arg_1d_Test;
@@ -122,10 +125,11 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
 
     // create reference output with required shape and values
     cv::Mat output_ref;
+    std::vector<int> ref_output;
     if (input_shape.size() == 2 ){
         int rows = input_shape[0];
         int cols = input_shape[1];
-        std::vector<int> ref_output(rows);
+        ref_output.resize(rows);
         for (int i = 0; i < rows; i++) {
             std::vector<float> row_vec(cols);
             for (int j = 0; j < cols; j++) {
@@ -143,7 +147,7 @@ TEST_P(Layer_Arg_1d_Test, Accuracy_01D) {
     std::vector<Mat> outputs;
 
     runLayer(layer, inputs, outputs);
-    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(1, outputs.size());
     ASSERT_EQ(shape(outputs[0]), shape(output_ref));
     normAssert(output_ref, outputs[0]);
 }


### PR DESCRIPTION
This has additional fixes requited for 0/1D tests. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
