### PR TITLE
Remove unused variables in rgb2hsv_b simd

### DIFF
--- a/modules/imgproc/src/color_hsv.simd.hpp
+++ b/modules/imgproc/src/color_hsv.simd.hpp
@@ -130,7 +130,7 @@ struct RGB2HSV_b
 
             // sdiv = sdiv_table[v]
             v_int32 sdiv0, sdiv1, sdiv2, sdiv3;;
-            v_uint16 vd0, vd1, vd2;
+            v_uint16 vd0, vd1;
             v_expand(v, vd0, vd1);
             v_int32 vq0, vq1, vq2, vq3;
             v_expand(v_reinterpret_as_s16(vd0), vq0, vq1);
@@ -150,7 +150,7 @@ struct RGB2HSV_b
 
             // hdiv = hdiv_table[diff]
             v_int32 hdiv0, hdiv1, hdiv2, hdiv3;
-            v_uint16 diffd0, diffd1, diffd2;
+            v_uint16 diffd0, diffd1;
             v_expand(diff, diffd0, diffd1);
             v_int32 diffq0, diffq1, diffq2, diffq3;
             v_expand(v_reinterpret_as_s16(diffd0), diffq0, diffq1);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
