### PR TITLE
Use onRuntimeInitialized with OpenCV.js Node tests

### DIFF
--- a/modules/js/test/init_cv.js
+++ b/modules/js/test/init_cv.js
@@ -5,17 +5,18 @@
 if (cv.getBuildInformation === undefined) {
     // WASM
     QUnit.test("init_cv", (assert) => {
-        const done = assert.async();
-        assert.ok(true);
         if (cv instanceof Promise) {
+            const done = assert.async();
             cv.then((ready_cv) => {
                 cv = ready_cv;
                 done();
             });
         } else {
+            const done = assert.async();
             cv['onRuntimeInitialized'] = () => {
                 done();
             }
         }
+        assert.ok(true);
     });
 }

--- a/modules/js/test/init_cv.js
+++ b/modules/js/test/init_cv.js
@@ -2,21 +2,18 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-if (cv.getBuildInformation === undefined) {
-    // WASM
-    QUnit.test("init_cv", (assert) => {
-        if (cv instanceof Promise) {
-            const done = assert.async();
-            cv.then((ready_cv) => {
-                cv = ready_cv;
-                done();
-            });
-        } else {
-            const done = assert.async();
-            cv['onRuntimeInitialized'] = () => {
-                done();
-            }
+QUnit.test("init_cv", (assert) => {
+    if (cv instanceof Promise) {
+        const done = assert.async();
+        cv.then((ready_cv) => {
+            cv = ready_cv;
+            done();
+        });
+    } else if (cv.getBuildInformation === undefined) {
+        const done = assert.async();
+        cv['onRuntimeInitialized'] = () => {
+            done();
         }
-        assert.ok(true);
-    });
-}
+    }
+    assert.ok(true);
+});

--- a/modules/js/test/init_cv.js
+++ b/modules/js/test/init_cv.js
@@ -11,4 +11,12 @@ if (cv instanceof Promise) {
             done();
         });
     });
+} else {
+    QUnit.test("init_cv", (assert) => {
+        const done = assert.async();
+        cv['onRuntimeInitialized'] = () => {
+            done();
+        }
+        assert.ok(true);
+    });
 }

--- a/modules/js/test/init_cv.js
+++ b/modules/js/test/init_cv.js
@@ -2,21 +2,20 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-if (cv instanceof Promise) {
+if (cv.getBuildInformation === undefined) {
+    // WASM
     QUnit.test("init_cv", (assert) => {
         const done = assert.async();
         assert.ok(true);
-        cv.then((ready_cv) => {
-            cv = ready_cv;
-            done();
-        });
-    });
-} else {
-    QUnit.test("init_cv", (assert) => {
-        const done = assert.async();
-        cv['onRuntimeInitialized'] = () => {
-            done();
+        if (cv instanceof Promise) {
+            cv.then((ready_cv) => {
+                cv = ready_cv;
+                done();
+            });
+        } else {
+            cv['onRuntimeInitialized'] = () => {
+                done();
+            }
         }
-        assert.ok(true);
     });
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

tests: https://github.com/opencv/ci-gha-workflow/pull/174

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```