### PR TITLE
minMaxIdx: new HAL signature

### DIFF
--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -859,7 +859,7 @@ inline int hal_ni_gemm64fc(const double* src1, size_t src1_step, const double* s
 //! @endcond
 
 /**
-   @brief Finds the global minimum and maximum in an array.
+   @brief Finds the global minimum and maximum in an array, returns indices of min/max elements in source image
    @param src_data Source image data
    @param src_step Source image step between rows
    @param width Source image width
@@ -867,15 +867,32 @@ inline int hal_ni_gemm64fc(const double* src1, size_t src1_step, const double* s
    @param depth Depth of source image
    @param minVal Pointer to the returned global minimum value in the array
    @param maxVal Pointer to the returned global maximum value in the array
-   @param minOffset Pointer to the returned minimum offset in the array
-   @param maxOffset Pointer to the returned maximum offset in the array
+   @param minOffset Pointer to the returned minimum element index in the array, should point to a buffer with at least 2 elements
+   @param maxOffset Pointer to the returned maximum element index in the array, should point to a buffer with at least 2 elements
    @param mask_data Mask data pointer
 */
 inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
-                            size_t* minOffset, size_t* maxOffset, const uchar* mask_data) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+                            int* minIdx, int* maxIdx, uchar* mask_data) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+
+/**
+   @brief Finds the global minimum and maximum in an array, returns offsets to min/max elements in source image
+   @param src_data Source image data
+   @param src_step Source image step between rows
+   @param width Source image width
+   @param height Source image height
+   @param depth Depth of source image
+   @param minVal Pointer to the returned global minimum value in the array
+   @param maxVal Pointer to the returned global maximum value in the array
+   @param minOffset Pointer to the returned minimum element offset in the array
+   @param maxOffset Pointer to the returned maximum element offset in the array
+   @param mask_data Mask data pointer
+*/
+inline int hal_ni_minMaxOffset(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
+                               size_t* minOffset, size_t* maxOffset, const uchar* mask_data) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_minMaxIdx hal_ni_minMaxIdx
+#define cv_hal_minMaxOffset hal_ni_minMaxOffset
 //! @endcond
 
 /**

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -886,9 +886,11 @@ inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, i
    @param minOffset Pointer to the returned minimum element offset in the array
    @param maxOffset Pointer to the returned maximum element offset in the array
    @param mask_data Mask data pointer
+   @param mask_step Mask step between rows
 */
 inline int hal_ni_minMaxOffset(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
-                               size_t* minOffset, size_t* maxOffset, const uchar* mask_data) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+                               size_t* minOffset, size_t* maxOffset, const uchar* mask_data, size_t mask_step)
+{ return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_minMaxIdx hal_ni_minMaxIdx

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -860,19 +860,19 @@ inline int hal_ni_gemm64fc(const double* src1, size_t src1_step, const double* s
 
 /**
    @brief Finds the global minimum and maximum in an array.
-   @param src_data Source image
-   @param src_step Source image
-   @param width Source image dimensions
-   @param height Source image dimensions
+   @param src_data Source image data
+   @param src_step Source image step between rows
+   @param width Source image width
+   @param height Source image height
    @param depth Depth of source image
-   @param minVal Pointer to the returned global minimum and maximum in an array.
-   @param maxVal Pointer to the returned global minimum and maximum in an array.
-   @param minIdx Pointer to the returned minimum and maximum location.
-   @param maxIdx Pointer to the returned minimum and maximum location.
-   @param mask Specified array region.
+   @param minVal Pointer to the returned global minimum value in the array
+   @param maxVal Pointer to the returned global maximum value in the array
+   @param minOffset Pointer to the returned minimum offset in the array
+   @param maxOffset Pointer to the returned maximum offset in the array
+   @param mask_data Mask data pointer
 */
 inline int hal_ni_minMaxIdx(const uchar* src_data, size_t src_step, int width, int height, int depth, double* minVal, double* maxVal,
-                            int* minIdx, int* maxIdx, uchar* mask) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+                            size_t* minOffset, size_t* maxOffset, const uchar* mask_data) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 //! @cond IGNORED
 #define cv_hal_minMaxIdx hal_ni_minMaxIdx

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1515,7 +1515,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
         int srcHalStep, srcHalWidth, srcHalHeight;
         if (src.dims <= 2)
         {
-            srcHalStep   = src.step;
+            srcHalStep   = (int)src.step;
             srcHalWidth  = src.cols * cn;
             srcHalHeight = src.rows;
         }

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1510,25 +1510,27 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     Mat src = _src.getMat(), mask = _mask.getMat();
 
     // HAL call
-    if (src.dims <= 2 || src.isContinuous())
+    if (src.dims <= 2 || (src.isContinuous() && (mask.empty() || mask.isContinuous())))
     {
-        int srcHalStep, srcHalWidth, srcHalHeight;
+        int srcHalStep, srcHalWidth, srcHalHeight, maskHalStep;
         if (src.dims <= 2)
         {
             srcHalStep   = (int)src.step;
             srcHalWidth  = src.cols * cn;
             srcHalHeight = src.rows;
+            maskHalStep  = (int)mask.step;
         }
         else // pass it like one continuous row
         {
             srcHalStep   = 0;
             srcHalWidth  = (int)src.total()*cn;
             srcHalHeight = 1;
+            maskHalStep  = 0;
         }
 
         size_t minOffset = SIZE_MAX, maxOffset = SIZE_MAX;
         int res = cv_hal_minMaxOffset(src.data, srcHalStep, srcHalWidth, srcHalHeight, src.depth(),
-                                      minVal, maxVal, &minOffset, &maxOffset, mask.data);
+                                      minVal, maxVal, &minOffset, &maxOffset, mask.data, maskHalStep);
 
         if (res == CV_HAL_ERROR_OK)
         {

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -849,7 +849,7 @@ static MinMaxIdxFunc getMinmaxTab(int depth)
 static void ofs2idx(const Mat& a, size_t ofs, int* idx)
 {
     int i, d = a.dims;
-    if( ofs != (size_t)(-1) )
+    if( ofs != SIZE_MAX )
     {
         for( i = d-1; i >= 0; i-- )
         {
@@ -1526,7 +1526,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
             srcHalHeight = 1;
         }
 
-        size_t minOffset = (size_t)(-1), maxOffset = (size_t)(-1);
+        size_t minOffset = SIZE_MAX, maxOffset = SIZE_MAX;
         int res = cv_hal_minMaxIdx(src.data, srcHalStep, srcHalWidth, srcHalHeight, src.depth(),
                                    minVal, maxVal, &minOffset, &maxOffset, mask.data);
 
@@ -1579,20 +1579,20 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     // => leave offset unset as is
     if (!src.empty() && mask.empty())
     {
-        if( minidx == (size_t)(-1) )
+        if( minidx == SIZE_MAX )
             minidx = 0;
-        if( maxidx == (size_t)(-1) )
+        if( maxidx == SIZE_MAX )
             maxidx = 0;
     }
 
-    if( minidx == (size_t)(-1))
+    if( minidx == SIZE_MAX)
         dminval = 0;
     else if( depth == CV_32F )
         dminval = fminval;
     else if( depth <= CV_32S )
         dminval = iminval;
 
-    if( maxidx == (size_t)(-1))
+    if( maxidx == SIZE_MAX)
         dmaxval = 0;
     else if( depth == CV_32F )
         dmaxval = fmaxval;

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1557,7 +1557,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
 
-    size_t minidx = (size_t)(-1), maxidx = (size_t)(-1);
+    size_t minidx = SIZE_MAX, maxidx = SIZE_MAX;
     int iminval = INT_MAX, imaxval = INT_MIN;
     float  fminval = std::numeric_limits<float>::infinity(),  fmaxval = -fminval;
     double dminval = std::numeric_limits<double>::infinity(), dmaxval = -dminval;

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1527,8 +1527,8 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
         }
 
         size_t minOffset = SIZE_MAX, maxOffset = SIZE_MAX;
-        int res = cv_hal_minMaxIdx(src.data, srcHalStep, srcHalWidth, srcHalHeight, src.depth(),
-                                   minVal, maxVal, &minOffset, &maxOffset, mask.data);
+        int res = cv_hal_minMaxOffset(src.data, srcHalStep, srcHalWidth, srcHalHeight, src.depth(),
+                                      minVal, maxVal, &minOffset, &maxOffset, mask.data);
 
         if (res == CV_HAL_ERROR_OK)
         {
@@ -1541,7 +1541,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
         else if (res != CV_HAL_ERROR_NOT_IMPLEMENTED)
         {
             CV_Error_(cv::Error::StsInternal,
-            ("HAL implementation minMaxIdx ==> " CVAUX_STR(cv_hal_minMaxIdx) " returned %d (0x%08x)", res, res));
+            ("HAL implementation minMaxOffset ==> " CVAUX_STR(cv_hal_minMaxOffset) " returned %d (0x%08x)", res, res));
         }
     }
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2887,8 +2887,8 @@ TEST(Core_MinMaxIdx, non_continuous)
     Mat small = big(Range(8, 8+16), Range(8, 8+16));
 
     small = 50;
-    small.at<float>(8, 8) = 100;
-    small.at<float>(9, 9) = 25;
+    small.at<float>(6, 7) = 100;
+    small.at<float>(8, 9) = 25;
 
     double minVal = 0, maxVal = 0;
     int minIdx[CV_MAX_DIM] = { 0 }, maxIdx[CV_MAX_DIM] = { 0 };
@@ -2897,10 +2897,10 @@ TEST(Core_MinMaxIdx, non_continuous)
     ASSERT_FLOAT_EQ(minVal, 25);
     ASSERT_FLOAT_EQ(maxVal, 100);
 
-    ASSERT_EQ(minIdx[0], 9);
+    ASSERT_EQ(minIdx[0], 8);
     ASSERT_EQ(minIdx[1], 9);
-    ASSERT_EQ(maxIdx[0], 8);
-    ASSERT_EQ(maxIdx[1], 8);
+    ASSERT_EQ(maxIdx[0], 6);
+    ASSERT_EQ(maxIdx[1], 7);
 }
 
 TEST(Core_Magnitude, regression_19506)

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2881,6 +2881,28 @@ TEST(Core_MinMaxIdx, rows_overflow)
     }
 }
 
+TEST(Core_MinMaxIdx, non_continuous)
+{
+    Mat big(32, 32, CV_32FC1, Scalar(15));
+    Mat small = big(Range(8, 8+16), Range(8, 8+16));
+
+    small = 50;
+    small.at<float>(8, 8) = 100;
+    small.at<float>(9, 9) = 25;
+
+    double minVal = 0, maxVal = 0;
+    int minIdx[CV_MAX_DIM] = { 0 }, maxIdx[CV_MAX_DIM] = { 0 };
+    cv::minMaxIdx(small, &minVal, &maxVal, minIdx, maxIdx);
+
+    ASSERT_FLOAT_EQ(minVal, 25);
+    ASSERT_FLOAT_EQ(maxVal, 100);
+
+    ASSERT_EQ(minIdx[0], 9);
+    ASSERT_EQ(minIdx[1], 9);
+    ASSERT_EQ(maxIdx[0], 8);
+    ASSERT_EQ(maxIdx[1], 8);
+}
+
 TEST(Core_Magnitude, regression_19506)
 {
     for (int N = 1; N <= 64; ++N)

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2894,8 +2894,8 @@ TEST(Core_MinMaxIdx, non_continuous)
     int minIdx[CV_MAX_DIM] = { 0 }, maxIdx[CV_MAX_DIM] = { 0 };
     cv::minMaxIdx(small, &minVal, &maxVal, minIdx, maxIdx);
 
-    ASSERT_FLOAT_EQ(minVal, 25);
-    ASSERT_FLOAT_EQ(maxVal, 100);
+    ASSERT_DOUBLE_EQ(minVal, 25);
+    ASSERT_DOUBLE_EQ(maxVal, 100);
 
     ASSERT_EQ(minIdx[0], 8);
     ASSERT_EQ(minIdx[1], 9);


### PR DESCRIPTION
Related to #25563 discussion

* HAL call added with a name `minMaxOffset` which now returns value offsets instead of indices
* test for non-continuous matrices added
* minor refactoring to make code more logical

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
