### PR TITLE
Added reference to Python example (stitching.py) in the High-Level St…

### DIFF
--- a/doc/tutorials/others/stitcher.markdown
+++ b/doc/tutorials/others/stitcher.markdown
@@ -27,7 +27,16 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/opencv/opencv/tree/4.x/samples/cpp/stitching.cpp).
 
+A similar script is available for Python 
+[here](https://github.com/opencv/opencv/tree/4.x/samples/python/stitching.py).
+
+Note: The C++ version includes additional options such as image division (--d3) and more detailed error handling, which are not present in the Python example.
+
+
 @include samples/cpp/stitching.cpp
+
+@include samples/python/stitching.py
+
 
 Explanation
 -----------

--- a/doc/tutorials/others/stitcher.markdown
+++ b/doc/tutorials/others/stitcher.markdown
@@ -27,7 +27,7 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/opencv/opencv/tree/4.x/samples/cpp/stitching.cpp).
 
-A similar script is available for Python 
+A similar script is available for Python
 [here](https://github.com/opencv/opencv/tree/4.x/samples/python/stitching.py).
 
 Note: The C++ version includes additional options such as image division (--d3) and more detailed error handling, which are not present in the Python example.


### PR DESCRIPTION
## What this Pull Request (PR) does
Added reference to Python example (stitching.py) in the High-Level Stitching API Tutorial for 4.x.

## Related issues
This PR addresses the issue where the tutorial only referenced the C++ example and did not include the Python example.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] The feature is well documented and sample code can be built with the project CMake
