### PR TITLE
imgproc: add optimized warpAffine kernels for 8U/16U/32F + C1/C3/C4 inputs

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -2269,7 +2269,7 @@ inline v_int32x4 v_round(const v_float32x4& a)
 #endif
 inline v_int32x4 v_floor(const v_float32x4& a)
 {
-#if CV_NEON_AARCH64
+#if __ARM_ARCH > 7
     return v_int32x4(vcvtmq_s32_f32(a.val));
 #else
     int32x4_t a1 = vcvtq_s32_f32(a.val);

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -2228,9 +2228,7 @@ inline v_int16x8 v_round(const v_float16x8 &a)
 
 inline v_int16x8 v_floor(const v_float16x8 &a)
 {
-    int16x8_t a1 = vcvtq_s16_f16(a.val);
-    uint16x8_t mask = vcgtq_f16(vcvtq_f16_s16(a1), a.val);
-    return v_int16x8(vaddq_s16(a1, vreinterpretq_s16_u16(mask)));
+    return v_int16x8(vcvtmq_s16_f16(a.val));
 }
 
 inline v_int16x8 v_ceil(const v_float16x8 &a)
@@ -2271,9 +2269,13 @@ inline v_int32x4 v_round(const v_float32x4& a)
 #endif
 inline v_int32x4 v_floor(const v_float32x4& a)
 {
+#if CV_NEON_AARCH64
+    return v_int32x4(vcvtmq_s32_f32(a.val));
+#else
     int32x4_t a1 = vcvtq_s32_f32(a.val);
     uint32x4_t mask = vcgtq_f32(vcvtq_f32_s32(a1), a.val);
     return v_int32x4(vaddq_s32(a1, vreinterpretq_s32_u32(mask)));
+#endif
 }
 
 inline v_int32x4 v_ceil(const v_float32x4& a)

--- a/modules/features2d/src/affine_feature.cpp
+++ b/modules/features2d/src/affine_feature.cpp
@@ -261,7 +261,7 @@ private:
             h = rect.height; w = rect.width;
             pose = Matx23f(c, -s, -(float)rect.x,
                         s,  c, -(float)rect.y);
-            warpAffine(image, rotImage, pose, Size(w, h), INTER_LINEAR, BORDER_REPLICATE);
+            warpAffine(image, rotImage, pose, Size(w, h), INTER_LINEAR, BORDER_REPLICATE, Scalar(), cv::ALGO_HINT_ACCURATE);
         }
         if( tilt == 1 )
             warpedImage = rotImage;
@@ -275,7 +275,7 @@ private:
             pose(0, 2) /= tilt;
         }
         if( phi != 0 || tilt != 1 )
-            warpAffine(mask0, warpedMask, pose, warpedImage.size(), INTER_NEAREST);
+            warpAffine(mask0, warpedMask, pose, warpedImage.size(), INTER_NEAREST, BORDER_CONSTANT, Scalar(), cv::ALGO_HINT_ACCURATE);
         else
             warpedMask = mask0;
     }

--- a/modules/features2d/test/test_affine_feature.cpp
+++ b/modules/features2d/test/test_affine_feature.cpp
@@ -3,7 +3,6 @@
 // of this distribution and at http://opencv.org/license.html
 
 #include "test_precomp.hpp"
-#include "opencv2/core/hal/intrin.hpp"
 
 // #define GENERATE_DATA // generate data in debug mode
 
@@ -83,11 +82,7 @@ TEST(Features2d_AFFINE_FEATURE, regression)
     const float badCountsRatio = 0.01f;
     const float badDescriptorDist = 1.0f;
     const float maxBadKeypointsRatio = 0.15f;
-#if CV_SIMD_FP16
-    const float maxBadDescriptorRatio = 0.41f;
-#else
     const float maxBadDescriptorRatio = 0.15f;
-#endif
 
     // read keypoints
     vector<KeyPoint> validKeypoints;
@@ -119,40 +114,6 @@ TEST(Features2d_AFFINE_FEATURE, regression)
         validKeypoints[i].octave = moctave.at<int>(i, 0);
         validKeypoints[i].class_id = mclass_id.at<int>(i, 0);
     }
-
-/*
-Previous:
-
-extracting with sift...
-img1 - 20532 features, img2 - 12710 features
-matching with bruteforce...
-execution time: 544.43 ms
-434 / 569 inliers/matched
-visualizing...
-only 50 inliers are visualized
-done
-
-Optimized-FP32:
-
-img1 - 20550 features, img2 - 12676 features
-matching with bruteforce...
-execution time: 555.62 ms
-395 / 564 inliers/matched
-visualizing...
-only 50 inliers are visualized
-done
-
-Optimized-FP16:
-
-img1 - 20540 features, img2 - 12686 features
-matching with bruteforce...
-execution time: 537.68 ms
-413 / 571 inliers/matched
-visualizing...
-only 50 inliers are visualized
-done
-
-*/
 
     // read descriptors
     fs["descriptors"] >> validDescriptors;

--- a/modules/features2d/test/test_affine_feature.cpp
+++ b/modules/features2d/test/test_affine_feature.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html
 
 #include "test_precomp.hpp"
+#include "opencv2/core/hal/intrin.hpp"
 
 // #define GENERATE_DATA // generate data in debug mode
 
@@ -82,7 +83,11 @@ TEST(Features2d_AFFINE_FEATURE, regression)
     const float badCountsRatio = 0.01f;
     const float badDescriptorDist = 1.0f;
     const float maxBadKeypointsRatio = 0.15f;
+#if CV_SIMD_FP16
+    const float maxBadDescriptorRatio = 0.41f;
+#else
     const float maxBadDescriptorRatio = 0.15f;
+#endif
 
     // read keypoints
     vector<KeyPoint> validKeypoints;
@@ -114,6 +119,40 @@ TEST(Features2d_AFFINE_FEATURE, regression)
         validKeypoints[i].octave = moctave.at<int>(i, 0);
         validKeypoints[i].class_id = mclass_id.at<int>(i, 0);
     }
+
+/*
+Previous:
+
+extracting with sift...
+img1 - 20532 features, img2 - 12710 features
+matching with bruteforce...
+execution time: 544.43 ms
+434 / 569 inliers/matched
+visualizing...
+only 50 inliers are visualized
+done
+
+Optimized-FP32:
+
+img1 - 20550 features, img2 - 12676 features
+matching with bruteforce...
+execution time: 555.62 ms
+395 / 564 inliers/matched
+visualizing...
+only 50 inliers are visualized
+done
+
+Optimized-FP16:
+
+img1 - 20540 features, img2 - 12686 features
+matching with bruteforce...
+execution time: 537.68 ms
+413 / 571 inliers/matched
+visualizing...
+only 50 inliers are visualized
+done
+
+*/
 
     // read descriptors
     fs["descriptors"] >> validDescriptors;

--- a/modules/imgproc/CMakeLists.txt
+++ b/modules/imgproc/CMakeLists.txt
@@ -10,6 +10,7 @@ ocv_add_dispatched_file(median_blur SSE2 SSE4_1 AVX2)
 ocv_add_dispatched_file(morph SSE2 SSE4_1 AVX2)
 ocv_add_dispatched_file(smooth SSE2 SSE4_1 AVX2)
 ocv_add_dispatched_file(sumpixels SSE2 AVX2 AVX512_SKX)
+ocv_add_dispatched_file(warp_kernels SSE2 SSE4_1 AVX2 NEON NEON_FP16 RVV LASX)
 ocv_define_module(imgproc opencv_core WRAP java objc python js)
 
 ocv_module_include_directories(opencv_imgproc ${ZLIB_INCLUDE_DIRS})

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2474,6 +2474,7 @@ flag #WARP_INVERSE_MAP that means that M is the inverse transformation (
 borderMode=#BORDER_TRANSPARENT, it means that the pixels in the destination image corresponding to
 the "outliers" in the source image are not modified by the function.
 @param borderValue value used in case of a constant border; by default, it is 0.
+@param hint Implementation modfication flags. See #AlgorithmHint
 
 @sa  warpPerspective, resize, remap, getRectSubPix, transform
  */
@@ -2481,7 +2482,8 @@ CV_EXPORTS_W void warpAffine( InputArray src, OutputArray dst,
                               InputArray M, Size dsize,
                               int flags = INTER_LINEAR,
                               int borderMode = BORDER_CONSTANT,
-                              const Scalar& borderValue = Scalar());
+                              const Scalar& borderValue = Scalar(),
+                              AlgorithmHint hint = cv::ALGO_HINT_DEFAULT);
 
 /** @example samples/cpp/snippets/warpPerspective_demo.cpp
 An example program shows using cv::getPerspectiveTransform and cv::warpPerspective for image warping

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -72,7 +72,7 @@ OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
     const WarpAffineParams params = GetParam();
     const Size srcSize = get<0>(params);
     const int type = get<1>(params), interpolation = get<2>(params);
-    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 2 : interpolation == INTER_CUBIC ? 2e-3 : 3e-2;
+    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : interpolation == INTER_CUBIC ? 2e-3 : 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -72,7 +72,10 @@ OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
     const WarpAffineParams params = GetParam();
     const Size srcSize = get<0>(params);
     const int type = get<1>(params), interpolation = get<2>(params);
-    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : interpolation == INTER_CUBIC ? 2e-3 : 1e-4;
+
+    // BUG: OpenCL and CPU version diverges a bit
+    // Ticket: https://github.com/opencv/opencv/issues/26235
+    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 2 : interpolation == INTER_CUBIC ? 2e-3 : 3e-2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -72,7 +72,7 @@ OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
     const WarpAffineParams params = GetParam();
     const Size srcSize = get<0>(params);
     const int type = get<1>(params), interpolation = get<2>(params);
-    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : interpolation == INTER_CUBIC ? 2e-3 : 1e-4;
+    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 2 : interpolation == INTER_CUBIC ? 2e-3 : 3e-2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -15,24 +15,6 @@ typedef TestBaseWithParam<MatInfo_SizePair_t> MatInfo_SizePair;
                           CV_16UC1, CV_16UC2, CV_16UC3, CV_16UC4, \
                           CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4
 
-// For gradient-ish testing of the other matrix formats
-template<typename T>
-static void fillFPGradient(Mat& img)
-{
-    const int ch = img.channels();
-
-    int r, c, i;
-    for(r=0; r<img.rows; r++)
-    {
-        for(c=0; c<img.cols; c++)
-        {
-            T vals[] = {(T)r, (T)c, (T)(r*c), (T)(r*c/(r+c+1))};
-            T *p = (T*)img.ptr(r, c);
-            for(i=0; i<ch; i++) p[i] = (T)vals[i];
-        }
-    }
-}
-
 PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
             testing::Values(
                 MatInfo_Size_Size_t(CV_8UC1, szVGA, szqHD),
@@ -51,7 +33,7 @@ PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
     Size to = get<2>(GetParam());
 
     cv::Mat src(from, matType), dst(to, matType);
-    cvtest::fillGradient(src);
+    cvtest::fillGradient<uint8_t>(src);
     declare.in(src).out(dst);
 
     TEST_CYCLE_MULTIRUN(10) resize(src, dst, to, 0, 0, INTER_LINEAR_EXACT);
@@ -79,9 +61,9 @@ PERF_TEST_P(MatInfo_SizePair, resizeUpLinearNonExact,
     cv::Mat src(from, matType), dst(to, matType);
     switch(src.depth())
     {
-        case CV_8U: cvtest::fillGradient(src); break;
-        case CV_16U: fillFPGradient<ushort>(src); break;
-        case CV_32F: fillFPGradient<float>(src); break;
+        case CV_8U: cvtest::fillGradient<uint8_t>(src); break;
+        case CV_16U: cvtest::fillGradient<ushort>(src); break;
+        case CV_32F: cvtest::fillGradient<float>(src); break;
     }
     declare.in(src).out(dst);
 
@@ -120,7 +102,7 @@ PERF_TEST_P(MatInfo_Size_Size, resizeDownLinear,
     Size to = get<2>(GetParam());
 
     cv::Mat src(from, matType), dst(to, matType);
-    cvtest::fillGradient(src);
+    cvtest::fillGradient<uint8_t>(src);
     declare.in(src).out(dst);
 
     TEST_CYCLE_MULTIRUN(10) resize(src, dst, to, 0, 0, INTER_LINEAR_EXACT);
@@ -155,9 +137,9 @@ PERF_TEST_P(MatInfo_SizePair, resizeDownLinearNonExact,
     cv::Mat src(from, matType), dst(to, matType);
     switch(src.depth())
     {
-        case CV_8U: cvtest::fillGradient(src); break;
-        case CV_16U: fillFPGradient<ushort>(src); break;
-        case CV_32F: fillFPGradient<float>(src); break;
+        case CV_8U: cvtest::fillGradient<uint8_t>(src); break;
+        case CV_16U: cvtest::fillGradient<ushort>(src); break;
+        case CV_32F: cvtest::fillGradient<float>(src); break;
     }
     declare.in(src).out(dst);
 

--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -12,7 +12,7 @@ CV_ENUM(InterType, INTER_NEAREST, INTER_LINEAR)
 CV_ENUM(InterTypeExtended, INTER_NEAREST, INTER_LINEAR, WARP_RELATIVE_MAP)
 CV_ENUM(RemapMode, HALF_SIZE, UPSIDE_DOWN, REFLECTION_X, REFLECTION_BOTH)
 
-typedef TestBaseWithParam< tuple<MatType, Size, InterType, BorderMode> > TestWarpAffine;
+typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, MatType> > TestWarpAffine;
 typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, int> > TestWarpPerspective;
 typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, MatType> > TestWarpPerspectiveNear_t;
 typedef TestBaseWithParam< tuple<MatType, Size, InterTypeExtended, BorderMode, RemapMode> > TestRemap;
@@ -21,58 +21,43 @@ void update_map(const Mat& src, Mat& map_x, Mat& map_y, const int remapMode, boo
 
 PERF_TEST_P( TestWarpAffine, WarpAffine,
              Combine(
-                Values(CV_8UC1, CV_8UC4),
                 Values( szVGA, sz720p, sz1080p ),
                 InterType::all(),
-                BorderMode::all()
+                BorderMode::all(),
+                Values(CV_8UC3, CV_16UC3, CV_32FC3, CV_8UC1, CV_16UC1, CV_32FC1, CV_8UC4, CV_16UC4, CV_32FC4)
              )
 )
 {
     Size sz, szSrc(512, 512);
-    int borderMode, interType, dataType;
-    dataType   = get<0>(GetParam());
-    sz         = get<1>(GetParam());
-    interType  = get<2>(GetParam());
-    borderMode = get<3>(GetParam());
+    int type, borderMode, interType;
+    sz         = get<0>(GetParam());
+    interType  = get<1>(GetParam());
+    borderMode = get<2>(GetParam());
+    type       = get<3>(GetParam());
     Scalar borderColor = Scalar::all(150);
 
-    Mat src(szSrc, dataType), dst(sz, dataType);
-    cvtest::fillGradient(src);
-    if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
+    Mat src(szSrc,type), dst(sz, type);
+    switch (src.depth()) {
+        case CV_8U: {
+            cvtest::fillGradient<uint8_t>(src);
+            if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder<uint8_t>(src, borderColor, 1);
+            break;
+        }
+        case CV_16U: {
+            cvtest::fillGradient<uint16_t>(src);
+            if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder<uint16_t>(src, borderColor, 1);
+            break;
+        }
+        case CV_32F: {
+            cvtest::fillGradient<float>(src);
+            if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder<float>(src, borderColor, 1);
+            break;
+        }
+    }
     Mat warpMat = getRotationMatrix2D(Point2f(src.cols/2.f, src.rows/2.f), 30., 2.2);
     declare.in(src).out(dst);
 
     TEST_CYCLE() warpAffine( src, dst, warpMat, sz, interType, borderMode, borderColor );
-
-    SANITY_CHECK(dst, 1);
-}
-
-PERF_TEST_P(TestWarpAffine, DISABLED_WarpAffine_ovx,
-    Combine(
-        Values(CV_8UC1, CV_8UC4),
-        Values(szVGA, sz720p, sz1080p),
-        InterType::all(),
-        BorderMode::all()
-    )
-)
-{
-    Size sz, szSrc(512, 512);
-    int borderMode, interType, dataType;
-
-    dataType   = get<0>(GetParam());
-    sz         = get<1>(GetParam());
-    interType  = get<2>(GetParam());
-    borderMode = get<3>(GetParam());
-
-    Scalar borderColor = Scalar::all(150);
-
-    Mat src(szSrc, dataType), dst(sz, dataType);
-    cvtest::fillGradient(src);
-    if (borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
-    Mat warpMat = getRotationMatrix2D(Point2f(src.cols / 2.f, src.rows / 2.f), 30., 2.2);
-    declare.in(src).out(dst);
-
-    TEST_CYCLE() warpAffine(src, dst, warpMat, sz, interType, borderMode, borderColor);
 
     SANITY_CHECK(dst, 1);
 }
@@ -96,8 +81,8 @@ PERF_TEST_P( TestWarpPerspective, WarpPerspective,
     Scalar borderColor = Scalar::all(150);
 
     Mat src(szSrc, CV_8UC(channels)), dst(sz, CV_8UC(channels));
-    cvtest::fillGradient(src);
-    if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
+    cvtest::fillGradient<uint8_t>(src);
+    if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder<uint8_t>(src, borderColor, 1);
     Mat rotMat = getRotationMatrix2D(Point2f(src.cols/2.f, src.rows/2.f), 30., 2.2);
     Mat warpMat(3, 3, CV_64FC1);
     for(int r=0; r<2; r++)
@@ -110,42 +95,6 @@ PERF_TEST_P( TestWarpPerspective, WarpPerspective,
     declare.in(src).out(dst);
 
     TEST_CYCLE() warpPerspective( src, dst, warpMat, sz, interType, borderMode, borderColor );
-
-    SANITY_CHECK(dst, 1);
-}
-
-PERF_TEST_P(TestWarpPerspective, DISABLED_WarpPerspective_ovx,
-    Combine(
-        Values(szVGA, sz720p, sz1080p),
-        InterType::all(),
-        BorderMode::all(),
-        Values(1)
-    )
-)
-{
-    Size sz, szSrc(512, 512);
-    int borderMode, interType, channels;
-    sz = get<0>(GetParam());
-    interType = get<1>(GetParam());
-    borderMode = get<2>(GetParam());
-    channels   = get<3>(GetParam());
-    Scalar borderColor = Scalar::all(150);
-
-    Mat src(szSrc, CV_8UC(channels)), dst(sz, CV_8UC(channels));
-    cvtest::fillGradient(src);
-    if (borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
-    Mat rotMat = getRotationMatrix2D(Point2f(src.cols / 2.f, src.rows / 2.f), 30., 2.2);
-    Mat warpMat(3, 3, CV_64FC1);
-    for (int r = 0; r<2; r++)
-        for (int c = 0; c<3; c++)
-            warpMat.at<double>(r, c) = rotMat.at<double>(r, c);
-    warpMat.at<double>(2, 0) = .3 / sz.width;
-    warpMat.at<double>(2, 1) = .3 / sz.height;
-    warpMat.at<double>(2, 2) = 1;
-
-    declare.in(src).out(dst);
-
-    TEST_CYCLE() warpPerspective(src, dst, warpMat, sz, interType, borderMode, borderColor);
 
     SANITY_CHECK(dst, 1);
 }
@@ -168,8 +117,8 @@ PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,
     Scalar borderColor = Scalar::all(150);
 
     Mat src(size, type), dst(size, type);
-    cvtest::fillGradient(src);
-    if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
+    cvtest::fillGradient<uint8_t>(src);
+    if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder<uint8_t>(src, borderColor, 1);
     int shift = static_cast<int>(src.cols*0.04);
     Mat srcVertices = (Mat_<Vec2f>(1, 4) << Vec2f(0, 0),
                                             Vec2f(static_cast<float>(size.width-1), 0),

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -55,6 +55,9 @@
 #include "opencv2/core/softfloat.hpp"
 #include "imgwarp.hpp"
 
+#include "warp_kernels.simd.hpp"
+#include "warp_kernels.simd_declarations.hpp"
+
 using namespace cv;
 
 namespace cv
@@ -2580,6 +2583,12 @@ void warpAffine(int src_type,
 
     Mat src(Size(src_width, src_height), src_type, const_cast<uchar*>(src_data), src_step);
     Mat dst(Size(dst_width, dst_height), src_type, dst_data, dst_step);
+
+    if (interpolation == INTER_LINEAR &&
+        (dst.channels() == 1 || dst.channels() == 3 || dst.channels() == 4) &&
+        (dst.depth() == CV_8U || dst.depth() == CV_16U || dst.depth() == CV_32F)) {
+        CV_CPU_DISPATCH(warpAffineSimdInvoker, (dst, src, M, interpolation, borderType, borderValue), CV_CPU_DISPATCH_MODES_ALL);
+    }
 
     int x;
     AutoBuffer<int> _abdelta(dst.cols*2);

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1354,6 +1354,9 @@ static bool ocl_remap(InputArray _src, OutputArray _dst, InputArray _map1, Input
     int cn = _src.channels(), type = _src.type(), depth = _src.depth(),
             rowsPerWI = dev.isIntel() ? 4 : 1;
 
+    if(!dev.hasFP64() && depth == CV_64F)
+        return false;
+
     if (borderType == BORDER_TRANSPARENT || !(interpolation == INTER_LINEAR || interpolation == INTER_NEAREST)
             || _map1.type() == CV_16SC1 || _map2.type() == CV_16SC1)
         return false;

--- a/modules/imgproc/src/warp_common.hpp
+++ b/modules/imgproc/src/warp_common.hpp
@@ -1,0 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef __OPENCV_IMGPROC_WARP_COMMON_HPP__
+#define __OPENCV_IMGPROC_WARP_COMMON_HPP__
+
+#include "warp_common.vector.hpp"
+#include "warp_common.scalar.hpp"
+
+#endif // __OPENCV_IMGPROC_WARP_COMMON_HPP__

--- a/modules/imgproc/src/warp_common.scalar.hpp
+++ b/modules/imgproc/src/warp_common.scalar.hpp
@@ -1,0 +1,171 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Shuffle
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(CN, cn, i) \
+    p00##CN = srcptr[i]; p01##CN = srcptr[i + cn]; \
+    p10##CN = srcptr[srcstep + i]; p11##CN = srcptr[srcstep + cn + i];
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD_C1() \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(g, 1, 0)
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD_C3() \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(r, 3, 0) \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(g, 3, 1) \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(b, 3, 2)
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD_C4() \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(r, 4, 0) \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(g, 4, 1) \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(b, 4, 2) \
+    CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD(a, 4, 3)
+
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C1() \
+    dstptr[x] = bval[0];
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C3() \
+    dstptr[x*3] = bval[0]; \
+    dstptr[x*3+1] = bval[1]; \
+    dstptr[x*3+2] = bval[2];
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C4() \
+    dstptr[x*4] = bval[0]; \
+    dstptr[x*4+1] = bval[1]; \
+    dstptr[x*4+2] = bval[2]; \
+    dstptr[x*4+3] = bval[3];
+
+#define CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_C1(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx; \
+        pxy##g = srcptr[ofs]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##g = bval[0]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##g = dstptr[x]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_; \
+        pxy##g = src[glob_ofs]; \
+    }
+#define CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_C3(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*3; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*3]; \
+        pxy##g = dstptr[x*3+1]; \
+        pxy##b = dstptr[x*3+2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*3; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+    }
+#define CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_C4(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*4; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+        pxy##a = srcptr[ofs+3]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+        pxy##a = bval[3]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*4]; \
+        pxy##g = dstptr[x*4+1]; \
+        pxy##b = dstptr[x*4+2]; \
+        pxy##a = dstptr[x*4+3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*4; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+        pxy##a = src[glob_ofs+3]; \
+    }
+
+#define CV_WARP_LINEAR_SCALAR_SHUFFLE(CN) \
+    if ((((unsigned)ix < (unsigned)(srccols-1)) & \
+        ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
+        CV_WARP_LINEAR_SCALAR_SHUFFLE_LOAD_##CN() \
+    } else { \
+        if ((border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) && \
+            (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
+                ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
+            if (border_type == BORDER_CONSTANT) { \
+                CV_WARP_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_##CN() \
+            } \
+            continue; \
+        } \
+        CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 0, p00); \
+        CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 1, p01); \
+        CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 0, p10); \
+        CV_WARP_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 1, p11); \
+    }
+
+
+// Linear interpolation calculation
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(cn) \
+    float v0##cn = p00##cn + sx*(p01##cn - p00##cn); \
+    float v1##cn = p10##cn + sx*(p11##cn - p10##cn);
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C1() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g)
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C3() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b)
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C4() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(a)
+
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(cn) \
+    v0##cn += sy*(v1##cn - v0##cn);
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32_C1() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(g)
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32_C3() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(b)
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32_C4() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(b) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32(a)
+
+#define CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(CN) \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_##CN() \
+    CV_WARP_LINEAR_SCALAR_INTER_CALC_BETA_F32_##CN()
+
+
+// Store
+#define CV_WARP_LINEAR_SCALAR_STORE_C1(dtype) \
+    dstptr[x] = saturate_cast<dtype>(v0g);
+#define CV_WARP_LINEAR_SCALAR_STORE_C3(dtype) \
+    dstptr[x*3] = saturate_cast<dtype>(v0r); \
+    dstptr[x*3+1] = saturate_cast<dtype>(v0g); \
+    dstptr[x*3+2] = saturate_cast<dtype>(v0b);
+#define CV_WARP_LINEAR_SCALAR_STORE_C4(dtype) \
+    dstptr[x*4] = saturate_cast<dtype>(v0r); \
+    dstptr[x*4+1] = saturate_cast<dtype>(v0g); \
+    dstptr[x*4+2] = saturate_cast<dtype>(v0b); \
+    dstptr[x*4+3] = saturate_cast<dtype>(v0a);
+#define CV_WARP_LINEAR_SCALAR_STORE_8U(CN) \
+    CV_WARP_LINEAR_SCALAR_STORE_##CN(uint8_t)
+#define CV_WARP_LINEAR_SCALAR_STORE_16U(CN) \
+    CV_WARP_LINEAR_SCALAR_STORE_##CN(uint16_t)
+#define CV_WARP_LINEAR_SCALAR_STORE_32F(CN) \
+    CV_WARP_LINEAR_SCALAR_STORE_##CN(float)
+
+#define CV_WARP_LINEAR_SCALAR_STORE(CN, DEPTH) \
+    CV_WARP_LINEAR_SCALAR_STORE_##DEPTH(CN)

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1,0 +1,387 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Shuffle (all pixels within image)
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C1(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf] = srcptr[1]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 1]; \
+    }
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C3(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf*4] = srcptr[1]; \
+        pixbuf[i + uf*8] = srcptr[2]; \
+        pixbuf[i + uf] = srcptr[3]; \
+        pixbuf[i + uf*5] = srcptr[4]; \
+        pixbuf[i + uf*9] = srcptr[5]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
+        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 3]; \
+        pixbuf[i + uf*7] = srcptr[srcstep + 4]; \
+        pixbuf[i + uf*11] = srcptr[srcstep + 5]; \
+    }
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C4(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf*4] = srcptr[1]; \
+        pixbuf[i + uf*8] = srcptr[2]; \
+        pixbuf[i + uf*12] = srcptr[3]; \
+        pixbuf[i + uf] = srcptr[4]; \
+        pixbuf[i + uf*5] = srcptr[5]; \
+        pixbuf[i + uf*9] = srcptr[6]; \
+        pixbuf[i + uf*13] = srcptr[7]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
+        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
+        pixbuf[i + uf*14] = srcptr[srcstep + 3]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 4]; \
+        pixbuf[i + uf*7] = srcptr[srcstep + 5]; \
+        pixbuf[i + uf*11] = srcptr[srcstep + 6]; \
+        pixbuf[i + uf*15] = srcptr[srcstep + 7]; \
+    }
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_8U(CN) \
+    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint8_t)
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_16U(CN) \
+    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint16_t)
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_32F(CN) \
+    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(float)
+
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(CN, DEPTH) \
+    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##DEPTH(CN)
+
+
+// Shuffle (not all pixels within image)
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC1() \
+    v_store_low(dstptr + x, bval_v0);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC3() \
+    v_store_low(dstptr + x*3,        bval_v0); \
+    v_store_low(dstptr + x*3 + uf,   bval_v1); \
+    v_store_low(dstptr + x*3 + uf*2, bval_v2);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC4() \
+    v_store_low(dstptr + x*4,        bval_v0); \
+    v_store_low(dstptr + x*4 + uf,   bval_v1); \
+    v_store_low(dstptr + x*4 + uf*2, bval_v2); \
+    v_store_low(dstptr + x*4 + uf*3, bval_v3);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC1() \
+    v_store(dstptr + x, bval_v0);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC3() \
+    v_store(dstptr + x*3,        bval_v0); \
+    v_store(dstptr + x*3 + uf,   bval_v1); \
+    v_store(dstptr + x*3 + uf*2, bval_v2);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC4() \
+    v_store(dstptr + x*4,        bval_v0); \
+    v_store(dstptr + x*4 + uf,   bval_v1); \
+    v_store(dstptr + x*4 + uf*2, bval_v2); \
+    v_store(dstptr + x*4 + uf*3, bval_v3);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC1() \
+    v_store(dstptr + x,             bval_v0_l); \
+    v_store(dstptr + x + vlanes_32, bval_v0_h);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC3() \
+    v_store(dstptr + x*3,                    bval_v0_l); \
+    v_store(dstptr + x*3 + vlanes_32,        bval_v0_h); \
+    v_store(dstptr + x*3 + uf,               bval_v1_l); \
+    v_store(dstptr + x*3 + uf + vlanes_32,   bval_v1_h); \
+    v_store(dstptr + x*3 + uf*2,             bval_v2_l); \
+    v_store(dstptr + x*3 + uf*2 + vlanes_32, bval_v2_h);
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC4() \
+    v_store(dstptr + x*4,                    bval_v0_l); \
+    v_store(dstptr + x*4 + vlanes_32,        bval_v0_h); \
+    v_store(dstptr + x*4 + uf,               bval_v1_l); \
+    v_store(dstptr + x*4 + uf + vlanes_32,   bval_v1_h); \
+    v_store(dstptr + x*4 + uf*2,             bval_v2_l); \
+    v_store(dstptr + x*4 + uf*2 + vlanes_32, bval_v2_h); \
+    v_store(dstptr + x*4 + uf*3,             bval_v3_l); \
+    v_store(dstptr + x*4 + uf*3 + vlanes_32, bval_v3_h);
+
+#define CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_C1(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[x + i]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    }
+#define CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_C3(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*3]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*3 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*3 + 2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    }
+#define CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_C4(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = bval[3]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*4]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*4 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*4 + 2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = dstptr[(x + i)*4 + 3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    }
+
+#define CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(CN, DEPTH) \
+    if (border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) { \
+        mask_0 = v_lt(v_reinterpret_as_u32(v_add(src_ix0, one)), outer_scols); \
+        mask_1 = v_lt(v_reinterpret_as_u32(v_add(src_ix1, one)), outer_scols); \
+        mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(v_add(src_iy0, one)), outer_srows)); \
+        mask_1 = v_and(mask_1, v_lt(v_reinterpret_as_u32(v_add(src_iy1, one)), outer_srows)); \
+        v_uint16 outer_mask = v_pack(mask_0, mask_1); \
+        if (v_reduce_max(outer_mask) == 0) { \
+            if (border_type == BORDER_CONSTANT) { \
+                CV_WARP_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_##DEPTH##CN() \
+            } \
+            continue; \
+        } \
+    } \
+    vx_store(src_ix, src_ix0); \
+    vx_store(src_iy, src_iy0); \
+    vx_store(src_ix + vlanes_32, src_ix1); \
+    vx_store(src_iy + vlanes_32, src_iy1); \
+    for (int i = 0; i < uf; i++) { \
+        int ix = src_ix[i], iy = src_iy[i]; \
+        CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 0, 0); \
+        CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 1, uf); \
+        CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 0, uf*2); \
+        CV_WARP_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 1, uf*3); \
+    }
+
+
+// Load pixels for linear interpolation (uint8_t -> int16_t)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(cn, i) \
+    v_int16  f00##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * i)), \
+             f01##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+1))), \
+             f10##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+2))), \
+             f11##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+3)));
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 0)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(a, 12)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16_##CN();
+
+// Load pixels for linear interpolation (uint16_t -> uint16_t)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(cn, i) \
+    v_uint16 f00##cn = vx_load(pixbuf + uf * i), \
+             f01##cn = vx_load(pixbuf + uf * (i+1)), \
+             f10##cn = vx_load(pixbuf + uf * (i+2)), \
+             f11##cn = vx_load(pixbuf + uf * (i+3));
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 0)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16(a, 12)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16_##CN();
+
+// Load pixels for linear interpolation (int16_t -> float)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(cn) \
+    v_float32 f00##cn##l = v_cvt_f32(v_expand_low(f00##cn)), f00##cn##h = v_cvt_f32(v_expand_high(f00##cn)), \
+              f01##cn##l = v_cvt_f32(v_expand_low(f01##cn)), f01##cn##h = v_cvt_f32(v_expand_high(f01##cn)), \
+              f10##cn##l = v_cvt_f32(v_expand_low(f10##cn)), f10##cn##h = v_cvt_f32(v_expand_high(f10##cn)), \
+              f11##cn##l = v_cvt_f32(v_expand_low(f11##cn)), f11##cn##h = v_cvt_f32(v_expand_high(f11##cn));
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(a)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32_##CN()
+
+// Load pixels for linear interpolation (uint16_t -> float)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(cn) \
+    v_float32 f00##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00##cn))), f00##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00##cn))), \
+              f01##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01##cn))), f01##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01##cn))), \
+              f10##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10##cn))), f10##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10##cn))), \
+              f11##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11##cn))), f11##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11##cn)));
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(a)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32_##CN()
+
+// Load pixels for linear interpolation (float -> float)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(cn, i) \
+    v_float32 f00##cn##l = vx_load(pixbuf + uf * i),      f00##cn##h = vx_load(pixbuf + uf * i     + vlanes_32), \
+              f01##cn##l = vx_load(pixbuf + uf * (i+1)),  f01##cn##h = vx_load(pixbuf + uf * (i+1) + vlanes_32), \
+              f10##cn##l = vx_load(pixbuf + uf * (i+2)),  f10##cn##h = vx_load(pixbuf + uf * (i+2) + vlanes_32), \
+              f11##cn##l = vx_load(pixbuf + uf * (i+3)),  f11##cn##h = vx_load(pixbuf + uf * (i+3) + vlanes_32);
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 0)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_CN_F32(a, 12)
+#define CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32_##CN()
+
+
+// Linear interpolation calculation
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(cn) \
+    f00##cn##l = v_fma(alphal, v_sub(f01##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(alphah, v_sub(f01##cn##h, f00##cn##h), f00##cn##h); \
+    f10##cn##l = v_fma(alphal, v_sub(f11##cn##l, f10##cn##l), f10##cn##l); f10##cn##h = v_fma(alphah, v_sub(f11##cn##h, f10##cn##h), f10##cn##h);
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g)
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b)
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(a)
+
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(cn) \
+    f00##cn##l = v_fma(betal,  v_sub(f10##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(betah,  v_sub(f10##cn##h, f00##cn##h), f00##cn##h);
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32_C1() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(g)
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32_C3() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(b)
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32_C4() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(b) \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32(a)
+
+#define CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(CN) \
+    v_float32 alphal = src_x0, alphah = src_x1, \
+              betal = src_y0, betah = src_y1; \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_##CN() \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_BETA_F32_##CN()
+
+
+// Store
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8_C1() \
+    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
+    v_uint8 f00_u8 = v_pack(f00_u16, vx_setall_u16(0)); \
+    v_store_low(dstptr + x, f00_u8);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8_C3() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
+    uint16_t tbuf[max_vlanes_16*3]; \
+    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16); \
+    v_pack_store(dstptr + x*3, vx_load(tbuf)); \
+    v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16)); \
+    v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8_C4() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
+             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
+    uint16_t tbuf[max_vlanes_16*4]; \
+    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16, f00a_u16); \
+    v_pack_store(dstptr + x*4, vx_load(tbuf)); \
+    v_pack_store(dstptr + x*4 + vlanes_16, vx_load(tbuf + vlanes_16)); \
+    v_pack_store(dstptr + x*4 + vlanes_16*2, vx_load(tbuf + vlanes_16*2)); \
+    v_pack_store(dstptr + x*4 + vlanes_16*3, vx_load(tbuf + vlanes_16*3));
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8_##CN()
+
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16_C1() \
+    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
+    v_store(dstptr + x, f00_u16);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16_C3() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
+    v_store_interleave(dstptr + x*3, f00r_u16, f00g_u16, f00b_u16);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16_C4() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
+             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
+    v_store_interleave(dstptr + x*4, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16_##CN()
+
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32_C1() \
+    vx_store(dstptr + x, f00gl); \
+    vx_store(dstptr + x + vlanes_32, f00gh);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32_C3() \
+    v_store_interleave(dstptr + x*3, f00rl, f00gl, f00bl); \
+    v_store_interleave(dstptr + x*3 + vlanes_32*3, f00rh, f00gh, f00bh);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32_C4() \
+    v_store_interleave(dstptr + x*4, f00rl, f00gl, f00bl, f00al); \
+    v_store_interleave(dstptr + x*4 + vlanes_32*4, f00rh, f00gh, f00bh, f00ah);
+#define CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(CN) \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32_##CN()

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -4,10 +4,10 @@
 
 #include <numeric>
 #include "precomp.hpp"
-
+#include "warp_common.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
-#define WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD() \
+#define CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD() \
     v_float32 src_x0 = v_fma(M0, dst_x0, M_x), \
               src_y0 = v_fma(M3, dst_x0, M_y), \
               src_x1 = v_fma(M0, dst_x1, M_x), \
@@ -27,562 +27,6 @@
     src_y0 = v_sub(src_y0, v_cvt_f32(src_iy0)); \
     src_x1 = v_sub(src_x1, v_cvt_f32(src_ix1)); \
     src_y1 = v_sub(src_y1, v_cvt_f32(src_iy1));
-
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C1(dtype) \
-    for (int i = 0; i < uf; i++) { \
-        const dtype* srcptr = src + addr[i]; \
-        pixbuf[i] = srcptr[0]; \
-        pixbuf[i + uf] = srcptr[1]; \
-        pixbuf[i + uf*2] = srcptr[srcstep]; \
-        pixbuf[i + uf*3] = srcptr[srcstep + 1]; \
-    }
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C3(dtype) \
-    for (int i = 0; i < uf; i++) { \
-        const dtype* srcptr = src + addr[i]; \
-        pixbuf[i] = srcptr[0]; \
-        pixbuf[i + uf*4] = srcptr[1]; \
-        pixbuf[i + uf*8] = srcptr[2]; \
-        pixbuf[i + uf] = srcptr[3]; \
-        pixbuf[i + uf*5] = srcptr[4]; \
-        pixbuf[i + uf*9] = srcptr[5]; \
-        pixbuf[i + uf*2] = srcptr[srcstep]; \
-        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
-        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
-        pixbuf[i + uf*3] = srcptr[srcstep + 3]; \
-        pixbuf[i + uf*7] = srcptr[srcstep + 4]; \
-        pixbuf[i + uf*11] = srcptr[srcstep + 5]; \
-    }
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C4(dtype) \
-    for (int i = 0; i < uf; i++) { \
-        const dtype* srcptr = src + addr[i]; \
-        pixbuf[i] = srcptr[0]; \
-        pixbuf[i + uf*4] = srcptr[1]; \
-        pixbuf[i + uf*8] = srcptr[2]; \
-        pixbuf[i + uf*12] = srcptr[3]; \
-        pixbuf[i + uf] = srcptr[4]; \
-        pixbuf[i + uf*5] = srcptr[5]; \
-        pixbuf[i + uf*9] = srcptr[6]; \
-        pixbuf[i + uf*13] = srcptr[7]; \
-        pixbuf[i + uf*2] = srcptr[srcstep]; \
-        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
-        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
-        pixbuf[i + uf*14] = srcptr[srcstep + 3]; \
-        pixbuf[i + uf*3] = srcptr[srcstep + 4]; \
-        pixbuf[i + uf*7] = srcptr[srcstep + 5]; \
-        pixbuf[i + uf*11] = srcptr[srcstep + 6]; \
-        pixbuf[i + uf*15] = srcptr[srcstep + 7]; \
-    }
-
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_8U(CN) \
-    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint8_t)
-    #define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_16U(CN) \
-    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint16_t)
-    #define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_32F(CN) \
-    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(float)
-
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(CN, DEPTH) \
-    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##DEPTH(CN)
-
-#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C1(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[x + i]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t addr_i = iy_*srcstep + ix_; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-    }
-#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C3(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx*3; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*3]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*3 + 1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*3 + 2]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t addr_i = iy_*srcstep + ix_*3; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-    }
-#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C4(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx*4; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = bval[3]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*4]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*4 + 1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*4 + 2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = dstptr[(x + i)*4 + 3]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t addr_i = iy_*srcstep + ix_*4; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
-    }
-
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC1() \
-    v_store_low(dstptr + x, bval_v0);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC3() \
-    v_store_low(dstptr + x*3,        bval_v0); \
-    v_store_low(dstptr + x*3 + uf,   bval_v1); \
-    v_store_low(dstptr + x*3 + uf*2, bval_v2);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC4() \
-    v_store_low(dstptr + x*4,        bval_v0); \
-    v_store_low(dstptr + x*4 + uf,   bval_v1); \
-    v_store_low(dstptr + x*4 + uf*2, bval_v2); \
-    v_store_low(dstptr + x*4 + uf*3, bval_v3);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC1() \
-    v_store(dstptr + x, bval_v0);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC3() \
-    v_store(dstptr + x*3,        bval_v0); \
-    v_store(dstptr + x*3 + uf,   bval_v1); \
-    v_store(dstptr + x*3 + uf*2, bval_v2);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC4() \
-    v_store(dstptr + x*4,        bval_v0); \
-    v_store(dstptr + x*4 + uf,   bval_v1); \
-    v_store(dstptr + x*4 + uf*2, bval_v2); \
-    v_store(dstptr + x*4 + uf*3, bval_v3);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC1() \
-    v_store(dstptr + x,             bval_v0_l); \
-    v_store(dstptr + x + vlanes_32, bval_v0_h);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC3() \
-    v_store(dstptr + x*3,                    bval_v0_l); \
-    v_store(dstptr + x*3 + vlanes_32,        bval_v0_h); \
-    v_store(dstptr + x*3 + uf,               bval_v1_l); \
-    v_store(dstptr + x*3 + uf + vlanes_32,   bval_v1_h); \
-    v_store(dstptr + x*3 + uf*2,             bval_v2_l); \
-    v_store(dstptr + x*3 + uf*2 + vlanes_32, bval_v2_h);
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC4() \
-    v_store(dstptr + x*4,                    bval_v0_l); \
-    v_store(dstptr + x*4 + vlanes_32,        bval_v0_h); \
-    v_store(dstptr + x*4 + uf,               bval_v1_l); \
-    v_store(dstptr + x*4 + uf + vlanes_32,   bval_v1_h); \
-    v_store(dstptr + x*4 + uf*2,             bval_v2_l); \
-    v_store(dstptr + x*4 + uf*2 + vlanes_32, bval_v2_h); \
-    v_store(dstptr + x*4 + uf*3,             bval_v3_l); \
-    v_store(dstptr + x*4 + uf*3 + vlanes_32, bval_v3_h);
-
-#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(CN, DEPTH) \
-    if (border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) { \
-        mask_0 = v_lt(v_reinterpret_as_u32(v_add(src_ix0, one)), outer_scols); \
-        mask_1 = v_lt(v_reinterpret_as_u32(v_add(src_ix1, one)), outer_scols); \
-        mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(v_add(src_iy0, one)), outer_srows)); \
-        mask_1 = v_and(mask_1, v_lt(v_reinterpret_as_u32(v_add(src_iy1, one)), outer_srows)); \
-        v_uint16 outer_mask = v_pack(mask_0, mask_1); \
-        if (v_reduce_max(outer_mask) == 0) { \
-            if (border_type == BORDER_CONSTANT) { \
-                WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_##DEPTH##CN() \
-            } \
-            continue; \
-        } \
-    } \
-    vx_store(src_ix, src_ix0); \
-    vx_store(src_iy, src_iy0); \
-    vx_store(src_ix + vlanes_32, src_ix1); \
-    vx_store(src_iy + vlanes_32, src_iy1); \
-    for (int i = 0; i < uf; i++) { \
-        int ix = src_ix[i], iy = src_iy[i]; \
-        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 0, 0); \
-        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 1, uf); \
-        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 0, uf*2); \
-        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 1, uf*3); \
-    }
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(cn, i) \
-    v_int16  f00##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * i)), \
-             f01##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+1))), \
-             f10##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+2))), \
-             f11##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+3)));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 0)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(a, 12)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_##CN();
-////
-
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(cn, i) \
-    v_uint16 f00##cn = vx_load(pixbuf + uf * i), \
-             f01##cn = vx_load(pixbuf + uf * (i+1)), \
-             f10##cn = vx_load(pixbuf + uf * (i+2)), \
-             f11##cn = vx_load(pixbuf + uf * (i+3));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 0)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(a, 12)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_##CN();
-////
-
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(cn) \
-    v_float32 f00##cn##l = v_cvt_f32(v_expand_low(f00##cn)), f00##cn##h = v_cvt_f32(v_expand_high(f00##cn)), \
-              f01##cn##l = v_cvt_f32(v_expand_low(f01##cn)), f01##cn##h = v_cvt_f32(v_expand_high(f01##cn)), \
-              f10##cn##l = v_cvt_f32(v_expand_low(f10##cn)), f10##cn##h = v_cvt_f32(v_expand_high(f10##cn)), \
-              f11##cn##l = v_cvt_f32(v_expand_low(f11##cn)), f11##cn##h = v_cvt_f32(v_expand_high(f11##cn));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(a)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_##CN()
-////
-
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(cn) \
-    v_float32 f00##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00##cn))), f00##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00##cn))), \
-              f01##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01##cn))), f01##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01##cn))), \
-              f10##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10##cn))), f10##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10##cn))), \
-              f11##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11##cn))), f11##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11##cn)));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(a)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_##CN()
-////
-
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(cn, i) \
-    v_float32 f00##cn##l = vx_load(pixbuf + uf * i),      f00##cn##h = vx_load(pixbuf + uf * i     + vlanes_32), \
-              f01##cn##l = vx_load(pixbuf + uf * (i+1)),  f01##cn##h = vx_load(pixbuf + uf * (i+1) + vlanes_32), \
-              f10##cn##l = vx_load(pixbuf + uf * (i+2)),  f10##cn##h = vx_load(pixbuf + uf * (i+2) + vlanes_32), \
-              f11##cn##l = vx_load(pixbuf + uf * (i+3)),  f11##cn##h = vx_load(pixbuf + uf * (i+3) + vlanes_32);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 0)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(a, 12)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_##CN()
-////
-
-
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(cn) \
-    f00##cn##l = v_fma(alphal, v_sub(f01##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(alphah, v_sub(f01##cn##h, f00##cn##h), f00##cn##h); \
-    f10##cn##l = v_fma(alphal, v_sub(f11##cn##l, f10##cn##l), f10##cn##l); f10##cn##h = v_fma(alphah, v_sub(f11##cn##h, f10##cn##h), f10##cn##h);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(a)
-
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(cn) \
-    f00##cn##l = v_fma(betal,  v_sub(f10##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(betah,  v_sub(f10##cn##h, f00##cn##h), f00##cn##h);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C1() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C3() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(b)
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C4() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(b) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(a)
-
-#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(CN) \
-    v_float32 alphal = src_x0, alphah = src_x1, \
-              betal = src_y0, betah = src_y1; \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_##CN() \
-    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_##CN()
-////
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C1() \
-    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
-    v_uint8 f00_u8 = v_pack(f00_u16, vx_setall_u16(0)); \
-    v_store_low(dstptr + x, f00_u8);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C3() \
-    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
-             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
-             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
-    uint16_t tbuf[max_vlanes_16*3]; \
-    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16); \
-    v_pack_store(dstptr + x*3, vx_load(tbuf)); \
-    v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16)); \
-    v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C4() \
-    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
-             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
-             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
-             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
-    uint16_t tbuf[max_vlanes_16*4]; \
-    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16, f00a_u16); \
-    v_pack_store(dstptr + x*4, vx_load(tbuf)); \
-    v_pack_store(dstptr + x*4 + vlanes_16, vx_load(tbuf + vlanes_16)); \
-    v_pack_store(dstptr + x*4 + vlanes_16*2, vx_load(tbuf + vlanes_16*2)); \
-    v_pack_store(dstptr + x*4 + vlanes_16*3, vx_load(tbuf + vlanes_16*3));
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_##CN()
-
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C1() \
-    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
-    v_store(dstptr + x, f00_u16);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C3() \
-    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
-             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
-             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
-    v_store_interleave(dstptr + x*3, f00r_u16, f00g_u16, f00b_u16);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C4() \
-    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
-             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
-             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
-             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
-    v_store_interleave(dstptr + x*4, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_##CN()
-
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C1() \
-    vx_store(dstptr + x, f00gl); \
-    vx_store(dstptr + x + vlanes_32, f00gh);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C3() \
-    v_store_interleave(dstptr + x*3, f00rl, f00gl, f00bl); \
-    v_store_interleave(dstptr + x*3 + vlanes_32*3, f00rh, f00gh, f00bh);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C4() \
-    v_store_interleave(dstptr + x*4, f00rl, f00gl, f00bl, f00al); \
-    v_store_interleave(dstptr + x*4 + vlanes_32*4, f00rh, f00gh, f00bh, f00ah);
-#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(CN) \
-    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_##CN()
-
-///////////////////////
-
-
-//
-// Scalar
-//
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(CN, cn, i) \
-    p00##CN = srcptr[i]; p01##CN = srcptr[i + cn]; \
-    p10##CN = srcptr[srcstep + i]; p11##CN = srcptr[srcstep + cn + i];
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C1() \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 1, 0)
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C3() \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(r, 3, 0) \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 3, 1) \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(b, 3, 2)
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C4() \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(r, 4, 0) \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 4, 1) \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(b, 4, 2) \
-    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(a, 4, 3)
-
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C1() \
-    dstptr[x] = bval[0];
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C3() \
-    dstptr[x*3] = bval[0]; \
-    dstptr[x*3+1] = bval[1]; \
-    dstptr[x*3+2] = bval[2];
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C4() \
-    dstptr[x*4] = bval[0]; \
-    dstptr[x*4+1] = bval[1]; \
-    dstptr[x*4+2] = bval[2]; \
-    dstptr[x*4+3] = bval[3];
-
-#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C1(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx; \
-        pxy##g = srcptr[ofs]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pxy##g = bval[0]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pxy##g = dstptr[x]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t glob_ofs = iy_*srcstep + ix_; \
-        pxy##g = src[glob_ofs]; \
-    }
-#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C3(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx*3; \
-        pxy##r = srcptr[ofs]; \
-        pxy##g = srcptr[ofs+1]; \
-        pxy##b = srcptr[ofs+2]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pxy##r = bval[0]; \
-        pxy##g = bval[1]; \
-        pxy##b = bval[2]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pxy##r = dstptr[x*3]; \
-        pxy##g = dstptr[x*3+1]; \
-        pxy##b = dstptr[x*3+2]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t glob_ofs = iy_*srcstep + ix_*3; \
-        pxy##r = src[glob_ofs]; \
-        pxy##g = src[glob_ofs+1]; \
-        pxy##b = src[glob_ofs+2]; \
-    }
-#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C4(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx*4; \
-        pxy##r = srcptr[ofs]; \
-        pxy##g = srcptr[ofs+1]; \
-        pxy##b = srcptr[ofs+2]; \
-        pxy##a = srcptr[ofs+3]; \
-    } else if (border_type == BORDER_CONSTANT) { \
-        pxy##r = bval[0]; \
-        pxy##g = bval[1]; \
-        pxy##b = bval[2]; \
-        pxy##a = bval[3]; \
-    } else if (border_type == BORDER_TRANSPARENT) { \
-        pxy##r = dstptr[x*4]; \
-        pxy##g = dstptr[x*4+1]; \
-        pxy##b = dstptr[x*4+2]; \
-        pxy##a = dstptr[x*4+3]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
-        size_t glob_ofs = iy_*srcstep + ix_*4; \
-        pxy##r = src[glob_ofs]; \
-        pxy##g = src[glob_ofs+1]; \
-        pxy##b = src[glob_ofs+2]; \
-        pxy##a = src[glob_ofs+3]; \
-    }
-
-#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE(CN) \
-    if ((((unsigned)ix < (unsigned)(srccols-1)) & \
-        ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
-        WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_##CN() \
-    } else { \
-        if ((border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) && \
-            (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
-                ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
-            if (border_type == BORDER_CONSTANT) { \
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_##CN() \
-            } \
-            continue; \
-        } \
-        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 0, p00); \
-        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 1, p01); \
-        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 0, p10); \
-        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 1, p11); \
-    }
-
-////
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(cn) \
-    float v0##cn = p00##cn + sx*(p01##cn - p00##cn); \
-    float v1##cn = p10##cn + sx*(p11##cn - p10##cn);
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C1() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g)
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C3() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b)
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C4() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(a)
-
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(cn) \
-    v0##cn += sy*(v1##cn - v0##cn);
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C1() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g)
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C3() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(b)
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C4() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(b) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(a)
-
-#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(CN) \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_##CN() \
-    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_##CN()
-////
-
-////
-#define WARPAFFINE_LINEAR_SCALAR_STORE_C1(dtype) \
-    dstptr[x] = saturate_cast<dtype>(v0g);
-#define WARPAFFINE_LINEAR_SCALAR_STORE_C3(dtype) \
-    dstptr[x*3] = saturate_cast<dtype>(v0r); \
-    dstptr[x*3+1] = saturate_cast<dtype>(v0g); \
-    dstptr[x*3+2] = saturate_cast<dtype>(v0b);
-#define WARPAFFINE_LINEAR_SCALAR_STORE_C4(dtype) \
-    dstptr[x*4] = saturate_cast<dtype>(v0r); \
-    dstptr[x*4+1] = saturate_cast<dtype>(v0g); \
-    dstptr[x*4+2] = saturate_cast<dtype>(v0b); \
-    dstptr[x*4+3] = saturate_cast<dtype>(v0a);
-#define WARPAFFINE_LINEAR_SCALAR_STORE_8U(CN) \
-    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(uint8_t)
-#define WARPAFFINE_LINEAR_SCALAR_STORE_16U(CN) \
-    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(uint16_t)
-#define WARPAFFINE_LINEAR_SCALAR_STORE_32F(CN) \
-    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(float)
-
-#define WARPAFFINE_LINEAR_SCALAR_STORE(CN, DEPTH) \
-    WARPAFFINE_LINEAR_SCALAR_STORE_##DEPTH(CN)
-////
 
 namespace cv{
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
@@ -732,7 +176,7 @@ void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int 
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
                         addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
@@ -785,10 +229,10 @@ void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int 
                     p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
     #else
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 8U);
     #endif
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
 
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                     p00g = vld1_u8(pixbuf);
@@ -804,13 +248,13 @@ void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int 
                         f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
                         f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
     #else
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16(C1);
     #endif
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C1);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -822,11 +266,11 @@ void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int 
                 int p00g, p01g, p10g, p11g;
                 const uint8_t *srcptr = src + srcstep * iy + ix;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 8U);
+                CV_WARP_LINEAR_SCALAR_STORE(C1, 8U);
             }
         }
     };
@@ -916,7 +360,7 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
@@ -991,10 +435,10 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                     p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
     #else
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 8U);
     #endif
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
 
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                     p00r = vld1_u8(pixbuf);
@@ -1028,13 +472,13 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                         f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
                         f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
     #else
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16(C3);
     #endif
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1047,11 +491,11 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                 int p10r, p10g, p10b, p11r, p11g, p11b;
                 const uint8_t* srcptr = src + srcstep*iy + ix*3;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 8U);
+                CV_WARP_LINEAR_SCALAR_STORE(C3, 8U);
             }
         }
     };
@@ -1145,7 +589,7 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
@@ -1231,10 +675,10 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
                     p10a = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11a = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
     #else
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 8U);
     #endif
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
 
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                     p00r = vld1_u8(pixbuf);
@@ -1277,14 +721,14 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
                         f10a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10a))),
                         f11a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11a)));
     #else
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8S16(C4);
     #endif
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_S16F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C4);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1297,11 +741,11 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
                 int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
                 const uint8_t* srcptr = src + srcstep*iy + ix*3;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 8U);
+                CV_WARP_LINEAR_SCALAR_STORE(C4, 8U);
             }
         }
     };
@@ -1380,7 +824,7 @@ void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, in
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
                         addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
@@ -1388,18 +832,18 @@ void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, in
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 16U);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 16U);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C1);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1411,11 +855,11 @@ void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, in
                 int p00g, p01g, p10g, p11g;
                 const uint16_t *srcptr = src + srcstep * iy + ix;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 16U);
+                CV_WARP_LINEAR_SCALAR_STORE(C1, 16U);
             }
         }
     };
@@ -1499,7 +943,7 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
@@ -1507,18 +951,18 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 16U);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 16U);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1531,11 +975,11 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
                 int p10r, p10g, p10b, p11r, p11g, p11b;
                 const uint16_t *srcptr = src + srcstep * iy + ix*3;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 16U);
+                CV_WARP_LINEAR_SCALAR_STORE(C3, 16U);
             }
         }
     };
@@ -1621,7 +1065,7 @@ void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, in
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
@@ -1629,18 +1073,18 @@ void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, in
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 16U);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 16U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 16U);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U16F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C4);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1653,11 +1097,11 @@ void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, in
                 int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
                 const uint16_t *srcptr = src + srcstep * iy + ix*4;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 16U);
+                CV_WARP_LINEAR_SCALAR_STORE(C4, 16U);
             }
         }
     };
@@ -1737,7 +1181,7 @@ void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int s
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
                         addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
@@ -1745,16 +1189,16 @@ void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int s
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 32F);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 32F);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C1);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C1);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1766,11 +1210,11 @@ void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int s
                 float p00g, p01g, p10g, p11g;
                 const float *srcptr = src + srcstep * iy + ix;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 32F);
+                CV_WARP_LINEAR_SCALAR_STORE(C1, 32F);
             }
         }
     };
@@ -1856,7 +1300,7 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
@@ -1864,16 +1308,16 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 32F);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 32F);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1886,11 +1330,11 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
                 float p10r, p10g, p10b, p11r, p11g, p11b;
                 const float *srcptr = src + srcstep * iy + ix*3;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C3);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 32F);
+                CV_WARP_LINEAR_SCALAR_STORE(C3, 32F);
             }
         }
     };
@@ -1979,7 +1423,7 @@ void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int s
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
@@ -1987,16 +1431,16 @@ void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int s
                 vx_store(addr + vlanes_32, addr_1);
 
                 if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 32F);
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 32F);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 32F);
                 }
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C4);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C4);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2009,11 +1453,11 @@ void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int s
                 float p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
                 const float *srcptr = src + srcstep * iy + ix*4;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C4);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 32F);
+                CV_WARP_LINEAR_SCALAR_STORE(C4, 32F);
             }
         }
     };
@@ -2091,7 +1535,7 @@ void warpAffineLinearApproxInvoker_8UC1(const uint8_t *src_data, size_t src_step
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
                         addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
@@ -2141,7 +1585,7 @@ void warpAffineLinearApproxInvoker_8UC1(const uint8_t *src_data, size_t src_step
                     p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
 
                     p00g = vld1_u8(pixbuf);
                     p01g = vld1_u8(pixbuf + 8);
@@ -2176,11 +1620,11 @@ void warpAffineLinearApproxInvoker_8UC1(const uint8_t *src_data, size_t src_step
                 int p00g, p01g, p10g, p11g;
                 const uint8_t *srcptr = src + srcstep * iy + ix;
 
-                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C1);
 
-                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 8U);
+                CV_WARP_LINEAR_SCALAR_STORE(C1, 8U);
             }
         }
     };
@@ -2271,7 +1715,7 @@ void warpAffineLinearApproxInvoker_8UC3(const uint8_t *src_data, size_t src_step
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
@@ -2343,7 +1787,7 @@ void warpAffineLinearApproxInvoker_8UC3(const uint8_t *src_data, size_t src_step
                     p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
 
                     p00r = vld1_u8(pixbuf);
                     p01r = vld1_u8(pixbuf + 8);
@@ -2490,7 +1934,7 @@ void warpAffineLinearApproxInvoker_8UC4(const uint8_t *src_data, size_t src_step
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+                CV_WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
@@ -2573,7 +2017,7 @@ void warpAffineLinearApproxInvoker_8UC4(const uint8_t *src_data, size_t src_step
                     p10a = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11a = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
                 } else {
-                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
+                    CV_WARP_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
 
                     p00r = vld1_u8(pixbuf);
                     p01r = vld1_u8(pixbuf + 8);

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -1843,6 +1843,22 @@ void warpAffineLinearApproxInvoker_8UC3(const uint8_t *src_data, size_t src_step
                 };
                 vst3_u8(dstptr + x*3, result);
             }
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p01r, p01g, p01b;
+                int p10r, p10g, p10b, p11r, p11g, p11b;
+                const uint8_t *srcptr = src + srcstep * iy + ix*3;
+
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C3);
+
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C3);
+
+                CV_WARP_LINEAR_SCALAR_STORE(C3, 8U);
+            }
         }
 
     };
@@ -2087,6 +2103,22 @@ void warpAffineLinearApproxInvoker_8UC4(const uint8_t *src_data, size_t src_step
                     vqmovun_s16(vcvtnq_s16_f16(f00a.val)),
                 };
                 vst4_u8(dstptr + x*4, result);
+            }
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const uint8_t *srcptr = src + srcstep * iy + ix*4;
+
+                CV_WARP_LINEAR_SCALAR_SHUFFLE(C4);
+
+                CV_WARP_LINEAR_SCALAR_INTER_CALC_F32(C4);
+
+                CV_WARP_LINEAR_SCALAR_STORE(C4, 8U);
             }
         }
     };

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -1,0 +1,2290 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <numeric>
+#include "precomp.hpp"
+
+#include "opencv2/core/hal/intrin.hpp"
+
+#define VECTOR_FETCH_PIXEL_C3(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*3]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*3 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*3 + 2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t addr_i = iy_*srcstep + ix_*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    }
+#define VECTOR_FETCH_PIXEL_C1(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[x + i]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t addr_i = iy_*srcstep + ix_; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    }
+#define VECTOR_FETCH_PIXEL_C4(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = bval[3]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*4]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*4 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*4 + 2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = dstptr[(x + i)*4 + 3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t addr_i = iy_*srcstep + ix_*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    }
+
+#define SCALAR_FETCH_PIXEL_C3(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*3; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*3]; \
+        pxy##g = dstptr[x*3+1]; \
+        pxy##b = dstptr[x*3+2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*3; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+    }
+#define SCALAR_FETCH_PIXEL_C1(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx; \
+        pxy = srcptr[ofs]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pxy = bval[0]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pxy = dstptr[x]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t glob_ofs = iy_*srcstep + ix_; \
+        pxy = src[glob_ofs]; \
+    }
+#define SCALAR_FETCH_PIXEL_C4(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*4; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+        pxy##a = srcptr[ofs+3]; \
+    } else if (borderType == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+        pxy##a = bval[3]; \
+    } else if (borderType == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*4]; \
+        pxy##g = dstptr[x*4+1]; \
+        pxy##b = dstptr[x*4+2]; \
+        pxy##a = dstptr[x*4+3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*4; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+        pxy##a = src[glob_ofs+3]; \
+    }
+
+#define VECTOR_COMPUTE_COORDINATES() \
+    v_float32 src_x0 = v_fma(M0, dst_x0, M_x), \
+              src_y0 = v_fma(M3, dst_x0, M_y), \
+              src_x1 = v_fma(M0, dst_x1, M_x), \
+              src_y1 = v_fma(M3, dst_x1, M_y); \
+    dst_x0 = v_add(dst_x0, delta);             \
+    dst_x1 = v_add(dst_x1, delta);             \
+    v_int32 src_ix0 = v_floor(src_x0),         \
+            src_iy0 = v_floor(src_y0),         \
+            src_ix1 = v_floor(src_x1),         \
+            src_iy1 = v_floor(src_y1);         \
+    v_uint32 mask_0 = v_lt(v_reinterpret_as_u32(src_ix0), inner_scols), \
+             mask_1 = v_lt(v_reinterpret_as_u32(src_ix1), inner_scols); \
+    mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(src_iy0), inner_srows)); \
+    mask_1 = v_and(mask_1, v_lt(v_reinterpret_as_u32(src_iy1), inner_srows)); \
+    v_uint16 inner_mask = v_pack(mask_0, mask_1); \
+    src_x0 = v_sub(src_x0, v_cvt_f32(src_ix0)); \
+    src_y0 = v_sub(src_y0, v_cvt_f32(src_iy0)); \
+    src_x1 = v_sub(src_x1, v_cvt_f32(src_ix1)); \
+    src_y1 = v_sub(src_y1, v_cvt_f32(src_iy1));
+
+#define VECTOR_LINEAR_C3_F32() \
+    v_float32 alphal = src_x0, alphah = src_x1,\
+              betal = src_y0, betah = src_y1;  \
+    f00rl = v_fma(alphal, v_sub(f01rl, f00rl), f00rl); f00rh = v_fma(alphah, v_sub(f01rh, f00rh), f00rh); \
+    f10rl = v_fma(alphal, v_sub(f11rl, f10rl), f10rl); f10rh = v_fma(alphah, v_sub(f11rh, f10rh), f10rh); \
+    f00gl = v_fma(alphal, v_sub(f01gl, f00gl), f00gl); f00gh = v_fma(alphah, v_sub(f01gh, f00gh), f00gh); \
+    f10gl = v_fma(alphal, v_sub(f11gl, f10gl), f10gl); f10gh = v_fma(alphah, v_sub(f11gh, f10gh), f10gh); \
+    f00bl = v_fma(alphal, v_sub(f01bl, f00bl), f00bl); f00bh = v_fma(alphah, v_sub(f01bh, f00bh), f00bh); \
+    f10bl = v_fma(alphal, v_sub(f11bl, f10bl), f10bl); f10bh = v_fma(alphah, v_sub(f11bh, f10bh), f10bh); \
+    f00rl = v_fma(betal, v_sub(f10rl, f00rl), f00rl); f00rh = v_fma(betah, v_sub(f10rh, f00rh), f00rh); \
+    f00gl = v_fma(betal, v_sub(f10gl, f00gl), f00gl); f00gh = v_fma(betah, v_sub(f10gh, f00gh), f00gh); \
+    f00bl = v_fma(betal, v_sub(f10bl, f00bl), f00bl); f00bh = v_fma(betah, v_sub(f10bh, f00bh), f00bh);
+#define VECTOR_LINEAR_C1_F32() \
+    v_float32 alphal = src_x0, alphah = src_x1, \
+              betal = src_y0, betah = src_y1; \
+    f00l = v_fma(alphal, v_sub(f01l, f00l), f00l); f00h = v_fma(alphah, v_sub(f01h, f00h), f00h); \
+    f10l = v_fma(alphal, v_sub(f11l, f10l), f10l); f10h = v_fma(alphah, v_sub(f11h, f10h), f10h); \
+    f00l = v_fma(betal, v_sub(f10l, f00l), f00l);  f00h = v_fma(betah, v_sub(f10h, f00h), f00h);
+#define VECTOR_LINEAR_C4_F32() \
+    v_float32 alphal = src_x0, alphah = src_x1,\
+              betal = src_y0, betah = src_y1;  \
+    f00rl = v_fma(alphal, v_sub(f01rl, f00rl), f00rl); f00rh = v_fma(alphah, v_sub(f01rh, f00rh), f00rh); \
+    f10rl = v_fma(alphal, v_sub(f11rl, f10rl), f10rl); f10rh = v_fma(alphah, v_sub(f11rh, f10rh), f10rh); \
+    f00gl = v_fma(alphal, v_sub(f01gl, f00gl), f00gl); f00gh = v_fma(alphah, v_sub(f01gh, f00gh), f00gh); \
+    f10gl = v_fma(alphal, v_sub(f11gl, f10gl), f10gl); f10gh = v_fma(alphah, v_sub(f11gh, f10gh), f10gh); \
+    f00bl = v_fma(alphal, v_sub(f01bl, f00bl), f00bl); f00bh = v_fma(alphah, v_sub(f01bh, f00bh), f00bh); \
+    f10bl = v_fma(alphal, v_sub(f11bl, f10bl), f10bl); f10bh = v_fma(alphah, v_sub(f11bh, f10bh), f10bh); \
+    f00al = v_fma(alphal, v_sub(f01al, f00al), f00al); f00ah = v_fma(alphah, v_sub(f01ah, f00ah), f00ah); \
+    f10al = v_fma(alphal, v_sub(f11al, f10al), f10al); f10ah = v_fma(alphah, v_sub(f11ah, f10ah), f10ah); \
+    f00rl = v_fma(betal, v_sub(f10rl, f00rl), f00rl); f00rh = v_fma(betah, v_sub(f10rh, f00rh), f00rh); \
+    f00gl = v_fma(betal, v_sub(f10gl, f00gl), f00gl); f00gh = v_fma(betah, v_sub(f10gh, f00gh), f00gh); \
+    f00bl = v_fma(betal, v_sub(f10bl, f00bl), f00bl); f00bh = v_fma(betah, v_sub(f10bh, f00bh), f00bh); \
+    f00al = v_fma(betal, v_sub(f10al, f00al), f00al); f00ah = v_fma(betah, v_sub(f10ah, f00ah), f00ah);
+
+#define VECTOR_LINEAR_STORE_BORDER_8UC3() \
+    v_store_low(dstptr + x*3,        bval_v0); \
+    v_store_low(dstptr + x*3 + uf,   bval_v1); \
+    v_store_low(dstptr + x*3 + uf*2, bval_v2);
+#define VECTOR_LINEAR_STORE_BORDER_16UC3() \
+    v_store(dstptr + x*3,        bval_v0); \
+    v_store(dstptr + x*3 + uf,   bval_v1); \
+    v_store(dstptr + x*3 + uf*2, bval_v2);
+#define VECTOR_LINEAR_STORE_BORDER_32FC3() \
+    v_store(dstptr + x*3,                    bval_v0_l); \
+    v_store(dstptr + x*3 + vlanes_32,        bval_v0_h); \
+    v_store(dstptr + x*3 + uf,               bval_v1_l); \
+    v_store(dstptr + x*3 + uf + vlanes_32,   bval_v1_h); \
+    v_store(dstptr + x*3 + uf*2,             bval_v2_l); \
+    v_store(dstptr + x*3 + uf*2 + vlanes_32, bval_v2_h);
+#define VECTOR_LINEAR_STORE_BORDER_8UC1() \
+    v_store_low(dstptr + x, bval_v0);
+#define VECTOR_LINEAR_STORE_BORDER_16UC1() \
+    v_store(dstptr + x, bval_v0);
+#define VECTOR_LINEAR_STORE_BORDER_32FC1() \
+    v_store(dstptr + x, bval_v0_l); \
+    v_store(dstptr + x + vlanes_32, bval_v0_h);
+#define VECTOR_LINEAR_STORE_BORDER_8UC4() \
+    v_store_low(dstptr + x*4,        bval_v0); \
+    v_store_low(dstptr + x*4 + uf,   bval_v1); \
+    v_store_low(dstptr + x*4 + uf*2, bval_v2); \
+    v_store_low(dstptr + x*4 + uf*3, bval_v3);
+#define VECTOR_LINEAR_STORE_BORDER_16UC4() \
+    v_store(dstptr + x*4,        bval_v0); \
+    v_store(dstptr + x*4 + uf,   bval_v1); \
+    v_store(dstptr + x*4 + uf*2, bval_v2); \
+    v_store(dstptr + x*4 + uf*3, bval_v3);
+#define VECTOR_LINEAR_STORE_BORDER_32FC4() \
+    v_store(dstptr + x*4,                    bval_v0_l); \
+    v_store(dstptr + x*4 + vlanes_32,        bval_v0_h); \
+    v_store(dstptr + x*4 + uf,               bval_v1_l); \
+    v_store(dstptr + x*4 + uf + vlanes_32,   bval_v1_h); \
+    v_store(dstptr + x*4 + uf*2,             bval_v2_l); \
+    v_store(dstptr + x*4 + uf*2 + vlanes_32, bval_v2_h); \
+    v_store(dstptr + x*4 + uf*3,             bval_v3_l); \
+    v_store(dstptr + x*4 + uf*3 + vlanes_32, bval_v3_h);
+
+#define VECTOR_LINEAR_SHUFFLE_NOTALLIN(depth, cn) \
+    if (borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) { \
+        mask_0 = v_lt(v_reinterpret_as_u32(v_add(src_ix0, one)), outer_scols); \
+        mask_1 = v_lt(v_reinterpret_as_u32(v_add(src_ix1, one)), outer_scols); \
+        mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(v_add(src_iy0, one)), outer_srows)); \
+        mask_1 = v_and(mask_1, v_lt(v_reinterpret_as_u32(v_add(src_iy1, one)), outer_srows)); \
+        v_uint16 outer_mask = v_pack(mask_0, mask_1); \
+        if (v_reduce_max(outer_mask) == 0) { \
+            if (borderType == BORDER_CONSTANT) { \
+                VECTOR_LINEAR_STORE_BORDER_##depth##cn(); \
+            } \
+            continue; \
+        } \
+    } \
+    vx_store(src_ix, src_ix0); \
+    vx_store(src_iy, src_iy0); \
+    vx_store(src_ix + vlanes_32, src_ix1); \
+    vx_store(src_iy + vlanes_32, src_iy1); \
+    for (int i = 0; i < uf; i++) { \
+        int ix = src_ix[i], iy = src_iy[i]; \
+        VECTOR_FETCH_PIXEL_##cn(0, 0, 0); \
+        VECTOR_FETCH_PIXEL_##cn(0, 1, uf); \
+        VECTOR_FETCH_PIXEL_##cn(1, 0, uf*2); \
+        VECTOR_FETCH_PIXEL_##cn(1, 1, uf*3); \
+    }
+
+#define SCALAR_LINEAR_SHUFFLE_C3() \
+    if ((((unsigned)ix < (unsigned)(srccols-1)) & \
+        ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
+        p00r = srcptr[0]; p00g = srcptr[1]; p00b = srcptr[2]; \
+        p01r = srcptr[3]; p01g = srcptr[4]; p01b = srcptr[5]; \
+        p10r = srcptr[srcstep + 0]; p10g = srcptr[srcstep + 1]; p10b = srcptr[srcstep + 2]; \
+        p11r = srcptr[srcstep + 3]; p11g = srcptr[srcstep + 4]; p11b = srcptr[srcstep + 5]; \
+    } else { \
+        if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) && \
+            (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
+                ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
+            if (borderType == BORDER_CONSTANT) { \
+                dstptr[x*3] = bval[0]; \
+                dstptr[x*3+1] = bval[1]; \
+                dstptr[x*3+2] = bval[2]; \
+            } \
+            continue; \
+        } \
+        SCALAR_FETCH_PIXEL_C3(0, 0, p00); \
+        SCALAR_FETCH_PIXEL_C3(0, 1, p01); \
+        SCALAR_FETCH_PIXEL_C3(1, 0, p10); \
+        SCALAR_FETCH_PIXEL_C3(1, 1, p11); \
+    }
+#define SCALAR_LINEAR_SHUFFLE_C4() \
+    if ((((unsigned)ix < (unsigned)(srccols-1)) & \
+        ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
+        p00r = srcptr[0]; p00g = srcptr[1]; p00b = srcptr[2]; p00a = srcptr[3]; \
+        p01r = srcptr[4]; p01g = srcptr[5]; p01b = srcptr[6]; p01a = srcptr[7]; \
+        p10r = srcptr[srcstep + 0]; p10g = srcptr[srcstep + 1]; p10b = srcptr[srcstep + 2]; p10a = srcptr[srcstep + 3]; \
+        p11r = srcptr[srcstep + 4]; p11g = srcptr[srcstep + 5]; p11b = srcptr[srcstep + 6]; p11a = srcptr[srcstep + 7]; \
+    } else { \
+        if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) && \
+            (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
+                ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
+            if (borderType == BORDER_CONSTANT) { \
+                dstptr[x*4] = bval[0]; \
+                dstptr[x*4+1] = bval[1]; \
+                dstptr[x*4+2] = bval[2]; \
+                dstptr[x*4+3] = bval[3]; \
+            } \
+            continue; \
+        } \
+        SCALAR_FETCH_PIXEL_C4(0, 0, p00); \
+        SCALAR_FETCH_PIXEL_C4(0, 1, p01); \
+        SCALAR_FETCH_PIXEL_C4(1, 0, p10); \
+        SCALAR_FETCH_PIXEL_C4(1, 1, p11); \
+    }
+
+#define SCALAR_LINEAR_CALC_C3() \
+    float v0r = p00r + sx*(p01r - p00r); \
+    float v0g = p00g + sx*(p01g - p00g); \
+    float v0b = p00b + sx*(p01b - p00b); \
+    float v1r = p10r + sx*(p11r - p10r); \
+    float v1g = p10g + sx*(p11g - p10g); \
+    float v1b = p10b + sx*(p11b - p10b); \
+    v0r += sy*(v1r - v0r); \
+    v0g += sy*(v1g - v0g); \
+    v0b += sy*(v1b - v0b);
+
+#define SCALAR_LINEAR_CALC_C4() \
+    float v0r = p00r + sx*(p01r - p00r); \
+    float v0g = p00g + sx*(p01g - p00g); \
+    float v0b = p00b + sx*(p01b - p00b); \
+    float v0a = p00a + sx*(p01a - p00a); \
+    float v1r = p10r + sx*(p11r - p10r); \
+    float v1g = p10g + sx*(p11g - p10g); \
+    float v1b = p10b + sx*(p11b - p10b); \
+    float v1a = p10a + sx*(p11a - p10a); \
+    v0r += sy*(v1r - v0r); \
+    v0g += sy*(v1g - v0g); \
+    v0b += sy*(v1b - v0b); \
+    v0a += sy*(v1a - v0a);
+
+namespace cv{
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+/* Only support bilinear interpolation on 3-channel image for now */
+void warpAffineSimdInvoker(Mat &output, const Mat &input, const double *M,
+                           int interpolation, int borderType, const double *borderValue);
+
+#ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+namespace {
+static inline int borderInterpolate_fast( int p, int len, int borderType )
+{
+    if( (unsigned)p < (unsigned)len )
+        ;
+    else if( borderType == BORDER_REPLICATE )
+        p = p < 0 ? 0 : len - 1;
+    else if( borderType == BORDER_REFLECT || borderType == BORDER_REFLECT_101 )
+    {
+        int delta = borderType == BORDER_REFLECT_101;
+        do
+        {
+            if( p < 0 )
+                p = -p - 1 + delta;
+            else
+                p = len - 1 - (p - len) - delta;
+        }
+        while( (unsigned)p >= (unsigned)len );
+    }
+    else if( borderType == BORDER_WRAP )
+    {
+        if( p < 0 )
+            p -= ((p-len+1)/len)*len;
+        if( p >= len )
+            p %= len;
+    }
+    return p;
+}
+
+template<typename T>
+static inline void shuffle_allin_c3(const T *src, const int32_t *addr, T *pixbuf,
+                                    int uf, size_t srcstep) {
+    for (int i = 0; i < uf; i++) {
+        const T* srcptr = src + addr[i];
+
+        pixbuf[i] = srcptr[0];
+        pixbuf[i + uf*4] = srcptr[1];
+        pixbuf[i + uf*8] = srcptr[2];
+
+        pixbuf[i + uf] = srcptr[3];
+        pixbuf[i + uf*5] = srcptr[4];
+        pixbuf[i + uf*9] = srcptr[5];
+
+        pixbuf[i + uf*2] = srcptr[srcstep];
+        pixbuf[i + uf*6] = srcptr[srcstep + 1];
+        pixbuf[i + uf*10] = srcptr[srcstep + 2];
+
+        pixbuf[i + uf*3] = srcptr[srcstep + 3];
+        pixbuf[i + uf*7] = srcptr[srcstep + 4];
+        pixbuf[i + uf*11] = srcptr[srcstep + 5];
+    }
+}
+template<typename T>
+static inline void shuffle_allin_c1(const T *src, const int32_t *addr, T *pixbuf,
+                                    int uf, size_t srcstep) {
+    for (int i = 0; i < uf; i++) {
+        const T* srcptr = src + addr[i];
+
+        pixbuf[i] = srcptr[0];
+        pixbuf[i + uf] = srcptr[1];
+        pixbuf[i + uf*2] = srcptr[srcstep];
+        pixbuf[i + uf*3] = srcptr[srcstep + 1];
+    }
+}
+template<typename T>
+static inline void shuffle_allin_c4(const T *src, const int32_t *addr, T *pixbuf,
+                                    int uf, size_t srcstep) {
+    for (int i = 0; i < uf; i++) {
+        const T* srcptr = src + addr[i];
+
+        pixbuf[i] = srcptr[0];
+        pixbuf[i + uf*4] = srcptr[1];
+        pixbuf[i + uf*8] = srcptr[2];
+        pixbuf[i + uf*12] = srcptr[3];
+
+        pixbuf[i + uf] = srcptr[4];
+        pixbuf[i + uf*5] = srcptr[5];
+        pixbuf[i + uf*9] = srcptr[6];
+        pixbuf[i + uf*13] = srcptr[7];
+
+        pixbuf[i + uf*2] = srcptr[srcstep];
+        pixbuf[i + uf*6] = srcptr[srcstep + 1];
+        pixbuf[i + uf*10] = srcptr[srcstep + 2];
+        pixbuf[i + uf*14] = srcptr[srcstep + 3];
+
+        pixbuf[i + uf*3] = srcptr[srcstep + 4];
+        pixbuf[i + uf*7] = srcptr[srcstep + 5];
+        pixbuf[i + uf*11] = srcptr[srcstep + 6];
+        pixbuf[i + uf*15] = srcptr[srcstep + 7];
+    }
+}
+
+class WarpAffineLinearInvoker_8UC3 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_8UC3(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint8_t>();
+        auto *dst = output->ptr<uint8_t>();
+        size_t srcstep = input->step, dststep = output->step;
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(borderValue[0]),
+            saturate_cast<uint8_t>(borderValue[1]),
+            saturate_cast<uint8_t>(borderValue[2]),
+            saturate_cast<uint8_t>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        uint8_t bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
+        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*3];
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+    #endif
+    #if !CV_SIMD128_FP16
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b;
+    #endif
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    uint8x8x4_t p00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t p01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t p10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t p11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, reds));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, reds));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, reds));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, reds));
+
+                    p00r = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01r = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10r = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11r = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, greens));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, greens));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, greens));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, greens));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, blues));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, blues));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, blues));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, blues));
+
+                    p00b = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01b = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+    #else // scalar implementation when neon intrinsics are not available
+                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
+    #endif
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C3);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    p00r = vld1_u8(pixbuf);
+                    p01r = vld1_u8(pixbuf + 8);
+                    p10r = vld1_u8(pixbuf + 16);
+                    p11r = vld1_u8(pixbuf + 24);
+
+                    p00g = vld1_u8(pixbuf + 32);
+                    p01g = vld1_u8(pixbuf + 32 + 8);
+                    p10g = vld1_u8(pixbuf + 32 + 16);
+                    p11g = vld1_u8(pixbuf + 32 + 24);
+
+                    p00b = vld1_u8(pixbuf + 64);
+                    p01b = vld1_u8(pixbuf + 64 + 8);
+                    p10b = vld1_u8(pixbuf + 64 + 16);
+                    p11b = vld1_u8(pixbuf + 64 + 24);
+    #endif
+                }
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
+                v_float16 f00r = v_float16(vcvtq_f16_u16(vmovl_u8(p00r)));
+                v_float16 f01r = v_float16(vcvtq_f16_u16(vmovl_u8(p01r)));
+                v_float16 f10r = v_float16(vcvtq_f16_u16(vmovl_u8(p10r)));
+                v_float16 f11r = v_float16(vcvtq_f16_u16(vmovl_u8(p11r)));
+
+                v_float16 f00g = v_float16(vcvtq_f16_u16(vmovl_u8(p00g)));
+                v_float16 f01g = v_float16(vcvtq_f16_u16(vmovl_u8(p01g)));
+                v_float16 f10g = v_float16(vcvtq_f16_u16(vmovl_u8(p10g)));
+                v_float16 f11g = v_float16(vcvtq_f16_u16(vmovl_u8(p11g)));
+
+                v_float16 f00b = v_float16(vcvtq_f16_u16(vmovl_u8(p00b)));
+                v_float16 f01b = v_float16(vcvtq_f16_u16(vmovl_u8(p01b)));
+                v_float16 f10b = v_float16(vcvtq_f16_u16(vmovl_u8(p10b)));
+                v_float16 f11b = v_float16(vcvtq_f16_u16(vmovl_u8(p11b)));
+
+                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
+                          beta = v_cvt_f16(src_y0, src_y1);
+
+                f00r = v_fma(alpha, v_sub(f01r, f00r), f00r);
+                f10r = v_fma(alpha, v_sub(f11r, f10r), f10r);
+
+                f00g = v_fma(alpha, v_sub(f01g, f00g), f00g);
+                f10g = v_fma(alpha, v_sub(f11g, f10g), f10g);
+
+                f00b = v_fma(alpha, v_sub(f01b, f00b), f00b);
+                f10b = v_fma(alpha, v_sub(f11b, f10b), f10b);
+
+                f00r = v_fma(beta,  v_sub(f10r, f00r), f00r);
+                f00g = v_fma(beta,  v_sub(f10g, f00g), f00g);
+                f00b = v_fma(beta,  v_sub(f10b, f00b), f00b);
+
+                uint8x8x3_t result = {
+                    vqmovun_s16(vcvtnq_s16_f16(f00r.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00g.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00b.val)),
+                };
+                vst3_u8(dstptr + x*3, result);
+    #else // Other platforms use fp32 intrinsics for interpolation calculation
+        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+                v_int16 f00r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00r))),
+                        f01r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01r))),
+                        f10r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10r))),
+                        f11r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11r)));
+                v_int16 f00g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00g))),
+                        f01g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01g))),
+                        f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
+                        f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
+                v_int16 f00b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00b))),
+                        f01b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01b))),
+                        f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
+                        f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
+        #else
+                v_int16  f00r = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
+                         f01r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
+                         f10r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
+                         f11r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
+                v_int16  f00g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*4)),
+                         f01g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*5)),
+                         f10g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*6)),
+                         f11g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*7));
+                v_int16  f00b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*8)),
+                         f01b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*9)),
+                         f10b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*10)),
+                         f11b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*11));
+        #endif
+                v_float32 f00rl = v_cvt_f32(v_expand_low(f00r)), f00rh = v_cvt_f32(v_expand_high(f00r)),
+                          f01rl = v_cvt_f32(v_expand_low(f01r)), f01rh = v_cvt_f32(v_expand_high(f01r)),
+                          f10rl = v_cvt_f32(v_expand_low(f10r)), f10rh = v_cvt_f32(v_expand_high(f10r)),
+                          f11rl = v_cvt_f32(v_expand_low(f11r)), f11rh = v_cvt_f32(v_expand_high(f11r));
+                v_float32 f00gl = v_cvt_f32(v_expand_low(f00g)), f00gh = v_cvt_f32(v_expand_high(f00g)),
+                          f01gl = v_cvt_f32(v_expand_low(f01g)), f01gh = v_cvt_f32(v_expand_high(f01g)),
+                          f10gl = v_cvt_f32(v_expand_low(f10g)), f10gh = v_cvt_f32(v_expand_high(f10g)),
+                          f11gl = v_cvt_f32(v_expand_low(f11g)), f11gh = v_cvt_f32(v_expand_high(f11g));
+                v_float32 f00bl = v_cvt_f32(v_expand_low(f00b)), f00bh = v_cvt_f32(v_expand_high(f00b)),
+                          f01bl = v_cvt_f32(v_expand_low(f01b)), f01bh = v_cvt_f32(v_expand_high(f01b)),
+                          f10bl = v_cvt_f32(v_expand_low(f10b)), f10bh = v_cvt_f32(v_expand_high(f10b)),
+                          f11bl = v_cvt_f32(v_expand_low(f11b)), f11bh = v_cvt_f32(v_expand_high(f11b));
+
+                VECTOR_LINEAR_C3_F32();
+
+                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
+                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
+                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh));
+                uint16_t tbuf[max_vlanes_16*3];
+                v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16);
+                v_pack_store(dstptr + x*3, vx_load(tbuf));
+                v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16));
+                v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
+    #endif // defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p01r, p01g, p01b;
+                int p10r, p10g, p10b, p11r, p11g, p11b;
+                const uint8_t* srcptr = src + srcstep*iy + ix*3;
+
+                SCALAR_LINEAR_SHUFFLE_C3();
+
+                SCALAR_LINEAR_CALC_C3();
+
+                dstptr[x*3] = saturate_cast<uint8_t>(v0r);
+                dstptr[x*3+1] = saturate_cast<uint8_t>(v0g);
+                dstptr[x*3+2] = saturate_cast<uint8_t>(v0b);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_16UC3 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_16UC3(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint16_t>();
+        auto *dst = output->ptr<uint16_t>();
+        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(borderValue[0]),
+            saturate_cast<uint16_t>(borderValue[1]),
+            saturate_cast<uint16_t>(borderValue[2]),
+            saturate_cast<uint16_t>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        uint16_t bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
+        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4*3];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C3);
+                }
+
+                v_uint16 f00r = vx_load(pixbuf),
+                         f01r = vx_load(pixbuf + uf),
+                         f10r = vx_load(pixbuf + uf*2),
+                         f11r = vx_load(pixbuf + uf*3);
+                v_uint16 f00g = vx_load(pixbuf + uf*4),
+                         f01g = vx_load(pixbuf + uf*5),
+                         f10g = vx_load(pixbuf + uf*6),
+                         f11g = vx_load(pixbuf + uf*7);
+                v_uint16 f00b = vx_load(pixbuf + uf*8),
+                         f01b = vx_load(pixbuf + uf*9),
+                         f10b = vx_load(pixbuf + uf*10),
+                         f11b = vx_load(pixbuf + uf*11);
+
+                v_float32 f00rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00r))), f00rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00r))),
+                          f01rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01r))), f01rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01r))),
+                          f10rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10r))), f10rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10r))),
+                          f11rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11r))), f11rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11r)));
+                v_float32 f00gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00g))), f00gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00g))),
+                          f01gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01g))), f01gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01g))),
+                          f10gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10g))), f10gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10g))),
+                          f11gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11g))), f11gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11g)));
+                v_float32 f00bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00b))), f00bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00b))),
+                          f01bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01b))), f01bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01b))),
+                          f10bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10b))), f10bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10b))),
+                          f11bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11b))), f11bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11b)));
+
+                VECTOR_LINEAR_C3_F32();
+
+                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
+                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
+                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh));
+                v_store_interleave(dstptr + x*3, f00r_u16, f00g_u16, f00b_u16);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p01r, p01g, p01b;
+                int p10r, p10g, p10b, p11r, p11g, p11b;
+                const uint16_t* srcptr = src + srcstep*iy + ix*3;
+
+                SCALAR_LINEAR_SHUFFLE_C3();
+
+                SCALAR_LINEAR_CALC_C3();
+
+                dstptr[x*3] = saturate_cast<uint16_t>(v0r);
+                dstptr[x*3+1] = saturate_cast<uint16_t>(v0g);
+                dstptr[x*3+2] = saturate_cast<uint16_t>(v0b);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_32FC3 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_32FC3(Mat *output_, const Mat *input_, const double *dM_,
+                                  int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const float>();
+        auto *dst = output->ptr<float>();
+        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(borderValue[0]),
+            saturate_cast<float>(borderValue[1]),
+            saturate_cast<float>(borderValue[2]),
+            saturate_cast<float>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        float bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
+        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
+        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
+        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4*3];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C3);
+                }
+
+                v_float32 f00rl = vx_load(pixbuf),         f00rh = vx_load(pixbuf + vlanes_32),
+                          f01rl = vx_load(pixbuf + uf),    f01rh = vx_load(pixbuf + uf + vlanes_32),
+                          f10rl = vx_load(pixbuf + uf*2),  f10rh = vx_load(pixbuf + uf*2 + vlanes_32),
+                          f11rl = vx_load(pixbuf + uf*3),  f11rh = vx_load(pixbuf + uf*3 + vlanes_32);
+                v_float32 f00gl = vx_load(pixbuf + uf*4),  f00gh = vx_load(pixbuf + uf*4 + vlanes_32),
+                          f01gl = vx_load(pixbuf + uf*5),  f01gh = vx_load(pixbuf + uf*5 + vlanes_32),
+                          f10gl = vx_load(pixbuf + uf*6),  f10gh = vx_load(pixbuf + uf*6 + vlanes_32),
+                          f11gl = vx_load(pixbuf + uf*7),  f11gh = vx_load(pixbuf + uf*7 + vlanes_32);
+                v_float32 f00bl = vx_load(pixbuf + uf*8),  f00bh = vx_load(pixbuf + uf*8 + vlanes_32),
+                          f01bl = vx_load(pixbuf + uf*9),  f01bh = vx_load(pixbuf + uf*9 + vlanes_32),
+                          f10bl = vx_load(pixbuf + uf*10), f10bh = vx_load(pixbuf + uf*10 + vlanes_32),
+                          f11bl = vx_load(pixbuf + uf*11), f11bh = vx_load(pixbuf + uf*11 + vlanes_32);
+
+                VECTOR_LINEAR_C3_F32();
+
+                v_store_interleave(dstptr + x*3, f00rl, f00gl, f00bl);
+                v_store_interleave(dstptr + x*3 + vlanes_32*3, f00rh, f00gh, f00bh);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00r, p00g, p00b, p01r, p01g, p01b;
+                float p10r, p10g, p10b, p11r, p11g, p11b;
+                const float* srcptr = src + srcstep*iy + ix*3;
+
+                SCALAR_LINEAR_SHUFFLE_C3();
+
+                SCALAR_LINEAR_CALC_C3();
+
+                dstptr[x*3] =   v0r;
+                dstptr[x*3+1] = v0g;
+                dstptr[x*3+2] = v0b;
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_8UC1 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_8UC1(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint8_t>();
+        auto *dst = output->ptr<uint8_t>();
+        size_t srcstep = input->step, dststep = output->step;
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(borderValue[0]),
+            saturate_cast<uint8_t>(borderValue[1]),
+            saturate_cast<uint8_t>(borderValue[2]),
+            saturate_cast<uint8_t>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        uint8_t bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4];
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8x8_t gray = {0, 8, 16, 24, 1, 9, 17, 25};
+    #endif
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00, p01, p10, p11;
+    #endif
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    uint8x8x4_t t00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t t01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t t10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t t11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(t00, gray));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(t01, gray));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(t10, gray));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(t11, gray));
+
+                    p00 = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01 = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10 = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11 = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+    #else
+                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
+    #endif
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C1);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    p00 = vld1_u8(pixbuf);
+                    p01 = vld1_u8(pixbuf + 8);
+                    p10 = vld1_u8(pixbuf + 16);
+                    p11 = vld1_u8(pixbuf + 24);
+    #endif
+                }
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
+                v_float16 f00 = v_float16(vcvtq_f16_u16(vmovl_u8(p00)));
+                v_float16 f01 = v_float16(vcvtq_f16_u16(vmovl_u8(p01)));
+                v_float16 f10 = v_float16(vcvtq_f16_u16(vmovl_u8(p10)));
+                v_float16 f11 = v_float16(vcvtq_f16_u16(vmovl_u8(p11)));
+
+                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
+                          beta = v_cvt_f16(src_y0, src_y1);
+
+                f00 = v_fma(alpha, v_sub(f01, f00), f00);
+                f10 = v_fma(alpha, v_sub(f11, f10), f10);
+                f00 = v_fma(beta,  v_sub(f10, f00), f00);
+
+                uint8x8_t result = {
+                    vqmovun_s16(vcvtnq_s16_f16(f00.val)),
+                };
+
+                vst1_u8(dstptr + x, result);
+    #else
+        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+                v_int16 f00 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00))),
+                        f01 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01))),
+                        f10 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10))),
+                        f11 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11)));
+        #else
+                v_int16  f00 = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
+                         f01 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
+                         f10 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
+                         f11 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
+        #endif
+                v_float32 f00l = v_cvt_f32(v_expand_low(f00)), f00h = v_cvt_f32(v_expand_high(f00)),
+                          f01l = v_cvt_f32(v_expand_low(f01)), f01h = v_cvt_f32(v_expand_high(f01)),
+                          f10l = v_cvt_f32(v_expand_low(f10)), f10h = v_cvt_f32(v_expand_high(f10)),
+                          f11l = v_cvt_f32(v_expand_low(f11)), f11h = v_cvt_f32(v_expand_high(f11));
+
+                VECTOR_LINEAR_C1_F32();
+
+                v_uint16 f00_u16 = v_pack_u(v_round(f00l), v_round(f00h));
+                v_uint8 f00_u8 = v_pack(f00_u16, vx_setall_u16(0));
+                v_store_low(dstptr + x, f00_u8);
+    #endif
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00, p01, p10, p11;
+                const uint8_t *srcptr = src + srcstep * iy + ix;
+
+                if ((((unsigned)ix < (unsigned)(srccols-1)) &
+                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
+                    p00 = srcptr[0]; p01 = srcptr[1];
+                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
+                } else {
+                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
+                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
+                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
+                        if (borderType == BORDER_CONSTANT) {
+                            dstptr[x] = bval[0];
+                        }
+                        continue;
+                    }
+                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
+                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
+                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
+                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
+                }
+                float v0 = p00 + sx*(p01 - p00);
+                float v1 = p10 + sx*(p11 - p10);
+                v0 += sy*(v1 - v0);
+                dstptr[x] = saturate_cast<uint8_t>(v0);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_16UC1 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_16UC1(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint16_t>();
+        auto *dst = output->ptr<uint16_t>();
+        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(borderValue[0]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        uint16_t bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C1);
+                }
+
+                v_uint16 f00 = vx_load(pixbuf),
+                         f01 = vx_load(pixbuf + uf),
+                         f10 = vx_load(pixbuf + uf*2),
+                         f11 = vx_load(pixbuf + uf*3);
+
+                v_float32 f00l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00))), f00h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00))),
+                          f01l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01))), f01h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01))),
+                          f10l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10))), f10h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10))),
+                          f11l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11))), f11h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11)));
+
+                VECTOR_LINEAR_C1_F32();
+
+                v_uint16 f00_u16 = v_pack_u(v_round(f00l), v_round(f00h));
+                v_store(dstptr + x, f00_u16);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00, p01, p10, p11;
+                const uint16_t *srcptr = src + srcstep * iy + ix;
+
+                if ((((unsigned)ix < (unsigned)(srccols-1)) &
+                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
+                    p00 = srcptr[0]; p01 = srcptr[1];
+                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
+                } else {
+                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
+                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
+                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
+                        if (borderType == BORDER_CONSTANT) {
+                            dstptr[x] = bval[0];
+                        }
+                        continue;
+                    }
+                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
+                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
+                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
+                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
+                }
+                float v0 = p00 + sx*(p01 - p00);
+                float v1 = p10 + sx*(p11 - p10);
+                v0 += sy*(v1 - v0);
+                dstptr[x] = saturate_cast<uint16_t>(v0);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_32FC1 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_32FC1(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const float>();
+        auto *dst = output->ptr<float>();
+        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(borderValue[0]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        float bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C1);
+                }
+
+                v_float32 f00l = vx_load(pixbuf),         f00h = vx_load(pixbuf + vlanes_32),
+                          f01l = vx_load(pixbuf + uf),    f01h = vx_load(pixbuf + uf + vlanes_32),
+                          f10l = vx_load(pixbuf + uf*2),  f10h = vx_load(pixbuf + uf*2 + vlanes_32),
+                          f11l = vx_load(pixbuf + uf*3),  f11h = vx_load(pixbuf + uf*3 + vlanes_32);
+
+                VECTOR_LINEAR_C1_F32();
+
+                vx_store(dstptr + x, f00l);
+                vx_store(dstptr + x + vlanes_32, f00h);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00, p01, p10, p11;
+                const float *srcptr = src + srcstep * iy + ix;
+
+                if ((((unsigned)ix < (unsigned)(srccols-1)) &
+                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
+                    p00 = srcptr[0]; p01 = srcptr[1];
+                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
+                } else {
+                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
+                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
+                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
+                        if (borderType == BORDER_CONSTANT) {
+                            dstptr[x] = bval[0];
+                        }
+                        continue;
+                    }
+                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
+                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
+                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
+                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
+                }
+                float v0 = p00 + sx*(p01 - p00);
+                float v1 = p10 + sx*(p11 - p10);
+                v0 += sy*(v1 - v0);
+                dstptr[x] = v0;
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_8UC4 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_8UC4(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint8_t>();
+        auto *dst = output->ptr<uint8_t>();
+        size_t srcstep = input->step, dststep = output->step;
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(borderValue[0]),
+            saturate_cast<uint8_t>(borderValue[1]),
+            saturate_cast<uint8_t>(borderValue[2]),
+            saturate_cast<uint8_t>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        uint8_t bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
+        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+        v_uint8 bval_v3 = vx_load_low(&bvalbuf[uf*3]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*4];
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8x8_t reds = {0, 8, 16, 24, 4, 12, 20, 28},
+                  greens = {1, 9, 17, 25, 5, 13, 21, 29},
+                  blues = {2, 10, 18, 26, 6, 14, 22, 30},
+                  alphas = {3, 11, 19, 27, 7, 15, 23, 31};
+    #endif
+    #if !CV_SIMD128_FP16
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b,
+                          p00a, p01a, p10a, p11a;
+    #endif
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    uint8x8x4_t p00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t p01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t p10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t p11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, reds));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, reds));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, reds));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, reds));
+
+                    p00r = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01r = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10r = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11r = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, greens));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, greens));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, greens));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, greens));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, blues));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, blues));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, blues));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, blues));
+
+                    p00b = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01b = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, alphas));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, alphas));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, alphas));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, alphas));
+
+                    p00a = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01a = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10a = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11a = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+    #else
+                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
+    #endif
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C4);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    p00r = vld1_u8(pixbuf);
+                    p01r = vld1_u8(pixbuf + 8);
+                    p10r = vld1_u8(pixbuf + 16);
+                    p11r = vld1_u8(pixbuf + 24);
+
+                    p00g = vld1_u8(pixbuf + 32);
+                    p01g = vld1_u8(pixbuf + 32 + 8);
+                    p10g = vld1_u8(pixbuf + 32 + 16);
+                    p11g = vld1_u8(pixbuf + 32 + 24);
+
+                    p00b = vld1_u8(pixbuf + 64);
+                    p01b = vld1_u8(pixbuf + 64 + 8);
+                    p10b = vld1_u8(pixbuf + 64 + 16);
+                    p11b = vld1_u8(pixbuf + 64 + 24);
+
+                    p00a = vld1_u8(pixbuf + 96);
+                    p01a = vld1_u8(pixbuf + 96 + 8);
+                    p10a = vld1_u8(pixbuf + 96 + 16);
+                    p11a = vld1_u8(pixbuf + 96 + 24);
+    #endif
+                }
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
+                v_float16 f00r = v_float16(vcvtq_f16_u16(vmovl_u8(p00r)));
+                v_float16 f01r = v_float16(vcvtq_f16_u16(vmovl_u8(p01r)));
+                v_float16 f10r = v_float16(vcvtq_f16_u16(vmovl_u8(p10r)));
+                v_float16 f11r = v_float16(vcvtq_f16_u16(vmovl_u8(p11r)));
+
+                v_float16 f00g = v_float16(vcvtq_f16_u16(vmovl_u8(p00g)));
+                v_float16 f01g = v_float16(vcvtq_f16_u16(vmovl_u8(p01g)));
+                v_float16 f10g = v_float16(vcvtq_f16_u16(vmovl_u8(p10g)));
+                v_float16 f11g = v_float16(vcvtq_f16_u16(vmovl_u8(p11g)));
+
+                v_float16 f00b = v_float16(vcvtq_f16_u16(vmovl_u8(p00b)));
+                v_float16 f01b = v_float16(vcvtq_f16_u16(vmovl_u8(p01b)));
+                v_float16 f10b = v_float16(vcvtq_f16_u16(vmovl_u8(p10b)));
+                v_float16 f11b = v_float16(vcvtq_f16_u16(vmovl_u8(p11b)));
+
+                v_float16 f00a = v_float16(vcvtq_f16_u16(vmovl_u8(p00a)));
+                v_float16 f01a = v_float16(vcvtq_f16_u16(vmovl_u8(p01a)));
+                v_float16 f10a = v_float16(vcvtq_f16_u16(vmovl_u8(p10a)));
+                v_float16 f11a = v_float16(vcvtq_f16_u16(vmovl_u8(p11a)));
+
+                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
+                          beta = v_cvt_f16(src_y0, src_y1);
+
+                f00r = v_fma(alpha, v_sub(f01r, f00r), f00r);
+                f10r = v_fma(alpha, v_sub(f11r, f10r), f10r);
+
+                f00g = v_fma(alpha, v_sub(f01g, f00g), f00g);
+                f10g = v_fma(alpha, v_sub(f11g, f10g), f10g);
+
+                f00b = v_fma(alpha, v_sub(f01b, f00b), f00b);
+                f10b = v_fma(alpha, v_sub(f11b, f10b), f10b);
+
+                f00a = v_fma(alpha, v_sub(f01a, f00a), f00a);
+                f10a = v_fma(alpha, v_sub(f11a, f10a), f10a);
+
+                f00r = v_fma(beta,  v_sub(f10r, f00r), f00r);
+                f00g = v_fma(beta,  v_sub(f10g, f00g), f00g);
+                f00b = v_fma(beta,  v_sub(f10b, f00b), f00b);
+                f00a = v_fma(beta,  v_sub(f10a, f00a), f00a);
+
+                uint8x8x4_t result = {
+                    vqmovun_s16(vcvtnq_s16_f16(f00r.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00g.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00b.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00a.val)),
+                };
+                vst4_u8(dstptr + x*4, result);
+    #else
+        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+                v_int16 f00r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00r))),
+                        f01r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01r))),
+                        f10r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10r))),
+                        f11r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11r)));
+                v_int16 f00g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00g))),
+                        f01g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01g))),
+                        f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
+                        f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
+                v_int16 f00b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00b))),
+                        f01b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01b))),
+                        f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
+                        f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
+                v_int16 f00a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00a))),
+                        f01a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01a))),
+                        f10a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10a))),
+                        f11a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11a)));
+        #else
+                v_int16  f00r = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
+                         f01r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
+                         f10r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
+                         f11r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
+                v_int16  f00g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*4)),
+                         f01g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*5)),
+                         f10g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*6)),
+                         f11g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*7));
+                v_int16  f00b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*8)),
+                         f01b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*9)),
+                         f10b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*10)),
+                         f11b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*11));
+                v_int16  f00a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*12)),
+                         f01a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*13)),
+                         f10a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*14)),
+                         f11a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*15));
+        #endif
+                v_float32 f00rl = v_cvt_f32(v_expand_low(f00r)), f00rh = v_cvt_f32(v_expand_high(f00r)),
+                          f01rl = v_cvt_f32(v_expand_low(f01r)), f01rh = v_cvt_f32(v_expand_high(f01r)),
+                          f10rl = v_cvt_f32(v_expand_low(f10r)), f10rh = v_cvt_f32(v_expand_high(f10r)),
+                          f11rl = v_cvt_f32(v_expand_low(f11r)), f11rh = v_cvt_f32(v_expand_high(f11r));
+                v_float32 f00gl = v_cvt_f32(v_expand_low(f00g)), f00gh = v_cvt_f32(v_expand_high(f00g)),
+                          f01gl = v_cvt_f32(v_expand_low(f01g)), f01gh = v_cvt_f32(v_expand_high(f01g)),
+                          f10gl = v_cvt_f32(v_expand_low(f10g)), f10gh = v_cvt_f32(v_expand_high(f10g)),
+                          f11gl = v_cvt_f32(v_expand_low(f11g)), f11gh = v_cvt_f32(v_expand_high(f11g));
+                v_float32 f00bl = v_cvt_f32(v_expand_low(f00b)), f00bh = v_cvt_f32(v_expand_high(f00b)),
+                          f01bl = v_cvt_f32(v_expand_low(f01b)), f01bh = v_cvt_f32(v_expand_high(f01b)),
+                          f10bl = v_cvt_f32(v_expand_low(f10b)), f10bh = v_cvt_f32(v_expand_high(f10b)),
+                          f11bl = v_cvt_f32(v_expand_low(f11b)), f11bh = v_cvt_f32(v_expand_high(f11b));
+                v_float32 f00al = v_cvt_f32(v_expand_low(f00a)), f00ah = v_cvt_f32(v_expand_high(f00a)),
+                          f01al = v_cvt_f32(v_expand_low(f01a)), f01ah = v_cvt_f32(v_expand_high(f01a)),
+                          f10al = v_cvt_f32(v_expand_low(f10a)), f10ah = v_cvt_f32(v_expand_high(f10a)),
+                          f11al = v_cvt_f32(v_expand_low(f11a)), f11ah = v_cvt_f32(v_expand_high(f11a));
+
+                VECTOR_LINEAR_C4_F32();
+
+                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
+                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
+                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)),
+                         f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah));
+                uint16_t tbuf[max_vlanes_16*4];
+                v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
+                v_pack_store(dstptr + x*4, vx_load(tbuf));
+                v_pack_store(dstptr + x*4 + vlanes_16, vx_load(tbuf + vlanes_16));
+                v_pack_store(dstptr + x*4 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
+                v_pack_store(dstptr + x*4 + vlanes_16*3, vx_load(tbuf + vlanes_16*3));
+    #endif // defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const uint8_t* srcptr = src + srcstep*iy + ix*4;
+
+                SCALAR_LINEAR_SHUFFLE_C4();
+
+                SCALAR_LINEAR_CALC_C4();
+
+                dstptr[x*4] = saturate_cast<uint8_t>(v0r);
+                dstptr[x*4+1] = saturate_cast<uint8_t>(v0g);
+                dstptr[x*4+2] = saturate_cast<uint8_t>(v0b);
+                dstptr[x*4+3] = saturate_cast<uint8_t>(v0a);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_16UC4 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_16UC4(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const uint16_t>();
+        auto *dst = output->ptr<uint16_t>();
+        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(borderValue[0]),
+            saturate_cast<uint16_t>(borderValue[1]),
+            saturate_cast<uint16_t>(borderValue[2]),
+            saturate_cast<uint16_t>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        uint16_t bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
+        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
+        v_uint16 bval_v3 = vx_load(&bvalbuf[uf*3]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4*4];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C4);
+                }
+
+                v_uint16 f00r = vx_load(pixbuf),
+                         f01r = vx_load(pixbuf + uf),
+                         f10r = vx_load(pixbuf + uf*2),
+                         f11r = vx_load(pixbuf + uf*3);
+                v_uint16 f00g = vx_load(pixbuf + uf*4),
+                         f01g = vx_load(pixbuf + uf*5),
+                         f10g = vx_load(pixbuf + uf*6),
+                         f11g = vx_load(pixbuf + uf*7);
+                v_uint16 f00b = vx_load(pixbuf + uf*8),
+                         f01b = vx_load(pixbuf + uf*9),
+                         f10b = vx_load(pixbuf + uf*10),
+                         f11b = vx_load(pixbuf + uf*11);
+                v_uint16 f00a = vx_load(pixbuf + uf*12),
+                         f01a = vx_load(pixbuf + uf*13),
+                         f10a = vx_load(pixbuf + uf*14),
+                         f11a = vx_load(pixbuf + uf*15);
+
+                v_float32 f00rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00r))), f00rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00r))),
+                          f01rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01r))), f01rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01r))),
+                          f10rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10r))), f10rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10r))),
+                          f11rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11r))), f11rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11r)));
+                v_float32 f00gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00g))), f00gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00g))),
+                          f01gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01g))), f01gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01g))),
+                          f10gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10g))), f10gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10g))),
+                          f11gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11g))), f11gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11g)));
+                v_float32 f00bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00b))), f00bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00b))),
+                          f01bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01b))), f01bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01b))),
+                          f10bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10b))), f10bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10b))),
+                          f11bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11b))), f11bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11b)));
+                v_float32 f00al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00a))), f00ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00a))),
+                          f01al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01a))), f01ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01a))),
+                          f10al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10a))), f10ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10a))),
+                          f11al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11a))), f11ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11a)));
+
+                VECTOR_LINEAR_C4_F32();
+
+                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
+                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
+                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)),
+                         f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah));
+                v_store_interleave(dstptr + x*4, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const uint16_t* srcptr = src + srcstep*iy + ix*4;
+
+                SCALAR_LINEAR_SHUFFLE_C4();
+
+                SCALAR_LINEAR_CALC_C4();
+
+                dstptr[x*4] =   saturate_cast<uint16_t>(v0r);
+                dstptr[x*4+1] = saturate_cast<uint16_t>(v0g);
+                dstptr[x*4+2] = saturate_cast<uint16_t>(v0b);
+                dstptr[x*4+3] = saturate_cast<uint16_t>(v0a);
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+class WarpAffineLinearInvoker_32FC4 : public ParallelLoopBody {
+public:
+    WarpAffineLinearInvoker_32FC4(Mat *output_, const Mat *input_, const double *dM_,
+                                 int borderType_, const double *borderValue_)
+        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
+
+    virtual void operator() (const Range &r) const CV_OVERRIDE {
+        CV_INSTRUMENT_REGION();
+
+        auto *src = input->ptr<const float>();
+        auto *dst = output->ptr<float>();
+        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
+        int srccols = input->cols, srcrows = input->rows;
+        int dstcols = output->cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(borderValue[0]),
+            saturate_cast<float>(borderValue[1]),
+            saturate_cast<float>(borderValue[2]),
+            saturate_cast<float>(borderValue[3]),
+        };
+        int borderType_x = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
+        int borderType_y = borderType != BORDER_CONSTANT &&
+                           borderType != BORDER_TRANSPARENT &&
+                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        float bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
+        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
+        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
+        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
+        v_float32 bval_v3_l = vx_load(&bvalbuf[uf*3]);
+        v_float32 bval_v3_h = vx_load(&bvalbuf[uf*3+vlanes_32]);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4*4];
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                VECTOR_COMPUTE_COORDINATES();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
+                } else {
+                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C4);
+                }
+
+                v_float32 f00rl = vx_load(pixbuf),         f00rh = vx_load(pixbuf + vlanes_32),
+                          f01rl = vx_load(pixbuf + uf),    f01rh = vx_load(pixbuf + uf + vlanes_32),
+                          f10rl = vx_load(pixbuf + uf*2),  f10rh = vx_load(pixbuf + uf*2 + vlanes_32),
+                          f11rl = vx_load(pixbuf + uf*3),  f11rh = vx_load(pixbuf + uf*3 + vlanes_32);
+                v_float32 f00gl = vx_load(pixbuf + uf*4),  f00gh = vx_load(pixbuf + uf*4 + vlanes_32),
+                          f01gl = vx_load(pixbuf + uf*5),  f01gh = vx_load(pixbuf + uf*5 + vlanes_32),
+                          f10gl = vx_load(pixbuf + uf*6),  f10gh = vx_load(pixbuf + uf*6 + vlanes_32),
+                          f11gl = vx_load(pixbuf + uf*7),  f11gh = vx_load(pixbuf + uf*7 + vlanes_32);
+                v_float32 f00bl = vx_load(pixbuf + uf*8),  f00bh = vx_load(pixbuf + uf*8 + vlanes_32),
+                          f01bl = vx_load(pixbuf + uf*9),  f01bh = vx_load(pixbuf + uf*9 + vlanes_32),
+                          f10bl = vx_load(pixbuf + uf*10), f10bh = vx_load(pixbuf + uf*10 + vlanes_32),
+                          f11bl = vx_load(pixbuf + uf*11), f11bh = vx_load(pixbuf + uf*11 + vlanes_32);
+                v_float32 f00al = vx_load(pixbuf + uf*12), f00ah = vx_load(pixbuf + uf*12 + vlanes_32),
+                          f01al = vx_load(pixbuf + uf*13), f01ah = vx_load(pixbuf + uf*13 + vlanes_32),
+                          f10al = vx_load(pixbuf + uf*14), f10ah = vx_load(pixbuf + uf*14 + vlanes_32),
+                          f11al = vx_load(pixbuf + uf*15), f11ah = vx_load(pixbuf + uf*15 + vlanes_32);
+
+                VECTOR_LINEAR_C4_F32();
+
+                v_store_interleave(dstptr + x*4, f00rl, f00gl, f00bl, f00al);
+                v_store_interleave(dstptr + x*4 + vlanes_32*4, f00rh, f00gh, f00bh, f00ah);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                float p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const float* srcptr = src + srcstep*iy + ix*4;
+
+                SCALAR_LINEAR_SHUFFLE_C4();
+
+                SCALAR_LINEAR_CALC_C4();
+
+                dstptr[x*4] =   v0r;
+                dstptr[x*4+1] = v0g;
+                dstptr[x*4+2] = v0b;
+                dstptr[x*4+3] = v0a;
+            }
+        }
+    }
+
+private:
+    Mat *output;
+    const Mat *input;
+    const double *dM;
+    int borderType;
+    const double *borderValue;
+};
+
+} // anonymous
+
+void warpAffineSimdInvoker(Mat &output, const Mat &input, const double *M,
+                           int interpolation, int borderType, const double *borderValue) {
+    CV_INSTRUMENT_REGION();
+
+    CV_CheckEQ(interpolation, INTER_LINEAR, "");
+    switch (output.type()) {
+        case CV_8UC3: {
+            WarpAffineLinearInvoker_8UC3 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_16UC3: {
+            WarpAffineLinearInvoker_16UC3 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_32FC3: {
+            WarpAffineLinearInvoker_32FC3 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_8UC1: {
+            WarpAffineLinearInvoker_8UC1 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_16UC1: {
+            WarpAffineLinearInvoker_16UC1 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_32FC1: {
+            WarpAffineLinearInvoker_32FC1 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_8UC4: {
+            WarpAffineLinearInvoker_8UC4 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_16UC4: {
+            WarpAffineLinearInvoker_16UC4 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        case CV_32FC4: {
+            WarpAffineLinearInvoker_32FC4 body(&output, &input, M, borderType, borderValue);
+            parallel_for_(Range(0, output.rows), body);
+            break;
+        }
+        default: CV_Error(Error::StsBadArg, "Unsupported type");
+    }
+}
+#endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+} // cv

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -739,7 +739,7 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
                 sx -= ix; sy -= iy;
                 int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
                 int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
-                const uint8_t* srcptr = src + srcstep*iy + ix*3;
+                const uint8_t* srcptr = src + srcstep*iy + ix*4;
 
                 CV_WARP_LINEAR_SCALAR_SHUFFLE(C4);
 
@@ -774,11 +774,11 @@ void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, in
             saturate_cast<uint16_t>(border_value[3]),
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
@@ -889,11 +889,11 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
             saturate_cast<uint16_t>(border_value[3]),
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
@@ -1009,11 +1009,11 @@ void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, in
             saturate_cast<uint16_t>(border_value[3]),
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
-                           border_type != BORDER_TRANSPARENT &&
-                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
@@ -1131,10 +1131,10 @@ void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int s
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
@@ -1244,10 +1244,10 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
@@ -1364,10 +1364,10 @@ void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int s
         };
         int border_type_x = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
         int border_type_y = border_type != BORDER_CONSTANT &&
                             border_type != BORDER_TRANSPARENT &&
-                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -7,143 +7,17 @@
 
 #include "opencv2/core/hal/intrin.hpp"
 
-#define VECTOR_FETCH_PIXEL_C3(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx*3; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*3]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*3 + 1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*3 + 2]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t addr_i = iy_*srcstep + ix_*3; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-    }
-#define VECTOR_FETCH_PIXEL_C1(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[x + i]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t addr_i = iy_*srcstep + ix_; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-    }
-#define VECTOR_FETCH_PIXEL_C4(dy, dx, pixbuf_ofs) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t addr_i = addr[i] + dy*srcstep + dx*4; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pixbuf[i + pixbuf_ofs] = bval[0]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = bval[3]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*4]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*4 + 1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*4 + 2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = dstptr[(x + i)*4 + 3]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t addr_i = iy_*srcstep + ix_*4; \
-        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
-        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
-        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
-        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
-    }
-
-#define SCALAR_FETCH_PIXEL_C3(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx*3; \
-        pxy##r = srcptr[ofs]; \
-        pxy##g = srcptr[ofs+1]; \
-        pxy##b = srcptr[ofs+2]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pxy##r = bval[0]; \
-        pxy##g = bval[1]; \
-        pxy##b = bval[2]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pxy##r = dstptr[x*3]; \
-        pxy##g = dstptr[x*3+1]; \
-        pxy##b = dstptr[x*3+2]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t glob_ofs = iy_*srcstep + ix_*3; \
-        pxy##r = src[glob_ofs]; \
-        pxy##g = src[glob_ofs+1]; \
-        pxy##b = src[glob_ofs+2]; \
-    }
-#define SCALAR_FETCH_PIXEL_C1(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx; \
-        pxy = srcptr[ofs]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pxy = bval[0]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pxy = dstptr[x]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t glob_ofs = iy_*srcstep + ix_; \
-        pxy = src[glob_ofs]; \
-    }
-#define SCALAR_FETCH_PIXEL_C4(dy, dx, pxy) \
-    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
-        size_t ofs = dy*srcstep + dx*4; \
-        pxy##r = srcptr[ofs]; \
-        pxy##g = srcptr[ofs+1]; \
-        pxy##b = srcptr[ofs+2]; \
-        pxy##a = srcptr[ofs+3]; \
-    } else if (borderType == BORDER_CONSTANT) { \
-        pxy##r = bval[0]; \
-        pxy##g = bval[1]; \
-        pxy##b = bval[2]; \
-        pxy##a = bval[3]; \
-    } else if (borderType == BORDER_TRANSPARENT) { \
-        pxy##r = dstptr[x*4]; \
-        pxy##g = dstptr[x*4+1]; \
-        pxy##b = dstptr[x*4+2]; \
-        pxy##a = dstptr[x*4+3]; \
-    } else { \
-        int ix_ = borderInterpolate_fast(ix + dx, srccols, borderType_x); \
-        int iy_ = borderInterpolate_fast(iy + dy, srcrows, borderType_y); \
-        size_t glob_ofs = iy_*srcstep + ix_*4; \
-        pxy##r = src[glob_ofs]; \
-        pxy##g = src[glob_ofs+1]; \
-        pxy##b = src[glob_ofs+2]; \
-        pxy##a = src[glob_ofs+3]; \
-    }
-
-#define VECTOR_COMPUTE_COORDINATES() \
+#define WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD() \
     v_float32 src_x0 = v_fma(M0, dst_x0, M_x), \
               src_y0 = v_fma(M3, dst_x0, M_y), \
               src_x1 = v_fma(M0, dst_x1, M_x), \
               src_y1 = v_fma(M3, dst_x1, M_y); \
-    dst_x0 = v_add(dst_x0, delta);             \
-    dst_x1 = v_add(dst_x1, delta);             \
-    v_int32 src_ix0 = v_floor(src_x0),         \
-            src_iy0 = v_floor(src_y0),         \
-            src_ix1 = v_floor(src_x1),         \
-            src_iy1 = v_floor(src_y1);         \
+    dst_x0 = v_add(dst_x0, delta); \
+    dst_x1 = v_add(dst_x1, delta); \
+    v_int32 src_ix0 = v_floor(src_x0), \
+            src_iy0 = v_floor(src_y0), \
+            src_ix1 = v_floor(src_x1), \
+            src_iy1 = v_floor(src_y1); \
     v_uint32 mask_0 = v_lt(v_reinterpret_as_u32(src_ix0), inner_scols), \
              mask_1 = v_lt(v_reinterpret_as_u32(src_ix1), inner_scols); \
     mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(src_iy0), inner_srows)); \
@@ -154,73 +28,157 @@
     src_x1 = v_sub(src_x1, v_cvt_f32(src_ix1)); \
     src_y1 = v_sub(src_y1, v_cvt_f32(src_iy1));
 
-#define VECTOR_LINEAR_C3_F32() \
-    v_float32 alphal = src_x0, alphah = src_x1,\
-              betal = src_y0, betah = src_y1;  \
-    f00rl = v_fma(alphal, v_sub(f01rl, f00rl), f00rl); f00rh = v_fma(alphah, v_sub(f01rh, f00rh), f00rh); \
-    f10rl = v_fma(alphal, v_sub(f11rl, f10rl), f10rl); f10rh = v_fma(alphah, v_sub(f11rh, f10rh), f10rh); \
-    f00gl = v_fma(alphal, v_sub(f01gl, f00gl), f00gl); f00gh = v_fma(alphah, v_sub(f01gh, f00gh), f00gh); \
-    f10gl = v_fma(alphal, v_sub(f11gl, f10gl), f10gl); f10gh = v_fma(alphah, v_sub(f11gh, f10gh), f10gh); \
-    f00bl = v_fma(alphal, v_sub(f01bl, f00bl), f00bl); f00bh = v_fma(alphah, v_sub(f01bh, f00bh), f00bh); \
-    f10bl = v_fma(alphal, v_sub(f11bl, f10bl), f10bl); f10bh = v_fma(alphah, v_sub(f11bh, f10bh), f10bh); \
-    f00rl = v_fma(betal, v_sub(f10rl, f00rl), f00rl); f00rh = v_fma(betah, v_sub(f10rh, f00rh), f00rh); \
-    f00gl = v_fma(betal, v_sub(f10gl, f00gl), f00gl); f00gh = v_fma(betah, v_sub(f10gh, f00gh), f00gh); \
-    f00bl = v_fma(betal, v_sub(f10bl, f00bl), f00bl); f00bh = v_fma(betah, v_sub(f10bh, f00bh), f00bh);
-#define VECTOR_LINEAR_C1_F32() \
-    v_float32 alphal = src_x0, alphah = src_x1, \
-              betal = src_y0, betah = src_y1; \
-    f00l = v_fma(alphal, v_sub(f01l, f00l), f00l); f00h = v_fma(alphah, v_sub(f01h, f00h), f00h); \
-    f10l = v_fma(alphal, v_sub(f11l, f10l), f10l); f10h = v_fma(alphah, v_sub(f11h, f10h), f10h); \
-    f00l = v_fma(betal, v_sub(f10l, f00l), f00l);  f00h = v_fma(betah, v_sub(f10h, f00h), f00h);
-#define VECTOR_LINEAR_C4_F32() \
-    v_float32 alphal = src_x0, alphah = src_x1,\
-              betal = src_y0, betah = src_y1;  \
-    f00rl = v_fma(alphal, v_sub(f01rl, f00rl), f00rl); f00rh = v_fma(alphah, v_sub(f01rh, f00rh), f00rh); \
-    f10rl = v_fma(alphal, v_sub(f11rl, f10rl), f10rl); f10rh = v_fma(alphah, v_sub(f11rh, f10rh), f10rh); \
-    f00gl = v_fma(alphal, v_sub(f01gl, f00gl), f00gl); f00gh = v_fma(alphah, v_sub(f01gh, f00gh), f00gh); \
-    f10gl = v_fma(alphal, v_sub(f11gl, f10gl), f10gl); f10gh = v_fma(alphah, v_sub(f11gh, f10gh), f10gh); \
-    f00bl = v_fma(alphal, v_sub(f01bl, f00bl), f00bl); f00bh = v_fma(alphah, v_sub(f01bh, f00bh), f00bh); \
-    f10bl = v_fma(alphal, v_sub(f11bl, f10bl), f10bl); f10bh = v_fma(alphah, v_sub(f11bh, f10bh), f10bh); \
-    f00al = v_fma(alphal, v_sub(f01al, f00al), f00al); f00ah = v_fma(alphah, v_sub(f01ah, f00ah), f00ah); \
-    f10al = v_fma(alphal, v_sub(f11al, f10al), f10al); f10ah = v_fma(alphah, v_sub(f11ah, f10ah), f10ah); \
-    f00rl = v_fma(betal, v_sub(f10rl, f00rl), f00rl); f00rh = v_fma(betah, v_sub(f10rh, f00rh), f00rh); \
-    f00gl = v_fma(betal, v_sub(f10gl, f00gl), f00gl); f00gh = v_fma(betah, v_sub(f10gh, f00gh), f00gh); \
-    f00bl = v_fma(betal, v_sub(f10bl, f00bl), f00bl); f00bh = v_fma(betah, v_sub(f10bh, f00bh), f00bh); \
-    f00al = v_fma(betal, v_sub(f10al, f00al), f00al); f00ah = v_fma(betah, v_sub(f10ah, f00ah), f00ah);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C1(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf] = srcptr[1]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 1]; \
+    }
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C3(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf*4] = srcptr[1]; \
+        pixbuf[i + uf*8] = srcptr[2]; \
+        pixbuf[i + uf] = srcptr[3]; \
+        pixbuf[i + uf*5] = srcptr[4]; \
+        pixbuf[i + uf*9] = srcptr[5]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
+        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 3]; \
+        pixbuf[i + uf*7] = srcptr[srcstep + 4]; \
+        pixbuf[i + uf*11] = srcptr[srcstep + 5]; \
+    }
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_C4(dtype) \
+    for (int i = 0; i < uf; i++) { \
+        const dtype* srcptr = src + addr[i]; \
+        pixbuf[i] = srcptr[0]; \
+        pixbuf[i + uf*4] = srcptr[1]; \
+        pixbuf[i + uf*8] = srcptr[2]; \
+        pixbuf[i + uf*12] = srcptr[3]; \
+        pixbuf[i + uf] = srcptr[4]; \
+        pixbuf[i + uf*5] = srcptr[5]; \
+        pixbuf[i + uf*9] = srcptr[6]; \
+        pixbuf[i + uf*13] = srcptr[7]; \
+        pixbuf[i + uf*2] = srcptr[srcstep]; \
+        pixbuf[i + uf*6] = srcptr[srcstep + 1]; \
+        pixbuf[i + uf*10] = srcptr[srcstep + 2]; \
+        pixbuf[i + uf*14] = srcptr[srcstep + 3]; \
+        pixbuf[i + uf*3] = srcptr[srcstep + 4]; \
+        pixbuf[i + uf*7] = srcptr[srcstep + 5]; \
+        pixbuf[i + uf*11] = srcptr[srcstep + 6]; \
+        pixbuf[i + uf*15] = srcptr[srcstep + 7]; \
+    }
 
-#define VECTOR_LINEAR_STORE_BORDER_8UC3() \
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_8U(CN) \
+    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint8_t)
+    #define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_16U(CN) \
+    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(uint16_t)
+    #define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_32F(CN) \
+    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##CN(float)
+
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(CN, DEPTH) \
+    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN_##DEPTH(CN)
+
+#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C1(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[x + i]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+    }
+#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C3(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*3]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*3 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*3 + 2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_*3; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+    }
+#define WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_C4(dy, dx, pixbuf_ofs) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t addr_i = addr[i] + dy*srcstep + dx*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pixbuf[i + pixbuf_ofs] = bval[0]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = bval[1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = bval[2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = bval[3]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pixbuf[i + pixbuf_ofs] = dstptr[(x + i)*4]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = dstptr[(x + i)*4 + 1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = dstptr[(x + i)*4 + 2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = dstptr[(x + i)*4 + 3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t addr_i = iy_*srcstep + ix_*4; \
+        pixbuf[i + pixbuf_ofs] = src[addr_i]; \
+        pixbuf[i + pixbuf_ofs + uf*4] = src[addr_i+1]; \
+        pixbuf[i + pixbuf_ofs + uf*8] = src[addr_i+2]; \
+        pixbuf[i + pixbuf_ofs + uf*12] = src[addr_i+3]; \
+    }
+
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC1() \
+    v_store_low(dstptr + x, bval_v0);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC3() \
     v_store_low(dstptr + x*3,        bval_v0); \
     v_store_low(dstptr + x*3 + uf,   bval_v1); \
     v_store_low(dstptr + x*3 + uf*2, bval_v2);
-#define VECTOR_LINEAR_STORE_BORDER_16UC3() \
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_8UC4() \
+    v_store_low(dstptr + x*4,        bval_v0); \
+    v_store_low(dstptr + x*4 + uf,   bval_v1); \
+    v_store_low(dstptr + x*4 + uf*2, bval_v2); \
+    v_store_low(dstptr + x*4 + uf*3, bval_v3);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC1() \
+    v_store(dstptr + x, bval_v0);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC3() \
     v_store(dstptr + x*3,        bval_v0); \
     v_store(dstptr + x*3 + uf,   bval_v1); \
     v_store(dstptr + x*3 + uf*2, bval_v2);
-#define VECTOR_LINEAR_STORE_BORDER_32FC3() \
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_16UC4() \
+    v_store(dstptr + x*4,        bval_v0); \
+    v_store(dstptr + x*4 + uf,   bval_v1); \
+    v_store(dstptr + x*4 + uf*2, bval_v2); \
+    v_store(dstptr + x*4 + uf*3, bval_v3);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC1() \
+    v_store(dstptr + x,             bval_v0_l); \
+    v_store(dstptr + x + vlanes_32, bval_v0_h);
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC3() \
     v_store(dstptr + x*3,                    bval_v0_l); \
     v_store(dstptr + x*3 + vlanes_32,        bval_v0_h); \
     v_store(dstptr + x*3 + uf,               bval_v1_l); \
     v_store(dstptr + x*3 + uf + vlanes_32,   bval_v1_h); \
     v_store(dstptr + x*3 + uf*2,             bval_v2_l); \
     v_store(dstptr + x*3 + uf*2 + vlanes_32, bval_v2_h);
-#define VECTOR_LINEAR_STORE_BORDER_8UC1() \
-    v_store_low(dstptr + x, bval_v0);
-#define VECTOR_LINEAR_STORE_BORDER_16UC1() \
-    v_store(dstptr + x, bval_v0);
-#define VECTOR_LINEAR_STORE_BORDER_32FC1() \
-    v_store(dstptr + x, bval_v0_l); \
-    v_store(dstptr + x + vlanes_32, bval_v0_h);
-#define VECTOR_LINEAR_STORE_BORDER_8UC4() \
-    v_store_low(dstptr + x*4,        bval_v0); \
-    v_store_low(dstptr + x*4 + uf,   bval_v1); \
-    v_store_low(dstptr + x*4 + uf*2, bval_v2); \
-    v_store_low(dstptr + x*4 + uf*3, bval_v3);
-#define VECTOR_LINEAR_STORE_BORDER_16UC4() \
-    v_store(dstptr + x*4,        bval_v0); \
-    v_store(dstptr + x*4 + uf,   bval_v1); \
-    v_store(dstptr + x*4 + uf*2, bval_v2); \
-    v_store(dstptr + x*4 + uf*3, bval_v3);
-#define VECTOR_LINEAR_STORE_BORDER_32FC4() \
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_32FC4() \
     v_store(dstptr + x*4,                    bval_v0_l); \
     v_store(dstptr + x*4 + vlanes_32,        bval_v0_h); \
     v_store(dstptr + x*4 + uf,               bval_v1_l); \
@@ -230,16 +188,16 @@
     v_store(dstptr + x*4 + uf*3,             bval_v3_l); \
     v_store(dstptr + x*4 + uf*3 + vlanes_32, bval_v3_h);
 
-#define VECTOR_LINEAR_SHUFFLE_NOTALLIN(depth, cn) \
-    if (borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) { \
+#define WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(CN, DEPTH) \
+    if (border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) { \
         mask_0 = v_lt(v_reinterpret_as_u32(v_add(src_ix0, one)), outer_scols); \
         mask_1 = v_lt(v_reinterpret_as_u32(v_add(src_ix1, one)), outer_scols); \
         mask_0 = v_and(mask_0, v_lt(v_reinterpret_as_u32(v_add(src_iy0, one)), outer_srows)); \
         mask_1 = v_and(mask_1, v_lt(v_reinterpret_as_u32(v_add(src_iy1, one)), outer_srows)); \
         v_uint16 outer_mask = v_pack(mask_0, mask_1); \
         if (v_reduce_max(outer_mask) == 0) { \
-            if (borderType == BORDER_CONSTANT) { \
-                VECTOR_LINEAR_STORE_BORDER_##depth##cn(); \
+            if (border_type == BORDER_CONSTANT) { \
+                WARPAFFINE_LINEAR_VECTOR_SHUFFLE_STORE_CONSTANT_BORDER_##DEPTH##CN() \
             } \
             continue; \
         } \
@@ -250,91 +208,422 @@
     vx_store(src_iy + vlanes_32, src_iy1); \
     for (int i = 0; i < uf; i++) { \
         int ix = src_ix[i], iy = src_iy[i]; \
-        VECTOR_FETCH_PIXEL_##cn(0, 0, 0); \
-        VECTOR_FETCH_PIXEL_##cn(0, 1, uf); \
-        VECTOR_FETCH_PIXEL_##cn(1, 0, uf*2); \
-        VECTOR_FETCH_PIXEL_##cn(1, 1, uf*3); \
+        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 0, 0); \
+        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(0, 1, uf); \
+        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 0, uf*2); \
+        WARPAFFINE_LINEAR_VECTOR_FETCH_PIXEL_##CN(1, 1, uf*3); \
+    }
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(cn, i) \
+    v_int16  f00##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * i)), \
+             f01##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+1))), \
+             f10##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+2))), \
+             f11##cn = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf * (i+3)));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 0)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(b, 8) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U8S16(a, 12)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16_##CN();
+////
+
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(cn, i) \
+    v_uint16 f00##cn = vx_load(pixbuf + uf * i), \
+             f01##cn = vx_load(pixbuf + uf * (i+1)), \
+             f10##cn = vx_load(pixbuf + uf * (i+2)), \
+             f11##cn = vx_load(pixbuf + uf * (i+3));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 0)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(b, 8) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16(a, 12)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16_##CN();
+////
+
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(cn) \
+    v_float32 f00##cn##l = v_cvt_f32(v_expand_low(f00##cn)), f00##cn##h = v_cvt_f32(v_expand_high(f00##cn)), \
+              f01##cn##l = v_cvt_f32(v_expand_low(f01##cn)), f01##cn##h = v_cvt_f32(v_expand_high(f01##cn)), \
+              f10##cn##l = v_cvt_f32(v_expand_low(f10##cn)), f10##cn##h = v_cvt_f32(v_expand_high(f10##cn)), \
+              f11##cn##l = v_cvt_f32(v_expand_low(f11##cn)), f11##cn##h = v_cvt_f32(v_expand_high(f11##cn));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(b) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_S16F32(a)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32_##CN()
+////
+
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(cn) \
+    v_float32 f00##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00##cn))), f00##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00##cn))), \
+              f01##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01##cn))), f01##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01##cn))), \
+              f10##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10##cn))), f10##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10##cn))), \
+              f11##cn##l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11##cn))), f11##cn##h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11##cn)));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(b) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_U16F32(a)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32_##CN()
+////
+
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(cn, i) \
+    v_float32 f00##cn##l = vx_load(pixbuf + uf * i),      f00##cn##h = vx_load(pixbuf + uf * i     + vlanes_32), \
+              f01##cn##l = vx_load(pixbuf + uf * (i+1)),  f01##cn##h = vx_load(pixbuf + uf * (i+1) + vlanes_32), \
+              f10##cn##l = vx_load(pixbuf + uf * (i+2)),  f10##cn##h = vx_load(pixbuf + uf * (i+2) + vlanes_32), \
+              f11##cn##l = vx_load(pixbuf + uf * (i+3)),  f11##cn##h = vx_load(pixbuf + uf * (i+3) + vlanes_32);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 0)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(r, 0) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(g, 4) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(b, 8) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_CN_F32(a, 12)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32_##CN()
+////
+
+
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(cn) \
+    f00##cn##l = v_fma(alphal, v_sub(f01##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(alphah, v_sub(f01##cn##h, f00##cn##h), f00##cn##h); \
+    f10##cn##l = v_fma(alphal, v_sub(f11##cn##l, f10##cn##l), f10##cn##l); f10##cn##h = v_fma(alphah, v_sub(f11##cn##h, f10##cn##h), f10##cn##h);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(b) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32(a)
+
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(cn) \
+    f00##cn##l = v_fma(betal,  v_sub(f10##cn##l, f00##cn##l), f00##cn##l); f00##cn##h = v_fma(betah,  v_sub(f10##cn##h, f00##cn##h), f00##cn##h);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C1() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C3() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(b)
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_C4() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(r) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(g) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(b) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32(a)
+
+#define WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(CN) \
+    v_float32 alphal = src_x0, alphah = src_x1, \
+              betal = src_y0, betah = src_y1; \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_ALPHA_F32_##CN() \
+    WARPAFFINE_LINEAR_VECTOR_INTER_CALC_BETA_F32_##CN()
+////
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C1() \
+    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
+    v_uint8 f00_u8 = v_pack(f00_u16, vx_setall_u16(0)); \
+    v_store_low(dstptr + x, f00_u8);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C3() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
+    uint16_t tbuf[max_vlanes_16*3]; \
+    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16); \
+    v_pack_store(dstptr + x*3, vx_load(tbuf)); \
+    v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16)); \
+    v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_C4() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
+             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
+    uint16_t tbuf[max_vlanes_16*4]; \
+    v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16, f00a_u16); \
+    v_pack_store(dstptr + x*4, vx_load(tbuf)); \
+    v_pack_store(dstptr + x*4 + vlanes_16, vx_load(tbuf + vlanes_16)); \
+    v_pack_store(dstptr + x*4 + vlanes_16*2, vx_load(tbuf + vlanes_16*2)); \
+    v_pack_store(dstptr + x*4 + vlanes_16*3, vx_load(tbuf + vlanes_16*3));
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8_##CN()
+
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C1() \
+    v_uint16 f00_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)); \
+    v_store(dstptr + x, f00_u16);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C3() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)); \
+    v_store_interleave(dstptr + x*3, f00r_u16, f00g_u16, f00b_u16);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_C4() \
+    v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)), \
+             f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)), \
+             f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)), \
+             f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah)); \
+    v_store_interleave(dstptr + x*4, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16_##CN()
+
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C1() \
+    vx_store(dstptr + x, f00gl); \
+    vx_store(dstptr + x + vlanes_32, f00gh);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C3() \
+    v_store_interleave(dstptr + x*3, f00rl, f00gl, f00bl); \
+    v_store_interleave(dstptr + x*3 + vlanes_32*3, f00rh, f00gh, f00bh);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_C4() \
+    v_store_interleave(dstptr + x*4, f00rl, f00gl, f00bl, f00al); \
+    v_store_interleave(dstptr + x*4 + vlanes_32*4, f00rh, f00gh, f00bh, f00ah);
+#define WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(CN) \
+    WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32_##CN()
+
+///////////////////////
+
+
+//
+// Scalar
+//
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(CN, cn, i) \
+    p00##CN = srcptr[i]; p01##CN = srcptr[i + cn]; \
+    p10##CN = srcptr[srcstep + i]; p11##CN = srcptr[srcstep + cn + i];
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C1() \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 1, 0)
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C3() \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(r, 3, 0) \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 3, 1) \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(b, 3, 2)
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_C4() \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(r, 4, 0) \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(g, 4, 1) \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(b, 4, 2) \
+    WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD(a, 4, 3)
+
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C1() \
+    dstptr[x] = bval[0];
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C3() \
+    dstptr[x*3] = bval[0]; \
+    dstptr[x*3+1] = bval[1]; \
+    dstptr[x*3+2] = bval[2];
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_C4() \
+    dstptr[x*4] = bval[0]; \
+    dstptr[x*4+1] = bval[1]; \
+    dstptr[x*4+2] = bval[2]; \
+    dstptr[x*4+3] = bval[3];
+
+#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C1(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx; \
+        pxy##g = srcptr[ofs]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##g = bval[0]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##g = dstptr[x]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_; \
+        pxy##g = src[glob_ofs]; \
+    }
+#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C3(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*3; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*3]; \
+        pxy##g = dstptr[x*3+1]; \
+        pxy##b = dstptr[x*3+2]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*3; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+    }
+#define WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_C4(dy, dx, pxy) \
+    if ((((unsigned)(ix + dx) < (unsigned)srccols) & ((unsigned)(iy + dy) < (unsigned)srcrows)) != 0) { \
+        size_t ofs = dy*srcstep + dx*4; \
+        pxy##r = srcptr[ofs]; \
+        pxy##g = srcptr[ofs+1]; \
+        pxy##b = srcptr[ofs+2]; \
+        pxy##a = srcptr[ofs+3]; \
+    } else if (border_type == BORDER_CONSTANT) { \
+        pxy##r = bval[0]; \
+        pxy##g = bval[1]; \
+        pxy##b = bval[2]; \
+        pxy##a = bval[3]; \
+    } else if (border_type == BORDER_TRANSPARENT) { \
+        pxy##r = dstptr[x*4]; \
+        pxy##g = dstptr[x*4+1]; \
+        pxy##b = dstptr[x*4+2]; \
+        pxy##a = dstptr[x*4+3]; \
+    } else { \
+        int ix_ = borderInterpolate_fast(ix + dx, srccols, border_type_x); \
+        int iy_ = borderInterpolate_fast(iy + dy, srcrows, border_type_y); \
+        size_t glob_ofs = iy_*srcstep + ix_*4; \
+        pxy##r = src[glob_ofs]; \
+        pxy##g = src[glob_ofs+1]; \
+        pxy##b = src[glob_ofs+2]; \
+        pxy##a = src[glob_ofs+3]; \
     }
 
-#define SCALAR_LINEAR_SHUFFLE_C3() \
+#define WARPAFFINE_LINEAR_SCALAR_SHUFFLE(CN) \
     if ((((unsigned)ix < (unsigned)(srccols-1)) & \
         ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
-        p00r = srcptr[0]; p00g = srcptr[1]; p00b = srcptr[2]; \
-        p01r = srcptr[3]; p01g = srcptr[4]; p01b = srcptr[5]; \
-        p10r = srcptr[srcstep + 0]; p10g = srcptr[srcstep + 1]; p10b = srcptr[srcstep + 2]; \
-        p11r = srcptr[srcstep + 3]; p11g = srcptr[srcstep + 4]; p11b = srcptr[srcstep + 5]; \
+        WARPAFFINE_LINEAR_SCALAR_SHUFFLE_LOAD_##CN() \
     } else { \
-        if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) && \
+        if ((border_type == BORDER_CONSTANT || border_type == BORDER_TRANSPARENT) && \
             (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
                 ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
-            if (borderType == BORDER_CONSTANT) { \
-                dstptr[x*3] = bval[0]; \
-                dstptr[x*3+1] = bval[1]; \
-                dstptr[x*3+2] = bval[2]; \
+            if (border_type == BORDER_CONSTANT) { \
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE_STORE_CONSTANT_BORDER_##CN() \
             } \
             continue; \
         } \
-        SCALAR_FETCH_PIXEL_C3(0, 0, p00); \
-        SCALAR_FETCH_PIXEL_C3(0, 1, p01); \
-        SCALAR_FETCH_PIXEL_C3(1, 0, p10); \
-        SCALAR_FETCH_PIXEL_C3(1, 1, p11); \
-    }
-#define SCALAR_LINEAR_SHUFFLE_C4() \
-    if ((((unsigned)ix < (unsigned)(srccols-1)) & \
-        ((unsigned)iy < (unsigned)(srcrows-1))) != 0) { \
-        p00r = srcptr[0]; p00g = srcptr[1]; p00b = srcptr[2]; p00a = srcptr[3]; \
-        p01r = srcptr[4]; p01g = srcptr[5]; p01b = srcptr[6]; p01a = srcptr[7]; \
-        p10r = srcptr[srcstep + 0]; p10g = srcptr[srcstep + 1]; p10b = srcptr[srcstep + 2]; p10a = srcptr[srcstep + 3]; \
-        p11r = srcptr[srcstep + 4]; p11g = srcptr[srcstep + 5]; p11b = srcptr[srcstep + 6]; p11a = srcptr[srcstep + 7]; \
-    } else { \
-        if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) && \
-            (((unsigned)(ix+1) >= (unsigned)(srccols+1))| \
-                ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) { \
-            if (borderType == BORDER_CONSTANT) { \
-                dstptr[x*4] = bval[0]; \
-                dstptr[x*4+1] = bval[1]; \
-                dstptr[x*4+2] = bval[2]; \
-                dstptr[x*4+3] = bval[3]; \
-            } \
-            continue; \
-        } \
-        SCALAR_FETCH_PIXEL_C4(0, 0, p00); \
-        SCALAR_FETCH_PIXEL_C4(0, 1, p01); \
-        SCALAR_FETCH_PIXEL_C4(1, 0, p10); \
-        SCALAR_FETCH_PIXEL_C4(1, 1, p11); \
+        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 0, p00); \
+        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(0, 1, p01); \
+        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 0, p10); \
+        WARPAFFINE_LINEAR_SCALAR_FETCH_PIXEL_##CN(1, 1, p11); \
     }
 
-#define SCALAR_LINEAR_CALC_C3() \
-    float v0r = p00r + sx*(p01r - p00r); \
-    float v0g = p00g + sx*(p01g - p00g); \
-    float v0b = p00b + sx*(p01b - p00b); \
-    float v1r = p10r + sx*(p11r - p10r); \
-    float v1g = p10g + sx*(p11g - p10g); \
-    float v1b = p10b + sx*(p11b - p10b); \
-    v0r += sy*(v1r - v0r); \
-    v0g += sy*(v1g - v0g); \
-    v0b += sy*(v1b - v0b);
+////
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(cn) \
+    float v0##cn = p00##cn + sx*(p01##cn - p00##cn); \
+    float v1##cn = p10##cn + sx*(p11##cn - p10##cn);
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C1() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g)
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C3() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b)
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_C4() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(r) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(g) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(b) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32(a)
 
-#define SCALAR_LINEAR_CALC_C4() \
-    float v0r = p00r + sx*(p01r - p00r); \
-    float v0g = p00g + sx*(p01g - p00g); \
-    float v0b = p00b + sx*(p01b - p00b); \
-    float v0a = p00a + sx*(p01a - p00a); \
-    float v1r = p10r + sx*(p11r - p10r); \
-    float v1g = p10g + sx*(p11g - p10g); \
-    float v1b = p10b + sx*(p11b - p10b); \
-    float v1a = p10a + sx*(p11a - p10a); \
-    v0r += sy*(v1r - v0r); \
-    v0g += sy*(v1g - v0g); \
-    v0b += sy*(v1b - v0b); \
-    v0a += sy*(v1a - v0a);
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(cn) \
+    v0##cn += sy*(v1##cn - v0##cn);
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C1() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g)
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C3() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(b)
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_C4() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(r) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(g) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(b) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32(a)
+
+#define WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(CN) \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_ALPHA_F32_##CN() \
+    WARPAFFINE_LINEAR_SCALAR_INTER_CALC_BETA_F32_##CN()
+////
+
+////
+#define WARPAFFINE_LINEAR_SCALAR_STORE_C1(dtype) \
+    dstptr[x] = saturate_cast<dtype>(v0g);
+#define WARPAFFINE_LINEAR_SCALAR_STORE_C3(dtype) \
+    dstptr[x*3] = saturate_cast<dtype>(v0r); \
+    dstptr[x*3+1] = saturate_cast<dtype>(v0g); \
+    dstptr[x*3+2] = saturate_cast<dtype>(v0b);
+#define WARPAFFINE_LINEAR_SCALAR_STORE_C4(dtype) \
+    dstptr[x*4] = saturate_cast<dtype>(v0r); \
+    dstptr[x*4+1] = saturate_cast<dtype>(v0g); \
+    dstptr[x*4+2] = saturate_cast<dtype>(v0b); \
+    dstptr[x*4+3] = saturate_cast<dtype>(v0a);
+#define WARPAFFINE_LINEAR_SCALAR_STORE_8U(CN) \
+    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(uint8_t)
+#define WARPAFFINE_LINEAR_SCALAR_STORE_16U(CN) \
+    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(uint16_t)
+#define WARPAFFINE_LINEAR_SCALAR_STORE_32F(CN) \
+    WARPAFFINE_LINEAR_SCALAR_STORE_##CN(float)
+
+#define WARPAFFINE_LINEAR_SCALAR_STORE(CN, DEPTH) \
+    WARPAFFINE_LINEAR_SCALAR_STORE_##DEPTH(CN)
+////
 
 namespace cv{
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-/* Only support bilinear interpolation on 3-channel image for now */
-void warpAffineSimdInvoker(Mat &output, const Mat &input, const double *M,
-                           int interpolation, int borderType, const double *borderValue);
+void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double M[6], int border_type, const double border_value[4]);
+
+void warpAffineLinearApproxInvoker_8UC1(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearApproxInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double M[6], int border_type, const double border_value[4]);
+void warpAffineLinearApproxInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double M[6], int border_type, const double border_value[4]);
 
 #ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
@@ -366,107 +655,40 @@ static inline int borderInterpolate_fast( int p, int len, int borderType )
     }
     return p;
 }
+} // anonymous
 
-template<typename T>
-static inline void shuffle_allin_c3(const T *src, const int32_t *addr, T *pixbuf,
-                                    int uf, size_t srcstep) {
-    for (int i = 0; i < uf; i++) {
-        const T* srcptr = src + addr[i];
-
-        pixbuf[i] = srcptr[0];
-        pixbuf[i + uf*4] = srcptr[1];
-        pixbuf[i + uf*8] = srcptr[2];
-
-        pixbuf[i + uf] = srcptr[3];
-        pixbuf[i + uf*5] = srcptr[4];
-        pixbuf[i + uf*9] = srcptr[5];
-
-        pixbuf[i + uf*2] = srcptr[srcstep];
-        pixbuf[i + uf*6] = srcptr[srcstep + 1];
-        pixbuf[i + uf*10] = srcptr[srcstep + 2];
-
-        pixbuf[i + uf*3] = srcptr[srcstep + 3];
-        pixbuf[i + uf*7] = srcptr[srcstep + 4];
-        pixbuf[i + uf*11] = srcptr[srcstep + 5];
-    }
-}
-template<typename T>
-static inline void shuffle_allin_c1(const T *src, const int32_t *addr, T *pixbuf,
-                                    int uf, size_t srcstep) {
-    for (int i = 0; i < uf; i++) {
-        const T* srcptr = src + addr[i];
-
-        pixbuf[i] = srcptr[0];
-        pixbuf[i + uf] = srcptr[1];
-        pixbuf[i + uf*2] = srcptr[srcstep];
-        pixbuf[i + uf*3] = srcptr[srcstep + 1];
-    }
-}
-template<typename T>
-static inline void shuffle_allin_c4(const T *src, const int32_t *addr, T *pixbuf,
-                                    int uf, size_t srcstep) {
-    for (int i = 0; i < uf; i++) {
-        const T* srcptr = src + addr[i];
-
-        pixbuf[i] = srcptr[0];
-        pixbuf[i + uf*4] = srcptr[1];
-        pixbuf[i + uf*8] = srcptr[2];
-        pixbuf[i + uf*12] = srcptr[3];
-
-        pixbuf[i + uf] = srcptr[4];
-        pixbuf[i + uf*5] = srcptr[5];
-        pixbuf[i + uf*9] = srcptr[6];
-        pixbuf[i + uf*13] = srcptr[7];
-
-        pixbuf[i + uf*2] = srcptr[srcstep];
-        pixbuf[i + uf*6] = srcptr[srcstep + 1];
-        pixbuf[i + uf*10] = srcptr[srcstep + 2];
-        pixbuf[i + uf*14] = srcptr[srcstep + 3];
-
-        pixbuf[i + uf*3] = srcptr[srcstep + 4];
-        pixbuf[i + uf*7] = srcptr[srcstep + 5];
-        pixbuf[i + uf*11] = srcptr[srcstep + 6];
-        pixbuf[i + uf*15] = srcptr[srcstep + 7];
-    }
-}
-
-class WarpAffineLinearInvoker_8UC3 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_8UC3(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
+void warpAffineLinearInvoker_8UC1(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
         CV_INSTRUMENT_REGION();
 
-        auto *src = input->ptr<const uint8_t>();
-        auto *dst = output->ptr<uint8_t>();
-        size_t srcstep = input->step, dststep = output->step;
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
         float M[6];
         for (int i = 0; i < 6; i++) {
             M[i] = static_cast<float>(dM[i]);
         }
         uint8_t bval[] = {
-            saturate_cast<uint8_t>(borderValue[0]),
-            saturate_cast<uint8_t>(borderValue[1]),
-            saturate_cast<uint8_t>(borderValue[2]),
-            saturate_cast<uint8_t>(borderValue[3]),
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
         };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-
         int vlanes_32 = VTraits<v_float32>::vlanes();
-
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
 
@@ -478,29 +700,20 @@ public:
                  outer_srows = vx_setall_u32((unsigned)srcrows + 1),
                  outer_scols = vx_setall_u32((unsigned)srccols + 1);
         v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
-        uint8_t bvalbuf[max_uf*3];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i*3] = bval[0];
-            bvalbuf[i*3+1] = bval[1];
-            bvalbuf[i*3+2] = bval[2];
-        }
-        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
-        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
-        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+        v_int32 one = vx_setall_s32(1);
         v_int32 v_srcstep = vx_setall_s32(int(srcstep));
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4*3];
+        uint8_t pixbuf[max_uf*4];
+
+        uint8_t bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
-                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
-                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
-    #endif
-    #if !CV_SIMD128_FP16
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
+        uint8x8_t gray = {0, 8, 16, 24, 1, 9, 17, 25};
     #endif
 #endif
 
@@ -519,7 +732,191 @@ public:
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                VECTOR_COMPUTE_COORDINATES();
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00g, p01g, p10g, p11g;
+    #endif
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    uint8x8x4_t t00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t t01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t t10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t t11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(t00, gray));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(t01, gray));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(t10, gray));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(t11, gray));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+    #else
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 8U);
+    #endif
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    p00g = vld1_u8(pixbuf);
+                    p01g = vld1_u8(pixbuf + 8);
+                    p10g = vld1_u8(pixbuf + 16);
+                    p11g = vld1_u8(pixbuf + 24);
+    #endif
+                }
+
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+                v_int16 f00g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00g))),
+                        f01g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01g))),
+                        f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
+                        f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
+    #else
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C1);
+    #endif
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C1);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00g, p01g, p10g, p11g;
+                const uint8_t *srcptr = src + srcstep * iy + ix;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 8U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*3];
+
+        uint8_t bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
+        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+    #endif
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
@@ -593,11 +990,11 @@ public:
                     p01b = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
                     p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
-    #else // scalar implementation when neon intrinsics are not available
-                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
+    #else
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 8U);
     #endif
                 } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C3);
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
 
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                     p00r = vld1_u8(pixbuf);
@@ -617,46 +1014,7 @@ public:
     #endif
                 }
 
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
-                v_float16 f00r = v_float16(vcvtq_f16_u16(vmovl_u8(p00r)));
-                v_float16 f01r = v_float16(vcvtq_f16_u16(vmovl_u8(p01r)));
-                v_float16 f10r = v_float16(vcvtq_f16_u16(vmovl_u8(p10r)));
-                v_float16 f11r = v_float16(vcvtq_f16_u16(vmovl_u8(p11r)));
-
-                v_float16 f00g = v_float16(vcvtq_f16_u16(vmovl_u8(p00g)));
-                v_float16 f01g = v_float16(vcvtq_f16_u16(vmovl_u8(p01g)));
-                v_float16 f10g = v_float16(vcvtq_f16_u16(vmovl_u8(p10g)));
-                v_float16 f11g = v_float16(vcvtq_f16_u16(vmovl_u8(p11g)));
-
-                v_float16 f00b = v_float16(vcvtq_f16_u16(vmovl_u8(p00b)));
-                v_float16 f01b = v_float16(vcvtq_f16_u16(vmovl_u8(p01b)));
-                v_float16 f10b = v_float16(vcvtq_f16_u16(vmovl_u8(p10b)));
-                v_float16 f11b = v_float16(vcvtq_f16_u16(vmovl_u8(p11b)));
-
-                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
-                          beta = v_cvt_f16(src_y0, src_y1);
-
-                f00r = v_fma(alpha, v_sub(f01r, f00r), f00r);
-                f10r = v_fma(alpha, v_sub(f11r, f10r), f10r);
-
-                f00g = v_fma(alpha, v_sub(f01g, f00g), f00g);
-                f10g = v_fma(alpha, v_sub(f11g, f10g), f10g);
-
-                f00b = v_fma(alpha, v_sub(f01b, f00b), f00b);
-                f10b = v_fma(alpha, v_sub(f11b, f10b), f10b);
-
-                f00r = v_fma(beta,  v_sub(f10r, f00r), f00r);
-                f00g = v_fma(beta,  v_sub(f10g, f00g), f00g);
-                f00b = v_fma(beta,  v_sub(f10b, f00b), f00b);
-
-                uint8x8x3_t result = {
-                    vqmovun_s16(vcvtnq_s16_f16(f00r.val)),
-                    vqmovun_s16(vcvtnq_s16_f16(f00g.val)),
-                    vqmovun_s16(vcvtnq_s16_f16(f00b.val)),
-                };
-                vst3_u8(dstptr + x*3, result);
-    #else // Other platforms use fp32 intrinsics for interpolation calculation
-        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
                 v_int16 f00r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00r))),
                         f01r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01r))),
                         f10r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10r))),
@@ -669,44 +1027,14 @@ public:
                         f01b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01b))),
                         f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
                         f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
-        #else
-                v_int16  f00r = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
-                         f01r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
-                         f10r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
-                         f11r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
-                v_int16  f00g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*4)),
-                         f01g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*5)),
-                         f10g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*6)),
-                         f11g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*7));
-                v_int16  f00b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*8)),
-                         f01b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*9)),
-                         f10b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*10)),
-                         f11b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*11));
-        #endif
-                v_float32 f00rl = v_cvt_f32(v_expand_low(f00r)), f00rh = v_cvt_f32(v_expand_high(f00r)),
-                          f01rl = v_cvt_f32(v_expand_low(f01r)), f01rh = v_cvt_f32(v_expand_high(f01r)),
-                          f10rl = v_cvt_f32(v_expand_low(f10r)), f10rh = v_cvt_f32(v_expand_high(f10r)),
-                          f11rl = v_cvt_f32(v_expand_low(f11r)), f11rh = v_cvt_f32(v_expand_high(f11r));
-                v_float32 f00gl = v_cvt_f32(v_expand_low(f00g)), f00gh = v_cvt_f32(v_expand_high(f00g)),
-                          f01gl = v_cvt_f32(v_expand_low(f01g)), f01gh = v_cvt_f32(v_expand_high(f01g)),
-                          f10gl = v_cvt_f32(v_expand_low(f10g)), f10gh = v_cvt_f32(v_expand_high(f10g)),
-                          f11gl = v_cvt_f32(v_expand_low(f11g)), f11gh = v_cvt_f32(v_expand_high(f11g));
-                v_float32 f00bl = v_cvt_f32(v_expand_low(f00b)), f00bh = v_cvt_f32(v_expand_high(f00b)),
-                          f01bl = v_cvt_f32(v_expand_low(f01b)), f01bh = v_cvt_f32(v_expand_high(f01b)),
-                          f10bl = v_cvt_f32(v_expand_low(f10b)), f10bh = v_cvt_f32(v_expand_high(f10b)),
-                          f11bl = v_cvt_f32(v_expand_low(f11b)), f11bh = v_cvt_f32(v_expand_high(f11b));
+    #else
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C3);
+    #endif
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C3);
 
-                VECTOR_LINEAR_C3_F32();
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
 
-                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
-                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
-                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh));
-                uint16_t tbuf[max_vlanes_16*3];
-                v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16);
-                v_pack_store(dstptr + x*3, vx_load(tbuf));
-                v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16));
-                v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
-    #endif // defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -719,879 +1047,52 @@ public:
                 int p10r, p10g, p10b, p11r, p11g, p11b;
                 const uint8_t* srcptr = src + srcstep*iy + ix*3;
 
-                SCALAR_LINEAR_SHUFFLE_C3();
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
 
-                SCALAR_LINEAR_CALC_C3();
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
 
-                dstptr[x*3] = saturate_cast<uint8_t>(v0r);
-                dstptr[x*3+1] = saturate_cast<uint8_t>(v0g);
-                dstptr[x*3+2] = saturate_cast<uint8_t>(v0b);
+                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 8U);
             }
         }
-    }
+    };
 
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
+    parallel_for_(Range(0, dst_rows), worker);
+}
 
-class WarpAffineLinearInvoker_16UC3 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_16UC3(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
+void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
         CV_INSTRUMENT_REGION();
 
-        auto *src = input->ptr<const uint16_t>();
-        auto *dst = output->ptr<uint16_t>();
-        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        uint16_t bval[] = {
-            saturate_cast<uint16_t>(borderValue[0]),
-            saturate_cast<uint16_t>(borderValue[1]),
-            saturate_cast<uint16_t>(borderValue[2]),
-            saturate_cast<uint16_t>(borderValue[3]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
-        uint16_t bvalbuf[max_uf*3];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i*3] = bval[0];
-            bvalbuf[i*3+1] = bval[1];
-            bvalbuf[i*3+2] = bval[2];
-        }
-        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
-        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
-        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4*3];
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            uint16_t* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
-                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C3);
-                }
-
-                v_uint16 f00r = vx_load(pixbuf),
-                         f01r = vx_load(pixbuf + uf),
-                         f10r = vx_load(pixbuf + uf*2),
-                         f11r = vx_load(pixbuf + uf*3);
-                v_uint16 f00g = vx_load(pixbuf + uf*4),
-                         f01g = vx_load(pixbuf + uf*5),
-                         f10g = vx_load(pixbuf + uf*6),
-                         f11g = vx_load(pixbuf + uf*7);
-                v_uint16 f00b = vx_load(pixbuf + uf*8),
-                         f01b = vx_load(pixbuf + uf*9),
-                         f10b = vx_load(pixbuf + uf*10),
-                         f11b = vx_load(pixbuf + uf*11);
-
-                v_float32 f00rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00r))), f00rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00r))),
-                          f01rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01r))), f01rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01r))),
-                          f10rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10r))), f10rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10r))),
-                          f11rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11r))), f11rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11r)));
-                v_float32 f00gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00g))), f00gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00g))),
-                          f01gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01g))), f01gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01g))),
-                          f10gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10g))), f10gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10g))),
-                          f11gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11g))), f11gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11g)));
-                v_float32 f00bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00b))), f00bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00b))),
-                          f01bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01b))), f01bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01b))),
-                          f10bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10b))), f10bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10b))),
-                          f11bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11b))), f11bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11b)));
-
-                VECTOR_LINEAR_C3_F32();
-
-                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
-                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
-                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh));
-                v_store_interleave(dstptr + x*3, f00r_u16, f00g_u16, f00b_u16);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                int p00r, p00g, p00b, p01r, p01g, p01b;
-                int p10r, p10g, p10b, p11r, p11g, p11b;
-                const uint16_t* srcptr = src + srcstep*iy + ix*3;
-
-                SCALAR_LINEAR_SHUFFLE_C3();
-
-                SCALAR_LINEAR_CALC_C3();
-
-                dstptr[x*3] = saturate_cast<uint16_t>(v0r);
-                dstptr[x*3+1] = saturate_cast<uint16_t>(v0g);
-                dstptr[x*3+2] = saturate_cast<uint16_t>(v0b);
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_32FC3 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_32FC3(Mat *output_, const Mat *input_, const double *dM_,
-                                  int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const float>();
-        auto *dst = output->ptr<float>();
-        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        float bval[] = {
-            saturate_cast<float>(borderValue[0]),
-            saturate_cast<float>(borderValue[1]),
-            saturate_cast<float>(borderValue[2]),
-            saturate_cast<float>(borderValue[3]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
-        float bvalbuf[max_uf*3];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i*3] = bval[0];
-            bvalbuf[i*3+1] = bval[1];
-            bvalbuf[i*3+2] = bval[2];
-        }
-        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
-        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
-        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
-        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
-        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
-        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        float pixbuf[max_uf*4*3];
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            float* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
-                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c3(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C3);
-                }
-
-                v_float32 f00rl = vx_load(pixbuf),         f00rh = vx_load(pixbuf + vlanes_32),
-                          f01rl = vx_load(pixbuf + uf),    f01rh = vx_load(pixbuf + uf + vlanes_32),
-                          f10rl = vx_load(pixbuf + uf*2),  f10rh = vx_load(pixbuf + uf*2 + vlanes_32),
-                          f11rl = vx_load(pixbuf + uf*3),  f11rh = vx_load(pixbuf + uf*3 + vlanes_32);
-                v_float32 f00gl = vx_load(pixbuf + uf*4),  f00gh = vx_load(pixbuf + uf*4 + vlanes_32),
-                          f01gl = vx_load(pixbuf + uf*5),  f01gh = vx_load(pixbuf + uf*5 + vlanes_32),
-                          f10gl = vx_load(pixbuf + uf*6),  f10gh = vx_load(pixbuf + uf*6 + vlanes_32),
-                          f11gl = vx_load(pixbuf + uf*7),  f11gh = vx_load(pixbuf + uf*7 + vlanes_32);
-                v_float32 f00bl = vx_load(pixbuf + uf*8),  f00bh = vx_load(pixbuf + uf*8 + vlanes_32),
-                          f01bl = vx_load(pixbuf + uf*9),  f01bh = vx_load(pixbuf + uf*9 + vlanes_32),
-                          f10bl = vx_load(pixbuf + uf*10), f10bh = vx_load(pixbuf + uf*10 + vlanes_32),
-                          f11bl = vx_load(pixbuf + uf*11), f11bh = vx_load(pixbuf + uf*11 + vlanes_32);
-
-                VECTOR_LINEAR_C3_F32();
-
-                v_store_interleave(dstptr + x*3, f00rl, f00gl, f00bl);
-                v_store_interleave(dstptr + x*3 + vlanes_32*3, f00rh, f00gh, f00bh);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                float p00r, p00g, p00b, p01r, p01g, p01b;
-                float p10r, p10g, p10b, p11r, p11g, p11b;
-                const float* srcptr = src + srcstep*iy + ix*3;
-
-                SCALAR_LINEAR_SHUFFLE_C3();
-
-                SCALAR_LINEAR_CALC_C3();
-
-                dstptr[x*3] =   v0r;
-                dstptr[x*3+1] = v0g;
-                dstptr[x*3+2] = v0b;
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_8UC1 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_8UC1(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const uint8_t>();
-        auto *dst = output->ptr<uint8_t>();
-        size_t srcstep = input->step, dststep = output->step;
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
         float M[6];
         for (int i = 0; i < 6; i++) {
             M[i] = static_cast<float>(dM[i]);
         }
         uint8_t bval[] = {
-            saturate_cast<uint8_t>(borderValue[0]),
-            saturate_cast<uint8_t>(borderValue[1]),
-            saturate_cast<uint8_t>(borderValue[2]),
-            saturate_cast<uint8_t>(borderValue[3]),
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
         };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1);
-        uint8_t bvalbuf[max_uf];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i] = bval[0];
-        }
-        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4];
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-        uint8x8_t gray = {0, 8, 16, 24, 1, 9, 17, 25};
-    #endif
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            uint8_t* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
-                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                uint8x8_t p00, p01, p10, p11;
-    #endif
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    uint8x8x4_t t00 = {
-                        vld1_u8(src + addr[0]),
-                        vld1_u8(src + addr[1]),
-                        vld1_u8(src + addr[2]),
-                        vld1_u8(src + addr[3])
-                    };
-
-                    uint8x8x4_t t01 = {
-                        vld1_u8(src + addr[4]),
-                        vld1_u8(src + addr[5]),
-                        vld1_u8(src + addr[6]),
-                        vld1_u8(src + addr[7])
-                    };
-
-                    uint8x8x4_t t10 = {
-                        vld1_u8(src + addr[0] + srcstep),
-                        vld1_u8(src + addr[1] + srcstep),
-                        vld1_u8(src + addr[2] + srcstep),
-                        vld1_u8(src + addr[3] + srcstep)
-                    };
-
-                    uint8x8x4_t t11 = {
-                        vld1_u8(src + addr[4] + srcstep),
-                        vld1_u8(src + addr[5] + srcstep),
-                        vld1_u8(src + addr[6] + srcstep),
-                        vld1_u8(src + addr[7] + srcstep)
-                    };
-
-                    uint32x2_t p00_, p01_, p10_, p11_;
-
-                    p00_ = vreinterpret_u32_u8(vtbl4_u8(t00, gray));
-                    p01_ = vreinterpret_u32_u8(vtbl4_u8(t01, gray));
-                    p10_ = vreinterpret_u32_u8(vtbl4_u8(t10, gray));
-                    p11_ = vreinterpret_u32_u8(vtbl4_u8(t11, gray));
-
-                    p00 = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
-                    p01 = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
-                    p10 = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
-                    p11 = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
-    #else
-                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
-    #endif
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C1);
-
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    p00 = vld1_u8(pixbuf);
-                    p01 = vld1_u8(pixbuf + 8);
-                    p10 = vld1_u8(pixbuf + 16);
-                    p11 = vld1_u8(pixbuf + 24);
-    #endif
-                }
-
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
-                v_float16 f00 = v_float16(vcvtq_f16_u16(vmovl_u8(p00)));
-                v_float16 f01 = v_float16(vcvtq_f16_u16(vmovl_u8(p01)));
-                v_float16 f10 = v_float16(vcvtq_f16_u16(vmovl_u8(p10)));
-                v_float16 f11 = v_float16(vcvtq_f16_u16(vmovl_u8(p11)));
-
-                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
-                          beta = v_cvt_f16(src_y0, src_y1);
-
-                f00 = v_fma(alpha, v_sub(f01, f00), f00);
-                f10 = v_fma(alpha, v_sub(f11, f10), f10);
-                f00 = v_fma(beta,  v_sub(f10, f00), f00);
-
-                uint8x8_t result = {
-                    vqmovun_s16(vcvtnq_s16_f16(f00.val)),
-                };
-
-                vst1_u8(dstptr + x, result);
-    #else
-        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
-                v_int16 f00 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00))),
-                        f01 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01))),
-                        f10 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10))),
-                        f11 = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11)));
-        #else
-                v_int16  f00 = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
-                         f01 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
-                         f10 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
-                         f11 = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
-        #endif
-                v_float32 f00l = v_cvt_f32(v_expand_low(f00)), f00h = v_cvt_f32(v_expand_high(f00)),
-                          f01l = v_cvt_f32(v_expand_low(f01)), f01h = v_cvt_f32(v_expand_high(f01)),
-                          f10l = v_cvt_f32(v_expand_low(f10)), f10h = v_cvt_f32(v_expand_high(f10)),
-                          f11l = v_cvt_f32(v_expand_low(f11)), f11h = v_cvt_f32(v_expand_high(f11));
-
-                VECTOR_LINEAR_C1_F32();
-
-                v_uint16 f00_u16 = v_pack_u(v_round(f00l), v_round(f00h));
-                v_uint8 f00_u8 = v_pack(f00_u16, vx_setall_u16(0));
-                v_store_low(dstptr + x, f00_u8);
-    #endif
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                int p00, p01, p10, p11;
-                const uint8_t *srcptr = src + srcstep * iy + ix;
-
-                if ((((unsigned)ix < (unsigned)(srccols-1)) &
-                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
-                    p00 = srcptr[0]; p01 = srcptr[1];
-                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
-                } else {
-                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
-                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
-                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
-                        if (borderType == BORDER_CONSTANT) {
-                            dstptr[x] = bval[0];
-                        }
-                        continue;
-                    }
-                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
-                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
-                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
-                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
-                }
-                float v0 = p00 + sx*(p01 - p00);
-                float v1 = p10 + sx*(p11 - p10);
-                v0 += sy*(v1 - v0);
-                dstptr[x] = saturate_cast<uint8_t>(v0);
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_16UC1 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_16UC1(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const uint16_t>();
-        auto *dst = output->ptr<uint16_t>();
-        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        uint16_t bval[] = {
-            saturate_cast<uint16_t>(borderValue[0]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1);
-        uint16_t bvalbuf[max_uf];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i] = bval[0];
-        }
-        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4];
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            uint16_t* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
-                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C1);
-                }
-
-                v_uint16 f00 = vx_load(pixbuf),
-                         f01 = vx_load(pixbuf + uf),
-                         f10 = vx_load(pixbuf + uf*2),
-                         f11 = vx_load(pixbuf + uf*3);
-
-                v_float32 f00l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00))), f00h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00))),
-                          f01l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01))), f01h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01))),
-                          f10l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10))), f10h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10))),
-                          f11l = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11))), f11h = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11)));
-
-                VECTOR_LINEAR_C1_F32();
-
-                v_uint16 f00_u16 = v_pack_u(v_round(f00l), v_round(f00h));
-                v_store(dstptr + x, f00_u16);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                int p00, p01, p10, p11;
-                const uint16_t *srcptr = src + srcstep * iy + ix;
-
-                if ((((unsigned)ix < (unsigned)(srccols-1)) &
-                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
-                    p00 = srcptr[0]; p01 = srcptr[1];
-                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
-                } else {
-                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
-                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
-                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
-                        if (borderType == BORDER_CONSTANT) {
-                            dstptr[x] = bval[0];
-                        }
-                        continue;
-                    }
-                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
-                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
-                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
-                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
-                }
-                float v0 = p00 + sx*(p01 - p00);
-                float v1 = p10 + sx*(p11 - p10);
-                v0 += sy*(v1 - v0);
-                dstptr[x] = saturate_cast<uint16_t>(v0);
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_32FC1 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_32FC1(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const float>();
-        auto *dst = output->ptr<float>();
-        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        float bval[] = {
-            saturate_cast<float>(borderValue[0]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1);
-        float bvalbuf[max_uf];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i] = bval[0];
-        }
-        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
-        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        float pixbuf[max_uf*4];
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            float* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
-                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c1(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C1);
-                }
-
-                v_float32 f00l = vx_load(pixbuf),         f00h = vx_load(pixbuf + vlanes_32),
-                          f01l = vx_load(pixbuf + uf),    f01h = vx_load(pixbuf + uf + vlanes_32),
-                          f10l = vx_load(pixbuf + uf*2),  f10h = vx_load(pixbuf + uf*2 + vlanes_32),
-                          f11l = vx_load(pixbuf + uf*3),  f11h = vx_load(pixbuf + uf*3 + vlanes_32);
-
-                VECTOR_LINEAR_C1_F32();
-
-                vx_store(dstptr + x, f00l);
-                vx_store(dstptr + x + vlanes_32, f00h);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                float p00, p01, p10, p11;
-                const float *srcptr = src + srcstep * iy + ix;
-
-                if ((((unsigned)ix < (unsigned)(srccols-1)) &
-                     ((unsigned)iy < (unsigned)(srcrows-1))) != 0) {
-                    p00 = srcptr[0]; p01 = srcptr[1];
-                    p10 = srcptr[srcstep + 0]; p11 = srcptr[srcstep + 1];
-                } else {
-                    if ((borderType == BORDER_CONSTANT || borderType == BORDER_TRANSPARENT) &&
-                        (((unsigned)(ix+1) >= (unsigned)(srccols+1))|
-                         ((unsigned)(iy+1) >= (unsigned)(srcrows+1))) != 0) {
-                        if (borderType == BORDER_CONSTANT) {
-                            dstptr[x] = bval[0];
-                        }
-                        continue;
-                    }
-                    SCALAR_FETCH_PIXEL_C1(0, 0, p00);
-                    SCALAR_FETCH_PIXEL_C1(0, 1, p01);
-                    SCALAR_FETCH_PIXEL_C1(1, 0, p10);
-                    SCALAR_FETCH_PIXEL_C1(1, 1, p11);
-                }
-                float v0 = p00 + sx*(p01 - p00);
-                float v1 = p10 + sx*(p11 - p10);
-                v0 += sy*(v1 - v0);
-                dstptr[x] = v0;
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_8UC4 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_8UC4(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const uint8_t>();
-        auto *dst = output->ptr<uint8_t>();
-        size_t srcstep = input->step, dststep = output->step;
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        uint8_t bval[] = {
-            saturate_cast<uint8_t>(borderValue[0]),
-            saturate_cast<uint8_t>(borderValue[1]),
-            saturate_cast<uint8_t>(borderValue[2]),
-            saturate_cast<uint8_t>(borderValue[3]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
 
@@ -1604,6 +1105,12 @@ public:
                  outer_scols = vx_setall_u32((unsigned)srccols + 1);
         v_float32 delta = vx_setall_f32(static_cast<float>(uf));
         v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*4];
+
         uint8_t bvalbuf[max_uf*4];
         for (int i = 0; i < uf; i++) {
             bvalbuf[i*4] = bval[0];
@@ -1615,20 +1122,11 @@ public:
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
         v_uint8 bval_v3 = vx_load_low(&bvalbuf[uf*3]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4*4];
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
         uint8x8_t reds = {0, 8, 16, 24, 4, 12, 20, 28},
                   greens = {1, 9, 17, 25, 5, 13, 21, 29},
                   blues = {2, 10, 18, 26, 6, 14, 22, 30},
                   alphas = {3, 11, 19, 27, 7, 15, 23, 31};
-    #endif
-    #if !CV_SIMD128_FP16
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
     #endif
 #endif
 
@@ -1647,7 +1145,7 @@ public:
             for (; x < dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
 
-                VECTOR_COMPUTE_COORDINATES();
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
 
                 v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
                         addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
@@ -1733,10 +1231,10 @@ public:
                     p10a = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
                     p11a = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
     #else
-                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 8U);
     #endif
                 } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(8U, C4);
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
 
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                     p00r = vld1_u8(pixbuf);
@@ -1761,7 +1259,1343 @@ public:
     #endif
                 }
 
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16 // [TODO] support risc-v fp16 intrinsics
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
+                v_int16 f00r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00r))),
+                        f01r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01r))),
+                        f10r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10r))),
+                        f11r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11r)));
+                v_int16 f00g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00g))),
+                        f01g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01g))),
+                        f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
+                        f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
+                v_int16 f00b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00b))),
+                        f01b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01b))),
+                        f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
+                        f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
+                v_int16 f00a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00a))),
+                        f01a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01a))),
+                        f10a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10a))),
+                        f11a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11a)));
+    #else
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U8S16(C4);
+    #endif
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_S16F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U8(C4);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const uint8_t* srcptr = src + srcstep*iy + ix*3;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 8U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearInvoker_16UC1(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(uint16_t), dststep = dst_step/sizeof(uint16_t);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(border_value[0]),
+            saturate_cast<uint16_t>(border_value[1]),
+            saturate_cast<uint16_t>(border_value[2]),
+            saturate_cast<uint16_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4];
+
+        uint16_t bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 16U);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 16U);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C1);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00g, p01g, p10g, p11g;
+                const uint16_t *srcptr = src + srcstep * iy + ix;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 16U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+
+void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(uint16_t), dststep = dst_step/sizeof(uint16_t);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(border_value[0]),
+            saturate_cast<uint16_t>(border_value[1]),
+            saturate_cast<uint16_t>(border_value[2]),
+            saturate_cast<uint16_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4*3];
+
+        uint16_t bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
+        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 16U);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 16U);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C3);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C3);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p01r, p01g, p01b;
+                int p10r, p10g, p10b, p11r, p11g, p11b;
+                const uint16_t *srcptr = src + srcstep * iy + ix*3;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 16U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+
+void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                  uint16_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(uint16_t), dststep = dst_step/sizeof(uint16_t);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint16_t bval[] = {
+            saturate_cast<uint16_t>(border_value[0]),
+            saturate_cast<uint16_t>(border_value[1]),
+            saturate_cast<uint16_t>(border_value[2]),
+            saturate_cast<uint16_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                           border_type != BORDER_TRANSPARENT &&
+                           src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint16_t pixbuf[max_uf*4*4];
+
+        uint16_t bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
+        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
+        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
+        v_uint16 bval_v3 = vx_load(&bvalbuf[uf*3]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            uint16_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 16U);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 16U);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_U16F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32U16(C4);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const uint16_t *srcptr = src + srcstep * iy + ix*4;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 16U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearInvoker_32FC1(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(float), dststep = dst_step/sizeof(float);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(border_value[0]),
+            saturate_cast<float>(border_value[1]),
+            saturate_cast<float>(border_value[2]),
+            saturate_cast<float>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4];
+
+        float bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C1, 32F);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 32F);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C1);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00g, p01g, p10g, p11g;
+                const float *srcptr = src + srcstep * iy + ix;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 32F);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(float), dststep = dst_step/sizeof(float);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(border_value[0]),
+            saturate_cast<float>(border_value[1]),
+            saturate_cast<float>(border_value[2]),
+            saturate_cast<float>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4*3];
+
+        float bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
+        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
+        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
+        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C3, 32F);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 32F);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C3);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C3);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00r, p00g, p00b, p01r, p01g, p01b;
+                float p10r, p10g, p10b, p11r, p11g, p11b;
+                const float *srcptr = src + srcstep * iy + ix*3;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C3);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C3);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C3, 32F);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int src_rows, int src_cols,
+                                  float *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                  const double dM[6], int border_type, const double border_value[4]) {
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step/sizeof(float), dststep = dst_step/sizeof(float);
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        float bval[] = {
+            saturate_cast<float>(border_value[0]),
+            saturate_cast<float>(border_value[1]),
+            saturate_cast<float>(border_value[2]),
+            saturate_cast<float>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_cols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            src_rows <= 1 ? BORDER_REPLICATE : border_type;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        float pixbuf[max_uf*4*4];
+
+        float bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
+        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
+        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
+        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
+        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
+        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
+        v_float32 bval_v3_l = vx_load(&bvalbuf[uf*3]);
+        v_float32 bval_v3_h = vx_load(&bvalbuf[uf*3+vlanes_32]);
+#endif
+
+        for (int y = r.start; y < r.end; y++) {
+            float* dstptr = dst + y*dststep;
+            int x = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_ALLWITHIN(C4, 32F);
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 32F);
+                }
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_LOAD_F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_VECTOR_INTER_STORE_F32F32(C4);
+            }
+#endif // (CV_SIMD || CV_SIMD_SCALABLE)
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                float p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
+                float p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
+                const float *srcptr = src + srcstep * iy + ix*4;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C4);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C4, 32F);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+}
+
+void warpAffineLinearApproxInvoker_8UC1(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double dM[6], int border_type, const double border_value[4]) {
+#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
+
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4];
+
+        uint8_t bvalbuf[max_uf];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i] = bval[0];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        uint8x8_t gray = {0, 8, 16, 24, 1, 9, 17, 25};
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, src_ix0),
+                        addr_1 = v_fma(v_srcstep, src_iy1, src_ix1);
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                uint8x8_t p00g, p01g, p10g, p11g;
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    uint8x8x4_t t00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t t01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t t10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t t11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(t00, gray));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(t01, gray));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(t10, gray));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(t11, gray));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C1, 8U);
+
+                    p00g = vld1_u8(pixbuf);
+                    p01g = vld1_u8(pixbuf + 8);
+                    p10g = vld1_u8(pixbuf + 16);
+                    p11g = vld1_u8(pixbuf + 24);
+                }
+
+                v_float16 f00 = v_float16(vcvtq_f16_u16(vmovl_u8(p00g)));
+                v_float16 f01 = v_float16(vcvtq_f16_u16(vmovl_u8(p01g)));
+                v_float16 f10 = v_float16(vcvtq_f16_u16(vmovl_u8(p10g)));
+                v_float16 f11 = v_float16(vcvtq_f16_u16(vmovl_u8(p11g)));
+
+                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
+                          beta = v_cvt_f16(src_y0, src_y1);
+
+                f00 = v_fma(alpha, v_sub(f01, f00), f00);
+                f10 = v_fma(alpha, v_sub(f11, f10), f10);
+                f00 = v_fma(beta,  v_sub(f10, f00), f00);
+
+                uint8x8_t result = {
+                    vqmovun_s16(vcvtnq_s16_f16(f00.val)),
+                };
+
+                vst1_u8(dstptr + x, result);
+            }
+
+            for (; x < dstcols; x++) {
+                float sx = x*M[0] + y*M[1] + M[2];
+                float sy = x*M[3] + y*M[4] + M[5];
+                int ix = cvFloor(sx), iy = cvFloor(sy);
+                sx -= ix; sy -= iy;
+                int p00g, p01g, p10g, p11g;
+                const uint8_t *srcptr = src + srcstep * iy + ix;
+
+                WARPAFFINE_LINEAR_SCALAR_SHUFFLE(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_INTER_CALC_F32(C1);
+
+                WARPAFFINE_LINEAR_SCALAR_STORE(C1, 8U);
+            }
+        }
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+#else
+    warpAffineLinearInvoker_8UC1(src_data, src_step, src_rows, src_cols,
+                                 dst_data, dst_step, dst_rows, dst_cols,
+                                 dM, border_type, border_value);
+#endif
+}
+
+void warpAffineLinearApproxInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double dM[6], int border_type, const double border_value[4]) {
+#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
+
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), three = vx_setall_s32(3);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*3];
+
+        uint8_t bvalbuf[max_uf*3];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*3] = bval[0];
+            bvalbuf[i*3+1] = bval[1];
+            bvalbuf[i*3+2] = bval[2];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
+        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, three)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, three));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b;
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    uint8x8x4_t p00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t p01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t p10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t p11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, reds));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, reds));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, reds));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, reds));
+
+                    p00r = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01r = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10r = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11r = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, greens));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, greens));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, greens));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, greens));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, blues));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, blues));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, blues));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, blues));
+
+                    p00b = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01b = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C3, 8U);
+
+                    p00r = vld1_u8(pixbuf);
+                    p01r = vld1_u8(pixbuf + 8);
+                    p10r = vld1_u8(pixbuf + 16);
+                    p11r = vld1_u8(pixbuf + 24);
+
+                    p00g = vld1_u8(pixbuf + 32);
+                    p01g = vld1_u8(pixbuf + 32 + 8);
+                    p10g = vld1_u8(pixbuf + 32 + 16);
+                    p11g = vld1_u8(pixbuf + 32 + 24);
+
+                    p00b = vld1_u8(pixbuf + 64);
+                    p01b = vld1_u8(pixbuf + 64 + 8);
+                    p10b = vld1_u8(pixbuf + 64 + 16);
+                    p11b = vld1_u8(pixbuf + 64 + 24);
+                }
+
+                v_float16 f00r = v_float16(vcvtq_f16_u16(vmovl_u8(p00r)));
+                v_float16 f01r = v_float16(vcvtq_f16_u16(vmovl_u8(p01r)));
+                v_float16 f10r = v_float16(vcvtq_f16_u16(vmovl_u8(p10r)));
+                v_float16 f11r = v_float16(vcvtq_f16_u16(vmovl_u8(p11r)));
+
+                v_float16 f00g = v_float16(vcvtq_f16_u16(vmovl_u8(p00g)));
+                v_float16 f01g = v_float16(vcvtq_f16_u16(vmovl_u8(p01g)));
+                v_float16 f10g = v_float16(vcvtq_f16_u16(vmovl_u8(p10g)));
+                v_float16 f11g = v_float16(vcvtq_f16_u16(vmovl_u8(p11g)));
+
+                v_float16 f00b = v_float16(vcvtq_f16_u16(vmovl_u8(p00b)));
+                v_float16 f01b = v_float16(vcvtq_f16_u16(vmovl_u8(p01b)));
+                v_float16 f10b = v_float16(vcvtq_f16_u16(vmovl_u8(p10b)));
+                v_float16 f11b = v_float16(vcvtq_f16_u16(vmovl_u8(p11b)));
+
+                v_float16 alpha = v_cvt_f16(src_x0, src_x1),
+                          beta = v_cvt_f16(src_y0, src_y1);
+
+                f00r = v_fma(alpha, v_sub(f01r, f00r), f00r);
+                f10r = v_fma(alpha, v_sub(f11r, f10r), f10r);
+
+                f00g = v_fma(alpha, v_sub(f01g, f00g), f00g);
+                f10g = v_fma(alpha, v_sub(f11g, f10g), f10g);
+
+                f00b = v_fma(alpha, v_sub(f01b, f00b), f00b);
+                f10b = v_fma(alpha, v_sub(f11b, f10b), f10b);
+
+                f00r = v_fma(beta,  v_sub(f10r, f00r), f00r);
+                f00g = v_fma(beta,  v_sub(f10g, f00g), f00g);
+                f00b = v_fma(beta,  v_sub(f10b, f00b), f00b);
+
+                uint8x8x3_t result = {
+                    vqmovun_s16(vcvtnq_s16_f16(f00r.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00g.val)),
+                    vqmovun_s16(vcvtnq_s16_f16(f00b.val)),
+                };
+                vst3_u8(dstptr + x*3, result);
+            }
+        }
+
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+#else
+    warpAffineLinearInvoker_8UC3(src_data, src_step, src_rows, src_cols,
+                                 dst_data, dst_step, dst_rows, dst_cols,
+                                 dM, border_type, border_value);
+#endif
+}
+
+void warpAffineLinearApproxInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
+                                        uint8_t *dst_data, size_t dst_step, int dst_rows, int dst_cols,
+                                        const double dM[6], int border_type, const double border_value[4]) {
+#if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
+    auto worker = [&](const Range &r) {
+        CV_INSTRUMENT_REGION();
+
+        const auto *src = src_data;
+        auto *dst = dst_data;
+        size_t srcstep = src_step, dststep = dst_step;
+        int srccols = src_cols, srcrows = src_rows;
+        int dstcols = dst_cols;
+        float M[6];
+        for (int i = 0; i < 6; i++) {
+            M[i] = static_cast<float>(dM[i]);
+        }
+        uint8_t bval[] = {
+            saturate_cast<uint8_t>(border_value[0]),
+            saturate_cast<uint8_t>(border_value[1]),
+            saturate_cast<uint8_t>(border_value[2]),
+            saturate_cast<uint8_t>(border_value[3]),
+        };
+        int border_type_x = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srccols <= 1 ? BORDER_REPLICATE : border_type;
+        int border_type_y = border_type != BORDER_CONSTANT &&
+                            border_type != BORDER_TRANSPARENT &&
+                            srcrows <= 1 ? BORDER_REPLICATE : border_type;
+
+        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
+        constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_32 = VTraits<v_float32>::vlanes();
+        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
+        int uf = vlanes_32 * 2;
+
+        std::array<float, max_vlanes_32> start_indices;
+        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
+
+        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
+                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
+                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
+                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
+        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
+        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
+        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
+        int32_t addr[max_uf],
+                src_ix[max_uf],
+                src_iy[max_uf];
+        uint8_t pixbuf[max_uf*4*4];
+
+        uint8_t bvalbuf[max_uf*4];
+        for (int i = 0; i < uf; i++) {
+            bvalbuf[i*4] = bval[0];
+            bvalbuf[i*4+1] = bval[1];
+            bvalbuf[i*4+2] = bval[2];
+            bvalbuf[i*4+3] = bval[3];
+        }
+        v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
+        v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
+        v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+        v_uint8 bval_v3 = vx_load_low(&bvalbuf[uf*3]);
+        uint8x8_t reds = {0, 8, 16, 24, 4, 12, 20, 28},
+                  greens = {1, 9, 17, 25, 5, 13, 21, 29},
+                  blues = {2, 10, 18, 26, 6, 14, 22, 30},
+                  alphas = {3, 11, 19, 27, 7, 15, 23, 31};
+
+        for (int y = r.start; y < r.end; y++) {
+            uint8_t* dstptr = dst + y*dststep;
+            int x = 0;
+
+            v_float32 dst_x0 = vx_load(start_indices.data());
+            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
+            v_float32 M0 = vx_setall_f32(M[0]),
+                      M3 = vx_setall_f32(M[3]);
+            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
+                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
+
+            for (; x < dstcols - uf; x += uf) {
+                // [TODO] apply halide trick
+
+                WARPAFFINE_LINEAR_VECTOR_COMPUTE_MAPPED_COORD();
+
+                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
+                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
+                vx_store(addr, addr_0);
+                vx_store(addr + vlanes_32, addr_1);
+
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b,
+                          p00a, p01a, p10a, p11a;
+
+                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
+                    uint8x8x4_t p00 = {
+                        vld1_u8(src + addr[0]),
+                        vld1_u8(src + addr[1]),
+                        vld1_u8(src + addr[2]),
+                        vld1_u8(src + addr[3])
+                    };
+
+                    uint8x8x4_t p01 = {
+                        vld1_u8(src + addr[4]),
+                        vld1_u8(src + addr[5]),
+                        vld1_u8(src + addr[6]),
+                        vld1_u8(src + addr[7])
+                    };
+
+                    uint8x8x4_t p10 = {
+                        vld1_u8(src + addr[0] + srcstep),
+                        vld1_u8(src + addr[1] + srcstep),
+                        vld1_u8(src + addr[2] + srcstep),
+                        vld1_u8(src + addr[3] + srcstep)
+                    };
+
+                    uint8x8x4_t p11 = {
+                        vld1_u8(src + addr[4] + srcstep),
+                        vld1_u8(src + addr[5] + srcstep),
+                        vld1_u8(src + addr[6] + srcstep),
+                        vld1_u8(src + addr[7] + srcstep)
+                    };
+
+                    uint32x2_t p00_, p01_, p10_, p11_;
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, reds));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, reds));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, reds));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, reds));
+
+                    p00r = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01r = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10r = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11r = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, greens));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, greens));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, greens));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, greens));
+
+                    p00g = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01g = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10g = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11g = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, blues));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, blues));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, blues));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, blues));
+
+                    p00b = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01b = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10b = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11b = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+
+                    p00_ = vreinterpret_u32_u8(vtbl4_u8(p00, alphas));
+                    p01_ = vreinterpret_u32_u8(vtbl4_u8(p01, alphas));
+                    p10_ = vreinterpret_u32_u8(vtbl4_u8(p10, alphas));
+                    p11_ = vreinterpret_u32_u8(vtbl4_u8(p11, alphas));
+
+                    p00a = vreinterpret_u8_u32(vtrn1_u32(p00_, p01_));
+                    p01a = vreinterpret_u8_u32(vtrn2_u32(p00_, p01_));
+                    p10a = vreinterpret_u8_u32(vtrn1_u32(p10_, p11_));
+                    p11a = vreinterpret_u8_u32(vtrn2_u32(p10_, p11_));
+                } else {
+                    WARPAFFINE_LINEAR_VECTOR_SHUFFLE_NOTALLWITHIN(C4, 8U);
+
+                    p00r = vld1_u8(pixbuf);
+                    p01r = vld1_u8(pixbuf + 8);
+                    p10r = vld1_u8(pixbuf + 16);
+                    p11r = vld1_u8(pixbuf + 24);
+
+                    p00g = vld1_u8(pixbuf + 32);
+                    p01g = vld1_u8(pixbuf + 32 + 8);
+                    p10g = vld1_u8(pixbuf + 32 + 16);
+                    p11g = vld1_u8(pixbuf + 32 + 24);
+
+                    p00b = vld1_u8(pixbuf + 64);
+                    p01b = vld1_u8(pixbuf + 64 + 8);
+                    p10b = vld1_u8(pixbuf + 64 + 16);
+                    p11b = vld1_u8(pixbuf + 64 + 24);
+
+                    p00a = vld1_u8(pixbuf + 96);
+                    p01a = vld1_u8(pixbuf + 96 + 8);
+                    p10a = vld1_u8(pixbuf + 96 + 16);
+                    p11a = vld1_u8(pixbuf + 96 + 24);
+                }
+
                 v_float16 f00r = v_float16(vcvtq_f16_u16(vmovl_u8(p00r)));
                 v_float16 f01r = v_float16(vcvtq_f16_u16(vmovl_u8(p01r)));
                 v_float16 f10r = v_float16(vcvtq_f16_u16(vmovl_u8(p10r)));
@@ -1809,480 +2643,17 @@ public:
                     vqmovun_s16(vcvtnq_s16_f16(f00a.val)),
                 };
                 vst4_u8(dstptr + x*4, result);
-    #else
-        #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 // In case neon fp16 intrinsics are not available; still requires A64
-                v_int16 f00r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00r))),
-                        f01r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01r))),
-                        f10r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10r))),
-                        f11r = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11r)));
-                v_int16 f00g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00g))),
-                        f01g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01g))),
-                        f10g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10g))),
-                        f11g = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11g)));
-                v_int16 f00b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00b))),
-                        f01b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01b))),
-                        f10b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10b))),
-                        f11b = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11b)));
-                v_int16 f00a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p00a))),
-                        f01a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p01a))),
-                        f10a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p10a))),
-                        f11a = v_reinterpret_as_s16(v_uint16(vmovl_u8(p11a)));
-        #else
-                v_int16  f00r = v_reinterpret_as_s16(vx_load_expand(pixbuf)),
-                         f01r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf)),
-                         f10r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*2)),
-                         f11r = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*3));
-                v_int16  f00g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*4)),
-                         f01g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*5)),
-                         f10g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*6)),
-                         f11g = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*7));
-                v_int16  f00b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*8)),
-                         f01b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*9)),
-                         f10b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*10)),
-                         f11b = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*11));
-                v_int16  f00a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*12)),
-                         f01a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*13)),
-                         f10a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*14)),
-                         f11a = v_reinterpret_as_s16(vx_load_expand(pixbuf + uf*15));
-        #endif
-                v_float32 f00rl = v_cvt_f32(v_expand_low(f00r)), f00rh = v_cvt_f32(v_expand_high(f00r)),
-                          f01rl = v_cvt_f32(v_expand_low(f01r)), f01rh = v_cvt_f32(v_expand_high(f01r)),
-                          f10rl = v_cvt_f32(v_expand_low(f10r)), f10rh = v_cvt_f32(v_expand_high(f10r)),
-                          f11rl = v_cvt_f32(v_expand_low(f11r)), f11rh = v_cvt_f32(v_expand_high(f11r));
-                v_float32 f00gl = v_cvt_f32(v_expand_low(f00g)), f00gh = v_cvt_f32(v_expand_high(f00g)),
-                          f01gl = v_cvt_f32(v_expand_low(f01g)), f01gh = v_cvt_f32(v_expand_high(f01g)),
-                          f10gl = v_cvt_f32(v_expand_low(f10g)), f10gh = v_cvt_f32(v_expand_high(f10g)),
-                          f11gl = v_cvt_f32(v_expand_low(f11g)), f11gh = v_cvt_f32(v_expand_high(f11g));
-                v_float32 f00bl = v_cvt_f32(v_expand_low(f00b)), f00bh = v_cvt_f32(v_expand_high(f00b)),
-                          f01bl = v_cvt_f32(v_expand_low(f01b)), f01bh = v_cvt_f32(v_expand_high(f01b)),
-                          f10bl = v_cvt_f32(v_expand_low(f10b)), f10bh = v_cvt_f32(v_expand_high(f10b)),
-                          f11bl = v_cvt_f32(v_expand_low(f11b)), f11bh = v_cvt_f32(v_expand_high(f11b));
-                v_float32 f00al = v_cvt_f32(v_expand_low(f00a)), f00ah = v_cvt_f32(v_expand_high(f00a)),
-                          f01al = v_cvt_f32(v_expand_low(f01a)), f01ah = v_cvt_f32(v_expand_high(f01a)),
-                          f10al = v_cvt_f32(v_expand_low(f10a)), f10ah = v_cvt_f32(v_expand_high(f10a)),
-                          f11al = v_cvt_f32(v_expand_low(f11a)), f11ah = v_cvt_f32(v_expand_high(f11a));
-
-                VECTOR_LINEAR_C4_F32();
-
-                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
-                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
-                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)),
-                         f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah));
-                uint16_t tbuf[max_vlanes_16*4];
-                v_store_interleave(tbuf, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
-                v_pack_store(dstptr + x*4, vx_load(tbuf));
-                v_pack_store(dstptr + x*4 + vlanes_16, vx_load(tbuf + vlanes_16));
-                v_pack_store(dstptr + x*4 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
-                v_pack_store(dstptr + x*4 + vlanes_16*3, vx_load(tbuf + vlanes_16*3));
-    #endif // defined(CV_NEON_AARCH64) && CV_NEON_AARCH64 && CV_SIMD128_FP16
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
-                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
-                const uint8_t* srcptr = src + srcstep*iy + ix*4;
-
-                SCALAR_LINEAR_SHUFFLE_C4();
-
-                SCALAR_LINEAR_CALC_C4();
-
-                dstptr[x*4] = saturate_cast<uint8_t>(v0r);
-                dstptr[x*4+1] = saturate_cast<uint8_t>(v0g);
-                dstptr[x*4+2] = saturate_cast<uint8_t>(v0b);
-                dstptr[x*4+3] = saturate_cast<uint8_t>(v0a);
             }
         }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_16UC4 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_16UC4(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const uint16_t>();
-        auto *dst = output->ptr<uint16_t>();
-        size_t srcstep = input->step/sizeof(uint16_t), dststep = output->step/sizeof(uint16_t);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        uint16_t bval[] = {
-            saturate_cast<uint16_t>(borderValue[0]),
-            saturate_cast<uint16_t>(borderValue[1]),
-            saturate_cast<uint16_t>(borderValue[2]),
-            saturate_cast<uint16_t>(borderValue[3]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
-        uint16_t bvalbuf[max_uf*4];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i*4] = bval[0];
-            bvalbuf[i*4+1] = bval[1];
-            bvalbuf[i*4+2] = bval[2];
-            bvalbuf[i*4+3] = bval[3];
-        }
-        v_uint16 bval_v0 = vx_load(&bvalbuf[0]);
-        v_uint16 bval_v1 = vx_load(&bvalbuf[uf]);
-        v_uint16 bval_v2 = vx_load(&bvalbuf[uf*2]);
-        v_uint16 bval_v3 = vx_load(&bvalbuf[uf*3]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4*4];
+    };
+    parallel_for_(Range(0, dst_rows), worker);
+#else
+    warpAffineLinearInvoker_8UC4(src_data, src_step, src_rows, src_cols,
+                                 dst_data, dst_step, dst_rows, dst_cols,
+                                 dM, border_type, border_value);
 #endif
-
-        for (int y = r.start; y < r.end; y++) {
-            uint16_t* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
-                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(16U, C4);
-                }
-
-                v_uint16 f00r = vx_load(pixbuf),
-                         f01r = vx_load(pixbuf + uf),
-                         f10r = vx_load(pixbuf + uf*2),
-                         f11r = vx_load(pixbuf + uf*3);
-                v_uint16 f00g = vx_load(pixbuf + uf*4),
-                         f01g = vx_load(pixbuf + uf*5),
-                         f10g = vx_load(pixbuf + uf*6),
-                         f11g = vx_load(pixbuf + uf*7);
-                v_uint16 f00b = vx_load(pixbuf + uf*8),
-                         f01b = vx_load(pixbuf + uf*9),
-                         f10b = vx_load(pixbuf + uf*10),
-                         f11b = vx_load(pixbuf + uf*11);
-                v_uint16 f00a = vx_load(pixbuf + uf*12),
-                         f01a = vx_load(pixbuf + uf*13),
-                         f10a = vx_load(pixbuf + uf*14),
-                         f11a = vx_load(pixbuf + uf*15);
-
-                v_float32 f00rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00r))), f00rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00r))),
-                          f01rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01r))), f01rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01r))),
-                          f10rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10r))), f10rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10r))),
-                          f11rl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11r))), f11rh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11r)));
-                v_float32 f00gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00g))), f00gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00g))),
-                          f01gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01g))), f01gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01g))),
-                          f10gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10g))), f10gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10g))),
-                          f11gl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11g))), f11gh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11g)));
-                v_float32 f00bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00b))), f00bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00b))),
-                          f01bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01b))), f01bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01b))),
-                          f10bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10b))), f10bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10b))),
-                          f11bl = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11b))), f11bh = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11b)));
-                v_float32 f00al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f00a))), f00ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f00a))),
-                          f01al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f01a))), f01ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f01a))),
-                          f10al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f10a))), f10ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f10a))),
-                          f11al = v_cvt_f32(v_reinterpret_as_s32(v_expand_low(f11a))), f11ah = v_cvt_f32(v_reinterpret_as_s32(v_expand_high(f11a)));
-
-                VECTOR_LINEAR_C4_F32();
-
-                v_uint16 f00r_u16 = v_pack_u(v_round(f00rl), v_round(f00rh)),
-                         f00g_u16 = v_pack_u(v_round(f00gl), v_round(f00gh)),
-                         f00b_u16 = v_pack_u(v_round(f00bl), v_round(f00bh)),
-                         f00a_u16 = v_pack_u(v_round(f00al), v_round(f00ah));
-                v_store_interleave(dstptr + x*4, f00r_u16, f00g_u16, f00b_u16, f00a_u16);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                int p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
-                int p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
-                const uint16_t* srcptr = src + srcstep*iy + ix*4;
-
-                SCALAR_LINEAR_SHUFFLE_C4();
-
-                SCALAR_LINEAR_CALC_C4();
-
-                dstptr[x*4] =   saturate_cast<uint16_t>(v0r);
-                dstptr[x*4+1] = saturate_cast<uint16_t>(v0g);
-                dstptr[x*4+2] = saturate_cast<uint16_t>(v0b);
-                dstptr[x*4+3] = saturate_cast<uint16_t>(v0a);
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-class WarpAffineLinearInvoker_32FC4 : public ParallelLoopBody {
-public:
-    WarpAffineLinearInvoker_32FC4(Mat *output_, const Mat *input_, const double *dM_,
-                                 int borderType_, const double *borderValue_)
-        : output(output_), input(input_), dM(dM_), borderType(borderType_), borderValue(borderValue_) {}
-
-    virtual void operator() (const Range &r) const CV_OVERRIDE {
-        CV_INSTRUMENT_REGION();
-
-        auto *src = input->ptr<const float>();
-        auto *dst = output->ptr<float>();
-        size_t srcstep = input->step/sizeof(float), dststep = output->step/sizeof(float);
-        int srccols = input->cols, srcrows = input->rows;
-        int dstcols = output->cols;
-        float M[6];
-        for (int i = 0; i < 6; i++) {
-            M[i] = static_cast<float>(dM[i]);
-        }
-        float bval[] = {
-            saturate_cast<float>(borderValue[0]),
-            saturate_cast<float>(borderValue[1]),
-            saturate_cast<float>(borderValue[2]),
-            saturate_cast<float>(borderValue[3]),
-        };
-        int borderType_x = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->cols <= 1 ? BORDER_REPLICATE : borderType;
-        int borderType_y = borderType != BORDER_CONSTANT &&
-                           borderType != BORDER_TRANSPARENT &&
-                           input->rows <= 1 ? BORDER_REPLICATE : borderType;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
-        constexpr int max_uf{max_vlanes_32*2};
-
-        int vlanes_32 = VTraits<v_float32>::vlanes();
-
-        // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
-        int uf = vlanes_32 * 2;
-
-        std::array<float, max_vlanes_32> start_indices;
-        std::iota(start_indices.data(), start_indices.data() + max_vlanes_32, 0.f);
-
-        v_uint32 inner_srows = vx_setall_u32((unsigned)srcrows - 2),
-                 inner_scols = vx_setall_u32((unsigned)srccols - 1),
-                 outer_srows = vx_setall_u32((unsigned)srcrows + 1),
-                 outer_scols = vx_setall_u32((unsigned)srccols + 1);
-        v_float32 delta = vx_setall_f32(static_cast<float>(uf));
-        v_int32 one = vx_setall_s32(1), four = vx_setall_s32(4);
-        float bvalbuf[max_uf*4];
-        for (int i = 0; i < uf; i++) {
-            bvalbuf[i*4] = bval[0];
-            bvalbuf[i*4+1] = bval[1];
-            bvalbuf[i*4+2] = bval[2];
-            bvalbuf[i*4+3] = bval[3];
-        }
-        v_float32 bval_v0_l = vx_load(&bvalbuf[0]);
-        v_float32 bval_v0_h = vx_load(&bvalbuf[vlanes_32]);
-        v_float32 bval_v1_l = vx_load(&bvalbuf[uf]);
-        v_float32 bval_v1_h = vx_load(&bvalbuf[uf+vlanes_32]);
-        v_float32 bval_v2_l = vx_load(&bvalbuf[uf*2]);
-        v_float32 bval_v2_h = vx_load(&bvalbuf[uf*2+vlanes_32]);
-        v_float32 bval_v3_l = vx_load(&bvalbuf[uf*3]);
-        v_float32 bval_v3_h = vx_load(&bvalbuf[uf*3+vlanes_32]);
-        v_int32 v_srcstep = vx_setall_s32(int(srcstep));
-        int32_t addr[max_uf],
-                src_ix[max_uf],
-                src_iy[max_uf];
-        float pixbuf[max_uf*4*4];
-#endif
-
-        for (int y = r.start; y < r.end; y++) {
-            float* dstptr = dst + y*dststep;
-            int x = 0;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]),
-                      M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                      M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-
-            for (; x < dstcols - uf; x += uf) {
-                // [TODO] apply halide trick
-
-                VECTOR_COMPUTE_COORDINATES();
-
-                v_int32 addr_0 = v_fma(v_srcstep, src_iy0, v_mul(src_ix0, four)),
-                        addr_1 = v_fma(v_srcstep, src_iy1, v_mul(src_ix1, four));
-                vx_store(addr, addr_0);
-                vx_store(addr + vlanes_32, addr_1);
-
-                if (v_reduce_min(inner_mask) != 0) { // all loaded pixels are completely inside the image
-                    shuffle_allin_c4(src, addr, pixbuf, uf, srcstep);
-                } else {
-                    VECTOR_LINEAR_SHUFFLE_NOTALLIN(32F, C4);
-                }
-
-                v_float32 f00rl = vx_load(pixbuf),         f00rh = vx_load(pixbuf + vlanes_32),
-                          f01rl = vx_load(pixbuf + uf),    f01rh = vx_load(pixbuf + uf + vlanes_32),
-                          f10rl = vx_load(pixbuf + uf*2),  f10rh = vx_load(pixbuf + uf*2 + vlanes_32),
-                          f11rl = vx_load(pixbuf + uf*3),  f11rh = vx_load(pixbuf + uf*3 + vlanes_32);
-                v_float32 f00gl = vx_load(pixbuf + uf*4),  f00gh = vx_load(pixbuf + uf*4 + vlanes_32),
-                          f01gl = vx_load(pixbuf + uf*5),  f01gh = vx_load(pixbuf + uf*5 + vlanes_32),
-                          f10gl = vx_load(pixbuf + uf*6),  f10gh = vx_load(pixbuf + uf*6 + vlanes_32),
-                          f11gl = vx_load(pixbuf + uf*7),  f11gh = vx_load(pixbuf + uf*7 + vlanes_32);
-                v_float32 f00bl = vx_load(pixbuf + uf*8),  f00bh = vx_load(pixbuf + uf*8 + vlanes_32),
-                          f01bl = vx_load(pixbuf + uf*9),  f01bh = vx_load(pixbuf + uf*9 + vlanes_32),
-                          f10bl = vx_load(pixbuf + uf*10), f10bh = vx_load(pixbuf + uf*10 + vlanes_32),
-                          f11bl = vx_load(pixbuf + uf*11), f11bh = vx_load(pixbuf + uf*11 + vlanes_32);
-                v_float32 f00al = vx_load(pixbuf + uf*12), f00ah = vx_load(pixbuf + uf*12 + vlanes_32),
-                          f01al = vx_load(pixbuf + uf*13), f01ah = vx_load(pixbuf + uf*13 + vlanes_32),
-                          f10al = vx_load(pixbuf + uf*14), f10ah = vx_load(pixbuf + uf*14 + vlanes_32),
-                          f11al = vx_load(pixbuf + uf*15), f11ah = vx_load(pixbuf + uf*15 + vlanes_32);
-
-                VECTOR_LINEAR_C4_F32();
-
-                v_store_interleave(dstptr + x*4, f00rl, f00gl, f00bl, f00al);
-                v_store_interleave(dstptr + x*4 + vlanes_32*4, f00rh, f00gh, f00bh, f00ah);
-            }
-#endif // (CV_SIMD || CV_SIMD_SCALABLE)
-
-            for (; x < dstcols; x++) {
-                float sx = x*M[0] + y*M[1] + M[2];
-                float sy = x*M[3] + y*M[4] + M[5];
-                int ix = cvFloor(sx), iy = cvFloor(sy);
-                sx -= ix; sy -= iy;
-                float p00r, p00g, p00b, p00a, p01r, p01g, p01b, p01a;
-                float p10r, p10g, p10b, p10a, p11r, p11g, p11b, p11a;
-                const float* srcptr = src + srcstep*iy + ix*4;
-
-                SCALAR_LINEAR_SHUFFLE_C4();
-
-                SCALAR_LINEAR_CALC_C4();
-
-                dstptr[x*4] =   v0r;
-                dstptr[x*4+1] = v0g;
-                dstptr[x*4+2] = v0b;
-                dstptr[x*4+3] = v0a;
-            }
-        }
-    }
-
-private:
-    Mat *output;
-    const Mat *input;
-    const double *dM;
-    int borderType;
-    const double *borderValue;
-};
-
-} // anonymous
-
-void warpAffineSimdInvoker(Mat &output, const Mat &input, const double *M,
-                           int interpolation, int borderType, const double *borderValue) {
-    CV_INSTRUMENT_REGION();
-
-    CV_CheckEQ(interpolation, INTER_LINEAR, "");
-    switch (output.type()) {
-        case CV_8UC3: {
-            WarpAffineLinearInvoker_8UC3 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_16UC3: {
-            WarpAffineLinearInvoker_16UC3 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_32FC3: {
-            WarpAffineLinearInvoker_32FC3 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_8UC1: {
-            WarpAffineLinearInvoker_8UC1 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_16UC1: {
-            WarpAffineLinearInvoker_16UC1 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_32FC1: {
-            WarpAffineLinearInvoker_32FC1 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_8UC4: {
-            WarpAffineLinearInvoker_8UC4 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_16UC4: {
-            WarpAffineLinearInvoker_16UC4 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        case CV_32FC4: {
-            WarpAffineLinearInvoker_32FC4 body(&output, &input, M, borderType, borderValue);
-            parallel_for_(Range(0, output.rows), body);
-            break;
-        }
-        default: CV_Error(Error::StsBadArg, "Unsupported type");
-    }
 }
+
 #endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
 

--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -172,7 +172,7 @@ OCL_TEST_P(WarpAffine, Mat)
 {
     for (int j = 0; j < test_loop_times; j++)
     {
-        double eps = depth < CV_32F ? 0.04 : 0.06;
+        double eps = depth < CV_32F ? ( depth < CV_16U ? 0.09 : 0.04 ) : 0.06;
         random_roi();
 
         Mat M = getRotationMatrix2D(Point2f(src_roi.cols / 2.0f, src_roi.rows / 2.0f),
@@ -189,7 +189,7 @@ OCL_TEST_P(WarpAffine, inplace_25853) // when src and dst are the same variable,
 {
     for (int j = 0; j < test_loop_times; j++)
     {
-        double eps = depth < CV_32F ? 0.04 : 0.06;
+        double eps = depth < CV_32F ? ( depth < CV_16U ? 0.09 : 0.04 ) : 0.06;
         random_roi();
 
         Mat M = getRotationMatrix2D(Point2f(src_roi.cols / 2.0f, src_roi.rows / 2.0f),

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -1095,7 +1095,7 @@ void CV_WarpAffine_Test::run_func()
 
 float CV_WarpAffine_Test::get_success_error_level(int _interpolation, int _depth) const
 {
-    return _depth == CV_8U ? 1.f : CV_ImageWarpBaseTest::get_success_error_level(_interpolation, _depth);
+    return _depth == CV_8U ? 0.f : CV_ImageWarpBaseTest::get_success_error_level(_interpolation, _depth);
 }
 
 void CV_WarpAffine_Test::run_reference_func()

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -686,7 +686,8 @@ TS* TS::ptr()
     return &ts;
 }
 
-void fillGradient(Mat& img, int delta)
+template<>
+void fillGradient<uint8_t>(Mat& img, int delta)
 {
     const int ch = img.channels();
     CV_Assert(!img.empty() && img.depth() == CV_8U && ch <= 4);
@@ -704,57 +705,6 @@ void fillGradient(Mat& img, int delta)
             uchar vals[] = {uchar(valR), uchar(valC), uchar(200*r/img.rows), uchar(255)};
             uchar *p = img.ptr(r, c);
             for(i=0; i<ch; i++) p[i] = vals[i];
-        }
-    }
-}
-
-void smoothBorder(Mat& img, const Scalar& color, int delta)
-{
-    const int ch = img.channels();
-    CV_Assert(!img.empty() && img.depth() == CV_8U && ch <= 4);
-
-    Scalar s;
-    uchar *p = NULL;
-    int n = 100/delta;
-    int nR = std::min(n, (img.rows+1)/2), nC = std::min(n, (img.cols+1)/2);
-
-    int r, c, i;
-    for(r=0; r<nR; r++)
-    {
-        double k1 = r*delta/100., k2 = 1-k1;
-        for(c=0; c<img.cols; c++)
-        {
-            p = img.ptr(r, c);
-            for(i=0; i<ch; i++) s[i] = p[i];
-            s = s * k1 + color * k2;
-            for(i=0; i<ch; i++) p[i] = uchar(s[i]);
-        }
-        for(c=0; c<img.cols; c++)
-        {
-            p = img.ptr(img.rows-r-1, c);
-            for(i=0; i<ch; i++) s[i] = p[i];
-            s = s * k1 + color * k2;
-            for(i=0; i<ch; i++) p[i] = uchar(s[i]);
-        }
-    }
-
-    for(r=0; r<img.rows; r++)
-    {
-        for(c=0; c<nC; c++)
-        {
-            double k1 = c*delta/100., k2 = 1-k1;
-            p = img.ptr(r, c);
-            for(i=0; i<ch; i++) s[i] = p[i];
-            s = s * k1 + color * k2;
-            for(i=0; i<ch; i++) p[i] = uchar(s[i]);
-        }
-        for(c=0; c<n; c++)
-        {
-            double k1 = c*delta/100., k2 = 1-k1;
-            p = img.ptr(r, img.cols-c-1);
-            for(i=0; i<ch; i++) s[i] = p[i];
-            s = s * k1 + color * k2;
-            for(i=0; i<ch; i++) p[i] = uchar(s[i]);
         }
     }
 }


### PR DESCRIPTION
Merge wtih https://github.com/opencv/opencv_extra/pull/1198.
Merge with https://github.com/opencv/opencv_contrib/pull/3787.

Perf:

M2 (16GB ram, with fp16 vector intrinsics support)

```
Geometric mean (ms)

                                 Name of Test                                   base  patch   patch   
                                                                                                vs    
                                                                                               base   
                                                                                            (x-factor)
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC1)      0.276 0.102    2.71   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC1)     0.338 0.137    2.46   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC1)     0.293 0.116    2.54   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC3)      0.447 0.140    3.19   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC3)     0.525 0.287    1.83   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC3)     0.391 0.258    1.52   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC4)      0.405 0.155    2.62   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC4)     0.613 0.348    1.76   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC4)     0.420 0.317    1.33   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC1)     0.274 0.095    2.89   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC1)    0.330 0.141    2.35   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC1)    0.294 0.167    1.76   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC3)     0.439 0.135    3.26   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC3)    0.528 0.284    1.86   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC3)    0.382 0.266    1.43   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC4)     0.411 0.162    2.53   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC4)    0.624 0.353    1.77   
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC4)    0.423 0.344    1.23   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC1)     0.516 0.178    2.90   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC1)    0.563 0.262    2.15   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC1)    0.516 0.219    2.36   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC3)     0.838 0.286    2.93   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC3)    0.902 0.552    1.63   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC3)    0.738 0.523    1.41   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC4)     0.825 0.305    2.70   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC4)    1.050 0.677    1.55   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC4)    0.815 0.649    1.26   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC1)    0.719 0.616    1.17   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC1)   0.750 0.700    1.07   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC1)   0.677 0.652    1.04   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC3)    1.167 0.737    1.58   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC3)   1.172 1.056    1.11   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC3)   0.907 0.989    0.92   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC4)    1.242 0.793    1.57   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC4)   1.419 1.223    1.16   
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC4)   1.013 1.136    0.89   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC1)    1.024 0.285    3.60   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC1)   1.020 0.365    2.79   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC1)   1.002 0.329    3.05   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC3)    1.641 0.384    4.28   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC3)   1.704 0.714    2.39   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC3)   1.450 0.717    2.02   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC4)    1.652 0.422    3.92   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC4)   1.867 0.870    2.15   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC4)   1.680 1.049    1.60   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC1)   1.734 2.364    0.73   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC1)  1.661 2.484    0.67   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC1)  1.567 2.461    0.64   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC3)   2.781 2.635    1.06   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC3)  2.545 3.059    0.83   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC3)  2.086 2.983    0.70   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC4)   3.061 2.799    1.09   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC4)  3.050 3.449    0.88   
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC4)  2.373 3.222    0.74   
```

Intel i7-12700K

```
Geometric mean (ms)

                                 Name of Test                                   base  patch   patch
                                                                                                vs
                                                                                               base
                                                                                            (x-factor)
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC1)      0.149 0.047    3.17
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC1)     0.181 0.046    3.96
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC1)     0.163 0.036    4.50
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC3)      0.196 0.115    1.70
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC3)     0.374 0.107    3.48
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC3)     0.228 0.108    2.11
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC4)      0.180 0.146    1.23
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC4)     0.446 0.141    3.17
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC4)     0.298 0.140    2.13
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC1)     0.144 0.047    3.08
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC1)    0.182 0.046    3.97
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC1)    0.162 0.036    4.50
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC3)     0.196 0.117    1.67
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC3)    0.366 0.108    3.40
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC3)    0.227 0.105    2.15
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC4)     0.180 0.148    1.22
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC4)    0.446 0.141    3.16
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC4)    0.300 0.148    2.03
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC1)     0.314 0.105    2.99
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC1)    0.377 0.103    3.65
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC1)    0.353 0.085    4.15
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC3)     0.401 0.241    1.66
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC3)    0.617 0.231    2.67
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC3)    0.866 0.230    3.77
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC4)     0.373 0.301    1.24
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC4)    1.087 0.344    3.17
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC4)    0.763 0.300    2.55
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC1)    0.406 0.244    1.66
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC1)   0.435 0.245    1.77
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC1)   0.401 0.230    1.74
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC3)    0.561 0.418    1.34
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC3)   0.759 0.400    1.90
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC3)   0.572 0.395    1.45
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC4)    0.590 0.484    1.22
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC4)   0.933 0.477    1.95
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC4)   0.669 0.462    1.45
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC1)    0.547 0.165    3.32
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC1)   0.554 0.163    3.39
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC1)   0.547 0.143    3.82
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC3)    0.629 0.322    1.96
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC3)   0.847 0.308    2.75
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC3)   2.616 0.333    7.86
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC4)    0.606 0.390    1.55
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC4)   2.548 0.380    6.71
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC4)   1.766 0.866    2.04
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC1)   0.847 0.880    0.96
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC1)  0.885 0.862    1.03
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC1)  0.759 0.829    0.92
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC3)   1.384 1.239    1.12
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC3)  1.594 1.169    1.36
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC3)  1.375 1.126    1.22
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC4)   1.546 1.272    1.22
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC4)  1.909 1.260    1.51
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC4)  1.396 1.317    1.06
```

Khadas VIM3 (A311D, 4xA73+2xA53, no fp16 vector intrinsics support)

```
Geometric mean (ms)

                                 Name of Test                                    base  patch    patch
                                                                                                  vs
                                                                                                 base
                                                                                              (x-factor)
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC1)      2.052  0.579     3.54
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC1)     3.237  0.523     6.20
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC1)     2.603  0.592     4.40
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC3)      4.153  1.048     3.96
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC3)     5.225  1.327     3.94
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC3)     3.388  1.665     2.03
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 8UC4)      3.746  1.353     2.77
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 16UC4)     6.727  1.784     3.77
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_CONSTANT, 32FC4)     4.006  2.308     1.74
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC1)     1.875  0.578     3.24
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC1)    3.046  0.587     5.19
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC1)    2.577  0.533     4.83
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC3)     4.072  1.041     3.91
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC3)    4.907  1.327     3.70
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC3)    3.512  1.656     2.12
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 8UC4)     3.689  1.361     2.71
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 16UC4)    6.403  1.795     3.57
WarpAffine::TestWarpAffine::(640x480, INTER_LINEAR, BORDER_REPLICATE, 32FC4)    4.335  2.317     1.87
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC1)     2.869  1.249     2.30
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC1)    4.047  1.274     3.18
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC1)    3.358  1.770     1.90
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC3)     5.454  2.365     2.31
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC3)    6.603  2.949     2.24
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC3)    6.177  4.540     1.36
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 8UC4)     6.166  2.988     2.06
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 16UC4)    7.685  3.993     1.92
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_CONSTANT, 32FC4)    7.637  6.011     1.27
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC1)    4.427  2.940     1.51
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC1)   6.068  2.981     2.04
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC1)   4.316  2.946     1.47
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC3)    7.169  5.075     1.41
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC3)   8.606  5.576     1.54
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC3)   7.533  5.995     1.26
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 8UC4)    8.751  5.985     1.46
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 16UC4)   15.192 6.713     2.26
WarpAffine::TestWarpAffine::(1280x720, INTER_LINEAR, BORDER_REPLICATE, 32FC4)   7.056  7.726     0.91
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC1)    8.686  2.083     4.17
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC1)   10.927 2.132     5.13
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC1)   7.764  3.213     2.42
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC3)    14.588 3.600     4.05
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC3)   17.251 4.896     3.52
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC3)   15.349 8.764     1.75
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 8UC4)    14.623 4.480     3.26
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 16UC4)   19.076 6.394     2.98
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_CONSTANT, 32FC4)   18.237 10.422    1.75
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC1)   12.835 10.112    1.27
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC1)  17.167 10.208    1.68
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC1)  12.486 9.994     1.25
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC3)   22.759 16.134    1.41
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC3)  29.616 16.531    1.79
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC3)  22.666 16.851    1.35
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 8UC4)   27.193 18.530    1.47
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 16UC4)  33.831 18.593    1.82
WarpAffine::TestWarpAffine::(1920x1080, INTER_LINEAR, BORDER_REPLICATE, 32FC4)  20.932 19.754    1.06
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Linux OpenCL
```