### PR TITLE
throw() -> noexcept

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -123,12 +123,12 @@ public:
      Instead, the macros CV_Error(), CV_Error_() and CV_Assert() are used.
     */
     Exception(int _code, const String& _err, const String& _func, const String& _file, int _line);
-    virtual ~Exception() throw();
+    virtual ~Exception() CV_NOEXCEPT;
 
     /*!
      \return the error description and the context as a text string.
     */
-    virtual const char *what() const throw() CV_OVERRIDE;
+    virtual const char *what() const CV_NOEXCEPT CV_OVERRIDE;
     void formatMessage();
 
     String msg; ///< the formatted error message

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -318,12 +318,12 @@ Exception::Exception(int _code, const String& _err, const String& _func, const S
     formatMessage();
 }
 
-Exception::~Exception() throw() {}
+Exception::~Exception() CV_NOEXCEPT {}
 
 /*!
  \return the error description and the context as a text string.
  */
-const char* Exception::what() const throw() { return msg.c_str(); }
+const char* Exception::what() const CV_NOEXCEPT { return msg.c_str(); }
 
 void Exception::formatMessage()
 {

--- a/modules/videoio/src/cap_gphoto2.cpp
+++ b/modules/videoio/src/cap_gphoto2.cpp
@@ -65,7 +65,7 @@ public:
         result = gPhoto2Result;
         method = methodStr;
     }
-    virtual const char * what() const throw() CV_OVERRIDE
+    virtual const char * what() const CV_NOEXCEPT CV_OVERRIDE
     {
         return gp_result_as_string(result);
     }


### PR DESCRIPTION
`throw()` was deprecated in C++11 and eliminated in C++17. `noexcept` is the appropriate replacement.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
