### PR TITLE
calib3d: fix data type for ilp64 lapack

### DIFF
--- a/modules/calib3d/src/usac/dls_solver.cpp
+++ b/modules/calib3d/src/usac/dls_solver.cpp
@@ -155,7 +155,12 @@ public:
         const auto &eigen_vectors = eigen_solver.eigenvectors();
         const auto &eigen_values = eigen_solver.eigenvalues();
 #else
+
+#if defined (ACCELERATE_NEW_LAPACK) && defined (ACCELERATE_LAPACK_ILP64)
+        long mat_order = 27, info, lda = 27, ldvl = 1, ldvr = 27, lwork = 500;
+#else
         int mat_order = 27, info, lda = 27, ldvl = 1, ldvr = 27, lwork = 500;
+#endif
         double wr[27], wi[27] = {0}; // 27 = mat_order
         std::vector<double> work(lwork), eig_vecs(729);
         char jobvl = 'N', jobvr = 'V'; // only left eigen vectors are computed

--- a/modules/calib3d/src/usac/essential_solver.cpp
+++ b/modules/calib3d/src/usac/essential_solver.cpp
@@ -259,7 +259,11 @@ public:
             action_mat_data[83] = -1.0; // 8 row, 3 col
             action_mat_data[96] = -1.0; // 9 row, 6 col
 
+#if defined (ACCELERATE_NEW_LAPACK) && defined (ACCELERATE_LAPACK_ILP64)
+            long mat_order = 10, info, lda = 10, ldvl = 10, ldvr = 1, lwork = 100;
+#else
             int mat_order = 10, info, lda = 10, ldvl = 10, ldvr = 1, lwork = 100;
+#endif
             double wr[10], wi[10] = {0}, eig_vecs[100], work[100]; // 10 = mat_order, 100 = lwork
             char jobvl = 'V', jobvr = 'N'; // only left eigen vectors are computed
             OCV_LAPACK_FUNC(dgeev)(&jobvl, &jobvr, &mat_order, action_mat_data, &lda, wr, wi, eig_vecs, &ldvl,


### PR DESCRIPTION
Previous https://github.com/opencv/opencv/pull/24804 https://github.com/opencv/opencv/pull/25625
Fixes https://github.com/opencv/opencv/issues/25675#issuecomment-2142208144
Closes https://github.com/opencv/opencv/issues/25675

When I was testing the two previous PRs, I only built `opencv_test_core` so the other places where `OCV_LAPACK_FUNC` is called is missed. I built the whole library this time with

```
cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_ZLIB=OFF -DCMAKE_INSTALL_PREFIX=build/install .
cmake --build build --target install -j4
```

and no errors occur. So it should be fine now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
