### PR TITLE
Tune test parameters for new segmentation model.

### DIFF
--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -669,8 +669,9 @@ TEST_P(Test_Model, Segmentation)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
 
-    if ((backend == DNN_BACKEND_OPENCV && (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_CPU_FP16))
+    if ((backend == DNN_BACKEND_OPENCV && (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_CPU_FP16))
         || (backend == DNN_BACKEND_CUDA && target == DNN_TARGET_CUDA_FP16))
+        || (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
     {
         norm = 7.0f;  // l1 = 0.01 lInf = 7
     }


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/25435

```
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from Test_Model
[ RUN      ] Test_Model.Segmentation/0, where GetParam() = NGRAPH/CPU
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:84: Failure
Expected: (normL1) <= (l1), actual: 0.259644 vs 0
  |ref| = 2
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:87: Failure
Expected: (normInf) <= (lInf), actual: 7 vs 0
  |ref| = 2
[  FAILED  ] Test_Model.Segmentation/0, where GetParam() = NGRAPH/CPU (11777 ms)
[ RUN      ] Test_Model.Segmentation/1, where GetParam() = OCV/OCL
[ WARN:0@13.437] global ocl4dnn_conv_spatial.cpp:1933 loadTunedConfig OpenCV(ocl4dnn): consider to specify kernel configuration cache directory through OPENCV_OCL4DNN_CONFIG_PATH parameter.
OpenCL program build log: dnn/dummy
Status -11: CL_BUILD_PROGRAM_FAILURE
-cl-no-subgroup-ifp
Error in processing command line: Don't understand command line argument "-cl-no-subgroup-ifp"!
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:84: Failure
Expected: (normL1) <= (l1), actual: 0.259644 vs 0
  |ref| = 2
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:87: Failure
Expected: (normInf) <= (lInf), actual: 7 vs 0
  |ref| = 2
[  FAILED  ] Test_Model.Segmentation/1, where GetParam() = OCV/OCL (2925 ms)
[ RUN      ] Test_Model.Segmentation/2, where GetParam() = OCV/OCL_FP16
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:87: Failure
Expected: (normInf) <= (lInf), actual: 7 vs 2
  |ref| = 2
[  FAILED  ] Test_Model.Segmentation/2, where GetParam() = OCV/OCL_FP16 (1506 ms)
[ RUN      ] Test_Model.Segmentation/3, where GetParam() = OCV/CPU
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:84: Failure
Expected: (normL1) <= (l1), actual: 0.259644 vs 0
  |ref| = 2
/home/alexander/Projects/OpenCV/opencv-master/modules/dnn/test/test_common.impl.hpp:87: Failure
Expected: (normInf) <= (lInf), actual: 7 vs 0
  |ref| = 2
[  FAILED  ] Test_Model.Segmentation/3, where GetParam() = OCV/CPU (2167 ms)
[----------] 4 tests from Test_Model (18375 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (18375 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] Test_Model.Segmentation/0, where GetParam() = NGRAPH/CPU
[  FAILED  ] Test_Model.Segmentation/1, where GetParam() = OCV/OCL
[  FAILED  ] Test_Model.Segmentation/2, where GetParam() = OCV/OCL_FP16
[  FAILED  ] Test_Model.Segmentation/3, where GetParam() = OCV/CPU
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
