### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2024.05

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/4.x_20231225
-# Binaries were created for OpenCV: 62f1a7410d5e5e03d6cee5c95549bf61d5ee98db
-ocv_update(FFMPEG_BINARIES_COMMIT "fbac408a47977ee4265f39e7659d33f1dfef5216")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "9b755ecbbade0a5b78332e9b4ef2dd1b")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "cb4db51ee9a423e6168b9d08bee61efc")
+# Binaries branch name: ffmpeg/4.x_20240522
+# Binaries were created for OpenCV: 8393885a39dac1e650bf5d0aaff84c04ad8bcdd3
+ocv_update(FFMPEG_BINARIES_COMMIT "394dca6ceb3085c979415e6385996b6570e94153")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "bdfbd1efb295f3e54c07d2cb7a843bf9")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "bfef029900f788480a363d6dc05c4f0e")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -266,8 +266,7 @@ TEST_P(videoio_container_get, read)
     ASSERT_EQ(bitrate, bitrateProp);
     const double fpsProp = container.get(CAP_PROP_FPS);
     ASSERT_EQ(fps, fpsProp);
-    // remove when PR fixing raw video CAP_PROP_POS_MSEC return value is merged and windows dll is updated
-#ifndef _WIN32
+
     vector<int> displayTimeMs;
     int iFrame = 1;
     while (container.grab()) {
@@ -283,7 +282,6 @@ TEST_P(videoio_container_get, read)
     const int frameTimeMs = static_cast<int>(1000.0 / fps);
     ASSERT_NEAR(frameTimeMs, *minTimeMsIt, 1);
     ASSERT_NEAR(frameTimeMs, *maxTimeMsIt, 1);
-#endif
 }
 
 const videoio_container_get_params_t videoio_container_get_params[] =


### PR DESCRIPTION
**Merge with 3rdparty**: https://github.com/opencv/opencv_3rdparty/pull/84

- FFmpeg 4.4.4
- OpenH264 version 1.8.0
- libVPX version 1.14.0
- libAOM version 3.9.0

previous update: #24767

```
force_builders=Win64,Win32
```