### PR TITLE
Fixed CuDNN runtime version check for CuDNN 9+.

### DIFF
--- a/modules/dnn/src/cuda4dnn/init.hpp
+++ b/modules/dnn/src/cuda4dnn/init.hpp
@@ -23,8 +23,19 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         //     Any patch release x.y.z is forward or backward-compatible with applications built against another cuDNN patch release x.y.w (meaning, of the same major and minor version number, but having w!=z).
         //     cuDNN minor releases beginning with cuDNN 7 are binary backward-compatible with applications built against the same or earlier patch release (meaning, an application built against cuDNN 7.x is binary compatible with cuDNN library 7.y, where y>=x).
         //     Applications compiled with a cuDNN version 7.y are not guaranteed to work with 7.x release when y > x.
-        auto cudnn_bversion = cudnnGetVersion();
-        auto cudnn_major_bversion = cudnn_bversion / 1000, cudnn_minor_bversion = cudnn_bversion % 1000 / 100;
+        int cudnn_bversion = cudnnGetVersion();
+        int cudnn_major_bversion = 0, cudnn_minor_bversion = 0;
+        // CuDNN changed major version multiplier in 9.0
+        if (cudnn_bversion >= 9*10000)
+        {
+            cudnn_major_bversion = cudnn_bversion / 10000;
+            cudnn_minor_bversion = cudnn_bversion % 10000 / 100;
+        }
+        else
+        {
+            cudnn_major_bversion = cudnn_bversion / 1000;
+            cudnn_minor_bversion = cudnn_bversion % 1000 / 100;
+        }
         if (cudnn_major_bversion != CUDNN_MAJOR || cudnn_minor_bversion < CUDNN_MINOR)
         {
             std::ostringstream oss;


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25711

Fixed warning:
```
[ WARN:0@410.036] global init.hpp:32 checkVersions cuDNN reports version 90.1 which is not compatible with the version 9.1 with which OpenCV was built
```

CuDNN changed version multipliers since 9.0. The patch accommodates to it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
