### PR TITLE
videoio: decreased log level for failed backends in capture and writer open

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -161,9 +161,9 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
-                                            info.name, e.what()));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
+                                              info.name, e.what()));
                 }
                 catch (const std::exception& e)
                 {
@@ -171,8 +171,8 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
-                                                  info.name, e.what()));
+                    CV_LOG_WARNING(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
+                                                    info.name, e.what()));
                 }
                 catch (...)
                 {
@@ -180,9 +180,9 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
-                                            info.name));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
+                                              info.name));
                 }
             }
             else
@@ -299,9 +299,9 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
-                                            info.name, e.what()));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
+                                              info.name, e.what()));
                 }
                 catch (const std::exception& e)
                 {
@@ -309,8 +309,8 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
-                                                  info.name, e.what()));
+                    CV_LOG_WARNING(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
+                                                    info.name, e.what()));
                 }
                 catch (...)
                 {
@@ -318,9 +318,9 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
                     {
                         throw;
                     }
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
-                                            info.name));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
+                                              info.name));
                 }
             }
             else
@@ -640,20 +640,20 @@ bool VideoWriter::open(const String& filename, int apiPreference, int fourcc, do
                 }
                 catch (const cv::Exception& e)
                 {
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
-                                            info.name, e.what()));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised OpenCV exception:\n\n%s\n",
+                                              info.name, e.what()));
                 }
                 catch (const std::exception& e)
                 {
-                    CV_LOG_ERROR(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
-                                                  info.name, e.what()));
+                    CV_LOG_WARNING(NULL, cv::format("VIDEOIO(%s): raised C++ exception:\n\n%s\n",
+                                                    info.name, e.what()));
                 }
                 catch (...)
                 {
-                    CV_LOG_ERROR(NULL,
-                                 cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
-                                            info.name));
+                    CV_LOG_WARNING(NULL,
+                                   cv::format("VIDEOIO(%s): raised unknown C++ exception!\n\n",
+                                              info.name));
                 }
             }
             else


### PR DESCRIPTION
Resolves #17879 by decreasing log messages level from "ERROR" to "WARNING".
