### PR TITLE
HAL for moments(): binarize input if needed

### DIFF
--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -575,7 +575,18 @@ static int moments(const cv::Mat& src, bool binary, cv::Moments& m)
     if( src.checkVector(2) >= 0 && (depth == CV_32F || depth == CV_32S))
         status = cv_hal_polygonMoments(src.data, src.total()/2, src.type(), m_data);
     else
-        status = cv_hal_imageMoments(src.data, src.step, src.type(), src.cols, src.rows, binary, m_data);
+    {
+        Mat in;
+        if( binary )
+        {
+            cv::compare(src, 0, in, cv::CMP_NE);
+        }
+        else
+        {
+            in = src;
+        }
+        status = cv_hal_imageMoments(in.data, in.step, in.type(), in.cols, in.rows, binary, m_data);
+    }
 
     if (status == CV_HAL_ERROR_OK)
     {


### PR DESCRIPTION
_Note: needs discussion_

Binarizes input if `binary` flag is set, the same way as it's done in the moments() function main loop

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
