### PR TITLE
Init member variables in QueueSourceBase::Priv constructor initializa…

### DIFF
--- a/modules/gapi/src/streaming/queue_source.cpp
+++ b/modules/gapi/src/streaming/queue_source.cpp
@@ -20,9 +20,8 @@ namespace wip {
 
 class QueueSourceBase::Priv {
 public:
-    explicit Priv(const cv::GMetaArg &meta) {
-        m = meta;
-        halted = false;
+    explicit Priv(const cv::GMetaArg &meta)
+        : m(meta), halted(false) {
     }
 
     cv::GMetaArg m;


### PR DESCRIPTION
To improve preformence it is better to init the member variables in the initialization list.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
