### PR TITLE
Fixed blank layer for OpenVINO 2022.1

### DIFF
--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -161,6 +161,9 @@ public:
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
         auto ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
+        // We use Reshape as blank layer.
+        // Previously, we used Concat layer, but it didn't work with scalar tensor.
+        // Also we used ConvertLike layer, but it did't work with old OpenVINO versions.
         auto shape = std::make_shared<ov::op::v0::ShapeOf>(ieInpNode);
         auto blank = std::make_shared<ov::op::v1::Reshape>(ieInpNode, shape, false);
         return Ptr<BackendNode>(new InfEngineNgraphNode(blank));

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -161,7 +161,8 @@ public:
                                         const std::vector<Ptr<BackendNode> >& nodes) CV_OVERRIDE
     {
         auto ieInpNode = nodes[0].dynamicCast<InfEngineNgraphNode>()->node;
-        auto blank = std::make_shared<ov::op::v1::ConvertLike>(ieInpNode, ieInpNode);
+        auto shape = std::make_shared<ov::op::v0::ShapeOf>(ieInpNode);
+        auto blank = std::make_shared<ov::op::v1::Reshape>(ieInpNode, shape, false);
         return Ptr<BackendNode>(new InfEngineNgraphNode(blank));
     }
 #endif  // HAVE_DNN_NGRAPH


### PR DESCRIPTION
Changed blank layer because it didn't work with old OpenVINO versions(2022.1). The blank layer was implemented using ConvertLike layer, now it is implemented using ShapeOf and Reshape layers.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
