### PR TITLE
Resolve Swift method name conflicts by adding missing namespace

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -481,6 +481,7 @@ class FuncInfo(GeneralInfo):
             self.objc_name = "getelem"
         if self.namespace in namespaces_dict:
             self.objc_name = '%s_%s' % (namespaces_dict[self.namespace], self.objc_name)
+            self.swift_name = '%s_%s' % (namespaces_dict[self.namespace], self.swift_name)
         for m in decl[2]:
             if m.startswith("="):
                 self.objc_name = m[1:]


### PR DESCRIPTION
Fixes #25926

We should include namespaces when generating swift bindings to avoid name conflicts.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
