### PR TITLE
Suppressed uncommended debug printout in chessboard.cpp

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -3373,7 +3373,7 @@ cv::Scalar Chessboard::Board::calcEdgeSharpness(cv::InputArray _img,float rise_d
     }
     if(count == 0)
     {
-        std::cout  <<"calcEdgeSharpness: checkerboard too small for calculation." << std::endl;
+        // std::cout  <<"calcEdgeSharpness: checkerboard too small for calculation." << std::endl;
         return cv::Scalar::all(9999);
     }
     sharpness = sharpness/float(count);


### PR DESCRIPTION
This is a one-line PR to suppress a very annoying message to stdout (the return value works) which looks like it was missed during some debugging. There was no bug report, and default CI testing should be sufficient since nothing of substance has changed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
