### PR TITLE
Disabled conversion to float of model's input

### DIFF
--- a/modules/dnn/src/cuda/concat.cu
+++ b/modules/dnn/src/cuda/concat.cu
@@ -152,6 +152,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void concat<__half>(const Stream&, TensorSpan<__half>, std::size_t, TensorView<__half>, std::size_t);
 #endif
     template void concat<float>(const Stream&, TensorSpan<float>, std::size_t, TensorView<float>,  std::size_t);
+    template void concat<int8_t>(const Stream&, TensorSpan<int8_t>, std::size_t, TensorView<int8_t>,  std::size_t);
+    template void concat<uint8_t>(const Stream&, TensorSpan<uint8_t>, std::size_t, TensorView<uint8_t>,  std::size_t);
     template void concat<int32_t>(const Stream&, TensorSpan<int32_t>, std::size_t, TensorView<int32_t>,  std::size_t);
     template void concat<int64_t>(const Stream&, TensorSpan<int64_t>, std::size_t, TensorView<int64_t>,  std::size_t);
 
@@ -277,6 +279,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void concat_with_offsets(const Stream&, TensorSpan<__half>, TensorView<__half>, std::vector<std::size_t>);
 #endif
     template void concat_with_offsets(const Stream&, TensorSpan<float>, TensorView<float>, std::vector<std::size_t>);
+    template void concat_with_offsets(const Stream&, TensorSpan<int8_t>, TensorView<int8_t>, std::vector<std::size_t>);
+    template void concat_with_offsets(const Stream&, TensorSpan<uint8_t>, TensorView<uint8_t>, std::vector<std::size_t>);
     template void concat_with_offsets(const Stream&, TensorSpan<int32_t>, TensorView<int32_t>, std::vector<std::size_t>);
     template void concat_with_offsets(const Stream&, TensorSpan<int64_t>, TensorView<int64_t>, std::vector<std::size_t>);
 

--- a/modules/dnn/src/cuda/eltwise_ops.cu
+++ b/modules/dnn/src/cuda/eltwise_ops.cu
@@ -371,6 +371,26 @@ void eltwise_fmod_2(const Stream& stream, TensorSpan<T> output, TensorView<T> x,
     template void eltwise_max_2(const Stream& stream, TensorSpan<float> output, TensorView<float> x, TensorView<float> y);
     template void eltwise_min_2(const Stream& stream, TensorSpan<float> output, TensorView<float> x, TensorView<float> y);
 
+    template void eltwise_mod_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_fmod_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_sub_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_div_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_prod_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_sum_coeff_2(const Stream&, TensorSpan<int8_t>, int8_t, TensorView<int8_t>, int8_t, TensorView<int8_t>);
+    template void eltwise_sum_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_max_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+    template void eltwise_min_2(const Stream& stream, TensorSpan<int8_t> output, TensorView<int8_t> x, TensorView<int8_t> y);
+
+    template void eltwise_mod_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_fmod_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_sub_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_div_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_prod_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_sum_coeff_2(const Stream&, TensorSpan<uint8_t>, uint8_t, TensorView<uint8_t>, uint8_t, TensorView<uint8_t>);
+    template void eltwise_sum_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_max_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+    template void eltwise_min_2(const Stream& stream, TensorSpan<uint8_t> output, TensorView<uint8_t> x, TensorView<uint8_t> y);
+
     template void eltwise_mod_2(const Stream& stream, TensorSpan<int32_t> output, TensorView<int32_t> x, TensorView<int32_t> y);
     template void eltwise_fmod_2(const Stream& stream, TensorSpan<int32_t> output, TensorView<int32_t> x, TensorView<int32_t> y);
     template void eltwise_sub_2(const Stream& stream, TensorSpan<int32_t> output, TensorView<int32_t> x, TensorView<int32_t> y);

--- a/modules/dnn/src/cuda/fill_copy.cu
+++ b/modules/dnn/src/cuda/fill_copy.cu
@@ -67,6 +67,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void fill(const Stream&, Span<__half>, __half);
 #endif
     template void fill(const Stream&, Span<float>, float);
+    template void fill(const Stream&, Span<int8_t>, int8_t);
+    template void fill(const Stream&, Span<uint8_t>, uint8_t);
     template void fill(const Stream&, Span<int>, int);
     template void fill(const Stream&, Span<int64_t>, int64_t);
 
@@ -95,6 +97,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void copy(const Stream&, Span<__half>, View<__half>);
 #endif
     template void copy(const Stream&, Span<float>, View<float>);
+    template void copy(const Stream&, Span<int8_t>, View<int8_t>);
+    template void copy(const Stream&, Span<uint8_t>, View<uint8_t>);
     template void copy(const Stream&, Span<int32_t>, View<int32_t>);
     template void copy(const Stream&, Span<int64_t>, View<int64_t>);
 

--- a/modules/dnn/src/cuda/limits.hpp
+++ b/modules/dnn/src/cuda/limits.hpp
@@ -32,6 +32,20 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace de
     };
 
     template <>
+    struct numeric_limits<signed char> {
+        __device__ static signed char min() { return 1; }
+        __device__ static signed char max() { return SCHAR_MAX; }
+        __device__ static signed char lowest() { return SCHAR_MIN; }
+    };
+
+    template <>
+    struct numeric_limits<unsigned char> {
+        __device__ static unsigned char min() { return 1; }
+        __device__ static unsigned char max() { return UCHAR_MAX; }
+        __device__ static unsigned char lowest() { return 0; }
+    };
+
+    template <>
     struct numeric_limits<int32_t> {
         __device__ static int32_t min() { return 1; }
         __device__ static int32_t max() { return INT_MAX; }

--- a/modules/dnn/src/cuda/max_unpooling.cu
+++ b/modules/dnn/src/cuda/max_unpooling.cu
@@ -258,6 +258,26 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
         const std::vector<std::size_t>&);
 
     template void max_pooling_with_indices(const Stream&,
+        TensorSpan<int8_t>, TensorSpan<int32_t>, TensorView<int8_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_pooling_with_indices(const Stream&,
+        TensorSpan<int8_t>, TensorSpan<int64_t>, TensorView<int8_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_pooling_with_indices(const Stream&,
+        TensorSpan<uint8_t>, TensorSpan<int32_t>, TensorView<uint8_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_pooling_with_indices(const Stream&,
+        TensorSpan<uint8_t>, TensorSpan<int64_t>, TensorView<uint8_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_pooling_with_indices(const Stream&,
         TensorSpan<int32_t>, TensorSpan<int32_t>, TensorView<int32_t>,
         const std::vector<std::size_t>&, const std::vector<std::size_t>&,
         const std::vector<std::size_t>&);
@@ -362,6 +382,26 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
     template void max_unpooling(const Stream&,
         TensorSpan<float>, TensorView<float>, TensorView<int64_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_unpooling(const Stream&,
+        TensorSpan<int8_t>, TensorView<int8_t>, TensorView<int32_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_unpooling(const Stream&,
+        TensorSpan<int8_t>, TensorView<int8_t>, TensorView<int64_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_unpooling(const Stream&,
+        TensorSpan<uint8_t>, TensorView<uint8_t>, TensorView<int32_t>,
+        const std::vector<std::size_t>&, const std::vector<std::size_t>&,
+        const std::vector<std::size_t>&);
+
+    template void max_unpooling(const Stream&,
+        TensorSpan<uint8_t>, TensorView<uint8_t>, TensorView<int64_t>,
         const std::vector<std::size_t>&, const std::vector<std::size_t>&,
         const std::vector<std::size_t>&);
 

--- a/modules/dnn/src/cuda/padding.cu
+++ b/modules/dnn/src/cuda/padding.cu
@@ -197,6 +197,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void copy_with_reflection101(const Stream&, TensorSpan<__half>, TensorView<__half>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
 #endif
     template void copy_with_reflection101(const Stream&, TensorSpan<float>, TensorView<float>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
+    template void copy_with_reflection101(const Stream&, TensorSpan<int8_t>, TensorView<int8_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
+    template void copy_with_reflection101(const Stream&, TensorSpan<uint8_t>, TensorView<uint8_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
     template void copy_with_reflection101(const Stream&, TensorSpan<int32_t>, TensorView<int32_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
     template void copy_with_reflection101(const Stream&, TensorSpan<int64_t>, TensorView<int64_t>, std::vector<std::pair<std::size_t, std::size_t>> ranges);
 

--- a/modules/dnn/src/cuda/permute.cu
+++ b/modules/dnn/src/cuda/permute.cu
@@ -107,6 +107,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
     template void transpose(const Stream&, Span<__half>, View<__half>, std::size_t, std::size_t);
     template void transpose(const Stream&, Span<float>, View<float>, std::size_t, std::size_t);
+    template void transpose(const Stream&, Span<int8_t>, View<int8_t>, std::size_t, std::size_t);
+    template void transpose(const Stream&, Span<uint8_t>, View<uint8_t>, std::size_t, std::size_t);
     template void transpose(const Stream&, Span<int32_t>, View<int32_t>, std::size_t, std::size_t);
     template void transpose(const Stream&, Span<int64_t>, View<int64_t>, std::size_t, std::size_t);
 
@@ -286,6 +288,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void permute(const Stream&, TensorSpan<__half>, TensorView<__half>, std::vector<std::size_t>);
 #endif
     template void permute(const Stream&, TensorSpan<float>, TensorView<float>, std::vector<std::size_t>);
+    template void permute(const Stream&, TensorSpan<int8_t>, TensorView<int8_t>, std::vector<std::size_t>);
+    template void permute(const Stream&, TensorSpan<uint8_t>, TensorView<uint8_t>, std::vector<std::size_t>);
     template void permute(const Stream&, TensorSpan<int32_t>, TensorView<int32_t>, std::vector<std::size_t>);
     template void permute(const Stream&, TensorSpan<int64_t>, TensorView<int64_t>, std::vector<std::size_t>);
 

--- a/modules/dnn/src/cuda/slice.cu
+++ b/modules/dnn/src/cuda/slice.cu
@@ -199,6 +199,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     template void slice(const Stream&, TensorSpan<__half>, TensorView<__half>, std::vector<std::size_t>);
 #endif
     template void slice(const Stream&, TensorSpan<float>, TensorView<float>, std::vector<std::size_t>);
+    template void slice(const Stream&, TensorSpan<int8_t>, TensorView<int8_t>, std::vector<std::size_t>);
+    template void slice(const Stream&, TensorSpan<uint8_t>, TensorView<uint8_t>, std::vector<std::size_t>);
     template void slice(const Stream&, TensorSpan<int32_t>, TensorView<int32_t>, std::vector<std::size_t>);
     template void slice(const Stream&, TensorSpan<int64_t>, TensorView<int64_t>, std::vector<std::size_t>);
 

--- a/modules/dnn/src/layer_internals.hpp
+++ b/modules/dnn/src/layer_internals.hpp
@@ -154,9 +154,10 @@ struct DataLayer : public Layer
         for (int i = 0; i < inputsData.size(); ++i)
         {
             bool isFP16 = outputs[i].depth() == CV_16F;
-            if (inputsData[i].type() == CV_32S || inputsData[i].type() == CV_64S) {
+            if (inputsData[i].type() != CV_32F)
+            {
                 CV_CheckTypeEQ(outputs[i].type(), inputsData[i].type(), "");
-                CV_Assert(means[i] == Scalar() && scaleFactors[i] == 1.0);
+                CV_CheckTrue(means[i] == Scalar() && scaleFactors[i] == 1.0, "Input mean and scale are supported only for float32 input");
                 inputsData[i].copyTo(outputs[i]);
                 continue;
             }
@@ -221,9 +222,10 @@ struct DataLayer : public Layer
         for (int i = 0; i < inputsData.size(); ++i)
         {
             bool isFP16 = outputs[i].depth() == CV_16F;
-            if (inputsData[i].type() == CV_32S || inputsData[i].type() == CV_64S) {
+            if (inputsData[i].type() != CV_32F)
+            {
                 CV_CheckTypeEQ(outputs[i].type(), inputsData[i].type(), "");
-                CV_Assert(means[i] == Scalar() && scaleFactors[i] == 1.0);
+                CV_CheckTrue(means[i] == Scalar() && scaleFactors[i] == 1.0, "Input mean and scale are supported only for float32 input");
                 inputsData[i].copyTo(outputs[i]);
                 continue;
             }

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -359,9 +359,7 @@ public:
         for (auto input : inputs)
         {
             CV_CheckTypeEQ(inputs[0], input, "All inputs should have equal types");
-            if (preferableTarget == DNN_TARGET_CUDA_FP16 || preferableTarget == DNN_TARGET_CUDA)
-                CV_CheckType(input, input == CV_32F || input == CV_32S || input == CV_64S, "Unsupported type");
-            else if (preferableTarget == DNN_TARGET_OPENCL_FP16)
+            if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_8S || input == CV_8U || input == CV_32S || input == CV_64S, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_8U || input == CV_32S || input == CV_64S, "");

--- a/modules/dnn/src/legacy_backend.cpp
+++ b/modules/dnn/src/legacy_backend.cpp
@@ -90,7 +90,7 @@ Ptr<BackendWrapper> wrapMat(int backendId, int targetId, cv::Mat& m)
         CV_Assert(haveCUDA());
 
 #ifdef HAVE_CUDA
-        CV_CheckType(m.depth(), m.depth() == CV_32F || m.depth() == CV_32S || m.depth() == CV_64S, "Unsupported type for CUDA");
+        CV_CheckType(m.depth(), m.depth() == CV_32F || m.depth() == CV_8S || m.depth() == CV_8U || m.depth() == CV_32S || m.depth() == CV_64S, "Unsupported type for CUDA");
         CV_Assert(IS_DNN_CUDA_TARGET(targetId));
         switch (m.depth())
         {
@@ -99,6 +99,10 @@ Ptr<BackendWrapper> wrapMat(int backendId, int targetId, cv::Mat& m)
                 return CUDABackendWrapperFP16::create(m);
             else
                 return CUDABackendWrapperFP32::create(m);
+        case CV_8S:
+            return CUDABackendWrapperINT8::create(m);
+        case CV_8U:
+            return CUDABackendWrapperUINT8::create(m);
         case CV_32S:
             return CUDABackendWrapperINT32::create(m);
         case CV_64S:

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -552,7 +552,7 @@ void Net::Impl::allocateLayers(const std::vector<LayerPin>& blobsToKeep_)
         Mat& inp = layers[0].outputBlobs[i];
         CV_Assert(inp.total());
         int type = inp.type();
-        if (type != CV_32S && type != CV_64S)
+        if (type == CV_32F)
         {
             type = CV_32F;
             if (preferableBackend == DNN_BACKEND_OPENCV &&
@@ -561,9 +561,6 @@ void Net::Impl::allocateLayers(const std::vector<LayerPin>& blobsToKeep_)
                 type = CV_16F;
                 if (layers[0].dtype == CV_32F)
                     layers[0].outputBlobs[i].create(inp.dims, inp.size, CV_16F);
-            }
-            if (netWasQuantized && inp.type() == CV_8S) {
-                type = CV_8S;
             }
         }
         inputShapes.push_back(shape(inp));

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -62,7 +62,7 @@ Ptr<BackendWrapper> Net::Impl::wrap(Mat& host)
         {
             CV_Assert(haveCUDA());
 #ifdef HAVE_CUDA
-            CV_CheckType(host.depth(), host.depth() == CV_32F || host.depth() == CV_32S || host.depth() == CV_64S, "Unsupported type for CUDA");
+            CV_CheckType(host.depth(), host.depth() == CV_32F || host.depth() == CV_8S || host.depth() == CV_8U || host.depth() == CV_32S || host.depth() == CV_64S, "Unsupported type for CUDA");
             CV_Assert(IS_DNN_CUDA_TARGET(preferableTarget));
             switch (host.depth())
             {
@@ -71,6 +71,10 @@ Ptr<BackendWrapper> Net::Impl::wrap(Mat& host)
                     return CUDABackendWrapperFP16::create(baseBuffer, shape);
                 else
                     return CUDABackendWrapperFP32::create(baseBuffer, shape);
+            case CV_8S:
+                return CUDABackendWrapperINT8::create(baseBuffer, shape);
+            case CV_8U:
+                return CUDABackendWrapperUINT8::create(baseBuffer, shape);
             case CV_32S:
                 return CUDABackendWrapperINT32::create(baseBuffer, shape);
             case CV_64S:

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1704,7 +1704,7 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }
 
-Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
+Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToInt8)
 {
     if (tensor_proto.raw_data().empty() && tensor_proto.float_data().empty() &&
         tensor_proto.double_data().empty() && tensor_proto.int64_data().empty() &&
@@ -1834,22 +1834,38 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto)
             Mat(sizes, CV_64SC1, (void*)src).copyTo(blob);
         }
     }
-    else if (datatype == opencv_onnx::TensorProto_DataType_INT8 ||
-             datatype == opencv_onnx::TensorProto_DataType_UINT8)
+    else if (datatype == opencv_onnx::TensorProto_DataType_INT8)
     {
-        // TODO : Add support for uint8 weights and acitvations. For now, converting uint8 tensors to int8.
-        int offset = datatype == opencv_onnx::TensorProto_DataType_INT8 ? 0 : -128;
-        int depth = datatype == opencv_onnx::TensorProto_DataType_INT8 ? CV_8S : CV_8U;
-
         if (!tensor_proto.int32_data().empty())
         {
             const ::google::protobuf::RepeatedField<int32_t> field = tensor_proto.int32_data();
-            Mat(sizes, CV_32SC1, (void*)field.data()).convertTo(blob, CV_8S, 1.0, offset);
+            Mat(sizes, CV_32SC1, (void*)field.data()).convertTo(blob, CV_8S);
         }
         else
         {
             char* val = const_cast<char*>(tensor_proto.raw_data().c_str());
-            Mat(sizes, depth, val).convertTo(blob, CV_8S, 1.0, offset);
+            Mat(sizes, CV_8S, val).copyTo(blob);
+        }
+    }
+    else if (datatype == opencv_onnx::TensorProto_DataType_UINT8)
+    {
+        // TODO : Add support for uint8 weights and acitvations. For now, converting uint8 tensors to int8.
+
+        if (!tensor_proto.int32_data().empty())
+        {
+            const ::google::protobuf::RepeatedField<int32_t> field = tensor_proto.int32_data();
+            if (uint8ToInt8)
+                Mat(sizes, CV_32SC1, (void*)field.data()).convertTo(blob, CV_8S, 1, -128); // handle as ONNX quantized weight
+            else
+                Mat(sizes, CV_32SC1, (void*)field.data()).convertTo(blob, CV_8U);
+        }
+        else
+        {
+            char* val = const_cast<char*>(tensor_proto.raw_data().c_str());
+            if (uint8ToInt8)
+                Mat(sizes, CV_8U, val).convertTo(blob, CV_8S, 1, -128);  // handle as ONNX quantized weight
+            else
+                Mat(sizes, CV_8U, val).copyTo(blob);
         }
     }
     else

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.hpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.hpp
@@ -32,7 +32,11 @@ void convertInt64ToInt32(const T1& src, T2& dst, int size)
     }
 }
 
-Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto);
+/** @brief converts tensor to Mat, preserving the tensor data type
+ *  @param uint8ToInt8 if true, handles uint8 tensor as quantized weight. So output Mat = int8(int32(uint8_tensor) - 128)).
+ *  if false, just returns uint8 Mat.
+*/
+Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToInt8 = true);
 
 CV__DNN_INLINE_NS_END
 }}  // namespace dnn, namespace cv

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4116,7 +4116,7 @@ Mat readTensorFromONNX(const String& path)
     {
         CV_Error(Error::StsUnsupportedFormat, cv::format("Failed to parse ONNX data: %s", path.c_str()));
     }
-    Mat mat = getMatFromTensor(tensor_proto);
+    Mat mat = getMatFromTensor(tensor_proto, false);
     releaseONNXTensor(tensor_proto);
     return mat;
 }

--- a/modules/dnn/src/op_cuda.hpp
+++ b/modules/dnn/src/op_cuda.hpp
@@ -108,6 +108,18 @@ namespace cv { namespace dnn {
         }
 
         template <> inline
+        void copyMatToTensor(const Mat& srcMat, const TensorSpan<int8_t> destTensor, const Stream& stream) {
+            CV_CheckTypeEQ(srcMat.type(), CV_8S, "");
+            copyMatToTensorImpl(srcMat, destTensor, stream);
+        }
+
+        template <> inline
+        void copyMatToTensor(const Mat& srcMat, const TensorSpan<uint8_t> destTensor, const Stream& stream) {
+            CV_CheckTypeEQ(srcMat.type(), CV_8U, "");
+            copyMatToTensorImpl(srcMat, destTensor, stream);
+        }
+
+        template <> inline
         void copyMatToTensor(const Mat& srcMat, const TensorSpan<int32_t> destTensor, const Stream& stream) {
             CV_CheckTypeEQ(srcMat.type(), CV_32S, "");
             copyMatToTensorImpl(srcMat, destTensor, stream);
@@ -217,9 +229,13 @@ namespace cv { namespace dnn {
 
     template <template <class> class NodeType, class ...Args>
     cv::Ptr<BackendNode> make_cuda_node_with_type(int targetId, int hostMatType, Args&& ...args) {
-        CV_CheckType(hostMatType, hostMatType == CV_32F || hostMatType == CV_32S || hostMatType == CV_64S, "");
+        CV_CheckType(hostMatType, hostMatType == CV_32F || hostMatType == CV_8S || hostMatType == CV_8U || hostMatType == CV_32S || hostMatType == CV_64S, "");
 
-        if (hostMatType == CV_32S)
+        if (hostMatType == CV_8S)
+            return Ptr<BackendNode>(new NodeType<int8_t>(std::forward<Args>(args)...));
+        else if (hostMatType == CV_8U)
+            return Ptr<BackendNode>(new NodeType<uint8_t>(std::forward<Args>(args)...));
+        else if (hostMatType == CV_32S)
             return Ptr<BackendNode>(new NodeType<int32_t>(std::forward<Args>(args)...));
         else if (hostMatType == CV_64S)
             return Ptr<BackendNode>(new NodeType<int64_t>(std::forward<Args>(args)...));
@@ -236,9 +252,13 @@ namespace cv { namespace dnn {
 
     template <template <class, class> class NodeType, class T_INDEX, class ...Args>
     cv::Ptr<BackendNode> make_cuda_node_with_indices(int targetId, int hostMatType, Args&& ...args) {
-        CV_CheckType(hostMatType, hostMatType == CV_32F || hostMatType == CV_32S || hostMatType == CV_64S, "");
+        CV_CheckType(hostMatType, hostMatType == CV_32F || hostMatType == CV_8S || hostMatType == CV_8U || hostMatType == CV_32S || hostMatType == CV_64S, "");
 
-        if (hostMatType == CV_32S)
+        if (hostMatType == CV_8S)
+            return Ptr<BackendNode>(new NodeType<int8_t, T_INDEX>(std::forward<Args>(args)...));
+        else if (hostMatType == CV_8U)
+            return Ptr<BackendNode>(new NodeType<uint8_t, T_INDEX>(std::forward<Args>(args)...));
+        else if (hostMatType == CV_32S)
             return Ptr<BackendNode>(new NodeType<int32_t, T_INDEX>(std::forward<Args>(args)...));
         else if (hostMatType == CV_64S)
             return Ptr<BackendNode>(new NodeType<int64_t, T_INDEX>(std::forward<Args>(args)...));
@@ -296,6 +316,16 @@ namespace cv { namespace dnn {
         }
 
         template <> inline
+        void convert_D2H<int8_t, int8_t>(const cv::Mat& mat, cuda4dnn::csl::View<int8_t> view, cuda4dnn::csl::ManagedPtr<int8_t>& device_temp, const cuda4dnn::csl::Stream& stream) {
+            cuda4dnn::csl::memcpy<int8_t>(reinterpret_cast<int8_t*>(mat.data), view.data(), view.size(), stream);
+        }
+
+        template <> inline
+        void convert_D2H<uint8_t, uint8_t>(const cv::Mat& mat, cuda4dnn::csl::View<uint8_t> view, cuda4dnn::csl::ManagedPtr<uint8_t>& device_temp, const cuda4dnn::csl::Stream& stream) {
+            cuda4dnn::csl::memcpy<uint8_t>(reinterpret_cast<uint8_t*>(mat.data), view.data(), view.size(), stream);
+        }
+
+        template <> inline
         void convert_D2H<int32_t, int32_t>(const cv::Mat& mat, cuda4dnn::csl::View<int32_t> view, cuda4dnn::csl::ManagedPtr<int32_t>& device_temp, const cuda4dnn::csl::Stream& stream) {
             cuda4dnn::csl::memcpy<int32_t>(reinterpret_cast<int32_t*>(mat.data), view.data(), view.size(), stream);
         }
@@ -336,6 +366,20 @@ namespace cv { namespace dnn {
         }
 
         template <> inline
+        void convert_D2H_background<int8_t, int8_t>(const cv::Mat& mat, cuda4dnn::csl::View<int8_t> view, cuda4dnn::csl::ManagedPtr<int8_t>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event) {
+            d2h_event.record(stream);
+            cuda4dnn::csl::StreamWaitOnEvent(d2h_stream, d2h_event);
+            cuda4dnn::csl::memcpy<int8_t>(reinterpret_cast<int8_t*>(mat.data), view.data(), view.size(), d2h_stream);
+        }
+
+        template <> inline
+        void convert_D2H_background<uint8_t, uint8_t>(const cv::Mat& mat, cuda4dnn::csl::View<uint8_t> view, cuda4dnn::csl::ManagedPtr<uint8_t>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event) {
+            d2h_event.record(stream);
+            cuda4dnn::csl::StreamWaitOnEvent(d2h_stream, d2h_event);
+            cuda4dnn::csl::memcpy<uint8_t>(reinterpret_cast<uint8_t*>(mat.data), view.data(), view.size(), d2h_stream);
+        }
+
+        template <> inline
         void convert_D2H_background<int32_t, int32_t>(const cv::Mat& mat, cuda4dnn::csl::View<int32_t> view, cuda4dnn::csl::ManagedPtr<int32_t>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event) {
             d2h_event.record(stream);
             cuda4dnn::csl::StreamWaitOnEvent(d2h_stream, d2h_event);
@@ -365,6 +409,16 @@ namespace cv { namespace dnn {
         template <> inline
         void convert_H2D<float, float>(cuda4dnn::csl::Span<float> span, const cv::Mat& mat, cuda4dnn::csl::ManagedPtr<float>& device_temp, const cuda4dnn::csl::Stream& stream) {
             cuda4dnn::csl::memcpy<float>(span.data(), reinterpret_cast<float*>(mat.data), span.size(), stream);
+        }
+
+        template <> inline
+        void convert_H2D<int8_t, int8_t>(cuda4dnn::csl::Span<int8_t> span, const cv::Mat& mat, cuda4dnn::csl::ManagedPtr<int8_t>& device_temp, const cuda4dnn::csl::Stream& stream) {
+            cuda4dnn::csl::memcpy<int8_t>(span.data(), reinterpret_cast<int8_t*>(mat.data), span.size(), stream);
+        }
+
+        template <> inline
+        void convert_H2D<uint8_t, uint8_t>(cuda4dnn::csl::Span<uint8_t> span, const cv::Mat& mat, cuda4dnn::csl::ManagedPtr<uint8_t>& device_temp, const cuda4dnn::csl::Stream& stream) {
+            cuda4dnn::csl::memcpy<uint8_t>(span.data(), reinterpret_cast<uint8_t*>(mat.data), span.size(), stream);
         }
 
         template <> inline
@@ -604,12 +658,16 @@ namespace cv { namespace dnn {
 
     using CUDABackendWrapperFP16 = GenericCUDABackendWrapper<half, float, DNN_TARGET_CUDA_FP16>;
     using CUDABackendWrapperFP32 = GenericCUDABackendWrapper<float, float, DNN_TARGET_CUDA>;
+    using CUDABackendWrapperINT8 = GenericCUDABackendWrapper<int8_t, int8_t, DNN_TARGET_CUDA>;
+    using CUDABackendWrapperUINT8 = GenericCUDABackendWrapper<uint8_t, uint8_t, DNN_TARGET_CUDA>;
     using CUDABackendWrapperINT32 = GenericCUDABackendWrapper<int32_t, int32_t, DNN_TARGET_CUDA>;
     using CUDABackendWrapperINT64 = GenericCUDABackendWrapper<int64_t, int64_t, DNN_TARGET_CUDA>;
 
     template <class T> struct GetCUDABackendWrapperType_ { };
     template <> struct GetCUDABackendWrapperType_<half> { typedef CUDABackendWrapperFP16 type; };
     template <> struct GetCUDABackendWrapperType_<float> { typedef CUDABackendWrapperFP32 type; };
+    template <> struct GetCUDABackendWrapperType_<int8_t> { typedef CUDABackendWrapperINT8 type; };
+    template <> struct GetCUDABackendWrapperType_<uint8_t> { typedef CUDABackendWrapperUINT8 type; };
     template <> struct GetCUDABackendWrapperType_<int32_t> { typedef CUDABackendWrapperINT32 type; };
     template <> struct GetCUDABackendWrapperType_<int64_t> { typedef CUDABackendWrapperINT64 type; };
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1295,39 +1295,6 @@ TEST_P(Layer_Test_Convolution_DLDT, Accuracy)
         ASSERT_EQ(net.getLayer(outLayers[0])->type, "Result");
 }
 
-TEST_P(Layer_Test_Convolution_DLDT, setInput_uint8)
-{
-    const Backend backendId = get<0>(GetParam());
-    const Target targetId = get<1>(GetParam());
-
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && targetId == DNN_TARGET_MYRIAD)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
-
-    if (backendId != DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && backendId != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-        throw SkipTestException("No support for async forward");
-
-    ASSERT_EQ(DNN_BACKEND_INFERENCE_ENGINE_NGRAPH, backendId);
-
-    int blobSize[] = {2, 6, 75, 113};
-    Mat inputs[] = {Mat(4, &blobSize[0], CV_8U), Mat()};
-
-    randu(inputs[0], 0, 255);
-    inputs[0].convertTo(inputs[1], CV_32F);
-
-    Mat outs[2];
-    for (int i = 0; i < 2; ++i)
-    {
-        Net net = readNet(_tf("layer_convolution.xml"), _tf("layer_convolution.bin"));
-        net.setPreferableBackend(backendId);
-        net.setPreferableTarget(targetId);
-        net.setInput(inputs[i]);
-        outs[i] = net.forward();
-        ASSERT_EQ(outs[i].type(), CV_32F);
-    }
-    if (targetId != DNN_TARGET_MYRIAD)
-        normAssert(outs[0], outs[1]);
-}
-
 TEST_P(Layer_Test_Convolution_DLDT, multithreading)
 {
     const Backend backendId = get<0>(GetParam());

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -451,7 +451,7 @@ TEST_P(setInput, normalization)
 INSTANTIATE_TEST_CASE_P(/**/, setInput, Combine(
   Values(1.0f, 1.0 / 127.5),
   Values(Vec3f(), Vec3f(50, 50, 50), Vec3f(10, 50, 140)),
-  Values(CV_32F, CV_8U),
+  Values(CV_32F),
   dnnBackendsAndTargets()
 ));
 
@@ -1059,8 +1059,8 @@ TEST_P(Test_two_inputs, basic)
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_two_inputs, Combine(
-    Values(CV_32F, CV_8U),
-    Values(CV_32F, CV_8U),
+    Values(CV_32F),
+    Values(CV_32F),
     dnnBackendsAndTargets()
 ));
 

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -835,7 +835,7 @@ TEST_P(Async, create_layer_pipeline_set_and_forward_all)
 }
 
 INSTANTIATE_TEST_CASE_P(/**/, Async, Combine(
-    Values(CV_32F, CV_8U),
+    Values(CV_32F),
     dnnBackendsAndTargetsIE()
 ));
 

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -112,133 +112,69 @@ CASE(test_and_bcast4v3d)
 CASE(test_and_bcast4v4d)
     // no filter
 CASE(test_argmax_default_axis_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_default_axis_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_default_axis_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_default_axis_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_negative_axis_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_negative_axis_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_negative_axis_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_negative_axis_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_no_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_no_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_no_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmax_no_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_default_axis_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_default_axis_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_default_axis_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_default_axis_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_negative_axis_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_negative_axis_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_negative_axis_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_negative_axis_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_no_keepdims_example)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_no_keepdims_example_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_no_keepdims_random)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_argmin_no_keepdims_random_select_last_index)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_asin)
     // no filter
 CASE(test_asin_example)
@@ -937,7 +873,7 @@ CASE(test_max_int16)
 CASE(test_max_int32)
     // no filter
 CASE(test_max_int64)
-    // no filter
+    SKIP;
 CASE(test_max_int8)
     // no filter
 CASE(test_max_one_input)
@@ -1037,7 +973,7 @@ CASE(test_min_int16)
 CASE(test_min_int32)
     // no filter
 CASE(test_min_int64)
-    // no filter
+    SKIP;
 CASE(test_min_int8)
     // no filter
 CASE(test_min_one_input)
@@ -1106,9 +1042,7 @@ CASE(test_mul_bcast)
 CASE(test_mul_example)
     // no filter
 CASE(test_mul_uint8)
-#if SKIP_SET_1
     SKIP;
-#endif
 CASE(test_mvn)
     // no filter
 CASE(test_mvn_expanded)
@@ -1276,7 +1210,7 @@ CASE(test_pow_types_int32_int32)
 CASE(test_pow_types_int64_float32)
     // no filter
 CASE(test_pow_types_int64_int64)
-    // no filter
+    SKIP;
 CASE(test_prelu_broadcast)
     // no filter
 CASE(test_prelu_example)

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -1,4 +1,4 @@
-"test_add_uint8", // output size mismatch in NORMASSERT
+// "test_add_uint8", // output size mismatch in NORMASSERT
 "test_averagepool_2d_pads_count_include_pad",  // wrong output
 "test_averagepool_2d_precomputed_pads_count_include_pad", // wrong output
 "test_averagepool_2d_same_lower", // wrong output
@@ -6,12 +6,12 @@
 "test_cast_STRING_to_FLOAT", // unexception during net.forward() call
 "test_castlike_FLOAT_to_STRING_expanded", // Unsupported type in function 'parseCast'
 "test_castlike_STRING_to_FLOAT_expanded", // unexception during net.forward() call
-"test_div_uint8",  // output type mismatch
+// "test_div_uint8",  // output type mismatch
 "test_maxpool_2d_dilations", // output size mismatch in NORMASSERT
 "test_maxpool_2d_same_lower", // wrong output
 "test_maxpool_2d_uint8",  // output type mismatch
 "test_maxpool_with_argmax_2d_precomputed_strides", // wrong output
 "test_maxunpool_export_with_output_shape",  // unexception during net.forward() call
-"test_mul_uint8",  // output type mismatch
-"test_sub_uint8",  // output type mismatch
+// "test_mul_uint8",  // output type mismatch
+// "test_sub_uint8",  // output type mismatch
 "test_upsample_nearest", // Dimension mismatch of input

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -1,4 +1,3 @@
-// "test_add_uint8", // output size mismatch in NORMASSERT
 "test_averagepool_2d_pads_count_include_pad",  // wrong output
 "test_averagepool_2d_precomputed_pads_count_include_pad", // wrong output
 "test_averagepool_2d_same_lower", // wrong output
@@ -6,12 +5,9 @@
 "test_cast_STRING_to_FLOAT", // unexception during net.forward() call
 "test_castlike_FLOAT_to_STRING_expanded", // Unsupported type in function 'parseCast'
 "test_castlike_STRING_to_FLOAT_expanded", // unexception during net.forward() call
-// "test_div_uint8",  // output type mismatch
 "test_maxpool_2d_dilations", // output size mismatch in NORMASSERT
 "test_maxpool_2d_same_lower", // wrong output
 "test_maxpool_2d_uint8",  // output type mismatch
 "test_maxpool_with_argmax_2d_precomputed_strides", // wrong output
 "test_maxunpool_export_with_output_shape",  // unexception during net.forward() call
-// "test_mul_uint8",  // output type mismatch
-// "test_sub_uint8",  // output type mismatch
 "test_upsample_nearest", // Dimension mismatch of input

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -180,13 +180,13 @@
 "test_max_int16", // Issue:: Unsupported data type
 // "test_max_int32",
 // "test_max_int64",
-"test_max_int8", // Issue:: Unkonwn error
+// "test_max_int8", // Issue:: Unkonwn error
 // "test_max_one_input",
 // "test_max_two_inputs",
 "test_max_uint16", // Issue:: Unsupported data type
 "test_max_uint32", // Issue:: Unsupported data type
 "test_max_uint64", // Issue:: Unsupported data type
-"test_max_uint8", // Issue:: Unkonwn error
+// "test_max_uint8", // Issue:: Unkonwn error
 "test_mean_example", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!result" of type "Mean" in function 'getLayerInstance'
 "test_mean_one_input",  // ---- same as above ---
 "test_mean_two_inputs",  // ---- same as above ---
@@ -197,23 +197,23 @@
 "test_min_int16",  // Issue:: Unsupported data type
 // "test_min_int32",
 // "test_min_int64",
-"test_min_int8", // Issue:: Unkonwn error
+// "test_min_int8", // Issue:: Unkonwn error
 // "test_min_one_input",
 // "test_min_two_inputs",
 "test_min_uint16", // Issue:: Unsupported data type
 "test_min_uint32", // Issue:: Unkonwn error
 "test_min_uint64", // Issue:: Unsupported data type
-"test_min_uint8", // Issue:: Unkonwn error
+// "test_min_uint8", // Issue:: Unkonwn error
 // "test_mod_broadcast",
 // "test_mod_int64_fmod",
 "test_mod_mixed_sign_int16", // Issue:: Unkonwn error
 // "test_mod_mixed_sign_int32",
 // "test_mod_mixed_sign_int64",
-"test_mod_mixed_sign_int8", // Issue:: Unkonwn error
+// "test_mod_mixed_sign_int8", // Issue:: Unkonwn error
 "test_mod_uint16", // Issue:: Unkonwn error
 "test_mod_uint32", // ---- same as above ---
 "test_mod_uint64", // ---- same as above ---
-"test_mod_uint8", // ---- same as above ---
+// "test_mod_uint8", // ---- same as above ---
 "test_momentum", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!X1_new" of type "ai.onnx.preview.training.Momentum" in function 'getLayerInstance'
 "test_momentum_multiple", // ---- same as above ---
 // "test_mul_example",

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -32,7 +32,6 @@
 "test_bitshift_right_uint64", // Issue::Unsuppoted data type
 "test_bitshift_right_uint8", // Issues::Layer::Can't create layer "onnx_node_output_0!z" of type "BitShift" in function 'getLayerInstance'
 "test_cast_BFLOAT16_to_FLOAT",  // Issue::Unsuppoted data type
-// "test_cast_DOUBLE_to_FLOAT",
 "test_cast_DOUBLE_to_FLOAT16", // Issue::Unsuppoted data type
 "test_cast_FLOAT16_to_DOUBLE", // Issue::Unsuppoted data type
 "test_cast_FLOAT16_to_FLOAT", // Issue::Unsuppoted data type
@@ -93,7 +92,6 @@
 "test_dequantizelinear_axis", // Issue::Parser::Weights are required as inputs
 "test_det_2d", // Issue:: Unkonwn error
 "test_det_nd", // Issue:: Unkonwn error
-// "test_div_example",
 "test_dropout_default_mask", // Issue:: Unsupported data type BOOL
 "test_dropout_default_mask_ratio", // Issue:: Unsupported data type BOOL
 "test_dynamicquantizelinear", // Issue:: Unkonwn error
@@ -117,8 +115,6 @@
 "test_gemm_all_attributes",  // Issue::Wrong output
 "test_gemm_alpha",  // Issue::Wrong output
 "test_gemm_beta",  // Issue::Wrong output
-// "test_gemm_default_matrix_bias",
-// "test_gemm_default_no_bias",
 "test_gemm_default_scalar_bias",  // Issue::Wrong output
 "test_gemm_default_single_elem_vector_bias",  // Issue::Wrong output
 "test_gemm_default_vector_bias",  // Issue::Wrong output
@@ -173,67 +169,36 @@
 "test_lstm_with_initial_bias", // ---- same as above ---
 "test_lstm_with_peepholes", // ---- same as above ---
 "test_matmulinteger", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!Y" of type "MatMulInteger" in function 'getLayerInstance'
-// "test_max_example",
-// "test_max_float16",
-// "test_max_float32",
-// "test_max_float64",
 "test_max_int16", // Issue:: Unsupported data type
-// "test_max_int32",
-// "test_max_int64",
-// "test_max_int8", // Issue:: Unkonwn error
-// "test_max_one_input",
-// "test_max_two_inputs",
 "test_max_uint16", // Issue:: Unsupported data type
 "test_max_uint32", // Issue:: Unsupported data type
 "test_max_uint64", // Issue:: Unsupported data type
-// "test_max_uint8", // Issue:: Unkonwn error
 "test_mean_example", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!result" of type "Mean" in function 'getLayerInstance'
 "test_mean_one_input",  // ---- same as above ---
 "test_mean_two_inputs",  // ---- same as above ---
-// "test_min_example",
-// "test_min_float16",
-// "test_min_float32",
-// "test_min_float64",
 "test_min_int16",  // Issue:: Unsupported data type
-// "test_min_int32",
-// "test_min_int64",
-// "test_min_int8", // Issue:: Unkonwn error
-// "test_min_one_input",
-// "test_min_two_inputs",
 "test_min_uint16", // Issue:: Unsupported data type
 "test_min_uint32", // Issue:: Unkonwn error
 "test_min_uint64", // Issue:: Unsupported data type
-// "test_min_uint8", // Issue:: Unkonwn error
-// "test_mod_broadcast",
-// "test_mod_int64_fmod",
 "test_mod_mixed_sign_int16", // Issue:: Unkonwn error
-// "test_mod_mixed_sign_int32",
-// "test_mod_mixed_sign_int64",
-// "test_mod_mixed_sign_int8", // Issue:: Unkonwn error
 "test_mod_uint16", // Issue:: Unkonwn error
 "test_mod_uint32", // ---- same as above ---
 "test_mod_uint64", // ---- same as above ---
-// "test_mod_uint8", // ---- same as above ---
 "test_momentum", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!X1_new" of type "ai.onnx.preview.training.Momentum" in function 'getLayerInstance'
 "test_momentum_multiple", // ---- same as above ---
-// "test_mul_example",
 "test_mvn", // Issues::Wrong answer
 "test_mvn_expanded", // Issues::Wrong answer
 "test_nesterov_momentum", // Issues::Layer does not exist (NesterovsAcceleratedGradient) Can't create layer "onnx_node_output_0!X_new" of type "ai.onnx.preview.training.Momentum" in function 'getLayerInstance'
 "test_nllloss_NC",  // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NC_expanded",
 "test_nllloss_NCd1", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1_expanded",
 "test_nllloss_NCd1_ii",  // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1_ii_expanded",  // Issue:: Unsupported data type
 "test_nllloss_NCd1_mean_weight_negative_ii", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1_mean_weight_negative_ii_expanded", // Issue:: Unsupported data type
 "test_nllloss_NCd1_weight", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1_weight_expanded",
 "test_nllloss_NCd1_weight_ii", // Issue:: Unsupported data type
 "test_nllloss_NCd1_weight_ii_expanded", // Issue:: Unsupported data type
 "test_nllloss_NCd1d2", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1d2_expanded",
 "test_nllloss_NCd1d2_no_weight_reduction_mean_ii", // Issue:: Unsupported data type
 "test_nllloss_NCd1d2_no_weight_reduction_mean_ii_expanded", // Issue:: Unsupported data type
 "test_nllloss_NCd1d2_reduction_mean", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
@@ -241,9 +206,7 @@
 "test_nllloss_NCd1d2_reduction_sum", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1d2_reduction_sum_expanded", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1d2_with_weight", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1d2_with_weight_expanded",
 "test_nllloss_NCd1d2_with_weight_reduction_mean",  // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1d2_with_weight_reduction_mean_expanded",
 "test_nllloss_NCd1d2_with_weight_reduction_sum", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1d2_with_weight_reduction_sum_expanded", // Issue::Wrong output on CUDA
 "test_nllloss_NCd1d2_with_weight_reduction_sum_ii", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
@@ -255,7 +218,6 @@
 "test_nllloss_NCd1d2d3d4d5_mean_weight", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
 "test_nllloss_NCd1d2d3d4d5_mean_weight_expanded", // Issue::Wrong output
 "test_nllloss_NCd1d2d3d4d5_none_no_weight", // Issue:: Layer does not exist (NegativeLogLikelihoodLoss, SoftmaxCrossEntropyLoss)
-// "test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded",
 "test_nonmaxsuppression_center_point_box_format", // Issue:: Layer does not exist (NonMaxSuppression)::Can't create layer "onnx_node_output_0!selected_indices" of type "NonMaxSuppression" in function 'getLayerInstance'
 "test_nonmaxsuppression_flipped_coordinates", // ---- same as above ---
 "test_nonmaxsuppression_identical_boxes", // ---- same as above ---
@@ -285,10 +247,6 @@
 "test_or_bcast4v2d", // ---- same as above ---
 "test_or_bcast4v3d", // ---- same as above ---
 "test_or_bcast4v4d", // ---- same as above ---
-// "test_pow",
-// "test_pow_bcast_array",
-// "test_pow_bcast_scalar",
-// "test_pow_example",
 "test_pow_types_float", // Issue:: Unsupported data type
 "test_pow_types_float32_int32", // ---- same as above ---
 "test_pow_types_float32_int64", // ---- same as above ---
@@ -298,7 +256,6 @@
 "test_pow_types_int32_float32", // ---- same as above ---
 "test_pow_types_int32_int32", // ---- same as above ---
 "test_pow_types_int64_float32", // ---- same as above ---
-// "test_pow_types_int64_int64",
 "test_prelu_broadcast", // Issue::Parser:Blob slope not found in const blobs in function 'getBlob' (weights are required as inputs)
 "test_prelu_example", // ---- same as above ---
 "test_qlinearconv", // Issue::Parser:  Blob x_scale not found in const blobs in function 'getBlob' (weights are required as inputs)
@@ -466,9 +423,6 @@
 "test_strnormalizer_export_monday_empty_output", // ---- same as above ---
 "test_strnormalizer_export_monday_insensintive_upper_twodim", // ---- same as above ---
 "test_strnormalizer_nostopwords_nochangecase", // Issue:: Parser: Can't create layer "onnx_node_output_0!y" of type "StringNormalizer" in function 'getLayerInstance'
-// "test_sub_example",
-// "test_sum_example",
-// "test_sum_two_inputs",
 "test_tfidfvectorizer_tf_batch_onlybigrams_skip0", // Issue:: Parser: Can't create layer "onnx_node_output_0!Y" of type "TfIdfVectorizer" in function 'getLayerInstance'
 "test_tfidfvectorizer_tf_batch_onlybigrams_skip5",  // ---- same as above ---
 "test_tfidfvectorizer_tf_batch_uniandbigrams_skip5",  // ---- same as above ---


### PR DESCRIPTION
In dnn 4.x usually any model's input is converted to float32 or float16 (except quantized models). Also mean and scale can be applied. In current dnn 5.x there is the same conversion except int32 and int64 types. I removed this conversion.

Here is how the pipeline works now:
- if input Mat type is float32, the pipeline applies mean and scale and may convert it to float16.
- if input Mat type is not float32, the pipeline preserves the input type and doesn't apply mean and scale

There was a conflict in protobuf parser between ONNX importer and tests. In ONNX importer any uint8 weight was handled as quantized weight and x = int8(x_uint8 - 128) conversion was used inside the protobuf parser. ONNX conformance tests used the same protobuf reader, so tests with uint8 inputs couldn't read the input values properly. I've made this conversion optional.

These ONNX conformance tests are enabled:
- test_add_uint8
- test_div_uint8
- test_mul_uint8
- test_sub_uint8
- test_max_int8
- test_max_uint8
- test_min_int8
- test_min_uint8
- test_mod_mixed_sign_int8
- test_mod_uint8

These tests were removed:
- Test_two_inputs.basic (when input is uint8)
- setInput.normalization (when input is uint8)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
