### PR TITLE
Fixed offset computation for ND case in MinMaxIdx HAL.

### DIFF
--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -1522,10 +1522,11 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
 
         if (res == CV_HAL_ERROR_OK)
         {
+            // minIdx[0] and minIdx[0] are always 0 for "flatten" version
             if (minIdx)
-                ofs2idx(src, minIdx[0], minIdx);
+                ofs2idx(src, minIdx[1], minIdx);
             if (maxIdx)
-                ofs2idx(src, maxIdx[0], maxIdx);
+                ofs2idx(src, maxIdx[1], maxIdx);
             return;
         }
         else if (res != CV_HAL_ERROR_NOT_IMPLEMENTED)


### PR DESCRIPTION
Fixes bug found in discussion https://github.com/opencv/opencv/pull/25563
Alternative to https://github.com/opencv/opencv/pull/25669

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
