### PR TITLE
Improve corners matching in ChessBoardDetector::NeighborsFinder::findCornerNeighbor

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -515,11 +515,13 @@ ChessBoardDetector::NeighborsFinder::NeighborsFinder(ChessBoardDetector& _detect
     neighbors_dists.resize(all_corners_count);
 }
 
-static double pointSideFromLine(const Point2f& line_direction_vector, const Point2f& vector) {
+static double pointSideFromLine(const Point2f& line_direction_vector, const Point2f& vector)
+{
     return line_direction_vector.cross(vector);
 }
 
-static bool arePointsOnSameSideFromLine(const Point2f& line_pt1, const Point2f& line_pt2, const Point2f& pt1, const Point2f& pt2) {
+static bool arePointsOnSameSideFromLine(const Point2f& line_pt1, const Point2f& line_pt2, const Point2f& pt1, const Point2f& pt2)
+{
     const Point2f line_direction_vector = line_pt2 - line_pt1;
     const Point2f vector1 = pt1 - line_pt1;
     const Point2f vector2 = pt2 - line_pt1;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Idea was mentioned in `Section III-B. New Heuristic for Quadrangle Linking` of `Rufli, Martin & Scaramuzza, Davide & Siegwart, Roland. (2008). Automatic Detection of Checkerboards on Blurred and Distorted Images. 2008 IEEE/RSJ International Conference on Intelligent Robots and Systems, IROS. 3121-3126. 10.1109/IROS.2008.4650703` (https://rpg.ifi.uzh.ch/docs/IROS08_scaramuzza_b.pdf):
![Снимок экрана от 2024-08-05 09-51-27](https://github.com/user-attachments/assets/7a090ccc-c24c-4dfb-b0dd-259c8709eb72)
```
* For each candidate pair, focus on the quadrangles they belong to and draw two straight lines passing through the midsections of the respective quadrangle edges (see Fig. 6).
* If the candidate corner and the source corner are on the same side of every of the four straight lines drawn this way (this corresponds to the yellow shaded area in Fig. 6), then the corners are successfully matched.
```

By improving corners matching, we can increase the search radius (`thresh_scale`).

I tested this PR with benchmark
```
python3 objdetect_benchmark.py --configuration=generate_run --board_x=7 --path=res_chessboard --synthetic_object=chessboard
```
PR increases detected chessboards number by `3/7%`:
```
cell_img_size = 100 (default)

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.910417                      13110             14400                           0.599746
Total detected time:  147.50906700000002 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.941667                      13560             14400                           0.596726
Total detected time:  136.68963200000007 sec

----------------------------------------------------------------------------------------------------------------------------------------------

cell_img_size = 10

before
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.539792                       7773             14400                           4.208237
Total detected time:  2.668964 sec

after
                                 category  detected chessboard  total detected chessboard  total chessboard  average detected error chessboard
                                      all             0.579167                       8340             14400                           4.198448
Total detected time:  2.535998999999999 sec
```

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
