### PR TITLE
Update gzguts.h: Fixed webassembly compile error

### DIFF
--- a/3rdparty/zlib/gzguts.h
+++ b/3rdparty/zlib/gzguts.h
@@ -36,6 +36,8 @@
 
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)
 #  include <io.h>
+#else
+#  include <unistd.h>
 #endif
 
 #if defined(_WIN32)


### PR DESCRIPTION
As we don't have unistd.h in gzread and gzwrite in zlib, we cannot compile for wasm and get error. I fixed it. I confirmed that this error still exists in recent commit. Error message is like:
```opencv-src/3rdparty/zlib/gzread.c:22:15: error: call to undeclared function 'read'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [v] I agree to contribute to the project under Apache 2 License.
- [v] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [v] The feature is well documented and sample code can be built with the project CMake
