### PR TITLE
Fixed 32-bit build with some GCC versions

### DIFF
--- a/modules/3d/src/octree.cpp
+++ b/modules/3d/src/octree.cpp
@@ -410,8 +410,9 @@ void Octree::getPointCloudByOctree(OutputArray restorePointCloud, OutputArray re
     double resolution = p->resolution;
     std::vector<Point3f> outPts, outColors;
 
-    std::stack<std::tuple<Ptr<OctreeNode>, size_t, size_t, size_t>> toCheck;
-    toCheck.push({root, 0, 0, 0});
+    typedef std::tuple<Ptr<OctreeNode>, size_t, size_t, size_t> stack_element;
+    std::stack<stack_element> toCheck;
+    toCheck.push(stack_element(root, 0, 0, 0));
     while (!toCheck.empty())
     {
         auto top = toCheck.top();
@@ -456,7 +457,7 @@ void Octree::getPointCloudByOctree(OutputArray restorePointCloud, OutputArray re
                     x_copy = (x_copy << 1) | x_offSet;
                     y_copy = (y_copy << 1) | y_offSet;
                     z_copy = (z_copy << 1) | z_offSet;
-                    toCheck.push({node->children[i], x_copy, y_copy, z_copy});
+                    toCheck.push(stack_element(node->children[i], x_copy, y_copy, z_copy));
                 }
             }
         }


### PR DESCRIPTION
Error message example:

```
/home/ubuntu/Projects/opencv/modules/3d/src/octree.cpp: In member function ‘void cv::Octree::getPointCloudByOctree(cv::OutputArray, cv::OutputArray)’:
/home/ubuntu/Projects/opencv/modules/3d/src/octree.cpp:414:36: error: converting to ‘std::stack<std::tuple<cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int> >::value_type {aka std::tuple<cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {cv::Ptr<cv::OctreeNode>&, unsigned int, unsigned int, unsigned int}; <template-parameter-2-2> = void; _Elements = {cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int}]’
     toCheck.push({root, 0u, 0u, 0u});
                                    ^
/home/ubuntu/Projects/opencv/modules/3d/src/octree.cpp:459:77: error: converting to ‘std::stack<std::tuple<cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int> >::value_type {aka std::tuple<cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int>}’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {cv::Ptr<cv::OctreeNode>&, unsigned int&, unsigned int&, unsigned int&}; <template-parameter-2-2> = void; _Elements = {cv::Ptr<cv::OctreeNode>, unsigned int, unsigned int, unsigned int}]’
                     toCheck.push({node->children[i], x_copy, y_copy, z_copy});
                                                                             ^
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
