### PR TITLE
Fix: compilation Issue on ARM64 (msys2 clangarm)

### DIFF
--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -52,5 +52,9 @@ if(WITH_NEON)
     endif()
 endif()
 
+ if(MINGW) 
+    target_compile_definitions(carotene_objs PRIVATE "-D_USE_MATH_DEFINES=1")
+ endif()
+
 # we add dummy file to fix XCode build
 add_library(carotene STATIC ${OPENCV_3RDPARTY_EXCLUDE_FROM_ALL} "$<TARGET_OBJECTS:carotene_objs>" "${CAROTENE_SOURCE_DIR}/dummy.cpp")


### PR DESCRIPTION
Added a definition for M_PI in the code to resolve a compilation error encountered when building OpenCV on the MSYS2 environment. The M_PI constant was not defined, causing the compilation to fail.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
