### PR TITLE
Added potential fix for Android H264 Encoding Bug

### DIFF
--- a/modules/videoio/src/cap_android_mediandk.cpp
+++ b/modules/videoio/src/cap_android_mediandk.cpp
@@ -587,6 +587,7 @@ public:
             LOGE("ERROR: AMediaCodec_createInputSurface (%d)", status);
             goto error;
         }
+        ANativeWindow_setBuffersGeometry(surface, width, height, AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM);
         #endif
 
         AMediaCodec_start(encoder);


### PR DESCRIPTION
Added potential fix for Android H264 / H265 Encoding Bug #23570 that was proposed in the issue comments.
I can't reproduce the issue because on my Android phone both the old and the new versions works fine. 
To test the changed code you need to build the sdk and run Video-recorder Android sample. Make sure that the application uses mediandk and doesn't print "Can't record H264. Switching to MJPG" to the logcat.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
