### PR TITLE
test: use cv::theRNG instead of own generator

### DIFF
--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -135,7 +135,7 @@ double Core_PowTest::get_success_error_level( int test_case_idx, int i, int j )
         return power == cvRound(power) && power >= 0 ? 0 : 1;
     else
     {
-        return depth != CV_64F ? Base::get_success_error_level( test_case_idx, i, j ) : DBL_EPSILON*1024*1.1;
+        return depth != CV_64F ? Base::get_success_error_level( test_case_idx, i, j ) : DBL_EPSILON*1024*1.11;
     }
 }
 

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -611,7 +611,7 @@ public:
     };
 
     // get RNG to generate random input data for a test
-    RNG& get_rng() { return rng; }
+    RNG& get_rng() { return cv::theRNG(); }
 
     // returns the current error code
     TS::FailureCode get_err_code() { return TS::FailureCode(current_test_info.code); }
@@ -629,7 +629,6 @@ public:
 protected:
 
     // these are allocated within a test to try to keep them valid in case of stack corruption
-    RNG rng;
 
     // information about the current test
     TestInfo current_test_info;

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -591,8 +591,6 @@ void TS::init( const string& modulename )
 
     if( params.use_optimized == 0 )
         cv::setUseOptimized(false);
-
-    rng = RNG(params.rng_seed);
 }
 
 
@@ -635,9 +633,6 @@ void TS::update_context( BaseTest* test, int test_case_idx, bool update_ts_conte
     {
         current_test_info.rng_seed = param_seed + test_case_idx;
         current_test_info.rng_seed0 = current_test_info.rng_seed;
-
-        rng = RNG(current_test_info.rng_seed);
-        cv::theRNG() = rng;
     }
 
     current_test_info.test = test;


### PR DESCRIPTION
It seems that random number generator in the `TS` varies depending on test set being run, e.g. have one seed when single test case is filtered and different seed when whole module is tested. Trying to use `cv::theRNG` instance  in tests.