### PR TITLE
Fixed cumsum layer, enabled conformance tests

### DIFF
--- a/modules/dnn/src/layers/cumsum_layer.cpp
+++ b/modules/dnn/src/layers/cumsum_layer.cpp
@@ -36,7 +36,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        outputs.assign(1, inputs[0]);
         return exclusive_raw == 0;
     }
 

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -438,11 +438,3 @@
 "test_unsqueeze_three_axes",  // ---- same as above ---
 "test_unsqueeze_two_axes",   // ---- same as above ---)
 "test_unsqueeze_unsorted_axes",  // ---- same as above ---)
-// // Cumsum related issue: https://github.com/opencv/opencv/issues/24437
-"test_cumsum_1d", //Issue:: output shape creation mismatch
-"test_cumsum_1d_exclusive",  // ---- same as above ---
-"test_cumsum_1d_reverse",  // ---- same as above ---
-"test_cumsum_1d_reverse_exclusive",  // ---- same as above ---
-"test_cumsum_2d_axis_0",  // ---- same as above ---
-"test_cumsum_2d_axis_1",  // ---- same as above ---
-"test_cumsum_2d_negative_axis",  // ---- same as above ---


### PR DESCRIPTION
Fixed cumsum layer, enabled conformance tests for the layer.

Fixes #24437 (looks like some of the mentioned problems were already fixed)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
