### PR TITLE
Change classic caffe models related tests and samples to onnx format

### DIFF
--- a/doc/js_tutorials/js_assets/js_image_classification.html
+++ b/doc/js_tutorials/js_assets/js_image_classification.html
@@ -123,6 +123,10 @@ labelsUrl = "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dn
 main = async function() {
     const labels = await loadLables(labelsUrl);
     const input = getBlobFromImage(inputSize, mean, std, swapRB, 'canvasInput');
+
+    // correct the model path if it is a onnx model
+    if(modelPath.endsWith('.onnx')) configPath = modelPath;
+
     let net = cv.readNet(configPath, modelPath);
     net.setInput(input);
     const start = performance.now();

--- a/doc/js_tutorials/js_assets/js_image_classification_model_info.json
+++ b/doc/js_tutorials/js_assets/js_image_classification_model_info.json
@@ -1,16 +1,6 @@
 {
     "caffe": [
         {
-            "model": "alexnet",
-            "mean": "104, 117, 123",
-            "std": "1",
-            "swapRB": "false",
-            "needSoftmax": "false",
-            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
-            "modelUrl": "http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel",
-            "configUrl": "https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_alexnet/deploy.prototxt"
-        },
-        {
             "model": "densenet",
             "mean": "127.5, 127.5, 127.5",
             "std": "0.007843",
@@ -60,6 +50,17 @@
             "needSoftmax": "false",
             "labelsUrl": "https://raw.githubusercontent.com/petewarden/tf_ios_makefile_example/master/data/imagenet_comp_graph_label_strings.txt",
             "modelUrl": "https://raw.githubusercontent.com/petewarden/tf_ios_makefile_example/master/data/tensorflow_inception_graph.pb"
+        }
+    ],
+    "onnx": [
+        {
+            "model": "alexnet",
+            "mean": "104, 117, 123",
+            "std": "1",
+            "swapRB": "false",
+            "needSoftmax": "false",
+            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
+            "modelUrl": "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/alexnet/model/bvlcalexnet-8.onnx"
         }
     ]
 }

--- a/doc/js_tutorials/js_assets/js_image_classification_model_info.json
+++ b/doc/js_tutorials/js_assets/js_image_classification_model_info.json
@@ -1,16 +1,6 @@
 {
     "caffe": [
         {
-            "model": "googlenet",
-            "mean": "104, 117, 123",
-            "std": "1",
-            "swapRB": "false",
-            "needSoftmax": "false",
-            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
-            "modelUrl": "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel",
-            "configUrl": "https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_googlenet/deploy.prototxt"
-        },
-        {
             "model": "squeezenet",
             "mean": "104, 117, 123",
             "std": "1",
@@ -60,6 +50,15 @@
             "needSoftmax": "true",
             "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
             "modelUrl": "https://github.com/onnx/models/raw/491ce05590abb7551d7fae43c067c060eeb575a6/validated/vision/classification/densenet-121/model/densenet-12.onnx"
+        },
+        {
+            "model": "googlenet",
+            "mean": "104, 117, 123",
+            "std": "1",
+            "swapRB": "false",
+            "needSoftmax": "false",
+            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
+            "modelUrl": "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx"
         }
     ]
 }

--- a/doc/js_tutorials/js_assets/js_image_classification_model_info.json
+++ b/doc/js_tutorials/js_assets/js_image_classification_model_info.json
@@ -1,16 +1,6 @@
 {
     "caffe": [
         {
-            "model": "squeezenet",
-            "mean": "104, 117, 123",
-            "std": "1",
-            "swapRB": "false",
-            "needSoftmax": "false",
-            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
-            "modelUrl": "https://raw.githubusercontent.com/forresti/SqueezeNet/master/SqueezeNet_v1.0/squeezenet_v1.0.caffemodel",
-            "configUrl": "https://raw.githubusercontent.com/forresti/SqueezeNet/master/SqueezeNet_v1.0/deploy.prototxt"
-        },
-        {
             "model": "VGG",
             "mean": "104, 117, 123",
             "std": "1",
@@ -53,12 +43,21 @@
         },
         {
             "model": "googlenet",
-            "mean": "104, 117, 123",
+            "mean": "103.939, 116.779, 123.675",
             "std": "1",
             "swapRB": "false",
             "needSoftmax": "false",
             "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
             "modelUrl": "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx"
+        },
+        {
+            "model": "squeezenet",
+            "mean": "123.675, 116.779, 103.939",
+            "std": "0.0171, 0.0175, 0.0174",
+            "swapRB": "true",
+            "needSoftmax": "false",
+            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
+            "modelUrl": "https://github.com/onnx/models/raw/491ce05590abb7551d7fae43c067c060eeb575a6/validated/vision/classification/squeezenet/model/squeezenet1.1-7.onnx"
         }
     ]
 }

--- a/doc/js_tutorials/js_assets/js_image_classification_model_info.json
+++ b/doc/js_tutorials/js_assets/js_image_classification_model_info.json
@@ -1,16 +1,4 @@
 {
-    "caffe": [
-        {
-            "model": "VGG",
-            "mean": "104, 117, 123",
-            "std": "1",
-            "swapRB": "false",
-            "needSoftmax": "false",
-            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
-            "modelUrl": "http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel",
-            "configUrl": "https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/f02f8769e64494bcd3d7e97d5d747ac275825721/VGG_ILSVRC_19_layers_deploy.prototxt"
-        }
-    ],
     "tensorflow": [
         {
             "model": "inception",

--- a/doc/js_tutorials/js_assets/js_image_classification_model_info.json
+++ b/doc/js_tutorials/js_assets/js_image_classification_model_info.json
@@ -1,16 +1,6 @@
 {
     "caffe": [
         {
-            "model": "densenet",
-            "mean": "127.5, 127.5, 127.5",
-            "std": "0.007843",
-            "swapRB": "false",
-            "needSoftmax": "true",
-            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
-            "modelUrl": "https://drive.google.com/open?id=0B7ubpZO7HnlCcHlfNmJkU2VPelE",
-            "configUrl": "https://raw.githubusercontent.com/shicai/DenseNet-Caffe/master/DenseNet_121.prototxt"
-        },
-        {
             "model": "googlenet",
             "mean": "104, 117, 123",
             "std": "1",
@@ -61,6 +51,15 @@
             "needSoftmax": "false",
             "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
             "modelUrl": "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/alexnet/model/bvlcalexnet-8.onnx"
+        },
+        {
+            "model": "densenet",
+            "mean": "127.5, 127.5, 127.5",
+            "std": "0.007843",
+            "swapRB": "false",
+            "needSoftmax": "true",
+            "labelsUrl": "https://raw.githubusercontent.com/opencv/opencv/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt",
+            "modelUrl": "https://github.com/onnx/models/raw/491ce05590abb7551d7fae43c067c060eeb575a6/validated/vision/classification/densenet-121/model/densenet-12.onnx"
         }
     ]
 }

--- a/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
+++ b/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
@@ -8,13 +8,13 @@ Load Caffe framework models  {#tutorial_dnn_googlenet}
 |    |    |
 | -: | :- |
 | Original author | Vitaliy Lyudvichenko |
-| Compatibility | OpenCV >= 3.3 |
+| Compatibility | OpenCV >= 4.5.4 |
 
 Introduction
 ------------
 
 In this tutorial you will learn how to use opencv_dnn module for image classification by using
-GoogLeNet trained network from [Caffe model zoo](http://caffe.berkeleyvision.org/model_zoo.html).
+GoogLeNet trained network from [ONNX model zoo](https://github.com/onnx/models).
 
 We will demonstrate results of this example on the following picture.
 ![Buran space shuttle](dnn/images/space_shuttle.jpg)
@@ -29,20 +29,18 @@ We will be using snippets from the example application, that can be downloaded [
 Explanation
 -----------
 
--# Firstly, download GoogLeNet model files:
-   [bvlc_googlenet.prototxt  ](https://github.com/opencv/opencv_extra/blob/5.x/testdata/dnn/bvlc_googlenet.prototxt) and
-   [bvlc_googlenet.caffemodel](http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel)
+-# Firstly, download GoogLeNet model file:
+   [googlenet-8.onnx](https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx)
 
    Also you need file with names of [ILSVRC2012](http://image-net.org/challenges/LSVRC/2012/browse-synsets) classes:
    [classification_classes_ILSVRC2012.txt](https://github.com/opencv/opencv/blob/5.x/samples/data/dnn/classification_classes_ILSVRC2012.txt).
 
    Put these files into working dir of this program example.
 
--# Read and initialize network using path to .prototxt and .caffemodel files
+-# Read and initialize network using path to .onnx file
    @snippet dnn/classification.cpp Read and initialize network
 
-   You can skip an argument `framework` if one of the files `model` or `config` has an
-   extension `.caffemodel` or `.prototxt`.
+   You can skip an argument `framework` if the file `model` has an extension `.onnx`.
    This way function cv::dnn::readNet can automatically detects a model's format.
 
 -# Read input image and convert to the blob, acceptable by GoogleNet
@@ -69,6 +67,6 @@ Explanation
 
 -# Run an example from command line
    @code
-   ./example_dnn_classification --model=bvlc_googlenet.caffemodel --config=bvlc_googlenet.prototxt --width=224 --height=224 --classes=classification_classes_ILSVRC2012.txt --input=space_shuttle.jpg --mean="104 117 123"
+   ./example_dnn_classification --model=googlenet-8.onnx --width=224 --height=224 --classes=classification_classes_ILSVRC2012.txt --input=space_shuttle.jpg --mean="104 117 123"
    @endcode
    For our image we get prediction of class `space shuttle` with more than 99% sureness.

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -251,16 +251,16 @@ class dnn_test(NewOpenCVTests):
 
     def test_classification_model(self):
         img_path = self.find_dnn_file("dnn/googlenet_0.png")
-        weights = self.find_dnn_file("dnn/squeezenet_v1.1.caffemodel", required=False)
-        config = self.find_dnn_file("dnn/squeezenet_v1.1.prototxt")
-        ref = np.load(self.find_dnn_file("dnn/squeezenet_v1.1_prob.npy"))
-        if weights is None or config is None:
-            raise unittest.SkipTest("Missing DNN test files (dnn/squeezenet_v1.1.{prototxt/caffemodel}). Verify OPENCV_DNN_TEST_DATA_PATH configuration parameter.")
+        model = self.find_dnn_file("dnn/onnx/models/squeezenet.onnx", required=False)
+        ref = np.load(self.find_dnn_file("dnn/squeezenet_v1.0_prob.npy"))
 
         frame = cv.imread(img_path)
-        model = cv.dnn_ClassificationModel(config, weights)
-        model.setInputSize(227, 227)
+        model = cv.dnn_ClassificationModel(model)
+        model.setInputSize(224, 224)
         model.setInputCrop(True)
+        model.setInputMean((123.675, 116.779, 103.939))
+        model.setInputScale((0.0171, 0.0175, 0.0174))
+        model.setInputSwapRB(True)
 
         out = model.predict(frame)
         normAssert(self, out, ref)

--- a/modules/dnn/perf/perf_caffe.cpp
+++ b/modules/dnn/perf/perf_caffe.cpp
@@ -65,14 +65,6 @@ static caffe::Net<float>* initNet(std::string proto, std::string weights)
     return net;
 }
 
-PERF_TEST(AlexNet_caffe, CaffePerfTest)
-{
-    caffe::Net<float>* net = initNet("dnn/bvlc_alexnet.prototxt",
-                                     "dnn/bvlc_alexnet.caffemodel");
-    TEST_CYCLE() net->Forward();
-    SANITY_CHECK_NOTHING();
-}
-
 PERF_TEST(GoogLeNet_caffe, CaffePerfTest)
 {
     caffe::Net<float>* net = initNet("dnn/bvlc_googlenet.prototxt",

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -144,7 +144,7 @@ PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_v2_TensorFlow)
 
 PERF_TEST_P_(DNNTestNetwork, DenseNet_121)
 {
-    processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", cv::Size(224, 224));
+    processNet("dnn/onnx/models/densenet121.onnx", "", cv::Size(224, 224));
 }
 
 PERF_TEST_P_(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -101,7 +101,7 @@ PERF_TEST_P_(DNNTestNetwork, AlexNet)
 
 PERF_TEST_P_(DNNTestNetwork, GoogLeNet)
 {
-    processNet("dnn/bvlc_googlenet.caffemodel", "dnn/bvlc_googlenet.prototxt", cv::Size(224, 224));
+    processNet("onnx/models/googlenet.onnx", "", cv::Size(224, 224));
 }
 
 PERF_TEST_P_(DNNTestNetwork, ResNet_50)

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -106,7 +106,7 @@ PERF_TEST_P_(DNNTestNetwork, GoogLeNet)
 
 PERF_TEST_P_(DNNTestNetwork, ResNet_50)
 {
-    processNet("dnn/ResNet-50-model.caffemodel", "dnn/ResNet-50-deploy.prototxt", cv::Size(224, 224));
+    processNet("onnx/models/resnet50v1.onnx", "", cv::Size(224, 224));
 }
 
 PERF_TEST_P_(DNNTestNetwork, SqueezeNet_v1_1)

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -109,7 +109,7 @@ PERF_TEST_P_(DNNTestNetwork, ResNet_50)
     processNet("dnn/onnx/models/resnet50v1.onnx", "", cv::Size(224, 224));
 }
 
-PERF_TEST_P_(DNNTestNetwork, SqueezeNet_v1_1)
+PERF_TEST_P_(DNNTestNetwork, SqueezeNet_v1)
 {
     processNet("dnn/onnx/models/squeezenet.onnx", "", cv::Size(227, 227));
 }

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -96,7 +96,7 @@ public:
 
 PERF_TEST_P_(DNNTestNetwork, AlexNet)
 {
-    processNet("dnn/bvlc_alexnet.caffemodel", "dnn/bvlc_alexnet.prototxt", cv::Size(227, 227));
+    processNet("onnx/models/alexnet.onnx", "", cv::Size(227, 227));
 }
 
 PERF_TEST_P_(DNNTestNetwork, GoogLeNet)

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -96,17 +96,17 @@ public:
 
 PERF_TEST_P_(DNNTestNetwork, AlexNet)
 {
-    processNet("onnx/models/alexnet.onnx", "", cv::Size(227, 227));
+    processNet("dnn/onnx/models/alexnet.onnx", "", cv::Size(227, 227));
 }
 
 PERF_TEST_P_(DNNTestNetwork, GoogLeNet)
 {
-    processNet("onnx/models/googlenet.onnx", "", cv::Size(224, 224));
+    processNet("dnn/onnx/models/googlenet.onnx", "", cv::Size(224, 224));
 }
 
 PERF_TEST_P_(DNNTestNetwork, ResNet_50)
 {
-    processNet("onnx/models/resnet50v1.onnx", "", cv::Size(224, 224));
+    processNet("dnn/onnx/models/resnet50v1.onnx", "", cv::Size(224, 224));
 }
 
 PERF_TEST_P_(DNNTestNetwork, SqueezeNet_v1_1)

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -111,7 +111,7 @@ PERF_TEST_P_(DNNTestNetwork, ResNet_50)
 
 PERF_TEST_P_(DNNTestNetwork, SqueezeNet_v1_1)
 {
-    processNet("dnn/squeezenet_v1.1.caffemodel", "dnn/squeezenet_v1.1.prototxt", cv::Size(227, 227));
+    processNet("dnn/onnx/models/squeezenet.onnx", "", cv::Size(227, 227));
 }
 
 PERF_TEST_P_(DNNTestNetwork, Inception_5h)

--- a/modules/dnn/test/imagenet_cls_test_alexnet.py
+++ b/modules/dnn/test/imagenet_cls_test_alexnet.py
@@ -155,6 +155,20 @@ class DnnCaffeModel(Framework):
         self.net.setInput(input_blob, self.in_blob_name)
         return self.net.forward(self.out_blob_name)
 
+class DNNOnnxModel(Framework):
+    net = object
+
+    def __init__(self, onnx_file, in_blob_name, out_blob_name):
+        self.net = cv.dnn.readNetFromONNX(onnx_file)
+        self.in_blob_name = in_blob_name
+        self.out_blob_name = out_blob_name
+
+    def get_name(self):
+        return 'DNN (ONNX)'
+
+    def get_output(self, input_blob):
+        self.net.setInput(input_blob, self.in_blob_name)
+        return self.net.forward(self.out_blob_name)
 
 class ClsAccEvaluation:
     log = sys.stdout
@@ -229,6 +243,8 @@ if __name__ == "__main__":
                                         "https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/deploy.prototxt")
     parser.add_argument("--caffemodel", help="path to caffemodel file, download it here: "
                                              "http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel")
+    parser.add_argument("--onnxmodel", help="path to onnx model file, download it here: "
+                                            "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/alexnet/model/bvlcalexnet-8.onnx")
     parser.add_argument("--log", help="path to logging file")
     parser.add_argument("--mean", help="path to ImageNet mean blob caffe file, imagenet_mean.binaryproto file from"
                                        "this archive: http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz")
@@ -241,7 +257,7 @@ if __name__ == "__main__":
     data_fetcher = MeanBlobFetch(args.frame_size, args.mean, args.imgs_dir)
 
     frameworks = [CaffeModel(args.prototxt, args.caffemodel, args.in_blob, args.out_blob),
-                  DnnCaffeModel(args.prototxt, args.caffemodel, '', args.out_blob)]
+                  DNNOnnxModel(args.onnxmodel, args.in_blob, args.out_blob)]
 
     acc_eval = ClsAccEvaluation(args.log, args.img_cls_file, args.batch_size)
     acc_eval.process(frameworks, data_fetcher)

--- a/modules/dnn/test/imagenet_cls_test_googlenet.py
+++ b/modules/dnn/test/imagenet_cls_test_googlenet.py
@@ -2,7 +2,7 @@ import numpy as np
 import sys
 import os
 import argparse
-from imagenet_cls_test_alexnet import MeanChannelsFetch, CaffeModel, DnnCaffeModel, ClsAccEvaluation
+from imagenet_cls_test_alexnet import MeanChannelsFetch, CaffeModel, DNNOnnxModel, ClsAccEvaluation
 try:
     import caffe
 except ImportError:
@@ -23,6 +23,8 @@ if __name__ == "__main__":
                                         "https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/deploy.prototxt")
     parser.add_argument("--caffemodel", help="path to caffemodel file, download it here: "
                                              "http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel")
+    parser.add_argument("--onnxmodel", help="path to ONNX model file, download it here: "
+                                            "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx")
     parser.add_argument("--log", help="path to logging file")
     parser.add_argument("--batch_size", help="size of images in batch", default=500, type=int)
     parser.add_argument("--frame_size", help="size of input image", default=224, type=int)
@@ -33,7 +35,7 @@ if __name__ == "__main__":
     data_fetcher = MeanChannelsFetch(args.frame_size, args.imgs_dir)
 
     frameworks = [CaffeModel(args.prototxt, args.caffemodel, args.in_blob, args.out_blob),
-                  DnnCaffeModel(args.prototxt, args.caffemodel, '', args.out_blob)]
+                  DNNOnnxModel(args.onnxmodel, args.in_blob, args.out_blob)]
 
     acc_eval = ClsAccEvaluation(args.log, args.img_cls_file, args.batch_size)
     acc_eval.process(frameworks, data_fetcher)

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -430,8 +430,8 @@ TEST_P(DNNTestNetwork, DenseNet_121)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        l1 = 0.008;
-        lInf = 0.06;
+        l1 = 0.02;
+        lInf = 0.08;
     }
     processNet("dnn/onnx/models/densenet121.onnx", "", Size(224, 224), "", l1, lInf);
     if (target != DNN_TARGET_MYRIAD || getInferenceEngineVPUType() != CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -134,8 +134,7 @@ TEST_P(DNNTestNetwork, GoogLeNet)
 {
     applyTestTag(target == DNN_TARGET_CPU ? "" : CV_TEST_TAG_MEMORY_512MB);
 
-    processNet("dnn/bvlc_googlenet.caffemodel", "dnn/bvlc_googlenet.prototxt",
-               Size(224, 224), "prob");
+    processNet("dnn/onnx/models/googlenet.onnx", "", Size(224, 224), "prob_1");
     expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);
 }

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -122,10 +122,9 @@ TEST_P(DNNTestNetwork, ResNet_50)
     expectNoFallbacksFromCUDA(net);
 }
 
-TEST_P(DNNTestNetwork, SqueezeNet_v1_1)
+TEST_P(DNNTestNetwork, SqueezeNet_v1)
 {
-    processNet("dnn/squeezenet_v1.1.caffemodel", "dnn/squeezenet_v1.1.prototxt",
-               Size(227, 227), "prob");
+    processNet("dnn/onnx/models/squeezenet.onnx", "", Size(224, 224));
     expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);
 }

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -104,8 +104,7 @@ TEST_P(DNNTestNetwork, DISABLED_YOLOv8n) {
 TEST_P(DNNTestNetwork, AlexNet)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_1GB);
-    processNet("dnn/bvlc_alexnet.caffemodel", "dnn/bvlc_alexnet.prototxt",
-               Size(227, 227), "prob");
+    processNet("dnn/onnx/models/alexnet.onnx", "", Size(224, 224), "prob_1");
     expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);
 }

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -435,7 +435,7 @@ TEST_P(DNNTestNetwork, DenseNet_121)
         l1 = 0.008;
         lInf = 0.06;
     }
-    processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", Size(224, 224), "", l1, lInf);
+    processNet("dnn/onnx/models/densenet121.onnx", "", Size(224, 224), "", l1, lInf);
     if (target != DNN_TARGET_MYRIAD || getInferenceEngineVPUType() != CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)
         expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -244,10 +244,7 @@ TEST(blobFromImagesWithParams_4ch, multi_image)
 
 TEST(readNet, Regression)
 {
-    Net net = readNet(findDataFile("dnn/squeezenet_v1.1.prototxt"),
-                      findDataFile("dnn/squeezenet_v1.1.caffemodel", false));
-    EXPECT_FALSE(net.empty());
-    net = readNet(findDataFile("dnn/tiny-yolo-voc.cfg"),
+    Net net = readNet(findDataFile("dnn/tiny-yolo-voc.cfg"),
                   findDataFile("dnn/tiny-yolo-voc.weights", false));
     EXPECT_FALSE(net.empty());
     net = readNet(findDataFile("dnn/ssd_mobilenet_v1_coco.pbtxt"),
@@ -258,9 +255,7 @@ TEST(readNet, Regression)
 TEST(readNet, do_not_call_setInput)  // https://github.com/opencv/opencv/issues/16618
 {
     // 1. load network
-    const string proto = findDataFile("dnn/squeezenet_v1.1.prototxt");
-    const string model = findDataFile("dnn/squeezenet_v1.1.caffemodel", false);
-    Net net = readNetFromCaffe(proto, model);
+    Net net = readNet(findDataFile("dnn/onnx/models/squeezenet.onnx", false), "");
 
     // 2. mistake: no inputs are specified through .setInput()
 
@@ -327,12 +322,11 @@ TEST_P(dump, Regression)
 {
     const int backend  = get<0>(GetParam());
     const int target   = get<1>(GetParam());
-    Net net = readNet(findDataFile("dnn/squeezenet_v1.1.prototxt"),
-                      findDataFile("dnn/squeezenet_v1.1.caffemodel", false));
+    Net net = readNet(findDataFile("dnn/onnx/models/squeezenet.onnx", false), "");
 
-    ASSERT_EQ(net.getLayerInputs(net.getLayerId("fire2/concat")).size(), 2);
+    ASSERT_EQ(net.getLayerInputs(net.getLayerId("onnx_node_output_0!fire2/concat_1")).size(), 2);
 
-    int size[] = {1, 3, 227, 227};
+    int size[] = {1, 3, 224, 224};
     Mat input = cv::Mat::ones(4, size, CV_32F);
     net.setInput(input);
     net.setPreferableBackend(backend);

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -275,13 +275,12 @@ TEST_P(Test_Model, Classify)
     std::pair<int, float> ref(652, 0.641789);
 
     std::string img_path = _tf("grace_hopper_227.png");
-    std::string config_file = _tf("bvlc_alexnet.prototxt");
-    std::string weights_file = _tf("bvlc_alexnet.caffemodel", false);
+    std::string model_file = _tf("onnx/models/alexnet.onnx", false);
 
     Size size{227, 227};
     float norm = 1e-4;
 
-    testClassifyModel(weights_file, config_file, img_path, ref, norm, size);
+    testClassifyModel(model_file, "", img_path, ref, norm, size);
 }
 
 

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -211,10 +211,9 @@ squeezenet:
 # Googlenet from https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet
 googlenet:
   load_info:
-    url: "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel"
-    sha1: "405fc5acd08a3bb12de8ee5e23a96bec22f08204"
-  model: "bvlc_googlenet.caffemodel"
-  config: "bvlc_googlenet.prototxt"
+    url: "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx"
+    sha1: "534a16d7e2472f6a9a1925a5ee6c9abc2f5c02b0"
+  model: "googlenet-8.onnx"
   mean: [104, 117, 123]
   scale: 1.0
   width: 224

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -196,15 +196,14 @@ faster_rcnn_tf:
 # SqueezeNet v1.1 from https://github.com/DeepScale/SqueezeNet
 squeezenet:
   load_info:
-    url: "https://raw.githubusercontent.com/DeepScale/SqueezeNet/b5c3f1a23713c8b3fd7b801d229f6b04c64374a5/SqueezeNet_v1.1/squeezenet_v1.1.caffemodel"
-    sha1: "3397f026368a45ae236403ccc81cfcbe8ebe1bd0"
-  model: "squeezenet_v1.1.caffemodel"
-  config: "squeezenet_v1.1.prototxt"
-  mean: [0, 0, 0]
-  scale: 1.0
-  width: 227
-  height: 227
-  rgb: false
+      url: "https://github.com/onnx/models/raw/491ce05590abb7551d7fae43c067c060eeb575a6/validated/vision/classification/squeezenet/model/squeezenet1.1-7.onnx"
+      sha1: "ec31942d17715941bb9b81f3a91dc59def9236be"
+  model: "squeezenet1.1-7.onnx"
+  mean: [123.675, 116.779, 103.939]
+  scale: [0.0171, 0.0175, 0.0174]
+  width: 224
+  height: 224
+  rgb: true
   classes: "classification_classes_ILSVRC2012.txt"
   sample: "classification"
 
@@ -214,7 +213,7 @@ googlenet:
     url: "https://github.com/onnx/models/raw/69c5d3751dda5349fd3fc53f525395d180420c07/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx"
     sha1: "534a16d7e2472f6a9a1925a5ee6c9abc2f5c02b0"
   model: "googlenet-8.onnx"
-  mean: [104, 117, 123]
+  mean: [103.939, 116.779, 123.675]
   scale: 1.0
   width: 224
   height: 224


### PR DESCRIPTION
**Merge with:** https://github.com/opencv/opencv_extra/pull/1175
Part of https://github.com/opencv/opencv/issues/25314

This PR aims to change the tests and samples related to `alexnet`, `densenet`, `googlenet`, `squeezenet`, `resnet-50` models from caffe framework to onnx. Tests in `test_int8_layer.cpp` and `test_caffe_importer.cpp` will be removed in https://github.com/opencv/opencv/pull/25323

**NOTE:**
- Removing the VGG sample in HTML because the model is too large to load in the browser. It's meaningless to add this.
    Error: `RuntimeError: Out of bounds memory`
- SqueezeNet onnx from opencv_extra is V1 not V1.1, so I change the testname from V1_1to V1
- May conflict with https://github.com/opencv/opencv/pull/25519

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
