### PR TITLE
Enable `CV_SIMD_SCALABLE` for median blur.

### DIFF
--- a/modules/imgproc/src/median_blur.simd.hpp
+++ b/modules/imgproc/src/median_blur.simd.hpp
@@ -845,7 +845,7 @@ void medianBlur(const Mat& src0, /*const*/ Mat& dst, int ksize)
     CV_INSTRUMENT_REGION();
 
     bool useSortNet = ksize == 3 || (ksize == 5
-#if !(CV_SIMD)
+#if !((CV_SIMD || CV_SIMD_SCALABLE))
             && ( src0.depth() > CV_8U || src0.channels() == 2 || src0.channels() > 4 )
 #endif
         );
@@ -881,7 +881,7 @@ void medianBlur(const Mat& src0, /*const*/ Mat& dst, int ksize)
 
         double img_size_mp = (double)(src0.total())/(1 << 20);
         if( ksize <= 3 + (img_size_mp < 1 ? 12 : img_size_mp < 4 ? 6 : 2)*
-            (CV_SIMD ? 1 : 3))
+            ((CV_SIMD || CV_SIMD_SCALABLE) ? 1 : 3))
             medianBlur_8u_Om( src, dst, ksize );
         else
             medianBlur_8u_O1( src, dst, ksize );


### PR DESCRIPTION
In the process of evolving Universal intrinsic from "wide" to "scalable", we have widly appended `|| CV_SIMD_SCALABLE` to the macro `CV_SIMD`. But it seems that we missed two macros in median blur, and this patch fixes this part.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
