### PR TITLE
Tune sanity threshold in Moments performance test for Android aarch64

### DIFF
--- a/modules/imgproc/perf/perf_moments.cpp
+++ b/modules/imgproc/perf/perf_moments.cpp
@@ -35,7 +35,7 @@ PERF_TEST_P(MomentsFixture_val, Moments1,
     mat += 1;
 
 
-    SANITY_CHECK_MOMENTS(m, 2e-4, ERROR_RELATIVE);
+    SANITY_CHECK_MOMENTS(m, 3.3e-4, ERROR_RELATIVE);
 }
 
 } // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
