### PR TITLE
Set using Orbbec SDK on MacOS OFF by default.

### DIFF
--- a/modules/videoio/cmake/detect_obsensor.cmake
+++ b/modules/videoio/cmake/detect_obsensor.cmake
@@ -1,10 +1,5 @@
 # --- obsensor ---
 if(NOT HAVE_OBSENSOR)
-  if(APPLE)
-    # force to use orbbec sdk on mac
-    set(OBSENSOR_USE_ORBBEC_SDK ON)
-  endif()
-
   if(OBSENSOR_USE_ORBBEC_SDK)
     include(${CMAKE_SOURCE_DIR}/3rdparty/orbbecsdk/orbbecsdk.cmake)
     download_orbbec_sdk(ORBBEC_SDK_ROOT_DIR)


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/25693

This PR is to turn off the downloading OrbbecSDK on MacOS by default. Only a very small percentage of OpenCV users on Mac would be using Orbbec cameras, so it makes sense not to download the SDK by default every time building OpenCV from source on MacOS. 

Then in order to use Orbbec 3D cameras on MacOS via OpenCV, users need to build OpenCV with `-DOBSENSOR_USE_ORBBEC_SDK=ON` explicitly.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
