### PR TITLE
fix: mark floodFill mask as optional in Python typing stubs

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -325,6 +325,7 @@ def _find_argument_index(arguments: Sequence[FunctionNode.Arg],
 NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "resize"): make_optional_arg("dsize"),
     SymbolName(("cv", ), (), "calcHist"): make_optional_arg("mask"),
+    SymbolName(("cv", ), (), "floodFill"): make_optional_arg("mask"),
 }
 
 ERROR_CLASS_PROPERTIES = (


### PR DESCRIPTION
closes #25714

Resulting `cv2/__init__.pyi` entries:
```py
@_typing.overload
def floodFill(
    image: cv2.typing.MatLike,
    mask: cv2.typing.MatLike | None,
    seedPoint: cv2.typing.Point,
    newVal: cv2.typing.Scalar,
    loDiff: cv2.typing.Scalar = ...,
    upDiff: cv2.typing.Scalar = ...,
    flags: int = ...
) -> tuple[int, cv2.typing.MatLike, cv2.typing.MatLike, cv2.typing.Rect]: ...

@_typing.overload
def floodFill(
    image: UMat,
    mask: UMat | None,
    seedPoint: cv2.typing.Point,
    newVal: cv2.typing.Scalar,
    loDiff: cv2.typing.Scalar = ...,
    upDiff: cv2.typing.Scalar = ...,
    flags: int = ...
) -> tuple[int, UMat, UMat, cv2.typing.Rect]: ...

```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
