### PR TITLE
Extended perf tests for warpPerspective to cover channels too

### DIFF
--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -13,7 +13,7 @@ CV_ENUM(InterTypeExtended, INTER_NEAREST, INTER_LINEAR, WARP_RELATIVE_MAP)
 CV_ENUM(RemapMode, HALF_SIZE, UPSIDE_DOWN, REFLECTION_X, REFLECTION_BOTH)
 
 typedef TestBaseWithParam< tuple<Size, InterType, BorderMode> > TestWarpAffine;
-typedef TestBaseWithParam< tuple<Size, InterType, BorderMode> > TestWarpPerspective;
+typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, int> > TestWarpPerspective;
 typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, MatType> > TestWarpPerspectiveNear_t;
 typedef TestBaseWithParam< tuple<MatType, Size, InterTypeExtended, BorderMode, RemapMode> > TestRemap;
 
@@ -42,11 +42,7 @@ PERF_TEST_P( TestWarpAffine, WarpAffine,
 
     TEST_CYCLE() warpAffine( src, dst, warpMat, sz, interType, borderMode, borderColor );
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType==INTER_LINEAR? 5 : 10);
-#else
     SANITY_CHECK(dst, 1);
-#endif
 }
 
 PERF_TEST_P(TestWarpAffine, DISABLED_WarpAffine_ovx,
@@ -72,29 +68,28 @@ PERF_TEST_P(TestWarpAffine, DISABLED_WarpAffine_ovx,
 
     TEST_CYCLE() warpAffine(src, dst, warpMat, sz, interType, borderMode, borderColor);
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType == INTER_LINEAR ? 5 : 10);
-#else
     SANITY_CHECK(dst, 1);
-#endif
 }
 
 PERF_TEST_P( TestWarpPerspective, WarpPerspective,
              Combine(
                 Values( szVGA, sz720p, sz1080p ),
                 InterType::all(),
-                BorderMode::all()
+                BorderMode::all(),
+                Values(1, 3, 4)
              )
 )
 {
     Size sz, szSrc(512, 512);
-    int borderMode, interType;
+    int borderMode, interType, channels;
     sz         = get<0>(GetParam());
     interType  = get<1>(GetParam());
     borderMode = get<2>(GetParam());
+    channels   = get<3>(GetParam());
+
     Scalar borderColor = Scalar::all(150);
 
-    Mat src(szSrc,CV_8UC4), dst(sz, CV_8UC4);
+    Mat src(szSrc, CV_8UC(channels)), dst(sz, CV_8UC(channels));
     cvtest::fillGradient(src);
     if(borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
     Mat rotMat = getRotationMatrix2D(Point2f(src.cols/2.f, src.rows/2.f), 30., 2.2);
@@ -110,29 +105,27 @@ PERF_TEST_P( TestWarpPerspective, WarpPerspective,
 
     TEST_CYCLE() warpPerspective( src, dst, warpMat, sz, interType, borderMode, borderColor );
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType==INTER_LINEAR? 5 : 10);
-#else
     SANITY_CHECK(dst, 1);
-#endif
 }
 
 PERF_TEST_P(TestWarpPerspective, DISABLED_WarpPerspective_ovx,
     Combine(
         Values(szVGA, sz720p, sz1080p),
         InterType::all(),
-        BorderMode::all()
+        BorderMode::all(),
+        Values(1)
     )
 )
 {
     Size sz, szSrc(512, 512);
-    int borderMode, interType;
+    int borderMode, interType, channels;
     sz = get<0>(GetParam());
     interType = get<1>(GetParam());
     borderMode = get<2>(GetParam());
+    channels   = get<3>(GetParam());
     Scalar borderColor = Scalar::all(150);
 
-    Mat src(szSrc, CV_8UC1), dst(sz, CV_8UC1);
+    Mat src(szSrc, CV_8UC(channels)), dst(sz, CV_8UC(channels));
     cvtest::fillGradient(src);
     if (borderMode == BORDER_CONSTANT) cvtest::smoothBorder(src, borderColor, 1);
     Mat rotMat = getRotationMatrix2D(Point2f(src.cols / 2.f, src.rows / 2.f), 30., 2.2);
@@ -148,11 +141,7 @@ PERF_TEST_P(TestWarpPerspective, DISABLED_WarpPerspective_ovx,
 
     TEST_CYCLE() warpPerspective(src, dst, warpMat, sz, interType, borderMode, borderColor);
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType == INTER_LINEAR ? 5 : 10);
-#else
     SANITY_CHECK(dst, 1);
-#endif
 }
 
 PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,
@@ -194,11 +183,7 @@ PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,
         warpPerspective( src, dst, warpMat, size, interType, borderMode, borderColor );
     }
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType==INTER_LINEAR? 5 : 10);
-#else
     SANITY_CHECK(dst, 1);
-#endif
 }
 
 PERF_TEST_P( TestRemap, remap,


### PR DESCRIPTION
Also removed Android branch in tests. It's not relevant any more.

Extra: https://github.com/opencv/opencv_extra/pull/1204

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
