### PR TITLE
Add alignment checks to Mat, silence cast alignment warnings

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1672,7 +1672,7 @@ template<typename _Tp> inline
 const _Tp* Mat_<_Tp>::operator [](int y) const
 {
     CV_DbgAssert( 0 <= y && y < size.p[0] );
-    _Tp* p = (const _Tp*)((void*)(data + y*step.p[0]));
+    const _Tp* p = (const _Tp*)((const void*)(data + y*step.p[0]));
     CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
     return p;
 }

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -713,14 +713,18 @@ template<typename _Tp> inline
 _Tp* Mat::ptr(int y)
 {
     CV_DbgAssert( y == 0 || (data && dims >= 1 && (unsigned)y < (unsigned)size.p[0]) );
-    return (_Tp*)(data + step.p[0] * y);
+    _Tp* p = (_Tp*)((void*)(data + step.p[0] * y));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 const _Tp* Mat::ptr(int y) const
 {
     CV_DbgAssert( y == 0 || (data && dims >= 1 && (unsigned)y < (unsigned)size.p[0]) );
-    return (const _Tp*)(data + step.p[0] * y);
+    const _Tp* p = (const _Tp*)((const void*)(data + step.p[0] * y));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 inline
@@ -750,7 +754,10 @@ _Tp* Mat::ptr(int i0, int i1)
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
-    return (_Tp*)(data + i0 * step.p[0] + i1 * step.p[1]);
+
+    _Tp* p = (_Tp*)((void*)(data + i0 * step.p[0] + i1 * step.p[1]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
@@ -760,7 +767,10 @@ const _Tp* Mat::ptr(int i0, int i1) const
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
-    return (const _Tp*)(data + i0 * step.p[0] + i1 * step.p[1]);
+
+    const _Tp* p = (const _Tp*)((const void*)(data + i0 * step.p[0] + i1 * step.p[1]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 inline
@@ -793,7 +803,10 @@ _Tp* Mat::ptr(int i0, int i1, int i2)
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
     CV_DbgAssert((unsigned)i2 < (unsigned)size.p[2]);
-    return (_Tp*)(data + i0 * step.p[0] + i1 * step.p[1] + i2 * step.p[2]);
+
+    _Tp* p = (_Tp*)((void*)(data + i0 * step.p[0] + i1 * step.p[1] + i2 * step.p[2]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
@@ -804,7 +817,10 @@ const _Tp* Mat::ptr(int i0, int i1, int i2) const
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
     CV_DbgAssert((unsigned)i2 < (unsigned)size.p[2]);
-    return (const _Tp*)(data + i0 * step.p[0] + i1 * step.p[1] + i2 * step.p[2]);
+
+    const _Tp* p = (const _Tp*)((const void*)(data + i0 * step.p[0] + i1 * step.p[1] + i2 * step.p[2]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 inline
@@ -846,7 +862,10 @@ _Tp* Mat::ptr(const int* idx)
         CV_DbgAssert( (unsigned)idx[i] < (unsigned)size.p[i] );
         p += idx[i] * step.p[i];
     }
-    return (_Tp*)p;
+
+    _Tp* tPtr = (_Tp*)((void*)p);
+    CV_DbgAssert(((uintptr_t)tPtr & (alignof(_Tp) - 1)) == 0);
+    return tPtr;
 }
 
 template<typename _Tp> inline
@@ -860,7 +879,10 @@ const _Tp* Mat::ptr(const int* idx) const
         CV_DbgAssert( (unsigned)idx[i] < (unsigned)size.p[i] );
         p += idx[i] * step.p[i];
     }
-    return (const _Tp*)p;
+
+    const _Tp* tPtr = (const _Tp*)((const void*)p);
+    CV_DbgAssert(((uintptr_t)tPtr & (alignof(_Tp) - 1)) == 0);
+    return tPtr;
 }
 
 template<int n> inline
@@ -898,7 +920,10 @@ _Tp& Mat::at(int i0, int i1)
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
-    return ((_Tp*)(data + step.p[0] * i0))[i1];
+
+    _Tp* p = ((_Tp*)((void*)(data + step.p[0] * i0))) + i1;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -909,7 +934,10 @@ const _Tp& Mat::at(int i0, int i1) const
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
-    return ((const _Tp*)(data + step.p[0] * i0))[i1];
+
+    const _Tp* p = ((const _Tp*)((const void*)(data + step.p[0] * i0))) + i1;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -920,7 +948,10 @@ _Tp& Mat::at(Point pt)
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
-    return ((_Tp*)(data + step.p[0] * pt.y))[pt.x];
+
+    _Tp* p = ((_Tp*)((void*)(data + step.p[0] * pt.y))) + pt.x;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -931,7 +962,10 @@ const _Tp& Mat::at(Point pt) const
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
     CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
-    return ((const _Tp*)(data + step.p[0] * pt.y))[pt.x];
+
+    const _Tp* p = ((const _Tp*)((const void*)(data + step.p[0] * pt.y))) + pt.x;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -942,11 +976,21 @@ _Tp& Mat::at(int i0)
     CV_DbgAssert((unsigned)i0 < (unsigned)(size.p[0] * size.p[1]));
     CV_DbgAssert(elemSize() == sizeof(_Tp));
     if( isContinuous() || size.p[0] == 1 )
-        return ((_Tp*)data)[i0];
+    {
+        _Tp* p = ((_Tp*)((void*)(data))) + i0;
+        CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+        return *p;
+    }
     if( size.p[1] == 1 )
-        return *(_Tp*)(data + step.p[0] * i0);
+    {
+        _Tp* p = (_Tp*)((void*)(data + step.p[0] * i0));
+        CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+        return *p;
+    }
     int i = i0 / cols, j = i0 - i * cols;
-    return ((_Tp*)(data + step.p[0] * i))[j];
+    _Tp* p = ((_Tp*)((void*)(data + step.p[0] * i))) + j;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -957,53 +1001,71 @@ const _Tp& Mat::at(int i0) const
     CV_DbgAssert((unsigned)i0 < (unsigned)(size.p[0] * size.p[1]));
     CV_DbgAssert(elemSize() == sizeof(_Tp));
     if( isContinuous() || size.p[0] == 1 )
-        return ((const _Tp*)data)[i0];
+    {
+        const _Tp* p = ((const _Tp*)((const void*)data)) + i0;
+        CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+        return *p;
+    }
     if( size.p[1] == 1 )
-        return *(const _Tp*)(data + step.p[0] * i0);
+    {
+        const _Tp* p = (const _Tp*)((const void*)(data + step.p[0] * i0));
+        CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+        return *p;
+    }
     int i = i0 / cols, j = i0 - i * cols;
-    return ((const _Tp*)(data + step.p[0] * i))[j];
+    const _Tp* p = ((const _Tp*)((const void*)(data + step.p[0] * i))) + j;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp& Mat::at(int i0, int i1, int i2)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(_Tp*)ptr(i0, i1, i2);
+    _Tp* p = (_Tp*)((void*)ptr(i0, i1, i2));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 const _Tp& Mat::at(int i0, int i1, int i2) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(const _Tp*)ptr(i0, i1, i2);
+    const _Tp* p = (const _Tp*)((const void*)ptr(i0, i1, i2));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp& Mat::at(const int* idx)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(_Tp*)ptr(idx);
+    _Tp* p = (_Tp*)((void*)ptr(idx));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 const _Tp& Mat::at(const int* idx) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(const _Tp*)ptr(idx);
+    const _Tp* p = (const _Tp*)((const void*)ptr(idx));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp, int n> inline
 _Tp& Mat::at(const Vec<int, n>& idx)
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(_Tp*)ptr(idx.val);
+    return *ptr<_Tp>(idx.val);
 }
 
 template<typename _Tp, int n> inline
 const _Tp& Mat::at(const Vec<int, n>& idx) const
 {
     CV_DbgAssert( elemSize() == sizeof(_Tp) );
-    return *(const _Tp*)ptr(idx.val);
+    return *ptr<_Tp>(idx.val);
 }
 
 template<typename _Tp> inline
@@ -1601,14 +1663,18 @@ template<typename _Tp> inline
 _Tp* Mat_<_Tp>::operator [](int y)
 {
     CV_DbgAssert( 0 <= y && y < size.p[0] );
-    return (_Tp*)(data + y*step.p[0]);
+    _Tp* p = (_Tp*)((void*)(data + y*step.p[0]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 const _Tp* Mat_<_Tp>::operator [](int y) const
 {
     CV_DbgAssert( 0 <= y && y < size.p[0] );
-    return (const _Tp*)(data + y*step.p[0]);
+    _Tp* p = (const _Tp*)((void*)(data + y*step.p[0]));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
@@ -1619,7 +1685,10 @@ _Tp& Mat_<_Tp>::operator ()(int i0, int i1)
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
     CV_DbgAssert(type() == traits::Type<_Tp>::value);
-    return ((_Tp*)(data + step.p[0] * i0))[i1];
+
+    _Tp* p = ((_Tp*)((void*)(data + step.p[0] * i0))) + i1;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -1630,7 +1699,10 @@ const _Tp& Mat_<_Tp>::operator ()(int i0, int i1) const
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)i1 < (unsigned)size.p[1]);
     CV_DbgAssert(type() == traits::Type<_Tp>::value);
-    return ((const _Tp*)(data + step.p[0] * i0))[i1];
+
+    const _Tp* p = ((const _Tp*)((const void*)(data + step.p[0] * i0))) + i1;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -1641,7 +1713,10 @@ _Tp& Mat_<_Tp>::operator ()(Point pt)
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)pt.x < (unsigned)size.p[1]);
     CV_DbgAssert(type() == traits::Type<_Tp>::value);
-    return ((_Tp*)(data + step.p[0] * pt.y))[pt.x];
+
+    _Tp* p = ((_Tp*)((void*)(data + step.p[0] * pt.y))) + pt.x;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -1652,7 +1727,10 @@ const _Tp& Mat_<_Tp>::operator ()(Point pt) const
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)pt.x < (unsigned)size.p[1]);
     CV_DbgAssert(type() == traits::Type<_Tp>::value);
-    return ((const _Tp*)(data + step.p[0] * pt.y))[pt.x];
+
+    const _Tp* p = ((const _Tp*)((const void*)(data + step.p[0] * pt.y))) + pt.x;
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
@@ -1930,89 +2008,113 @@ size_t SparseMat::nzcount() const
 template<typename _Tp> inline
 _Tp& SparseMat::ref(int i0, size_t* hashval)
 {
-    return *(_Tp*)((SparseMat*)this)->ptr(i0, true, hashval);
+    _Tp* p = (_Tp*)((void*)(((SparseMat*)this)->ptr(i0, true, hashval)));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp& SparseMat::ref(int i0, int i1, size_t* hashval)
 {
-    return *(_Tp*)((SparseMat*)this)->ptr(i0, i1, true, hashval);
+    _Tp* p = (_Tp*)((void*)(((SparseMat*)this)->ptr(i0, i1, true, hashval)));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp& SparseMat::ref(int i0, int i1, int i2, size_t* hashval)
 {
-    return *(_Tp*)((SparseMat*)this)->ptr(i0, i1, i2, true, hashval);
+    _Tp* p = (_Tp*)((void*)(((SparseMat*)this)->ptr(i0, i1, i2, true, hashval)));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp& SparseMat::ref(const int* idx, size_t* hashval)
 {
-    return *(_Tp*)((SparseMat*)this)->ptr(idx, true, hashval);
+    _Tp* p = (_Tp*)((void*)(((SparseMat*)this)->ptr(idx, true, hashval)));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 _Tp SparseMat::value(int i0, size_t* hashval) const
 {
-    const _Tp* p = (const _Tp*)((SparseMat*)this)->ptr(i0, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(i0, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
     return p ? *p : _Tp();
 }
 
 template<typename _Tp> inline
 _Tp SparseMat::value(int i0, int i1, size_t* hashval) const
 {
-    const _Tp* p = (const _Tp*)((SparseMat*)this)->ptr(i0, i1, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(i0, i1, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
     return p ? *p : _Tp();
 }
 
 template<typename _Tp> inline
 _Tp SparseMat::value(int i0, int i1, int i2, size_t* hashval) const
 {
-    const _Tp* p = (const _Tp*)((SparseMat*)this)->ptr(i0, i1, i2, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(i0, i1, i2, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
     return p ? *p : _Tp();
 }
 
 template<typename _Tp> inline
 _Tp SparseMat::value(const int* idx, size_t* hashval) const
 {
-    const _Tp* p = (const _Tp*)((SparseMat*)this)->ptr(idx, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(idx, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
     return p ? *p : _Tp();
 }
 
 template<typename _Tp> inline
 const _Tp* SparseMat::find(int i0, size_t* hashval) const
 {
-    return (const _Tp*)((SparseMat*)this)->ptr(i0, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(i0, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 const _Tp* SparseMat::find(int i0, int i1, size_t* hashval) const
 {
-    return (const _Tp*)((SparseMat*)this)->ptr(i0, i1, false, hashval);
+    const _Tp* p = (const _Tp*)((void*)((SparseMat*)this)->ptr(i0, i1, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 const _Tp* SparseMat::find(int i0, int i1, int i2, size_t* hashval) const
 {
-    return (const _Tp*)((SparseMat*)this)->ptr(i0, i1, i2, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(i0, i1, i2, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 const _Tp* SparseMat::find(const int* idx, size_t* hashval) const
 {
-    return (const _Tp*)((SparseMat*)this)->ptr(idx, false, hashval);
+    const _Tp* p = (const _Tp*)((const void*)((SparseMat*)this)->ptr(idx, false, hashval));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return p;
 }
 
 template<typename _Tp> inline
 _Tp& SparseMat::value(Node* n)
 {
-    return *(_Tp*)((uchar*)n + hdr->valueOffset);
+    _Tp* p = (_Tp*)((void*)((uchar*)n + hdr->valueOffset));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 template<typename _Tp> inline
 const _Tp& SparseMat::value(const Node* n) const
 {
-    return *(const _Tp*)((const uchar*)n + hdr->valueOffset);
+    const _Tp* p = (const _Tp*)((const void*)((const uchar*)n + hdr->valueOffset));
+    CV_DbgAssert(((uintptr_t)p & (alignof(_Tp) - 1)) == 0);
+    return *p;
 }
 
 inline
@@ -2501,7 +2603,7 @@ MatConstIterator_<_Tp>& MatConstIterator_<_Tp>::operator = (const MatConstIterat
 template<typename _Tp> inline
 const _Tp& MatConstIterator_<_Tp>::operator *() const
 {
-    return *(_Tp*)(this->ptr);
+    return *(_Tp*)((void*)(this->ptr));
 }
 
 template<typename _Tp> inline
@@ -2607,7 +2709,7 @@ MatConstIterator_<_Tp> operator - (const MatConstIterator_<_Tp>& a, ptrdiff_t of
 template<typename _Tp> inline
 const _Tp& MatConstIterator_<_Tp>::operator [](ptrdiff_t i) const
 {
-    return *(_Tp*)MatConstIterator::operator [](i);
+    return *(_Tp*)((void*)MatConstIterator::operator [](i));
 }
 
 
@@ -2654,7 +2756,7 @@ MatIterator_<_Tp>& MatIterator_<_Tp>::operator = (const MatIterator_<_Tp>& it )
 template<typename _Tp> inline
 _Tp& MatIterator_<_Tp>::operator *() const
 {
-    return *(_Tp*)(this->ptr);
+    return *(_Tp*)((void*)(this->ptr));
 }
 
 template<typename _Tp> inline
@@ -2769,7 +2871,7 @@ inline SparseMatConstIterator& SparseMatConstIterator::operator = (const SparseM
 template<typename _Tp> inline
 const _Tp& SparseMatConstIterator::value() const
 {
-    return *(const _Tp*)ptr;
+    return *(const _Tp*)((const void*)ptr);
 }
 
 inline
@@ -2837,7 +2939,7 @@ SparseMatIterator& SparseMatIterator::operator = (const SparseMatIterator& it)
 template<typename _Tp> inline
 _Tp& SparseMatIterator::value() const
 {
-    return *(_Tp*)ptr;
+    return *(_Tp*)((void*)ptr);
 }
 
 inline
@@ -2897,7 +2999,7 @@ SparseMatConstIterator_<_Tp>& SparseMatConstIterator_<_Tp>::operator = (const Sp
 template<typename _Tp> inline
 const _Tp& SparseMatConstIterator_<_Tp>::operator *() const
 {
-    return *(const _Tp*)this->ptr;
+    return *(const _Tp*)((const void*)this->ptr);
 }
 
 template<typename _Tp> inline
@@ -2949,7 +3051,7 @@ SparseMatIterator_<_Tp>& SparseMatIterator_<_Tp>::operator = (const SparseMatIte
 template<typename _Tp> inline
 _Tp& SparseMatIterator_<_Tp>::operator *() const
 {
-    return *(_Tp*)this->ptr;
+    return *(_Tp*)((void*)this->ptr);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
Working towards solving issue "Cast with incorrect alignment" https://github.com/opencv/opencv/issues/24265.

This PR adds alignment checks (`DbgAssert`) for accessing data in `Mat`, and silences alignment warnings (from `-Wcast-align=strict`) using an intermediate cast to `void*`.

**A few tests break due to these changes (such as `Core_Transform` tests), as they fail the alignment checks. Not sure how to resolve this issue.**

Example code for behavior of proposed changes: 
```
#include <opencv2/opencv.hpp>
#include <iostream>

int main()
{
    std::cout << "Alignment of <uchar>:  " << alignof(uchar) << std::endl;
    std::cout << "Alignment of <double>: " << alignof(double) << std::endl;

    int cols = 6;
    int rows = 4;

    // Create 64F Mat
    cv::Mat mat64F(rows, cols, CV_64F);
    for (int row = 0; row < rows; ++row)
        for (int col = 0; col < cols; ++col)
            mat64F.at<double>(row, col) = row + col;

    // Access using double works (same size as 64F)
    std::cout << "This works: " << *mat64F.ptr<double>(0, 0) << std::endl;
    std::cout << "This works: " << *mat64F.ptr<double>(1, 1) << std::endl;
    // Access using uchar works (smaller than 64F)
    std::cout << "This works: " << 'a' + *mat64F.ptr<uchar>(0, 0) << std::endl;
    std::cout << "This works: " << 'a' + *mat64F.ptr<uchar>(1, 1) << std::endl;

    // Create 8U Mat
    cv::Mat mat8U(rows, cols, CV_8U);
    for (int row = 0; row < rows; ++row)
        for (int col = 0; col < cols; ++col)
            mat8U.at<uchar>(row, col) = 'a' + row + col;

    // Access using uchar works (same size as 8U)
    std::cout << "This works: " << *mat8U.ptr<uchar>(0, 0) << std::endl;
    std::cout << "This works: " << *mat8U.ptr<uchar>(1, 1) << std::endl;
    // Access using double works when the address is aligned to alignof(double)
    std::cout << "This works? " << *mat8U.ptr<double>(0, 0) << std::endl;
    // Access using double does NOT work when the address is not aligned to alignof(double)
    std::cout << "This don't:\n" << *mat8U.ptr<double>(1, 1) << std::endl;

    return 0;
}
```
Output of example code:
```
Alignment of <uchar>:  1
Alignment of <double>: 8
This works: 0
This works: 2
This works: 97
This works: 97
This works: a
This works: c
This works? 5.55527e+170
This don't:
OpenCV(4.10.0-dev) Error: Assertion failed (((uintptr_t)p & (alignof(_Tp) - 1)) == 0) in ptr, file /my/path/opencv4/opencv2/core/mat.inl.hpp, line 759
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.10.0-dev) /my/path/opencv4/opencv2/core/mat.inl.hpp:759: error: (-215:Assertion failed) ((uintptr_t)p & (alignof(_Tp) - 1)) == 0 in function 'ptr'

zsh: IOT instruction (core dumped)  ./opencv-test-build/opencv-test
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
