### PR TITLE
Fix: reduce redundant code by optimizing device name retrieval

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -1382,14 +1382,11 @@ int videoInput::listDevices(bool silent){
                  // Find the description or friendly name.
                 VARIANT varName;
                 VariantInit(&varName);
-                hr = pPropBag->Read(L"Description", &varName, 0);
+                hr = pPropBag->Read(L"FriendlyName", &varName, 0);
 
-                if (FAILED(hr)) hr = pPropBag->Read(L"FriendlyName", &varName, 0);
+                if (FAILED(hr)) hr = pPropBag->Read(L"Description", &varName, 0);
 
                 if (SUCCEEDED(hr)){
-
-                    hr = pPropBag->Read(L"FriendlyName", &varName, 0);
-
                     int count = 0;
                     int maxLen = sizeof(deviceNames[0])/sizeof(deviceNames[0][0]) - 2;
                     while( varName.bstrVal[count] != 0x00 && count < maxLen) {


### PR DESCRIPTION
Close #26033.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
