### PR TITLE
Make sure all the lines of a JPEG are read

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -494,13 +494,12 @@ bool  JpegDecoder::readData( Mat& img )
 
             jpeg_start_decompress( cinfo );
 
-            int num_read_lines = 0;
             if( doDirectRead)
             {
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    num_read_lines += jpeg_read_scanlines( cinfo, &data, 1 );
+                    jpeg_read_scanlines( cinfo, &data, 1 );
                 }
             }
             else
@@ -511,7 +510,7 @@ bool  JpegDecoder::readData( Mat& img )
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    num_read_lines += jpeg_read_scanlines( cinfo, buffer, 1 );
+                    jpeg_read_scanlines( cinfo, buffer, 1 );
 
                     if( color )
                     {
@@ -540,7 +539,7 @@ bool  JpegDecoder::readData( Mat& img )
                 }
             }
 
-            result = num_read_lines >= m_height;
+            result = true;
             jpeg_finish_decompress( cinfo );
         }
     }

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -494,12 +494,13 @@ bool  JpegDecoder::readData( Mat& img )
 
             jpeg_start_decompress( cinfo );
 
+            int num_read_lines = 0;
             if( doDirectRead)
             {
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    jpeg_read_scanlines( cinfo, &data, 1 );
+                    num_read_lines += jpeg_read_scanlines( cinfo, &data, 1 );
                 }
             }
             else
@@ -510,7 +511,7 @@ bool  JpegDecoder::readData( Mat& img )
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    jpeg_read_scanlines( cinfo, buffer, 1 );
+                    num_read_lines += jpeg_read_scanlines( cinfo, buffer, 1 );
 
                     if( color )
                     {
@@ -539,7 +540,7 @@ bool  JpegDecoder::readData( Mat& img )
                 }
             }
 
-            result = true;
+            result = num_read_lines >= m_height;
             jpeg_finish_decompress( cinfo );
         }
     }

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -499,7 +499,7 @@ bool  JpegDecoder::readData( Mat& img )
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    jpeg_read_scanlines( cinfo, &data, 1 );
+                    if (jpeg_read_scanlines( cinfo, &data, 1 ) != 1) return false;
                 }
             }
             else
@@ -510,7 +510,7 @@ bool  JpegDecoder::readData( Mat& img )
                 for( int iy = 0 ; iy < m_height; iy ++ )
                 {
                     uchar* data = img.ptr<uchar>(iy);
-                    jpeg_read_scanlines( cinfo, buffer, 1 );
+                    if (jpeg_read_scanlines( cinfo, buffer, 1 ) != 1) return false;
 
                     if( color )
                     {


### PR DESCRIPTION
In case of corrupted JPEG, imread would still return a JPEG of the proper size (as indicated by the header) but with some uninitialized values. I do not have a short reproducer I can add as a test as this was found by our fuzzers.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
