### PR TITLE
Replace static numpy allocator by function containing static.

### DIFF
--- a/modules/core/misc/python/pyopencv_umat.hpp
+++ b/modules/core/misc/python/pyopencv_umat.hpp
@@ -28,7 +28,7 @@ static void* cv_UMat_context()
 static Mat cv_UMat_get(const UMat* _self)
 {
     Mat m;
-    m.allocator = &g_numpyAllocator;
+    m.allocator = &GetNumpyAllocator();
     _self->copyTo(m);
     return m;
 }

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -56,7 +56,7 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
     if(!o || o == Py_None)
     {
         if( !m.data )
-            m.allocator = &g_numpyAllocator;
+            m.allocator = &GetNumpyAllocator();
         return true;
     }
 
@@ -298,14 +298,14 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
 #endif
 
     m = Mat(ndims, size, type, PyArray_DATA(oarr), step);
-    m.u = g_numpyAllocator.allocate(o, ndims, size, type, step);
+    m.u = GetNumpyAllocator().allocate(o, ndims, size, type, step);
     m.addref();
 
     if( !needcopy )
     {
         Py_INCREF(o);
     }
-    m.allocator = &g_numpyAllocator;
+    m.allocator = &GetNumpyAllocator();
 
     return true;
 }
@@ -316,9 +316,9 @@ PyObject* pyopencv_from(const cv::Mat& m)
     if( !m.data )
         Py_RETURN_NONE;
     cv::Mat temp, *p = (cv::Mat*)&m;
-    if(!p->u || p->allocator != &g_numpyAllocator)
+    if(!p->u || p->allocator != &GetNumpyAllocator())
     {
-        temp.allocator = &g_numpyAllocator;
+        temp.allocator = &GetNumpyAllocator();
         ERRWRAP2(m.copyTo(temp));
         p = &temp;
     }

--- a/modules/python/src2/cv2_numpy.cpp
+++ b/modules/python/src2/cv2_numpy.cpp
@@ -6,8 +6,6 @@
 #include "cv2_numpy.hpp"
 #include "cv2_util.hpp"
 
-NumpyAllocator g_numpyAllocator;
-
 using namespace cv;
 
 UMatData* NumpyAllocator::allocate(PyObject* o, int dims, const int* sizes, int type, size_t* step) const

--- a/modules/python/src2/cv2_numpy.hpp
+++ b/modules/python/src2/cv2_numpy.hpp
@@ -18,7 +18,7 @@ public:
     const cv::MatAllocator* stdAllocator;
 };
 
-extern NumpyAllocator g_numpyAllocator;
+inline NumpyAllocator& GetNumpyAllocator() {static NumpyAllocator gNumpyAllocator;return gNumpyAllocator;}
 
 //======================================================================================================================
 


### PR DESCRIPTION
There is no bug with the current implementation.

But this change enables the numpy code to be its own library, in case some users want to (e.g. CLIF library) and have the Python wrapper link to it. It would not be possible without this change as there would be a static initialization order fiasco otherwise.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch