### PR TITLE
Add support for v_sin and v_cos (Sine and Cosine)

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -3167,15 +3167,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x8& a)
 inline void v256_cleanup() { _mm256_zeroall(); }
 
 #include "intrin_math.hpp"
-inline v_float32x8 v_exp(v_float32x8 x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
-inline v_float32x8 v_log(v_float32x8 x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_exp(const v_float32x8& x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_log(const v_float32x8& x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
 inline void v_sincos(const v_float32x8& x, v_float32x8& s, v_float32x8& c) { v_sincos_default_32f<v_float32x8, v_int32x8>(x, s, c); }
 inline v_float32x8 v_sin(const v_float32x8& x) { return v_sin_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_cos(const v_float32x8& x) { return v_cos_default_32f<v_float32x8, v_int32x8>(x); }
-inline v_float32x8 v_erf(v_float32x8 x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_erf(const v_float32x8& x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
 
-inline v_float64x4 v_exp(v_float64x4 x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
-inline v_float64x4 v_log(v_float64x4 x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_exp(const v_float64x4& x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_log(const v_float64x4& x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
 inline void v_sincos(const v_float64x4& x, v_float64x4& s, v_float64x4& c) { v_sincos_default_64f<v_float64x4, v_int64x4>(x, s, c); }
 inline v_float64x4 v_sin(const v_float64x4& x) { return v_sin_default_64f<v_float64x4, v_int64x4>(x); }
 inline v_float64x4 v_cos(const v_float64x4& x) { return v_cos_default_64f<v_float64x4, v_int64x4>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -3169,10 +3169,16 @@ inline void v256_cleanup() { _mm256_zeroall(); }
 #include "intrin_math.hpp"
 inline v_float32x8 v_exp(v_float32x8 x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_log(v_float32x8 x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
+inline void v_sincos(const v_float32x8& x, v_float32x8& s, v_float32x8& c) { v_sincos_default_32f<v_float32x8, v_int32x8>(x, s, c); }
+inline v_float32x8 v_sin(const v_float32x8& x) { return v_sin_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_cos(const v_float32x8& x) { return v_cos_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_erf(v_float32x8 x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
 
 inline v_float64x4 v_exp(v_float64x4 x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
 inline v_float64x4 v_log(v_float64x4 x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
+inline void v_sincos(const v_float64x4& x, v_float64x4& s, v_float64x4& c) { v_sincos_default_64f<v_float64x4, v_int64x4>(x, s, c); }
+inline v_float64x4 v_sin(const v_float64x4& x) { return v_sin_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_cos(const v_float64x4& x) { return v_cos_default_64f<v_float64x4, v_int64x4>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -3079,15 +3079,15 @@ inline int v_scan_forward(const v_float64x8& a) { return trailingZeros32(v_signm
 inline void v512_cleanup() { _mm256_zeroall(); }
 
 #include "intrin_math.hpp"
-inline v_float32x16 v_exp(v_float32x16 x) { return v_exp_default_32f<v_float32x16, v_int32x16>(x); }
-inline v_float32x16 v_log(v_float32x16 x) { return v_log_default_32f<v_float32x16, v_int32x16>(x); }
+inline v_float32x16 v_exp(const v_float32x16& x) { return v_exp_default_32f<v_float32x16, v_int32x16>(x); }
+inline v_float32x16 v_log(const v_float32x16& x) { return v_log_default_32f<v_float32x16, v_int32x16>(x); }
 inline void v_sincos(const v_float32x16& x, v_float32x16& s, v_float32x16& c) { v_sincos_default_32f<v_float32x16, v_int32x16>(x, s, c); }
 inline v_float32x16 v_sin(const v_float32x16& x) { return v_sin_default_32f<v_float32x16, v_int32x16>(x); }
 inline v_float32x16 v_cos(const v_float32x16& x) { return v_cos_default_32f<v_float32x16, v_int32x16>(x); }
-inline v_float32x16 v_erf(v_float32x16 x) { return v_erf_default_32f<v_float32x16, v_int32x16>(x); }
+inline v_float32x16 v_erf(const v_float32x16& x) { return v_erf_default_32f<v_float32x16, v_int32x16>(x); }
 
-inline v_float64x8 v_exp(v_float64x8 x) { return v_exp_default_64f<v_float64x8, v_int64x8>(x); }
-inline v_float64x8 v_log(v_float64x8 x) { return v_log_default_64f<v_float64x8, v_int64x8>(x); }
+inline v_float64x8 v_exp(const v_float64x8& x) { return v_exp_default_64f<v_float64x8, v_int64x8>(x); }
+inline v_float64x8 v_log(const v_float64x8& x) { return v_log_default_64f<v_float64x8, v_int64x8>(x); }
 inline void v_sincos(const v_float64x8& x, v_float64x8& s, v_float64x8& c) { v_sincos_default_64f<v_float64x8, v_int64x8>(x, s, c); }
 inline v_float64x8 v_sin(const v_float64x8& x) { return v_sin_default_64f<v_float64x8, v_int64x8>(x); }
 inline v_float64x8 v_cos(const v_float64x8& x) { return v_cos_default_64f<v_float64x8, v_int64x8>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -3081,10 +3081,16 @@ inline void v512_cleanup() { _mm256_zeroall(); }
 #include "intrin_math.hpp"
 inline v_float32x16 v_exp(v_float32x16 x) { return v_exp_default_32f<v_float32x16, v_int32x16>(x); }
 inline v_float32x16 v_log(v_float32x16 x) { return v_log_default_32f<v_float32x16, v_int32x16>(x); }
+inline void v_sincos(const v_float32x16& x, v_float32x16& s, v_float32x16& c) { v_sincos_default_32f<v_float32x16, v_int32x16>(x, s, c); }
+inline v_float32x16 v_sin(const v_float32x16& x) { return v_sin_default_32f<v_float32x16, v_int32x16>(x); }
+inline v_float32x16 v_cos(const v_float32x16& x) { return v_cos_default_32f<v_float32x16, v_int32x16>(x); }
 inline v_float32x16 v_erf(v_float32x16 x) { return v_erf_default_32f<v_float32x16, v_int32x16>(x); }
 
 inline v_float64x8 v_exp(v_float64x8 x) { return v_exp_default_64f<v_float64x8, v_int64x8>(x); }
 inline v_float64x8 v_log(v_float64x8 x) { return v_log_default_64f<v_float64x8, v_int64x8>(x); }
+inline void v_sincos(const v_float64x8& x, v_float64x8& s, v_float64x8& c) { v_sincos_default_64f<v_float64x8, v_int64x8>(x, s, c); }
+inline v_float64x8 v_sin(const v_float64x8& x) { return v_sin_default_64f<v_float64x8, v_int64x8>(x); }
+inline v_float64x8 v_cos(const v_float64x8& x) { return v_cos_default_64f<v_float64x8, v_int64x8>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -264,7 +264,7 @@ Most of these operations return only one value.
 ### Other math
 
 - Some frequent operations: @ref v_sqrt, @ref v_invsqrt, @ref v_magnitude, @ref v_sqr_magnitude, @ref v_exp, @ref v_log,
-                            @ref v_erf
+                            @ref v_erf, @ref v_sin, @ref v_cos
 - Absolute values: @ref v_abs, @ref v_absdiff, @ref v_absdiffs
 
 ### Conversions
@@ -366,6 +366,7 @@ Floating point:
 |broadcast_element  | x |   |
 |exp                | x | x |
 |log                | x | x |
+|sin, cos           | x | x |
 
  @{ */
 
@@ -745,10 +746,41 @@ OPENCV_HAL_IMPL_MATH_FUNC(v_log, std::log, _Tp)
  */
 OPENCV_HAL_IMPL_MATH_FUNC(v_erf, std::erf, _Tp)
 
-//! @cond IGNORED
+/**
+ * @brief Compute sine \f$ sin(x) \f$ and cosine \f$ cos(x) \f$ of elements at the same time
+ *
+ * Only for floating point types. Core implementation steps:
+ * 1. Input Normalization: Scale the periodicity from 2π to 4 and reduce the angle to the range \f$ [0, \frac{\pi}{4}] \f$ using periodicity and trigonometric identities.
+ * 2. Polynomial Approximation for \f$ sin(x) \f$ and \f$ cos(x) \f$:
+ *   - For float16 and float32, use a Taylor series with 4 terms for sine and 5 terms for cosine.
+ *   - For float64, use a Taylor series with 7 terms for sine and 8 terms for cosine.
+ * 3. Select Results: select and convert the final sine and cosine values for the original input angle.
+ *
+ * @note The precision of the calculation depends on the implementation and the data type of the input vector.
+ */
+template<typename _Tp, int n>
+inline void v_sincos(const v_reg<_Tp, n>& x, v_reg<_Tp, n>& s, v_reg<_Tp, n>& c)
+{
+    for( int i = 0; i < n; i++ )
+    {
+        s.s[i] = std::sin(x.s[i]);
+        c.s[i] = std::cos(x.s[i]);
+    }
+}
+
+/**
+ * @brief Sine \f$ sin(x) \f$ of elements
+ *
+ * Only for floating point types. Core implementation the same as @ref v_sincos.
+ */
 OPENCV_HAL_IMPL_MATH_FUNC(v_sin, std::sin, _Tp)
+
+/**
+ * @brief Cosine \f$ cos(x) \f$ of elements
+ *
+ * Only for floating point types. Core implementation the same as @ref v_sincos.
+ */
 OPENCV_HAL_IMPL_MATH_FUNC(v_cos, std::cos, _Tp)
-//! @endcond
 
 /** @brief Absolute value of elements
 

--- a/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
@@ -3014,15 +3014,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x8& a)
 inline void v256_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x8 v_exp(v_float32x8 x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
-inline v_float32x8 v_log(v_float32x8 x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_exp(const v_float32x8& x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_log(const v_float32x8& x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
 inline void v_sincos(const v_float32x8& x, v_float32x8& s, v_float32x8& c) { v_sincos_default_32f<v_float32x8, v_int32x8>(x, s, c); }
 inline v_float32x8 v_sin(const v_float32x8& x) { return v_sin_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_cos(const v_float32x8& x) { return v_cos_default_32f<v_float32x8, v_int32x8>(x); }
-inline v_float32x8 v_erf(v_float32x8 x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_erf(const v_float32x8& x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
 
-inline v_float64x4 v_exp(v_float64x4 x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
-inline v_float64x4 v_log(v_float64x4 x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_exp(const v_float64x4& x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_log(const v_float64x4& x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
 inline void v_sincos(const v_float64x4& x, v_float64x4& s, v_float64x4& c) { v_sincos_default_64f<v_float64x4, v_int64x4>(x, s, c); }
 inline v_float64x4 v_sin(const v_float64x4& x) { return v_sin_default_64f<v_float64x4, v_int64x4>(x); }
 inline v_float64x4 v_cos(const v_float64x4& x) { return v_cos_default_64f<v_float64x4, v_int64x4>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
@@ -3016,10 +3016,16 @@ inline void v256_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x8 v_exp(v_float32x8 x) { return v_exp_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_log(v_float32x8 x) { return v_log_default_32f<v_float32x8, v_int32x8>(x); }
+inline void v_sincos(const v_float32x8& x, v_float32x8& s, v_float32x8& c) { v_sincos_default_32f<v_float32x8, v_int32x8>(x, s, c); }
+inline v_float32x8 v_sin(const v_float32x8& x) { return v_sin_default_32f<v_float32x8, v_int32x8>(x); }
+inline v_float32x8 v_cos(const v_float32x8& x) { return v_cos_default_32f<v_float32x8, v_int32x8>(x); }
 inline v_float32x8 v_erf(v_float32x8 x) { return v_erf_default_32f<v_float32x8, v_int32x8>(x); }
 
 inline v_float64x4 v_exp(v_float64x4 x) { return v_exp_default_64f<v_float64x4, v_int64x4>(x); }
 inline v_float64x4 v_log(v_float64x4 x) { return v_log_default_64f<v_float64x4, v_int64x4>(x); }
+inline void v_sincos(const v_float64x4& x, v_float64x4& s, v_float64x4& c) { v_sincos_default_64f<v_float64x4, v_int64x4>(x, s, c); }
+inline v_float64x4 v_sin(const v_float64x4& x) { return v_sin_default_64f<v_float64x4, v_int64x4>(x); }
+inline v_float64x4 v_cos(const v_float64x4& x) { return v_cos_default_64f<v_float64x4, v_int64x4>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
@@ -2524,15 +2524,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x4& a)
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
@@ -2526,10 +2526,16 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_math.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_math.hpp
@@ -405,6 +405,252 @@ inline _TpVec64F v_log_default_64f(const _TpVec64F &x) {
 }
 //! @}
 
+#if !defined(OPENCV_HAL_MATH_HAVE_SINCOS) || (defined(CV_FORCE_SIMD128_CPP) && CV_SIMD_WIDTH != 16)
+
+//! @name Sine and Cosine
+//! @{
+#if defined(CV_SIMD_FP16) && CV_SIMD_FP16
+    inline void v_sincos(const v_float16 &x, v_float16 &ysin, v_float16 &ycos) {
+        const v_float16 v_cephes_FOPI = vx_setall_f16(hfloat(1.27323954473516f)); // 4 / M_PI
+        const v_float16 v_minus_DP1 = vx_setall_f16(hfloat(-0.78515625f));
+        const v_float16 v_minus_DP2 = vx_setall_f16(hfloat(-2.4187564849853515625E-4f));
+        const v_float16 v_minus_DP3 = vx_setall_f16(hfloat(-3.77489497744594108E-8f));
+        const v_float16 v_sincof_p0 = vx_setall_f16(hfloat(-1.9515295891E-4f));
+        const v_float16 v_sincof_p1 = vx_setall_f16(hfloat(8.3321608736E-3f));
+        const v_float16 v_sincof_p2 = vx_setall_f16(hfloat(-1.6666654611E-1f));
+        const v_float16 v_coscof_p0 = vx_setall_f16(hfloat(2.443315711809948E-5f));
+        const v_float16 v_coscof_p1 = vx_setall_f16(hfloat(-1.388731625493765E-3f));
+        const v_float16 v_coscof_p2 = vx_setall_f16(hfloat(4.166664568298827E-2f));
+        const v_float16 v_nan = v_reinterpret_as_f16(vx_setall_s16(0x7e00));
+        const v_float16 v_neg_zero = vx_setall_f16(hfloat(-0.f));
+
+        v_float16 _vx, _vy, sign_mask_sin, sign_mask_cos;
+        v_int16 emm2;
+
+        sign_mask_sin = v_lt(x, vx_setzero_f16());
+        _vx = v_abs(x);
+        _vy = v_mul(_vx, v_cephes_FOPI);
+
+        emm2 = v_trunc(_vy);
+        emm2 = v_add(emm2, vx_setall_s16(1));
+        emm2 = v_and(emm2, vx_setall_s16(~1));
+        _vy = v_cvt_f16(emm2);
+
+        v_float16 poly_mask = v_reinterpret_as_f16(v_eq(v_and(emm2, vx_setall_s16(2)), vx_setall_s16(0)));
+
+        _vx = v_fma(_vy, v_minus_DP1, _vx);
+        _vx = v_fma(_vy, v_minus_DP2, _vx);
+        _vx = v_fma(_vy, v_minus_DP3, _vx);
+
+        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f16(v_eq(v_and(emm2, vx_setall_s16(4)), vx_setall_s16(0))));
+        sign_mask_cos = v_reinterpret_as_f16(v_eq(v_and(v_sub(emm2, vx_setall_s16(2)), vx_setall_s16(4)), vx_setall_s16(0)));
+
+        v_float16 _vxx = v_mul(_vx, _vx);
+        v_float16 y1, y2;
+
+        y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
+        y1 = v_fma(y1, _vxx, v_coscof_p2);
+        y1 = v_fma(y1, _vxx, vx_setall_f16(hfloat(-0.5f)));
+        y1 = v_fma(y1, _vxx, vx_setall_f16(hfloat(1)));
+
+        y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
+        y2 = v_fma(y2, _vxx, v_sincof_p2);
+        y2 = v_mul(y2, _vxx);
+        y2 = v_fma(y2, _vx, _vx);
+
+        ysin = v_select(poly_mask, y2, y1);
+        ycos = v_select(poly_mask, y1, y2);
+        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+
+        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+        v_float16 mask_inf = v_eq(_vx, v_reinterpret_as_f16(vx_setall_s16(0x7c00)));
+        v_float16 mask_nan = v_or(mask_inf, v_ne(x, x));
+        ysin = v_select(mask_nan, v_nan, ysin);
+        ycos = v_select(mask_nan, v_nan, ycos);
+    }
+
+    inline v_float16 v_sin(const v_float16 &x)
+    {
+        v_float16 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ysin;
+    }
+
+    inline v_float16 v_cos(const v_float16 &x)
+    {
+        v_float16 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ycos;
+    }
+#endif // CV_SIMD_FP16
+
+    inline void v_sincos(const v_float32 &x, v_float32 &ysin, v_float32 &ycos)
+    {
+        const v_float32 v_cephes_FOPI = vx_setall_f32(1.27323954473516f); // 4 / M_PI
+        const v_float32 v_minus_DP1 = vx_setall_f32(-0.78515625f);
+        const v_float32 v_minus_DP2 = vx_setall_f32(-2.4187564849853515625E-4f);
+        const v_float32 v_minus_DP3 = vx_setall_f32(-3.77489497744594108E-8f);
+        const v_float32 v_sincof_p0 = vx_setall_f32(-1.9515295891E-4f);
+        const v_float32 v_sincof_p1 = vx_setall_f32(8.3321608736E-3f);
+        const v_float32 v_sincof_p2 = vx_setall_f32(-1.6666654611E-1f);
+        const v_float32 v_coscof_p0 = vx_setall_f32(2.443315711809948E-5f);
+        const v_float32 v_coscof_p1 = vx_setall_f32(-1.388731625493765E-3f);
+        const v_float32 v_coscof_p2 = vx_setall_f32(4.166664568298827E-2f);
+        const v_float32 v_nan = v_reinterpret_as_f32(vx_setall_s32(0x7fc00000));
+        const v_float32 v_neg_zero = vx_setall_f32(-0.f);
+
+        v_float32 _vx, _vy, sign_mask_sin, sign_mask_cos;
+        v_int32 emm2;
+
+        sign_mask_sin = v_lt(x, vx_setzero_f32());
+        _vx = v_abs(x);
+        _vy = v_mul(_vx, v_cephes_FOPI);
+
+        emm2 = v_trunc(_vy);
+        emm2 = v_add(emm2, vx_setall_s32(1));
+        emm2 = v_and(emm2, vx_setall_s32(~1));
+        _vy = v_cvt_f32(emm2);
+
+        v_float32 poly_mask = v_reinterpret_as_f32(v_eq(v_and(emm2, vx_setall_s32(2)), vx_setall_s32(0)));
+
+        _vx = v_fma(_vy, v_minus_DP1, _vx);
+        _vx = v_fma(_vy, v_minus_DP2, _vx);
+        _vx = v_fma(_vy, v_minus_DP3, _vx);
+
+        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f32(v_eq(v_and(emm2, vx_setall_s32(4)), vx_setall_s32(0))));
+        sign_mask_cos = v_reinterpret_as_f32(v_eq(v_and(v_sub(emm2, vx_setall_s32(2)), vx_setall_s32(4)), vx_setall_s32(0)));
+
+        v_float32 _vxx = v_mul(_vx, _vx);
+        v_float32 y1, y2;
+
+        y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
+        y1 = v_fma(y1, _vxx, v_coscof_p2);
+        y1 = v_fma(y1, _vxx, vx_setall_f32(-0.5f));
+        y1 = v_fma(y1, _vxx, vx_setall_f32(1));
+
+        y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
+        y2 = v_fma(y2, _vxx, v_sincof_p2);
+        y2 = v_mul(y2, _vxx);
+        y2 = v_fma(y2, _vx, _vx);
+
+        ysin = v_select(poly_mask, y2, y1);
+        ycos = v_select(poly_mask, y1, y2);
+        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+
+        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+        v_float32 mask_inf = v_eq(_vx, v_reinterpret_as_f32(vx_setall_s32(0x7f800000)));
+        v_float32 mask_nan = v_or(mask_inf, v_ne(x, x));
+        ysin = v_select(mask_nan, v_nan, ysin);
+        ycos = v_select(mask_nan, v_nan, ycos);
+    }
+
+    inline v_float32 v_sin(const v_float32 &x)
+    {
+        v_float32 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ysin;
+    }
+
+    inline v_float32 v_cos(const v_float32 &x)
+    {
+        v_float32 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ycos;
+    }
+
+#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
+    inline void v_sincos(const v_float64 &x, v_float64 &ysin, v_float64 &ycos) {
+        const v_float64 v_cephes_FOPI = vx_setall_f64(1.2732395447351626861510701069801148); // 4 / M_PI
+        const v_float64 v_minus_DP1 = vx_setall_f64(-7.853981554508209228515625E-1);
+        const v_float64 v_minus_DP2 = vx_setall_f64(-7.94662735614792836714E-9);
+        const v_float64 v_minus_DP3 = vx_setall_f64(-3.06161699786838294307E-17);
+        const v_float64 v_sin_C1 = vx_setall_f64(1.58962301576546568060E-10);
+        const v_float64 v_sin_C2 = vx_setall_f64(-2.50507477628578072866E-8);
+        const v_float64 v_sin_C3 = vx_setall_f64(2.75573136213857245213E-6);
+        const v_float64 v_sin_C4 = vx_setall_f64(-1.98412698295895385996E-4);
+        const v_float64 v_sin_C5 = vx_setall_f64(8.33333333332211858878E-3);
+        const v_float64 v_sin_C6 = vx_setall_f64(-1.66666666666666307295E-1);
+        const v_float64 v_cos_C1 = vx_setall_f64(-1.13585365213876817300E-11);
+        const v_float64 v_cos_C2 = vx_setall_f64(2.08757008419747316778E-9);
+        const v_float64 v_cos_C3 = vx_setall_f64(-2.75573141792967388112E-7);
+        const v_float64 v_cos_C4 = vx_setall_f64(2.48015872888517045348E-5);
+        const v_float64 v_cos_C5 = vx_setall_f64(-1.38888888888730564116E-3);
+        const v_float64 v_cos_C6 = vx_setall_f64(4.16666666666665929218E-2);
+        const v_float64 v_nan = v_reinterpret_as_f64(vx_setall_s64(0x7ff8000000000000));
+        const v_float64 v_neg_zero = vx_setall_f64(-0.0);
+
+        v_float64 _vx, _vy, sign_mask_sin, sign_mask_cos;
+        v_int64 emm2;
+
+        sign_mask_sin = v_lt(x, vx_setzero_f64());
+        _vx = v_abs(x);
+        _vy = v_mul(_vx, v_cephes_FOPI);
+
+        emm2 = v_expand_low(v_trunc(_vy));
+        emm2 = v_add(emm2, vx_setall_s64(1));
+        emm2 = v_and(emm2, vx_setall_s64(~1));
+        _vy = v_cvt_f64(emm2);
+
+        v_float64 poly_mask = v_reinterpret_as_f64(v_eq(v_and(emm2, vx_setall_s64(2)), vx_setall_s64(0)));
+
+        _vx = v_fma(_vy, v_minus_DP1, _vx);
+        _vx = v_fma(_vy, v_minus_DP2, _vx);
+        _vx = v_fma(_vy, v_minus_DP3, _vx);
+
+        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f64(v_eq(v_and(emm2, vx_setall_s64(4)), vx_setall_s64(0))));
+        sign_mask_cos = v_reinterpret_as_f64(v_eq(v_and(v_sub(emm2, vx_setall_s64(2)), vx_setall_s64(4)), vx_setall_s64(0)));
+
+        v_float64 _vxx = v_mul(_vx, _vx);
+        v_float64 y1, y2;
+
+        y1 = v_fma(v_cos_C1, _vxx, v_cos_C2);
+        y1 = v_fma(y1, _vxx, v_cos_C3);
+        y1 = v_fma(y1, _vxx, v_cos_C4);
+        y1 = v_fma(y1, _vxx, v_cos_C5);
+        y1 = v_fma(y1, _vxx, v_cos_C6);
+        y1 = v_fma(y1, _vxx, vx_setall_f64(-0.5));
+        y1 = v_fma(y1, _vxx, vx_setall_f64(1.0));
+
+        y2 = v_fma(v_sin_C1, _vxx, v_sin_C2);
+        y2 = v_fma(y2, _vxx, v_sin_C3);
+        y2 = v_fma(y2, _vxx, v_sin_C4);
+        y2 = v_fma(y2, _vxx, v_sin_C5);
+        y2 = v_fma(y2, _vxx, v_sin_C6);
+        y2 = v_mul(y2, _vxx);
+        y2 = v_fma(y2, _vx, _vx);
+
+        ysin = v_select(poly_mask, y2, y1);
+        ycos = v_select(poly_mask, y1, y2);
+        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+
+        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+        v_float64 mask_inf = v_eq(_vx, v_reinterpret_as_f64(vx_setall_s64(0x7ff0000000000000)));
+        v_float64 mask_nan = v_or(mask_inf, v_ne(x, x));
+        ysin = v_select(mask_nan, v_nan, ysin);
+        ycos = v_select(mask_nan, v_nan, ycos);
+    }
+
+    inline v_float64 v_sin(const v_float64 &x)
+    {
+        v_float64 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ysin;
+    }
+
+    inline v_float64 v_cos(const v_float64 &x)
+    {
+        v_float64 ysin, ycos;
+        v_sincos(x, ysin, ycos);
+        return ycos;
+    }
+#endif // CV_SIMD_64F || CV_SIMD_SCALABLE_64F
+//! @}
+#define OPENCV_HAL_MATH_HAVE_SINCOS 1
+#endif // OPENCV_HAL_MATH_HAVE_SINCOS
+
 /* This implementation is derived from the approximation approach of Error Function (Erf) from PyTorch
    https://github.com/pytorch/pytorch/blob/9c50ecc84b9a6e699a7f058891b889aafbf976c7/aten/src/ATen/cpu/vec/vec512/vec512_float.h#L189-L220
 */

--- a/modules/core/include/opencv2/core/hal/intrin_math.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_math.hpp
@@ -440,10 +440,8 @@ inline void v_sincos_default_16f(const _TpVec16F &x, _TpVec16F &ysin, _TpVec16F 
     _vx = v_fma(_vy, v_minus_DP2, _vx);
     _vx = v_fma(_vy, v_minus_DP3, _vx);
 
-    sign_mask_sin = v_xor(sign_mask_sin,
-                          v_reinterpret_as_f16(v_eq(v_and(emm2, v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0))));
-    sign_mask_cos = v_reinterpret_as_f16(
-            v_eq(v_and(v_sub(emm2, v_setall_<_TpVec16S>((short)2)), v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0)));
+    sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f16(v_eq(v_and(emm2, v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0))));
+    sign_mask_cos = v_reinterpret_as_f16(v_eq(v_and(v_sub(emm2, v_setall_<_TpVec16S>((short)2)), v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0)));
 
     _TpVec16F _vxx = v_mul(_vx, _vx);
     _TpVec16F y1, y2;
@@ -646,7 +644,6 @@ inline _TpVec64F v_cos_default_64f(const _TpVec64F &x) {
     v_sincos_default_64f<_TpVec64F, _TpVec64S>(x, ysin, ycos);
     return ycos;
 }
-
 //! @}
 
 

--- a/modules/core/include/opencv2/core/hal/intrin_math.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_math.hpp
@@ -405,251 +405,250 @@ inline _TpVec64F v_log_default_64f(const _TpVec64F &x) {
 }
 //! @}
 
-#if !defined(OPENCV_HAL_MATH_HAVE_SINCOS) || (defined(CV_FORCE_SIMD128_CPP) && CV_SIMD_WIDTH != 16)
-
 //! @name Sine and Cosine
 //! @{
-#if defined(CV_SIMD_FP16) && CV_SIMD_FP16
-    inline void v_sincos(const v_float16 &x, v_float16 &ysin, v_float16 &ycos) {
-        const v_float16 v_cephes_FOPI = vx_setall_f16(hfloat(1.27323954473516f)); // 4 / M_PI
-        const v_float16 v_minus_DP1 = vx_setall_f16(hfloat(-0.78515625f));
-        const v_float16 v_minus_DP2 = vx_setall_f16(hfloat(-2.4187564849853515625E-4f));
-        const v_float16 v_minus_DP3 = vx_setall_f16(hfloat(-3.77489497744594108E-8f));
-        const v_float16 v_sincof_p0 = vx_setall_f16(hfloat(-1.9515295891E-4f));
-        const v_float16 v_sincof_p1 = vx_setall_f16(hfloat(8.3321608736E-3f));
-        const v_float16 v_sincof_p2 = vx_setall_f16(hfloat(-1.6666654611E-1f));
-        const v_float16 v_coscof_p0 = vx_setall_f16(hfloat(2.443315711809948E-5f));
-        const v_float16 v_coscof_p1 = vx_setall_f16(hfloat(-1.388731625493765E-3f));
-        const v_float16 v_coscof_p2 = vx_setall_f16(hfloat(4.166664568298827E-2f));
-        const v_float16 v_nan = v_reinterpret_as_f16(vx_setall_s16(0x7e00));
-        const v_float16 v_neg_zero = vx_setall_f16(hfloat(-0.f));
+template<typename _TpVec16F, typename _TpVec16S>
+inline void v_sincos_default_16f(const _TpVec16F &x, _TpVec16F &ysin, _TpVec16F &ycos) {
+    const _TpVec16F v_cephes_FOPI = v_setall_<_TpVec16F>(hfloat(1.27323954473516f)); // 4 / M_PI
+    const _TpVec16F v_minus_DP1 = v_setall_<_TpVec16F>(hfloat(-0.78515625f));
+    const _TpVec16F v_minus_DP2 = v_setall_<_TpVec16F>(hfloat(-2.4187564849853515625E-4f));
+    const _TpVec16F v_minus_DP3 = v_setall_<_TpVec16F>(hfloat(-3.77489497744594108E-8f));
+    const _TpVec16F v_sincof_p0 = v_setall_<_TpVec16F>(hfloat(-1.9515295891E-4f));
+    const _TpVec16F v_sincof_p1 = v_setall_<_TpVec16F>(hfloat(8.3321608736E-3f));
+    const _TpVec16F v_sincof_p2 = v_setall_<_TpVec16F>(hfloat(-1.6666654611E-1f));
+    const _TpVec16F v_coscof_p0 = v_setall_<_TpVec16F>(hfloat(2.443315711809948E-5f));
+    const _TpVec16F v_coscof_p1 = v_setall_<_TpVec16F>(hfloat(-1.388731625493765E-3f));
+    const _TpVec16F v_coscof_p2 = v_setall_<_TpVec16F>(hfloat(4.166664568298827E-2f));
+    const _TpVec16F v_nan = v_reinterpret_as_f16(v_setall_<_TpVec16S>((short)0x7e00));
+    const _TpVec16F v_neg_zero = v_setall_<_TpVec16F>(hfloat(-0.f));
 
-        v_float16 _vx, _vy, sign_mask_sin, sign_mask_cos;
-        v_int16 emm2;
+    _TpVec16F _vx, _vy, sign_mask_sin, sign_mask_cos;
+    _TpVec16S emm2;
 
-        sign_mask_sin = v_lt(x, vx_setzero_f16());
-        _vx = v_abs(x);
-        _vy = v_mul(_vx, v_cephes_FOPI);
+    sign_mask_sin = v_lt(x, v_setzero_<_TpVec16F>());
+    _vx = v_abs(x);
+    _vy = v_mul(_vx, v_cephes_FOPI);
 
-        emm2 = v_trunc(_vy);
-        emm2 = v_add(emm2, vx_setall_s16(1));
-        emm2 = v_and(emm2, vx_setall_s16(~1));
-        _vy = v_cvt_f16(emm2);
+    emm2 = v_trunc(_vy);
+    emm2 = v_add(emm2, v_setall_<_TpVec16S>((short)1));
+    emm2 = v_and(emm2, v_setall_<_TpVec16S>((short)~1));
+    _vy = v_cvt_f16(emm2);
 
-        v_float16 poly_mask = v_reinterpret_as_f16(v_eq(v_and(emm2, vx_setall_s16(2)), vx_setall_s16(0)));
+    _TpVec16F poly_mask = v_reinterpret_as_f16(v_eq(v_and(emm2, v_setall_<_TpVec16S>((short)2)), v_setall_<_TpVec16S>((short)0)));
 
-        _vx = v_fma(_vy, v_minus_DP1, _vx);
-        _vx = v_fma(_vy, v_minus_DP2, _vx);
-        _vx = v_fma(_vy, v_minus_DP3, _vx);
+    _vx = v_fma(_vy, v_minus_DP1, _vx);
+    _vx = v_fma(_vy, v_minus_DP2, _vx);
+    _vx = v_fma(_vy, v_minus_DP3, _vx);
 
-        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f16(v_eq(v_and(emm2, vx_setall_s16(4)), vx_setall_s16(0))));
-        sign_mask_cos = v_reinterpret_as_f16(v_eq(v_and(v_sub(emm2, vx_setall_s16(2)), vx_setall_s16(4)), vx_setall_s16(0)));
+    sign_mask_sin = v_xor(sign_mask_sin,
+                          v_reinterpret_as_f16(v_eq(v_and(emm2, v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0))));
+    sign_mask_cos = v_reinterpret_as_f16(
+            v_eq(v_and(v_sub(emm2, v_setall_<_TpVec16S>((short)2)), v_setall_<_TpVec16S>((short)4)), v_setall_<_TpVec16S>((short)0)));
 
-        v_float16 _vxx = v_mul(_vx, _vx);
-        v_float16 y1, y2;
+    _TpVec16F _vxx = v_mul(_vx, _vx);
+    _TpVec16F y1, y2;
 
-        y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
-        y1 = v_fma(y1, _vxx, v_coscof_p2);
-        y1 = v_fma(y1, _vxx, vx_setall_f16(hfloat(-0.5f)));
-        y1 = v_fma(y1, _vxx, vx_setall_f16(hfloat(1)));
+    y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
+    y1 = v_fma(y1, _vxx, v_coscof_p2);
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec16F>(hfloat(-0.5f)));
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec16F>(hfloat(1)));
 
-        y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
-        y2 = v_fma(y2, _vxx, v_sincof_p2);
-        y2 = v_mul(y2, _vxx);
-        y2 = v_fma(y2, _vx, _vx);
+    y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
+    y2 = v_fma(y2, _vxx, v_sincof_p2);
+    y2 = v_mul(y2, _vxx);
+    y2 = v_fma(y2, _vx, _vx);
 
-        ysin = v_select(poly_mask, y2, y1);
-        ycos = v_select(poly_mask, y1, y2);
-        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
-        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+    ysin = v_select(poly_mask, y2, y1);
+    ycos = v_select(poly_mask, y1, y2);
+    ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+    ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
 
-        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
-        v_float16 mask_inf = v_eq(_vx, v_reinterpret_as_f16(vx_setall_s16(0x7c00)));
-        v_float16 mask_nan = v_or(mask_inf, v_ne(x, x));
-        ysin = v_select(mask_nan, v_nan, ysin);
-        ycos = v_select(mask_nan, v_nan, ycos);
-    }
+    // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+    _TpVec16F mask_inf = v_eq(_vx, v_reinterpret_as_f16(v_setall_<_TpVec16S>((short)0x7c00)));
+    _TpVec16F mask_nan = v_or(mask_inf, v_ne(x, x));
+    ysin = v_select(mask_nan, v_nan, ysin);
+    ycos = v_select(mask_nan, v_nan, ycos);
+}
 
-    inline v_float16 v_sin(const v_float16 &x)
-    {
-        v_float16 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ysin;
-    }
+template<typename _TpVec16F, typename _TpVec16S>
+inline _TpVec16F v_sin_default_16f(const _TpVec16F &x) {
+    _TpVec16F ysin, ycos;
+    v_sincos_default_16f<_TpVec16F, _TpVec16S>()(x, ysin, ycos);
+    return ysin;
+}
 
-    inline v_float16 v_cos(const v_float16 &x)
-    {
-        v_float16 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ycos;
-    }
-#endif // CV_SIMD_FP16
+template<typename _TpVec16F, typename _TpVec16S>
+inline _TpVec16F v_cos_default_16f(const _TpVec16F &x) {
+    _TpVec16F ysin, ycos;
+    v_sincos_default_16f<_TpVec16F, _TpVec16S>(x, ysin, ycos);
+    return ycos;
+}
 
-    inline void v_sincos(const v_float32 &x, v_float32 &ysin, v_float32 &ycos)
-    {
-        const v_float32 v_cephes_FOPI = vx_setall_f32(1.27323954473516f); // 4 / M_PI
-        const v_float32 v_minus_DP1 = vx_setall_f32(-0.78515625f);
-        const v_float32 v_minus_DP2 = vx_setall_f32(-2.4187564849853515625E-4f);
-        const v_float32 v_minus_DP3 = vx_setall_f32(-3.77489497744594108E-8f);
-        const v_float32 v_sincof_p0 = vx_setall_f32(-1.9515295891E-4f);
-        const v_float32 v_sincof_p1 = vx_setall_f32(8.3321608736E-3f);
-        const v_float32 v_sincof_p2 = vx_setall_f32(-1.6666654611E-1f);
-        const v_float32 v_coscof_p0 = vx_setall_f32(2.443315711809948E-5f);
-        const v_float32 v_coscof_p1 = vx_setall_f32(-1.388731625493765E-3f);
-        const v_float32 v_coscof_p2 = vx_setall_f32(4.166664568298827E-2f);
-        const v_float32 v_nan = v_reinterpret_as_f32(vx_setall_s32(0x7fc00000));
-        const v_float32 v_neg_zero = vx_setall_f32(-0.f);
 
-        v_float32 _vx, _vy, sign_mask_sin, sign_mask_cos;
-        v_int32 emm2;
+template<typename _TpVec32F, typename _TpVec32S>
+inline void v_sincos_default_32f(const _TpVec32F &x, _TpVec32F &ysin, _TpVec32F &ycos) {
+    const _TpVec32F v_cephes_FOPI = v_setall_<_TpVec32F>(1.27323954473516f); // 4 / M_PI
+    const _TpVec32F v_minus_DP1 = v_setall_<_TpVec32F>(-0.78515625f);
+    const _TpVec32F v_minus_DP2 = v_setall_<_TpVec32F>(-2.4187564849853515625E-4f);
+    const _TpVec32F v_minus_DP3 = v_setall_<_TpVec32F>(-3.77489497744594108E-8f);
+    const _TpVec32F v_sincof_p0 = v_setall_<_TpVec32F>(-1.9515295891E-4f);
+    const _TpVec32F v_sincof_p1 = v_setall_<_TpVec32F>(8.3321608736E-3f);
+    const _TpVec32F v_sincof_p2 = v_setall_<_TpVec32F>(-1.6666654611E-1f);
+    const _TpVec32F v_coscof_p0 = v_setall_<_TpVec32F>(2.443315711809948E-5f);
+    const _TpVec32F v_coscof_p1 = v_setall_<_TpVec32F>(-1.388731625493765E-3f);
+    const _TpVec32F v_coscof_p2 = v_setall_<_TpVec32F>(4.166664568298827E-2f);
+    const _TpVec32F v_nan = v_reinterpret_as_f32(v_setall_<_TpVec32S>((int)0x7fc00000));
+    const _TpVec32F v_neg_zero = v_setall_<_TpVec32F>(-0.f);
 
-        sign_mask_sin = v_lt(x, vx_setzero_f32());
-        _vx = v_abs(x);
-        _vy = v_mul(_vx, v_cephes_FOPI);
+    _TpVec32F _vx, _vy, sign_mask_sin, sign_mask_cos;
+    _TpVec32S emm2;
 
-        emm2 = v_trunc(_vy);
-        emm2 = v_add(emm2, vx_setall_s32(1));
-        emm2 = v_and(emm2, vx_setall_s32(~1));
-        _vy = v_cvt_f32(emm2);
+    sign_mask_sin = v_lt(x, v_setzero_<_TpVec32F>());
+    _vx = v_abs(x);
+    _vy = v_mul(_vx, v_cephes_FOPI);
 
-        v_float32 poly_mask = v_reinterpret_as_f32(v_eq(v_and(emm2, vx_setall_s32(2)), vx_setall_s32(0)));
+    emm2 = v_trunc(_vy);
+    emm2 = v_add(emm2, v_setall_<_TpVec32S>(1));
+    emm2 = v_and(emm2, v_setall_<_TpVec32S>(~1));
+    _vy = v_cvt_f32(emm2);
 
-        _vx = v_fma(_vy, v_minus_DP1, _vx);
-        _vx = v_fma(_vy, v_minus_DP2, _vx);
-        _vx = v_fma(_vy, v_minus_DP3, _vx);
+    _TpVec32F poly_mask = v_reinterpret_as_f32(v_eq(v_and(emm2, v_setall_<_TpVec32S>(2)), v_setall_<_TpVec32S>(0)));
 
-        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f32(v_eq(v_and(emm2, vx_setall_s32(4)), vx_setall_s32(0))));
-        sign_mask_cos = v_reinterpret_as_f32(v_eq(v_and(v_sub(emm2, vx_setall_s32(2)), vx_setall_s32(4)), vx_setall_s32(0)));
+    _vx = v_fma(_vy, v_minus_DP1, _vx);
+    _vx = v_fma(_vy, v_minus_DP2, _vx);
+    _vx = v_fma(_vy, v_minus_DP3, _vx);
 
-        v_float32 _vxx = v_mul(_vx, _vx);
-        v_float32 y1, y2;
+    sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f32(v_eq(v_and(emm2, v_setall_<_TpVec32S>(4)), v_setall_<_TpVec32S>(0))));
+    sign_mask_cos = v_reinterpret_as_f32(v_eq(v_and(v_sub(emm2, v_setall_<_TpVec32S>(2)), v_setall_<_TpVec32S>(4)), v_setall_<_TpVec32S>(0)));
 
-        y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
-        y1 = v_fma(y1, _vxx, v_coscof_p2);
-        y1 = v_fma(y1, _vxx, vx_setall_f32(-0.5f));
-        y1 = v_fma(y1, _vxx, vx_setall_f32(1));
+    _TpVec32F _vxx = v_mul(_vx, _vx);
+    _TpVec32F y1, y2;
 
-        y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
-        y2 = v_fma(y2, _vxx, v_sincof_p2);
-        y2 = v_mul(y2, _vxx);
-        y2 = v_fma(y2, _vx, _vx);
+    y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
+    y1 = v_fma(y1, _vxx, v_coscof_p2);
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec32F>(-0.5f));
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec32F>(1.f));
 
-        ysin = v_select(poly_mask, y2, y1);
-        ycos = v_select(poly_mask, y1, y2);
-        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
-        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+    y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
+    y2 = v_fma(y2, _vxx, v_sincof_p2);
+    y2 = v_mul(y2, _vxx);
+    y2 = v_fma(y2, _vx, _vx);
 
-        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
-        v_float32 mask_inf = v_eq(_vx, v_reinterpret_as_f32(vx_setall_s32(0x7f800000)));
-        v_float32 mask_nan = v_or(mask_inf, v_ne(x, x));
-        ysin = v_select(mask_nan, v_nan, ysin);
-        ycos = v_select(mask_nan, v_nan, ycos);
-    }
+    ysin = v_select(poly_mask, y2, y1);
+    ycos = v_select(poly_mask, y1, y2);
+    ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+    ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
 
-    inline v_float32 v_sin(const v_float32 &x)
-    {
-        v_float32 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ysin;
-    }
+    // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+    _TpVec32F mask_inf = v_eq(_vx, v_reinterpret_as_f32(v_setall_<_TpVec32S>((int)0x7f800000)));
+    _TpVec32F mask_nan = v_or(mask_inf, v_ne(x, x));
+    ysin = v_select(mask_nan, v_nan, ysin);
+    ycos = v_select(mask_nan, v_nan, ycos);
+}
 
-    inline v_float32 v_cos(const v_float32 &x)
-    {
-        v_float32 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ycos;
-    }
+template<typename _TpVec32F, typename _TpVec32S>
+inline _TpVec32F v_sin_default_32f(const _TpVec32F &x) {
+    _TpVec32F ysin, ycos;
+    v_sincos_default_32f<_TpVec32F, _TpVec32S>(x, ysin, ycos);
+    return ysin;
+}
 
-#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
-    inline void v_sincos(const v_float64 &x, v_float64 &ysin, v_float64 &ycos) {
-        const v_float64 v_cephes_FOPI = vx_setall_f64(1.2732395447351626861510701069801148); // 4 / M_PI
-        const v_float64 v_minus_DP1 = vx_setall_f64(-7.853981554508209228515625E-1);
-        const v_float64 v_minus_DP2 = vx_setall_f64(-7.94662735614792836714E-9);
-        const v_float64 v_minus_DP3 = vx_setall_f64(-3.06161699786838294307E-17);
-        const v_float64 v_sin_C1 = vx_setall_f64(1.58962301576546568060E-10);
-        const v_float64 v_sin_C2 = vx_setall_f64(-2.50507477628578072866E-8);
-        const v_float64 v_sin_C3 = vx_setall_f64(2.75573136213857245213E-6);
-        const v_float64 v_sin_C4 = vx_setall_f64(-1.98412698295895385996E-4);
-        const v_float64 v_sin_C5 = vx_setall_f64(8.33333333332211858878E-3);
-        const v_float64 v_sin_C6 = vx_setall_f64(-1.66666666666666307295E-1);
-        const v_float64 v_cos_C1 = vx_setall_f64(-1.13585365213876817300E-11);
-        const v_float64 v_cos_C2 = vx_setall_f64(2.08757008419747316778E-9);
-        const v_float64 v_cos_C3 = vx_setall_f64(-2.75573141792967388112E-7);
-        const v_float64 v_cos_C4 = vx_setall_f64(2.48015872888517045348E-5);
-        const v_float64 v_cos_C5 = vx_setall_f64(-1.38888888888730564116E-3);
-        const v_float64 v_cos_C6 = vx_setall_f64(4.16666666666665929218E-2);
-        const v_float64 v_nan = v_reinterpret_as_f64(vx_setall_s64(0x7ff8000000000000));
-        const v_float64 v_neg_zero = vx_setall_f64(-0.0);
+template<typename _TpVec32F, typename _TpVec32S>
+inline _TpVec32F v_cos_default_32f(const _TpVec32F &x) {
+    _TpVec32F ysin, ycos;
+    v_sincos_default_32f<_TpVec32F, _TpVec32S>(x, ysin, ycos);
+    return ycos;
+}
 
-        v_float64 _vx, _vy, sign_mask_sin, sign_mask_cos;
-        v_int64 emm2;
+template<typename _TpVec64F, typename _TpVec64S>
+inline void v_sincos_default_64f(const _TpVec64F &x, _TpVec64F &ysin, _TpVec64F &ycos) {
+    const _TpVec64F v_cephes_FOPI = v_setall_<_TpVec64F>(1.2732395447351626861510701069801148); // 4 / M_PI
+    const _TpVec64F v_minus_DP1 = v_setall_<_TpVec64F>(-7.853981554508209228515625E-1);
+    const _TpVec64F v_minus_DP2 = v_setall_<_TpVec64F>(-7.94662735614792836714E-9);
+    const _TpVec64F v_minus_DP3 = v_setall_<_TpVec64F>(-3.06161699786838294307E-17);
+    const _TpVec64F v_sin_C1 = v_setall_<_TpVec64F>(1.58962301576546568060E-10);
+    const _TpVec64F v_sin_C2 = v_setall_<_TpVec64F>(-2.50507477628578072866E-8);
+    const _TpVec64F v_sin_C3 = v_setall_<_TpVec64F>(2.75573136213857245213E-6);
+    const _TpVec64F v_sin_C4 = v_setall_<_TpVec64F>(-1.98412698295895385996E-4);
+    const _TpVec64F v_sin_C5 = v_setall_<_TpVec64F>(8.33333333332211858878E-3);
+    const _TpVec64F v_sin_C6 = v_setall_<_TpVec64F>(-1.66666666666666307295E-1);
+    const _TpVec64F v_cos_C1 = v_setall_<_TpVec64F>(-1.13585365213876817300E-11);
+    const _TpVec64F v_cos_C2 = v_setall_<_TpVec64F>(2.08757008419747316778E-9);
+    const _TpVec64F v_cos_C3 = v_setall_<_TpVec64F>(-2.75573141792967388112E-7);
+    const _TpVec64F v_cos_C4 = v_setall_<_TpVec64F>(2.48015872888517045348E-5);
+    const _TpVec64F v_cos_C5 = v_setall_<_TpVec64F>(-1.38888888888730564116E-3);
+    const _TpVec64F v_cos_C6 = v_setall_<_TpVec64F>(4.16666666666665929218E-2);
+    const _TpVec64F v_nan = v_reinterpret_as_f64(v_setall_<_TpVec64S>((int64)0x7ff8000000000000));
+    const _TpVec64F v_neg_zero = v_setall_<_TpVec64F>(-0.0);
 
-        sign_mask_sin = v_lt(x, vx_setzero_f64());
-        _vx = v_abs(x);
-        _vy = v_mul(_vx, v_cephes_FOPI);
+    _TpVec64F _vx, _vy, sign_mask_sin, sign_mask_cos;
+    _TpVec64S emm2;
 
-        emm2 = v_expand_low(v_trunc(_vy));
-        emm2 = v_add(emm2, vx_setall_s64(1));
-        emm2 = v_and(emm2, vx_setall_s64(~1));
-        _vy = v_cvt_f64(emm2);
+    sign_mask_sin = v_lt(x, v_setzero_<_TpVec64F>());
+    _vx = v_abs(x);
+    _vy = v_mul(_vx, v_cephes_FOPI);
 
-        v_float64 poly_mask = v_reinterpret_as_f64(v_eq(v_and(emm2, vx_setall_s64(2)), vx_setall_s64(0)));
+    emm2 = v_expand_low(v_trunc(_vy));
+    emm2 = v_add(emm2, v_setall_<_TpVec64S>((int64)1));
+    emm2 = v_and(emm2, v_setall_<_TpVec64S>((int64)~1));
+    _vy = v_cvt_f64(emm2);
 
-        _vx = v_fma(_vy, v_minus_DP1, _vx);
-        _vx = v_fma(_vy, v_minus_DP2, _vx);
-        _vx = v_fma(_vy, v_minus_DP3, _vx);
+    _TpVec64F poly_mask = v_reinterpret_as_f64(v_eq(v_and(emm2, v_setall_<_TpVec64S>((int64)2)), v_setall_<_TpVec64S>((int64)0)));
 
-        sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f64(v_eq(v_and(emm2, vx_setall_s64(4)), vx_setall_s64(0))));
-        sign_mask_cos = v_reinterpret_as_f64(v_eq(v_and(v_sub(emm2, vx_setall_s64(2)), vx_setall_s64(4)), vx_setall_s64(0)));
+    _vx = v_fma(_vy, v_minus_DP1, _vx);
+    _vx = v_fma(_vy, v_minus_DP2, _vx);
+    _vx = v_fma(_vy, v_minus_DP3, _vx);
 
-        v_float64 _vxx = v_mul(_vx, _vx);
-        v_float64 y1, y2;
+    sign_mask_sin = v_xor(sign_mask_sin, v_reinterpret_as_f64(v_eq(v_and(emm2, v_setall_<_TpVec64S>((int64)4)), v_setall_<_TpVec64S>((int64)0))));
+    sign_mask_cos = v_reinterpret_as_f64(v_eq(v_and(v_sub(emm2, v_setall_<_TpVec64S>((int64)2)), v_setall_<_TpVec64S>((int64)4)), v_setall_<_TpVec64S>((int64)0)));
 
-        y1 = v_fma(v_cos_C1, _vxx, v_cos_C2);
-        y1 = v_fma(y1, _vxx, v_cos_C3);
-        y1 = v_fma(y1, _vxx, v_cos_C4);
-        y1 = v_fma(y1, _vxx, v_cos_C5);
-        y1 = v_fma(y1, _vxx, v_cos_C6);
-        y1 = v_fma(y1, _vxx, vx_setall_f64(-0.5));
-        y1 = v_fma(y1, _vxx, vx_setall_f64(1.0));
+    _TpVec64F _vxx = v_mul(_vx, _vx);
+    _TpVec64F y1, y2;
 
-        y2 = v_fma(v_sin_C1, _vxx, v_sin_C2);
-        y2 = v_fma(y2, _vxx, v_sin_C3);
-        y2 = v_fma(y2, _vxx, v_sin_C4);
-        y2 = v_fma(y2, _vxx, v_sin_C5);
-        y2 = v_fma(y2, _vxx, v_sin_C6);
-        y2 = v_mul(y2, _vxx);
-        y2 = v_fma(y2, _vx, _vx);
+    y1 = v_fma(v_cos_C1, _vxx, v_cos_C2);
+    y1 = v_fma(y1, _vxx, v_cos_C3);
+    y1 = v_fma(y1, _vxx, v_cos_C4);
+    y1 = v_fma(y1, _vxx, v_cos_C5);
+    y1 = v_fma(y1, _vxx, v_cos_C6);
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec64F>(-0.5));
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec64F>(1.0));
 
-        ysin = v_select(poly_mask, y2, y1);
-        ycos = v_select(poly_mask, y1, y2);
-        ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
-        ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
+    y2 = v_fma(v_sin_C1, _vxx, v_sin_C2);
+    y2 = v_fma(y2, _vxx, v_sin_C3);
+    y2 = v_fma(y2, _vxx, v_sin_C4);
+    y2 = v_fma(y2, _vxx, v_sin_C5);
+    y2 = v_fma(y2, _vxx, v_sin_C6);
+    y2 = v_mul(y2, _vxx);
+    y2 = v_fma(y2, _vx, _vx);
 
-        // sincos(NAN) -> NAN, sincos(±INF) -> NAN
-        v_float64 mask_inf = v_eq(_vx, v_reinterpret_as_f64(vx_setall_s64(0x7ff0000000000000)));
-        v_float64 mask_nan = v_or(mask_inf, v_ne(x, x));
-        ysin = v_select(mask_nan, v_nan, ysin);
-        ycos = v_select(mask_nan, v_nan, ycos);
-    }
+    ysin = v_select(poly_mask, y2, y1);
+    ycos = v_select(poly_mask, y1, y2);
+    ysin = v_select(sign_mask_sin, ysin, v_xor(v_neg_zero, ysin));
+    ycos = v_select(sign_mask_cos, v_xor(v_neg_zero, ycos), ycos);
 
-    inline v_float64 v_sin(const v_float64 &x)
-    {
-        v_float64 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ysin;
-    }
+    // sincos(NAN) -> NAN, sincos(±INF) -> NAN
+    _TpVec64F mask_inf = v_eq(_vx, v_reinterpret_as_f64(v_setall_<_TpVec64S>((int64)0x7ff0000000000000)));
+    _TpVec64F mask_nan = v_or(mask_inf, v_ne(x, x));
+    ysin = v_select(mask_nan, v_nan, ysin);
+    ycos = v_select(mask_nan, v_nan, ycos);
+}
 
-    inline v_float64 v_cos(const v_float64 &x)
-    {
-        v_float64 ysin, ycos;
-        v_sincos(x, ysin, ycos);
-        return ycos;
-    }
-#endif // CV_SIMD_64F || CV_SIMD_SCALABLE_64F
+template<typename _TpVec64F, typename _TpVec64S>
+inline _TpVec64F v_sin_default_64f(const _TpVec64F &x) {
+    _TpVec64F ysin, ycos;
+    v_sincos_default_64f<_TpVec64F, _TpVec64S>(x, ysin, ycos);
+    return ysin;
+}
+
+template<typename _TpVec64F, typename _TpVec64S>
+inline _TpVec64F v_cos_default_64f(const _TpVec64F &x) {
+    _TpVec64F ysin, ycos;
+    v_sincos_default_64f<_TpVec64F, _TpVec64S>(x, ysin, ycos);
+    return ycos;
+}
+
 //! @}
-#define OPENCV_HAL_MATH_HAVE_SINCOS 1
-#endif // OPENCV_HAL_MATH_HAVE_SINCOS
+
 
 /* This implementation is derived from the approximation approach of Error Function (Erf) from PyTorch
    https://github.com/pytorch/pytorch/blob/9c50ecc84b9a6e699a7f058891b889aafbf976c7/aten/src/ATen/cpu/vec/vec512/vec512_float.h#L189-L220

--- a/modules/core/include/opencv2/core/hal/intrin_math.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_math.hpp
@@ -449,7 +449,7 @@ inline void v_sincos_default_16f(const _TpVec16F &x, _TpVec16F &ysin, _TpVec16F 
     y1 = v_fma(v_coscof_p0, _vxx, v_coscof_p1);
     y1 = v_fma(y1, _vxx, v_coscof_p2);
     y1 = v_fma(y1, _vxx, v_setall_<_TpVec16F>(hfloat(-0.5f)));
-    y1 = v_fma(y1, _vxx, v_setall_<_TpVec16F>(hfloat(1)));
+    y1 = v_fma(y1, _vxx, v_setall_<_TpVec16F>(hfloat(1.f)));
 
     y2 = v_fma(v_sincof_p0, _vxx, v_sincof_p1);
     y2 = v_fma(y2, _vxx, v_sincof_p2);
@@ -471,7 +471,7 @@ inline void v_sincos_default_16f(const _TpVec16F &x, _TpVec16F &ysin, _TpVec16F 
 template<typename _TpVec16F, typename _TpVec16S>
 inline _TpVec16F v_sin_default_16f(const _TpVec16F &x) {
     _TpVec16F ysin, ycos;
-    v_sincos_default_16f<_TpVec16F, _TpVec16S>()(x, ysin, ycos);
+    v_sincos_default_16f<_TpVec16F, _TpVec16S>(x, ysin, ycos);
     return ysin;
 }
 

--- a/modules/core/include/opencv2/core/hal/intrin_msa.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_msa.hpp
@@ -1864,15 +1864,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x4& v)
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_msa.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_msa.hpp
@@ -1866,10 +1866,16 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -2650,21 +2650,21 @@ inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
 #if defined(CV_SIMD_FP16) && CV_SIMD_FP16
-inline v_float16x8 v_exp(v_float16x8 x) { return v_exp_default_16f<v_float16x8, v_int16x8>(x); }
-inline v_float16x8 v_log(v_float16x8 x) { return v_log_default_16f<v_float16x8, v_int16x8>(x); }
+inline v_float16x8 v_exp(const v_float16x8& x) { return v_exp_default_16f<v_float16x8, v_int16x8>(x); }
+inline v_float16x8 v_log(const v_float16x8& x) { return v_log_default_16f<v_float16x8, v_int16x8>(x); }
 inline void v_sincos(const v_float16x8& x, v_float16x8& s, v_float16x8& c) { v_sincos_default_16f<v_float16x8, v_int16x8>(x, s, c); }
 inline v_float16x8 v_sin(const v_float16x8& x) { return v_sin_default_16f<v_float16x8, v_int16x8>(x); }
 inline v_float16x8 v_cos(const v_float16x8& x) { return v_cos_default_16f<v_float16x8, v_int16x8>(x); }
 #endif
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 #if CV_SIMD128_64F
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -2652,13 +2652,22 @@ inline void v_cleanup() {}
 #if defined(CV_SIMD_FP16) && CV_SIMD_FP16
 inline v_float16x8 v_exp(v_float16x8 x) { return v_exp_default_16f<v_float16x8, v_int16x8>(x); }
 inline v_float16x8 v_log(v_float16x8 x) { return v_log_default_16f<v_float16x8, v_int16x8>(x); }
+inline void v_sincos(const v_float16x8& x, v_float16x8& s, v_float16x8& c) { v_sincos_default_16f<v_float16x8, v_int16x8>(x, s, c); }
+inline v_float16x8 v_sin(const v_float16x8& x) { return v_sin_default_16f<v_float16x8, v_int16x8>(x); }
+inline v_float16x8 v_cos(const v_float16x8& x) { return v_cos_default_16f<v_float16x8, v_int16x8>(x); }
 #endif
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 #if CV_SIMD128_64F
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 #endif
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END

--- a/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
@@ -2867,15 +2867,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x4& v)
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
@@ -2869,10 +2869,16 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -2183,10 +2183,16 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32 v_exp(v_float32 x) { return v_exp_default_32f<v_float32, v_int32>(x); }
 inline v_float32 v_log(v_float32 x) { return v_log_default_32f<v_float32, v_int32>(x); }
+inline void v_sincos(const v_float32& x, v_float32& s, v_float32& c) { v_sincos_default_32f<v_float32, v_int32>(x, s, c); }
+inline v_float32 v_sin(const v_float32& x) { return v_sin_default_32f<v_float32, v_int32>(x); }
+inline v_float32 v_cos(const v_float32& x) { return v_cos_default_32f<v_float32, v_int32>(x); }
 inline v_float32 v_erf(v_float32 x) { return v_erf_default_32f<v_float32, v_int32>(x); }
 
 inline v_float64 v_exp(v_float64 x) { return v_exp_default_64f<v_float64, v_int64>(x); }
 inline v_float64 v_log(v_float64 x) { return v_log_default_64f<v_float64, v_int64>(x); }
+inline void v_sincos(const v_float64& x, v_float64& s, v_float64& c) { v_sincos_default_64f<v_float64, v_int64>(x, s, c); }
+inline v_float64 v_sin(const v_float64& x) { return v_sin_default_64f<v_float64, v_int64>(x); }
+inline v_float64 v_cos(const v_float64& x) { return v_cos_default_64f<v_float64, v_int64>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -2181,15 +2181,15 @@ inline v_float32 v_matmuladd(const v_float32& v, const v_float32& m0,
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32 v_exp(v_float32 x) { return v_exp_default_32f<v_float32, v_int32>(x); }
-inline v_float32 v_log(v_float32 x) { return v_log_default_32f<v_float32, v_int32>(x); }
+inline v_float32 v_exp(const v_float32& x) { return v_exp_default_32f<v_float32, v_int32>(x); }
+inline v_float32 v_log(const v_float32& x) { return v_log_default_32f<v_float32, v_int32>(x); }
 inline void v_sincos(const v_float32& x, v_float32& s, v_float32& c) { v_sincos_default_32f<v_float32, v_int32>(x, s, c); }
 inline v_float32 v_sin(const v_float32& x) { return v_sin_default_32f<v_float32, v_int32>(x); }
 inline v_float32 v_cos(const v_float32& x) { return v_cos_default_32f<v_float32, v_int32>(x); }
-inline v_float32 v_erf(v_float32 x) { return v_erf_default_32f<v_float32, v_int32>(x); }
+inline v_float32 v_erf(const v_float32& x) { return v_erf_default_32f<v_float32, v_int32>(x); }
 
-inline v_float64 v_exp(v_float64 x) { return v_exp_default_64f<v_float64, v_int64>(x); }
-inline v_float64 v_log(v_float64 x) { return v_log_default_64f<v_float64, v_int64>(x); }
+inline v_float64 v_exp(const v_float64& x) { return v_exp_default_64f<v_float64, v_int64>(x); }
+inline v_float64 v_log(const v_float64& x) { return v_log_default_64f<v_float64, v_int64>(x); }
 inline void v_sincos(const v_float64& x, v_float64& s, v_float64& c) { v_sincos_default_64f<v_float64, v_int64>(x, s, c); }
 inline v_float64 v_sin(const v_float64& x) { return v_sin_default_64f<v_float64, v_int64>(x); }
 inline v_float64 v_cos(const v_float64& x) { return v_cos_default_64f<v_float64, v_int64>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -3460,15 +3460,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x4& v)
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -3462,10 +3462,17 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
+
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -1597,15 +1597,15 @@ inline Tvec v_broadcast_element(const Tvec& v)
 { return Tvec(vec_splat(v.val, i)); }
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -1599,10 +1599,16 @@ inline Tvec v_broadcast_element(const Tvec& v)
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
@@ -2772,10 +2772,16 @@ inline void v_cleanup() {}
 #include "intrin_math.hpp"
 inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
+inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
 inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
+inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
@@ -2770,15 +2770,15 @@ inline void v_pack_store(hfloat* ptr, const v_float32x4& v)
 inline void v_cleanup() {}
 
 #include "intrin_math.hpp"
-inline v_float32x4 v_exp(v_float32x4 x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_log(v_float32x4 x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_exp(const v_float32x4& x) { return v_exp_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_log(const v_float32x4& x) { return v_log_default_32f<v_float32x4, v_int32x4>(x); }
 inline void v_sincos(const v_float32x4& x, v_float32x4& s, v_float32x4& c) { v_sincos_default_32f<v_float32x4, v_int32x4>(x, s, c); }
 inline v_float32x4 v_sin(const v_float32x4& x) { return v_sin_default_32f<v_float32x4, v_int32x4>(x); }
 inline v_float32x4 v_cos(const v_float32x4& x) { return v_cos_default_32f<v_float32x4, v_int32x4>(x); }
-inline v_float32x4 v_erf(v_float32x4 x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
+inline v_float32x4 v_erf(const v_float32x4& x) { return v_erf_default_32f<v_float32x4, v_int32x4>(x); }
 
-inline v_float64x2 v_exp(v_float64x2 x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
-inline v_float64x2 v_log(v_float64x2 x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_exp(const v_float64x2& x) { return v_exp_default_64f<v_float64x2, v_int64x2>(x); }
+inline v_float64x2 v_log(const v_float64x2& x) { return v_log_default_64f<v_float64x2, v_int64x2>(x); }
 inline void v_sincos(const v_float64x2& x, v_float64x2& s, v_float64x2& c) { v_sincos_default_64f<v_float64x2, v_int64x2>(x, s, c); }
 inline v_float64x2 v_sin(const v_float64x2& x) { return v_sin_default_64f<v_float64x2, v_int64x2>(x); }
 inline v_float64x2 v_cos(const v_float64x2& x) { return v_cos_default_64f<v_float64x2, v_int64x2>(x); }

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -1939,7 +1939,7 @@ template<typename R> struct TheTest
             v_sincos(x, s, c);
             Data<R> resSin = s, resCos = c;
             for (int j = 0; j < n; ++j) {
-                SCOPED_TRACE(cv::format("Random test value: %f", (double) dataRand[j]));
+                SCOPED_TRACE(cv::format("Random test value: %lf", (double) dataRand[j]));
                 LaneType std_sin = (LaneType) std::sin(dataRand[j]);
                 LaneType std_cos = (LaneType) std::cos(dataRand[j]);
                 // input NaN, +INF, -INF -> output NaN


### PR DESCRIPTION
This PR aims to implement `v_sincos(v_float16 x)`, `v_sincos(v_float32 x)` and `v_sincos(v_float64 x)`. 
Merged after https://github.com/opencv/opencv/pull/25891 and https://github.com/opencv/opencv/pull/26023

**NOTE:** 
Also, the patch changes already added `v_exp`, `v_log` and `v_erf` to pass parameters by reference instead of by value, to match API of other universal intrinsics.

TODO:
- [x] double and half float precision
- [x] tests for them
- [x] doc to explain the implementation

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
