### PR TITLE
Optimize RowVec_8u32f SIMD

### DIFF
--- a/modules/imgproc/src/filter.simd.hpp
+++ b/modules/imgproc/src/filter.simd.hpp
@@ -490,10 +490,20 @@ struct RowVec_8u32f
             {
                 v_float32 f = vx_setall_f32(_kx[k]);
                 const uchar* src = (const uchar*)_src + i + k * cn;
-                v_float32 vs_ll = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(src)));
-                v_float32 vs_lh = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(src + VTraits<v_float32>::vlanes())));
-                v_float32 vs_hl = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(src + 2*VTraits<v_float32>::vlanes())));
-                v_float32 vs_hh = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(src + 3*VTraits<v_float32>::vlanes())));
+                v_uint8 v_src = vx_load(src);
+                v_uint16 v_src_d0; 
+                v_uint16 v_src_d1; 
+                v_expand(v_src, v_src_d0, v_src_d1);
+                v_uint32 v_src_q0;
+                v_uint32 v_src_q1;
+                v_uint32 v_src_q2;
+                v_uint32 v_src_q3;
+                v_expand(v_src_d0, v_src_q0, v_src_q1);
+                v_expand(v_src_d1, v_src_q2, v_src_q3);
+                v_float32 vs_ll = v_cvt_f32(v_reinterpret_as_s32(v_src_q0));
+                v_float32 vs_lh = v_cvt_f32(v_reinterpret_as_s32(v_src_q1));
+                v_float32 vs_hl = v_cvt_f32(v_reinterpret_as_s32(v_src_q2));
+                v_float32 vs_hh = v_cvt_f32(v_reinterpret_as_s32(v_src_q3));
                 s0 = v_muladd(vs_ll, f, s0);
                 s1 = v_muladd(vs_lh, f, s1);
                 s2 = v_muladd(vs_hl, f, s2);

--- a/modules/imgproc/src/filter.simd.hpp
+++ b/modules/imgproc/src/filter.simd.hpp
@@ -491,8 +491,8 @@ struct RowVec_8u32f
                 v_float32 f = vx_setall_f32(_kx[k]);
                 const uchar* src = (const uchar*)_src + i + k * cn;
                 v_uint8 v_src = vx_load(src);
-                v_uint16 v_src_d0; 
-                v_uint16 v_src_d1; 
+                v_uint16 v_src_d0;
+                v_uint16 v_src_d1;
                 v_expand(v_src, v_src_d0, v_src_d1);
                 v_uint32 v_src_q0;
                 v_uint32 v_src_q1;


### PR DESCRIPTION
Currently, OpenCV uses 4 v_load_expand_q, which loads four times and expands four times. Generally, less load results to lower latency. The same job can be done using one load and six expand.

Specifically, take AVX2 as an example. Old SIMD uses 4 `_mm_loadl_epi64` and 4 `_mm256_cvtepu8_epi32` whose latency is 36. New SIMD uses 1 `_mm256_loadu_si256`, 2 `_mm256_cvtepu8_epi16`, 4 `_mm256_cvtepu16_epi32` and 6 `_mm256_castsi256_si128` whose latency is 25.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
