### PR TITLE
Enable checkerboard detection with a  central / corner marker on a black tile

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -1625,36 +1625,30 @@ bool Chessboard::Board::normalizeMarkerOrientation()
             if(!current_cell->marker || !current_cell->right || !current_cell->right->marker)
                 continue;
 
-            if(current_cell->black)
+            if(current_cell->right->top && current_cell->right->top->marker)
             {
-                if(current_cell->right->top && current_cell->right->top->marker)
-                {
-                    rotateLeft();
-                    rotateLeft();
-                    pcell = current_cell->right;
-                    break;
-                }
-                if(current_cell->right->bottom && current_cell->right->bottom->marker)
-                {
-                    rotateLeft();
-                    pcell = current_cell->right;
-                    break;
-                }
+                rotateLeft();
+                rotateLeft();
+                pcell = current_cell->right;
+                break;
             }
-            else
+            if(current_cell->right->bottom && current_cell->right->bottom->marker)
             {
-                if(current_cell->top && current_cell->top->marker)
-                {
-                    rotateRight();
-                    pcell = current_cell;
-                    break;
-                }
-                if(current_cell->bottom && current_cell->bottom->marker)
-                {
-                    // correct orientation
-                    pcell = current_cell;
-                    break;
-                }
+                rotateLeft();
+                pcell = current_cell->right;
+                break;
+            }
+            if(current_cell->top && current_cell->top->marker)
+            {
+                rotateRight();
+                pcell = current_cell;
+                break;
+            }
+            if(current_cell->bottom && current_cell->bottom->marker)
+            {
+                // correct orientation
+                pcell = current_cell;
+                break;
             }
         }
     }

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -679,6 +679,26 @@ TEST(Calib3d_AsymmetricCirclesPatternDetector, accuracy) { CV_ChessboardDetector
 TEST(Calib3d_AsymmetricCirclesPatternDetectorWithClustering, accuracy) { CV_ChessboardDetectorTest test( ASYMMETRIC_CIRCLES_GRID, CALIB_CB_CLUSTERING ); test.safe_run(); }
 #endif
 
+TEST(Calib3d_ChessboardWithMarkers, regression_25806_white)
+{
+    const cv::String dataDir = string(TS::ptr()->get_data_path()) + "cv/cameracalibration/";
+    const cv::Mat image = cv::imread(dataDir + "checkerboard_marker_white.png");
+
+    std::vector<Point2f> corners;
+    const bool success = cv::findChessboardCornersSB(image, Size(9, 14), corners, CALIB_CB_MARKER);
+    ASSERT_TRUE(success);
+}
+
+TEST(Calib3d_ChessboardWithMarkers, regression_25806_black)
+{
+    const cv::String dataDir = string(TS::ptr()->get_data_path()) + "cv/cameracalibration/";
+    const cv::Mat image = cv::imread(dataDir + "checkerboard_marker_black.png");
+
+    std::vector<Point2f> corners;
+    const bool success = cv::findChessboardCornersSB(image, Size(9, 14), corners, CALIB_CB_MARKER);
+    ASSERT_TRUE(success);
+}
+
 TEST(Calib3d_CirclesPatternDetectorWithClustering, accuracy)
 {
     cv::String dataDir = string(TS::ptr()->get_data_path()) + "cv/cameracalibration/circles/";


### PR DESCRIPTION
This pull request closes the issue #25806.

The issue doesn't require any documentation - it's quite intuitive that the detection result shouldn't depend on the color of the marker's tile.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
