### PR TITLE
Fix Reduce layer for cosnt inputs

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1209,6 +1209,15 @@ void ONNXImporter::parseReduce(LayerParams& layerParams, const opencv_onnx::Node
         for (int i = 0; i < num_axes; ++i)
             axes[i] = mat_axes.at<int>(i);
         layerParams.set("axes", DictValue::arrayInt(&axes[0], num_axes));
+        if (constBlobs.find(node_proto.input(0)) != constBlobs.end()){
+            std::vector<Mat> inputs, output;
+            inputs.push_back(getBlob(node_proto, 0));
+            layerParams.type = "Reduce";
+            runLayer(layerParams, inputs, output);
+            CV_Assert(output.size() == 1);
+            addConstant(node_proto.output(0), output[0]);
+            return;
+        }
     }
 
     layerParams.type = "Reduce";

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1168,6 +1168,7 @@ void ONNXImporter::parseGlobalPool(LayerParams &layerParams, const opencv_onnx::
 
 void ONNXImporter::parseReduce(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
+    layerParams.type = "Reduce";
     const auto& op_type = node_proto.op_type();
     String reduce_type;
     if (op_type == "ReduceMax")
@@ -1212,7 +1213,6 @@ void ONNXImporter::parseReduce(LayerParams& layerParams, const opencv_onnx::Node
         if (constBlobs.find(node_proto.input(0)) != constBlobs.end()){
             std::vector<Mat> inputs, output;
             inputs.push_back(getBlob(node_proto, 0));
-            layerParams.type = "Reduce";
             runLayer(layerParams, inputs, output);
             CV_Assert(output.size() == 1);
             addConstant(node_proto.output(0), output[0]);
@@ -1220,7 +1220,6 @@ void ONNXImporter::parseReduce(LayerParams& layerParams, const opencv_onnx::Node
         }
     }
 
-    layerParams.type = "Reduce";
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1549,6 +1549,10 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
     testONNXModels("einsum_const_inputs", npy, 0, 0, false, false, 1);
 }
 
+TEST_P(Test_ONNX_layers, ReduceSum_Consts){
+    testONNXModels("reducesum_consts");
+}
+
 TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 {
     testONNXModels("ReflectionPad2d");


### PR DESCRIPTION
### Pull Request Readiness Checklist

This PR adds support for const inputs for reducing the layer. Particularly, it fixes the following case. The test model and data are located in [1194](https://github.com/opencv/opencv_extra/pull/1194)

<img width="190" alt="image" src="https://github.com/user-attachments/assets/45a90f0a-b798-4529-bece-24c7bfc9e7ba">


See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
