### PR TITLE
Fix `cv::imread` with `OutputArray dst`

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -279,7 +279,7 @@ This is an overloaded member function, provided for convenience. It differs from
 @note
 The image passing through the img parameter can be pre-allocated. The memory is reused if the shape and the type match with the load image.
  */
-CV_EXPORTS_W void imread( const String& filename, OutputArray dst, int flags = IMREAD_COLOR );
+CV_EXPORTS_W bool imread( const String& filename, OutputArray dst, int flags = IMREAD_COLOR );
 
 /** @brief Loads a multi-page image from a file.
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -641,14 +641,14 @@ Mat imread( const String& filename, int flags )
     return img;
 }
 
-void imread( const String& filename, OutputArray dst, int flags )
+bool imread( const String& filename, OutputArray dst, int flags )
 {
     CV_TRACE_FUNCTION();
 
     Mat& img = dst.getMatRef();
 
     /// load the data
-    imread_(filename, flags, img);
+    return imread_(filename, flags, img);
 }
 
 /**

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -645,7 +645,7 @@ void imread( const String& filename, OutputArray dst, int flags )
 {
     CV_TRACE_FUNCTION();
 
-    Mat img = dst.getMat();
+    Mat& img = dst.getMatRef();
 
     /// load the data
     imread_(filename, flags, img);

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -220,7 +220,7 @@ void test_image_io(const Mat& image, const std::string& fname, const std::string
 #endif
 }
 
-TEST_P(Imgcodecs_Image, read_write_BGR)
+TEST_P(Imgcodecs_Image, read_with_output_array_given)
 {
     const string ext = this->GetParam();
     const string fname = cv::tempfile(ext.c_str());
@@ -237,8 +237,34 @@ TEST_P(Imgcodecs_Image, read_write_BGR)
 #endif
 
     Mat image = generateTestImageBGR();
-    EXPECT_NO_THROW(test_image_io(image, fname, ext, IMREAD_COLOR, psnrThreshold));
+    vector<uchar> buf;
+    ASSERT_NO_THROW(imencode("." + ext, image, buf));
+    ASSERT_NO_THROW(imwrite(fname, image));
 
+    Mat loaded;
+    imread(fname, loaded, IMREAD_COLOR);
+    EXPECT_FALSE(loaded.empty());
+
+    EXPECT_EQ(0, remove(fname.c_str()));
+}
+
+TEST_P(Imgcodecs_Image, read_write_BGR)
+{
+    const string ext = this->GetParam();
+    const string fname = cv::tempfile(ext.c_str());
+
+    double psnrThreshold = 100;
+    if (ext == "jpg")
+        psnrThreshold = 32;
+#if defined(HAVE_JASPER)
+    if (ext == "jp2")
+        psnrThreshold = 95;
+#elif defined(HAVE_OPENJPEG)
+    if (ext == "jp2")
+        psnrThreshold = 35;
+#endif
+
+    Mat image = generateTestImageBGR();   
     EXPECT_EQ(0, remove(fname.c_str()));
 }
 

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -52,6 +52,25 @@ TEST_P(Imgcodecs_Resize, imread_reduce_flags)
     }
 }
 
+TEST_P(Imgcodecs_Resize, imread_with_output_array)
+{
+    const string file_name = findDataFile(get<0>(get<0>(GetParam())));
+    const Size imageSize = get<1>(get<0>(GetParam()));
+
+    const int imread_flag = get<0>(get<1>(GetParam()));
+    const int scale = get<1>(get<1>(GetParam()));
+
+    const int cols = imageSize.width / scale;
+    const int rows = imageSize.height / scale;
+    {
+        Mat img;
+        imread(file_name, img, imread_flag);
+        ASSERT_FALSE(img.empty());
+        EXPECT_EQ(cols, img.cols);
+        EXPECT_EQ(rows, img.rows);
+    }
+}
+
 //==================================================================================================
 
 TEST_P(Imgcodecs_Resize, imdecode_reduce_flags)
@@ -220,34 +239,6 @@ void test_image_io(const Mat& image, const std::string& fname, const std::string
 #endif
 }
 
-TEST_P(Imgcodecs_Image, read_with_output_array_given)
-{
-    const string ext = this->GetParam();
-    const string fname = cv::tempfile(ext.c_str());
-
-    double psnrThreshold = 100;
-    if (ext == "jpg")
-        psnrThreshold = 32;
-#if defined(HAVE_JASPER)
-    if (ext == "jp2")
-        psnrThreshold = 95;
-#elif defined(HAVE_OPENJPEG)
-    if (ext == "jp2")
-        psnrThreshold = 35;
-#endif
-
-    Mat image = generateTestImageBGR();
-    vector<uchar> buf;
-    ASSERT_NO_THROW(imencode("." + ext, image, buf));
-    ASSERT_NO_THROW(imwrite(fname, image));
-
-    Mat loaded;
-    imread(fname, loaded, IMREAD_COLOR);
-    EXPECT_FALSE(loaded.empty());
-
-    EXPECT_EQ(0, remove(fname.c_str()));
-}
-
 TEST_P(Imgcodecs_Image, read_write_BGR)
 {
     const string ext = this->GetParam();
@@ -264,7 +255,9 @@ TEST_P(Imgcodecs_Image, read_write_BGR)
         psnrThreshold = 35;
 #endif
 
-    Mat image = generateTestImageBGR();   
+    Mat image = generateTestImageBGR();
+    EXPECT_NO_THROW(test_image_io(image, fname, ext, IMREAD_COLOR, psnrThreshold));
+
     EXPECT_EQ(0, remove(fname.c_str()));
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/opencv/opencv/issues/25694.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
