### PR TITLE
Add size() to CUDA PtrStepSz

### DIFF
--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -125,9 +125,9 @@ namespace cv
             int cols;
             int rows;
 
-            __CV_CUDA_HOST_DEVICE__ [[nodiscard]] Size size() const { return {cols, rows}; }
-            __CV_CUDA_HOST_DEVICE__       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
-            __CV_CUDA_HOST_DEVICE__ const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD Size size() const { return {cols, rows}; }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
         };
 
         typedef PtrStepSz<unsigned char> PtrStepSzb;

--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -124,6 +124,8 @@ namespace cv
 
             int cols;
             int rows;
+
+            __CV_CUDA_HOST_DEVICE__ [[nodiscard]] Size size() const { return {cols, rows}; }
         };
 
         typedef PtrStepSz<unsigned char> PtrStepSzb;

--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -66,13 +66,8 @@
     #define __CV_CUDA_HOST_DEVICE__
 #endif
 
-#ifdef __NVCC__
-#define CV_NODISCARD_NVCC
-#else
 #include "opencv2/core/cvdef.h"
-#define CV_NODISCARD_NVCC CV_NODISCARD_STD
-#endif
-
+#include "opencv2/core.hpp"
 
 namespace cv
 {
@@ -133,9 +128,10 @@ namespace cv
             int cols;
             int rows;
 
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC Size size() const { return {cols, rows}; }
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
+            CV_NODISCARD_STD __CV_CUDA_HOST_DEVICE__ Size size() const { return {cols, rows}; }
+            CV_NODISCARD_STD __CV_CUDA_HOST_DEVICE__ T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
+            CV_NODISCARD_STD __CV_CUDA_HOST_DEVICE__ const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
+            using PtrStep<T>::operator();
         };
 
         typedef PtrStepSz<unsigned char> PtrStepSzb;

--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -126,6 +126,8 @@ namespace cv
             int rows;
 
             __CV_CUDA_HOST_DEVICE__ [[nodiscard]] Size size() const { return {cols, rows}; }
+            __CV_CUDA_HOST_DEVICE__       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
+            __CV_CUDA_HOST_DEVICE__ const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
         };
 
         typedef PtrStepSz<unsigned char> PtrStepSzb;

--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -66,6 +66,14 @@
     #define __CV_CUDA_HOST_DEVICE__
 #endif
 
+#ifdef __NVCC__
+#define CV_NODISCARD_NVCC
+#else
+#include "opencv2/core/cvdef.h"
+#define CV_NODISCARD_NVCC CV_NODISCARD_STD
+#endif
+
+
 namespace cv
 {
     namespace cuda
@@ -125,9 +133,9 @@ namespace cv
             int cols;
             int rows;
 
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD Size size() const { return {cols, rows}; }
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
-            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_STD const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC Size size() const { return {cols, rows}; }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC       T& operator ()(const Point &pos)       { return (*this)(pos.y, pos.x); }
+            __CV_CUDA_HOST_DEVICE__ CV_NODISCARD_NVCC const T& operator ()(const Point &pos) const { return (*this)(pos.y, pos.x); }
         };
 
         typedef PtrStepSz<unsigned char> PtrStepSzb;

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -747,7 +747,11 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #    define __has_cpp_attribute(__x) 0
 #  endif
 #  if __has_cpp_attribute(nodiscard)
-#    define CV_NODISCARD_STD [[nodiscard]]
+#    if defined(__NVCC__) && __CUDACC_VER_MAJOR__ < 12
+#       define CV_NODISCARD_STD
+#    else
+#       define CV_NODISCARD_STD [[nodiscard]]
+#    endif
 #  elif __cplusplus >= 201703L
 //   available when compiler is C++17 compliant
 #    define CV_NODISCARD_STD [[nodiscard]]


### PR DESCRIPTION
According to [cppreference.com compiler support table](https://en.cppreference.com/w/cpp/compiler_support/17), `nvcc` supports `[[nodiscard]]` from version 11.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Related: https://github.com/opencv/opencv/pull/25659