### PR TITLE
Use `hfloat` instead of `__fp16`.

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -386,6 +386,8 @@ typedef union Cv16suf
     ushort u;
 #if CV_FP16_TYPE && defined __ARM_FP16_FORMAT_IEEE
     __fp16 h;
+#elif CV_FP16_TYPE // Other platforms suggested to use _Float16
+    _Float16 h;
 #endif
 }
 Cv16suf;
@@ -817,13 +819,17 @@ namespace cv
 class hfloat
 {
 public:
-#if CV_FP16_TYPE && defined __ARM_FP16_FORMAT_IEEE
-
+#if CV_FP16_TYPE
     hfloat() = default;
     explicit hfloat(float x) { h = (__fp16)x; }
     operator float() const { return (float)h; }
+#if defined __ARM_FP16_FORMAT_IEEE
 protected:
     __fp16 h;
+#else
+protected:
+    _Float16 h;
+#endif
 
 #else
     hfloat() : w(0) {}

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -384,7 +384,7 @@ typedef union Cv16suf
 {
     short i;
     ushort u;
-#if CV_FP16_TYPE
+#if CV_FP16_TYPE && defined __ARM_FP16_FORMAT_IEEE
     __fp16 h;
 #endif
 }
@@ -817,9 +817,9 @@ namespace cv
 class hfloat
 {
 public:
-#if CV_FP16_TYPE
+#if CV_FP16_TYPE && defined __ARM_FP16_FORMAT_IEEE
 
-    hfloat() : h(0) {}
+    hfloat() = default;
     explicit hfloat(float x) { h = (__fp16)x; }
     operator float() const { return (float)h; }
 protected:

--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -166,7 +166,7 @@ CV_INTRIN_DEF_TYPE_TRAITS(schar, schar, uchar, uchar, short, int, int);
 CV_INTRIN_DEF_TYPE_TRAITS(ushort, short, ushort, ushort, unsigned, uint64, unsigned);
 CV_INTRIN_DEF_TYPE_TRAITS(short, short, ushort, ushort, int, int64, int);
 #if CV_FP16_TYPE
-CV_INTRIN_DEF_TYPE_TRAITS(__fp16, short, ushort, __fp16, float, double, float);
+CV_INTRIN_DEF_TYPE_TRAITS(hfloat, short, ushort, hfloat, float, double, float);
 #endif
 CV_INTRIN_DEF_TYPE_TRAITS_NO_Q_TYPE(unsigned, int, unsigned, unsigned, uint64, unsigned);
 CV_INTRIN_DEF_TYPE_TRAITS_NO_Q_TYPE(int, int, unsigned, unsigned, int64, int);
@@ -370,7 +370,7 @@ template<typename _Tp> struct V_RegTraits
     CV_DEF_REG_TRAITS(v, v_uint16x8, ushort, u16, v_uint16x8, v_uint32x4, v_uint64x2, v_int16x8, void);
     CV_DEF_REG_TRAITS(v, v_int16x8, short, s16, v_uint16x8, v_int32x4, v_int64x2, v_int16x8, void);
 #if CV_SIMD128_FP16
-    CV_DEF_REG_TRAITS(v, v_float16x8, __fp16, f16, v_float16x8, v_float32x4, v_float64x2, v_int16x8, v_int16x8);
+    CV_DEF_REG_TRAITS(v, v_float16x8, hfloat, f16, v_float16x8, v_float32x4, v_float64x2, v_int16x8, v_int16x8);
 #endif
     CV_DEF_REG_TRAITS(v, v_uint32x4, unsigned, u32, v_uint32x4, v_uint64x2, void, v_int32x4, void);
     CV_DEF_REG_TRAITS(v, v_int32x4, int, s32, v_uint32x4, v_int64x2, void, v_int32x4, void);
@@ -570,7 +570,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_setall_u16(ushort v) { return VXPREFIX(_setall_u16)(v); }
     inline v_int16 vx_setall_s16(short v) { return VXPREFIX(_setall_s16)(v); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_setall_f16(__fp16 v) { return VXPREFIX(_setall_f16)(v); }
+    inline v_float16 vx_setall_f16(hfloat v) { return VXPREFIX(_setall_f16)(v); }
 #endif
     inline v_int32 vx_setall_s32(int v) { return VXPREFIX(_setall_s32)(v); }
     inline v_uint32 vx_setall_u32(unsigned v) { return VXPREFIX(_setall_u32)(v); }
@@ -610,7 +610,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_load(const ushort * ptr) { return VXPREFIX(_load)(ptr); }
     inline v_int16 vx_load(const short * ptr) { return VXPREFIX(_load)(ptr); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_load(const __fp16 * ptr) { return VXPREFIX(_load)(ptr); }
+    inline v_float16 vx_load(const hfloat * ptr) { return VXPREFIX(_load)(ptr); }
 #endif
     inline v_int32 vx_load(const int * ptr) { return VXPREFIX(_load)(ptr); }
     inline v_uint32 vx_load(const unsigned * ptr) { return VXPREFIX(_load)(ptr); }
@@ -630,7 +630,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_load_aligned(const ushort * ptr) { return VXPREFIX(_load_aligned)(ptr); }
     inline v_int16 vx_load_aligned(const short * ptr) { return VXPREFIX(_load_aligned)(ptr); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_load_aligned(const __fp16 * ptr) { return VXPREFIX(_load_aligned)(ptr); }
+    inline v_float16 vx_load_aligned(const hfloat * ptr) { return VXPREFIX(_load_aligned)(ptr); }
 #endif
     inline v_int32 vx_load_aligned(const int * ptr) { return VXPREFIX(_load_aligned)(ptr); }
     inline v_uint32 vx_load_aligned(const unsigned * ptr) { return VXPREFIX(_load_aligned)(ptr); }
@@ -650,7 +650,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_load_low(const ushort * ptr) { return VXPREFIX(_load_low)(ptr); }
     inline v_int16 vx_load_low(const short * ptr) { return VXPREFIX(_load_low)(ptr); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_load_low(const __fp16 * ptr) { return VXPREFIX(_load_low)(ptr); }
+    inline v_float16 vx_load_low(const hfloat * ptr) { return VXPREFIX(_load_low)(ptr); }
 #endif
     inline v_int32 vx_load_low(const int * ptr) { return VXPREFIX(_load_low)(ptr); }
     inline v_uint32 vx_load_low(const unsigned * ptr) { return VXPREFIX(_load_low)(ptr); }
@@ -670,7 +670,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_load_halves(const ushort * ptr0, const ushort * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
     inline v_int16 vx_load_halves(const short * ptr0, const short * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_load_halves(const __fp16 * ptr0, const __fp16 * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
+    inline v_float16 vx_load_halves(const hfloat * ptr0, const hfloat * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
 #endif
     inline v_int32 vx_load_halves(const int * ptr0, const int * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
     inline v_uint32 vx_load_halves(const unsigned * ptr0, const unsigned * ptr1) { return VXPREFIX(_load_halves)(ptr0, ptr1); }
@@ -690,7 +690,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_lut(const ushort * ptr, const int* idx) { return VXPREFIX(_lut)(ptr, idx); }
     inline v_int16 vx_lut(const short* ptr, const int* idx) { return VXPREFIX(_lut)(ptr, idx); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_lut(const __fp16 * ptr, const int * idx) { return VXPREFIX(_lut)(ptr, idx); }
+    inline v_float16 vx_lut(const hfloat * ptr, const int * idx) { return VXPREFIX(_lut)(ptr, idx); }
 #endif
     inline v_int32 vx_lut(const int* ptr, const int* idx) { return VXPREFIX(_lut)(ptr, idx); }
     inline v_uint32 vx_lut(const unsigned* ptr, const int* idx) { return VXPREFIX(_lut)(ptr, idx); }
@@ -710,7 +710,7 @@ namespace CV__SIMD_NAMESPACE {
     inline v_uint16 vx_lut_pairs(const ushort * ptr, const int* idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }
     inline v_int16 vx_lut_pairs(const short* ptr, const int* idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }
 #if CV_SIMD_FP16
-    inline v_float16 vx_lut_pairs(const __fp16 * ptr, const int * idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }
+    inline v_float16 vx_lut_pairs(const hfloat * ptr, const int * idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }
 #endif
     inline v_int32 vx_lut_pairs(const int* ptr, const int* idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }
     inline v_uint32 vx_lut_pairs(const unsigned* ptr, const int* idx) { return VXPREFIX(_lut_pairs)(ptr, idx); }

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -55,13 +55,13 @@ template <typename R> struct Data
     template <typename T> Data<R> & operator*=(T m)
     {
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
-            d[i] *= (LaneType)m;
+            d[i] = (LaneType)(d[i] * m);
         return *this;
     }
     template <typename T> Data<R> & operator+=(T m)
     {
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
-            d[i] += (LaneType)m;
+            d[i] = (LaneType)(d[i] + m);
         return *this;
     }
     void fill(LaneType val, int s, int c = VTraits<R>::vlanes())
@@ -113,9 +113,9 @@ template <typename R> struct Data
     }
     LaneType sum(int s, int c)
     {
-        LaneType res = 0;
+        LaneType res = (LaneType)0;
         for (int i = s; i < s + c; ++i)
-            res += d[i];
+            res = (LaneType)(res + d[i]);
         return res;
     }
     LaneType sum()
@@ -131,7 +131,7 @@ template <typename R> struct Data
     }
     void clear()
     {
-        fill(0);
+        fill((LaneType)0);
     }
     bool isZero() const
     {
@@ -183,7 +183,7 @@ template<> inline void EXPECT_COMPARE_EQ_<double>(const double a, const double b
 }
 
 #if CV_SIMD_FP16
-template<> inline void EXPECT_COMPARE_EQ_<__fp16>(const __fp16 a, const __fp16 b)
+template<> inline void EXPECT_COMPARE_EQ_<hfloat>(const hfloat a, const hfloat b)
 {
     EXPECT_LT(std::abs(float(a - b)), 0.126);
 }
@@ -352,9 +352,9 @@ template<typename R> struct TheTest
     TheTest & test_interleave()
     {
         Data<R> data1, data2, data3, data4;
-        data2 += 20;
-        data3 += 40;
-        data4 += 60;
+        data2 += (LaneType)20;
+        data3 += (LaneType)40;
+        data4 += (LaneType)60;
 
 
         R a = data1, b = data2, c = data3;
@@ -366,7 +366,7 @@ template<typename R> struct TheTest
         v_store_interleave(buf3, a, b, c);
         v_store_interleave(buf4, d, e, f, g);
 
-        Data<R> z(0);
+        Data<R> z((LaneType)0);
         a = b = c = d = e = f = g = z;
 
         v_load_deinterleave(buf3, a, b, c);
@@ -647,9 +647,9 @@ template<typename R> struct TheTest
     TheTest & test_abs_fp16()
     {
         typedef typename V_RegTraits<R>::u_reg Ru; // v_float16x8
-        typedef typename VTraits<Ru>::lane_type u_type; // __fp16
-        typedef typename VTraits<R>::lane_type R_type; // __fp16
-        Data<R> dataA, dataB(10);
+        typedef typename VTraits<Ru>::lane_type u_type; // hfloat
+        typedef typename VTraits<R>::lane_type R_type; // hfloat
+        Data<R> dataA, dataB((LaneType)10);
         R a = dataA, b = dataB;
         a = v_sub(a, b);
 
@@ -659,7 +659,7 @@ template<typename R> struct TheTest
         for (int i = 0; i < VTraits<Ru>::vlanes(); ++i)
         {
             SCOPED_TRACE(cv::format("i=%d", i));
-            R_type ssub = (dataA[i] - dataB[i]) < R_type_lowest ? R_type_lowest : dataA[i] - dataB[i];
+            R_type ssub = (R_type)((dataA[i] - dataB[i]) < R_type_lowest ? R_type_lowest : dataA[i] - dataB[i]);
             EXPECT_EQ((u_type)std::abs(ssub), resC[i]);
         }
 
@@ -930,10 +930,10 @@ template<typename R> struct TheTest
     {
         Data<R> dataA(std::numeric_limits<LaneType>::max()),
                 dataB(std::numeric_limits<LaneType>::min());
-        dataA[0] = -1;
-        dataB[0] = 1;
-        dataA[1] = 2;
-        dataB[1] = -2;
+        dataA[0] = (LaneType)-1;
+        dataB[0] = (LaneType)1;
+        dataA[1] = (LaneType)2;
+        dataB[1] = (LaneType)-2;
         R a = dataA, b = dataB;
         Data<R> resC = v_absdiff(a, b);
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
@@ -1008,9 +1008,9 @@ template<typename R> struct TheTest
         typedef typename VTraits<int_reg>::lane_type int_type;
         typedef typename VTraits<uint_reg>::lane_type uint_type;
 
-        Data<R> dataA, dataB(0), dataC, dataD(1), dataE(2);
+        Data<R> dataA, dataB((LaneType)0), dataC, dataD((LaneType)1), dataE((LaneType)2);
         dataA[0] = (LaneType)std::numeric_limits<int_type>::max();
-        dataA[1] *= (LaneType)-1;
+        dataA[1] = (LaneType)(dataA[1] * (LaneType)-1);
         union
         {
             LaneType l;
@@ -1025,7 +1025,7 @@ template<typename R> struct TheTest
         dataB[VTraits<R>::vlanes() / 2] = mask_one;
         dataC *= (LaneType)-1;
         R a = dataA, b = dataB, c = dataC, d = dataD, e = dataE;
-        dataC[VTraits<R>::vlanes() - 1] = 0;
+        dataC[VTraits<R>::vlanes() - 1] = (LaneType)0;
         R nl = dataC;
 
         EXPECT_EQ(2, v_signmask(a));
@@ -1559,14 +1559,15 @@ template<typename R> struct TheTest
         int i = 0;
         for (int j = i; j < i + 8; ++j) {
             SCOPED_TRACE(cv::format("i=%d j=%d", i, j));
-            LaneType val = dataV[i]     * data0[j] +
+            LaneType val = (LaneType)(
+                           dataV[i]     * data0[j] +
                            dataV[i + 1] * data1[j] +
                            dataV[i + 2] * data2[j] +
                            dataV[i + 3] * data3[j] +
                            dataV[i + 4] * data4[j] +
                            dataV[i + 5] * data5[j] +
                            dataV[i + 6] * data6[j] +
-                           dataV[i + 7] * data7[j];
+                           dataV[i + 7] * data7[j]);
             EXPECT_COMPARE_EQ(val, res[j]);
         }
 
@@ -1574,14 +1575,15 @@ template<typename R> struct TheTest
         i = 0;
         for (int j = i; j < i + 8; ++j) {
             SCOPED_TRACE(cv::format("i=%d j=%d", i, j));
-            LaneType val = dataV[i]     * data0[j] +
+            LaneType val = (LaneType)(
+                           dataV[i]     * data0[j] +
                            dataV[i + 1] * data1[j] +
                            dataV[i + 2] * data2[j] +
                            dataV[i + 3] * data3[j] +
                            dataV[i + 4] * data4[j] +
                            dataV[i + 5] * data5[j] +
                            dataV[i + 6] * data6[j] +
-                           data7[j];
+                           data7[j]);
             EXPECT_COMPARE_EQ(val, resAdd[j]);
         }
 #else


### PR DESCRIPTION
Related: #25743

Currently, the type for the half-precision floating point data in the OpenCV source code is `__fp16`, which is a unique(?) type supported by the ARM compiler. Other compilers have very limited support for `__fp16`, so in order to introduce more backends that support FP16 (such as RISC-V), we may need a the more general FP16 type.

In this patch, we use `hfloat` instead of `__fp16` in non-ARM code blocks, mainly affected parts are:
- `core/hal/intrin.hpp`: Type Traits, REG Traits and `vx_` interface.
- `core/hal/intrin_neon.hpp`: Universal Intrinsic API for FP16 type.
- `core/test/test_intrin_utils.hpp`: Usage of Univseral Intrinsic
- `core/include/opencv2/core/cvdef.h`: Definition of class `hfloat`

If I understand correctly, class `hfloat` acts as a wrapper around FP16 types in different platform (`__fp16` for ARM and `_Float16` for RISC-V). Any OpenCV generic interface/source code should use `hfloat`, while platform-specific FP16 types only used in macro-guarded code blocks.

/cc @fengyuentau  @mshabunin 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
