### PR TITLE
Tests for cvSmooth -> tests for boxFilter

### DIFF
--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -773,7 +773,7 @@ void CV_BlurTest::get_test_array_types_and_sizes( int test_case_idx,
 void CV_BlurTest::run_func()
 {
     cv::boxFilter(inplace ? test_mat[OUTPUT][0] : test_mat[INPUT][0], test_mat[OUTPUT][0],
-                  -1, aperture_size, cv::Point(-1, -1), normalize, cv::BORDER_REPLICATE);
+                  test_mat[OUTPUT][0].type(), aperture_size, cv::Point(-1, -1), normalize, cv::BORDER_REPLICATE);
 }
 
 

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -772,9 +772,8 @@ void CV_BlurTest::get_test_array_types_and_sizes( int test_case_idx,
 
 void CV_BlurTest::run_func()
 {
-    cvSmooth( inplace ? test_array[OUTPUT][0] : test_array[INPUT][0],
-              test_array[OUTPUT][0], normalize ? CV_BLUR : CV_BLUR_NO_SCALE,
-              aperture_size.width, aperture_size.height );
+    cv::boxFilter(inplace ? test_mat[OUTPUT][0] : test_mat[INPUT][0], test_mat[OUTPUT][0],
+                  -1, aperture_size, cv::Point(-1, -1), normalize, cv::BORDER_REPLICATE);
 }
 
 


### PR DESCRIPTION
fixes #25448

### Motivation
The obsolete function `cvSmooth` has two modes in which it calls `cv::boxFilter()` inside with and without normalization.
This function is covered by tests exactly for that modes.
This means that by replacing `cvSmooth` call by `cv::boxFilter()` we will leave the coverage untouched (but more obvious) and remove that obsolete function from tests.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
