### PR TITLE
Mask support with CV_Bool in remaining modules

### DIFF
--- a/modules/3d/src/homography_decomp.cpp
+++ b/modules/3d/src/homography_decomp.cpp
@@ -513,7 +513,8 @@ void filterHomographyDecompByVisibleRefpoints(InputArrayOfArrays _rotations,
     Mat pointsMask = _pointsMask.getMat();
     int nsolutions = (int)_rotations.total();
     int npoints = (int)beforeRectifiedPoints.total();
-    CV_Assert(pointsMask.empty() || pointsMask.checkVector(1, CV_8U) == npoints);
+    CV_Assert(pointsMask.empty() || pointsMask.checkVector(1, CV_8U) == npoints ||
+              pointsMask.checkVector(1, CV_Bool) == npoints);
     const uchar* pointsMaskPtr = pointsMask.data;
 
     std::vector<uchar> solutionMask(nsolutions, (uchar)1);

--- a/modules/features/include/opencv2/features.hpp
+++ b/modules/features/include/opencv2/features.hpp
@@ -145,7 +145,7 @@ public:
     @param image Image.
     @param keypoints The detected keypoints. In the second variant of the method keypoints[i] is a set
     of keypoints detected in images[i] .
-    @param mask Mask specifying where to look for keypoints (optional). It must be a 8-bit integer
+    @param mask Mask specifying where to look for keypoints (optional). It must be CV_8U or CV_Bool
     matrix with non-zero values in the region of interest.
      */
     CV_WRAP virtual void detect( InputArray image,

--- a/modules/features/src/fast.cpp
+++ b/modules/features/src/fast.cpp
@@ -48,6 +48,7 @@ The references are:
 #include "hal_replacement.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 #include "opencv2/core/utils/buffer_area.private.hpp"
+#include <iostream>
 
 namespace cv
 {
@@ -517,7 +518,9 @@ public:
             gray = ogray;
         }
         FAST( gray, keypoints, threshold, nonmaxSuppression, type );
+        std::cout << "FAST keypoints size: " << keypoints.size() << std::endl;
         KeyPointsFilter::runByPixelsMask( keypoints, mask );
+        std::cout << "FAST keypoints after filter size: " << keypoints.size() << std::endl;
     }
 
     void set(int prop, double value)

--- a/modules/features/src/keypoint.cpp
+++ b/modules/features/src/keypoint.cpp
@@ -40,6 +40,7 @@
 //M*/
 
 #include "precomp.hpp"
+#include <iostream>
 
 namespace cv
 {
@@ -165,6 +166,8 @@ void KeyPointsFilter::runByPixelsMask( std::vector<KeyPoint>& keypoints, const M
     if( mask.empty() )
         return;
 
+    int nz_mask = countNonZero(mask);
+    std::cout << "nz_mask: " << nz_mask << std::endl;
     keypoints.erase(std::remove_if(keypoints.begin(), keypoints.end(), MaskPredicate(mask)), keypoints.end());
 }
 /*

--- a/modules/features/src/matchers.cpp
+++ b/modules/features/src/matchers.cpp
@@ -636,7 +636,7 @@ void DescriptorMatcher::checkMasks( InputArrayOfArrays _masks, int queryDescript
             if (hasTrainDesc || hasUTrainDesc)
             {
                 const int rows = hasTrainDesc ? trainDescCollection[i].rows : utrainDescCollection[i].rows;
-                CV_Assert(masks[i].type() == CV_8UC1
+                CV_Assert((masks[i].type() == CV_8UC1 || masks[i].type() == CV_BoolC1)
                     && masks[i].rows == queryDescriptorsCount
                     && masks[i].cols == rows);
             }

--- a/modules/features/src/orb.cpp
+++ b/modules/features/src/orb.cpp
@@ -37,6 +37,7 @@
 #include "precomp.hpp"
 #include "opencl_kernels_features.hpp"
 #include <iterator>
+#include <iostream>
 
 #ifndef CV_IMPL_ADD
 #define CV_IMPL_ADD(x)
@@ -892,6 +893,8 @@ static void computeKeyPoints(const Mat& imagePyramid,
         fd->detect(img, keypoints, mask);
         }
 
+        std::cout << "keypoints in detect: " << keypoints.size() << std::endl;
+
         // Remove keypoints very close to the border
         KeyPointsFilter::runByImageBorder(keypoints, img.size(), edgeThreshold);
 
@@ -1129,7 +1132,8 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
             if( !mask.empty() )
             {
                 resize(prevMask, currMask, sz, 0, 0, INTER_LINEAR_EXACT);
-                if( level > firstLevel )
+
+                if( (level > firstLevel) && (currMask.type() == CV_8U) )
                     threshold(currMask, currMask, 254, 0, THRESH_TOZERO);
             }
 
@@ -1147,12 +1151,16 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
                 copyMakeBorder(mask, extMask, border, border, border, border,
                                BORDER_CONSTANT+BORDER_ISOLATED);
         }
+
         if (level > firstLevel)
         {
             prevImg = currImg;
             prevMask = currMask;
         }
     }
+
+    int nz_mask = countNonZero(maskPyramid);
+    std::cout << "maskPyramid nz: " << nz_mask << std::endl;
 
     if( useOCL )
         copyVectorToUMat(layerOfs, ulayerInfo);

--- a/modules/features/src/sift.dispatch.cpp
+++ b/modules/features/src/sift.dispatch.cpp
@@ -511,8 +511,7 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     if( image.empty() || image.depth() != CV_8U )
         CV_Error( Error::StsBadArg, "image is empty or has incorrect depth (!=CV_8U)" );
 
-    if( !mask.empty() && mask.type() != CV_8UC1 )
-        CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1)" );
+    CV_Assert( mask.empty() || mask.type() == CV_8UC1 || mask.type() == CV_BoolC1 );
 
     if( useProvidedKeypoints )
     {

--- a/modules/features/test/test_affine_feature.cpp
+++ b/modules/features/test/test_affine_feature.cpp
@@ -204,4 +204,26 @@ TEST(Features2d_AFFINE_FEATURE, mask)
     }
 }
 
+TEST(Features2d_AFFINE_FEATURE, maskBool)
+{
+    Mat gray = imread(cvtest::findDataFile("features2d/tsukuba.png"), IMREAD_GRAYSCALE);
+    ASSERT_FALSE(gray.empty()) << "features2d/tsukuba.png image was not found in test data!";
+
+    // small tilt range to limit internal mask warping
+    Ptr<AffineFeature> ext = AffineFeature::create(SIFT::create(), 1, 0);
+    Mat mask = Mat::zeros(gray.size(), CV_Bool);
+    mask(Rect(50, 50, mask.cols-100, mask.rows-100)).setTo(1);
+
+    // calc and compare keypoints
+    vector<KeyPoint> calcKeypoints;
+    ext->detectAndCompute(gray, mask, calcKeypoints, noArray(), false);
+
+    // added expanded test range to cover sub-pixel coordinates for features on mask border
+    for( size_t i = 0; i < calcKeypoints.size(); i++ )
+    {
+        ASSERT_TRUE((calcKeypoints[i].pt.x >= 50-1) && (calcKeypoints[i].pt.x <= mask.cols-50+1));
+        ASSERT_TRUE((calcKeypoints[i].pt.y >= 50-1) && (calcKeypoints[i].pt.y <= mask.rows-50+1));
+    }
+}
+
 }} // namespace

--- a/modules/features/test/test_sift.cpp
+++ b/modules/features/test/test_sift.cpp
@@ -42,5 +42,67 @@ TEST(Features2d_SIFT, regression_26139)
     ASSERT_EQ(descriptors.size(), Size(128, 1));
 }
 
+TEST(Features2d_SIFT, MaskType)
+{
+    Mat gray = imread(cvtest::findDataFile("features2d/tsukuba.png"), IMREAD_GRAYSCALE);
+    ASSERT_FALSE(gray.empty());
+
+    cv::Rect roi(gray.cols/4, gray.rows/4, gray.cols/2, gray.rows/2);
+    Mat mask = Mat::zeros(gray.size(), CV_8UC1);
+    mask(roi).setTo(255);
+
+    Mat mask_bool = Mat::zeros(gray.size(), CV_BoolC1);
+    mask_bool(roi).setTo(255);
+
+    Ptr<SIFT> siftFloat = cv::SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+
+    vector<KeyPoint> keypoints_mask;
+    Mat descriptorsFloat_mask;
+    siftFloat->detectAndCompute(gray, mask, keypoints_mask, descriptorsFloat_mask, false);
+    ASSERT_EQ(descriptorsFloat_mask.type(), CV_32F) << "type mismatch";
+
+    vector<KeyPoint> keypoints_mask_bool;
+    Mat descriptorsFloat_mask_bool;
+    siftFloat->detectAndCompute(gray, mask_bool, keypoints_mask_bool, descriptorsFloat_mask_bool, false);
+    ASSERT_EQ(descriptorsFloat_mask_bool.type(), CV_32F) << "type mismatch";
+
+    Mat diff = descriptorsFloat_mask_bool != descriptorsFloat_mask;
+    ASSERT_EQ(countNonZero(diff), 0) << "descriptors are not identical";
+}
+
+CV_ENUM(MaskType, CV_8U, CV_Bool);
+typedef testing::TestWithParam<MaskType> SIFTMask;
+
+static bool checkPointinRect(const cv::Point& pt, const cv::Rect& rect)
+{
+    return (pt.x >= rect.x) && (pt.x <= rect.x+rect.width) && (pt.y >= rect.y) && (pt.y <= rect.y+rect.height);
+}
+
+TEST_P(SIFTMask, inRect)
+{
+    int mask_type = GetParam();
+
+    Mat gray = imread(cvtest::findDataFile("features2d/tsukuba.png"), IMREAD_GRAYSCALE);
+    ASSERT_FALSE(gray.empty());
+
+    cv::Rect roi(gray.cols/4, gray.rows/4, gray.cols/2, gray.rows/2);
+    Mat mask = Mat::zeros(gray.size(), mask_type);
+    mask(roi).setTo(255);
+
+    Ptr<SIFT> siftFloat = cv::SIFT::create(0, 3, 0.04, 10, 1.6, CV_32F);
+
+    vector<KeyPoint> keypoints_mask;
+    Mat descriptorsFloat_mask;
+    siftFloat->detectAndCompute(gray, mask, keypoints_mask, descriptorsFloat_mask, false);
+    ASSERT_EQ(descriptorsFloat_mask.type(), CV_32F) << "type mismatch";
+
+    for (size_t i = 0; i < keypoints_mask.size(); i++)
+    {
+        ASSERT_TRUE(checkPointinRect(keypoints_mask[i].pt, roi));
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, SIFTMask, MaskType::all());
+
 
 }} // namespace

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2106,7 +2106,8 @@ quality measure = 1500, and the qualityLevel=0.01 , then all the corners with th
 less than 15 are rejected.
 @param minDistance Minimum possible Euclidean distance between the returned corners.
 @param mask Optional region of interest. If the image is not empty (it needs to have the type
-CV_8UC1 and the same size as image ), it specifies the region in which the corners are detected.
+CV_8UC1 or CV_BoolC1 and the same size as image , it specifies the region in which the corners
+are detected.
 @param blockSize Size of an average block for computing a derivative covariation matrix over each
 pixel neighborhood. See cornerEigenValsAndVecs .
 @param useHarrisDetector Parameter indicating whether to use a Harris detector (see #cornerHarris)
@@ -2141,8 +2142,8 @@ quality measure less than the product are rejected. For example, if the best cor
 quality measure = 1500, and the qualityLevel=0.01 , then all the corners with the quality measure
 less than 15 are rejected.
 @param minDistance Minimum possible Euclidean distance between the returned corners.
-@param mask Region of interest. If the image is not empty (it needs to have the type
-CV_8UC1 and the same size as image ), it specifies the region in which the corners are detected.
+@param mask Region of interest. If the image is not empty (it needs to have the type CV_8UC1 or
+CV_BoolC1 and the same size as image), it specifies the region in which the corners are detected.
 @param cornersQuality Output vector of quality measure of the detected corners.
 @param blockSize Size of an average block for computing a derivative covariation matrix over each
 pixel neighborhood. See cornerEigenValsAndVecs .
@@ -2866,7 +2867,7 @@ viewed by a still camera and for the further foreground-background segmentation.
 
 @param src Input image of type CV_8UC(n), CV_16UC(n), CV_32FC(n) or CV_64FC(n), where n is a positive integer.
 @param dst %Accumulator image with the same number of channels as input image, and a depth of CV_32F or CV_64F.
-@param mask Optional operation mask.
+@param mask Optional operation mask of type CV_8U or CV_Bool.
 
 @sa  accumulateSquare, accumulateProduct, accumulateWeighted
  */
@@ -2885,7 +2886,7 @@ The function supports multi-channel images. Each channel is processed independen
 @param src Input image as 1- or 3-channel, 8-bit or 32-bit floating point.
 @param dst %Accumulator image with the same number of channels as input image, 32-bit or 64-bit
 floating-point.
-@param mask Optional operation mask.
+@param mask Optional operation mask of type CV_8U or CV_Bool.
 
 @sa  accumulateSquare, accumulateProduct, accumulateWeighted
  */
@@ -2904,7 +2905,7 @@ The function supports multi-channel images. Each channel is processed independen
 @param src2 Second input image of the same type and the same size as src1 .
 @param dst %Accumulator image with the same number of channels as input images, 32-bit or 64-bit
 floating-point.
-@param mask Optional operation mask.
+@param mask Optional operation mask of type CV_8U or CV_Bool.
 
 @sa  accumulate, accumulateSquare, accumulateWeighted
  */
@@ -2925,7 +2926,7 @@ The function supports multi-channel images. Each channel is processed independen
 @param dst %Accumulator image with the same number of channels as input image, 32-bit or 64-bit
 floating-point.
 @param alpha Weight of the input image.
-@param mask Optional operation mask.
+@param mask Optional operation mask of type CV_8U or CV_Bool.
 
 @sa  accumulate, accumulateSquare, accumulateProduct
  */
@@ -3890,10 +3891,11 @@ is \f$W \times H\f$ and templ is \f$w \times h\f$ , then result is \f$(W-w+1) \t
 @param method Parameter specifying the comparison method, see #TemplateMatchModes
 @param mask Optional mask. It must have the same size as templ. It must either have the same number
             of channels as template or only one channel, which is then used for all template and
-            image channels. If the data type is #CV_8U, the mask is interpreted as a binary mask,
-            meaning only elements where mask is nonzero are used and are kept unchanged independent
-            of the actual mask value (weight equals 1). For data type #CV_32F, the mask values are
-            used as weights. The exact formulas are documented in #TemplateMatchModes.
+            image channels. If the data type is #CV_8U or CV_Bool, the mask is interpreted as
+            a binary mask, meaning only elements where mask is nonzero are used and are kept
+            unchanged independent of the actual mask value (weight equals 1). For data type
+            #CV_32F, the mask values are used as weights. The exact formulas are documented
+            in #TemplateMatchModes.
  */
 CV_EXPORTS_W void matchTemplate( InputArray image, InputArray templ,
                                  OutputArray result, int method, InputArray mask = noArray() );
@@ -4375,9 +4377,6 @@ CV_EXPORTS_W RotatedRect fitEllipseAMS( InputArray points );
  The scaling factor guarantees that  \f$A^T C A =1\f$.
 
  @param points Input 2D point set, stored in std::vector\<\> or Mat
-
- @note Input point types are @ref Point2i or @ref Point2f and at least 5 points are required.
- @note @ref getClosestEllipsePoints function can be used to compute the ellipse fitting error.
  */
 CV_EXPORTS_W RotatedRect fitEllipseDirect( InputArray points );
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1549,11 +1549,13 @@ void cv::remap( InputArray _src, OutputArray _dst,
     {
         {
             remapNearest<uchar, false>, remapNearest<schar, false>, remapNearest<ushort, false>, remapNearest<short, false>,
-            remapNearest<int, false>, remapNearest<float, false>, remapNearest<double, false>, 0
+            remapNearest<int, false>, remapNearest<float, false>, remapNearest<double, false>, 0 /*fp16*/, 0 /*bf16*/,
+            remapNearest<uchar, false> /*bool*/, 0
         },
         {
             remapNearest<uchar, true>, remapNearest<schar, true>, remapNearest<ushort, true>, remapNearest<short, true>,
-            remapNearest<int, true>, remapNearest<float, true>, remapNearest<double, true>, 0
+            remapNearest<int, true>, remapNearest<float, true>, remapNearest<double, true>, 0 /*fp16*/, 0 /*bf16*/,
+            remapNearest<uchar, true> /*bool*/, 0
         }
     };
 

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -761,7 +761,7 @@ void crossCorr( const Mat& img, const Mat& _templ, Mat& corr,
 
 static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _result, int method, InputArray _mask )
 {
-    CV_Assert(_mask.depth() == CV_8U || _mask.depth() == CV_32F);
+    CV_Assert(_mask.depth() == CV_8U || _mask.depth() == CV_Bool || _mask.depth() == CV_32F);
     CV_Assert(_mask.channels() == _templ.channels() || _mask.channels() == 1);
     CV_Assert(_templ.size() == _mask.size());
     CV_Assert(_img.size().height >= _templ.size().height &&
@@ -782,6 +782,12 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
         Mat maskBin;
         threshold(mask, maskBin, 0/*threshold*/, 1.0/*maxVal*/, THRESH_BINARY);
         maskBin.convertTo(mask, CV_32F);
+    }
+    if (mask.depth() == CV_Bool)
+    {
+        cv::Mat maskConverted;
+        mask.convertTo(maskConverted, CV_32F);
+        mask = maskConverted;
     }
 
     Size corrSize(img.cols - templ.cols + 1, img.rows - templ.rows + 1);

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -18,139 +18,151 @@ namespace opencv_test { namespace {
         ((T*)dst_pt)[cn] = saturate_cast<T>((val + fixedRound) >> (fixedShift * 2));
     }
 
-TEST(Resize_Bitexact, Linear8U)
+typedef testing::TestWithParam<std::tuple<int, cv::Size>> ResizeBitexact8U;
+
+TEST_P(ResizeBitexact8U, accuracy)
 {
     static const int64_t fixedOne = (1L << fixedShiftU8);
 
-    struct testmode
+    int type = get<0>(GetParam());
+    Size sz = get<1>(GetParam());
+
+    int depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    int dcols = sz.width, drows = sz.height;
+    int cols = 1024, rows = 768;
+
+    double inv_scale_x = (double)dcols / cols;
+    double inv_scale_y = (double)drows / rows;
+    softdouble scale_x = softdouble::one() / softdouble(inv_scale_x);
+    softdouble scale_y = softdouble::one() / softdouble(inv_scale_y);
+
+    Mat src(rows, cols, type), refdst(drows, dcols, type), dst;
+    RNG rnd(0x123456789abcdefULL);
+    for (int j = 0; j < rows; j++)
     {
-        int type;
-        Size sz;
-    } modes[] = {
-        { CV_8UC1, Size( 512, 768) }, //   1/2       1
-        { CV_8UC3, Size( 512, 768) },
-        { CV_8UC1, Size(1024, 384) }, //    1       1/2
-        { CV_8UC4, Size(1024, 384) },
-        { CV_8UC1, Size( 512, 384) }, //   1/2      1/2
-        { CV_8UC2, Size( 512, 384) },
-        { CV_8UC3, Size( 512, 384) },
-        { CV_8UC4, Size( 512, 384) },
-        { CV_8UC1, Size( 256, 192) }, //   1/4      1/4
-        { CV_8UC2, Size( 256, 192) },
-        { CV_8UC3, Size( 256, 192) },
-        { CV_8UC4, Size( 256, 192) },
-        { CV_8UC1, Size(   4,   3) }, //   1/256    1/256
-        { CV_8UC2, Size(   4,   3) },
-        { CV_8UC3, Size(   4,   3) },
-        { CV_8UC4, Size(   4,   3) },
-        { CV_8UC1, Size( 342, 384) }, //   1/3      1/2
-        { CV_8UC1, Size( 342, 256) }, //   1/3      1/3
-        { CV_8UC2, Size( 342, 256) },
-        { CV_8UC3, Size( 342, 256) },
-        { CV_8UC4, Size( 342, 256) },
-        { CV_8UC1, Size( 512, 256) }, //   1/2      1/3
-        { CV_8UC1, Size( 146, 110) }, //   1/7      1/7
-        { CV_8UC3, Size( 146, 110) },
-        { CV_8UC4, Size( 146, 110) },
-        { CV_8UC1, Size( 931, 698) }, //  10/11    10/11
-        { CV_8UC2, Size( 931, 698) },
-        { CV_8UC3, Size( 931, 698) },
-        { CV_8UC4, Size( 931, 698) },
-        { CV_8UC1, Size( 853, 640) }, //  10/12    10/12
-        { CV_8UC3, Size( 853, 640) },
-        { CV_8UC4, Size( 853, 640) },
-        { CV_8UC1, Size(1004, 753) }, // 251/256  251/256
-        { CV_8UC2, Size(1004, 753) },
-        { CV_8UC3, Size(1004, 753) },
-        { CV_8UC4, Size(1004, 753) },
-        { CV_8UC1, Size(2048,1536) }, //    2        2
-        { CV_8UC2, Size(2048,1536) },
-        { CV_8UC4, Size(2048,1536) },
-        { CV_8UC1, Size(3072,2304) }, //    3        3
-        { CV_8UC3, Size(3072,2304) },
-        { CV_8UC1, Size(7168,5376) }  //    7        7
-    };
+        uint8_t* line = src.ptr(j);
+        for (int i = 0; i < cols; i++)
+            for (int c = 0; c < cn; c++)
+            {
+                double val = j < rows / 2 ? ( i < cols / 2 ? ((sin((i + 1)*CV_PI / 256.)*sin((j + 1)*CV_PI / 256.)*sin((cn + 4)*CV_PI / 8.) + 1.)*128.)                         :
+                                                                (((i / 128 + j / 128) % 2) * 250 + (j / 128) % 2)                                                                ) :
+                                            ( i < cols / 2 ? ((i / 128) * (85 - j / 256 * 40) * ((j / 128) % 2) + (7 - i / 128) * (85 - j / 256 * 40) * ((j / 128 + 1) % 2))    :
+                                                                ((uchar)rnd)                                                                                                     ) ;
+                if ((depth == CV_8U) || (depth == CV_Bool))
+                    line[i*cn + c] = (uint8_t)val;
+                else if (depth == CV_16U)
+                    ((uint16_t*)line)[i*cn + c] = (uint16_t)val;
+                else if (depth == CV_16S)
+                    ((int16_t*)line)[i*cn + c] = (int16_t)val;
+                else if (depth == CV_32S)
+                    ((int32_t*)line)[i*cn + c] = (int32_t)val;
+                else
+                    CV_Assert(0);
+            }
+    }
 
-    for (int modeind = 0, _modecnt = sizeof(modes) / sizeof(modes[0]); modeind < _modecnt; ++modeind)
+    for (int j = 0; j < drows; j++)
+    {
+        softdouble src_row_flt = scale_y*(softdouble(j) + softdouble(0.5)) - softdouble(0.5);
+        int src_row = cvFloor(src_row_flt);
+        int64_t ycoeff1 = cvRound64((src_row_flt - softdouble(src_row))*softdouble(fixedOne));
+        int64_t ycoeff0 = fixedOne - ycoeff1;
+
+        for (int i = 0; i < dcols; i++)
         {
-            int type = modes[modeind].type, depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
-            int dcols = modes[modeind].sz.width, drows = modes[modeind].sz.height;
-            int cols = 1024, rows = 768;
+            softdouble src_col_flt = scale_x*(softdouble(i) + softdouble(0.5)) - softdouble(0.5);
+            int src_col = cvFloor(src_col_flt);
+            int64_t xcoeff1 = cvRound64((src_col_flt - softdouble(src_col))*softdouble(fixedOne));
+            int64_t xcoeff0 = fixedOne - xcoeff1;
 
-            double inv_scale_x = (double)dcols / cols;
-            double inv_scale_y = (double)drows / rows;
-            softdouble scale_x = softdouble::one() / softdouble(inv_scale_x);
-            softdouble scale_y = softdouble::one() / softdouble(inv_scale_y);
-
-            Mat src(rows, cols, type), refdst(drows, dcols, type), dst;
-            RNG rnd(0x123456789abcdefULL);
-            for (int j = 0; j < rows; j++)
+            uint8_t* dst_pt = refdst.ptr(j, i);
+            uint8_t* src_pt00 = src.ptr( src_row      < 0 ? 0 :  src_row      >= rows ? rows - 1 :  src_row     ,
+                                            src_col      < 0 ? 0 :  src_col      >= cols ? cols - 1 :  src_col     );
+            uint8_t* src_pt01 = src.ptr( src_row      < 0 ? 0 :  src_row      >= rows ? rows - 1 :  src_row     ,
+                                        (src_col + 1) < 0 ? 0 : (src_col + 1) >= cols ? cols - 1 : (src_col + 1));
+            uint8_t* src_pt10 = src.ptr((src_row + 1) < 0 ? 0 : (src_row + 1) >= rows ? rows - 1 : (src_row + 1),
+                                            src_col      < 0 ? 0 :  src_col      >= cols ? cols - 1 :  src_col     );
+            uint8_t* src_pt11 = src.ptr((src_row + 1) < 0 ? 0 : (src_row + 1) >= rows ? rows - 1 : (src_row + 1),
+                                        (src_col + 1) < 0 ? 0 : (src_col + 1) >= cols ? cols - 1 : (src_col + 1));
+            for (int c = 0; c < cn; c++)
             {
-                uint8_t* line = src.ptr(j);
-                for (int i = 0; i < cols; i++)
-                    for (int c = 0; c < cn; c++)
-                    {
-                        double val = j < rows / 2 ? ( i < cols / 2 ? ((sin((i + 1)*CV_PI / 256.)*sin((j + 1)*CV_PI / 256.)*sin((cn + 4)*CV_PI / 8.) + 1.)*128.)                         :
-                                                                     (((i / 128 + j / 128) % 2) * 250 + (j / 128) % 2)                                                                ) :
-                                                    ( i < cols / 2 ? ((i / 128) * (85 - j / 256 * 40) * ((j / 128) % 2) + (7 - i / 128) * (85 - j / 256 * 40) * ((j / 128 + 1) % 2))    :
-                                                                     ((uchar)rnd)                                                                                                     ) ;
-                        if (depth == CV_8U)
-                            line[i*cn + c] = (uint8_t)val;
-                        else if (depth == CV_16U)
-                            ((uint16_t*)line)[i*cn + c] = (uint16_t)val;
-                        else if (depth == CV_16S)
-                            ((int16_t*)line)[i*cn + c] = (int16_t)val;
-                        else if (depth == CV_32S)
-                            ((int32_t*)line)[i*cn + c] = (int32_t)val;
-                        else
-                            CV_Assert(0);
-                    }
+                if ((depth == CV_8U) || (depth == CV_Bool))
+                    eval4< uint8_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
+                else if (depth == CV_16U)
+                    eval4<uint16_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
+                else if (depth == CV_16S)
+                    eval4< int16_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
+                else if (depth == CV_32S)
+                    eval4< int32_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
+                else
+                    CV_Assert(0);
             }
-
-            for (int j = 0; j < drows; j++)
-            {
-                softdouble src_row_flt = scale_y*(softdouble(j) + softdouble(0.5)) - softdouble(0.5);
-                int src_row = cvFloor(src_row_flt);
-                int64_t ycoeff1 = cvRound64((src_row_flt - softdouble(src_row))*softdouble(fixedOne));
-                int64_t ycoeff0 = fixedOne - ycoeff1;
-
-                for (int i = 0; i < dcols; i++)
-                {
-                    softdouble src_col_flt = scale_x*(softdouble(i) + softdouble(0.5)) - softdouble(0.5);
-                    int src_col = cvFloor(src_col_flt);
-                    int64_t xcoeff1 = cvRound64((src_col_flt - softdouble(src_col))*softdouble(fixedOne));
-                    int64_t xcoeff0 = fixedOne - xcoeff1;
-
-                    uint8_t* dst_pt = refdst.ptr(j, i);
-                    uint8_t* src_pt00 = src.ptr( src_row      < 0 ? 0 :  src_row      >= rows ? rows - 1 :  src_row     ,
-                                                 src_col      < 0 ? 0 :  src_col      >= cols ? cols - 1 :  src_col     );
-                    uint8_t* src_pt01 = src.ptr( src_row      < 0 ? 0 :  src_row      >= rows ? rows - 1 :  src_row     ,
-                                                (src_col + 1) < 0 ? 0 : (src_col + 1) >= cols ? cols - 1 : (src_col + 1));
-                    uint8_t* src_pt10 = src.ptr((src_row + 1) < 0 ? 0 : (src_row + 1) >= rows ? rows - 1 : (src_row + 1),
-                                                 src_col      < 0 ? 0 :  src_col      >= cols ? cols - 1 :  src_col     );
-                    uint8_t* src_pt11 = src.ptr((src_row + 1) < 0 ? 0 : (src_row + 1) >= rows ? rows - 1 : (src_row + 1),
-                                                (src_col + 1) < 0 ? 0 : (src_col + 1) >= cols ? cols - 1 : (src_col + 1));
-                    for (int c = 0; c < cn; c++)
-                    {
-                        if (depth == CV_8U)
-                            eval4< uint8_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
-                        else if (depth == CV_16U)
-                            eval4<uint16_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
-                        else if (depth == CV_16S)
-                            eval4< int16_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
-                        else if (depth == CV_32S)
-                            eval4< int32_t, fixedShiftU8>(xcoeff0, xcoeff1, ycoeff0, ycoeff1, c, src_pt00, src_pt01, src_pt10, src_pt11, dst_pt);
-                        else
-                            CV_Assert(0);
-                    }
-                }
-            }
-
-            cv::resize(src, dst, Size(dcols, drows), 0, 0, cv::INTER_LINEAR_EXACT);
-            EXPECT_GE(0, cvtest::norm(refdst, dst, cv::NORM_L1))
-                << "Resize " << cn << "-chan mat from " << cols << "x" << rows << " to " << dcols << "x" << drows << " failed with max diff " << cvtest::norm(refdst, dst, cv::NORM_INF);
         }
+    }
+
+    printf("before resize\n");
+    cv::resize(src, dst, Size(dcols, drows), 0, 0, cv::INTER_LINEAR_EXACT);
+    printf("after resize\n");
+    EXPECT_GE(0, cvtest::norm(refdst, dst, cv::NORM_L1))
+        << "Resize " << cn << "-chan mat from " << cols << "x" << rows << " to " << dcols << "x" << drows << " failed with max diff " << cvtest::norm(refdst, dst, cv::NORM_INF);
 }
+
+INSTANTIATE_TEST_CASE_P(Image, ResizeBitexact8U, testing::Values(
+     std::make_tuple( CV_8UC1, Size( 512, 768) ), //   1/2       1
+     std::make_tuple( CV_8UC3, Size( 512, 768) ),
+     std::make_tuple( CV_8UC1, Size(1024, 384) ), //    1       1/2
+     std::make_tuple( CV_8UC4, Size(1024, 384) ),
+     std::make_tuple( CV_8UC1, Size( 512, 384) ), //   1/2      1/2
+     std::make_tuple( CV_8UC2, Size( 512, 384) ),
+     std::make_tuple( CV_8UC3, Size( 512, 384) ),
+     std::make_tuple( CV_8UC4, Size( 512, 384) ),
+     std::make_tuple( CV_8UC1, Size( 256, 192) ), //   1/4      1/4
+     std::make_tuple( CV_8UC2, Size( 256, 192) ),
+     std::make_tuple( CV_8UC3, Size( 256, 192) ),
+     std::make_tuple( CV_8UC4, Size( 256, 192) ),
+     std::make_tuple( CV_8UC1, Size(   4,   3) ), //   1/256    1/256
+     std::make_tuple( CV_8UC2, Size(   4,   3) ),
+     std::make_tuple( CV_8UC3, Size(   4,   3) ),
+     std::make_tuple( CV_8UC4, Size(   4,   3) ),
+     std::make_tuple( CV_8UC1, Size( 342, 384) ), //   1/3      1/2
+     std::make_tuple( CV_8UC1, Size( 342, 256) ), //   1/3      1/3
+     std::make_tuple( CV_8UC2, Size( 342, 256) ),
+     std::make_tuple( CV_8UC3, Size( 342, 256) ),
+     std::make_tuple( CV_8UC4, Size( 342, 256) ),
+     std::make_tuple( CV_8UC1, Size( 512, 256) ), //   1/2      1/3
+     std::make_tuple( CV_8UC1, Size( 146, 110) ), //   1/7      1/7
+     std::make_tuple( CV_8UC3, Size( 146, 110) ),
+     std::make_tuple( CV_8UC4, Size( 146, 110) ),
+     std::make_tuple( CV_8UC1, Size( 931, 698) ), //  10/11    10/11
+     std::make_tuple( CV_8UC2, Size( 931, 698) ),
+     std::make_tuple( CV_8UC3, Size( 931, 698) ),
+     std::make_tuple( CV_8UC4, Size( 931, 698) ),
+     std::make_tuple( CV_8UC1, Size( 853, 640) ), //  10/12    10/12
+     std::make_tuple( CV_8UC3, Size( 853, 640) ),
+     std::make_tuple( CV_8UC4, Size( 853, 640) ),
+     std::make_tuple( CV_8UC1, Size(1004, 753) ), // 251/256  251/256
+     std::make_tuple( CV_8UC2, Size(1004, 753) ),
+     std::make_tuple( CV_8UC3, Size(1004, 753) ),
+     std::make_tuple( CV_8UC4, Size(1004, 753) ),
+     std::make_tuple( CV_8UC1, Size(2048,1536) ), //    2        2
+     std::make_tuple( CV_8UC2, Size(2048,1536) ),
+     std::make_tuple( CV_8UC4, Size(2048,1536) ),
+     std::make_tuple( CV_8UC1, Size(3072,2304) ), //    3        3
+     std::make_tuple( CV_8UC3, Size(3072,2304) ),
+     std::make_tuple( CV_8UC1, Size(7168,5376) )  //    7        7
+));
+
+INSTANTIATE_TEST_CASE_P(BoolMask, ResizeBitexact8U, testing::Values(
+     std::make_tuple( CV_BoolC1, Size( 512, 768) ), //   1/2       1
+     std::make_tuple( CV_BoolC1, Size(1024, 384) ), //    1       1/2
+     std::make_tuple( CV_BoolC1, Size( 512, 384) ), //   1/2      1/2
+     std::make_tuple( CV_BoolC1, Size(   4,   3) ), //   1/256    1/256
+     std::make_tuple( CV_BoolC1, Size( 342, 384) ), //   1/3      1/2
+     std::make_tuple( CV_BoolC1, Size( 342, 256) ), //   1/3      1/3
+     std::make_tuple( CV_BoolC1, Size( 512, 256) ), //   1/2      1/3
+     std::make_tuple( CV_BoolC1, Size( 146, 110) ), //   1/7      1/7
+     std::make_tuple( CV_BoolC1, Size(1004, 753) ) // 251/256  251/256
+));
 
 PARAM_TEST_CASE(Resize_Bitexact, int)
 {

--- a/modules/imgproc/test/test_templmatchmask.cpp
+++ b/modules/imgproc/test/test_templmatchmask.cpp
@@ -58,7 +58,7 @@ void Imgproc_MatchTemplateWithMask::SetUp()
     img_testtype_.convertTo(img_, CV_32F);
     templ_testtype_.convertTo(templ_, CV_32F);
     mask_testtype_.convertTo(mask_, CV_32F);
-    if (CV_MAT_DEPTH(type_mask) == CV_8U)
+    if (CV_MAT_DEPTH(type_mask) == CV_8U || CV_MAT_DEPTH(type_mask) == CV_Bool)
     {
         // CV_8U masks are interpreted as binary masks
         mask_.setTo(Scalar::all(1), mask_ != 0);
@@ -189,7 +189,7 @@ TEST_P(Imgproc_MatchTemplateWithMask, CompareNaiveImplCCOEFF_NORMED)
 INSTANTIATE_TEST_CASE_P(SingleChannelMask, Imgproc_MatchTemplateWithMask,
     Combine(
         Values(CV_32FC1, CV_32FC3, CV_8UC1, CV_8UC3),
-        Values(CV_32FC1, CV_8UC1)));
+        Values(CV_32FC1, CV_8UC1, CV_BoolC1)));
 
 INSTANTIATE_TEST_CASE_P(MultiChannelMask, Imgproc_MatchTemplateWithMask,
     Combine(

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -212,7 +212,7 @@ public:
     const cv::UMat& matchingMask() const { return matching_mask_; }
     void setMatchingMask(const cv::UMat &mask)
     {
-        CV_Assert(mask.type() == CV_8U && mask.cols == mask.rows);
+        CV_Assert((mask.type() == CV_8U || mask.type() == CV_Bool) && mask.cols == mask.rows);
         matching_mask_ = mask.clone();
     }
 

--- a/modules/stitching/include/opencv2/stitching/detail/motion_estimators.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/motion_estimators.hpp
@@ -136,7 +136,7 @@ public:
     CV_WRAP Mat refinementMask() const { return refinement_mask_.clone(); }
     CV_WRAP void setRefinementMask(const Mat &mask)
     {
-        CV_Assert(mask.type() == CV_8U && mask.size() == Size(3, 3));
+        CV_Assert((mask.type() == CV_8U || mask.type() == CV_Bool) && mask.size() == Size(3, 3));
         refinement_mask_ = mask.clone();
     }
 

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -340,7 +340,7 @@ void FeaturesMatcher::match(const std::vector<ImageFeatures> &features, std::vec
 {
     const int num_images = static_cast<int>(features.size());
 
-    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows));
+    CV_Assert(mask.empty() || ((mask.type() == CV_8U || mask.type() == CV_Bool) && mask.cols == num_images && mask.rows));
     Mat_<uchar> mask_(mask.getMat(ACCESS_READ));
     if (mask_.empty())
         mask_ = Mat::ones(num_images, num_images, CV_8U);
@@ -491,7 +491,7 @@ void BestOf2NearestRangeMatcher::match(const std::vector<ImageFeatures> &feature
 {
     const int num_images = static_cast<int>(features.size());
 
-    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows));
+    CV_Assert(mask.empty() || ((mask.type() == CV_8U || mask.type() == CV_Bool) && mask.cols == num_images && mask.rows));
     Mat_<uchar> mask_(mask.getMat(ACCESS_READ));
     if (mask_.empty())
         mask_ = Mat::ones(num_images, num_images, CV_8U);

--- a/modules/stitching/test/test_blenders.cpp
+++ b/modules/stitching/test/test_blenders.cpp
@@ -43,8 +43,13 @@
 
 namespace opencv_test { namespace {
 
-TEST(MultiBandBlender, CanBlendTwoImages)
+CV_ENUM(MaskType, CV_8U, CV_Bool);
+typedef testing::TestWithParam<MaskType> MultiBandBlender;
+
+TEST_P(MultiBandBlender, CanBlendTwoImages)
 {
+    int mask_type = GetParam();
+
     Mat image1 = imread(string(cvtest::TS::ptr()->get_data_path()) + "cv/shared/baboon.png");
     Mat image2 = imread(string(cvtest::TS::ptr()->get_data_path()) + "cv/shared/lena.png");
     ASSERT_EQ(image1.rows, image2.rows); ASSERT_EQ(image1.cols, image2.cols);
@@ -53,11 +58,11 @@ TEST(MultiBandBlender, CanBlendTwoImages)
     image1.convertTo(image1s, CV_16S);
     image2.convertTo(image2s, CV_16S);
 
-    Mat mask1(image1s.size(), CV_8U);
+    Mat mask1(image1s.size(), mask_type);
     mask1(Rect(0, 0, mask1.cols/2, mask1.rows)).setTo(255);
     mask1(Rect(mask1.cols/2, 0, mask1.cols - mask1.cols/2, mask1.rows)).setTo(0);
 
-    Mat mask2(image2s.size(), CV_8U);
+    Mat mask2(image2s.size(), mask_type);
     mask2(Rect(0, 0, mask2.cols/2, mask2.rows)).setTo(0);
     mask2(Rect(mask2.cols/2, 0, mask2.cols - mask2.cols/2, mask2.rows)).setTo(255);
 
@@ -75,5 +80,7 @@ TEST(MultiBandBlender, CanBlendTwoImages)
     double psnr = cvtest::PSNR(expected, result);
     EXPECT_GE(psnr, 50);
 }
+
+INSTANTIATE_TEST_CASE_P(/**/, MultiBandBlender, MaskType::all());
 
 }} // namespace

--- a/modules/stitching/test/test_blenders.cuda.cpp
+++ b/modules/stitching/test/test_blenders.cuda.cpp
@@ -76,7 +76,7 @@ TEST(CUDA_MultiBandBlender, Accuracy)
     mask1(Rect(0, 0, mask1.cols/2, mask1.rows)).setTo(255);
     mask1(Rect(mask1.cols/2, 0, mask1.cols - mask1.cols/2, mask1.rows)).setTo(0);
 
-    Mat mask2(image2s.size(), CV_8U);
+    Mat mask2(image2s.size(), CV_Bool);
     mask2(Rect(0, 0, mask2.cols/2, mask2.rows)).setTo(0);
     mask2(Rect(mask2.cols/2, 0, mask2.cols - mask2.cols/2, mask2.rows)).setTo(255);
 

--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -45,8 +45,12 @@ namespace opencv_test { namespace {
 
 #if defined(HAVE_OPENCV_XFEATURES2D) && defined(OPENCV_ENABLE_NONFREE)
 
-TEST(SurfFeaturesFinder, CanFindInROIs)
+CV_ENUM(MaskType, CV_8U, CV_Bool);
+typedef testing::TestWithParam<MaskType> SurfFeaturesFinder;
+
+TEST_P(SurfFeaturesFinder, CanFindInROIs)
 {
+    int mask_type = GetParam();
     Ptr<Feature2D> finder = xfeatures2d::SURF::create();
     Mat img  = imread(string(cvtest::TS::ptr()->get_data_path()) + "cv/shared/lena.png");
 
@@ -55,7 +59,7 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
     rois.push_back(Rect(img.cols / 2, img.rows / 2, img.cols - img.cols / 2, img.rows - img.rows / 2));
 
     // construct mask
-    Mat mask = Mat::zeros(img.size(), CV_8U);
+    Mat mask = Mat::zeros(img.size(), mask_type);
     for (const Rect &roi : rois)
     {
         Mat(mask, roi) = 1;
@@ -81,6 +85,8 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
     EXPECT_GT(br_rect_count, 0);
     EXPECT_EQ(bad_count, 0);
 }
+
+INSTANTIATE_TEST_CASE_P(/**/, SurfFeaturesFinder, MaskType::all());
 
 #endif // HAVE_OPENCV_XFEATURES2D && OPENCV_ENABLE_NONFREE
 


### PR DESCRIPTION
Partially address https://github.com/opencv/opencv/issues/25895
Continues https://github.com/opencv/opencv/pull/25902

Also:
- added remap and resize for CV_Bool to support pyramids and masks warping;

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
