### PR TITLE
Fixed ONNX Range layer to support any input type

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3005,7 +3005,7 @@ Mat runRangeLayer(const Mat& startMat, const Mat& limitMat, const Mat& deltaMat)
     T delta = deltaMat.at<T>(0);
 
     int numberOfElements;
-    if (start.depth() == CV_32S || start.depth() == CV_64S) {
+    if (startMat.depth() == CV_32S || startMat.depth() == CV_64S) {
         if (delta > 0)
             numberOfElements = (limit - start + delta - 1) / delta;
         else
@@ -3017,8 +3017,8 @@ Mat runRangeLayer(const Mat& startMat, const Mat& limitMat, const Mat& deltaMat)
     }
     numberOfElements = std::max(numberOfElements, 0);
 
-    Mat r(numberOfElements, 1, startMat.type());
-    for (int i = 0; i < number_of_elements; i++)
+    Mat r(std::vector<int>{numberOfElements}, startMat.type());
+    for (int i = 0; i < numberOfElements; i++)
     {
         r.at<T>(i) = start + (i * delta);
     }
@@ -3039,9 +3039,9 @@ void ONNXImporter::parseRange(LayerParams& layerParams, const opencv_onnx::NodeP
     // only supports the case which all inputs are constant
     CV_Assert(const_id.size() == 3);
 
-    Mat startMat = getIntBlob(node_proto, 0);
-    Mat limitMat = getIntBlob(node_proto, 1);
-    Mat deltaMat = getIntBlob(node_proto, 2);
+    Mat startMat = getBlob(node_proto, 0);
+    Mat limitMat = getBlob(node_proto, 1);
+    Mat deltaMat = getBlob(node_proto, 2);
 
     Mat result;
     switch (startMat.depth())

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -807,12 +807,24 @@ TEST_P(Test_ONNX_layers, CumSumExclusiveInplace)
     testONNXModels("cumsum_exclusive_inplace");
 }
 
-// Issue: https://github.com/opencv/opencv/issues/25363
-// The issue was addressed in 4.x, but the solution does not fit 5.x design
-TEST_P(Test_ONNX_layers, DISABLED_Range)
+TEST_P(Test_ONNX_layers, RangeFloat)
 {
     testONNXModels("range_float");
     testONNXModels("range_float_negative");
+}
+
+TEST_P(Test_ONNX_layers, RangeInt32)
+{
+    testONNXModels("range_int32");
+    testONNXModels("range_int32_negative");
+}
+
+TEST_P(Test_ONNX_layers, RangeInt64)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH); // OpenVINO uses int32 precision for int64 operations
+    testONNXModels("range_int64");
+    testONNXModels("range_int64_negative");
 }
 
 TEST_P(Test_ONNX_layers, Eltwise3D)


### PR DESCRIPTION
Fixed ONNX Range layer to support any input type

Extra PR: https://github.com/opencv/opencv_extra/pull/1173
Fixes #25363 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
