### PR TITLE
imgproc: use double to determine whether the corners points are within src

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -475,6 +475,14 @@ public:
     template<typename _Tp2> operator Rect_<_Tp2>() const;
 
     //! checks whether the rectangle contains the point
+    /*! @note After 4.11.0, when calling Rect.contains() with cv::Point2f / cv::Point2d point, point should not convert/round to int.
+     * See https://github.com/opencv/opencv/issues/26016
+     * ```
+     * Rect_<int> r(0,0,500,500); Point_<float> p(250.0f, 499.9f).
+     * r.contains(pt) returns false(4.10.0-)
+     * r.contains(pt) returns true (4.11.0+)
+     * ```
+     */
     template<typename _Tp2> inline bool contains(const Point_<_Tp2>& pt) const;
 
     _Tp x; //!< x coordinate of the top-left corner

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -475,12 +475,11 @@ public:
     template<typename _Tp2> operator Rect_<_Tp2>() const;
 
     //! checks whether the rectangle contains the point
-    /*! @note After 4.11.0, when calling Rect.contains() with cv::Point2f / cv::Point2d point, point should not convert/round to int.
-     * See https://github.com/opencv/opencv/issues/26016
+    /*! @warning After OpenCV 4.11.0, when calling Rect.contains() with cv::Point2f / cv::Point2d point, point should not convert/round to int.
      * ```
-     * Rect_<int> r(0,0,500,500); Point_<float> p(250.0f, 499.9f).
-     * r.contains(pt) returns false(4.10.0-)
-     * r.contains(pt) returns true (4.11.0+)
+     * Rect_<int> r(0,0,500,500); Point_<float> pt(250.0f, 499.9f);
+     * r.contains(pt) returns false.(OpenCV 4.10.0 or before)
+     * r.contains(pt) returns true. (OpenCV 4.11.0 or later)
      * ```
      */
     template<typename _Tp2> inline bool contains(const Point_<_Tp2>& pt) const;

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -475,7 +475,7 @@ public:
     template<typename _Tp2> operator Rect_<_Tp2>() const;
 
     //! checks whether the rectangle contains the point
-    bool contains(const Point_<_Tp>& pt) const;
+    template<typename _Tp2> inline bool contains(const Point_<_Tp2>& pt) const;
 
     _Tp x; //!< x coordinate of the top-left corner
     _Tp y; //!< y coordinate of the top-left corner
@@ -1861,12 +1861,29 @@ Rect_<_Tp>::operator Rect_<_Tp2>() const
     return Rect_<_Tp2>(saturate_cast<_Tp2>(x), saturate_cast<_Tp2>(y), saturate_cast<_Tp2>(width), saturate_cast<_Tp2>(height));
 }
 
-template<typename _Tp> inline
-bool Rect_<_Tp>::contains(const Point_<_Tp>& pt) const
+template<typename _Tp> template<typename _Tp2> inline
+bool Rect_<_Tp>::contains(const Point_<_Tp2>& pt) const
 {
     return x <= pt.x && pt.x < x + width && y <= pt.y && pt.y < y + height;
 }
-
+// See https://github.com/opencv/opencv/issues/26016
+template<> template<> inline
+bool Rect_<int>::contains(const Point_<double>& pt) const
+{
+    // std::numeric_limits<int>::digits is 31.
+    // std::numeric_limits<double>::digits is 53.
+    // So conversion int->double does not lead to accuracy errors.
+    const Rect_<double> _rect(static_cast<double>(x), static_cast<double>(y), static_cast<double>(width), static_cast<double>(height));
+    return _rect.contains(pt);
+}
+template<> template<> inline
+bool Rect_<int>::contains(const Point_<float>& _pt) const
+{
+    // std::numeric_limits<float>::digits is 24.
+    // std::numeric_limits<double>::digits is 53.
+    // So conversion float->double does not lead to accuracy errors.
+    return contains(Point_<double>(static_cast<double>(_pt.x), static_cast<double>(_pt.y)));
+}
 
 template<typename _Tp> static inline
 Rect_<_Tp>& operator += ( Rect_<_Tp>& a, const Point_<_Tp>& b )

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -918,7 +918,7 @@ template<> float cv_nexttoward<float>(float v, float v2) { return std::nextafter
 template<> double cv_nexttoward<double>(double v, double v2) { return std::nexttoward(v,v2); }
 TYPED_TEST_P(Rect_Test, OnTheEdge) {
   Rect_<int> rect(0,0,500,500);
-  TypeParam h = rect.height;
+  TypeParam h = static_cast<TypeParam>(rect.height);
   ASSERT_TRUE ( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h - 1))));
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h    ))));
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h + 1))));

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -908,7 +908,22 @@ TYPED_TEST_P(Rect_Test, Overflows) {
   EXPECT_EQ(R(), R(20, 0, 10, 10) & R(0, num_lowest, 10, 10));
   EXPECT_EQ(R(), R(num_lowest, 0, 10, 10) & R(0, num_lowest, 10, 10));
 }
-REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows);
+
+// See https://github.com/opencv/opencv/issues/26016
+// Rect_<int>.contains(Point_<float/double>) needs template specialization.
+// This is test for a point on the edge and its nearest points.
+template<typename T> T cv_nexttoward(T v, T v2);
+template<> int cv_nexttoward<int>(int v, int v2) { CV_UNUSED(v); return v2; }
+template<> float cv_nexttoward<float>(float v, float v2) { return std::nextafter(v,v2); }
+template<> double cv_nexttoward<double>(double v, double v2) { return std::nexttoward(v,v2); }
+TYPED_TEST_P(Rect_Test, OnTheEdge) {
+  Rect_<int> rect(0,0,500,500);
+  TypeParam h = rect.height;
+  ASSERT_TRUE ( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h - 1))));
+  ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h    ))));
+  ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h + 1))));
+}
+REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge);
 
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);

--- a/modules/features2d/src/keypoint.cpp
+++ b/modules/features2d/src/keypoint.cpp
@@ -96,7 +96,9 @@ struct RoiPredicate
 
     bool operator()( const KeyPoint& keyPt ) const
     {
-        return !r.contains( keyPt.pt );
+        // workaround for https://github.com/opencv/opencv/issues/26016
+        // To keep its behaviour, keyPt.pt casts to Point_<int>.
+        return !r.contains( Point_<int>(keyPt.pt) );
     }
 
     Rect r;

--- a/modules/imgproc/src/cornersubpix.cpp
+++ b/modules/imgproc/src/cornersubpix.cpp
@@ -96,7 +96,7 @@ void cv::cornerSubPix( InputArray _image, InputOutputArray _corners,
     for( int pt_i = 0; pt_i < count; pt_i++ )
     {
         Point2f cT = corners[pt_i], cI = cT;
-        CV_Assert( Rect2f(0, 0, src.cols, src.rows).contains(cT) );
+        CV_Assert( Rect(0, 0, src.cols, src.rows).contains(cT) );
         int iter = 0;
         double err = 0;
 

--- a/modules/imgproc/src/cornersubpix.cpp
+++ b/modules/imgproc/src/cornersubpix.cpp
@@ -96,7 +96,7 @@ void cv::cornerSubPix( InputArray _image, InputOutputArray _corners,
     for( int pt_i = 0; pt_i < count; pt_i++ )
     {
         Point2f cT = corners[pt_i], cI = cT;
-        CV_Assert( Rect(0, 0, src.cols, src.rows).contains(cT) );
+        CV_Assert( Rect2f(0, 0, src.cols, src.rows).contains(cT) );
         int iter = 0;
         double err = 0;
 

--- a/modules/imgproc/src/cornersubpix.cpp
+++ b/modules/imgproc/src/cornersubpix.cpp
@@ -96,7 +96,7 @@ void cv::cornerSubPix( InputArray _image, InputOutputArray _corners,
     for( int pt_i = 0; pt_i < count; pt_i++ )
     {
         Point2f cT = corners[pt_i], cI = cT;
-        CV_Assert( Rect2f(0.0f, 0.0f, static_cast<float>(src.cols), static_cast<float>(src.rows)).contains(cT) );
+        CV_Assert( Rect2f(0, 0, src.cols, src.rows).contains(cT) );
         int iter = 0;
         double err = 0;
 

--- a/modules/imgproc/src/cornersubpix.cpp
+++ b/modules/imgproc/src/cornersubpix.cpp
@@ -96,7 +96,7 @@ void cv::cornerSubPix( InputArray _image, InputOutputArray _corners,
     for( int pt_i = 0; pt_i < count; pt_i++ )
     {
         Point2f cT = corners[pt_i], cI = cT;
-        CV_Assert( Rect2f(0, 0, src.cols, src.rows).contains(cT) );
+        CV_Assert( Rect2f(0.0f, 0.0f, static_cast<float>(src.cols), static_cast<float>(src.rows)).contains(cT) );
         int iter = 0;
         double err = 0;
 

--- a/modules/imgproc/test/test_cornersubpix.cpp
+++ b/modules/imgproc/test/test_cornersubpix.cpp
@@ -62,7 +62,7 @@ TEST(Imgproc_CornerSubPix, out_of_image_corners)
     cv::cornerSubPix(image, corners, win, zeroZone, criteria);
 
     ASSERT_EQ(corners.size(), 1u);
-    ASSERT_TRUE(Rect2f(0, 0, image.cols, image.rows).contains(corners.front()));
+    ASSERT_TRUE(Rect2f(0.0f, 0.0f, static_cast<float>(image.cols), static_cast<float>(image.rows)).contains(corners.front()));
 }
 
 // See https://github.com/opencv/opencv/issues/26016

--- a/modules/imgproc/test/test_cornersubpix.cpp
+++ b/modules/imgproc/test/test_cornersubpix.cpp
@@ -62,7 +62,34 @@ TEST(Imgproc_CornerSubPix, out_of_image_corners)
     cv::cornerSubPix(image, corners, win, zeroZone, criteria);
 
     ASSERT_EQ(corners.size(), 1u);
-    ASSERT_TRUE(Rect(0, 0, image.cols, image.rows).contains(corners.front()));
+    ASSERT_TRUE(Rect2f(0, 0, image.cols, image.rows).contains(corners.front()));
+}
+
+// See https://github.com/opencv/opencv/issues/26016
+TEST(Imgproc_CornerSubPix, corners_on_the_edge)
+{
+    cv::Mat image(500, 500, CV_8UC1);
+    cv::Size win(1, 1);
+    cv::Size zeroZone(-1, -1);
+    cv::TermCriteria criteria;
+
+    std::vector<cv::Point2f> cornersOK1 = { cv::Point2f(250, std::nextafter(499.5f, 499.5f - 1.0f)) };
+    EXPECT_NO_THROW( cv::cornerSubPix(image, cornersOK1, win, zeroZone, criteria) ) << cornersOK1;
+
+    std::vector<cv::Point2f> cornersOK2 = { cv::Point2f(250, 499.5f) };
+    EXPECT_NO_THROW( cv::cornerSubPix(image, cornersOK2, win, zeroZone, criteria) ) << cornersOK2;
+
+    std::vector<cv::Point2f> cornersOK3 = { cv::Point2f(250, std::nextafter(499.5f, 499.5f + 1.0f)) };
+    EXPECT_NO_THROW( cv::cornerSubPix(image, cornersOK3, win, zeroZone, criteria) ) << cornersOK3;
+
+    std::vector<cv::Point2f> cornersOK4 = { cv::Point2f(250, std::nextafter(500.0f, 500.0f - 1.0f)) };
+    EXPECT_NO_THROW( cv::cornerSubPix(image, cornersOK4, win, zeroZone, criteria) ) << cornersOK4;
+
+    std::vector<cv::Point2f> cornersNG1 = { cv::Point2f(250, 500.0f) };
+    EXPECT_ANY_THROW( cv::cornerSubPix(image, cornersNG1, win, zeroZone, criteria) ) << cornersNG1;
+
+    std::vector<cv::Point2f> cornersNG2 = { cv::Point2f(250, std::nextafter(500.0f, 500.0f + 1.0f)) };
+    EXPECT_ANY_THROW( cv::cornerSubPix(image, cornersNG2, win, zeroZone, criteria) ) << cornersNG2;
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_cornersubpix.cpp
+++ b/modules/imgproc/test/test_cornersubpix.cpp
@@ -62,7 +62,7 @@ TEST(Imgproc_CornerSubPix, out_of_image_corners)
     cv::cornerSubPix(image, corners, win, zeroZone, criteria);
 
     ASSERT_EQ(corners.size(), 1u);
-    ASSERT_TRUE(Rect2f(0.0f, 0.0f, static_cast<float>(image.cols), static_cast<float>(image.rows)).contains(corners.front()));
+    ASSERT_TRUE(Rect2f(0, 0, image.cols, image.rows).contains(corners.front()));
 }
 
 // See https://github.com/opencv/opencv/issues/26016

--- a/modules/imgproc/test/test_cornersubpix.cpp
+++ b/modules/imgproc/test/test_cornersubpix.cpp
@@ -62,7 +62,7 @@ TEST(Imgproc_CornerSubPix, out_of_image_corners)
     cv::cornerSubPix(image, corners, win, zeroZone, criteria);
 
     ASSERT_EQ(corners.size(), 1u);
-    ASSERT_TRUE(Rect2f(0, 0, image.cols, image.rows).contains(corners.front()));
+    ASSERT_TRUE(Rect(0, 0, image.cols, image.rows).contains(corners.front()));
 }
 
 // See https://github.com/opencv/opencv/issues/26016

--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -67,9 +67,11 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
     int tl_rect_count = 0, br_rect_count = 0, bad_count = 0;
     for (const auto &keypoint : roi_features.keypoints)
     {
-        if (rois[0].contains(keypoint.pt))
+        // Workaround for https://github.com/opencv/opencv/issues/26016
+        // To keep its behaviour, keypoint.pt casts to Point_<int>.
+        if (rois[0].contains(Point_<int>(keypoint.pt)))
             tl_rect_count++;
-        else if (rois[1].contains(keypoint.pt))
+        else if (rois[1].contains(Point_<int>(keypoint.pt)))
             br_rect_count++;
         else
             bad_count++;


### PR DESCRIPTION
close #26016 
Related https://github.com/opencv/opencv_contrib/pull/3778

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
