### PR TITLE
Disambiguate cv::format

### DIFF
--- a/modules/calib3d/test/test_homography.cpp
+++ b/modules/calib3d/test/test_homography.cpp
@@ -718,12 +718,12 @@ TEST(Calib3d_Homography, not_normalized)
     {
         Mat h = findHomography(p1, p2, method);
         for (auto it = h.begin<double>(); it != h.end<double>(); ++it) {
-            ASSERT_FALSE(cvIsNaN(*it)) << format("method %d\nResult:\n", method) << h;
+            ASSERT_FALSE(cvIsNaN(*it)) << cv::format("method %d\nResult:\n", method) << h;
         }
         if (h.at<double>(0, 0) * ref.at<double>(0, 0) < 0) {
             h *= -1;
         }
-        ASSERT_LE(cv::norm(h, ref, NORM_INF), 1e-8) << format("method %d\nResult:\n", method) << h;
+        ASSERT_LE(cv::norm(h, ref, NORM_INF), 1e-8) << cv::format("method %d\nResult:\n", method) << h;
     }
 }
 


### PR DESCRIPTION
Otherwise, this test does not compile with C++20, which includes std::format.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
