### PR TITLE
Added dynamic input support to Pad layer

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -420,6 +420,8 @@ CV__DNN_INLINE_NS_BEGIN
         CV_PROP String name; //!< Name of the layer instance, can be used for logging or other internal purposes.
         CV_PROP String type; //!< Type name which was used for creating layer by layer factory.
         CV_PROP int preferableTarget; //!< prefer target for layer forwarding
+        CV_PROP bool dynamicShape; //!< true when a previous layer has a dynamic shape
+
 
         Layer();
         explicit Layer(const LayerParams &params);      //!< Initializes only #name, #type and #blobs fields.
@@ -828,7 +830,6 @@ CV__DNN_INLINE_NS_BEGIN
          * @return overall ticks for model inference.
          */
         CV_WRAP int64 getPerfProfile(CV_OUT std::vector<double>& timings);
-
 
         struct Impl;
         inline Impl* getImpl() const { return impl.get(); }

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -9,7 +9,7 @@ namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
 
-Layer::Layer() { preferableTarget = DNN_TARGET_CPU; }
+Layer::Layer() { preferableTarget = DNN_TARGET_CPU; dynamicShape=false;}
 
 Layer::Layer(const LayerParams& params)
     : blobs(params.blobs)
@@ -17,6 +17,7 @@ Layer::Layer(const LayerParams& params)
     , type(params.type)
 {
     preferableTarget = DNN_TARGET_CPU;
+    dynamicShape = false;
 }
 
 void Layer::setParamsFrom(const LayerParams& params)
@@ -24,6 +25,8 @@ void Layer::setParamsFrom(const LayerParams& params)
     blobs = params.blobs;
     name = params.name;
     type = params.type;
+    if (params.has("dynamicShape"))
+        dynamicShape = true;
 }
 
 int Layer::inputNameToIndex(String)

--- a/modules/dnn/src/layer_internals.hpp
+++ b/modules/dnn/src/layer_internals.hpp
@@ -47,6 +47,7 @@ struct LayerData
         , dtype(CV_32F)
         , skip(false)
         , flag(0)
+        , dynamicShape(false)
     {}
     LayerData(int _id, const String& _name, const String& _type, const int& _dtype, LayerParams& _params)
         : id(_id)
@@ -56,6 +57,7 @@ struct LayerData
         , params(_params)
         , skip(false)
         , flag(0)
+        , dynamicShape(false)
     {
         CV_TRACE_FUNCTION();
 
@@ -95,6 +97,7 @@ struct LayerData
     bool skip;
 
     int flag;
+    bool dynamicShape;
 
 
     void resetAllocation()

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -119,6 +119,15 @@ public:
         CV_TRACE_FUNCTION();
         CV_TRACE_ARG_VALUE(name, "name", name.c_str());
 
+        if (dynamicShape)
+        {
+            std::vector<Mat> inputs, outputs;
+            inputs_arr.getMatVector(inputs);
+            outputs_arr.getMatVector(outputs);
+            outputs_arr.create(1, 1, inputs[0].type());
+            std::vector<Mat>& vec = *(std::vector<Mat>*)outputs_arr.getObj();
+            vec[0] = Mat(inputs[0].size(), inputs[0].type());
+        }
         CV_OCL_RUN(IS_DNN_OPENCL_TARGET(preferableTarget),
                    forward_ocl(inputs_arr, outputs_arr, internals_arr))
 

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -634,6 +634,26 @@ public:
         CV_TRACE_FUNCTION();
         CV_TRACE_ARG_VALUE(name, "name", name.c_str());
 
+        if (dynamicShape)
+        {
+            std::vector<Mat> inputs, outputs;
+            inputs_arr.getMatVector(inputs);
+            outputs_arr.getMatVector(outputs);
+            std::vector<MatShape> inpShape;
+            for (int i = 0; i < inputs.size(); i++)
+            {
+                MatShape xi(inputs[i].dims);
+                for (int j = 0; j < inputs[i].dims; j++)
+                    xi[j] = inputs[i].size[j];
+                inpShape.push_back(xi);
+            }
+            MatShape outShape = findCommonShape(inpShape);
+            outputs_arr.create(1, 1, inputs[0].type());
+            std::vector<Mat>& vec = *(std::vector<Mat>*)outputs_arr.getObj();
+            vec[0] = Mat(outShape, inputs[0].type());
+            outputs_arr.getMatVector(outputs);
+            finalize(inputs, outputs);
+        }
         if (inputs_arr.depth() == CV_16F)
         {
             helper.reInit(sizeof(float));

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -401,5 +401,6 @@ int64 Net::getPerfProfile(std::vector<double>& timings)
     return impl->getPerfProfile(timings);
 }
 
+
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -728,9 +728,15 @@ void Net::Impl::forwardLayer(LayerData& ld)
                 for (int i = 0; i < ld.inputBlobs.size(); ++i)
                 {
                     inps[i] = *ld.inputBlobs[i];
+                    const LayerData loid = getLayerData(ld.inputBlobsId[i].lid);
+                    if (loid.dynamicShape)
+                        layer->dynamicShape = true;
                 }
                 layer->forward(inps, ld.outputBlobs, ld.internals);
-
+                if (layer->dynamicShape)
+                {
+                    ld.dynamicShape = true;
+                }
                 if (getParam_DNN_CHECK_NAN_INF())
                 {
                     bool fail = false;
@@ -872,10 +878,10 @@ void Net::Impl::forwardToLayer(LayerData& ld, bool clearFlags)
     // forward parents
     for (MapIdToLayerData::iterator it = layers.begin(); it != layers.end() && (it->second.id < ld.id); ++it)
     {
-        LayerData& ld = it->second;
-        if (ld.flag)
+        LayerData& ldIt = it->second;
+        if (ldIt.flag)
             continue;
-        forwardLayer(ld);
+        forwardLayer(ldIt);
     }
 
     // forward itself

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2038,6 +2038,9 @@ void ONNXImporter::parseConv(LayerParams& layerParams, const opencv_onnx::NodePr
             layerParams.blobs.push_back(getBlob(node_proto, j));
         }
     }
+    bool b = layerParams.blobs.empty();
+    auto idx = node_proto.input(1);
+    Mat xx = layerParams.blobs[0];
     int outCn = layerParams.blobs.empty() ? outShapes[node_proto.input(1)][0] : layerParams.blobs[0].size[0];
     layerParams.set("num_output", outCn);
 
@@ -2544,7 +2547,16 @@ void ONNXImporter::parseGather(LayerParams& layerParams, const opencv_onnx::Node
     // TODO: get rid of the type conversions and 1-d/0-d special-casing when the time comes
     if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
     {
-        int real_ndims = getBlobExtraInfo(node_proto.input(1)).real_ndims;
+        std::map<std::string, TensorInfo>::const_iterator constBlobExtraInfo = constBlobsExtraInfo.find(node_proto.input(1));
+        int real_ndims;
+        if (constBlobExtraInfo == constBlobsExtraInfo.end())
+        {
+            real_ndims = -1;
+        }
+        else
+        {
+            real_ndims = constBlobExtraInfo->second.real_ndims;
+        }
         layerParams.set("real_ndims", real_ndims);
         if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
         {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2038,9 +2038,6 @@ void ONNXImporter::parseConv(LayerParams& layerParams, const opencv_onnx::NodePr
             layerParams.blobs.push_back(getBlob(node_proto, j));
         }
     }
-    bool b = layerParams.blobs.empty();
-    auto idx = node_proto.input(1);
-    Mat xx = layerParams.blobs[0];
     int outCn = layerParams.blobs.empty() ? outShapes[node_proto.input(1)][0] : layerParams.blobs[0].size[0];
     layerParams.set("num_output", outCn);
 


### PR DESCRIPTION
### Pull Request Readiness Checklist
Question : Is opencv team want to solve bug  #24729 and #25118?

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

onnx model : 
![image](https://github.com/opencv/opencv/assets/3591626/fa51e6c7-6842-42f2-94dd-01d8a155e4a7)

[test_pad_add.zip](https://github.com/opencv/opencv/files/15351220/test_pad_add.zip)

this model has a dynamic Pad layer : padding values are output result of Concat layer


I use this program : 
        cv::dnn::Net x1 = cv::dnn::readNet("test_pad_add.onnx");
        std::vector<int> sza = { 2, 1 };
        Mat inpa = (Mat_<int>(2, 1) << 1, 2);
        Mat inpb = (Mat_<int>(2, 1) << 3, 1);
        Mat inpx = (Mat_<float>(3, 2) << 10, 11, 12, 13, 14, 15);
        x1.setInput(inpa, "inpa");
        x1.setInput(inpb, "inpb");
        x1.setInput(inpx, "inpx");
        std::vector<Mat> res(3);
        x1.forward(res, std::vector< String >{ "out_add", "pad_values", "out_pad" });
        displayBlobSize(res[0], "\nout_add");
        displayBlob(res[0], "out_add");
        displayBlobSize(res[1], "\npad_values");
        displayBlob(res[1], "pad_values");
        displayBlobSize(res[2], "\nout_pad");
        displayBlob(res[2], "out_pad");


and result

out_add blob size
dim  0 : 6      dim  1 : 6
out_add =
[2, 2, 2, 2, 2, 2;
 2, 2, 2, 12, 13, 2;
 2, 2, 2, 14, 15, 2;
 2, 2, 2, 16, 17, 2;
 2, 2, 2, 2, 2, 2;
 2, 2, 2, 2, 2, 2]
pad_values blob size
dim  0 : 4      dim  1 : 1
pad_values =
[1;
 2;
 3;
 1]
out_pad blob size
dim  0 : 6      dim  1 : 6
out_pad =
[0, 0, 0, 0, 0, 0;
 0, 0, 0, 10, 11, 0;
 0, 0, 0, 12, 13, 0;
 0, 0, 0, 14, 15, 0;
 0, 0, 0, 0, 0, 0;
 0, 0, 0, 0, 0, 0]

