### PR TITLE
pyrDown: offset HAL added, IPP removed

### DIFF
--- a/modules/imgproc/src/hal_replacement.hpp
+++ b/modules/imgproc/src/hal_replacement.hpp
@@ -1050,6 +1050,33 @@ inline int hal_ni_pyrdown(const uchar* src_data, size_t src_step, int src_width,
 //! @endcond
 
 /**
+   @brief Perform Gaussian Blur and downsampling for input tile with optional margins for submatrix
+   @param src_data Source image data
+   @param src_step Source image step
+   @param src_width Source image width
+   @param src_height Source image height
+   @param dst_data Destination image data
+   @param dst_step Destination image step
+   @param dst_width Destination image width
+   @param dst_height Destination image height
+   @param depth Depths of source and destination image
+   @param cn Number of channels
+   @param margin_left Left margins for source image
+   @param margin_top Top margins for source image
+   @param margin_right Right margins for source image
+   @param margin_bottom Bottom margins for source image
+   @param border_type Border type
+*/
+inline int hal_ni_pyrdown_offset(const uchar* src_data, size_t src_step, int src_width, int src_height,
+                                 uchar* dst_data, size_t dst_step, int dst_width, int dst_height,
+                                 int depth, int cn, int margin_left, int margin_top, int margin_right, int margin_bottom, int border_type)
+{ return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+
+//! @cond IGNORED
+#define cv_hal_pyrdown_offset hal_ni_pyrdown_offset
+//! @endcond
+
+/**
    @brief Canny edge detector
    @param src_data Source image data
    @param src_step Source image step

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1363,10 +1363,10 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
     Mat dst = _dst.getMat();
     int depth = src.depth();
 
-    Point ofs;
-    Size wsz(src.cols, src.rows);
     if(src.isSubmatrix() && !(borderType & BORDER_ISOLATED))
     {
+        Point ofs;
+        Size wsz(src.cols, src.rows);
         src.locateROI( wsz, ofs );
         CALL_HAL(pyrDown, cv_hal_pyrdown_offset, src.data, src.step, src.cols, src.rows,
                  dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(),

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1377,8 +1377,6 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
         CALL_HAL(pyrDown, cv_hal_pyrdown, src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(), borderType);
     }
 
-    // IPP code was incorrect, removed
-
     PyrFunc func = 0;
     if( depth == CV_8U )
         func = pyrDown_< FixPtCast<uchar, 8> >;

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1365,7 +1365,7 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
 
     Point ofs;
     Size wsz(src.cols, src.rows);
-    if(!(borderType & BORDER_ISOLATED))
+    if(src.isSubmatrix() && !(borderType & BORDER_ISOLATED))
     {
         src.locateROI( wsz, ofs );
         CALL_HAL(pyrDown, cv_hal_pyrdown_offset, src.data, src.step, src.cols, src.rows,

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1266,6 +1266,8 @@ static bool ocl_pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int 
 
 }
 
+// TODO: enable it when the corresponding IPP code is fixed
+#if 0
 #if defined(HAVE_IPP)
 namespace cv
 {
@@ -1282,7 +1284,6 @@ static bool ipp_pyrdown( InputArray _src, OutputArray _dst, const Size& _dsz, in
     _dst.create( dsz, src.type() );
     Mat dst = _dst.getMat();
     int depth = src.depth();
-
 
     {
         bool isolated = (borderType & BORDER_ISOLATED) != 0;
@@ -1328,6 +1329,8 @@ static bool ipp_pyrdown( InputArray _src, OutputArray _dst, const Size& _dsz, in
 }
 }
 #endif
+// TODO: enable it when the corresponding IPP code is fixed
+#endif // #if 0
 
 #ifdef HAVE_OPENVX
 namespace cv
@@ -1440,12 +1443,15 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
         CALL_HAL(pyrDown, cv_hal_pyrdown, src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(), borderType);
     }
 
+// TODO: enable it when the corresponding IPP code is fixed
+#if 0
 #ifdef HAVE_IPP
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
 #endif
     CV_IPP_RUN(borderTypeNI == BORDER_DEFAULT && (!_src.isSubmatrix() || isolated) && dsz == Size((_src.cols() + 1)/2, (_src.rows() + 1)/2),
         ipp_pyrdown( _src,  _dst,  _dsz,  borderType));
+#endif // #if 0
 
 
     PyrFunc func = 0;

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1266,72 +1266,6 @@ static bool ocl_pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int 
 
 }
 
-// TODO: enable it when the corresponding IPP code is fixed
-#if 0
-#if defined(HAVE_IPP)
-namespace cv
-{
-static bool ipp_pyrdown( InputArray _src, OutputArray _dst, const Size& _dsz, int borderType )
-{
-    CV_INSTRUMENT_REGION_IPP();
-
-#if IPP_VERSION_X100 >= 810 && !IPP_DISABLE_PYRAMIDS_DOWN
-    Size dsz = _dsz.empty() ? Size((_src.cols() + 1)/2, (_src.rows() + 1)/2) : _dsz;
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-
-    Mat src = _src.getMat();
-    _dst.create( dsz, src.type() );
-    Mat dst = _dst.getMat();
-    int depth = src.depth();
-
-    {
-        bool isolated = (borderType & BORDER_ISOLATED) != 0;
-        int borderTypeNI = borderType & ~BORDER_ISOLATED;
-        if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size(src.cols*2, src.rows*2))
-        {
-            typedef IppStatus (CV_STDCALL * ippiPyrUp)(const void* pSrc, int srcStep, void* pDst, int dstStep, IppiSize srcRoi, Ipp8u* buffer);
-            int type = src.type();
-            CV_SUPPRESS_DEPRECATED_START
-            ippiPyrUp pyrUpFunc = type == CV_8UC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C1R :
-                                  type == CV_8UC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C3R :
-                                  type == CV_32FC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C1R :
-                                  type == CV_32FC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C3R : 0;
-            CV_SUPPRESS_DEPRECATED_END
-
-            if (pyrUpFunc)
-            {
-                int bufferSize;
-                IppiSize srcRoi = { src.cols, src.rows };
-                IppDataType dataType = depth == CV_8U ? ipp8u : ipp32f;
-                CV_SUPPRESS_DEPRECATED_START
-                IppStatus ok = ippiPyrUpGetBufSize_Gauss5x5(srcRoi.width, dataType, src.channels(), &bufferSize);
-                CV_SUPPRESS_DEPRECATED_END
-                if (ok >= 0)
-                {
-                    Ipp8u* buffer = ippsMalloc_8u_L(bufferSize);
-                    ok = pyrUpFunc(src.data, (int) src.step, dst.data, (int) dst.step, srcRoi, buffer);
-                    ippsFree(buffer);
-
-                    if (ok >= 0)
-                    {
-                        CV_IMPL_ADD(CV_IMPL_IPP);
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-#else
-    CV_UNUSED(_src); CV_UNUSED(_dst); CV_UNUSED(_dsz); CV_UNUSED(borderType);
-#endif
-    return false;
-}
-}
-#endif
-// TODO: enable it when the corresponding IPP code is fixed
-#endif // #if 0
-
 #ifdef HAVE_OPENVX
 namespace cv
 {
@@ -1443,16 +1377,7 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
         CALL_HAL(pyrDown, cv_hal_pyrdown, src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(), borderType);
     }
 
-// TODO: enable it when the corresponding IPP code is fixed
-#if 0
-#ifdef HAVE_IPP
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-#endif
-    CV_IPP_RUN(borderTypeNI == BORDER_DEFAULT && (!_src.isSubmatrix() || isolated) && dsz == Size((_src.cols() + 1)/2, (_src.rows() + 1)/2),
-        ipp_pyrdown( _src,  _dst,  _dsz,  borderType));
-#endif // #if 0
-
+    // IPP code was incorrect, removed
 
     PyrFunc func = 0;
     if( depth == CV_8U )

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1426,7 +1426,19 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
     Mat dst = _dst.getMat();
     int depth = src.depth();
 
-    CALL_HAL(pyrDown, cv_hal_pyrdown, src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(), borderType);
+    Point ofs;
+    Size wsz(src.cols, src.rows);
+    if(!(borderType & BORDER_ISOLATED))
+    {
+        src.locateROI( wsz, ofs );
+        CALL_HAL(pyrDown, cv_hal_pyrdown_offset, src.data, src.step, src.cols, src.rows,
+                 dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(),
+                 ofs.x, ofs.y, wsz.width - src.cols - ofs.x, wsz.height - src.rows - ofs.y, borderType & (~BORDER_ISOLATED));
+    }
+    else
+    {
+        CALL_HAL(pyrDown, cv_hal_pyrdown, src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, depth, src.channels(), borderType);
+    }
 
 #ifdef HAVE_IPP
     bool isolated = (borderType & BORDER_ISOLATED) != 0;

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -1192,7 +1192,7 @@ CV_PyramidDownTest::CV_PyramidDownTest() : CV_PyramidBaseTest( true )
 
 void CV_PyramidDownTest::run_func()
 {
-    cvPyrDown( test_array[INPUT][0], test_array[OUTPUT][0], CV_GAUSSIAN_5x5 );
+    cv::pyrDown(test_mat[INPUT][0], test_mat[OUTPUT][0]);
 }
 
 


### PR DESCRIPTION
Resolves #25976

### Changes
* HAL added for offset support so that border pixels can be fetched from outside of the image ROI (see `BORDER_ISOLATED` parameter)
* IPP removed since there is `pyrUp` instead of `pyrDown` and there's no easy way to fix this other than rewriting it from scratch
* replaced old C call by modern `cv::pyrDown`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
