### PR TITLE
Extended bilateralFilter test to cover more branches

### DIFF
--- a/modules/imgproc/perf/perf_bilateral.cpp
+++ b/modules/imgproc/perf/perf_bilateral.cpp
@@ -7,23 +7,25 @@ namespace opencv_test {
 
 CV_ENUM(Mat_Type, CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3)
 
-typedef TestBaseWithParam< tuple<Size, int, Mat_Type> > TestBilateralFilter;
+typedef TestBaseWithParam< tuple<Size, int, Mat_Type, double> > TestBilateralFilter;
 
 PERF_TEST_P( TestBilateralFilter, BilateralFilter,
              Combine(
                 Values( szVGA, sz1080p ), // image size
                 Values( 3, 5 ), // d
-                Mat_Type::all() // image type
+                Mat_Type::all(), // image type
+                Values(1., 5.)
              )
 )
 {
     Size sz;
     int d, type;
-    const double sigmaColor = 1., sigmaSpace = 1.;
+    double sigmaColor, sigmaSpace;
 
     sz         = get<0>(GetParam());
     d          = get<1>(GetParam());
     type       = get<2>(GetParam());
+    sigmaColor = sigmaSpace = get<3>(GetParam());
 
     Mat src(sz, type);
     Mat dst(sz, type);

--- a/modules/imgproc/test/test_bilateral_filter.cpp
+++ b/modules/imgproc/test/test_bilateral_filter.cpp
@@ -243,7 +243,7 @@ namespace opencv_test { namespace {
 
         rng.fill(_src, RNG::UNIFORM, 0, 256);
 
-        _sigma_color = _sigma_space = 1.;
+        _sigma_color = _sigma_space = rng.uniform(0., 10.);
 
         return 1;
     }


### PR DESCRIPTION
extra: https://github.com/opencv/opencv_extra/pull/1184

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
