### PR TITLE
Fix file descriptor leak in HDR decoder

### DIFF
--- a/modules/imgcodecs/src/grfmt_hdr.cpp
+++ b/modules/imgcodecs/src/grfmt_hdr.cpp
@@ -59,6 +59,9 @@ HdrDecoder::HdrDecoder()
 
 HdrDecoder::~HdrDecoder()
 {
+    if(file) {
+        fclose(file);
+    }
 }
 
 size_t HdrDecoder::signatureLength() const


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

For invalid input data there is an exception here:

https://github.com/opencv/opencv/blob/bbf65a166e027f079835920f117db5725d3ec030/modules/imgcodecs/src/grfmt_hdr.cpp#L79

which leads to missing `fclose` call. It's possible to wrap `RGBE_ReadHeader` with try-catch and call `fclose` in place, but I chose a more reliable way. Please let me know if another way is preferred for the fix.