### PR TITLE
Fix #25833: The correct way to disable top-most state is with HWND_NOTOPMOST, not HWND_TOP.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -681,7 +681,7 @@ void cvSetPropTopmost_W32(const char* name, const bool topmost)
 
 static bool setPropTopmost_(CvWindow& window, bool topmost)
 {
-    HWND flag    = topmost ? HWND_TOPMOST : HWND_TOP;
+    HWND flag    = topmost ? HWND_TOPMOST : HWND_NOTOPMOST;
     BOOL success = SetWindowPos(window.frame, flag, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
     if (!success)


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25833

Would it make sense to add a test case for this? It would be a pair of `setWindowProperty` / `getWindowProperty` to verify that `WND_PROP_TOPMOST` actually changes (one symptom of the bug). Unfortunately I can't seem to get the tests to even appear in the generated VS solution right now...
