### PR TITLE
Fix  parser for supporting mean operation from conformance tests

### DIFF
--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -709,8 +709,16 @@ public:
             }
             case OPERATION::MEAN:
             {
-                auto mean = [](const T &a, const T &b) { return (a + b) / T{2}; };
-                nary_forward<T>(mean, T{1} / ninputs, std::forward<Args>(args)...);
+                if (ninputs == 2){
+                    auto mean = [](const T &a, const T &b) { return (a + b) / T{2}; };
+                    binary_forward<T, T>(mean, std::forward<Args>(args)...);
+                }  else if (ninputs == 3) {
+                    auto mean = [](const T &a, const T &b, const T &c) { return (a + b + c) / T{3}; };
+                    trinary_forward<T, T, T, T>(mean, std::forward<Args>(args)...);
+                } else {
+                    auto mean = [](const T &a, const T &b) { return (a + b) / T{2}; };
+                    nary_forward<T>(mean, T{1} / ninputs, std::forward<Args>(args)...);
+                }
                 break;
             }
             case OPERATION::MIN:

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4038,7 +4038,7 @@ void ONNXImporter::buildDispatchMap_ONNX_AI(int opset_version)
 
     dispatch["Equal"] = dispatch["Greater"] = dispatch["Less"] = dispatch["Pow"] = dispatch["Add"] =
             dispatch["Sub"] = dispatch["Mul"] = dispatch["Div"] = dispatch["GreaterOrEqual"] =
-            dispatch["LessOrEqual"] = dispatch["Mod"] = dispatch["And"] = dispatch["Or"] = dispatch["Xor"] = &ONNXImporter::parseElementWise;
+            dispatch["LessOrEqual"] = dispatch["Mod"] = dispatch["And"] = dispatch["Or"] = dispatch["Xor"] = dispatch["Mean"] = &ONNXImporter::parseElementWise;
 
     dispatch["Sum"] = dispatch["Min"] = dispatch["Max"] = &ONNXImporter::parseElementWise;
     dispatch["Where"] = &ONNXImporter::parseElementWise;

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -151,9 +151,6 @@
 "test_max_uint16", // Issue:: Unsupported data type
 "test_max_uint32", // Issue:: Unsupported data type
 "test_max_uint64", // Issue:: Unsupported data type
-"test_mean_example", // Issues::Layer does not exist. Can't create layer "onnx_node_output_0!result" of type "Mean" in function 'getLayerInstance'
-"test_mean_one_input",  // ---- same as above ---
-"test_mean_two_inputs",  // ---- same as above ---
 "test_min_int16",  // Issue:: Unsupported data type
 "test_min_uint16", // Issue:: Unsupported data type
 "test_min_uint32", // Issue:: Unkonwn error


### PR DESCRIPTION
This PR fix parser and NaryLater dispatcher to add support for conformance test from ONNX. This might have better solution, please suggest.  


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
