### PR TITLE
add test for conv2d with padding

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1550,6 +1550,10 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
     testONNXModels("einsum_const_inputs", npy, 0, 0, false, false, 1);
 }
 
+TEST_P(Test_ONNX_layers, Conv2DPadding) {
+    testONNXModels("conv2dPadding", npy, 0, 0, false, false, 1);
+}
+
 TEST_P(Test_ONNX_layers, ReduceSum_Consts){
     testONNXModels("reducesum_consts");
 }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1551,7 +1551,7 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
 }
 
 TEST_P(Test_ONNX_layers, Conv2DPadding) {
-    testONNXModels("conv2dPadding", npy, 0, 0, false, false, 1);
+    testONNXModels("conv2dPadding", npy, 1e-08, 1e-08, false, false, 1);
 }
 
 TEST_P(Test_ONNX_layers, ReduceSum_Consts){

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -1551,7 +1551,7 @@ TEST_P(Test_ONNX_layers, Einsum_const_inputs) {
 }
 
 TEST_P(Test_ONNX_layers, Conv2DPadding) {
-    testONNXModels("conv2dPadding", npy, 1e-08, 1e-08, false, false, 1);
+    testONNXModels("conv2dPadding", npy, 0, 0, false, false, 1);
 }
 
 TEST_P(Test_ONNX_layers, ReduceSum_Consts){


### PR DESCRIPTION
This PR add test for conv2d with `padding=1` as the output of the convolution operation in opencv does not match with torch exactly. This causes diffusion model output deviate a little bit compared to torch(see this [PR](https://github.com/opencv/opencv/pull/25950)). This PR does not provide solution for the problem, but merely highlights it. Would it be possible to check the cause of the issue @fengyuentau @dkurt 

Test data and model for this test are located in this [PR](https://github.com/opencv/opencv_extra/pull/1196)
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
