### PR TITLE
Fixed the simd bugs of iPow8u and iPow16u

### DIFF
--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -704,7 +704,7 @@ OCL_PERF_TEST_P(PowFixture, iPow, ::testing::Combine(
 
     OCL_TEST_CYCLE() cv::pow(src, 7.0, dst);
 
-    SANITY_CHECK(dst, 1.5e-6, ERROR_RELATIVE);
+    SANITY_CHECK_NOTHING();
 }
 ///////////// AddWeighted////////////////////////
 

--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -688,6 +688,24 @@ OCL_PERF_TEST_P(PowFixture, Pow, ::testing::Combine(
     SANITY_CHECK(dst, 1.5e-6, ERROR_RELATIVE);
 }
 
+///////////// iPow ////////////////////////
+OCL_PERF_TEST_P(PowFixture, iPow, ::testing::Combine(
+                OCL_TEST_SIZES, OCL_PERF_ENUM(CV_8UC1, CV_8SC1,CV_16UC1,CV_16SC1,CV_32SC1)))
+{
+    const Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int type = get<1>(params);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, type);
+
+    UMat src(srcSize, type), dst(srcSize, type);
+    randu(src, 0, 100);
+    declare.in(src).out(dst);
+
+    OCL_TEST_CYCLE() cv::pow(src, 7.0, dst);
+
+    SANITY_CHECK(dst, 1.5e-6, ERROR_RELATIVE);
+}
 ///////////// AddWeighted////////////////////////
 
 typedef Size_MatType AddWeightedFixture;

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -791,7 +791,7 @@ struct iPow_SIMD
 #if (CV_SIMD || CV_SIMD_SCALABLE)
 
 template <>
-struct iPow_SIMD<uchar, int>
+struct iPow_SIMD<uchar, unsigned>
 {
     int operator() ( const uchar * src, uchar * dst, int len, int power )
     {
@@ -871,7 +871,7 @@ struct iPow_SIMD<schar, int>
 };
 
 template <>
-struct iPow_SIMD<ushort, int>
+struct iPow_SIMD<ushort, unsigned>
 {
     int operator() ( const ushort * src, ushort * dst, int len, int power)
     {


### PR DESCRIPTION
Add the following cases in opencv_perf_core:

* OCL_PowFixture_iPow.iPow/0, where GetParam() = (640x480, 8UC1)
* OCL_PowFixture_iPow.iPow/2, where GetParam() = (640x480, 16UC1)

iPow8u and iPow16u failed to call to simd accelerating while executing.

Fix the bug by changing the input type of iPow_SIMD function.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
