### PR TITLE
doc: disable inheritance graphs

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -319,7 +319,7 @@ DOT_FONTPATH           =
 DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
 DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
 DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
-CLASS_GRAPH            = YES
+CLASS_GRAPH            = NO
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = NO
 UML_LOOK               = YES

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4030,16 +4030,6 @@ CV_EXPORTS_W void findContours( InputArray image, OutputArrayOfArrays contours,
 CV_EXPORTS void findContours( InputArray image, OutputArrayOfArrays contours,
                               int mode, int method, Point offset = Point());
 
-/** @example samples/cpp/squares.cpp
-A program using pyramid scaling, Canny, contours and contour simplification to find
-squares in a list of images (pic1-6.png). Returns sequence of squares detected on the image.
-*/
-
-/** @example samples/tapi/squares.cpp
-A program using pyramid scaling, Canny, contours and contour simplification to find
-squares in the input image.
-*/
-
 //! @brief Find contours using link runs algorithm
 //!
 //! This function implements an algorithm different from cv::findContours:


### PR DESCRIPTION
Resolves #25481

Some clas inheritance graphs are too big, so I decided to turn them off completely. Graphs for selected classes can be enabled using `inheritancegraph` command (https://www.doxygen.nl/manual/commands.html#cmdinheritancegraph).

I noticed that some collaboration diagrams can be quite large as well (see second diagram here: https://docs.opencv.org/4.x/d3/d63/classcv_1_1Mat.html), so we might need to disable them too (`COLLABORATION_GRAPH` option).

Extra change was needed to fix Javadoc documentation generation (version 17), for some reason two examples caused build issues.