### PR TITLE
Added missing CV_32S support to separable filter

### DIFF
--- a/modules/imgproc/src/filter.simd.hpp
+++ b/modules/imgproc/src/filter.simd.hpp
@@ -2987,6 +2987,8 @@ Ptr<BaseRowFilter> getLinearRowFilter(
                                   (kernel, anchor, RowVec_16s32f(kernel));
     if( sdepth == CV_16S && ddepth == CV_64F )
         return makePtr<RowFilter<short, double, RowNoVec> >(kernel, anchor);
+    if( sdepth == CV_32S && ddepth == CV_32F )
+        return makePtr<RowFilter<int, float, RowNoVec> >(kernel, anchor);
     if( sdepth == CV_32F && ddepth == CV_32F )
         return makePtr<RowFilter<float, float, RowVec_32f> >
             (kernel, anchor, RowVec_32f(kernel));
@@ -3083,6 +3085,9 @@ Ptr<BaseColumnFilter> getLinearColumnFilter(
                   SymmColumnVec_32f16s(kernel, symmetryType, 0, delta));
         if( ddepth == CV_16S && sdepth == CV_64F )
             return makePtr<SymmColumnFilter<Cast<double, short>, ColumnNoVec> >
+                (kernel, anchor, delta, symmetryType);
+        if( ddepth == CV_32S && sdepth == CV_32F )
+            return makePtr<SymmColumnFilter<Cast<float, int>, ColumnNoVec> >
                 (kernel, anchor, delta, symmetryType);
         if( ddepth == CV_32F && sdepth == CV_32F )
             return makePtr<SymmColumnFilter<Cast<float, float>, SymmColumnVec_32f> >


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
