### PR TITLE
YUV codes for cvtColor: descriptions added

### DIFF
--- a/modules/imgproc/doc/colors.markdown
+++ b/modules/imgproc/doc/colors.markdown
@@ -53,7 +53,7 @@ Y, Cr, and Cb cover the whole value range.
 @anchor color_convert_rgb_yuv_42x
 RGB <-> YUV with subsampling
 ------------------------------
-Both RGB and YUV values are 8-bit only.
+Only 8-bit values are supported.
 The coefficients correspond to BT.601 standard with resulting values Y [16, 235], U and V [16, 240] centered at 128.
 
 Two subsampling schemes are supported: 4:2:0 (Fourcc codes NV12, NV21, YV12, I420 and synonimic)
@@ -65,7 +65,7 @@ of a source image.
 In 4:2:0 scheme U and V values are averaged over 2x2 squares, i.e. only 1 U and 1 V value is saved per each 4 pixels.
 U and V values are saved interleaved into a separate plane (NV12, NV21) or into two separate semi-planes (YV12, I420).
 
-In 4:2:2 scheme U and V values are averaged horizontally over each pair of pixels, i.e. only 1 U and 1 v value is saved
+In 4:2:2 scheme U and V values are averaged horizontally over each pair of pixels, i.e. only 1 U and 1 V value is saved
 per each 2 pixels. U and V values are saved interleaved with Y values for both pixels according to its Fourcc code.
 
 Note that different conversions are perfomed with different precision for speed or compatibility purposes. For example,

--- a/modules/imgproc/doc/colors.markdown
+++ b/modules/imgproc/doc/colors.markdown
@@ -50,6 +50,37 @@ where
 Y, Cr, and Cb cover the whole value range.
 @see cv::COLOR_BGR2YCrCb, cv::COLOR_RGB2YCrCb, cv::COLOR_YCrCb2BGR, cv::COLOR_YCrCb2RGB
 
+@anchor color_convert_rgb_yuv_42x
+RGB <-> YUV with subsampling
+------------------------------
+Both RGB and YUV values are 8-bit only.
+The coefficients correspond to BT.601 standard with resulting values Y [16, 235], U and V [16, 240] centered at 128.
+
+Two subsampling schemes are supported: 4:2:0 (Fourcc codes NV12, NV21, YV12, I420 and synonimic)
+and 4:2:2 (Fourcc codes UYVY, YUY2, YVYU and synonimic).
+
+In both subsampling schemes Y values are written for each pixel so that Y plane is in fact a scaled and biased gray version
+of a source image.
+
+In 4:2:0 scheme U and V values are averaged over 2x2 squares, i.e. only 1 U and 1 V value is saved per each 4 pixels.
+U and V values are saved interleaved into a separate plane (NV12, NV21) or into two separate semi-planes (YV12, I420).
+
+In 4:2:2 scheme U and V values are averaged horizontally over each pair of pixels, i.e. only 1 U and 1 v value is saved
+per each 2 pixels. U and V values are saved interleaved with Y values for both pixels according to its Fourcc code.
+
+Note that different conversions are perfomed with different precision for speed or compatibility purposes. For example,
+RGB to YUV 4:2:2 is converted using 14-bit fixed-point arithmetics while other conversions use 20 bits.
+
+\f[R \leftarrow 1.164 \cdot (Y - 16) + 1.596 \cdot (V - 128)\f]
+\f[G \leftarrow 1.164 \cdot (Y - 16) - 0.813 \cdot (V - 128) - 0.391 \cdot (U - 128)\f]
+\f[B \leftarrow 1.164 \cdot (Y - 16) + 2.018 \cdot (U - 128)\f]
+
+\f[Y \leftarrow (R \cdot 0.299 + G \cdot 0.587 + B \cdot 0.114) \cdot \frac{235 - 16}{256} + 16 \f]
+\f[U \leftarrow -0.148 \cdot R_{avg} - 0.291 \cdot G_{avg} + 0.439 \cdot B_{avg} + 128 \f]
+\f[V \leftarrow  0.439 \cdot R_{avg} - 0.368 \cdot G_{avg} - 0.071 \cdot B_{avg} + 128 \f]
+
+@see cv::COLOR_YUV2RGB_NV12, cv::COLOR_YUV2RGBA_YUY2, cv::COLOR_BGR2YUV_YV12 and similar ones
+
 @anchor color_convert_rgb_hsv
 RGB <-> HSV
 -----------

--- a/modules/imgproc/doc/colors.markdown
+++ b/modules/imgproc/doc/colors.markdown
@@ -75,7 +75,7 @@ RGB to YUV 4:2:2 is converted using 14-bit fixed-point arithmetics while other c
 \f[G \leftarrow 1.164 \cdot (Y - 16) - 0.813 \cdot (V - 128) - 0.391 \cdot (U - 128)\f]
 \f[B \leftarrow 1.164 \cdot (Y - 16) + 2.018 \cdot (U - 128)\f]
 
-\f[Y \leftarrow (R \cdot 0.299 + G \cdot 0.587 + B \cdot 0.114) \cdot \frac{235 - 16}{256} + 16 \f]
+\f[Y \leftarrow (R \cdot 0.299 + G \cdot 0.587 + B \cdot 0.114) \cdot \frac{236 - 16}{256} + 16 \f]
 \f[U \leftarrow -0.148 \cdot R_{avg} - 0.291 \cdot G_{avg} + 0.439 \cdot B_{avg} + 128 \f]
 \f[V \leftarrow  0.439 \cdot R_{avg} - 0.368 \cdot G_{avg} - 0.071 \cdot B_{avg} + 128 \f]
 

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -718,8 +718,8 @@ enum ColorConversionCodes {
     COLOR_YUV2RGBA_YUNV = COLOR_YUV2RGBA_YUY2, //!< synonym to YUY2
     COLOR_YUV2BGRA_YUNV = COLOR_YUV2BGRA_YUY2, //!< synonym to YUY2
 
-    COLOR_YUV2GRAY_UYVY = 123, //!< extract channel from YUV 4:2:2 image
-    COLOR_YUV2GRAY_YUY2 = 124, //!< extract channel from YUV 4:2:2 image
+    COLOR_YUV2GRAY_UYVY = 123, //!< extract Y channel from YUV 4:2:2 image
+    COLOR_YUV2GRAY_YUY2 = 124, //!< extract Y channel from YUV 4:2:2 image
     //CV_YUV2GRAY_VYUY  = CV_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY
     COLOR_YUV2GRAY_Y422 = COLOR_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY
     COLOR_YUV2GRAY_UYNV = COLOR_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -641,112 +641,150 @@ enum ColorConversionCodes {
     COLOR_YUV2BGR      = 84,
     COLOR_YUV2RGB      = 85,
 
-    //! YUV 4:2:0 family to RGB
-    COLOR_YUV2RGB_NV12  = 90,
-    COLOR_YUV2BGR_NV12  = 91,
-    COLOR_YUV2RGB_NV21  = 92,
-    COLOR_YUV2BGR_NV21  = 93,
-    COLOR_YUV420sp2RGB  = COLOR_YUV2RGB_NV21,
-    COLOR_YUV420sp2BGR  = COLOR_YUV2BGR_NV21,
+    COLOR_YUV2RGB_NV12  = 90, //!< convert between YUV NV12 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_NV12  = 91, //!< convert between YUV NV12 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_NV21  = 92, //!< convert between YUV NV21 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_NV21  = 93, //!< convert between YUV NV21 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV420sp2RGB  = COLOR_YUV2RGB_NV21, //!< synonym to NV21
+    COLOR_YUV420sp2BGR  = COLOR_YUV2BGR_NV21, //!< synonym to NV21
 
-    COLOR_YUV2RGBA_NV12 = 94,
-    COLOR_YUV2BGRA_NV12 = 95,
-    COLOR_YUV2RGBA_NV21 = 96,
-    COLOR_YUV2BGRA_NV21 = 97,
-    COLOR_YUV420sp2RGBA = COLOR_YUV2RGBA_NV21,
-    COLOR_YUV420sp2BGRA = COLOR_YUV2BGRA_NV21,
+    COLOR_YUV2RGBA_NV12 = 94, //!< convert between YUV NV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_NV12 = 95, //!< convert between YUV NV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_NV21 = 96, //!< convert between YUV NV21 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_NV21 = 97, //!< convert between YUV NV21 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
+                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV420sp2RGBA = COLOR_YUV2RGBA_NV21, //!< synonym to NV21
+    COLOR_YUV420sp2BGRA = COLOR_YUV2BGRA_NV21, //!< synonym to NV21
 
-    COLOR_YUV2RGB_YV12  = 98,
-    COLOR_YUV2BGR_YV12  = 99,
-    COLOR_YUV2RGB_IYUV  = 100,
-    COLOR_YUV2BGR_IYUV  = 101,
-    COLOR_YUV2RGB_I420  = COLOR_YUV2RGB_IYUV,
-    COLOR_YUV2BGR_I420  = COLOR_YUV2BGR_IYUV,
-    COLOR_YUV420p2RGB   = COLOR_YUV2RGB_YV12,
-    COLOR_YUV420p2BGR   = COLOR_YUV2BGR_YV12,
+    COLOR_YUV2RGB_YV12  =  98, //!< convert between YUV YV12 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_YV12  =  99, //!< convert between YUV YV12 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_IYUV  = 100, //!< convert between YUV IYUV and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_IYUV  = 101, //!< convert between YUV IYUV and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_I420  = COLOR_YUV2RGB_IYUV, //!< synonym to IYUV
+    COLOR_YUV2BGR_I420  = COLOR_YUV2BGR_IYUV, //!< synonym to IYUV
+    COLOR_YUV420p2RGB   = COLOR_YUV2RGB_YV12, //!< synonym to YV12
+    COLOR_YUV420p2BGR   = COLOR_YUV2BGR_YV12, //!< synonym to YV12
 
-    COLOR_YUV2RGBA_YV12 = 102,
-    COLOR_YUV2BGRA_YV12 = 103,
-    COLOR_YUV2RGBA_IYUV = 104,
-    COLOR_YUV2BGRA_IYUV = 105,
-    COLOR_YUV2RGBA_I420 = COLOR_YUV2RGBA_IYUV,
-    COLOR_YUV2BGRA_I420 = COLOR_YUV2BGRA_IYUV,
-    COLOR_YUV420p2RGBA  = COLOR_YUV2RGBA_YV12,
-    COLOR_YUV420p2BGRA  = COLOR_YUV2BGRA_YV12,
+    COLOR_YUV2RGBA_YV12 = 102, //!< convert between YUV YV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_YV12 = 103, //!< convert between YUV YV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_IYUV = 104, //!< convert between YUV YV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_IYUV = 105, //!< convert between YUV YV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_I420 = COLOR_YUV2RGBA_IYUV, //!< synonym to IYUV
+    COLOR_YUV2BGRA_I420 = COLOR_YUV2BGRA_IYUV, //!< synonym to IYUV
+    COLOR_YUV420p2RGBA  = COLOR_YUV2RGBA_YV12, //!< synonym to YV12
+    COLOR_YUV420p2BGRA  = COLOR_YUV2BGRA_YV12, //!< synonym to YV12
 
-    COLOR_YUV2GRAY_420  = 106,
-    COLOR_YUV2GRAY_NV21 = COLOR_YUV2GRAY_420,
-    COLOR_YUV2GRAY_NV12 = COLOR_YUV2GRAY_420,
-    COLOR_YUV2GRAY_YV12 = COLOR_YUV2GRAY_420,
-    COLOR_YUV2GRAY_IYUV = COLOR_YUV2GRAY_420,
-    COLOR_YUV2GRAY_I420 = COLOR_YUV2GRAY_420,
-    COLOR_YUV420sp2GRAY = COLOR_YUV2GRAY_420,
-    COLOR_YUV420p2GRAY  = COLOR_YUV2GRAY_420,
+    COLOR_YUV2GRAY_420  = 106, //!< extract Y channel from YUV 4:2:0 image
+    COLOR_YUV2GRAY_NV21 = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV2GRAY_NV12 = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV2GRAY_YV12 = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV2GRAY_IYUV = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV2GRAY_I420 = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV420sp2GRAY = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
+    COLOR_YUV420p2GRAY  = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
 
-    //! YUV 4:2:2 family to RGB
-    COLOR_YUV2RGB_UYVY = 107,
-    COLOR_YUV2BGR_UYVY = 108,
-    //COLOR_YUV2RGB_VYUY = 109,
-    //COLOR_YUV2BGR_VYUY = 110,
-    COLOR_YUV2RGB_Y422 = COLOR_YUV2RGB_UYVY,
-    COLOR_YUV2BGR_Y422 = COLOR_YUV2BGR_UYVY,
-    COLOR_YUV2RGB_UYNV = COLOR_YUV2RGB_UYVY,
-    COLOR_YUV2BGR_UYNV = COLOR_YUV2BGR_UYVY,
+    COLOR_YUV2RGB_UYVY = 107, //!< convert between YUV UYVY and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_UYVY = 108, //!< convert between YUV UYVY and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    //COLOR_YUV2RGB_VYUY = 109, //!< convert between YUV VYUY and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
+                                //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    //COLOR_YUV2BGR_VYUY = 110, //!< convert between YUV VYUY and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
+                                //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_Y422 = COLOR_YUV2RGB_UYVY, //!< synonym to UYVY
+    COLOR_YUV2BGR_Y422 = COLOR_YUV2BGR_UYVY, //!< synonym to UYVY
+    COLOR_YUV2RGB_UYNV = COLOR_YUV2RGB_UYVY, //!< synonym to UYVY
+    COLOR_YUV2BGR_UYNV = COLOR_YUV2BGR_UYVY, //!< synonym to UYVY
 
-    COLOR_YUV2RGBA_UYVY = 111,
-    COLOR_YUV2BGRA_UYVY = 112,
-    //COLOR_YUV2RGBA_VYUY = 113,
-    //COLOR_YUV2BGRA_VYUY = 114,
-    COLOR_YUV2RGBA_Y422 = COLOR_YUV2RGBA_UYVY,
-    COLOR_YUV2BGRA_Y422 = COLOR_YUV2BGRA_UYVY,
-    COLOR_YUV2RGBA_UYNV = COLOR_YUV2RGBA_UYVY,
-    COLOR_YUV2BGRA_UYNV = COLOR_YUV2BGRA_UYVY,
+    COLOR_YUV2RGBA_UYVY = 111, //!< convert between YUV UYVY and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_UYVY = 112, //!< convert between YUV UYVY and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    //COLOR_YUV2RGBA_VYUY = 113, //!< convert between YUV VYUY and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
+                                 //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    //COLOR_YUV2BGRA_VYUY = 114, //!< convert between YUV VYUY and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
+                                 //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_Y422 = COLOR_YUV2RGBA_UYVY, //!< synonym to UYVY
+    COLOR_YUV2BGRA_Y422 = COLOR_YUV2BGRA_UYVY, //!< synonym to UYVY
+    COLOR_YUV2RGBA_UYNV = COLOR_YUV2RGBA_UYVY, //!< synonym to UYVY
+    COLOR_YUV2BGRA_UYNV = COLOR_YUV2BGRA_UYVY, //!< synonym to UYVY
 
-    COLOR_YUV2RGB_YUY2 = 115,
-    COLOR_YUV2BGR_YUY2 = 116,
-    COLOR_YUV2RGB_YVYU = 117,
-    COLOR_YUV2BGR_YVYU = 118,
-    COLOR_YUV2RGB_YUYV = COLOR_YUV2RGB_YUY2,
-    COLOR_YUV2BGR_YUYV = COLOR_YUV2BGR_YUY2,
-    COLOR_YUV2RGB_YUNV = COLOR_YUV2RGB_YUY2,
-    COLOR_YUV2BGR_YUNV = COLOR_YUV2BGR_YUY2,
+    COLOR_YUV2RGB_YUY2 = 115, //!< convert between YUV YUY2 and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_YUY2 = 116, //!< convert between YUV YUY2 and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_YVYU = 117, //!< convert between YUV YVYU and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGR_YVYU = 118, //!< convert between YUV YVYU and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_YUYV = COLOR_YUV2RGB_YUY2, //!< synonym to YUY2
+    COLOR_YUV2BGR_YUYV = COLOR_YUV2BGR_YUY2, //!< synonym to YUY2
+    COLOR_YUV2RGB_YUNV = COLOR_YUV2RGB_YUY2, //!< synonym to YUY2
+    COLOR_YUV2BGR_YUNV = COLOR_YUV2BGR_YUY2, //!< synonym to YUY2
 
-    COLOR_YUV2RGBA_YUY2 = 119,
-    COLOR_YUV2BGRA_YUY2 = 120,
-    COLOR_YUV2RGBA_YVYU = 121,
-    COLOR_YUV2BGRA_YVYU = 122,
-    COLOR_YUV2RGBA_YUYV = COLOR_YUV2RGBA_YUY2,
-    COLOR_YUV2BGRA_YUYV = COLOR_YUV2BGRA_YUY2,
-    COLOR_YUV2RGBA_YUNV = COLOR_YUV2RGBA_YUY2,
-    COLOR_YUV2BGRA_YUNV = COLOR_YUV2BGRA_YUY2,
+    COLOR_YUV2RGBA_YUY2 = 119, //!< convert between YUV YUY2 and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_YUY2 = 120, //!< convert between YUV YUY2 and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_YVYU = 121, //!< convert between YUV YVYU and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2BGRA_YVYU = 122, //!< convert between YUV YVYU and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_YUYV = COLOR_YUV2RGBA_YUY2, //!< synonym to YUY2
+    COLOR_YUV2BGRA_YUYV = COLOR_YUV2BGRA_YUY2, //!< synonym to YUY2
+    COLOR_YUV2RGBA_YUNV = COLOR_YUV2RGBA_YUY2, //!< synonym to YUY2
+    COLOR_YUV2BGRA_YUNV = COLOR_YUV2BGRA_YUY2, //!< synonym to YUY2
 
-    COLOR_YUV2GRAY_UYVY = 123,
-    COLOR_YUV2GRAY_YUY2 = 124,
-    //CV_YUV2GRAY_VYUY    = CV_YUV2GRAY_UYVY,
-    COLOR_YUV2GRAY_Y422 = COLOR_YUV2GRAY_UYVY,
-    COLOR_YUV2GRAY_UYNV = COLOR_YUV2GRAY_UYVY,
-    COLOR_YUV2GRAY_YVYU = COLOR_YUV2GRAY_YUY2,
-    COLOR_YUV2GRAY_YUYV = COLOR_YUV2GRAY_YUY2,
-    COLOR_YUV2GRAY_YUNV = COLOR_YUV2GRAY_YUY2,
+    COLOR_YUV2GRAY_UYVY = 123, //!< extract channel from YUV 4:2:2 image
+    COLOR_YUV2GRAY_YUY2 = 124, //!< extract channel from YUV 4:2:2 image
+    //CV_YUV2GRAY_VYUY  = CV_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY
+    COLOR_YUV2GRAY_Y422 = COLOR_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY
+    COLOR_YUV2GRAY_UYNV = COLOR_YUV2GRAY_UYVY, //!< synonym to COLOR_YUV2GRAY_UYVY
+    COLOR_YUV2GRAY_YVYU = COLOR_YUV2GRAY_YUY2, //!< synonym to COLOR_YUV2GRAY_YUY2
+    COLOR_YUV2GRAY_YUYV = COLOR_YUV2GRAY_YUY2, //!< synonym to COLOR_YUV2GRAY_YUY2
+    COLOR_YUV2GRAY_YUNV = COLOR_YUV2GRAY_YUY2, //!< synonym to COLOR_YUV2GRAY_YUY2
 
     //! alpha premultiplication
     COLOR_RGBA2mRGBA    = 125,
     COLOR_mRGBA2RGBA    = 126,
 
-    //! RGB to YUV 4:2:0 family
-    COLOR_RGB2YUV_I420  = 127,
-    COLOR_BGR2YUV_I420  = 128,
-    COLOR_RGB2YUV_IYUV  = COLOR_RGB2YUV_I420,
-    COLOR_BGR2YUV_IYUV  = COLOR_BGR2YUV_I420,
+    COLOR_RGB2YUV_I420  = 127, //!< convert between RGB and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_BGR2YUV_I420  = 128, //!< convert between BGR and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGB2YUV_IYUV  = COLOR_RGB2YUV_I420, //!< synonym to I420
+    COLOR_BGR2YUV_IYUV  = COLOR_BGR2YUV_I420, //!< synonym to I420
 
-    COLOR_RGBA2YUV_I420 = 129,
-    COLOR_BGRA2YUV_I420 = 130,
-    COLOR_RGBA2YUV_IYUV = COLOR_RGBA2YUV_I420,
-    COLOR_BGRA2YUV_IYUV = COLOR_BGRA2YUV_I420,
-    COLOR_RGB2YUV_YV12  = 131,
-    COLOR_BGR2YUV_YV12  = 132,
-    COLOR_RGBA2YUV_YV12 = 133,
-    COLOR_BGRA2YUV_YV12 = 134,
+
+    COLOR_RGBA2YUV_I420 = 129, //!< convert between RGBA and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_BGRA2YUV_I420 = 130, //!< convert between BGRA and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_IYUV = COLOR_RGBA2YUV_I420, //!< synonym to I420
+    COLOR_BGRA2YUV_IYUV = COLOR_BGRA2YUV_I420, //!< synonym to I420
+    COLOR_RGB2YUV_YV12  = 131, //!< convert between RGB and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_BGR2YUV_YV12  = 132, //!< convert between BGR and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_YV12 = 133, //!< convert between RGBA and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_BGRA2YUV_YV12 = 134, //!< convert between BGRA and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
+                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
 
     //! Demosaicing, see @ref color_convert_bayer "color conversions" for additional information
     COLOR_BayerBG2BGR = 46, //!< equivalent to RGGB Bayer pattern
@@ -842,39 +880,49 @@ enum ColorConversionCodes {
     COLOR_BayerRG2RGBA = COLOR_BayerBG2BGRA, //!< equivalent to BGGR Bayer pattern
     COLOR_BayerGR2RGBA = COLOR_BayerGB2BGRA, //!< equivalent to GBRG Bayer pattern
 
-    //! RGB to YUV 4:2:2 family
+    COLOR_RGB2YUV_UYVY = 143, //!< convert between RGB and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGR2YUV_UYVY = 144, //!< convert between BGR and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGB2YUV_Y422 = COLOR_RGB2YUV_UYVY, //!< synonym to UYVY
+    COLOR_BGR2YUV_Y422 = COLOR_BGR2YUV_UYVY, //!< synonym to UYVY
+    COLOR_RGB2YUV_UYNV = COLOR_RGB2YUV_UYVY, //!< synonym to UYVY
+    COLOR_BGR2YUV_UYNV = COLOR_BGR2YUV_UYVY, //!< synonym to UYVY
 
-    COLOR_RGB2YUV_UYVY = 143,
-    COLOR_BGR2YUV_UYVY = 144,
-    COLOR_RGB2YUV_Y422 = COLOR_RGB2YUV_UYVY,
-    COLOR_BGR2YUV_Y422 = COLOR_BGR2YUV_UYVY,
-    COLOR_RGB2YUV_UYNV = COLOR_RGB2YUV_UYVY,
-    COLOR_BGR2YUV_UYNV = COLOR_BGR2YUV_UYVY,
+    COLOR_RGBA2YUV_UYVY = 145, //!< convert between RGBA and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGRA2YUV_UYVY = 146, //!< convert between BGRA and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_Y422 = COLOR_RGBA2YUV_UYVY, //!< synonym to UYVY
+    COLOR_BGRA2YUV_Y422 = COLOR_BGRA2YUV_UYVY, //!< synonym to UYVY
+    COLOR_RGBA2YUV_UYNV = COLOR_RGBA2YUV_UYVY, //!< synonym to UYVY
+    COLOR_BGRA2YUV_UYNV = COLOR_BGRA2YUV_UYVY, //!< synonym to UYVY
 
-    COLOR_RGBA2YUV_UYVY = 145,
-    COLOR_BGRA2YUV_UYVY = 146,
-    COLOR_RGBA2YUV_Y422 = COLOR_RGBA2YUV_UYVY,
-    COLOR_BGRA2YUV_Y422 = COLOR_BGRA2YUV_UYVY,
-    COLOR_RGBA2YUV_UYNV = COLOR_RGBA2YUV_UYVY,
-    COLOR_BGRA2YUV_UYNV = COLOR_BGRA2YUV_UYVY,
+    COLOR_RGB2YUV_YUY2 = 147, //!< convert between RGB and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGR2YUV_YUY2 = 148, //!< convert between BGR and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGB2YUV_YVYU = 149, //!< convert between RGB and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGR2YUV_YVYU = 150, //!< convert between BGR and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGB2YUV_YUYV = COLOR_RGB2YUV_YUY2, //!< synonym to YUY2
+    COLOR_BGR2YUV_YUYV = COLOR_BGR2YUV_YUY2, //!< synonym to YUY2
+    COLOR_RGB2YUV_YUNV = COLOR_RGB2YUV_YUY2, //!< synonym to YUY2
+    COLOR_BGR2YUV_YUNV = COLOR_BGR2YUV_YUY2, //!< synonym to YUY2
 
-    COLOR_RGB2YUV_YUY2 = 147,
-    COLOR_BGR2YUV_YUY2 = 148,
-    COLOR_RGB2YUV_YVYU = 149,
-    COLOR_BGR2YUV_YVYU = 150,
-    COLOR_RGB2YUV_YUYV = COLOR_RGB2YUV_YUY2,
-    COLOR_BGR2YUV_YUYV = COLOR_BGR2YUV_YUY2,
-    COLOR_RGB2YUV_YUNV = COLOR_RGB2YUV_YUY2,
-    COLOR_BGR2YUV_YUNV = COLOR_BGR2YUV_YUY2,
-
-    COLOR_RGBA2YUV_YUY2 = 151,
-    COLOR_BGRA2YUV_YUY2 = 152,
-    COLOR_RGBA2YUV_YVYU = 153,
-    COLOR_BGRA2YUV_YVYU = 154,
-    COLOR_RGBA2YUV_YUYV = COLOR_RGBA2YUV_YUY2,
-    COLOR_BGRA2YUV_YUYV = COLOR_BGRA2YUV_YUY2,
-    COLOR_RGBA2YUV_YUNV = COLOR_RGBA2YUV_YUY2,
-    COLOR_BGRA2YUV_YUNV = COLOR_BGRA2YUV_YUY2,
+    COLOR_RGBA2YUV_YUY2 = 151, //!< convert between RGBA and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGRA2YUV_YUY2 = 152, //!< convert between BGRA and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_YVYU = 153, //!< convert between RGBA and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_BGRA2YUV_YVYU = 154, //!< convert between BGRA and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
+                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_YUYV = COLOR_RGBA2YUV_YUY2, //!< synonym to YUY2
+    COLOR_BGRA2YUV_YUYV = COLOR_BGRA2YUV_YUY2, //!< synonym to YUY2
+    COLOR_RGBA2YUV_YUNV = COLOR_RGBA2YUV_YUY2, //!< synonym to YUY2
+    COLOR_BGRA2YUV_YUNV = COLOR_BGRA2YUV_YUY2, //!< synonym to YUY2
 
     COLOR_COLORCVT_MAX  = 155
 };

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -641,49 +641,33 @@ enum ColorConversionCodes {
     COLOR_YUV2BGR      = 84,
     COLOR_YUV2RGB      = 85,
 
-    COLOR_YUV2RGB_NV12  = 90, //!< convert between YUV NV12 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_NV12  = 91, //!< convert between YUV NV12 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGB_NV21  = 92, //!< convert between YUV NV21 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_NV21  = 93, //!< convert between YUV NV21 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_NV12  = 90, //!< convert between 4:2:0-subsampled YUV NV12 and RGB, two planes (in one or separate arrays): Y and U/V interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_NV12  = 91, //!< convert between 4:2:0-subsampled YUV NV12 and BGR, two planes (in one or separate arrays): Y and U/V interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGB_NV21  = 92, //!< convert between 4:2:0-subsampled YUV NV21 and RGB, two planes (in one or separate arrays): Y and V/U interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_NV21  = 93, //!< convert between 4:2:0-subsampled YUV NV21 and BGR, two planes (in one or separate arrays): Y and V/U interleaved, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV420sp2RGB  = COLOR_YUV2RGB_NV21, //!< synonym to NV21
     COLOR_YUV420sp2BGR  = COLOR_YUV2BGR_NV21, //!< synonym to NV21
 
-    COLOR_YUV2RGBA_NV12 = 94, //!< convert between YUV NV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_NV12 = 95, //!< convert between YUV NV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], U/V interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGBA_NV21 = 96, //!< convert between YUV NV21 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_NV21 = 97, //!< convert between YUV NV21 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), two planes (in one or separate arrays):
-                              //!< Y [16, 235], V/U interleaved [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_NV12 = 94, //!< convert between 4:2:0-subsampled YUV NV12 and RGBA, two planes (in one or separate arrays): Y and U/V interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_NV12 = 95, //!< convert between 4:2:0-subsampled YUV NV12 and BGRA, two planes (in one or separate arrays): Y and U/V interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGBA_NV21 = 96, //!< convert between 4:2:0-subsampled YUV NV21 and RGBA, two planes (in one or separate arrays): Y and V/U interleaved, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_NV21 = 97, //!< convert between 4:2:0-subsampled YUV NV21 and BGRA, two planes (in one or separate arrays): Y and V/U interleaved, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV420sp2RGBA = COLOR_YUV2RGBA_NV21, //!< synonym to NV21
     COLOR_YUV420sp2BGRA = COLOR_YUV2BGRA_NV21, //!< synonym to NV21
 
-    COLOR_YUV2RGB_YV12  =  98, //!< convert between YUV YV12 and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_YV12  =  99, //!< convert between YUV YV12 and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGB_IYUV  = 100, //!< convert between YUV IYUV and RGB, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_IYUV  = 101, //!< convert between YUV IYUV and BGR, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_YV12  =  98, //!< convert between 4:2:0-subsampled YUV YV12 and RGB, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_YV12  =  99, //!< convert between 4:2:0-subsampled YUV YV12 and BGR, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGB_IYUV  = 100, //!< convert between 4:2:0-subsampled YUV IYUV and RGB, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_IYUV  = 101, //!< convert between 4:2:0-subsampled YUV IYUV and BGR, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGB_I420  = COLOR_YUV2RGB_IYUV, //!< synonym to IYUV
     COLOR_YUV2BGR_I420  = COLOR_YUV2BGR_IYUV, //!< synonym to IYUV
     COLOR_YUV420p2RGB   = COLOR_YUV2RGB_YV12, //!< synonym to YV12
     COLOR_YUV420p2BGR   = COLOR_YUV2BGR_YV12, //!< synonym to YV12
 
-    COLOR_YUV2RGBA_YV12 = 102, //!< convert between YUV YV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_YV12 = 103, //!< convert between YUV YV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGBA_IYUV = 104, //!< convert between YUV YV12 and RGBA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_IYUV = 105, //!< convert between YUV YV12 and BGRA, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_YV12 = 102, //!< convert between 4:2:0-subsampled YUV YV12 and RGBA, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_YV12 = 103, //!< convert between 4:2:0-subsampled YUV YV12 and BGRA, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGBA_IYUV = 104, //!< convert between 4:2:0-subsampled YUV YV12 and RGBA, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_IYUV = 105, //!< convert between 4:2:0-subsampled YUV YV12 and BGRA, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGBA_I420 = COLOR_YUV2RGBA_IYUV, //!< synonym to IYUV
     COLOR_YUV2BGRA_I420 = COLOR_YUV2BGRA_IYUV, //!< synonym to IYUV
     COLOR_YUV420p2RGBA  = COLOR_YUV2RGBA_YV12, //!< synonym to YV12
@@ -698,53 +682,37 @@ enum ColorConversionCodes {
     COLOR_YUV420sp2GRAY = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
     COLOR_YUV420p2GRAY  = COLOR_YUV2GRAY_420, //!< synonym to COLOR_YUV2GRAY_420
 
-    COLOR_YUV2RGB_UYVY = 107, //!< convert between YUV UYVY and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_UYVY = 108, //!< convert between YUV UYVY and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    //COLOR_YUV2RGB_VYUY = 109, //!< convert between YUV VYUY and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
-                                //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    //COLOR_YUV2BGR_VYUY = 110, //!< convert between YUV VYUY and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
-                                //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_UYVY = 107, //!< convert between YUV UYVY and RGB, YUV is 4:2:2-subsampled and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_UYVY = 108, //!< convert between YUV UYVY and BGR, YUV is 4:2:2-subsampled and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    //COLOR_YUV2RGB_VYUY = 109, //!< convert between YUV VYUY and RGB, YUV is 4:2:2-subsampled and interleaved as V/Y1/U/Y2, see @ref color_convert_rgb_yuv_42x
+    //COLOR_YUV2BGR_VYUY = 110, //!< convert between YUV VYUY and BGR, YUV is 4:2:2-subsampled and interleaved as V/Y1/U/Y2, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGB_Y422 = COLOR_YUV2RGB_UYVY, //!< synonym to UYVY
     COLOR_YUV2BGR_Y422 = COLOR_YUV2BGR_UYVY, //!< synonym to UYVY
     COLOR_YUV2RGB_UYNV = COLOR_YUV2RGB_UYVY, //!< synonym to UYVY
     COLOR_YUV2BGR_UYNV = COLOR_YUV2BGR_UYVY, //!< synonym to UYVY
 
-    COLOR_YUV2RGBA_UYVY = 111, //!< convert between YUV UYVY and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_UYVY = 112, //!< convert between YUV UYVY and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    //COLOR_YUV2RGBA_VYUY = 113, //!< convert between YUV VYUY and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
-                                 //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    //COLOR_YUV2BGRA_VYUY = 114, //!< convert between YUV VYUY and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as V/Y1/U/Y2:
-                                 //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_UYVY = 111, //!< convert between YUV UYVY and RGBA, YUV is 4:2:2-subsampled and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_UYVY = 112, //!< convert between YUV UYVY and BGRA, YUV is 4:2:2-subsampled and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    //COLOR_YUV2RGBA_VYUY = 113, //!< convert between YUV VYUY and RGBA, YUV is 4:2:2-subsampled and interleaved as V/Y1/U/Y2, see @ref color_convert_rgb_yuv_42x
+    //COLOR_YUV2BGRA_VYUY = 114, //!< convert between YUV VYUY and BGRA, YUV is 4:2:2-subsampled and interleaved as V/Y1/U/Y2, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGBA_Y422 = COLOR_YUV2RGBA_UYVY, //!< synonym to UYVY
     COLOR_YUV2BGRA_Y422 = COLOR_YUV2BGRA_UYVY, //!< synonym to UYVY
     COLOR_YUV2RGBA_UYNV = COLOR_YUV2RGBA_UYVY, //!< synonym to UYVY
     COLOR_YUV2BGRA_UYNV = COLOR_YUV2BGRA_UYVY, //!< synonym to UYVY
 
-    COLOR_YUV2RGB_YUY2 = 115, //!< convert between YUV YUY2 and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_YUY2 = 116, //!< convert between YUV YUY2 and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGB_YVYU = 117, //!< convert between YUV YVYU and RGB, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGR_YVYU = 118, //!< convert between YUV YVYU and BGR, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGB_YUY2 = 115, //!< convert between YUV YUY2 and RGB, YUV is 4:2:2-subsampled and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_YUY2 = 116, //!< convert between YUV YUY2 and BGR, YUV is 4:2:2-subsampled and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGB_YVYU = 117, //!< convert between YUV YVYU and RGB, YUV is 4:2:2-subsampled and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGR_YVYU = 118, //!< convert between YUV YVYU and BGR, YUV is 4:2:2-subsampled and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGB_YUYV = COLOR_YUV2RGB_YUY2, //!< synonym to YUY2
     COLOR_YUV2BGR_YUYV = COLOR_YUV2BGR_YUY2, //!< synonym to YUY2
     COLOR_YUV2RGB_YUNV = COLOR_YUV2RGB_YUY2, //!< synonym to YUY2
     COLOR_YUV2BGR_YUNV = COLOR_YUV2BGR_YUY2, //!< synonym to YUY2
 
-    COLOR_YUV2RGBA_YUY2 = 119, //!< convert between YUV YUY2 and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_YUY2 = 120, //!< convert between YUV YUY2 and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2RGBA_YVYU = 121, //!< convert between YUV YVYU and RGBA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_YUV2BGRA_YVYU = 122, //!< convert between YUV YVYU and BGRA, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_YUV2RGBA_YUY2 = 119, //!< convert between YUV YUY2 and RGBA, YUV is 4:2:2-subsampled and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_YUY2 = 120, //!< convert between YUV YUY2 and BGRA, YUV is 4:2:2-subsampled and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2RGBA_YVYU = 121, //!< convert between YUV YVYU and RGBA, YUV is 4:2:2-subsampled and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
+    COLOR_YUV2BGRA_YVYU = 122, //!< convert between YUV YVYU and BGRA, YUV is 4:2:2-subsampled and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
     COLOR_YUV2RGBA_YUYV = COLOR_YUV2RGBA_YUY2, //!< synonym to YUY2
     COLOR_YUV2BGRA_YUYV = COLOR_YUV2BGRA_YUY2, //!< synonym to YUY2
     COLOR_YUV2RGBA_YUNV = COLOR_YUV2RGBA_YUY2, //!< synonym to YUY2
@@ -763,28 +731,19 @@ enum ColorConversionCodes {
     COLOR_RGBA2mRGBA    = 125,
     COLOR_mRGBA2RGBA    = 126,
 
-    COLOR_RGB2YUV_I420  = 127, //!< convert between RGB and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_BGR2YUV_I420  = 128, //!< convert between BGR and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGB2YUV_I420  = 127, //!< convert between RGB and 4:2:0-subsampled YUV I420, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGR2YUV_I420  = 128, //!< convert between BGR and 4:2:0-subsampled YUV I420, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
     COLOR_RGB2YUV_IYUV  = COLOR_RGB2YUV_I420, //!< synonym to I420
     COLOR_BGR2YUV_IYUV  = COLOR_BGR2YUV_I420, //!< synonym to I420
 
-
-    COLOR_RGBA2YUV_I420 = 129, //!< convert between RGBA and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_BGRA2YUV_I420 = 130, //!< convert between BGRA and YUV I420, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_I420 = 129, //!< convert between RGBA and 4:2:0-subsampled YUV I420, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGRA2YUV_I420 = 130, //!< convert between BGRA and 4:2:0-subsampled YUV I420, three planes in one array: Y, U and V, see @ref color_convert_rgb_yuv_42x
     COLOR_RGBA2YUV_IYUV = COLOR_RGBA2YUV_I420, //!< synonym to I420
     COLOR_BGRA2YUV_IYUV = COLOR_BGRA2YUV_I420, //!< synonym to I420
-    COLOR_RGB2YUV_YV12  = 131, //!< convert between RGB and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_BGR2YUV_YV12  = 132, //!< convert between BGR and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_RGBA2YUV_YV12 = 133, //!< convert between RGBA and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
-    COLOR_BGRA2YUV_YV12 = 134, //!< convert between BGRA and YUV YV12, YUV is 4:2:0 (U and V are 2x2 subsampled), three planes in one array:
-                               //!< Y [16, 235], V and U [16, 240], 8 bit only, calculations are done in 20-bit fixed-point arithmetics
+    COLOR_RGB2YUV_YV12  = 131, //!< convert between RGB and 4:2:0-subsampled YUV YV12, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGR2YUV_YV12  = 132, //!< convert between BGR and 4:2:0-subsampled YUV YV12, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_RGBA2YUV_YV12 = 133, //!< convert between RGBA and 4:2:0-subsampled YUV YV12, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGRA2YUV_YV12 = 134, //!< convert between BGRA and 4:2:0-subsampled YUV YV12, three planes in one array: Y, V and U, see @ref color_convert_rgb_yuv_42x
 
     //! Demosaicing, see @ref color_convert_bayer "color conversions" for additional information
     COLOR_BayerBG2BGR = 46, //!< equivalent to RGGB Bayer pattern
@@ -880,45 +839,33 @@ enum ColorConversionCodes {
     COLOR_BayerRG2RGBA = COLOR_BayerBG2BGRA, //!< equivalent to BGGR Bayer pattern
     COLOR_BayerGR2RGBA = COLOR_BayerGB2BGRA, //!< equivalent to GBRG Bayer pattern
 
-    COLOR_RGB2YUV_UYVY = 143, //!< convert between RGB and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGR2YUV_UYVY = 144, //!< convert between BGR and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGB2YUV_UYVY = 143, //!< convert between RGB and YUV UYVU, YUV is 4:2:2 and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGR2YUV_UYVY = 144, //!< convert between BGR and YUV UYVU, YUV is 4:2:2 and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
     COLOR_RGB2YUV_Y422 = COLOR_RGB2YUV_UYVY, //!< synonym to UYVY
     COLOR_BGR2YUV_Y422 = COLOR_BGR2YUV_UYVY, //!< synonym to UYVY
     COLOR_RGB2YUV_UYNV = COLOR_RGB2YUV_UYVY, //!< synonym to UYVY
     COLOR_BGR2YUV_UYNV = COLOR_BGR2YUV_UYVY, //!< synonym to UYVY
 
-    COLOR_RGBA2YUV_UYVY = 145, //!< convert between RGBA and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGRA2YUV_UYVY = 146, //!< convert between BGRA and YUV UYVU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as U/Y1/V/Y2:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_UYVY = 145, //!< convert between RGBA and YUV UYVU, YUV is 4:2:2 and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGRA2YUV_UYVY = 146, //!< convert between BGRA and YUV UYVU, YUV is 4:2:2 and interleaved as U/Y1/V/Y2, see @ref color_convert_rgb_yuv_42x
     COLOR_RGBA2YUV_Y422 = COLOR_RGBA2YUV_UYVY, //!< synonym to UYVY
     COLOR_BGRA2YUV_Y422 = COLOR_BGRA2YUV_UYVY, //!< synonym to UYVY
     COLOR_RGBA2YUV_UYNV = COLOR_RGBA2YUV_UYVY, //!< synonym to UYVY
     COLOR_BGRA2YUV_UYNV = COLOR_BGRA2YUV_UYVY, //!< synonym to UYVY
 
-    COLOR_RGB2YUV_YUY2 = 147, //!< convert between RGB and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGR2YUV_YUY2 = 148, //!< convert between BGR and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_RGB2YUV_YVYU = 149, //!< convert between RGB and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGR2YUV_YVYU = 150, //!< convert between BGR and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                              //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGB2YUV_YUY2 = 147, //!< convert between RGB and YUV YUY2, YUV is 4:2:2 and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGR2YUV_YUY2 = 148, //!< convert between BGR and YUV YUY2, YUV is 4:2:2 and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_RGB2YUV_YVYU = 149, //!< convert between RGB and YUV YVYU, YUV is 4:2:2 and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGR2YUV_YVYU = 150, //!< convert between BGR and YUV YVYU, YUV is 4:2:2 and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
     COLOR_RGB2YUV_YUYV = COLOR_RGB2YUV_YUY2, //!< synonym to YUY2
     COLOR_BGR2YUV_YUYV = COLOR_BGR2YUV_YUY2, //!< synonym to YUY2
     COLOR_RGB2YUV_YUNV = COLOR_RGB2YUV_YUY2, //!< synonym to YUY2
     COLOR_BGR2YUV_YUNV = COLOR_BGR2YUV_YUY2, //!< synonym to YUY2
 
-    COLOR_RGBA2YUV_YUY2 = 151, //!< convert between RGBA and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGRA2YUV_YUY2 = 152, //!< convert between BGRA and YUV YUY2, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/U/Y2/V:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_RGBA2YUV_YVYU = 153, //!< convert between RGBA and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
-    COLOR_BGRA2YUV_YVYU = 154, //!< convert between BGRA and YUV YVYU, YUV is 4:2:2 (U and V are 2x1 horizontally subsampled) interleaved as Y1/V/Y2/U:
-                               //!< Y [16, 235], U and V [16, 240], 8 bit only, calculations are done in 14-bit fixed-point arithmetics
+    COLOR_RGBA2YUV_YUY2 = 151, //!< convert between RGBA and YUV YUY2, YUV is 4:2:2 and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGRA2YUV_YUY2 = 152, //!< convert between BGRA and YUV YUY2, YUV is 4:2:2 and interleaved as Y1/U/Y2/V, see @ref color_convert_rgb_yuv_42x
+    COLOR_RGBA2YUV_YVYU = 153, //!< convert between RGBA and YUV YVYU, YUV is 4:2:2 and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
+    COLOR_BGRA2YUV_YVYU = 154, //!< convert between BGRA and YUV YVYU, YUV is 4:2:2 and interleaved as Y1/V/Y2/U, see @ref color_convert_rgb_yuv_42x
     COLOR_RGBA2YUV_YUYV = COLOR_RGBA2YUV_YUY2, //!< synonym to YUY2
     COLOR_BGRA2YUV_YUYV = COLOR_BGRA2YUV_YUY2, //!< synonym to YUY2
     COLOR_RGBA2YUV_YUNV = COLOR_RGBA2YUV_YUY2, //!< synonym to YUY2

--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -403,6 +403,9 @@ void cvtColorYUV2BGR(InputArray _src, OutputArray _dst, int dcn, bool swapb, boo
                      h.depth, dcn, swapb, crcb);
 }
 
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtColorOnePlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool swapb, int uidx, int ycn)
 {
     CvtHelper< Set<2>, Set<3, 4>, Set<CV_8U>, FROM_UYVY > h(_src, _dst, dcn);
@@ -411,6 +414,9 @@ void cvtColorOnePlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool s
                              dcn, swapb, uidx, ycn);
 }
 
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 14-bit fixed-point arithmetics is used
 void cvtColorOnePlaneBGR2YUV( InputArray _src, OutputArray _dst, bool swapb, int uidx, int ycn)
 {
     CvtHelper< Set<3, 4>, Set<2>, Set<CV_8U>, TO_UYVY > h(_src, _dst, 2);
@@ -426,6 +432,9 @@ void cvtColorYUV2Gray_ch( InputArray _src, OutputArray _dst, int coi )
     extractChannel(_src, _dst, coi);
 }
 
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtColorBGR2ThreePlaneYUV( InputArray _src, OutputArray _dst, bool swapb, int uidx)
 {
     CvtHelper< Set<3, 4>, Set<1>, Set<CV_8U>, TO_YUV > h(_src, _dst, 1);
@@ -448,6 +457,9 @@ void cvtColorYUV2Gray_420( InputArray _src, OutputArray _dst )
     h.src(Range(0, h.dstSz.height), Range::all()).copyTo(h.dst);
 }
 
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtColorThreePlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool swapb, int uidx)
 {
     if(dcn <= 0) dcn = 3;
@@ -457,9 +469,10 @@ void cvtColorThreePlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool
                                dcn, swapb, uidx);
 }
 
-// http://www.fourcc.org/yuv.php#NV21 == yuv420sp -> a plane of 8 bit Y samples followed by an interleaved V/U plane containing 8 bit 2x2 subsampled chroma samples
-// http://www.fourcc.org/yuv.php#NV12 -> a plane of 8 bit Y samples followed by an interleaved U/V plane containing 8 bit 2x2 subsampled colour difference samples
-
+// 4:2:0, two planes in one array: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
+// see also: http://www.fourcc.org/yuv.php#NV21, http://www.fourcc.org/yuv.php#NV12
 void cvtColorTwoPlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool swapb, int uidx )
 {
     if(dcn <= 0) dcn = 3;
@@ -469,6 +482,9 @@ void cvtColorTwoPlaneYUV2BGR( InputArray _src, OutputArray _dst, int dcn, bool s
                              dcn, swapb, uidx);
 }
 
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtColorTwoPlaneYUV2BGRpair( InputArray _ysrc, InputArray _uvsrc, OutputArray _dst, int dcn, bool swapb, int uidx )
 {
     int stype = _ysrc.type();

--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -115,6 +115,9 @@ void cvtYUVtoBGR(const uchar * src_data, size_t src_step,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:0, two planes in one array: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
                          int dst_width, int dst_height,
@@ -129,6 +132,9 @@ void cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step,
             dst_width, dst_height, dcn, swapBlue, uIdx);
 }
 
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtTwoPlaneYUVtoBGR(const uchar * y_data, const uchar * uv_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
                          int dst_width, int dst_height,
@@ -139,6 +145,9 @@ void cvtTwoPlaneYUVtoBGR(const uchar * y_data, const uchar * uv_data, size_t src
     cvtTwoPlaneYUVtoBGR(y_data, src_step, uv_data, src_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue, uIdx);
 }
 
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtTwoPlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * uv_data, size_t uv_step,
                          uchar * dst_data, size_t dst_step,
                          int dst_width, int dst_height,
@@ -153,6 +162,9 @@ void cvtTwoPlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * uv_d
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                            uchar * dst_data, size_t dst_step,
                            int dst_width, int dst_height,
@@ -166,6 +178,9 @@ void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
                            uchar * dst_data, size_t dst_step,
                            int width, int height,
@@ -179,6 +194,9 @@ void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
                          uchar * y_data, uchar * uv_data, size_t dst_step,
                          int width, int height,
@@ -193,6 +211,9 @@ void cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
                          int width, int height,
@@ -206,6 +227,9 @@ void cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 14-bit fixed-point arithmetics is used
 void cvtOnePlaneBGRtoYUV(const uchar * src_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
                          int width, int height,

--- a/modules/imgproc/src/color_yuv.simd.hpp
+++ b/modules/imgproc/src/color_yuv.simd.hpp
@@ -1015,7 +1015,7 @@ struct YCrCb2RGB_i<ushort>
 
 ///////////////////////////////////// YUV420 -> RGB /////////////////////////////////////
 
-static const int ITUR_BT_601_CY = 1220542;
+static const int ITUR_BT_601_CY  = 1220542;
 static const int ITUR_BT_601_CUB = 2116026;
 static const int ITUR_BT_601_CUG = -409993;
 static const int ITUR_BT_601_CVG = -852492;
@@ -1023,14 +1023,14 @@ static const int ITUR_BT_601_CVR = 1673527;
 static const int ITUR_BT_601_SHIFT = 20;
 
 // Coefficients for RGB to YUV420p conversion
-static const int ITUR_BT_601_CRY =  269484;
-static const int ITUR_BT_601_CGY =  528482;
-static const int ITUR_BT_601_CBY =  102760;
-static const int ITUR_BT_601_CRU = -155188;
-static const int ITUR_BT_601_CGU = -305135;
-static const int ITUR_BT_601_CBU =  460324;
-static const int ITUR_BT_601_CGV = -385875;
-static const int ITUR_BT_601_CBV = -74448;
+static const int ITUR_BT_601_CRY =  269484; // 0.299055 * (236-16)/256 * (1 << ITUR_BT_601_SHIFT)
+static const int ITUR_BT_601_CGY =  528482; // 0.586472 * (236-16)/256 * (1 << ITUR_BT_601_SHIFT)
+static const int ITUR_BT_601_CBY =  102760; // 0.114035 * (236-16)/256 * (1 << ITUR_BT_601_SHIFT)
+static const int ITUR_BT_601_CRU = -155188; // -0.148 * (1 << (ITUR_BT_601_SHIFT-1))
+static const int ITUR_BT_601_CGU = -305135; // -0.291 * (1 << (ITUR_BT_601_SHIFT-1))
+static const int ITUR_BT_601_CBU =  460324; //  0.439 * (1 << (ITUR_BT_601_SHIFT-1))
+static const int ITUR_BT_601_CGV = -385875; // -0.368 * (1 << (ITUR_BT_601_SHIFT-1))
+static const int ITUR_BT_601_CBV =  -74448; // -0.071 * (1 << (ITUR_BT_601_SHIFT-1))
 
 //R = 1.164(Y - 16) + 1.596(V - 128)
 //G = 1.164(Y - 16) - 0.813(V - 128) - 0.391(U - 128)
@@ -1870,9 +1870,9 @@ static const int RGB2YUV422_SHIFT = 14;
 // and rounding to the nearest integer so that resulting values are in these bounds:
 // Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
 
-static const int R2Y422 =  4211; // 0.299077 * (235 - 16) / 256 * 16384
-static const int G2Y422 =  8258; // 0.586505 * (235 - 16) / 256 * 16384
-static const int B2Y422 =  1606; // 0.114062 * (235 - 16) / 256 * 16384
+static const int R2Y422 =  4211; // 0.299077 * (236 - 16) / 256 * 16384
+static const int G2Y422 =  8258; // 0.586506 * (236 - 16) / 256 * 16384
+static const int B2Y422 =  1606; // 0.114062 * (236 - 16) / 256 * 16384
 
 static const int R2U422 = -1212; // -0.148 * 8192
 static const int G2U422 = -2384; // -0.291 * 8192

--- a/modules/imgproc/src/color_yuv.simd.hpp
+++ b/modules/imgproc/src/color_yuv.simd.hpp
@@ -1867,15 +1867,22 @@ static const int RGB2YUV422_SHIFT = 14;
 // separately. For U and V, they are reduced by half to account for two RGB pixels contributing
 // to the same U and V values. In other words, the U and V contributions from the two RGB pixels
 // are averaged. The integer versions are obtained by multiplying the float versions by 16384
-// and rounding to the nearest integer.
+// and rounding to the nearest integer so that resulting values are in these bounds:
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
 
-int   c_RGB2YUV422Coeffs_i[10]  = {1024, 8192, 4211,  8258,  1606,
-                                   -1212, -2384,  3596, -3015,  -582};
+static const int R2Y422 =  4211; // 0.299077 * (235 - 16) / 256 * 16384
+static const int G2Y422 =  8258; // 0.586505 * (235 - 16) / 256 * 16384
+static const int B2Y422 =  1606; // 0.114062 * (235 - 16) / 256 * 16384
+
+static const int R2U422 = -1212; // -0.148 * 8192
+static const int G2U422 = -2384; // -0.291 * 8192
+static const int B2U422 =  3596; //  0.439 * 8192
+static const int G2V422 = -3015; // -0.368 * 8192
+static const int B2V422 =  -582; // -0.071 * 8192
 
 static inline void RGB2Y(const uchar r, const uchar g, const uchar b, uchar& y)
 {
-    int y_ = r * c_RGB2YUV422Coeffs_i[2] + g * c_RGB2YUV422Coeffs_i[3] +
-             b * c_RGB2YUV422Coeffs_i[4] + c_RGB2YUV422Coeffs_i[0]*256;
+    int y_ = r * R2Y422 + g * G2Y422 + b * B2Y422 + (1 << RGB2YUV422_SHIFT) * 16;
     y = saturate_cast<uchar>(((1 << (RGB2YUV422_SHIFT-1)) + y_) >> RGB2YUV422_SHIFT);
 }
 
@@ -1885,12 +1892,10 @@ static inline void RGB2UV(const uchar r1, const uchar g1, const uchar b1,
 {
     int sr = r1 + r2, sg = g1 + g2, sb = b1 + b2;
 
-    int u_ = sr * c_RGB2YUV422Coeffs_i[5] + sg * c_RGB2YUV422Coeffs_i[6] +
-             sb * c_RGB2YUV422Coeffs_i[7] + c_RGB2YUV422Coeffs_i[1]*256;
+    int u_ = sr * R2U422 + sg * G2U422 + sb * B2U422 + (1 << (RGB2YUV422_SHIFT-1)) * 256;
     u = saturate_cast<uchar>(((1 << (RGB2YUV422_SHIFT-1)) + u_) >> RGB2YUV422_SHIFT);
 
-    int v_ = sr * c_RGB2YUV422Coeffs_i[7] + sg * c_RGB2YUV422Coeffs_i[8] +
-             sb * c_RGB2YUV422Coeffs_i[9] + c_RGB2YUV422Coeffs_i[1]*256;
+    int v_ = sr * B2U422 + sg * G2V422 + sb * B2V422 + (1 << (RGB2YUV422_SHIFT-1)) * 256;
     v = saturate_cast<uchar>(((1 << (RGB2YUV422_SHIFT-1)) + v_) >> RGB2YUV422_SHIFT);
 }
 
@@ -2000,14 +2005,17 @@ void cvtYUVtoBGR(const uchar * src_data, size_t src_step,
         CvtColorLoop(src_data, src_step, dst_data, dst_step, width, height, YCrCb2RGB_f<float>(dcn, blueIdx, isCbCr));
 }
 
-typedef void (*cvt_2plane_yuv_ptr_t)(uchar * /* dst_data*/,
-                       size_t /* dst_step */,
-                       int /* dst_width */,
-                       int /* dst_height */,
-                       const uchar* /* _y1 */,
-                       size_t /* _y1_step */,
-                       const uchar* /* _uv */,
-                       size_t /* _uv_step */);
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
+typedef void (*cvt_2plane_yuv_ptr_t)(uchar *      /* dst_data   */,
+                                     size_t       /* dst_step   */,
+                                     int          /* dst_width  */,
+                                     int          /* dst_height */,
+                                     const uchar* /* _y1        */,
+                                     size_t       /* _y1_step   */,
+                                     const uchar* /* _uv        */,
+                                     size_t       /* _uv_step   */);
 
 void cvtTwoPlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * uv_data, size_t uv_step,
                          uchar * dst_data, size_t dst_step,
@@ -2035,21 +2043,24 @@ void cvtTwoPlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * uv_d
     cvtPtr(dst_data, dst_step, dst_width, dst_height, y_data, y_step, uv_data, uv_step);
 }
 
-typedef void (*cvt_3plane_yuv_ptr_t)(uchar * /* dst_data */,
-                                     size_t /* dst_step */,
-                                     int /* dst_width */,
-                                     int /* dst_height */,
-                                     size_t /* _stride */,
-                                     const uchar* /* _y1 */,
-                                     const uchar* /* _u */,
-                                     const uchar* /* _v */,
-                                     int /* ustepIdx */,
-                                     int /* vstepIdx */);
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
+typedef void (*cvt_3plane_yuv_ptr_t)(uchar *      /* dst_data   */,
+                                     size_t       /* dst_step   */,
+                                     int          /* dst_width  */,
+                                     int          /* dst_height */,
+                                     size_t       /* _stride    */,
+                                     const uchar* /* _y1        */,
+                                     const uchar* /* _u         */,
+                                     const uchar* /* _v         */,
+                                     int          /* ustepIdx   */,
+                                     int          /* vstepIdx   */);
 
 void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
-                                  uchar * dst_data, size_t dst_step,
-                                  int dst_width, int dst_height,
-                                  int dcn, bool swapBlue, int uIdx)
+                                 uchar * dst_data, size_t dst_step,
+                                 int dst_width, int dst_height,
+                                 int dcn, bool swapBlue, int uIdx)
 {
     CV_INSTRUMENT_REGION();
 
@@ -2075,6 +2086,9 @@ void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
     cvtPtr(dst_data, dst_step, dst_width, dst_height, src_step, src_data, u, v, ustepIdx, vstepIdx);
 }
 
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
                            uchar * dst_data, size_t dst_step,
                            int width, int height,
@@ -2093,6 +2107,9 @@ void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
         cvt(Range(0, height/2));
 }
 
+// 4:2:0, two planes: Y, UV interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
                          uchar * y_data, uchar * uv_data, size_t dst_step,
                          int width, int height,
@@ -2109,12 +2126,15 @@ void cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
         cvt(Range(0, height/2));
 }
 
-typedef void (*cvt_1plane_yuv_ptr_t)(uchar * /* dst_data */,
-                                     size_t /* dst_step */,
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
+typedef void (*cvt_1plane_yuv_ptr_t)(uchar *       /* dst_data */,
+                                     size_t        /* dst_step */,
                                      const uchar * /* src_data */,
-                                     size_t /* src_step */,
-                                     int /* width */,
-                                     int /* height */);
+                                     size_t        /* src_step */,
+                                     int           /* width    */,
+                                     int           /* height   */);
 
 void cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
@@ -2145,6 +2165,9 @@ void cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
     cvtPtr(dst_data, dst_step, src_data, src_step, width, height);
 }
 
+// 4:2:2 interleaved
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 14-bit fixed-point arithmetics is used
 void cvtOnePlaneBGRtoYUV(const uchar * src_data, size_t src_step,
                          uchar * dst_data, size_t dst_step,
                          int width, int height,

--- a/modules/imgproc/src/hal_replacement.hpp
+++ b/modules/imgproc/src/hal_replacement.hpp
@@ -576,6 +576,7 @@ inline int hal_ni_cvtLabtoBGR(const uchar * src_data, size_t src_step, uchar * d
    @param uIdx U-channel index in the interleaved U/V plane (0 or 1)
    Convert from YUV (YUV420sp (or NV12/NV21) - Y plane followed by interleaved U/V plane) to BGR, RGB, BGRA or RGBA.
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
@@ -594,6 +595,7 @@ inline int hal_ni_cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step, u
    @param uIdx U-channel index in the interleaved U/V plane (0 or 1)
    Convert from YUV (YUV420sp (or NV12/NV21) - Y plane followed by interleaved U/V plane) to BGR, RGB, BGRA or RGBA.
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtTwoPlaneYUVtoBGREx(const uchar * y_data, size_t y_step, const uchar * uv_data, size_t uv_step,
                                       uchar * dst_data, size_t dst_step, int dst_width, int dst_height,
@@ -614,6 +616,7 @@ inline int hal_ni_cvtTwoPlaneYUVtoBGREx(const uchar * y_data, size_t y_step, con
    @param uIdx U-channel plane index (0 or 1)
    Convert from BGR, RGB, BGRA or RGBA to YUV (YUV420sp (or NV12/NV21) - Y plane followed by interleaved U/V plane).
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
                                       uchar * y_data, size_t y_step, uchar * uv_data, size_t uv_step,
@@ -633,6 +636,7 @@ inline int hal_ni_cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
    @param uIdx U-channel plane index (0 or 1)
    Convert from YUV (YUV420p (or YV12/YV21) - Y plane followed by U and V planes) to BGR, RGB, BGRA or RGBA.
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
@@ -649,6 +653,7 @@ inline int hal_ni_cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
    @param uIdx U-channel plane index (0 or 1)
    Convert from BGR, RGB, BGRA or RGBA to YUV (YUV420p (or YV12/YV21) - Y plane followed by U and V planes).
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int width, int height, int scn, bool swapBlue, int uIdx) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
@@ -664,8 +669,9 @@ inline int hal_ni_cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
    @param swapBlue if set to true B and R destination channels will be swapped (write RGB)
    @param uIdx U-channel index (0 or 1)
    @param ycn Y-channel index (0 or 1)
-   Convert from UYVY, YUY2 or YVYU to BGR, RGB, BGRA or RGBA.
+   Convert from interleaved YUV 4:2:2 (UYVY, YUY2 or YVYU) to BGR, RGB, BGRA or RGBA.
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int width, int height, int dcn, bool swapBlue, int uIdx, int ycn) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
@@ -678,8 +684,9 @@ inline int hal_ni_cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step, u
    @param swapBlue if set to true B and R destination channels will be swapped (write RGB)
    @param uIdx U-channel index (0 or 1)
    @param ycn Y-channel index (0 or 1)
-   Convert from BGR, RGB, BGRA or RGBA to UYVY, YUY2 or YVYU.
+   Convert from BGR, RGB, BGRA or RGBA to interleaved YUV 4:2:2 (UYVY, YUY2 or YVYU).
    Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
  */
 inline int hal_ni_cvtOnePlaneBGRtoYUV(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int width, int height, int scn, bool swapBlue, int uIdx, int ycn) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 


### PR DESCRIPTION
This PR contains descriptions for various RGB <-> YUV color conversion codes as well as detailed comments in the source code.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
