### PR TITLE
core: deployment compatibility for old mac after Accelerate New LAPACK fix

### DIFF
--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -112,11 +112,15 @@ macro(ocv_lapack_check)
       execute_process(COMMAND sw_vers -productVersion
                       OUTPUT_VARIABLE MACOS_VERSION
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
-      # Enable Accelerate New LAPACK if macOS >= 13.3
-      if (MACOS_VERSION VERSION_GREATER "13.3" OR MACOS_VERSION VERSION_EQUAL "13.3")
-        set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
-        add_compile_definitions(ACCELERATE_NEW_LAPACK)
-        add_compile_definitions(ACCELERATE_LAPACK_ILP64)
+      # Compatibility for deployment on old macOS
+      if(${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER "13.3" OR ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_EQUAL "13.3")
+        # Enable Accelerate New LAPACK if macOS >= 13.3
+        if(MACOS_VERSION VERSION_GREATER "13.3" OR MACOS_VERSION VERSION_EQUAL "13.3")
+          message(STATUS "LAPACK(${LAPACK_IMPL}): Accelerate New LAPACK is enabled.")
+          set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
+          add_compile_definitions(ACCELERATE_NEW_LAPACK)
+          add_compile_definitions(ACCELERATE_LAPACK_ILP64)
+        endif()
       endif()
     endif()
 

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -11,8 +11,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
 endif()
 
 if(DEFINED _apple_device_min_target_os_version AND
-   (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER ${_apple_device_min_target_os_version} OR
-    ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_EQUAL ${_apple_device_min_target_os_version}))
+   ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_GREATER ${_apple_device_min_target_os_version} OR
+    "${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_EQUAL ${_apple_device_min_target_os_version}))
   set(_apple_device_has_required_min_os_version ON)
 else()
   set(_apple_device_has_required_min_os_version OFF)

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -1,3 +1,26 @@
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(_apple_device_min_target_os_version "13.3")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  set(_apple_device_min_target_os_version "16.4")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "watchOS")
+  set(_apple_device_min_target_os_version "9.4")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
+  set(_apple_device_min_target_os_version "16.4")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
+  set(_apple_device_min_target_os_version "1.0")
+endif()
+
+if(DEFINED _apple_device_min_target_os_version AND
+   (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER ${_apple_device_min_target_os_version} OR
+    ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_EQUAL ${_apple_device_min_target_os_version}))
+  set(_apple_device_has_required_min_os_version ON)
+else()
+  set(_apple_device_has_required_min_os_version OFF)
+endif()
+
+OCV_OPTION(OPENCV_OSX_USE_ACCELERATE_NEW_LAPACK "Use new BLAS/LAPACK interfaces from Accelerate framework on Apple platform" _apple_device_has_required_min_os_version
+  VISIBLE_IF APPLE)
+
 macro(_find_header_file_in_dirs VAR NAME)
   unset(${VAR})
   unset(${VAR} CACHE)
@@ -107,14 +130,11 @@ macro(ocv_lapack_check)
     endif()
 
     set(LAPACK_TRY_COMPILE_DEF "")
-    if(LAPACK_IMPL STREQUAL "LAPACK/Apple" AND NOT IOS) # https://github.com/opencv/opencv/issues/24660
-      # Enable Accelerate New LAPACK if target macOS >= 13.3
-      if(${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER "13.3" OR ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_EQUAL "13.3")
-        message(STATUS "LAPACK(${LAPACK_IMPL}): Accelerate New LAPACK is enabled.")
-        set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
-        add_compile_definitions(ACCELERATE_NEW_LAPACK)
-        add_compile_definitions(ACCELERATE_LAPACK_ILP64)
-      endif()
+    if(LAPACK_IMPL STREQUAL "LAPACK/Apple" AND OPENCV_OSX_USE_ACCELERATE_NEW_LAPACK)
+      message(STATUS "LAPACK(${LAPACK_IMPL}): Accelerate New LAPACK is enabled.")
+      set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
+      add_compile_definitions(ACCELERATE_NEW_LAPACK)
+      add_compile_definitions(ACCELERATE_LAPACK_ILP64)
     endif()
 
     try_compile(__VALID_LAPACK

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -11,8 +11,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
 endif()
 
 if(DEFINED _apple_device_min_target_os_version AND
-   ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_GREATER ${_apple_device_min_target_os_version} OR
-    "${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_EQUAL ${_apple_device_min_target_os_version}))
+   ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_GREATER "${_apple_device_min_target_os_version}" OR
+    "${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_EQUAL "${_apple_device_min_target_os_version}"))
   set(_apple_device_has_required_min_os_version ON)
 else()
   set(_apple_device_has_required_min_os_version OFF)

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -108,19 +108,12 @@ macro(ocv_lapack_check)
 
     set(LAPACK_TRY_COMPILE_DEF "")
     if(LAPACK_IMPL STREQUAL "LAPACK/Apple" AND NOT IOS) # https://github.com/opencv/opencv/issues/24660
-      # Get macOS version
-      execute_process(COMMAND sw_vers -productVersion
-                      OUTPUT_VARIABLE MACOS_VERSION
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-      # Compatibility for deployment on old macOS
+      # Enable Accelerate New LAPACK if target macOS >= 13.3
       if(${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER "13.3" OR ${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_EQUAL "13.3")
-        # Enable Accelerate New LAPACK if macOS >= 13.3
-        if(MACOS_VERSION VERSION_GREATER "13.3" OR MACOS_VERSION VERSION_EQUAL "13.3")
-          message(STATUS "LAPACK(${LAPACK_IMPL}): Accelerate New LAPACK is enabled.")
-          set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
-          add_compile_definitions(ACCELERATE_NEW_LAPACK)
-          add_compile_definitions(ACCELERATE_LAPACK_ILP64)
-        endif()
+        message(STATUS "LAPACK(${LAPACK_IMPL}): Accelerate New LAPACK is enabled.")
+        set(LAPACK_TRY_COMPILE_DEF "-DACCELERATE_NEW_LAPACK")
+        add_compile_definitions(ACCELERATE_NEW_LAPACK)
+        add_compile_definitions(ACCELERATE_LAPACK_ILP64)
       endif()
     endif()
 


### PR DESCRIPTION
Attempt to fix https://github.com/opencv/opencv/pull/24804#discussion_r1609957747

We may need to explicitly add build option `-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0` or environment variable (`export MACOSX_DEPLOYMENT_TARGET=12.0`) for mac builds (python package most probably) on builders with new macOS (>= 13.3).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
