### PR TITLE
Disable strict mode when reading avif files

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -143,6 +143,7 @@ AvifDecoder::AvifDecoder() {
   m_buf_supported = true;
   channels_ = 0;
   decoder_ = avifDecoderCreate();
+  decoder_->strictFlags = AVIF_STRICT_DISABLED;
 }
 
 AvifDecoder::~AvifDecoder() {
@@ -166,6 +167,7 @@ bool AvifDecoder::checkSignature(const String &signature) const {
   std::unique_ptr<avifDecoder, decltype(&avifDecoderDestroy)> decoder(
       avifDecoderCreate(), avifDecoderDestroy);
   if (!decoder) return false;
+  decoder->strictFlags = AVIF_STRICT_DISABLED;
   OPENCV_AVIF_CHECK_STATUS(
       avifDecoderSetIOMemory(
           decoder.get(), reinterpret_cast<const uint8_t *>(signature.c_str()),


### PR DESCRIPTION
This is to increase the compatibility with AVIF files (especially older ones).

This fixes https://github.com/opencv/opencv/issues/26011

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
