### PR TITLE
handling I32/I64 data types in G-API ONNX back-end

### DIFF
--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -928,7 +928,7 @@ void ONNXCompiled::Run(const std::vector<cv::Mat>& ins,
                          out_run_names.data(),
                          &out_tensors.front(),
                          params.output_names.size());
-        if (out_tensor_info[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) { 
+        if (out_tensor_info[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
             // cv::Mat does not support int64 output data.
             // Conversion from int 64 to int 32 is carried in the copyFromONNX function
             // The output is written to out_mat

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -494,7 +494,7 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
         return i64_tensor;
     }
     default:
-    GAPI_Error("ONNX. Unsupported data type");
+        GAPI_Error("ONNX. Unsupported data type");
     }
     return Ort::Value{nullptr};
 }
@@ -944,9 +944,9 @@ void ONNXCompiled::Run(const std::vector<cv::Mat>& ins,
         // Easy path - just run the session which is bound to G-API's
         // internal data
         for (auto i : ade::util::iota(params.output_names.size())) {
-            out_tensors.emplace_back(createTensor(this_memory_info,
-                                                out_tensor_info[i],
-                                                outs[i]));
+        out_tensors.emplace_back(createTensor(this_memory_info,
+                                              out_tensor_info[i],
+                                              outs[i]));
         }
         auto out_run_names = getCharNames(params.output_names);
         this_session.Run(Ort::RunOptions{nullptr},

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -479,7 +479,7 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
 
         // creating temp tensor a top of exisiting memory (this will not last)
         auto ort_dims = toORT(data.size);
-       
+
         // create an empty tensor
         Ort::AllocatorWithDefaultOptions allocator;
         Ort::Value i64_tensor = Ort::Value::CreateTensor<int64_t>(allocator,
@@ -923,7 +923,7 @@ void ONNXCompiled::Run(const std::vector<cv::Mat>& ins,
             out_tensors.emplace_back(createTensor(this_memory_info,
                                                 out_tensor_info[i],
                                                 outs[i]));
-        } 
+        }
         auto out_run_names = getCharNames(params.output_names);
         // running the model
         this_session.Run(Ort::RunOptions{nullptr},
@@ -933,7 +933,7 @@ void ONNXCompiled::Run(const std::vector<cv::Mat>& ins,
                          out_run_names.data(),
                          &out_tensors.front(),
                          params.output_names.size());
-        
+
         for (auto &&iter : ade::util::zip(ade::util::toRange(out_tensors),
                                           ade::util::toRange(outs))) {
             auto &out_tensor = std::get<0>(iter);

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -322,14 +322,14 @@ inline std::vector<int64_t> toORT(const cv::MatSize &sz) {
 inline void preprocess(const cv::Mat& src,
                        const cv::gimpl::onnx::TensorInfo& ti,
                              cv::Mat& dst) {
-    GAPI_Assert(src.depth() == CV_32F || src.depth() == CV_8U);
+    GAPI_Assert(src.depth() == CV_32F || src.depth() == CV_8U || src.depth() == CV_32S);
     // CNN input type
     const auto type = toCV(ti.type);
-    if (src.depth() == CV_32F) {
+    if (src.depth() == CV_32F || src.depth() == CV_32S) {
         // Just pass the tensor as-is.
         // No layout or dimension transformations done here!
         // TODO: This needs to be aligned across all NN backends.
-        GAPI_Assert(type == CV_32F && "Only 32F model input is supported for 32F input data");
+        GAPI_Assert((type == CV_32F || type == CV_32S) && "Only 32F model input is supported for 32F input data");
         const auto tensor_dims = toORT(src.size);
         if (tensor_dims.size() == ti.dims.size()) {
             for (size_t i = 0; i < ti.dims.size(); ++i) {
@@ -743,13 +743,13 @@ ONNXCompiled::ONNXCompiled(const gapi::onnx::detail::ParamDesc &pp)
     }
 
     // Validate what is supported currently
-    GAPI_Assert(std::all_of(in_tensor_info.begin(),
-                            in_tensor_info.end(),
-                            [](const cv::gimpl::onnx::TensorInfo &p) {
-                                return p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
-                                    || p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-                            })
-                && "Only FP32 and U8 inputs for NN are supported");
+    // GAPI_Assert(std::all_of(in_tensor_info.begin(),
+    //                         in_tensor_info.end(),
+    //                         [](const cv::gimpl::onnx::TensorInfo &p) {
+    //                             return p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+    //                                 || p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+    //                         })
+    //             && "Only FP32 and U8 inputs for NN are supported");
 
     // Put mean and std in appropriate tensor params
     if (!params.mean.empty() || !params.stdev.empty()) {

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -332,7 +332,7 @@ inline void preprocess(const cv::Mat& src,
         if (tensor_dims.size() == ti.dims.size()) {
             for (size_t i = 0; i < ti.dims.size(); ++i) {
                 GAPI_Assert((ti.dims[i] == -1 || ti.dims[i] == tensor_dims[i]) &&
-                            "non-U8 tensor dimensions should match with all non-dynamic NN input dimensions");
+                            "32F tensor dimensions should match with all non-dynamic NN input dimensions");
             }
         } else {
             GAPI_Error("32F tensor size should match with NN input");
@@ -470,8 +470,7 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
         return createTensor<int32_t>(memory_info, tensor_params, data);
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-        // Conversion to int64 is done later
-        return createTensor<int32_t>(memory_info, tensor_params, data); 
+        return createTensor<int64_t>(memory_info, tensor_params, data);
     default:
         GAPI_Error("ONNX. Unsupported data type");
     }

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -332,10 +332,10 @@ inline void preprocess(const cv::Mat& src,
         if (tensor_dims.size() == ti.dims.size()) {
             for (size_t i = 0; i < ti.dims.size(); ++i) {
                 GAPI_Assert((ti.dims[i] == -1 || ti.dims[i] == tensor_dims[i]) &&
-                            "32F tensor dimensions should match with all non-dynamic NN input dimensions");
+                            "Non-U8 tensor dimensions should match with all non-dynamic NN input dimensions");
             }
         } else {
-            GAPI_Error("32F tensor size should match with NN input");
+            GAPI_Error("Non-U8 tensor size should match with NN input");
         }
 
         dst = src;
@@ -470,6 +470,7 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
         return createTensor<int32_t>(memory_info, tensor_params, data);
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+    // Conversion to i32 is carried out later
         return createTensor<int64_t>(memory_info, tensor_params, data);
     default:
         GAPI_Error("ONNX. Unsupported data type");

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -332,7 +332,7 @@ inline void preprocess(const cv::Mat& src,
         if (tensor_dims.size() == ti.dims.size()) {
             for (size_t i = 0; i < ti.dims.size(); ++i) {
                 GAPI_Assert((ti.dims[i] == -1 || ti.dims[i] == tensor_dims[i]) &&
-                            "32F tensor dimensions should match with all non-dynamic NN input dimensions");
+                            "non-U8 tensor dimensions should match with all non-dynamic NN input dimensions");
             }
         } else {
             GAPI_Error("32F tensor size should match with NN input");
@@ -470,7 +470,8 @@ inline Ort::Value createTensor(const Ort::MemoryInfo& memory_info,
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
         return createTensor<int32_t>(memory_info, tensor_params, data);
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-        return createTensor<int32_t>(memory_info, tensor_params, data);
+        // Conversion to int64 is done later
+        return createTensor<int32_t>(memory_info, tensor_params, data); 
     default:
         GAPI_Error("ONNX. Unsupported data type");
     }

--- a/modules/gapi/src/backends/onnx/gonnxbackend.cpp
+++ b/modules/gapi/src/backends/onnx/gonnxbackend.cpp
@@ -743,13 +743,14 @@ ONNXCompiled::ONNXCompiled(const gapi::onnx::detail::ParamDesc &pp)
     }
 
     // Validate what is supported currently
-    // GAPI_Assert(std::all_of(in_tensor_info.begin(),
-    //                         in_tensor_info.end(),
-    //                         [](const cv::gimpl::onnx::TensorInfo &p) {
-    //                             return p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
-    //                                 || p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-    //                         })
-    //             && "Only FP32 and U8 inputs for NN are supported");
+    GAPI_Assert(std::all_of(in_tensor_info.begin(),
+                            in_tensor_info.end(),
+                            [](const cv::gimpl::onnx::TensorInfo &p) {
+                                return p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+                                    || p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8
+                                    || p.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+                            })
+                && "Only FP32 and U8 inputs for NN are supported");
 
     // Put mean and std in appropriate tensor params
     if (!params.mean.empty() || !params.stdev.empty()) {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
