### PR TITLE
Fixed kotlin requirement in Android build.gradle

### DIFF
--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -90,7 +90,9 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-@KOTLIN_PLUGIN_DECLARATION@
+if (getPluginManager().hasPlugin('kotlin-android')) {
+    @KOTLIN_PLUGIN_DECLARATION@
+}
 
 def openCVersionName = "@OPENCV_VERSION@"
 def openCVersionCode = ((@OPENCV_VERSION_MAJOR@ * 100 + @OPENCV_VERSION_MINOR@) * 100 + @OPENCV_VERSION_PATCH@) * 10 + 0

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -90,8 +90,11 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-if (getPluginManager().hasPlugin('kotlin-android')) {
+try {
     @KOTLIN_PLUGIN_DECLARATION@
+    println "Configure OpenCV with Kotlin"
+} catch (Exception e) {
+    println "Configure OpenCV without Kotlin"
 }
 
 def openCVersionName = "@OPENCV_VERSION@"


### PR DESCRIPTION
Now OpenCV Android SDK doesn't always require kotlin plugin. Kotlin code is compiled only if the application uses kotlin plugin.

Fixes #24663 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
