### PR TITLE
Replace use of "eval()" with "getattr()".

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.markdown
+++ b/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.markdown
@@ -46,12 +46,12 @@ assert template is not None, "file could not be read, check with os.path.exists(
 w, h = template.shape[::-1]
 
 # All the 6 methods for comparison in a list
-methods = ['cv.TM_CCOEFF', 'cv.TM_CCOEFF_NORMED', 'cv.TM_CCORR',
-            'cv.TM_CCORR_NORMED', 'cv.TM_SQDIFF', 'cv.TM_SQDIFF_NORMED']
+methods = ['TM_CCOEFF', 'TM_CCOEFF_NORMED', 'TM_CCORR',
+            'TM_CCORR_NORMED', 'TM_SQDIFF', 'TM_SQDIFF_NORMED']
 
 for meth in methods:
     img = img2.copy()
-    method = eval(meth)
+    method = getattr(cv, meth)
 
     # Apply template Matching
     res = cv.matchTemplate(img,template,method)


### PR DESCRIPTION
The use of `eval()` should be avoided where possible. Functionally, this will make the suptitle no longer start with "cv.", but could be put back in if there is a desire for it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
