### PR TITLE
fix statckblur big kernel case

### DIFF
--- a/modules/imgproc/src/stackblur.cpp
+++ b/modules/imgproc/src/stackblur.cpp
@@ -547,7 +547,7 @@ public:
         }
         else
         {
-            size_t bufSize = CN * (width + radius) * sizeof(TBuf) + 2 * CN * sizeof(TBuf);
+            size_t bufSize = CN * (width + kernelSize) * sizeof(TBuf) + 2 * CN * sizeof(TBuf);
             AutoBuffer<uchar> _buf(bufSize + 16);
             uchar* bufptr = alignPtr(_buf.data(), 16);
             TBuf* diffVal = (TBuf*)bufptr;


### PR DESCRIPTION
fix the issue: https://github.com/opencv/opencv/issues/25498

`kernelSize = radius*2 + 1`. If the kernel size is bigger then width, we need to set a bigger buffer for it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
