### PR TITLE
Properly check markers when none are provided.

### DIFF
--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -305,23 +305,27 @@ struct CharucoDetector::CharucoDetectorImpl {
     void detectBoard(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
                      InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) {
         CV_Assert((markerCorners.empty() && markerIds.empty() && !image.empty()) || (markerCorners.total() == markerIds.total()));
+        vector<vector<Point2f>> tmpMarkerCorners;
+        vector<int> tmpMarkerIds;
+        InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : tmpMarkerCorners;
+        InputOutputArray _markerIds = markerIds.needed() ? markerIds : tmpMarkerIds;
 
         if (markerCorners.empty() && markerIds.empty()) {
             vector<vector<Point2f> > rejectedMarkers;
-            arucoDetector.detectMarkers(image, markerCorners, markerIds, rejectedMarkers);
+            arucoDetector.detectMarkers(image, _markerCorners, _markerIds, rejectedMarkers);
             if (charucoParameters.tryRefineMarkers)
-                arucoDetector.refineDetectedMarkers(image, board, markerCorners, markerIds, rejectedMarkers);
-            if (markerCorners.empty() && markerIds.empty())
+                arucoDetector.refineDetectedMarkers(image, board, _markerCorners, _markerIds, rejectedMarkers);
+            if (_markerCorners.empty() && _markerIds.empty())
                 return;
         }
         // if camera parameters are avaible, use approximated calibration
         if(!charucoParameters.cameraMatrix.empty())
-            interpolateCornersCharucoApproxCalib(markerCorners, markerIds, image, charucoCorners, charucoIds);
+            interpolateCornersCharucoApproxCalib(_markerCorners, _markerIds, image, charucoCorners, charucoIds);
         // else use local homography
         else
-            interpolateCornersCharucoLocalHom(markerCorners, markerIds, image, charucoCorners, charucoIds);
+            interpolateCornersCharucoLocalHom(_markerCorners, _markerIds, image, charucoCorners, charucoIds);
         // to return a charuco corner, its closest aruco markers should have been detected
-        filterCornersWithoutMinMarkers(charucoCorners, charucoIds, markerIds, charucoCorners, charucoIds);
+        filterCornersWithoutMinMarkers(charucoCorners, charucoIds, _markerIds, charucoCorners, charucoIds);
 }
 
 };

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -762,23 +762,29 @@ TEST_P(CharucoBoard, testWrongSizeDetection)
     ASSERT_FALSE(boardSize.width == boardSize.height);
     aruco::CharucoBoard board(boardSize, 1.f, 0.5f, aruco::getPredefinedDictionary(aruco::DICT_4X4_50));
 
-    vector<int> detectedCharucoIds, detectedArucoIds;
-    vector<Point2f> detectedCharucoCorners;
-    vector<vector<Point2f>> detectedArucoCorners;
     Mat boardImage;
     board.generateImage(boardSize*40, boardImage);
 
     swap(boardSize.width, boardSize.height);
     aruco::CharucoDetector detector(aruco::CharucoBoard(boardSize, 1.f, 0.5f, aruco::getPredefinedDictionary(aruco::DICT_4X4_50)));
     // try detect board with wrong size
-    detector.detectBoard(boardImage, detectedCharucoCorners, detectedCharucoIds, detectedArucoCorners, detectedArucoIds);
+    for(int i: {0, 1}) {
+        vector<int> detectedCharucoIds, detectedArucoIds;
+        vector<Point2f> detectedCharucoCorners;
+        vector<vector<Point2f>> detectedArucoCorners;
+        if (i == 0) {
+            detector.detectBoard(boardImage, detectedCharucoCorners, detectedCharucoIds, detectedArucoCorners, detectedArucoIds);
+            // aruco markers must be found
+            ASSERT_EQ(detectedArucoIds.size(), board.getIds().size());
+            ASSERT_EQ(detectedArucoCorners.size(), board.getIds().size());
+        } else {
+            detector.detectBoard(boardImage, detectedCharucoCorners, detectedCharucoIds);
+        }
 
-    // aruco markers must be found
-    ASSERT_EQ(detectedArucoIds.size(), board.getIds().size());
-    ASSERT_EQ(detectedArucoCorners.size(), board.getIds().size());
-    // charuco corners should not be found in board with wrong size
-    ASSERT_TRUE(detectedCharucoCorners.empty());
-    ASSERT_TRUE(detectedCharucoIds.empty());
+        // charuco corners should not be found in board with wrong size
+        ASSERT_TRUE(detectedCharucoCorners.empty());
+        ASSERT_TRUE(detectedCharucoIds.empty());
+    }
 }
 
 


### PR DESCRIPTION
CharucoDetectorImpl::detectBoard finds temporary markers when none are provided but those are discarded when
charucoDetectorImpl::checkBoard is called.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
