### PR TITLE
Supress more ONNX conformance test cases for quant-dequant with CUDA.

### DIFF
--- a/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_denylist.inl.hpp
@@ -91,3 +91,7 @@
 "test_scatternd_min",
 "test_scatternd_multiply",
 "test_nllloss_NCd1d2d3d4d5_none_no_weight_expanded", // crash: https://github.com/opencv/opencv/issues/25471
+"test_dequantizelinear_blocked", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear_axis", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear_blocked", // Issue https://github.com/opencv/opencv/issues/25999

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_fp16_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__cuda_fp16_denylist.inl.hpp
@@ -19,3 +19,7 @@
 "test_softmax_large_number", // fp16 accuracy issue
 "test_softmax_large_number_expanded", // fp16 accuracy issue
 "test_tan", // fp16 accuracy issue
+"test_dequantizelinear_blocked", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear_axis", // Issue https://github.com/opencv/opencv/issues/25999
+"test_quantizelinear_blocked", // Issue https://github.com/opencv/opencv/issues/25999


### PR DESCRIPTION
Introduced in: https://github.com/opencv/opencv/pull/25998
Related issue: https://github.com/opencv/opencv/issues/25999

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
