### PR TITLE
Support Matrices with axes > 6 CUDA

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/tensor.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/tensor.hpp
@@ -28,7 +28,7 @@
 #include <utility>
 
 #ifndef CSL_MAX_TENSOR_RANK
-    #define CSL_MAX_TENSOR_RANK 6
+    #define CSL_MAX_TENSOR_RANK 7
 #endif
 
 namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_denylist.inl.hpp
@@ -90,7 +90,6 @@
 "test_scatternd_max",
 "test_scatternd_min",
 "test_scatternd_multiply",
-"test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded", // crash: https://github.com/opencv/opencv/issues/25471
 "test_dequantizelinear_blocked", // Issue https://github.com/opencv/opencv/issues/25999
 "test_quantizelinear", // Issue https://github.com/opencv/opencv/issues/25999
 "test_quantizelinear_axis", // Issue https://github.com/opencv/opencv/issues/25999


### PR DESCRIPTION
This PR fixes CUDA backend to support matrixes with number of axes > 6

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
