### PR TITLE
js/build_js.py: Cleanup emcc build flags

### DIFF
--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -280,11 +280,10 @@ if __name__ == "__main__":
         builder.clean_build_dir()
 
     if not args.skip_config:
-        target = "default target"
-        if args.build_wasm:
-            target = "wasm"
-        elif args.disable_wasm:
+        if args.disable_wasm:
             target = "asm.js"
+        else:
+            target = "wasm"
         log.info("=====")
         log.info("===== Config OpenCV.js build for %s" % target)
         log.info("=====")

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -177,25 +177,21 @@ class Builder:
 
     def get_build_flags(self):
         flags = ""
-        if self.options.build_wasm:
-            flags += "-s WASM=1 "
-        elif self.options.disable_wasm:
-            flags += "-s WASM=0 "
+        if self.options.disable_wasm:
+            flags += "-sWASM=0 "
         if not self.options.disable_single_file:
-            flags += "-s SINGLE_FILE=1 "
+            flags += "-sSINGLE_FILE "
         if self.options.threads:
-            flags += "-s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 "
-        else:
-            flags += "-s USE_PTHREADS=0 "
+            flags += "-pthread -sPTHREAD_POOL_SIZE=4 "
         if self.options.enable_exception:
-            flags += "-s DISABLE_EXCEPTION_CATCHING=0 "
+            flags += "-sDISABLE_EXCEPTION_CATCHING=0 "
         if self.options.simd:
             flags += "-msimd128 "
         if self.options.build_flags:
             flags += self.options.build_flags + " "
         if self.options.webnn:
-            flags += "-s USE_WEBNN=1 "
-        flags += "-s EXPORTED_FUNCTIONS=\"['_malloc', '_free']\""
+            flags += "-sUSE_WEBNN "
+        flags += "-sEXPORTED_FUNCTIONS=_malloc,_free"
         return flags
 
     def config(self):
@@ -237,7 +233,6 @@ if __name__ == "__main__":
     parser.add_argument("build_dir", help="Building directory (and output)")
     parser.add_argument('--opencv_dir', default=opencv_dir, help='Opencv source directory (default is "../.." relative to script location)')
     parser.add_argument('--emscripten_dir', default=emscripten_dir, help="Path to Emscripten to use for build (deprecated in favor of 'emcmake' launcher)")
-    parser.add_argument('--build_wasm', action="store_true", help="Build OpenCV.js in WebAssembly format")
     parser.add_argument('--disable_wasm', action="store_true", help="Build OpenCV.js in Asm.js format")
     parser.add_argument('--disable_single_file', action="store_true", help="Do not merge JavaScript and WebAssembly into one single file")
     parser.add_argument('--threads', action="store_true", help="Build OpenCV.js with threads optimization")


### PR DESCRIPTION
- Use simplified list format for `-sEXPORTED_FUNCTIONS`
- Avoid spaces between `-s` and the setting name
- Avoid redundant =1 suffix
- Avoid redundant default settings such as `-sWASM=1`
- Remove `--build_wasm` command line flag (this has been the default for many years now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js:22.04-3.1.64
build_image:Custom=javascript:3.1.64
Xbuild_image:Custom=javascript
buildworker:Custom=linux-4
buildworker:Docs=linux-4
```