### PR TITLE
Adding getStdAllocator() to cv::cuda::GpuMat

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -118,6 +118,7 @@ public:
     //! default allocator
     CV_WRAP static GpuMat::Allocator* defaultAllocator();
     CV_WRAP static void setDefaultAllocator(GpuMat::Allocator* allocator);
+    CV_WRAP static GpuMat::Allocator* getStdAllocator();
 
     //! default constructor
     CV_WRAP explicit GpuMat(GpuMat::Allocator* allocator = GpuMat::defaultAllocator());

--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -135,6 +135,7 @@ namespace
 
     DefaultAllocator cudaDefaultAllocator;
     GpuMat::Allocator* g_defaultAllocator = &cudaDefaultAllocator;
+    GpuMat::Allocator* g_stdAllocator = &cudaDefaultAllocator;
 }
 
 GpuMat::Allocator* cv::cuda::GpuMat::defaultAllocator()
@@ -147,6 +148,12 @@ void cv::cuda::GpuMat::setDefaultAllocator(Allocator* allocator)
     CV_Assert( allocator != 0 );
     g_defaultAllocator = allocator;
 }
+
+GpuMat::Allocator* cv::cuda::GpuMat::getStdAllocator()
+{
+    return g_stdAllocator;
+}
+
 
 /////////////////////////////////////////////////////
 /// create

--- a/modules/core/src/cuda_gpu_mat.cpp
+++ b/modules/core/src/cuda_gpu_mat.cpp
@@ -420,6 +420,11 @@ void cv::cuda::GpuMat::setDefaultAllocator(Allocator* allocator)
     throw_no_cuda();
 }
 
+GpuMat::Allocator* cv::cuda::GpuMat::getStdAllocator()
+{
+    return 0;
+}
+
 void cv::cuda::GpuMat::create(int _rows, int _cols, int _type)
 {
     CV_UNUSED(_rows);


### PR DESCRIPTION
To be on par with `cv::Mat`, let's add `cv::cuda::GpuMat::getStdAllocator()` This is useful anyway, because when a user wants to use custom allocators, he might want to resort to the standard default allocator behaviour, not some other allocator that could have been set by `setDefaultAllocator()`

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
