### PR TITLE
imgproc: reduce template sizes in templMatch test

### DIFF
--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -318,7 +318,7 @@ TEST_P(matchTemplate_Modes, accuracy)
         SCOPED_TRACE(cv::format("iteration %d", ITER));
 
         const Size imgSize(rng.uniform(128, 320), rng.uniform(128, 240));
-        const Size templSize(rng.uniform(1, 100), rng.uniform(1, 100));
+        const Size templSize(rng.uniform(1, 30), rng.uniform(1, 30));
         Mat img(imgSize, data_type, Scalar::all(0));
         Mat templ(templSize, data_type, Scalar::all(0));
         cvtest::randUni(rng, img, Scalar::all(0), Scalar::all(255));


### PR DESCRIPTION
Fix after #25842

New rewritten `templMatch` test takes too long on slow platforms (RISC-V via QEMU). Reduced template sizes to speed up the test (150 sec -> 25 sec with x86_64 Debug configuration).