### PR TITLE
Fix HAL interface for hal_ni_minMaxIdx

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -912,11 +912,8 @@ CV_EXPORTS_W void reduceArgMax(InputArray src, OutputArray dst, int axis, bool l
 
 The function cv::minMaxIdx finds the minimum and maximum element values and their positions. The
 extremums are searched across the whole array or, if mask is not an empty array, in the specified
-array region. The function does not work with multi-channel arrays. If you need to find minimum or
-maximum elements across all the channels, use Mat::reshape first to reinterpret the array as
-single-channel. Or you may extract the particular channel using either extractImageCOI, or
-mixChannels, or split. In case of a sparse matrix, the minimum is found among non-zero elements
-only.
+array region. In case of a sparse matrix, the minimum is found among non-zero elements
+only. Multi-channel input is supported without mask and extremums indexes (should be nullptr).
 @note When minIdx is not NULL, it must have at least 2 elements (as well as maxIdx), even if src is
 a single-row or single-column matrix. In OpenCV (following MATLAB) each array has at least 2
 dimensions, i.e. single-column matrix is Mx1 matrix (and therefore minIdx/maxIdx will be

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -829,14 +829,14 @@ inline int hal_ni_gemm64fc(const double* src1, size_t src1_step, const double* s
    @param src_step Source image
    @param width Source image dimensions
    @param height Source image dimensions
-   @param type Type of source image
+   @param depth Depth of source image
    @param minVal Pointer to the returned global minimum and maximum in an array.
    @param maxVal Pointer to the returned global minimum and maximum in an array.
    @param minIdx Pointer to the returned minimum and maximum location.
    @param maxIdx Pointer to the returned minimum and maximum location.
    @param mask Specified array region.
 */
-inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int type, double* minVal, double* maxVal,
+inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
                             int* minIdx, int* maxIdx, uchar* mask) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -829,14 +829,14 @@ inline int hal_ni_gemm64fc(const double* src1, size_t src1_step, const double* s
    @param src_step Source image
    @param width Source image dimensions
    @param height Source image dimensions
-   @param depth Depth of source image
+   @param type Type of source image
    @param minVal Pointer to the returned global minimum and maximum in an array.
    @param maxVal Pointer to the returned global minimum and maximum in an array.
    @param minIdx Pointer to the returned minimum and maximum location.
    @param maxIdx Pointer to the returned minimum and maximum location.
    @param mask Specified array region.
 */
-inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
+inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int type, double* minVal, double* maxVal,
                             int* minIdx, int* maxIdx, uchar* mask) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1512,25 +1512,16 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
 
     if (src.dims <= 2)
     {
-        if (cn == 1)
-        {
-            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.depth(), minVal, maxVal,
-                     minIdx, maxIdx, mask.data);
-        }
-        else
-        {
-            int _minIdx, _maxIdx;
-            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols*cn, src.rows, src.depth(), minVal, maxVal,
-                     &_minIdx, &_maxIdx, nullptr);
-        }
+        int _minIdx, _maxIdx;
+        int* min_offset = (cn == 1) ? minIdx : &_minIdx;
+        int* max_offset = (cn == 1) ? maxIdx : &_maxIdx;
+        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols*cn, src.rows, src.depth(),
+                    minVal, maxVal, min_offset, max_offset, mask.data);
     }
-    else
+    else if (src.isContinuous())
     {
-        if (src.isContinuous())
-        {
-            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, 0, src.total(), 1, src.depth(), minVal, maxVal,
-                     minIdx, maxIdx, mask.data);
-        }
+        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, 0, src.total()*cn, 1, src.depth(),
+                 minVal, maxVal, minIdx, maxIdx, mask.data);
     }
 
     CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MINMAXLOC>(src.cols, src.rows),

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1511,7 +1511,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     Mat src = _src.getMat(), mask = _mask.getMat();
 
     if (src.dims <= 2)
-        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.depth(), minVal, maxVal,
+        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.type(), minVal, maxVal,
                  minIdx, maxIdx, mask.data);
 
     CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MINMAXLOC>(src.cols, src.rows),

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1510,18 +1510,18 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
 
     Mat src = _src.getMat(), mask = _mask.getMat();
 
+    int _minIdx, _maxIdx;
+    int* min_offset = (cn == 1) ? minIdx : &_minIdx;
+    int* max_offset = (cn == 1) ? maxIdx : &_maxIdx;
     if (src.dims <= 2)
     {
-        int _minIdx, _maxIdx;
-        int* min_offset = (cn == 1) ? minIdx : &_minIdx;
-        int* max_offset = (cn == 1) ? maxIdx : &_maxIdx;
         CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols*cn, src.rows, src.depth(),
                     minVal, maxVal, min_offset, max_offset, mask.data);
     }
     else if (src.isContinuous())
     {
-        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, 0, src.total()*cn, 1, src.depth(),
-                 minVal, maxVal, minIdx, maxIdx, mask.data);
+        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, 0, (int)src.total()*cn, 1, src.depth(),
+                 minVal, maxVal, min_offset, max_offset, mask.data);
     }
 
     CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MINMAXLOC>(src.cols, src.rows),

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1511,8 +1511,19 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     Mat src = _src.getMat(), mask = _mask.getMat();
 
     if (src.dims <= 2)
-        CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.type(), minVal, maxVal,
-                 minIdx, maxIdx, mask.data);
+    {
+        if (cn == 1)
+        {
+            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.depth(), minVal, maxVal,
+                    minIdx, maxIdx, mask.data);
+        }
+        else
+        {
+            int _minIdx, _maxIdx;
+            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols*cn, src.rows, src.depth(), minVal, maxVal,
+                    &_minIdx, &_maxIdx, nullptr);
+        }
+    }
 
     CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MINMAXLOC>(src.cols, src.rows),
                openvx_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1515,13 +1515,21 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
         if (cn == 1)
         {
             CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols, src.rows, src.depth(), minVal, maxVal,
-                    minIdx, maxIdx, mask.data);
+                     minIdx, maxIdx, mask.data);
         }
         else
         {
             int _minIdx, _maxIdx;
             CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, src.step, src.cols*cn, src.rows, src.depth(), minVal, maxVal,
-                    &_minIdx, &_maxIdx, nullptr);
+                     &_minIdx, &_maxIdx, nullptr);
+        }
+    }
+    else
+    {
+        if (src.isContinuous())
+        {
+            CALL_HAL(minMaxIdx, cv_hal_minMaxIdx, src.data, 0, src.total(), 1, src.depth(), minVal, maxVal,
+                     minIdx, maxIdx, mask.data);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25540

The original implementation call HAL with the same parameters independently from amount of channels. The patch uses HAL correctly for the case cn > 1.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
