### PR TITLE
added ximgproc edgedrawing to opencvjs, 

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -802,14 +802,13 @@ class JSWrapperGenerator(object):
                         # Register the smart pointer
                         base_class_name = variant.rettype
                         base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
-                        self.classes[base_class_name].has_smart_ptr = True
+
+                        prefix_class_name = base_class_name if base_class_name in self.classes else ns_id + '_' + base_class_name
+                        self.classes[prefix_class_name].has_smart_ptr = True
 
                         # Adds the external constructor
-                        class_name = func.name.replace("create", "")
-                        if not class_name in self.classes:
-                            self.classes[base_class_name].methods[func.cname] = func
-                        else:
-                            self.classes[class_name].methods[func.cname] = func
+                        self.classes[prefix_class_name].methods[func.cname] = func
+
                         ext_cnst = True
                 if ext_cnst:
                     continue

--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -95,6 +95,11 @@ typedef aruco::DetectorParameters aruco_DetectorParameters;
 typedef QRCodeDetectorAruco::Params QRCodeDetectorAruco_Params;
 #endif
 
+#ifdef HAVE_OPENCV_IMGCODECS
+using namespace cv::ximgproc;
+typedef ximgproc::EdgeDrawing::Params EdgeDrawing_Params;
+#endif
+
 #ifdef HAVE_OPENCV_DNN
 using namespace cv::dnn;
 #endif

--- a/platforms/js/opencv_js.config.py
+++ b/platforms/js/opencv_js.config.py
@@ -210,7 +210,10 @@ calib3d = {
     ],
 }
 
-white_list = makeWhiteList([core, imgproc, objdetect, video, dnn, features2d, photo, calib3d])
+ximgproc = { '': ['createEdgeDrawing'], 'ximgproc_EdgeDrawing': ["setParams", "detectEdges", "getEdgeImage"], 'ximgproc_EdgeDrawing_Params': ["Params", "PFmode"] }
 
+white_list = makeWhiteList([core, imgproc, objdetect, video, dnn, features2d, photo, calib3d, ximgproc])
+
+namespace_prefix_override['ximgproc'] = ''
 # namespace_prefix_override['dnn'] = ''  # compatibility stuff (enabled by default)
 # namespace_prefix_override['aruco'] = ''  # compatibility stuff (enabled by default)


### PR DESCRIPTION
fixed external constructor from function which returns a Ptr<class>

The problem was that `Ptr< EdgeDrawing > 	createEdgeDrawing ()` gets `base_class_name="EdgeDrawing"` where the `self.classes` are added with namespace prefixed `ximgproc_EdgeDrawing`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```