### PR TITLE
Fixed input buffer read overflow in vectorized G-API convertTo implementation

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -2915,7 +2915,7 @@ CV_ALWAYS_INLINE
 typename std::enable_if<DST_SHORT_OR_USHORT, void>::type
 convertto_simd_nocoeff_impl(const uchar* inx, DST* outx)
 {
-    v_uint8 a = vx_load(inx);
+    v_uint8 a = vx_load_low(inx);
     v_uint16 res = v_expand_low(a);
 
     store_i16(outx, res);


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25741

`vx_load` loads twice more items that we need at the very end of the buffer. It leads to reading overflow.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
