### PR TITLE
Fix CharuCo slowdown

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -164,15 +164,18 @@ public:
 
     /** @brief get CharucoBoard::chessboardCorners
      */
-    CV_WRAP std::vector<Point3f>& getChessboardCorners() const;
+    CV_WRAP std::vector<Point3f> getChessboardCorners() const;
+    CV_WRAP std::vector<Point3f>& getChessboardCornersRef() const;
 
     /** @brief get CharucoBoard::nearestMarkerIdx, for each charuco corner, nearest marker index in ids array
      */
-    CV_PROP std::vector<std::vector<int> >& getNearestMarkerIdx() const;
+    CV_PROP std::vector<std::vector<int> > getNearestMarkerIdx() const;
+    CV_PROP std::vector<std::vector<int> >& getNearestMarkerIdxRef() const;
 
     /** @brief get CharucoBoard::nearestMarkerCorners, for each charuco corner, nearest marker corner id of each marker
      */
-    CV_PROP std::vector<std::vector<int> >& getNearestMarkerCorners() const;
+    CV_PROP std::vector<std::vector<int> > getNearestMarkerCorners() const;
+    CV_PROP std::vector<std::vector<int> >& getNearestMarkerCornersRef() const;
 
     /** @brief check whether the ChArUco markers are collinear
      *

--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -164,15 +164,15 @@ public:
 
     /** @brief get CharucoBoard::chessboardCorners
      */
-    CV_WRAP std::vector<Point3f> getChessboardCorners() const;
+    CV_WRAP std::vector<Point3f>& getChessboardCorners() const;
 
     /** @brief get CharucoBoard::nearestMarkerIdx, for each charuco corner, nearest marker index in ids array
      */
-    CV_PROP std::vector<std::vector<int> > getNearestMarkerIdx() const;
+    CV_PROP std::vector<std::vector<int> >& getNearestMarkerIdx() const;
 
     /** @brief get CharucoBoard::nearestMarkerCorners, for each charuco corner, nearest marker corner id of each marker
      */
-    CV_PROP std::vector<std::vector<int> > getNearestMarkerCorners() const;
+    CV_PROP std::vector<std::vector<int> >& getNearestMarkerCorners() const;
 
     /** @brief check whether the ChArUco markers are collinear
      *

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -634,19 +634,31 @@ bool CharucoBoard::checkCharucoCornersCollinear(InputArray charucoIds) const {
     return true;
 }
 
-std::vector<Point3f>& CharucoBoard::getChessboardCorners() const {
+std::vector<Point3f>& CharucoBoard::getChessboardCornersRef() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->chessboardCorners;
 }
 
-std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerIdx() const {
+std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerIdxRef() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerIdx;
 }
 
-std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerCorners() const {
+std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerCornersRef() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerCorners;
+}
+
+std::vector<Point3f> CharucoBoard::getChessboardCorners() const {
+    return getChessboardCornersRef();
+}
+
+std::vector<std::vector<int> > CharucoBoard::getNearestMarkerIdx() const {
+    return getNearestMarkerIdxRef();
+}
+
+std::vector<std::vector<int> > CharucoBoard::getNearestMarkerCorners() const {
+    return getNearestMarkerCornersRef();
 }
 
 }

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -634,17 +634,17 @@ bool CharucoBoard::checkCharucoCornersCollinear(InputArray charucoIds) const {
     return true;
 }
 
-std::vector<Point3f> CharucoBoard::getChessboardCorners() const {
+std::vector<Point3f>& CharucoBoard::getChessboardCorners() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->chessboardCorners;
 }
 
-std::vector<std::vector<int> > CharucoBoard::getNearestMarkerIdx() const {
+std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerIdx() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerIdx;
 }
 
-std::vector<std::vector<int> > CharucoBoard::getNearestMarkerCorners() const {
+std::vector<std::vector<int> >& CharucoBoard::getNearestMarkerCorners() const {
     CV_Assert(impl);
     return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerCorners;
 }


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25188

Several functions were returning by value, rather than reference, which was creating unnecessary copies within for loops and seriously affecting the performance of Charuco detection.

Using the benchmarking app referenced in the linked issue, we can see the speed up with the changes:

Return by value
```
Testing new api
Number of Aruco markers detected: 204
Number of Charuco corners detected: 368
Time to detect markers: 0.053611095600000006
Time to detect charuco: 0.0427095
```

Return by reference:
```
Testing new api
Number of Aruco markers detected: 204
Number of Charuco corners detected: 368
Time to detect markers: 0.054944104199999996
Time to detect charuco: 0.0050371666
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
