### PR TITLE
Add a new function that approximates the polygon bounding a convex hull with a certain number of sides

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -1467,3 +1467,12 @@
   volume = {60},
   journal = {ISPRS Journal of Photogrammetry and Remote Sensing}
 }
+@article{LowIlie2003,
+  author   = {Kok-Lim Low, Adrian Ilie},
+  year = {2003},
+  pages = {3-15},
+  title    = {View Frustum Optimization to Maximize Object's Image Area},
+  journal  = {Journal of Graphics, (GPU, & Game) Tools (JGT)},
+  volume = {8},
+  url = {https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=1fbd43f3827fffeb76641a9c5ab5b625eb5a75ba}
+}

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4062,7 +4062,7 @@ CV_EXPORTS_W void approxPolyDP( InputArray curve,
 
 /** @brief Approximates a polygon with a convex hull with a specified accuracy and number of sides.
 
-The cv::approxBoundingPoly function approximates a polygon with a convex hull
+The cv::approxPolyN function approximates a polygon with a convex hull
 so that the difference between the contour area of the original contour and the new polygon is minimal.
 It uses a greedy algorithm for contracting two vertices into one in such a way that the additional area is minimal.
 Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
@@ -4072,15 +4072,15 @@ The algorithm based on the paper @cite LowIlie2003 .
 
 @param curve Input vector of a 2D points stored in std::vector or Mat, points must be float or integer.
 @param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.
-@param side The parameter defines the number of sides of the result polygon.
+@param nsides The parameter defines the number of sides of the result polygon.
 @param epsilon_percentage defines the percentage of the maximum of additional area.
 If it equals -1, it is not used. Otherwise algorighm stops if additional area is greater than contourArea(_curve) * percentage.
 If additional area exceeds the limit, algorithm returns as many vertices as there were at the moment the limit was exceeded.
-@param make_hull If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
+@param ensure_convex If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
  */
-CV_EXPORTS_W void approxBoundingPoly(InputArray curve, OutputArray approxCurve,
-                                    int side, float epsilon_percentage = -1.0,
-                                    bool make_hull = true);
+CV_EXPORTS_W void approxPolyN(InputArray curve, OutputArray approxCurve,
+                              int nsides, float epsilon_percentage = -1.0,
+                              bool ensure_convex = true);
 
 /** @brief Calculates a contour perimeter or a curve length.
 

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4068,8 +4068,7 @@ It uses a greedy algorithm for contracting two vertices into one in such a way t
 Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
 Each vertex will lie either on the original contour or outside it.
 
-The algorithm based on the paper
-<https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=1fbd43f3827fffeb76641a9c5ab5b625eb5a75ba>.
+The algorithm based on the paper @cite LowIlie2003 .
 
 @param curve Input vector of a 2D points stored in std::vector or Mat, points must be float or integer.
 @param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4060,6 +4060,26 @@ CV_EXPORTS_W void approxPolyDP( InputArray curve,
                                 OutputArray approxCurve,
                                 double epsilon, bool closed );
 
+/** @brief Approximates a polygon with a convex hull with a specified accuracy and number of sides.
+
+The cv::approxBoundingPoly function approximates a polygon with a convex hull
+so that the difference between the contour area of the original contour and the new polygon is minimal.
+It uses a greedy algorithm for contracting two vertices into one in such a way that the additional area is minimal.
+Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
+Each vertex will lie either on the original contour or outside it
+
+@param curve Input vector of a 2D points stored in std::vector or Mat, points must be float or integer.
+@param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.
+@param side The parameter defines the number of sides of the result polygon.
+@param epsilon_percentage defines the percentage of the maximum of additional area.
+If it equals -1, it is not used. Otherwise algorighm stops if additional area is greater than contourArea(_curve) * percentage.
+If additional area exceeds the limit, algorithm returns as many vertices as there were at the moment the limit was exceeded.
+@param make_hull If it is true, algorithm creates a convex hull of input contour. Otherwise input vector should be convex.
+ */
+CV_EXPORTS_W void approxBoundingPoly(InputArray curve, OutputArray approxCurve,
+                                    int side, float epsilon_percentage = -1.0,
+                                    bool make_hull = true);
+
 /** @brief Calculates a contour perimeter or a curve length.
 
 The function computes a curve length or a closed contour perimeter.

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4066,7 +4066,10 @@ The cv::approxBoundingPoly function approximates a polygon with a convex hull
 so that the difference between the contour area of the original contour and the new polygon is minimal.
 It uses a greedy algorithm for contracting two vertices into one in such a way that the additional area is minimal.
 Straight lines formed by each edge of the convex contour are drawn and the areas of the resulting triangles are considered.
-Each vertex will lie either on the original contour or outside it
+Each vertex will lie either on the original contour or outside it.
+
+The algorithm based on the paper
+<https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=1fbd43f3827fffeb76641a9c5ab5b625eb5a75ba>.
 
 @param curve Input vector of a 2D points stored in std::vector or Mat, points must be float or integer.
 @param approxCurve Result of the approximation. The type is vector of a 2D point (Point2f or Point) in std::vector or Mat.

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -956,13 +956,13 @@ static void update(std::vector<neighbours>& hull, int vertex_id)
 /*
     A greedy algorithm based on contraction of vertices for approximating a convex contour by a bounding polygon
 */
-void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
-    int side, float epsilon_percentage, bool make_hull)
+void cv::approxPolyN(InputArray _curve, OutputArray _approxCurve,
+    int nsides, float epsilon_percentage, bool ensure_convex)
 {
     CV_INSTRUMENT_REGION();
 
     CV_Assert(epsilon_percentage > 0 || epsilon_percentage == -1);
-    CV_Assert(side > 2);
+    CV_Assert(nsides > 2);
 
     if (_approxCurve.fixedType())
     {
@@ -974,7 +974,7 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
 
     CV_Assert(depth == CV_32F || depth == CV_32S);
 
-    if (make_hull)
+    if (ensure_convex)
     {
         cv::convexHull(_curve, curve);
     }
@@ -984,8 +984,8 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
         curve = _curve.getMat();
     }
 
-    CV_Assert((curve.cols == 1 && curve.rows >= side)
-        || (curve.rows == 1 && curve.cols >= side));
+    CV_Assert((curve.cols == 1 && curve.rows >= nsides)
+        || (curve.rows == 1 && curve.cols >= nsides));
 
     if (curve.rows == 1)
     {
@@ -1016,7 +1016,7 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
     hull[0].prev = size - 1;
     hull[size - 1].next = 0;
 
-    if (size > side)
+    if (size > nsides)
     {
         for (int vertex_id = 0; vertex_id < size; ++vertex_id)
         {
@@ -1027,7 +1027,7 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
         }
     }
 
-    while (size > side)
+    while (size > nsides)
     {
         changes base = areas.top();
         int vertex_id = base.vertex;

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -963,9 +963,11 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
 
     CV_Assert(epsilon_percentage > 0 || epsilon_percentage == -1);
     CV_Assert(side > 2);
-    CV_Assert(_approxCurve.type() == CV_32FC2
-        || _approxCurve.type() == CV_32SC2
-        || _approxCurve.type() == 0);
+
+    if (_approxCurve.fixedType())
+    {
+        CV_Assert(_approxCurve.type() == CV_32FC2 || _approxCurve.type() == CV_32SC2);
+    }
 
     Mat curve;
     int depth = _curve.depth();
@@ -974,7 +976,6 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
 
     if (make_hull)
     {
-
         cv::convexHull(_curve, curve);
     }
     else
@@ -1060,7 +1061,7 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
             update(hull, vertex_id);
         }
     }
-    if (_approxCurve.type() != 0) depth = _approxCurve.depth();
+    if (_approxCurve.fixedType()) depth = _approxCurve.depth();
     Mat buf(1, size, CV_MAKETYPE(depth, 2));
     int last_free = 0;
 

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -1061,8 +1061,13 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
             update(hull, vertex_id);
         }
     }
-    if (_approxCurve.fixedType()) depth = _approxCurve.depth();
-    Mat buf(1, size, CV_MAKETYPE(depth, 2));
+
+    if (_approxCurve.fixedType())
+    {
+        depth = _approxCurve.depth();
+    }
+    _approxCurve.create(1, size, CV_MAKETYPE(depth, 2));
+    Mat buf = _approxCurve.getMat();
     int last_free = 0;
 
     if (depth == CV_32S)
@@ -1090,8 +1095,6 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
             }
         }
     }
-
-    buf.copyTo(_approxCurve);
 }
 
 /* End of file. */

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -985,7 +985,7 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
 
     CV_Assert((curve.cols == 1 && curve.rows >= side)
         || (curve.rows == 1 && curve.cols >= side));
- 
+
     if (curve.rows == 1)
     {
         curve = curve.reshape(0, curve.cols);

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -908,7 +908,7 @@ struct changes
 /*
   returns intersection point and extra area
 */
-int recalculation(std::vector<neighbours>& hull, int vertex_id, float& area_, float& x, float& y)
+static int recalculation(std::vector<neighbours>& hull, int vertex_id, float& area_, float& x, float& y)
 {
     cv::Point2f vertex = hull[vertex_id].point,
         next_vertex = hull[hull[vertex_id].next].point,
@@ -934,7 +934,7 @@ int recalculation(std::vector<neighbours>& hull, int vertex_id, float& area_, fl
     return 0;
 }
 
-void update(std::vector<neighbours>& hull, int vertex_id)
+static void update(std::vector<neighbours>& hull, int vertex_id)
 {
     neighbours& v1 = hull[vertex_id], & removed = hull[v1.next], & v2 = hull[removed.next];
 
@@ -974,12 +974,18 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
         curve = _curve.getMat();
     }
 
-    CV_Assert(curve.cols == 1);
-    CV_Assert(curve.rows >= side);
+    CV_Assert((curve.cols == 1 && curve.rows >= side)
+        || (curve.rows == 1 && curve.cols >= side));
+
+    curve = curve.t();
+    if (curve.rows == 1)
+    {
+        curve = curve.t();
+    }
 
     std::vector<neighbours> hull(curve.rows);
     int size = curve.rows;
-    std::priority_queue<changes, std::vector<changes>, std::greater<>> areas;
+    std::priority_queue<changes, std::vector<changes>, std::greater<changes>> areas;
     float extra_area = 0, max_extra_area = epsilon_percentage * contourArea(_curve);
 
     if (curve.depth() == CV_32S)

--- a/modules/imgproc/src/approx.cpp
+++ b/modules/imgproc/src/approx.cpp
@@ -926,7 +926,8 @@ static int recalculation(std::vector<neighbours>& hull, int vertex_id, float& ar
     float t = (curr_edge.x * next_edge.y - curr_edge.y * next_edge.x) / cross;
     cv::Point2f intersection = vertex + cv::Point2f(prev_edge.x * t, prev_edge.y * t);
 
-    float area = 0.5f * abs((next_vertex.x - vertex.x) * (intersection.y - vertex.y) - (intersection.x - vertex.x) * (next_vertex.y - vertex.y));
+    float area = 0.5f * abs((next_vertex.x - vertex.x) * (intersection.y - vertex.y)
+        - (intersection.x - vertex.x) * (next_vertex.y - vertex.y));
 
     area_ = area;
     x = intersection.x;
@@ -986,14 +987,14 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
     std::vector<neighbours> hull(curve.rows);
     int size = curve.rows;
     std::priority_queue<changes, std::vector<changes>, std::greater<changes>> areas;
-    float extra_area = 0, max_extra_area = epsilon_percentage * contourArea(_curve);
+    float extra_area = 0, max_extra_area = epsilon_percentage * static_cast<float>(contourArea(_curve));
 
     if (curve.depth() == CV_32S)
     {
         for (int i = 0; i < size; ++i)
         {
             Point t = curve.at<cv::Point>(i, 0);
-            hull[i] = neighbours(i + 1, i - 1, Point2f(t.x, t.y));
+            hull[i] = neighbours(i + 1, i - 1, Point2f(static_cast<float>(t.x), static_cast<float>(t.y)));
         }
     }
     else
@@ -1072,7 +1073,9 @@ void cv::approxBoundingPoly(InputArray _curve, OutputArray _approxCurve,
         {
             if (hull[i].relevant != -1)
             {
-                Point t = Point(round(hull[i].point.x), round(hull[i].point.y));
+                Point t = Point(static_cast<int>(round(hull[i].point.x)),
+                                static_cast<int>(round(hull[i].point.y)));
+
                 buf.at<Point>(0, last_free) = t;
                 last_free++;
             }

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -379,34 +379,38 @@ TEST(Imgproc_ApproxPoly, bad_epsilon)
 
 TEST(Imgproc_ApproxPoly, boundingPolygon)
 {
-    string imgPath = cvtest::findDataFile("imgproc/approxBoundingPoly.png");
-    Mat img = imread(imgPath, IMREAD_GRAYSCALE);
-    Mat thresh;
-    vector<vector<Point>> contours;
-    vector<vector<Point>> out, right_out;
-    right_out = {
-        { {132, 30}, {87, 135}, {30, 121}, {70, 30} },
-        { {262, 29}, {209, 165}, {115, 142}, {162, 29} },
-        { {420, 216}, {247, 174}, {303, 28}, {483, 26} },
-        { {140, 25}, {91, 141}, {22, 126}, {66, 25} },
-        { {270, 23}, {212, 172}, {107, 145}, {158, 23} },
-        { {492, 20}, {424, 223}, {240, 178}, {299, 22} },
-        { {475, 256}, {10, 131}, {61, 16}, {556, 0} },
-        { {559, 0}, {559, 261}, {0, 261}, {0, 0} }
+    vector<vector<Point>> inputPoints = {
+        {  {87, 103}, {100, 112}, {96, 138}, {80, 169}, {60, 183}, {38, 176}, {41, 145}, {56, 118}, {76, 104} },
+        {  {196, 102}, {205, 118}, {174, 196}, {152, 207}, {102, 194}, {100, 175}, {131, 109} },
+        {  {372, 101}, {377, 119}, {337, 238}, {324, 248}, {240, 229}, {199, 214}, {232, 123}, {245, 103} },
+        {  {463, 86}, {563, 112}, {574, 135}, {596, 221}, {518, 298}, {412, 266}, {385, 164}, {462, 86} }
     };
-    cv::adaptiveThreshold(img, thresh, 255, CV_ADAPTIVE_THRESH_GAUSSIAN_C, CV_THRESH_BINARY, 11, 2);
-    cv::findContours(thresh, contours, 1, 1);
-    for (auto contour : contours)
-    {
-        vector<Point> corners;
-        Mat contour1;
-        cv::convexHull(contour, contour1);
-        if (contour1.rows < 4) continue;
-        approxBoundingPoly(contour1, corners, 4, -1, false);
-        out.push_back(corners);
+    vector<vector<Point>> rightCorners = {
+        { {72, 187}, {37, 176}, {42, 127}, {133, 64} },
+        { {168, 212}, {92, 192}, {131, 109}, {213, 100} },
+        { {72, 187}, {37, 176}, {42, 127}, {133, 64} },
+        { {384, 100}, {333, 251}, {197, 220}, {239, 103} },
+        { {168, 212}, {92, 192}, {131, 109}, {213, 100} },
+        { {333, 251}, {197, 220}, {239, 103}, {384, 100} },
+        { {542, 6}, {596, 221}, {518, 299}, {312, 236} },
+        { {596, 221}, {518, 299}, {312, 236}, {542, 6} }
     };
+    vector<vector<Point>> contours, detectedCorners;
+    Mat image(600, 600, CV_8UC1, Scalar(0));
 
-    ASSERT_EQ(out, right_out);
+    for (vector<Point>& polygon : inputPoints) {
+        polylines(image, { polygon }, true, Scalar(255), 1);
+    }
+
+    findContours(image, contours, 1, 1);
+
+    for (size_t i = 0; i < contours.size(); ++i) {
+        vector<Point> corners;
+        approxBoundingPoly(contours[i], corners, 4, -1, true);
+        detectedCorners.push_back(corners);
+    }
+
+    ASSERT_EQ(detectedCorners, rightCorners);
 }
 
 TEST(Imgproc_ApproxPoly, bad_args)

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -377,7 +377,7 @@ TEST(Imgproc_ApproxPoly, bad_epsilon)
     ASSERT_ANY_THROW(approxPolyDP(inputPoints, outputPoints, eps, false));
 }
 
-struct ApproxBoundingPolyTest: public testing::Test
+struct ApproxPolyN: public testing::Test
 {
     void SetUp()
     {
@@ -400,7 +400,7 @@ struct ApproxBoundingPolyTest: public testing::Test
     vector<vector<Point>> contours;
 };
 
-TEST_F(ApproxBoundingPolyTest, accuracyInt)
+TEST_F(ApproxPolyN, accuracyInt)
 {
     vector<vector<Point>> rightCorners = {
         { {72, 187}, {37, 176}, {42, 127}, {133, 64} },
@@ -416,12 +416,12 @@ TEST_F(ApproxBoundingPolyTest, accuracyInt)
 
     for (size_t i = 0; i < contours.size(); ++i) {
         std::vector<Point> corners;
-        approxBoundingPoly(contours[i], corners, 4, -1, true);
+        approxPolyN(contours[i], corners, 4, -1, true);
         ASSERT_EQ(rightCorners[i], corners );
     }
 }
 
-TEST_F(ApproxBoundingPolyTest, accuracyFloat)
+TEST_F(ApproxPolyN, accuracyFloat)
 {
     vector<vector<Point2f>> rightCorners = {
         { {72.f, 187.f}, {37.f, 176.f}, {42.f, 127.f}, {133.f, 64.f} },
@@ -437,19 +437,19 @@ TEST_F(ApproxBoundingPolyTest, accuracyFloat)
 
     for (size_t i = 0; i < contours.size(); ++i) {
         std::vector<Point2f> corners;
-        approxBoundingPoly(contours[i], corners, 4, -1, true);
+        approxPolyN(contours[i], corners, 4, -1, true);
         EXPECT_LT(cvtest::norm(rightCorners[i], corners, NORM_INF), .5f);
     }
 }
 
-TEST_F(ApproxBoundingPolyTest, bad_args)
+TEST_F(ApproxPolyN, bad_args)
 {
     Mat contour(10, 1, CV_32FC2);
     vector<vector<Point>> bad_contours;
     vector<Point> corners;
-    ASSERT_ANY_THROW(approxBoundingPoly(contour, corners, 0));
-    ASSERT_ANY_THROW(approxBoundingPoly(contour, corners, 3, 0));
-    ASSERT_ANY_THROW(approxBoundingPoly(bad_contours, corners, 4));
+    ASSERT_ANY_THROW(approxPolyN(contour, corners, 0));
+    ASSERT_ANY_THROW(approxPolyN(contour, corners, 3, 0));
+    ASSERT_ANY_THROW(approxPolyN(bad_contours, corners, 4));
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -377,4 +377,46 @@ TEST(Imgproc_ApproxPoly, bad_epsilon)
     ASSERT_ANY_THROW(approxPolyDP(inputPoints, outputPoints, eps, false));
 }
 
+TEST(Imgproc_ApproxPoly, boundingPolygon)
+{
+    string imgPath = cvtest::findDataFile("imgproc/approxBoundingPoly.png");
+    Mat img = imread(imgPath, IMREAD_GRAYSCALE);
+    Mat thresh;
+    vector<vector<Point>> contours;
+    vector<vector<Point>> out, right_out;
+    right_out = {
+        { {132, 30}, {87, 135}, {30, 121}, {70, 30} },
+        { {262, 29}, {209, 165}, {115, 142}, {162, 29} },
+        { {420, 216}, {247, 174}, {303, 28}, {483, 26} },
+        { {140, 25}, {91, 141}, {22, 126}, {66, 25} },
+        { {270, 23}, {212, 172}, {107, 145}, {158, 23} },
+        { {492, 20}, {424, 223}, {240, 178}, {299, 22} },
+        { {475, 256}, {10, 131}, {61, 16}, {556, 0} },
+        { {559, 0}, {559, 261}, {0, 261}, {0, 0} }
+    };
+    cv::adaptiveThreshold(img, thresh, 255, CV_ADAPTIVE_THRESH_GAUSSIAN_C, CV_THRESH_BINARY, 11, 2);
+    cv::findContours(thresh, contours, 1, 1);
+    for (auto contour : contours)
+    {
+        vector<Point> corners;
+        Mat contour1;
+        cv::convexHull(contour, contour1);
+        if (contour1.rows < 4) continue;
+        approxBoundingPoly(contour1, corners, 4, -1, false);
+        out.push_back(corners);
+    };
+
+    ASSERT_EQ(out, right_out);
+}
+
+TEST(Imgproc_ApproxPoly, bad_args)
+{
+    Mat contour(10, 1, CV_32FC2);
+    vector<vector<Point>> contours;
+    vector<Point> corners;
+    ASSERT_ANY_THROW(approxBoundingPoly(contour, corners, 0));
+    ASSERT_ANY_THROW(approxBoundingPoly(contour, corners, 3, 0));
+    ASSERT_ANY_THROW(approxBoundingPoly(contours, corners, 4));
+}
+
 }} // namespace


### PR DESCRIPTION
merge PR with <https://github.com/opencv/opencv_extra/pull/1179>

This PR is based on the paper [View Frustum Optimization To Maximize Object’s Image Area](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=1fbd43f3827fffeb76641a9c5ab5b625eb5a75ba).

# Problem
I needed to reduce the number of vertices of the convex hull so that the additional area was minimal, andall vertices of the original contour enter the new contour.

![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/efac35f6-b8f0-46ec-91e4-60800432620c)

![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/2292d9d7-1c10-49c9-8489-23221b4b28f7)

# Description
Initially in the contour of n vertices, at each stage we consider the intersection points of the lines formed by each adjacent edges. Each of these intersection points will form a triangle with vertices through which lines pass. Let's choose a triangle with the minimum area and merge the two vertices at the intersection point. We continue until there are more vertices than the specified number of sides of the approximated polygon.
![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/b87b21c4-112e-450d-a776-2a120048ca30)

# Complexity:
Using a std::priority_queue or std::set  time complexity is **(O(n\*ln(n))**, memory **O(n)**,
n - number of vertices in convex hull.

count of sides - the number of points by which we must reduce.
![image](https://github.com/Fest1veNapkin/opencv/assets/98156294/31ad5562-a67d-4e3c-bdc2-29f8b52caf88)

## Comment
If epsilon_percentage more 0, algorithm can return more values than _side_.
Algorithm returns OutputArray. If OutputArray.type() equals 0, algorithm returns values with InputArray.type().
New test uses image which are not in opencv_extra, needs to be added.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
