### PR TITLE
Fixed asserts in fillPoly

### DIFF
--- a/modules/imgproc/misc/python/test/test_imgproc.py
+++ b/modules/imgproc/misc/python/test/test_imgproc.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+class Imgproc_Tests(NewOpenCVTests):
+
+    def test_python_986(self):
+        cntls = []
+        img = np.zeros((100,100,3), dtype=np.uint8)
+        color = (0,0,0)
+        cnts = np.array(cntls, dtype=np.int32).reshape((1, -1, 2))
+        try:
+            cv.fillPoly(img, cnts, color)
+            assert False
+        except:
+            assert True

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -2044,8 +2044,11 @@ void fillPoly( InputOutputArray _img, const Point** pts, const int* npts, int nc
     edges.reserve( total + 1 );
     for (i = 0; i < ncontours; i++)
     {
-        std::vector<Point2l> _pts(pts[i], pts[i] + npts[i]);
-        CollectPolyEdges(img, _pts.data(), npts[i], edges, buf, line_type, shift, offset);
+        if (npts[i] > 0 && pts[i])
+        {
+            std::vector<Point2l> _pts(pts[i], pts[i] + npts[i]);
+            CollectPolyEdges(img, _pts.data(), npts[i], edges, buf, line_type, shift, offset);
+        }
     }
 
     FillEdgeCollection(img, edges, buf, line_type);
@@ -2430,7 +2433,7 @@ void cv::fillPoly(InputOutputArray img, InputArrayOfArrays pts,
     for( i = 0; i < ncontours; i++ )
     {
         Mat p = pts.getMat(manyContours ? i : -1);
-        CV_Assert(p.checkVector(2, CV_32S) >= 0);
+        CV_Assert(p.checkVector(2, CV_32S) > 0);
         ptsptr[i] = p.ptr<Point>();
         npts[i] = p.rows*p.cols*p.channels()/2;
     }


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv-python/issues/986

The PR changes checks in the function to disallow empty input.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
