### PR TITLE
Documentation update for minMaxLoc

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -855,19 +855,19 @@ CV_EXPORTS void normalize( const SparseMat& src, SparseMat& dst, double alpha, i
 /** @brief Finds the global minimum and maximum in an array.
 
 The function cv::minMaxLoc finds the minimum and maximum element values and their positions. The
-extremums are searched across the whole array or, if mask is not an empty array, in the specified
+extrema are searched across the whole array or, if mask is not an empty array, in the specified
 array region.
 
 In C++, if the input is multi-channel, you should omit the minLoc, maxLoc, and mask arguments
 (i.e. leave them as NULL, NULL, and noArray() respectively). These arguments are not
 supported for multi-channel input arrays. If working with multi-channel input and you
 need the minLoc, maxLoc, or mask arguments, then use Mat::reshape first to reinterpret
-the array as single-channel. Or you may extract the particular channel using either
-cv::extractImageCOI, cv::mixChannels, or cv::split.
+the array as single-channel. Alternatively, you can extract the particular channel using either
+extractImageCOI, mixChannels, or split.
 
 In Python, multi-channel input is not supported at all due to a limitation in the
 binding generation process (there is no way to set minLoc and maxLoc to NULL). A
-workaround is to operate each channel individually or to use numpy to achieve the same
+workaround is to operate on each channel individually or to use NumPy to achieve the same
 functionality.
 
 @param src input single-channel array.

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -858,10 +858,17 @@ The function cv::minMaxLoc finds the minimum and maximum element values and thei
 extremums are searched across the whole array or, if mask is not an empty array, in the specified
 array region.
 
-Multi-channel input is supported under the same conditions as cv::minMaxIdx. If you need the
-indices of the minimum and maximum elements across a multi-channel array, then use Mat::reshape
-first to reinterpret the array as single-channel. Or you may extract the particular channel
-using either extractImageCOI, or mixChannels, or split.
+In C++, if the input is multi-channel, you should omit the minLoc, maxLoc, and mask arguments
+(i.e. leave them as NULL, NULL, and noArray() respectively). These arguments are not
+supported for multi-channel input arrays. If working with multi-channel input and you
+need the minLoc, maxLoc, or mask arguments, then use Mat::reshape first to reinterpret
+the array as single-channel. Or you may extract the particular channel using either
+cv::extractImageCOI, cv::mixChannels, or cv::split.
+
+In Python, multi-channel input is not supported at all due to a limitation in the
+binding generation process (there is no way to set minLoc and maxLoc to NULL). A
+workaround is to operate each channel individually or to use numpy to achieve the same
+functionality.
 
 @param src input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -858,10 +858,11 @@ The function cv::minMaxLoc finds the minimum and maximum element values and thei
 extremums are searched across the whole array or, if mask is not an empty array, in the specified
 array region.
 
-The function do not work with multi-channel arrays. If you need to find minimum or maximum
-elements across all the channels, use Mat::reshape first to reinterpret the array as
-single-channel. Or you may extract the particular channel using either extractImageCOI, or
-mixChannels, or split.
+Multi-channel input is supported under the same conditions as cv::minMaxIdx. If you need the
+indices of the minimum and maximum elements across a multi-channel array, then use Mat::reshape
+first to reinterpret the array as single-channel. Or you may extract the particular channel
+using either extractImageCOI, or mixChannels, or split.
+
 @param src input single-channel array.
 @param minVal pointer to the returned minimum value; NULL is used if not required.
 @param maxVal pointer to the returned maximum value; NULL is used if not required.


### PR DESCRIPTION
Fixes #25784 

Update documentation for minMaxLoc to be more specific about when multi-channel images are and are not supported.

Testing:
Built documentation locally to check that updates were incorporated correctly.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
