### PR TITLE
 Android SDK build script: HWAsan flags added for release mode

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -271,7 +271,10 @@ class Builder:
             hwasan_flags = "-fno-omit-frame-pointer -fsanitize=hwaddress"
             for s in ['OPENCV_EXTRA_C_FLAGS', 'OPENCV_EXTRA_CXX_FLAGS', 'OPENCV_EXTRA_EXE_LINKER_FLAGS',
                       'OPENCV_EXTRA_SHARED_LINKER_FLAGS', 'OPENCV_EXTRA_MODULE_LINKER_FLAGS']:
-                cmake_vars[s] = hwasan_flags
+                if s in cmake_vars.keys():
+                    cmake_vars[s] = cmake_vars[s] + ' ' + hwasan_flags
+                else:
+                    cmake_vars[s] = hwasan_flags
 
         cmake_vars.update(abi.cmake_vars)
 

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -268,9 +268,9 @@ class Builder:
 
         if self.hwasan and "arm64" in abi.name:
             hwasan_flags = "-fno-omit-frame-pointer -fsanitize=hwaddress"
-            cmake_vars['CMAKE_CXX_FLAGS_DEBUG']    = hwasan_flags
-            cmake_vars['CMAKE_C_FLAGS_DEBUG']      = hwasan_flags
-            cmake_vars['CMAKE_LINKER_FLAGS_DEBUG'] = hwasan_flags
+            for s in ['CMAKE_CXX_FLAGS_DEBUG',   'CMAKE_C_FLAGS_DEBUG',   'CMAKE_LINKER_FLAGS_DEBUG',
+                      'CMAKE_CXX_FLAGS_RELEASE', 'CMAKE_C_FLAGS_RELEASE', 'CMAKE_LINKER_FLAGS_RELEASE']:
+                cmake_vars[s] = hwasan_flags
 
         cmake_vars.update(abi.cmake_vars)
 

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -267,9 +267,10 @@ class Builder:
             cmake_vars['WITH_ANDROID_MEDIANDK'] = "OFF"
 
         if self.hwasan and "arm64" in abi.name:
+            cmake_vars['OPENCV_ENABLE_MEMORY_SANITIZER'] = "ON"
             hwasan_flags = "-fno-omit-frame-pointer -fsanitize=hwaddress"
-            for s in ['CMAKE_CXX_FLAGS_DEBUG',   'CMAKE_C_FLAGS_DEBUG',   'CMAKE_LINKER_FLAGS_DEBUG',
-                      'CMAKE_CXX_FLAGS_RELEASE', 'CMAKE_C_FLAGS_RELEASE', 'CMAKE_LINKER_FLAGS_RELEASE']:
+            for s in ['OPENCV_EXTRA_C_FLAGS', 'OPENCV_EXTRA_CXX_FLAGS', 'OPENCV_EXTRA_EXE_LINKER_FLAGS',
+                      'OPENCV_EXTRA_SHARED_LINKER_FLAGS', 'OPENCV_EXTRA_MODULE_LINKER_FLAGS']:
                 cmake_vars[s] = hwasan_flags
 
         cmake_vars.update(abi.cmake_vars)


### PR DESCRIPTION
A quick fix for #25718

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
