### PR TITLE
Tests added for mixed type arithmetic operations

### DIFF
--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -698,10 +698,10 @@ PERF_TEST_P_(ArithmMixedTest, reciprocal)
 INSTANTIATE_TEST_CASE_P(/*nothing*/ , ArithmMixedTest,
     testing::Combine(
         testing::Values(szVGA, sz720p, sz1080p),
-        testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
-                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
-                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
-                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F}
+        testing::Values(std::tuple<perf::MatType, perf::MatType>{CV_8U, CV_16U},
+                        std::tuple<perf::MatType, perf::MatType>{CV_8S, CV_16S},
+                        std::tuple<perf::MatType, perf::MatType>{CV_8U, CV_32F},
+                        std::tuple<perf::MatType, perf::MatType>{CV_8S, CV_32F}
             )
     )
 );

--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -452,6 +452,260 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/ , BinaryOpTest,
     )
 );
 
+///////////// Mixed type arithmetics ////////
+
+typedef perf::TestBaseWithParam<std::tuple<cv::Size, std::tuple<perf::MatType, perf::MatType>>> ArithmMixedTest;
+
+PERF_TEST_P_(ArithmMixedTest, add)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, srcType);
+    cv::Mat b = Mat(sz, srcType);
+    cv::Mat c = Mat(sz, dstType);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+    declare.time(50);
+
+    if (CV_MAT_DEPTH(srcType) == CV_32S)
+    {
+        //see ticket 1529: add can be without saturation on 32S
+        a /= 2;
+        b /= 2;
+    }
+
+    TEST_CYCLE() cv::add(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, addScalarDouble)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: add can be without saturation on 32S
+        a /= 2;
+        b /= 2;
+    }
+
+    TEST_CYCLE() cv::add(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, addScalarSameType)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: add can be without saturation on 32S
+        a /= 2;
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::add(a, b, c, noArray(), type);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, subtract)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, type);
+    cv::Mat b = Mat(sz, type);
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: subtract can be without saturation on 32S
+        a /= 2;
+        b /= 2;
+    }
+
+    TEST_CYCLE() cv::subtract(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, subtractScalarDouble)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: subtract can be without saturation on 32S
+        a /= 2;
+        b /= 2;
+    }
+
+    TEST_CYCLE() cv::subtract(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, subtractScalarSameType)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: subtract can be without saturation on 32S
+        a /= 2;
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::subtract(a, b, c, noArray(), type);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, multiply)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //According to docs, saturation is not applied when result is 32bit integer
+        a /= (2 << 16);
+        b /= (2 << 16);
+    }
+
+    TEST_CYCLE() cv::multiply(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, multiplyScale)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+    double scale = 0.5;
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //According to docs, saturation is not applied when result is 32bit integer
+        a /= (2 << 16);
+        b /= (2 << 16);
+    }
+
+    TEST_CYCLE() cv::multiply(a, b, c, scale);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, divide)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+    double scale = 0.5;
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    TEST_CYCLE() cv::divide(a, b, c, scale);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(ArithmMixedTest, reciprocal)
+{
+    auto p = GetParam();
+    Size sz = get<0>(p);
+    int srcType = get<0>(get<1>(p));
+    int dstType = get<1>(get<1>(p));
+
+    cv::Mat b(sz, type), c(sz, type);
+    double scale = 0.5;
+
+    declare.in(b, WARMUP_RNG).out(c);
+
+    TEST_CYCLE() cv::divide(scale, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/ , ArithmMixedTest,
+    testing::Combine(
+        testing::Values(szVGA, sz720p, sz1080p),
+        testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                        std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F}
+            )
+    )
+);
+
 ///////////// Rotate ////////////////////////
 
 typedef perf::TestBaseWithParam<std::tuple<cv::Size, int, perf::MatType>> RotateTest;

--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -470,14 +470,14 @@ PERF_TEST_P_(ArithmMixedTest, add)
     declare.in(a, b, WARMUP_RNG).out(c);
     declare.time(50);
 
-    if (CV_MAT_DEPTH(srcType) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b /= 2;
     }
 
-    TEST_CYCLE() cv::add(a, b, c);
+    TEST_CYCLE() cv::add(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -489,20 +489,20 @@ PERF_TEST_P_(ArithmMixedTest, addScalarDouble)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a = Mat(sz, type);
+    cv::Mat a = Mat(sz, srcType);
     cv::Scalar b;
-    cv::Mat c = Mat(sz, type);
+    cv::Mat c = Mat(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b /= 2;
     }
 
-    TEST_CYCLE() cv::add(a, b, c);
+    TEST_CYCLE() cv::add(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -514,24 +514,24 @@ PERF_TEST_P_(ArithmMixedTest, addScalarSameType)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a = Mat(sz, type);
+    cv::Mat a = Mat(sz, srcType);
     cv::Scalar b;
-    cv::Mat c = Mat(sz, type);
+    cv::Mat c = Mat(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) < CV_32S)
+    if (CV_MAT_DEPTH(dstType) < CV_32S)
     {
         b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
     }
-    else if (CV_MAT_DEPTH(type) == CV_32S)
+    else if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
     }
 
-    TEST_CYCLE() cv::add(a, b, c, noArray(), type);
+    TEST_CYCLE() cv::add(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -543,20 +543,20 @@ PERF_TEST_P_(ArithmMixedTest, subtract)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a = Mat(sz, type);
-    cv::Mat b = Mat(sz, type);
-    cv::Mat c = Mat(sz, type);
+    cv::Mat a = Mat(sz, srcType);
+    cv::Mat b = Mat(sz, srcType);
+    cv::Mat c = Mat(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b /= 2;
     }
 
-    TEST_CYCLE() cv::subtract(a, b, c);
+    TEST_CYCLE() cv::subtract(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -568,20 +568,20 @@ PERF_TEST_P_(ArithmMixedTest, subtractScalarDouble)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a = Mat(sz, type);
+    cv::Mat a = Mat(sz, srcType);
     cv::Scalar b;
-    cv::Mat c = Mat(sz, type);
+    cv::Mat c = Mat(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b /= 2;
     }
 
-    TEST_CYCLE() cv::subtract(a, b, c);
+    TEST_CYCLE() cv::subtract(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -593,24 +593,24 @@ PERF_TEST_P_(ArithmMixedTest, subtractScalarSameType)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a = Mat(sz, type);
+    cv::Mat a = Mat(sz, srcType);
     cv::Scalar b;
-    cv::Mat c = Mat(sz, type);
+    cv::Mat c = Mat(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) < CV_32S)
+    if (CV_MAT_DEPTH(dstType) < CV_32S)
     {
         b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
     }
-    else if (CV_MAT_DEPTH(type) == CV_32S)
+    else if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
     }
 
-    TEST_CYCLE() cv::subtract(a, b, c, noArray(), type);
+    TEST_CYCLE() cv::subtract(a, b, c, /* mask */ noArray(), dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -622,17 +622,17 @@ PERF_TEST_P_(ArithmMixedTest, multiply)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+    cv::Mat a(sz, srcType), b(sz, srcType), c(sz, dstType);
 
     declare.in(a, b, WARMUP_RNG).out(c);
-    if (CV_MAT_DEPTH(type) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //According to docs, saturation is not applied when result is 32bit integer
         a /= (2 << 16);
         b /= (2 << 16);
     }
 
-    TEST_CYCLE() cv::multiply(a, b, c);
+    TEST_CYCLE() cv::multiply(a, b, c, /* scale */ 1.0, dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -644,19 +644,19 @@ PERF_TEST_P_(ArithmMixedTest, multiplyScale)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+    cv::Mat a(sz, srcType), b(sz, srcType), c(sz, dstType);
     double scale = 0.5;
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) == CV_32S)
+    if (CV_MAT_DEPTH(dstType) == CV_32S)
     {
         //According to docs, saturation is not applied when result is 32bit integer
         a /= (2 << 16);
         b /= (2 << 16);
     }
 
-    TEST_CYCLE() cv::multiply(a, b, c, scale);
+    TEST_CYCLE() cv::multiply(a, b, c, scale, dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -668,12 +668,12 @@ PERF_TEST_P_(ArithmMixedTest, divide)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat a(sz, type), b(sz, type), c(sz, type);
+    cv::Mat a(sz, srcType), b(sz, srcType), c(sz, dstType);
     double scale = 0.5;
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() cv::divide(a, b, c, scale);
+    TEST_CYCLE() cv::divide(a, b, c, scale, dstType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -685,12 +685,12 @@ PERF_TEST_P_(ArithmMixedTest, reciprocal)
     int srcType = get<0>(get<1>(p));
     int dstType = get<1>(get<1>(p));
 
-    cv::Mat b(sz, type), c(sz, type);
+    cv::Mat b(sz, srcType), c(sz, dstType);
     double scale = 0.5;
 
     declare.in(b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() cv::divide(scale, b, c);
+    TEST_CYCLE() cv::divide(scale, b, c, dstType);
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -1081,7 +1081,7 @@ static ExtendedTypeFunc getMulExtFunc(int src1Type, int src2Type, int dstType)
     {
         return mul8u16uWrapper;
     }
-    else if (src1Type == CV_8U && src2Type == CV_8S && dstType == CV_16S)
+    else if (src1Type == CV_8S && src2Type == CV_8S && dstType == CV_16S)
     {
         return mul8s16sWrapper;
     }

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1695,49 +1695,56 @@ TEST_P(ArithmExtendTest, accuracy)
 
 INSTANTIATE_TEST_CASE_P(Core_AddExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_AddScalarExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddSOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_AddWeightedExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddWeightedOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_SubExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new SubOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_SubScalarMinusArgExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new SubRSOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_MulExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new MulOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_MulScalarExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new MulSOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_DivExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new DivOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 INSTANTIATE_TEST_CASE_P(Core_RecipExtend, ArithmExtendTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new RecipOp)),
-                                           ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
-                                                             std::tuple<int, int>{CV_8S, CV_16S},
-                                                             std::tuple<int, int>{CV_8U, CV_32F})));
+                                           ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
+                                                             std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
 
 TEST(Core_ArithmMask, uninitialized)
 {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1681,9 +1681,9 @@ TEST_P(ArithmExtendTest, accuracy)
 
         double minval=0, maxval=0;
         op->getValueRange(srcDepth, minval, maxval);
-        int i, ninputs = op->ninputs;
+        int ninputs = op->ninputs;
         vector<Mat> src(ninputs);
-        for( i = 0; i < ninputs; i++ )
+        for(int i = 0; i < ninputs; i++ )
             src[i] = cvtest::randomMat(rng, size, srcDepth, minval, maxval, true);
         Mat dst0, dst, mask;
         if( haveMask )

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -203,11 +203,13 @@ struct MulOp : public BaseElemWiseOp
     }
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cv::multiply(src[0], src[1], dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::multiply(src[0], src[1], dst, alpha, dtype);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::multiply(src[0], src[1], dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cvtest::multiply(src[0], src[1], dst, alpha, dtype);
     }
     double getMaxErr(int depth)
     {
@@ -227,11 +229,13 @@ struct MulSOp : public BaseElemWiseOp
     }
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cv::multiply(src[0], alpha, dst);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::multiply(src[0], alpha, dst, /* scale */ 1.0, dtype);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::multiply(src[0], Mat(), dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cvtest::multiply(Mat(), src[0], dst, alpha, dtype);
     }
     double getMaxErr(int depth)
     {
@@ -244,11 +248,13 @@ struct DivOp : public BaseElemWiseOp
     DivOp() : BaseElemWiseOp(2, FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cv::divide(src[0], src[1], dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::divide(src[0], src[1], dst, alpha, dtype);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::divide(src[0], src[1], dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cvtest::divide(src[0], src[1], dst, alpha, dtype);
     }
     double getMaxErr(int depth)
     {
@@ -261,11 +267,13 @@ struct RecipOp : public BaseElemWiseOp
     RecipOp() : BaseElemWiseOp(1, FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cv::divide(alpha, src[0], dst);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::divide(alpha, src[0], dst, dtype);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::divide(Mat(), src[0], dst, alpha);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cvtest::divide(Mat(), src[0], dst, alpha, dtype);
     }
     double getMaxErr(int depth)
     {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1614,6 +1614,31 @@ INSTANTIATE_TEST_CASE_P(Core_reduceArgMinMax, ElemWiseTest, ::testing::Values(El
 INSTANTIATE_TEST_CASE_P(Core_CartToPolarToCart, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CartToPolarToCartOp)));
 
 
+typedef std::tuple<int, std::tuple<int, int>> SomeType;
+class ArithmExtendTest : public ::testing::TestWithParam<SomeType>
+{
+public:
+    enum {ADD = 0, SUB = 1, MUL = 2, DIV = 3};
+};
+
+TEST_P(ArithmExtendTest, accuracy)
+{
+    auto p = GetParam();
+    int op = std::get<0>(p);
+    int srcType = std::get<0>(std::get<1>(p));
+    int dstType = std::get<1>(std::get<1>(p));
+
+    //TODO: test itself
+}
+
+INSTANTIATE_TEST_CASE_P(Core_AddExtend, ArithmExtendTest, ::testing::Combine(
+                        ::testing::Values(ArithmExtendTest::ADD),
+                        ::testing::Values(std::tuple<int, int>{CV_8U, CV_16U},
+                                          std::tuple<int, int>{CV_8S, CV_16S},
+                                          std::tuple<int, int>{CV_8U, CV_32F})
+                        ));
+
+
 TEST(Core_ArithmMask, uninitialized)
 {
             RNG& rng = theRNG();

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -250,6 +250,13 @@ struct DivOp : public BaseElemWiseOp
     {
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cv::divide(src[0], src[1], dst, alpha, dtype);
+        if (flags & MIXED_TYPE)
+        {
+            // div by zero result is implementation-defined
+            // since it may involve conversions to/from intermediate format
+            Mat zeroMask = src[1] == 0;
+            dst.setTo(0, zeroMask);
+        }
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
@@ -269,6 +276,13 @@ struct RecipOp : public BaseElemWiseOp
     {
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cv::divide(alpha, src[0], dst, dtype);
+        if (flags & MIXED_TYPE)
+        {
+            // div by zero result is implementation-defined
+            // since it may involve conversions to/from intermediate format
+            Mat zeroMask = src[0] == 0;
+            dst.setTo(0, zeroMask);
+        }
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1643,7 +1643,7 @@ INSTANTIATE_TEST_CASE_P(Core_CartToPolarToCart, ElemWiseTest, ::testing::Values(
 
 // Mixed Type Arithmetic Operations
 
-typedef std::tuple<ElemWiseOpPtr, std::tuple<int, int>> SomeType;
+typedef std::tuple<ElemWiseOpPtr, std::tuple<cvtest::MatDepth, cvtest::MatDepth>> SomeType;
 class ArithmExtendTest : public ::testing::TestWithParam<SomeType> {};
 
 TEST_P(ArithmExtendTest, accuracy)
@@ -1671,17 +1671,13 @@ TEST_P(ArithmExtendTest, accuracy)
         Mat dst0, dst, mask;
         if( haveMask )
         {
-            bool multiChannelMask = false;
-            int masktype = CV_8UC1;
-            mask = cvtest::randomMat(rng, size, masktype, 0, 2, true);
+            mask = cvtest::randomMat(rng, size, CV_8UC1, 0, 2, true);
         }
 
-        if(haveMask || ninputs == 0)
-        {
-            dst0 = cvtest::randomMat(rng, size, dstDepth, minval, maxval, false);
-            dst = cvtest::randomMat(rng, size, dstDepth, minval, maxval, true);
-            cvtest::copy(dst, dst0);
-        }
+        dst0 = cvtest::randomMat(rng, size, dstDepth, minval, maxval, false);
+        dst = cvtest::randomMat(rng, size, dstDepth, minval, maxval, true);
+        cvtest::copy(dst, dst0);
+
         op->generateScalars(dstDepth, rng);
 
         op->refop(src, dst0, mask);

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1661,9 +1661,9 @@ INSTANTIATE_TEST_CASE_P(Core_CartToPolarToCart, ElemWiseTest, ::testing::Values(
 // Mixed Type Arithmetic Operations
 
 typedef std::tuple<ElemWiseOpPtr, std::tuple<cvtest::MatDepth, cvtest::MatDepth>> SomeType;
-class ArithmExtendTest : public ::testing::TestWithParam<SomeType> {};
+class ArithmMixedTest : public ::testing::TestWithParam<SomeType> {};
 
-TEST_P(ArithmExtendTest, accuracy)
+TEST_P(ArithmMixedTest, accuracy)
 {
     auto p = GetParam();
     ElemWiseOpPtr op = std::get<0>(p);
@@ -1707,55 +1707,55 @@ TEST_P(ArithmExtendTest, accuracy)
 }
 
 
-INSTANTIATE_TEST_CASE_P(Core_AddExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_AddMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_AddScalarExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_AddScalarMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddSOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_AddWeightedExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_AddWeightedMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new AddWeightedOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_SubExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_SubMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new SubOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_SubScalarMinusArgExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_SubScalarMinusArgMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new SubRSOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_MulExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_MulMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new MulOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_MulScalarExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_MulScalarMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new MulSOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_DivExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_DivMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new DivOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_16U},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_16S},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));
-INSTANTIATE_TEST_CASE_P(Core_RecipExtend, ArithmExtendTest,
+INSTANTIATE_TEST_CASE_P(Core_RecipMixed, ArithmMixedTest,
                         ::testing::Combine(::testing::Values(ElemWiseOpPtr(new RecipOp)),
                                            ::testing::Values(std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8U, CV_32F},
                                                              std::tuple<cvtest::MatDepth, cvtest::MatDepth>{CV_8S, CV_32F})));

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -172,7 +172,7 @@ struct ScaleAddOp : public BaseAddOp
     }
     double getMaxErr(int depth)
     {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-4 : 1e-12;
+        return depth < CV_32F ? 1 : depth == CV_32F ? 3e-5 : 1e-12;
     }
 };
 
@@ -184,10 +184,6 @@ struct AddWeightedOp : public BaseAddOp
     {
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cv::addWeighted(src[0], alpha, src[1], beta, gamma[0], dst, dtype);
-    }
-    double getMaxErr(int depth)
-    {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-5 : 1e-10;
     }
 };
 
@@ -211,10 +207,6 @@ struct MulOp : public BaseElemWiseOp
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cvtest::multiply(src[0], src[1], dst, alpha, dtype);
     }
-    double getMaxErr(int depth)
-    {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-5 : 1e-12;
-    }
 };
 
 struct MulSOp : public BaseElemWiseOp
@@ -236,10 +228,6 @@ struct MulSOp : public BaseElemWiseOp
     {
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cvtest::multiply(Mat(), src[0], dst, alpha, dtype);
-    }
-    double getMaxErr(int depth)
-    {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-5 : 1e-12;
     }
 };
 
@@ -263,10 +251,6 @@ struct DivOp : public BaseElemWiseOp
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cvtest::divide(src[0], src[1], dst, alpha, dtype);
     }
-    double getMaxErr(int depth)
-    {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-5 : 1e-12;
-    }
 };
 
 struct RecipOp : public BaseElemWiseOp
@@ -288,10 +272,6 @@ struct RecipOp : public BaseElemWiseOp
     {
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cvtest::divide(Mat(), src[0], dst, alpha, dtype);
-    }
-    double getMaxErr(int depth)
-    {
-        return depth <= CV_32S ? 2 : depth < CV_64F ? 1e-5 : 1e-12;
     }
 };
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -135,10 +135,8 @@ struct SubOp : public BaseAddOp
     SubOp() : BaseAddOp(2, FIX_ALPHA+FIX_BETA+FIX_GAMMA+SUPPORT_MASK, 1, -1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
-        if( mask.empty() )
-            cv::subtract(src[0], src[1], dst);
-        else
-            cv::subtract(src[0], src[1], dst, mask);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::subtract(src[0], src[1], dst, mask, dtype);
     }
 };
 
@@ -159,10 +157,8 @@ struct SubRSOp : public BaseAddOp
     SubRSOp() : BaseAddOp(1, FIX_ALPHA+FIX_BETA+SUPPORT_MASK, -1, 0, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
-        if( mask.empty() )
-            cv::subtract(gamma, src[0], dst);
-        else
-            cv::subtract(gamma, src[0], dst, mask);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::subtract(gamma, src[0], dst, mask, dtype);
     }
 };
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -148,10 +148,8 @@ struct AddSOp : public BaseAddOp
     AddSOp() : BaseAddOp(1, FIX_ALPHA+FIX_BETA+SUPPORT_MASK, 1, 0, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
-        if( mask.empty() )
-            cv::add(src[0], gamma, dst);
-        else
-            cv::add(src[0], gamma, dst, mask);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::add(src[0], gamma, dst, mask, dtype);
     }
 };
 
@@ -188,7 +186,8 @@ struct AddWeightedOp : public BaseAddOp
     AddWeightedOp() : BaseAddOp(2, REAL_GAMMA, 1, 1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cv::addWeighted(src[0], alpha, src[1], beta, gamma[0], dst);
+        int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
+        cv::addWeighted(src[0], alpha, src[1], beta, gamma[0], dst, dtype);
     }
     double getMaxErr(int depth)
     {

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -300,8 +300,8 @@ Mat randomMat(RNG& rng, Size size, int type, double minVal, double maxVal, bool 
 Mat randomMat(RNG& rng, const vector<int>& size, int type, double minVal, double maxVal, bool useRoi);
 void add(const Mat& a, double alpha, const Mat& b, double beta,
                       Scalar gamma, Mat& c, int ctype, bool calcAbs=false);
-void multiply(const Mat& a, const Mat& b, Mat& c, double alpha=1);
-void divide(const Mat& a, const Mat& b, Mat& c, double alpha=1);
+void multiply(const Mat& a, const Mat& b, Mat& c, double alpha=1, int ctype=-1);
+void divide(const Mat& a, const Mat& b, Mat& c, double alpha=1, int ctype=-1);
 
 void convert(const Mat& src, cv::OutputArray dst, int dtype, double alpha=1, double beta=0);
 void copy(const Mat& src, Mat& dst, const Mat& mask=Mat(), bool invertMask=false);

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -2551,30 +2551,31 @@ void max(const Mat& src1, double val, Mat& dst)
 }
 
 
-template<typename _Tp> static void
-muldiv_(const _Tp* src1, const _Tp* src2, _Tp* dst, size_t total, double scale, char op)
+template<typename SrcType, typename DstType> static void
+muldiv_(const SrcType* src1, const SrcType* src2, DstType* dst, size_t total, double scale, char op)
 {
-    if( op == '*' )
-        for( size_t i = 0; i < total; i++ )
-            dst[i] = saturate_cast<_Tp>((scale*src1[i])*src2[i]);
-    else if( src1 )
-        for( size_t i = 0; i < total; i++ )
-            dst[i] = src2[i] ? saturate_cast<_Tp>((scale*src1[i])/src2[i]) : 0;
-    else
-        for( size_t i = 0; i < total; i++ )
-            dst[i] = src2[i] ? saturate_cast<_Tp>(scale/src2[i]) : 0;
+    for( size_t i = 0; i < total; i++ )
+    {
+        double m1 = src1 ? (double)src1[i] : 1.0;
+        double m2 = src2 ? (double)src2[i] : 1.0;
+        if (op == '/')
+        {
+            m2 = abs(m2) > FLT_EPSILON ? (1.0 / m2) : 0;
+        }
+        dst[i] = saturate_cast<DstType>(scale * m1 * m2);
+    }
 }
 
-static void muldiv(const Mat& src1, const Mat& src2, Mat& dst, double scale, char op)
+static void muldiv(const Mat& src1, const Mat& src2, Mat& dst, int ctype, double scale, char op)
 {
-    dst.create(src2.dims, src2.size, src2.type());
+    dst.create(src2.dims, src2.size, (ctype >= 0 ? ctype : src2.type()));
     CV_Assert( src1.empty() || (src1.type() == src2.type() && src1.size == src2.size) );
     const Mat *arrays[]={&src1, &src2, &dst, 0};
     Mat planes[3];
 
     NAryMatIterator it(arrays, planes);
     size_t total = planes[1].total()*planes[1].channels();
-    size_t i, nplanes = it.nplanes, depth = src2.depth();
+    size_t i, nplanes = it.nplanes, srcDepth = src2.depth(), dstDepth = dst.depth();
 
     for( i = 0; i < nplanes; i++, ++it )
     {
@@ -2582,44 +2583,70 @@ static void muldiv(const Mat& src1, const Mat& src2, Mat& dst, double scale, cha
         const uchar* sptr2 = planes[1].ptr();
         uchar* dptr = planes[2].ptr();
 
-        switch( depth )
+        if (srcDepth == dstDepth)
         {
-        case CV_8U:
-            muldiv_((const uchar*)sptr1, (const uchar*)sptr2, (uchar*)dptr, total, scale, op);
-            break;
-        case CV_8S:
-            muldiv_((const schar*)sptr1, (const schar*)sptr2, (schar*)dptr, total, scale, op);
-            break;
-        case CV_16U:
-            muldiv_((const ushort*)sptr1, (const ushort*)sptr2, (ushort*)dptr, total, scale, op);
-            break;
-        case CV_16S:
-            muldiv_((const short*)sptr1, (const short*)sptr2, (short*)dptr, total, scale, op);
-            break;
-        case CV_32S:
-            muldiv_((const int*)sptr1, (const int*)sptr2, (int*)dptr, total, scale, op);
-            break;
-        case CV_32F:
-            muldiv_((const float*)sptr1, (const float*)sptr2, (float*)dptr, total, scale, op);
-            break;
-        case CV_64F:
-            muldiv_((const double*)sptr1, (const double*)sptr2, (double*)dptr, total, scale, op);
-            break;
-        default:
-            CV_Error(Error::StsUnsupportedFormat, "");
+            switch( srcDepth )
+            {
+            case CV_8U:
+                muldiv_((const uchar*)sptr1, (const uchar*)sptr2, (uchar*)dptr, total, scale, op);
+                break;
+            case CV_8S:
+                muldiv_((const schar*)sptr1, (const schar*)sptr2, (schar*)dptr, total, scale, op);
+                break;
+            case CV_16U:
+                muldiv_((const ushort*)sptr1, (const ushort*)sptr2, (ushort*)dptr, total, scale, op);
+                break;
+            case CV_16S:
+                muldiv_((const short*)sptr1, (const short*)sptr2, (short*)dptr, total, scale, op);
+                break;
+            case CV_32S:
+                muldiv_((const int*)sptr1, (const int*)sptr2, (int*)dptr, total, scale, op);
+                break;
+            case CV_32F:
+                muldiv_((const float*)sptr1, (const float*)sptr2, (float*)dptr, total, scale, op);
+                break;
+            case CV_64F:
+                muldiv_((const double*)sptr1, (const double*)sptr2, (double*)dptr, total, scale, op);
+                break;
+            default:
+                CV_Error(Error::StsUnsupportedFormat, "");
+            }
+        }
+        else
+        {
+            if (srcDepth == CV_8U && dstDepth == CV_16U)
+            {
+                muldiv_((const uchar*)sptr1, (const uchar*)sptr2, (ushort*)dptr, total, scale, op);
+            }
+            else if (srcDepth == CV_8S && dstDepth == CV_16S)
+            {
+                muldiv_((const schar*)sptr1, (const schar*)sptr2, (short*)dptr, total, scale, op);
+            }
+            else if (srcDepth == CV_8U && dstDepth == CV_32F)
+            {
+                muldiv_((const uchar*)sptr1, (const uchar*)sptr2, (float*)dptr, total, scale, op);
+            }
+            else if (srcDepth == CV_8S && dstDepth == CV_32F)
+            {
+                muldiv_((const schar*)sptr1, (const schar*)sptr2, (float*)dptr, total, scale, op);
+            }
+            else
+            {
+                CV_Error(Error::StsUnsupportedFormat, "This format combination is not supported yet");
+            }
         }
     }
 }
 
 
-void multiply(const Mat& src1, const Mat& src2, Mat& dst, double scale)
+void multiply(const Mat& src1, const Mat& src2, Mat& dst, double scale, int ctype)
 {
-    muldiv( src1, src2, dst, scale, '*' );
+    muldiv( src1, src2, dst, ctype, scale, '*' );
 }
 
-void divide(const Mat& src1, const Mat& src2, Mat& dst, double scale)
+void divide(const Mat& src1, const Mat& src2, Mat& dst, double scale, int ctype)
 {
-    muldiv( src1, src2, dst, scale, '/' );
+    muldiv( src1, src2, dst, ctype, scale, '/' );
 }
 
 


### PR DESCRIPTION
### Changes
* added accuracy tests for mixed type arithmetic operations
    _Note: div-by-zero values are removed from checking since the result is implementation-defined in common case_
* added perf tests for the same cases
* fixed a typo in `getMulExtTab()` function that lead to dead code

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
