### PR TITLE
Convert single layer caffe tests to onnx format

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -110,9 +110,8 @@ class dnn_test(NewOpenCVTests):
                               required=required)
 
     def checkIETarget(self, backend, target):
-        proto = self.find_dnn_file('dnn/layers/layer_convolution.prototxt')
-        model = self.find_dnn_file('dnn/layers/layer_convolution.caffemodel')
-        net = cv.dnn.readNet(proto, model)
+        model = self.find_dnn_file('dnn/layers/layer_convolution.onnx')
+        net = cv.dnn.readNet(model)
         try:
             net.setPreferableBackend(backend)
             net.setPreferableTarget(target)
@@ -324,10 +323,9 @@ class dnn_test(NewOpenCVTests):
 
     def test_async(self):
         timeout = 10*1000*10**6  # in nanoseconds (10 sec)
-        proto = self.find_dnn_file('dnn/layers/layer_convolution.prototxt')
-        model = self.find_dnn_file('dnn/layers/layer_convolution.caffemodel')
-        if proto is None or model is None:
-            raise unittest.SkipTest("Missing DNN test files (dnn/layers/layer_convolution.{prototxt/caffemodel}). Verify OPENCV_DNN_TEST_DATA_PATH configuration parameter.")
+        model = self.find_dnn_file('dnn/layers/layer_convolution.onnx')
+        if model is None:
+            raise unittest.SkipTest("Missing DNN test files (dnn/layers/layer_convolution.onnx). Verify OPENCV_DNN_TEST_DATA_PATH configuration parameter.")
 
         print('\n')
         for backend, target in self.dnnBackendsAndTargets:
@@ -336,11 +334,11 @@ class dnn_test(NewOpenCVTests):
 
             printParams(backend, target)
 
-            netSync = cv.dnn.readNet(proto, model)
+            netSync = cv.dnn.readNet(model)
             netSync.setPreferableBackend(backend)
             netSync.setPreferableTarget(target)
 
-            netAsync = cv.dnn.readNet(proto, model)
+            netAsync = cv.dnn.readNet(model)
             netAsync.setPreferableBackend(backend)
             netAsync.setPreferableTarget(target)
 


### PR DESCRIPTION
**Merged with:** https://github.com/opencv/opencv_extra/pull/1176 (**testdata also should be review**)
part of https://github.com/opencv/opencv/issues/25314

This PR is used to convert all caffe tests with 'single' layer to onnx format. Tests in `test_int8_layer.cpp` and `test_caffe_importer.cpp` will be removed in https://github.com/opencv/opencv/pull/25323

Most layers converted by [caffe2onnx](https://github.com/asiryan/caffe2onnx)
Some of them are generated by `pytorch` and `onnxruntime`
Some of them are wrong after converting, so I use [onnx-modifier](https://github.com/ZhangGe6/onnx-modifier) to correct it.

### EXTRA NOTE

**UPDATE(2024-08):** All below tests are kept because we decide to keep Caffe platform.

- **Remove** `layer_lrn_spatial`: norm_region is `WITHIN_CHANNEL` , but ONNX defines the default mode as `ACROSS_CHANNELS`, and if users want it, they may try `BatchNormalization`. (ref: [LRN in ONNX](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#lrn-13))
- **Change** `layer_deconvolution`: onnx doesn't define `deconvolution` operator, use `ConvTranspose` to replace. (ref: [ConvTranspose in ONNX](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#convtranspose-11)) 
- **Remove** `InnerProduct`: ONNX doesn't define this layer, user may convert it to GEMM or MatMul
- **Change** `layer_mvn`: onnx doesn't define `MVN` operator, use `InstanceNormalization` to replace.

- **Remove** `layer_batch_norm_local_stats`: `use_global_stats: false` is useless in ONNX. (ref: [BatchNormalization in ONNX](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#batchnormalization-9))

- **Remove** `layer_eltwise`: the model has a node with 2 inputs but from the same layer, which then causes an error. However, we have enough eltwise tests.
- **Remove** `accum` and `accum_ref`: they use `1x2x2x4` accum `1x3x8x12`, we can't use `ADD` operator to replace it.
- **Remove** `flow_wrap`: ONNX doesn't define this operator.
- **Remove** `DataAugmentation`: ONNX doesn't define this operator.
- **Remove** `nearest_2inps` and `nearest`: ONNX doesn't define `Resample` operator.
- **Remove** `Correlation`: ONNX doesn't define this operator.
- **Remove** `conv_2_inps`: ONNX doesn't support this defination, no need to test it in ONNX.
- **Remove** `layer_interp`: ONNX doesn't define `Interp` operator.
- **Disabled** `net_roi_pooling`: can be replaced by `RoiAlign` operator in ONNX, but OpenCV dnn doesn't support.

- **Remove** `reshape_splice_split`: Can't be converted to ONNX format. Because there are many re-use layers in caffe format.
 


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
