### PR TITLE
Docfix - Remove notice on using deprecated itemset

### DIFF
--- a/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
+++ b/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
@@ -51,23 +51,6 @@ You can modify the pixel values the same way.
 Numpy is an optimized library for fast array calculations. So simply accessing each and every pixel
 value and modifying it will be very slow and it is discouraged.
 
-@note The above method is normally used for selecting a region of an array, say the first 5 rows
-and last 3 columns. For individual pixel access, the Numpy array methods, array.item() and
-array.itemset() are considered better. They always return a scalar, however, so if you want to access
-all the B,G,R values, you will need to call array.item() separately for each value.
-
-Better pixel accessing and editing method :
-@code{.py}
-# accessing RED value
->>> img.item(10,10,2)
-59
-
-# modifying RED value
->>> img.itemset((10,10,2),100)
->>> img.item(10,10,2)
-100
-@endcode
-
 Accessing Image Properties
 --------------------------
 


### PR DESCRIPTION
fix #26035

The tutorial of basic image operations https://docs.opencv.org/4.10.0/d3/df2/tutorial_py_basic_ops.html is still recommending using itemset. However this is now a deprecated functionality in Numpy 2.+ and in 1.+ there is a deprecation warning (or at least that is what they say).  

We can still keep the warning about single pixel accessing as in the big picture that is still valid to not encourage people to access single pixels like this, but .itemset ain't a good option anymore.

### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] N/A There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] N/A The feature is well documented and sample code can be built with the project CMake
