### PR TITLE
DNN: add tensorrt backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,9 @@ OCV_OPTION(WITH_ONNX "Include Microsoft ONNX Runtime support" OFF
 OCV_OPTION(WITH_TIMVX "Include Tim-VX support" OFF
   VISIBLE_IF TRUE
   VERIFY HAVE_TIMVX)
+OCV_OPTION(WITH_TRT "Include TensorRT support" OFF
+  VISIBLE_IF TRUE
+  VERIFY HAVE_TRT)
 # Attention when OBSENSOR_USE_ORBBEC_SDK set to off:
 #   Astra2 cameras currently only support Windows and Linux kernel versions no higher than 4.15, and higher versions of Linux kernel may have exceptions.
 OCV_OPTION(OBSENSOR_USE_ORBBEC_SDK "Use Orbbec SDK as backend to support more camera models and platforms (force to ON on MacOS)" OFF)
@@ -842,6 +845,9 @@ if(WITH_TIMVX)
 endif()
 if(WITH_CANN)
   include(cmake/OpenCVFindCANN.cmake)
+endif()
+if(WITH_TRT)
+  include(cmake/OpenCVFindTRT.cmake)
 endif()
 
 # ----------------------------------------------------------------------------
@@ -1901,6 +1907,16 @@ if(WITH_TIMVX)
     status("    Include path"  TIMVX_INCLUDE_DIR THEN "${TIMVX_INCLUDE_DIR}" ELSE "NO")
     status("    Link libraries:" TIMVX_LIBRARY THEN "${TIMVX_LIBRARY}" ELSE "NO")
     status("    VIVANTE SDK path" VIVANTE_SDK_DIR THEN "${VIVANTE_SDK_DIR}" ELSE "NO")
+  endif()
+endif()
+
+if(WITH_TRT)
+  status("")
+  status("  TensorRT:"     HAVE_TRT THEN "YES" ELSE "NO")
+  if(HAVE_TRT)
+    status("    TensorRT include:"  TRT_SDK_INC THEN "${TRT_SDK_INC}" ELSE "NO")
+    status("    TensorRT lib:" TRT_SDK_LIB THEN "${TRT_SDK_LIB}" ELSE "NO")
+    status("    CUDAToolkit_VERSION:" TRT_SDK_LIB THEN "${CUDAToolkit_VERSION}" ELSE "NO")
   endif()
 endif()
 

--- a/cmake/OpenCVFindTRT.cmake
+++ b/cmake/OpenCVFindTRT.cmake
@@ -1,0 +1,34 @@
+set(TRT_SDK "" CACHE PATH "TensorRT SDK directory.")
+
+find_package(CUDAToolkit)
+
+if(CUDAToolkit_FOUND)
+  message ( STATUS  "TensorRT backend: CUDAToolkit_FOUND=${CUDAToolkit_FOUND}!")
+  message ( STATUS  "TensorRT backend: CUDAToolkit_VERSION=${CUDAToolkit_VERSION}" )
+else()
+  message(STATUS "TensorRT backend: CAN NOT found CUDAToolkit! Please check if enviroment has the CUDA_PATH!")
+endif()
+
+set(TRT_SDK_LIB_PATH "${TRT_SDK}/lib")
+set(TRT_SDK_INC "${TRT_SDK}/include")
+
+find_library(TRT_SDK_LIB "nvinfer" PATHS "${TRT_SDK_LIB_PATH}" NO_DEFAULT_PATH)
+find_library(TRT_SDK_LIB_ONNX "nvonnxparser" PATHS "${TRT_SDK_LIB_PATH}" NO_DEFAULT_PATH)
+
+set(TRT_FOUND 0)
+if(TRT_SDK_LIB AND TRT_SDK_LIB_ONNX AND CUDAToolkit_FOUND)
+  set(TRT_FOUND 1)
+else()
+  message(STATUS "TensorRT backend: Failed to find nvinfer in ${TRT_SDK_LIB_PATH}. Please note that ${TRT_SDK} must contain the lib and include folder! Turning off TensorRT backend!")
+  set(TRT_FOUND 0)
+endif()
+
+if(TRT_FOUND)
+  set(HAVE_TRT 1)
+endif()
+
+MARK_AS_ADVANCED(
+  TRT_SDK_INC
+  TRT_SDK_LIB
+  TRT_SDK_LIB_ONNX
+)

--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -28,6 +28,9 @@
 /* Clp support */
 #cmakedefine HAVE_CLP
 
+/* TensorRT support */
+#cmakedefine HAVE_TRT
+
 /* NVIDIA CUDA Runtime API*/
 #cmakedefine HAVE_CUDA
 

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -35,6 +35,10 @@ if(HAVE_CANN)
   ocv_target_compile_definitions(${the_module} PRIVATE "HAVE_CANN=1")
 endif()
 
+if(HAVE_TRT)
+  ocv_target_compile_definitions(${the_module} PRIVATE "HAVE_TRT=1")
+endif()
+
 ocv_option(OPENCV_DNN_CUDA "Build with CUDA support"
     HAVE_CUDA
     AND HAVE_CUBLAS
@@ -194,6 +198,16 @@ if(NOT EMSCRIPTEN)
   endif()
 endif()
 
+# Include and Link TensorRT
+if(HAVE_TRT)
+  message(STATUS "Find TensorRT, and add it to dnn.")
+  message(STATUS "TRT_SDK_INC : ${TRT_SDK_INC}")
+  message(STATUS "TRT_SDK_LIB : ${TRT_SDK_LIB}")
+  message(STATUS "TRT_SDK_LIB_ONNX : ${TRT_SDK_LIB_ONNX}") # ONNX model parser
+  list(APPEND include_dirs ${TRT_SDK_INC})
+  list(APPEND libs ${TRT_SDK_LIB} ${TRT_SDK_LIB_ONNX} CUDA::cudart CUDA::npps CUDA::nppial CUDA::nppidei)
+endif()
+
 ocv_module_include_directories(${include_dirs})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   ocv_append_source_files_cxx_compiler_options(fw_srcs "-Wno-suggest-override")  # GCC
@@ -215,7 +229,7 @@ set(dnn_plugin_srcs ${dnn_srcs} ${dnn_int_hdrs})
 ocv_list_filterout_ex(dnn_plugin_srcs
     "/src/dnn.cpp$|/src/dnn_utils.cpp$|/src/dnn_utils.cpp$|/src/dnn_read.cpp$|/src/registry.cpp$|/src/backend.cpp$"
     # importers
-    "/src/(caffe|darknet|onnx|tensorflow|torch)/"
+    "/src/(caffe|darknet|onnx|tensorflow|torch|tensorrt)/"
     # executors
     "/src/(cuda|cuda4dnn|ocl4dnn|vkcom|webnn)/"
 )

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -80,6 +80,7 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_BACKEND_WEBNN,
         DNN_BACKEND_TIMVX,
         DNN_BACKEND_CANN,
+        DNN_BACKEND_TENSORRT,
 #if defined(__OPENCV_BUILD) || defined(BUILD_PLUGIN)
 #if !defined(OPENCV_BINDING_PARSER)
         DNN_BACKEND_INFERENCE_ENGINE_NGRAPH = 1000000,     // internal - use DNN_BACKEND_INFERENCE_ENGINE + setInferenceEngineBackendType()
@@ -105,6 +106,7 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_TARGET_HDDL,
         DNN_TARGET_NPU,
         DNN_TARGET_CPU_FP16, // Only the ARM platform is supported. Low precision computing, accelerate model inference.
+        DNN_TARGET_TENSORRT,
     };
 
     /**
@@ -1119,6 +1121,36 @@ CV__DNN_INLINE_NS_BEGIN
      *        in failure cases.
      */
     CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer);
+
+     /** @brief This struct contains all the configuration of TensorRT backend.
+      */
+    struct CV_EXPORTS_W_SIMPLE TrtConfig
+    {
+        CV_PROP_RW int deviceId;      //!< Running TensorRT with specific GPU
+        CV_PROP_RW bool useCache;     //!< It will speed up the ONNX model initialization. Write back the converted trt file to where the input model is located.
+        CV_PROP_RW char* cachePath;   //!< Setting the path to write back the converted .trt file to specific path instead of the input file location.
+        CV_PROP_RW bool useFP16;      //!< Inference model with FP16, need hardware supports FP16, it may affect the accuracy.
+        CV_PROP_RW bool useTimeCache; //!< To speed up the ONNX -> trt converting processing, it will write the time cache file to cachePath.
+        CV_PROP_RW char* inputName;            //!< Setting the input name and shape to convert dynamic shape ONNX to trt. Current only support single input.
+        CV_PROP_RW std::vector<int> inputShape;//!< Setting the specific input shape.
+        
+        TrtConfig();
+
+        // create Trt config by default config.
+        TrtConfig(TrtConfig& config);
+
+        TrtConfig& operator=(const TrtConfig config);
+    };
+
+    /** @brief Reads a trt model directly or <a href="https://onnx.ai/">ONNX</a>.
+     *  @param trtFile path to the original .onnx file or converted .trt file.
+     *  @returns Network object that ready to do forward, throw an exception in failure cases.
+     *  @param config model runing config
+     * 
+     *  @note
+     *  When the input is ONNX, it will take few mins to convert the ONNX model to trt first than to read it.
+     */
+    CV_EXPORTS_W Net readNetFromTensorRT(CV_WRAP_FILE_PATH const String &trtFile, const TrtConfig config = TrtConfig());
 
     /** @brief Creates blob from .pb file.
      *  @param path to the .pb file with input tensor.

--- a/modules/dnn/src/dnn_read.cpp
+++ b/modules/dnn/src/dnn_read.cpp
@@ -51,6 +51,10 @@ Net readNet(const String& _model, const String& _config, const String& _framewor
             std::swap(model, config);
         return readNetFromModelOptimizer(config, model);
     }
+    if (framework == "tensorrt" && (modelExt == "onnx" || modelExt == "trt"))
+    {
+        return readNetFromTensorRT(model);
+    }
     if (framework == "onnx" || modelExt == "onnx")
     {
         return readNetFromONNX(model);

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -150,7 +150,6 @@ struct Net::Impl : public detail::NetImplBase
     std::vector<int> getUnconnectedOutLayers() const;
     std::vector<String> getUnconnectedOutLayersNames() /*const*/;
 
-
     void setInputsNames(const std::vector<String>& inputBlobNames);
     void setInputShape(const String& inputName, const MatShape& shape);
     virtual void setInput(InputArray blob, const String& name, double scalefactor, const Scalar& mean);
@@ -158,7 +157,6 @@ struct Net::Impl : public detail::NetImplBase
     void setParam(int layer, int numParam, const Mat& blob);
     std::vector<Ptr<Layer>> getLayerInputs(int layerId) const;
     std::vector<String> getLayerNames() const;
-
 
     // TODO drop?
     void getLayerTypes(std::vector<String>& layersTypes) const;
@@ -222,12 +220,12 @@ struct Net::Impl : public detail::NetImplBase
 
     void forwardToLayer(LayerData& ld, bool clearFlags = true);
 
-    Mat forward(const String& outputName);
-    AsyncArray forwardAsync(const String& outputName);
-    void forward(OutputArrayOfArrays outputBlobs, const String& outputName);
-    void forward(OutputArrayOfArrays outputBlobs,
+    virtual Mat forward(const String& outputName);
+    virtual AsyncArray forwardAsync(const String& outputName);
+    virtual void forward(OutputArrayOfArrays outputBlobs, const String& outputName);
+    virtual void forward(OutputArrayOfArrays outputBlobs,
             const std::vector<String>& outBlobNames);
-    void forward(std::vector<std::vector<Mat>>& outputBlobs,
+    virtual void forward(std::vector<std::vector<Mat>>& outputBlobs,
             const std::vector<String>& outBlobNames);
 
 

--- a/modules/dnn/src/tensorrt/net_tensorrt.cpp
+++ b/modules/dnn/src/tensorrt/net_tensorrt.cpp
@@ -1,0 +1,873 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+
+#include <mutex>
+#include <map>
+#include <cstring> // memcpy
+
+#include "opencv2/dnn/dnn.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
+#include <opencv2/core/utils/logger.hpp>
+#include "net_impl.hpp"
+
+#ifdef HAVE_TRT
+#include <cuda_runtime_api.h>
+#include <NvInfer.h>
+#include <NvOnnxParser.h>
+#include "./trt_utils.h"
+#include "./trt_logger.h"
+#endif
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+#ifdef HAVE_TRT
+#define DNN_TENSORRT_UNSUPPORTED() CV_Error(Error::StsError, "DNN/TenosrRT Backend: unsupported function!")
+
+using namespace dnn_trt;
+
+TrtConfig::TrtConfig(TrtConfig& config)
+{
+    deviceId = config.deviceId;
+    useCache = config.useCache;
+    cachePath = config.cachePath;
+    useFP16 = config.useFP16;
+    useTimeCache = config.useTimeCache;
+    inputShape = config.inputShape;
+    inputName = config.inputName;
+}
+
+TrtConfig::TrtConfig() :deviceId(0), useCache(false), cachePath(nullptr), useFP16(false), useTimeCache(false), inputName(nullptr)
+{}
+
+TrtConfig& TrtConfig::operator=(const TrtConfig config)
+{
+    TrtConfig trtConfig;
+    trtConfig.deviceId = config.deviceId;
+    trtConfig.useCache = config.useCache;
+    trtConfig.cachePath = config.cachePath;
+    trtConfig.useFP16 = config.useFP16;
+    trtConfig.useTimeCache = config.useTimeCache;
+    trtConfig.inputName = config.inputName;
+    trtConfig.inputShape = config.inputShape;
+    return trtConfig;
+}
+
+#define OPT_MAX_WORK_SPACE_SIZE ((size_t)1 << 30)
+
+inline int convertTrt2CVType(const ::nvinfer1::DataType type)
+{
+    int cvType = -1;
+
+    if (::nvinfer1::DataType::kFLOAT == type)
+    {
+        cvType = CV_32F;
+    }
+    else if (::nvinfer1::DataType::kHALF == type)
+    {
+        cvType = CV_16F;
+    }
+    else if (::nvinfer1::DataType::kINT8 == type)
+    {
+        cvType = CV_8S;
+    }
+    else if (::nvinfer1::DataType::kINT32 == type)
+    {
+        cvType = CV_32S;
+    }
+    else if (::nvinfer1::DataType::kUINT8 == type)
+    {
+        cvType = CV_8U;
+    }
+    else
+    {
+        CV_Error(CV_StsError, "TensorRT: Unsupported Trt Tensor type!");
+    }
+
+    return cvType;
+}
+
+// Per TensorRT documentation, logger needs to be a singleton.
+TensorrtLogger& getTensorrtLogger(bool verbose_log = false) 
+{
+    const auto log_level = verbose_log ? nvinfer1::ILogger::Severity::kVERBOSE : nvinfer1::ILogger::Severity::kWARNING;
+    static TensorrtLogger trt_logger(log_level);
+    
+    if (log_level != trt_logger.get_level()) 
+    {
+        trt_logger.set_level(verbose_log ? nvinfer1::ILogger::Severity::kVERBOSE : nvinfer1::ILogger::Severity::kWARNING);
+    }
+    
+    return trt_logger;
+}
+
+class NetImplTrt CV_FINAL : public Net::Impl
+{
+public:
+    typedef Net::Impl Base;
+
+    explicit NetImplTrt(const Ptr<Net::Impl>& basePtr)
+        : Net::Impl()
+    {
+        CV_LOG_INFO(NULL, "Initializing NetImplTrt");
+        basePtr_ = basePtr;
+        init();
+
+        CV_LOG_INFO(NULL, "Finished initializing NetImplTrt");
+    }
+
+    ~NetImplTrt()
+    {
+        for (int i = 0; i < bufferListDevice.size(); i++)
+        {
+            cudaFree(bufferListDevice[i]);
+        }
+
+        cudaStreamDestroy(stream_);
+    }
+
+    void init()
+    {
+        CV_TRACE_FUNCTION();
+        CV_Assert(basePtr_);
+        Net::Impl& base = *basePtr_;
+        CV_Assert(!base.netWasAllocated);
+        CV_Assert(!base.netWasQuantized); // does not support quantized net for now
+        netInputLayer = base.netInputLayer;
+        blobsToKeep = base.blobsToKeep;
+        layers = base.layers;
+        for (MapIdToLayerData::iterator it = layers.begin(); it != layers.end(); it++)
+        {
+            LayerData& ld = it->second;
+            ld.resetAllocation();
+        }
+        layerNameToId = base.layerNameToId;
+        outputNameToId = base.outputNameToId;
+        preferableBackend = DNN_BACKEND_TENSORRT;
+        preferableTarget = DNN_TARGET_TENSORRT; // force using TensorRT
+        hasDynamicShapes = base.hasDynamicShapes;
+        CV_Assert(base.backendWrappers.empty());  //backendWrappers = base.backendWrappers;
+        lastLayerId = base.lastLayerId;
+        netWasAllocated = base.netWasAllocated;
+        netWasQuantized = base.netWasQuantized;
+        fusion = base.fusion;
+    }
+
+    bool empty() const override
+    {
+        return builder_ != nullptr;
+    }
+
+    void setPreferableBackend(Net& net, int backendId) override
+    {
+        if (backendId == preferableBackend)
+            return;  // no-op
+        else
+            CV_Error(Error::StsError, "DNN: Can't switch backend from TensorRT to other");
+        Ptr<Net::Impl>& impl_ptr_ref = accessor::DnnNetAccessor::getImplPtrRef(net);
+        impl_ptr_ref = basePtr_;
+        basePtr_->setPreferableBackend(net, backendId);
+    }
+
+    void setPreferableTarget(int targetId) override
+    {
+        if (targetId != preferableTarget)
+        {
+            CV_Error(Error::StsError, "DNN: Can't switch target from TensorRT to other");
+        }
+    }
+
+    Ptr<BackendWrapper> wrap(Mat& host) override
+    {
+        CV_Error(Error::StsNotImplemented, "DNN: Asynchronous forward is supported for Inference Engine backend only");
+        return Ptr<BackendWrapper>();
+    }
+
+    // void fuseLayers(const std::vector<LayerPin>& blobsToKeep_); // fusion is done in the CANN graph engine
+
+    void initBackend(const std::vector<LayerPin>& blobsToKeep_) override;
+
+    void forwardLayer(LayerData& ld) override;
+
+    void fuseLayers(const std::vector<LayerPin>& ) override
+    {
+        CV_LOG_INFO(NULL, "DNN TensorRT Backend not-implementation, skip the fuseLayers function!");
+    }
+
+    void allocateLayers(const std::vector<LayerPin>& )
+    {
+        CV_LOG_INFO(NULL, "DNN TensorRT Backend not-implementation, skip the allocateLayers function!");
+    }
+
+    void NetImplTrt::setInput(InputArray blob, const String& name, double scalefactor, const Scalar& mean);
+
+    Mat forward(const String& outputName) override;
+
+    void forward(OutputArrayOfArrays outputBlobs, const String& outputName) override;
+
+    void forward(OutputArrayOfArrays outputBlobs, const std::vector<String>& outBlobNames) override;
+
+    void forward(std::vector<std::vector<Mat>>& outputBlobs, const std::vector<String>& outBlobNames) override;
+
+    AsyncArray forwardAsync(const String& outputName) override
+    {
+        CV_Error(Error::StsNotImplemented, "DNN: Asynchronous forward is supported for Inference Engine backend only");
+    }
+
+    // internal readNet function
+    void readNet(const String& model, const TrtConfig& config);
+    void readNet(const char* buffer, size_t sizeBuffer, const String &ext, const TrtConfig& config);
+
+private:
+    // Allocate Host memory and binding to the engine.
+    void allocMem();
+    void tensors2Mats(const std::vector<int>& outputIdxs, std::vector<Mat>& outputMat);
+    
+    int getOutputIndex(const String &name);
+    int getInputIndex(const String& name);
+
+    TrtConfig configTRT;
+    std::vector<int> input_idxs;
+    std::vector<int> output_idxs;
+
+    //<<<<<<<<<<<<<<<<<< Common resource  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    int inputCount = 0;
+    int outputCount = 0;
+    std::vector<std::string> inputNamesString; // reserve model input name.
+    std::vector<std::string> outputNamesString;
+
+    std::vector<MatShape> inputMatShape;
+    std::vector<MatShape> outputMatShape;
+
+    //<<<<<<<<<<<<<<<<<< TensorRT resource  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    std::vector<::nvinfer1::Dims> inputMatShapeTrt;                      //!< The dimensions of the input to the network.
+    std::vector<::nvinfer1::Dims> outputMatShapeTrt;                      //!< The dimensions of the input to the network.
+
+    // The following two buffer list contains both input/output. It orgnizes as input_idxs/output_idxs
+    std::vector<std::pair<AutoBuffer<uchar>, size_t>> bufferListHost; // pointer and size (can be overwritten by user)
+    std::vector<void *> bufferListDevice;                  // pointer to GPU memory
+
+    Ptr<::nvinfer1::IRuntime> runtime_;
+    Ptr<::nvinfer1::ICudaEngine> engine_;
+    Ptr<::nvinfer1::IExecutionContext> context_;
+
+    Ptr<::nvinfer1::IBuilder> builder_;
+    Ptr<::nvinfer1::INetworkDefinition> network_;
+    Ptr<::nvinfer1::IBuilderConfig> config_;
+    const bool verboseLog = false;
+
+    //<<<<<<<<<<<<<<<<<< CUDA resource  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    cudaStream_t stream_ = nullptr;
+    int device_id_;
+    std::string compute_capability_;
+
+    cv::Mutex mutex;
+};
+
+void NetImplTrt::initBackend(const std::vector<LayerPin>& blobsToKeep_)
+{
+    CV_LOG_INFO(NULL, "DNN TensorRT Backend skip the initBackend function!");
+}
+
+void NetImplTrt::forwardLayer(LayerData& ld)
+{
+    CV_LOG_INFO(NULL, "DNN TensorRT Backend skip the forwardLayer function!");
+}
+
+int NetImplTrt::getOutputIndex(const String &name)
+{
+    int indexRes = -1;
+
+    // if the name is empty, we need to check out if the mode only need 1 input,
+    // if it's true, then we set this input as this input.
+    if (name.empty())
+    {
+        CV_Assert(outputNamesString.size() == 1 && "Please set the input name, the default input name can only be used in single input model.");
+        indexRes = 0;
+    }
+
+    // find input index to get shape info.
+    if (indexRes == -1)
+    {
+        auto iter = std::find(outputNamesString.begin(), outputNamesString.end(), name);
+
+        if (iter != outputNamesString.end())
+        {
+            indexRes = iter - outputNamesString.begin();
+        }
+    }
+
+    return indexRes;
+}
+
+int NetImplTrt::getInputIndex(const String& name)
+{
+    int indexRes = -1;
+
+    // if the name is empty, we need to check out if the mode only need 1 input,
+    // if it's true, then we set this input as this input.
+    if (name.empty())
+    {
+        CV_Assert(inputNamesString.size() == 1 && "Please set the input name, the default input name can only be used in single input model.");
+        indexRes = 0;
+    }
+
+    // find input index to get shape info.
+    if (indexRes == -1)
+    {
+        auto iter = std::find(inputNamesString.begin(), inputNamesString.end(), name);
+
+        if (iter != inputNamesString.end())
+        {
+            indexRes = iter - inputNamesString.begin();
+        }
+    }
+
+    return indexRes;
+}
+
+void NetImplTrt::setInput(InputArray blob, const String& name, double scalefactor, const Scalar& mean)
+{
+    // TODO support the scalefactor and mean
+    if (scalefactor != 1.0 || mean != Scalar())
+    {
+        CV_Error(Error::StsUnsupportedFormat, cv::format("DNN TensorRT: Failed to setInput with scalefactor or mean, please use blobFromImage!"));
+    }
+
+    int indexRes = getInputIndex(name);
+    CV_Assert(indexRes != -1 && indexRes < inputCount && "TensorRT Backend: indexRes error called in setInput()!");
+
+    // Trt model has two type of input: shape tensor and execution tensor.
+    bool isShapeTensor = engine_->isShapeInferenceIO(name.c_str());
+    CV_Assert(!isShapeTensor && "DNN TensorRT: Unsupported execution tensor input right now!");
+    Mat blob_ = blob.getMat();
+
+    std::vector<int> tensorShape = inputMatShape[indexRes];
+    std::vector<int> matShape = shape(blob_);
+    size_t totalValueT = total(tensorShape);
+    size_t totalValueM = blob_.total();
+
+    if (totalValueT != totalValueM || tensorShape.size() != matShape.size())
+    {
+        if (tensorShape.size() == 4 && matShape.size() == 4)
+        {
+            CV_LOG_WARNING(NULL, cv::format("The given input shape is [%d x %d x %d x %d], and the expected input shape is [%d x %d x %d x %d]", matShape[0], matShape[1], matShape[2], matShape[3], tensorShape[0], tensorShape[1], tensorShape[2], tensorShape[3]));
+        }
+
+        if (tensorShape.size() == 3 && matShape.size() == 3)
+            CV_LOG_WARNING(NULL, cv::format("The given input shape is [%d x %d x %d], and the expected input shape is [%d x %d x %d]", matShape[0], matShape[1], matShape[2], tensorShape[0], tensorShape[1], tensorShape[2]));
+        CV_Error(CV_StsError, "The input shape dose not match the expacted input shape! \n");
+    }
+
+    int bindingIdx = input_idxs[indexRes];// idx in tensorrt
+    int cvType = convertTrt2CVType(engine_->getBindingDataType(bindingIdx));
+    CV_Assert(cvType == blob_.depth() && "The input Mat type is not match the Trt Tensor type!");
+
+    memcpy(bufferListHost[bindingIdx].first.data(), blob_.data, bufferListHost[bindingIdx].second);
+}
+
+Mat NetImplTrt::forward(const String& outputName)
+{
+    std::vector<String> outputNames = {outputName};
+    if (outputName.empty())
+    {
+        CV_Assert(outputNamesString.size() == 1 && "forward error! Please set the correct output name at .forward(\"SET_OUTPUT_NAME_HERE\")!");
+        outputNames[0] = outputNamesString[0];
+    }
+
+    std::vector<Mat> outs;
+    this->forward(outs, outputNames);
+
+    return outs[0];
+}
+
+void NetImplTrt::forward(OutputArrayOfArrays outputBlobs, const String& outputName)
+{
+    std::vector<String> outputNames = {outputName};
+
+    if (outputName.empty())
+    {
+        CV_Assert(outputNamesString.size() == 1 && "forward error! Please set the correct output name at .forward(\"SET_OUTPUT_NAME_HERE\")!");
+        outputNames[0] = outputNamesString[0];
+    }
+
+    return this->forward(outputBlobs, outputNames);
+}
+
+void NetImplTrt::forward(OutputArrayOfArrays outputBlobs,
+        const std::vector<String>& outBlobNames)
+{
+    CV_Assert(!empty());
+    CV_Assert(outputBlobs.isMatVector());
+    // Output depth can be CV_32F or CV_8S
+    std::vector<Mat>& outputvec = *(std::vector<Mat>*)outputBlobs.getObj();
+    int outSize = outBlobNames.size();
+    CV_Assert(outSize <= outputCount && "OpenCV DNN forward() error, expected value exceeds existing value.");
+
+    std::vector<int> outputIdx(outSize, -1);
+
+    for(int i = 0; i < outSize; i++)
+    {
+        int res = getOutputIndex(outBlobNames[i]);
+
+        if (res == -1) // un-found output name
+        {
+            CV_Error(Error::StsBadArg, cv::String("DNN TensorRT: Can not found the expacted output name = " + outputNamesString[i] + "!"));
+            return;
+        }
+
+        outputIdx[i] = res;
+    }
+
+    for (int i = 0; i < inputCount; i++) 
+    {
+        cudaMemcpyAsync(bufferListDevice[input_idxs[i]], bufferListHost[input_idxs[i]].first.data(), 
+            bufferListHost[input_idxs[i]].second, cudaMemcpyHostToDevice, stream_);
+    }
+
+    context_->enqueueV3(stream_);
+
+    for (int i = 0; i < outputCount; i++) 
+    {
+        cudaMemcpyAsync(bufferListHost[output_idxs[i]].first.data(), bufferListDevice[output_idxs[i]], 
+            bufferListHost[output_idxs[i]].second, cudaMemcpyDeviceToHost, stream_);
+    }
+
+    tensors2Mats(outputIdx, outputvec);
+    cudaStreamSynchronize(stream_);
+}
+
+void NetImplTrt::forward(std::vector<std::vector<Mat>>& outputBlobs,
+        const std::vector<String>& outBlobNames)
+{
+    outputBlobs.clear();
+    std::vector<Mat> outs;
+    this->forward(outs, outBlobNames);
+    outputBlobs.push_back(outs);
+}
+
+// alloc gpu memory by cuda.
+void NetImplTrt::allocMem()
+{
+    int allIONb = inputCount + outputCount;
+
+    bufferListDevice.resize(allIONb, nullptr);
+    bufferListHost.resize(allIONb, {AutoBuffer<uchar>(), 0});
+
+    for (int i = 0; i < input_idxs.size(); i++)
+    {
+        int idx = input_idxs[i];
+        CV_Assert(idx >=0 && idx < allIONb);
+        int cvType = convertTrt2CVType(engine_->getBindingDataType(idx));
+        size_t dataSize = CV_ELEM_SIZE1(cvType) * total(inputMatShape[i]);
+        bufferListHost[idx].first.allocate(dataSize);
+        CV_Assert(bufferListHost[idx].first.data());
+        bufferListHost[idx].second = dataSize;
+        cudaMalloc(&bufferListDevice[idx], dataSize);
+        CV_Assert(bufferListDevice[idx]);
+
+        context_->setTensorAddress(inputNamesString[i].c_str(), bufferListDevice[idx]);
+    }
+
+    for (int i = 0; i < output_idxs.size(); i++)
+    {
+        int idx = output_idxs[i];
+        CV_Assert(idx >=0 && idx < allIONb);
+        int cvType = convertTrt2CVType(engine_->getBindingDataType(idx));
+        size_t dataSize = CV_ELEM_SIZE1(cvType) * total(outputMatShape[i]);
+        bufferListHost[idx].first.allocate(dataSize);
+        bufferListHost[idx].second = dataSize;
+        CV_Assert(bufferListHost[idx].first.data());
+        cudaMalloc(&bufferListDevice[idx], dataSize);
+        CV_Assert(bufferListDevice[idx]);
+
+        context_->setTensorAddress(outputNamesString[i].c_str(), bufferListDevice[idx]);
+    }
+}
+
+// convert GPU tensorrt to opencv cpu Mats.
+void NetImplTrt::tensors2Mats(const std::vector<int>& outputIdxs, std::vector<Mat>& outs)
+{
+    if (outs.empty() || outs.size() != outputIdxs.size())
+        outs.resize(outputIdxs.size());
+
+    for (int i = 0; i < outputIdxs.size(); i++)
+    {
+        int idx = outputIdxs[i];
+        int bindingIdx = output_idxs[idx];
+        int cvType = convertTrt2CVType(engine_->getBindingDataType(bindingIdx));
+
+        CV_Assert(cvType != -1 && "Unsupported data type");
+        Mat(outputMatShape[idx], cvType, bufferListHost[bindingIdx].first.data()).copyTo(outs[idx]);
+    }
+}
+
+// remove the file name and return the file prefix path.
+static inline std::string removeFileName(const std::string& filePath)
+{
+    size_t pos = filePath.find_last_of("/\\");
+
+    if (pos != std::string::npos)
+    {
+        return filePath.substr(0, pos);
+    }
+    else
+    {
+        return "";
+    }
+}
+
+// return file name with file extention suffix
+static inline std::string extractFileName(const std::string& filePath)
+{
+    size_t pos = filePath.find_last_of("/\\");
+
+    if (pos != std::string::npos)
+    {
+        return filePath.substr(pos + 1);
+    }
+    else
+    {
+        return filePath;
+    }
+}
+
+// remove file extention suffix
+static inline std::string removeFileSuffix(const std::string& filePath)
+{
+    size_t pos = filePath.find_last_of(".");
+
+    if (pos != std::string::npos)
+    {
+        return filePath.substr(0, pos);
+    }
+    else
+    {
+        return filePath;    
+    }
+}
+
+static inline MatShape convertDim2Shape(const ::nvinfer1::Dims& dim)
+{
+    MatShape shape(dim.nbDims, 0);
+    memcpy(shape.data(), dim.d, dim.nbDims * sizeof(int));
+
+    return shape;
+}
+
+static inline ::nvinfer1::Dims convertShape2Dim(const MatShape& shape)
+{
+    ::nvinfer1::Dims dim;
+    dim.nbDims = shape.size();
+    memcpy(dim.d, shape.data(), shape.size() * sizeof(int));
+
+    return dim;
+}
+
+
+static std::vector<char> loadTimingCacheFile(const std::string inFileName) 
+{
+    std::ifstream iFile(inFileName, std::ios::in | std::ios::binary);
+    
+    if (!iFile) 
+    {
+        CV_LOG_INFO(NULL, cv::String("[TensorRT EP] Could not read timing cache from: "+inFileName
+                            +". A new timing cache will be generated and written."));
+        return std::vector<char>();
+    }
+    
+    iFile.seekg(0, std::ifstream::end);
+    size_t fsize = iFile.tellg();
+    iFile.seekg(0, std::ifstream::beg);
+    std::vector<char> content(fsize);
+    iFile.read(content.data(), fsize);
+    iFile.close();
+    
+    return content;
+}
+
+static void saveTimingCacheFile(const std::string outFileName, const nvinfer1::IHostMemory* blob) 
+{
+    std::ofstream oFile(outFileName, std::ios::out | std::ios::binary);
+    
+    if (!oFile) 
+    {
+        CV_LOG_INFO(NULL, cv::String("[TensorRT EP] Could not write timing cache to: "+outFileName));
+        return;
+    }
+    
+    oFile.write((char*)blob->data(), blob->size());
+    oFile.close();
+}
+
+static std::string get_compute_capability(int device_id)
+{
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, device_id);
+
+    return "_" + std::to_string(deviceProp.major) + "." + std::to_string(deviceProp.minor);
+}
+
+void NetImplTrt::readNet(const String& model, const TrtConfig& configTRT)
+{
+    device_id_ = configTRT.deviceId;
+    std::string trt_model_filename = ""; // Contain the cache file name, when input is ONNX and need to save cache.
+    std::string path_to_write = "";
+
+    int GPU_count = 0;
+    cudaGetDeviceCount(&GPU_count);
+    CV_Assert(device_id_ >= 0 && device_id_ < GPU_count && "The device id does not exist!");
+
+    // TODO support multi-GPU
+    cudaSetDevice(device_id_); // set specific GPU device for TensorRT backend.
+
+    this->compute_capability_ = get_compute_capability(device_id_);
+
+    const std::string modelExt = model.substr(model.rfind('.') + 1);
+    bool is_trt_model = false;
+    
+    if (configTRT.useCache)
+    {
+        if (configTRT.cachePath)
+        {
+            path_to_write = std::string(configTRT.cachePath) + "/";
+        }
+        else
+        {
+            path_to_write = removeFileName(model) + "/";
+        }
+    }
+
+    if (modelExt == "trt")
+    {
+        is_trt_model = true;
+    }
+    else if (modelExt == "onnx")
+    {
+        // The input is onnx, try to find out if there is a converted model under the cachePath.
+        if (configTRT.useCache)
+        {
+            std::string modelFileName = removeFileSuffix(extractFileName(model));
+            trt_model_filename = path_to_write + modelFileName + ".trt\0";
+            std::ifstream trtFile(trt_model_filename);
+
+            if (trtFile.is_open())  // related cache file exist, use cache file.
+            {
+                CV_LOG_INFO(NULL, cv::String("DNN TensorRT backend: found Trt cache model:" + trt_model_filename));
+                is_trt_model = true;
+            }
+            else // no cache file was found,
+            {
+                is_trt_model = false;
+            }
+        }
+    }
+    else
+        CV_Error(Error::StsUnsupportedFormat, cv::format("Failed to load file with extension: %s !", modelExt.c_str()));
+
+    {
+        AutoLock lock(mutex);
+        runtime_ = Ptr<::nvinfer1::IRuntime>(::nvinfer1::createInferRuntime(getTensorrtLogger()));
+    }
+    
+    if (!runtime_) 
+    {
+        CV_Error(Error::StsError, "DNN TensorRT backend: Failed to create runtime!");
+        return;
+    }
+
+    std::string timeCachingPath = "";
+    /*** create engine from model file ***/
+    if (is_trt_model)
+    {
+        /* Just load TensorRT model (serialized model) */
+        std::ifstream engine_file(trt_model_filename, std::ios::binary | std::ios::in);
+        engine_file.seekg(0, std::ios::end);
+        size_t engine_size = engine_file.tellg();
+        engine_file.seekg(0, std::ios::beg);
+        std::unique_ptr<char[]> engine_buf{new char[engine_size]};
+        engine_file.read((char*)engine_buf.get(), engine_size);
+
+        {
+            AutoLock lock(mutex);
+            engine_ = Ptr<::nvinfer1::ICudaEngine>(runtime_->deserializeCudaEngine(engine_buf.get(), engine_size));
+        }
+        
+        engine_file.close();
+        if (!engine_)
+        {
+            CV_Error(Error::StsError, "TensorRT backend: Failed to create engine!");
+            return;
+        }
+    }
+    else // is onnx
+    {
+        if (configTRT.useTimeCache)
+        {
+            timeCachingPath = getTimingCachePath(path_to_write, this->compute_capability_);
+        }
+        
+        /* Create a TensorRT model from another format */
+        AutoLock lock(mutex);
+        builder_ = Ptr<::nvinfer1::IBuilder>(::nvinfer1::createInferBuilder(getTensorrtLogger()));
+        
+        const auto explicitBatch = 1U << static_cast<uint32_t>(::nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
+        network_ = Ptr<::nvinfer1::INetworkDefinition>(builder_->createNetworkV2(explicitBatch));
+        config_ = Ptr<::nvinfer1::IBuilderConfig>(builder_->createBuilderConfig());
+
+        if (configTRT.inputName && !configTRT.inputShape.empty())
+        {
+            ::nvinfer1::IOptimizationProfile* profile = builder_->createOptimizationProfile();
+            ::nvinfer1::Dims dim = convertShape2Dim(configTRT.inputShape);
+            profile->setDimensions(configTRT.inputName, ::nvinfer1::OptProfileSelector::kMIN, dim);
+            profile->setDimensions(configTRT.inputName, ::nvinfer1::OptProfileSelector::kOPT, dim);
+            profile->setDimensions(configTRT.inputName, ::nvinfer1::OptProfileSelector::kMAX, dim);
+
+            config_->addOptimizationProfile(profile);
+        }
+
+        auto parser = Ptr<nvonnxparser::IParser>(nvonnxparser::createParser(*network_, getTensorrtLogger()));
+
+        if (!parser->parseFromFile(model.c_str(), (int)::nvinfer1::ILogger::Severity::kWARNING))
+        {
+            CV_Error(Error::StsError, "TensorRT backend: Failed to parse onnx file!");
+            return;
+        }
+
+        config_->setMaxWorkspaceSize(OPT_MAX_WORK_SPACE_SIZE);
+
+        if (configTRT.useFP16)
+        {
+            config_->setFlag(::nvinfer1::BuilderFlag::kFP16);
+        }
+
+        // Trying to load time cache file
+        std::unique_ptr<nvinfer1::ITimingCache> timing_cache = nullptr;
+        if (configTRT.useTimeCache)
+        {
+            // Loading time cache file, create a fresh cache if the file doesn't exist.
+            std::vector<char> loaded_timing_cache = loadTimingCacheFile(timeCachingPath);
+            timing_cache.reset(config_->createTimingCache(static_cast<const void*>(loaded_timing_cache.data()), loaded_timing_cache.size()));
+            if (timing_cache == nullptr)
+            {
+                CV_Error(Error::StsError, "TensorRT backend: Failed to create timing cache!");
+                return;
+            }
+            config_->setTimingCache(*timing_cache, false);
+        }
+
+        auto plan = Ptr<::nvinfer1::IHostMemory>(builder_->buildSerializedNetwork(*network_, *config_));
+
+        if (!plan)
+        {
+            CV_Error(Error::StsError, "TensorRT backend: Failed to serialized network!");
+            return;
+        }
+
+        engine_ = Ptr<::nvinfer1::ICudaEngine>(runtime_->deserializeCudaEngine(plan->data(), plan->size()));
+
+        if (!engine_) 
+        {
+            CV_Error(Error::StsError, "TensorRT backend: Failed to create engine!");
+            return;
+        }
+
+        /* save serialized model to cache folder */
+        if (configTRT.useCache && !configTRT.cachePath)
+        {
+            std::ofstream ofs(std::string(trt_model_filename), std::ios::out | std::ios::binary);
+            ofs.write((char*)(plan->data()), plan->size());
+            ofs.close();
+        }
+
+        // Trying to save time cache file.
+        if (configTRT.useTimeCache)
+        {
+            auto timing_cache = config_->getTimingCache();
+            std::unique_ptr<nvinfer1::IHostMemory> timingCacheHostData{timing_cache->serialize()};
+            
+            if (timingCacheHostData == nullptr) 
+            {
+                CV_Error(Error::StsError, cv::String("TensorRT backend: could not serialize timing cache:"+trt_model_filename));
+                return;
+            }
+            saveTimingCacheFile(timeCachingPath, timingCacheHostData.get());
+        }
+    }
+
+    {
+        AutoLock lock(mutex);
+        context_ = Ptr<::nvinfer1::IExecutionContext>(engine_->createExecutionContext());
+    }
+
+    if (!context_)
+    {
+        CV_Error(Error::StsError, "TensorRT backend: Failed to create context!");
+        return;
+    }
+
+    // parsing model i/o name, dim, data type.
+    int ioNb = engine_->getNbIOTensors();
+
+    for (int i = 0; i < ioNb; i++)
+    {
+        bool isInput = engine_->bindingIsInput(i);
+        std::string name = std::string(engine_->getBindingName(i));
+        ::nvinfer1::Dims dim = engine_->getBindingDimensions(i);
+        MatShape shape = convertDim2Shape(dim);
+
+        if (isInput)
+        {
+            inputCount++;
+            inputNamesString.push_back(name);
+            inputMatShape.push_back(shape);
+            input_idxs.push_back(i);
+            inputMatShapeTrt.push_back(dim);
+        }
+        else
+        {
+            outputCount++;
+            outputNamesString.push_back(name);
+            outputMatShape.push_back(shape);
+            output_idxs.push_back(i);
+            outputMatShapeTrt.push_back(dim);
+        }
+    }
+
+    this->allocMem();
+}
+
+void NetImplTrt::readNet(const char* buffer, size_t sizeBuffer, const String &ext, const TrtConfig& config)
+{
+    // TODO
+}
+
+// TensorRT read Net function.
+Net readNetFromTensorRT(const String& trtFile, const TrtConfig config)
+{
+    Net net;
+
+    Ptr<Net::Impl>& impl_ptr_ref = accessor::DnnNetAccessor::getImplPtrRef(net);
+    Ptr<NetImplTrt> impl_ptr_trt = makePtr<NetImplTrt>(impl_ptr_ref);
+
+    impl_ptr_trt->readNet(trtFile, config);
+    impl_ptr_ref = impl_ptr_trt;
+    return net;
+}
+
+#else
+
+Net readNetFromTensorRT(const String& trtFile, const TrtConfig config)
+{
+    CV_Error(Error::StsError, "TenosrRT Backend: unsupport TensorRT, please recompile OpenCV with TensorRT!");
+    Net net;
+    return net;
+}
+
+CV__DNN_INLINE_NS_END
+#endif // HAVE_TRT
+
+}} // namespace cv::dnn

--- a/modules/dnn/src/tensorrt/trt_logger.h
+++ b/modules/dnn/src/tensorrt/trt_logger.h
@@ -1,0 +1,53 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "NvInferRuntimeCommon.h"
+#include <opencv2/core/utils/logger.hpp>
+
+namespace cv {
+namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+namespace dnn_trt {
+
+class TensorrtLogger : public nvinfer1::ILogger {
+  nvinfer1::ILogger::Severity verbosity_;
+
+ public:
+  TensorrtLogger(Severity verbosity = Severity::kWARNING)
+      : verbosity_(verbosity) {}
+  void log(Severity severity, const char* msg) noexcept override {
+    if (severity <= verbosity_) {
+      time_t rawtime = std::time(0);
+      struct tm stm;
+#ifdef _MSC_VER
+      gmtime_s(&stm, &rawtime);
+#else
+      gmtime_r(&rawtime, &stm);
+#endif
+      char buf[256];
+      strftime(&buf[0], 256,
+               "%Y-%m-%d %H:%M:%S",
+               &stm);
+      const char* sevstr = (severity == Severity::kINTERNAL_ERROR ? "    BUG" : severity == Severity::kERROR ? "  ERROR"
+                                                                            : severity == Severity::kWARNING ? "WARNING"
+                                                                            : severity == Severity::kINFO    ? "   INFO"
+                                                                                                             : "UNKNOWN");
+      if (severity <= Severity::kERROR) {
+        CV_LOG_ERROR(NULL, "[" << buf << " " << sevstr << "] " << msg);
+      } else {
+        CV_LOG_WARNING(NULL, "[" << buf << " " << sevstr << "] " << msg);
+      }
+    }
+  }
+  void set_level(Severity verbosity) {
+    verbosity_ = verbosity;
+  }
+  Severity get_level() const {
+    return verbosity_;
+  }
+};
+
+}
+CV__DNN_INLINE_NS_END
+}}  //

--- a/modules/dnn/src/tensorrt/trt_utils.h
+++ b/modules/dnn/src/tensorrt/trt_utils.h
@@ -1,0 +1,35 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "NvInferRuntimeCommon.h"
+#include <opencv2/core/utils/logger.hpp>
+
+namespace cv {
+namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+namespace dnn_trt {
+
+/*
+ * Get compute capability
+ *
+ */
+std::string getComputeCapacity(const cudaDeviceProp& prop) {
+  const std::string compute_capability = std::to_string(prop.major * 10 + prop.minor);
+  return compute_capability;
+}
+
+/*
+ * Get Timing by compute capability
+ *
+ */
+std::string getTimingCachePath(const std::string& root, std::string& compute_cap) {
+  // append compute capability of the GPU as this invalidates the cache and TRT will throw when loading the cache
+  const std::string timing_cache_name = root + "OpenCV_DNN_TensorRT_cache_sm" +
+                                        compute_cap + ".timing";
+  return timing_cache_name;
+}
+
+}
+CV__DNN_INLINE_NS_END
+}}  //


### PR DESCRIPTION
## How to use TensorRT?
**Step 0**: download and configure the CUDA, CMake will load the `CUDA_PATH` environment variable from system.
**Step 1**: download TensorRT 8.6 from nvidia and unzip `tensorrt_8.6.zip` to `tensorrt_86`.
**Step 2**: compile opencv dnn with tensorrt with the following compile scrip:

```
cmake -DWITH_TRT=ON -DTRT_SDK="/tensorrt_86" ..
make -j
```
**Step 3**: cpp code.
```cpp
std::string netCof = "";
std::string netFrame = "tensorrt";
Net net = readNet(onnxmodel, netCof, netFrame);

// OR
TrtConfig config;
config.deviceId = 0;
config.useCache = true;
config.useTimeCache = true;

Net net = readNetFromTensorRT(onnxmodel, config);
Mat out = net.forward("");
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
