### PR TITLE
Fix rounding mode for test

### DIFF
--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -42,6 +42,7 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp" // T-API like tests
+#include <fenv.h>
 
 namespace opencv_test {
 namespace {
@@ -1596,9 +1597,12 @@ TEST_P(Core_Arith_Regression24163, test_for_ties_to_even)
     const Mat src2(matSize, matType, Scalar(beta, beta, beta, beta));
     const Mat result = ( src1 + src2 ) / 2;
 
-    // Expected that default is FE_TONEAREST(Ties to Even).
+    const int rounding = fegetround();
+    fesetround(FE_TONEAREST);
     const int mean = lrint( static_cast<double>(alpha + beta) / 2.0 );
-    const Mat expected(matSize, matType, Scalar(mean,mean,mean,mean));
+    fesetround(rounding);
+
+    const Mat expected(matSize, matType, Scalar::all(mean));
 
     // Compare result and extected.
     ASSERT_EQ(expected.size(), result.size());


### PR DESCRIPTION
Ensure rounding mode for lrint to fix interference with 3rd party libraries

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
