### PR TITLE
Add missing cv2eigen overload

### DIFF
--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -287,6 +287,16 @@ void cv2eigen( const Mat& src,
     }
 }
 
+template<typename _Tp>  static inline
+void cv2eigen( const Mat& src,
+               Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
+{
+    dst.resize(src.rows, src.cols);
+    const Mat _dst(src.rows, src.cols, traits::Type<_Tp>::value,
+             dst.data(), (size_t)(dst.outerStride()*sizeof(_Tp)));
+    src.convertTo(_dst, _dst.type());
+}
+
 // Matx case
 template<typename _Tp, int _rows, int _cols> static inline
 void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
@@ -305,6 +315,16 @@ void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
                  dst.data(), (size_t)(dst.outerStride()*sizeof(_Tp)));
         Mat(src).copyTo(_dst);
     }
+}
+
+template<typename _Tp, int _rows, int _cols> static inline
+void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
+               Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
+{
+    dst.resize(_rows, _cols);
+    const Mat _dst(_rows, _cols, traits::Type<_Tp>::value,
+                   dst.data(), (size_t)(dst.outerStride()*sizeof(_Tp)));
+    Mat(src).copyTo(_dst);
 }
 
 template<typename _Tp> static inline

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -291,6 +291,7 @@ template<typename _Tp>  static inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
 {
+    CV_CheckEQ(src.dims, 2, "");
     dst.resize(src.rows, src.cols);
     const Mat _dst(src.rows, src.cols, traits::Type<_Tp>::value,
              dst.data(), (size_t)(dst.outerStride()*sizeof(_Tp)));
@@ -321,6 +322,7 @@ template<typename _Tp, int _rows, int _cols> static inline
 void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
 {
+    CV_CheckEQ(src.dims, 2, "");
     dst.resize(_rows, _cols);
     const Mat _dst(_rows, _cols, traits::Type<_Tp>::value,
                    dst.data(), (size_t)(dst.outerStride()*sizeof(_Tp)));

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2259,6 +2259,23 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
     EXPECT_ANY_THROW(eigen2cv(eigen_A, d_mat));
     //EXPECT_EQ(CV_64FC1, d_mat.type());
 }
+
+TEST(Core_Eigen, cv2eigen_check_RowMajor)
+{
+    Mat A(2, 2, CV_32FC1, Scalar::all(0));
+    A.at<float>(0,0) = 1.0;
+    A.at<float>(0,1) = 2.0;
+    A.at<float>(1,0) = 3.0;
+    A.at<float>(1,1) = 4.0;
+
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> eigen_A;
+    EXPECT_NO_THROW(cv2eigen(A, eigen_A));
+
+    ASSERT_EQ(eigen_A(0, 0), 1.0);
+    ASSERT_EQ(eigen_A(0, 1), 2.0);
+    ASSERT_EQ(eigen_A(1, 0), 3.0);
+    ASSERT_EQ(eigen_A(1, 1), 4.0);
+}
 #endif // HAVE_EIGEN
 
 #ifdef OPENCV_EIGEN_TENSOR_SUPPORT

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2273,12 +2273,12 @@ TEST(Core_Eigen, cv2eigen_check_RowMajor)
     Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> eigen_A;
     EXPECT_NO_THROW(cv2eigen(A, eigen_A));
 
-    ASSERT_EQ(eigen_A(0, 0), 1.0);
-    ASSERT_EQ(eigen_A(0, 1), 2.0);
-    ASSERT_EQ(eigen_A(1, 0), 3.0);
-    ASSERT_EQ(eigen_A(1, 1), 4.0);
-    ASSERT_EQ(eigen_A(2, 0), 5.0);
-    ASSERT_EQ(eigen_A(2, 1), 6.0);
+    ASSERT_EQ(1.0, eigen_A(0, 0));
+    ASSERT_EQ(2.0, eigen_A(0, 1));
+    ASSERT_EQ(3.0, eigen_A(1, 0));
+    ASSERT_EQ(4.0, eigen_A(1, 1));
+    ASSERT_EQ(5.0, eigen_A(2, 0));
+    ASSERT_EQ(6.0, eigen_A(2, 1));
 }
 #endif // HAVE_EIGEN
 

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2262,11 +2262,13 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
 
 TEST(Core_Eigen, cv2eigen_check_RowMajor)
 {
-    Mat A(2, 2, CV_32FC1, Scalar::all(0));
+    Mat A(3, 2, CV_32FC1, Scalar::all(0));
     A.at<float>(0,0) = 1.0;
     A.at<float>(0,1) = 2.0;
     A.at<float>(1,0) = 3.0;
     A.at<float>(1,1) = 4.0;
+    A.at<float>(2,0) = 5.0;
+    A.at<float>(2,1) = 6.0;
 
     Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> eigen_A;
     EXPECT_NO_THROW(cv2eigen(A, eigen_A));
@@ -2275,6 +2277,8 @@ TEST(Core_Eigen, cv2eigen_check_RowMajor)
     ASSERT_EQ(eigen_A(0, 1), 2.0);
     ASSERT_EQ(eigen_A(1, 0), 3.0);
     ASSERT_EQ(eigen_A(1, 1), 4.0);
+    ASSERT_EQ(eigen_A(2, 0), 5.0);
+    ASSERT_EQ(eigen_A(2, 1), 6.0);
 }
 #endif // HAVE_EIGEN
 


### PR DESCRIPTION
Fixes #16606 

Add overloads to cv2eigen to handle eigen matrices of type
Eigen::Matrix<Tp_, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
