### PR TITLE
Fixed narrowing conversion warning with MSVC compiler.

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2800,7 +2800,7 @@ TEST_P(Test_ONNX_nets, YOLOv9)
     float iou_threshold = 0.50;
 
     std::vector<int> refClassIds{1, 16, 2}; // wrong class mapping for yolov9
-    std::vector<float> refScores{0.959274f, 0.901125, 0.559396f};
+    std::vector<float> refScores{0.959274f, 0.901125f, 0.559396f};
 
     std::vector<Rect2d> refBoxes{
         Rect2d(106.255, 107.927, 472.497, 350.309),


### PR DESCRIPTION
Addresses warning on buildbot:
```
C:\build\precommit_windows64\4.x\opencv\modules\dnn\test\test_onnx_importer.cpp(2803): error C2398: Element '2': conversion from 'double' to 'float' requires a narrowing conversion [C:\build\precommit_windows64\build\modules\dnn\opencv_test_dnn.vcxproj]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
