### PR TITLE
fix: js/html perf tests

### DIFF
--- a/modules/js/perf/perf_64bits.js
+++ b/modules/js/perf/perf_64bits.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if (isNodeJs) {
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_helpfunc.js
+++ b/modules/js/perf/perf_helpfunc.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if(isNodeJs) {
   var Base = require("./base");

--- a/modules/js/perf/perf_imgproc/perf_blur.js
+++ b/modules/js/perf/perf_imgproc/perf_blur.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_cvtcolor.js
+++ b/modules/js/perf/perf_imgproc/perf_cvtcolor.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if (isNodeJs) {
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_dilate.js
+++ b/modules/js/perf/perf_imgproc/perf_dilate.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_erode.js
+++ b/modules/js/perf/perf_imgproc/perf_erode.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_filter2D.js
+++ b/modules/js/perf/perf_imgproc/perf_filter2D.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_gaussianBlur.js
+++ b/modules/js/perf/perf_imgproc/perf_gaussianBlur.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_medianBlur.js
+++ b/modules/js/perf/perf_imgproc/perf_medianBlur.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_pyrDown.js
+++ b/modules/js/perf/perf_imgproc/perf_pyrDown.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_remap.js
+++ b/modules/js/perf/perf_imgproc/perf_remap.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_resize.js
+++ b/modules/js/perf/perf_imgproc/perf_resize.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_scharr.js
+++ b/modules/js/perf/perf_imgproc/perf_scharr.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_sobel.js
+++ b/modules/js/perf/perf_imgproc/perf_sobel.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_threshold.js
+++ b/modules/js/perf/perf_imgproc/perf_threshold.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_warpAffine.js
+++ b/modules/js/perf/perf_imgproc/perf_warpAffine.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');

--- a/modules/js/perf/perf_imgproc/perf_warpPerspective.js
+++ b/modules/js/perf/perf_imgproc/perf_warpPerspective.js
@@ -1,4 +1,4 @@
-const isNodeJs = (typeof window) === 'undefined'? true : false;
+var isNodeJs = (typeof window) === 'undefined'? true : false;
 
 if　(isNodeJs)　{
   var Benchmark = require('benchmark');


### PR DESCRIPTION
`modules/js/perf/perf_helpfunc.js` and target tests, e.g. perf_gaussianBlur.js, contain "const isNodeJs", leading to re-definition when using associated *.html files: 

```html
	//... script above
     <script src="https://cdnjs.cloudflare.com/ajax/libs/benchmark/2.1.4/benchmark.js"></script>$
     <script src="../../opencv.js" type="text/javascript"></script>$
     <script src="../base.js"></script>$
     <script src="../perf_helpfunc.js"></script>$
     <script src="./perf_gaussianBlur.js"></script>$
   </body>$
</html>$
```

`perf_helpfunc.js` was imported (which globally defined `const isNodeJs`) and then `perf_gussianBlur.js` was imported (which globally defined `const isNodeJs`). Changing them to `var` resolves scoping issues when running in browser, while maintaining nodejs support. 

Special thanks to https://github.com/youar for supporting this work; please inform if applying a copyright-header is appropriate attribution. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```