### PR TITLE
Add Support for Hardmax Layer

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -274,6 +274,12 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<EinsumLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS HardmaxLayer : public Layer
+    {
+    public:
+        static Ptr<HardmaxLayer> create(const LayerParams& params);
+    };
+
     class CV_EXPORTS BaseConvolutionLayer : public Layer
     {
     public:

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -196,6 +196,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(GRU,            GRULayer);
     CV_DNN_REGISTER_LAYER_CLASS(CumSum,         CumSumLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Einsum,         EinsumLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Hardmax,        HardmaxLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Scatter,        ScatterLayer);
     CV_DNN_REGISTER_LAYER_CLASS(ScatterND,      ScatterNDLayer);

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -96,13 +96,13 @@ public:
 
         switch (src.depth())
         {
-            case CV_8U:  hardmaxImpl<uchar>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_8S:  hardmaxImpl<schar>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_16U: hardmaxImpl<ushort>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_16S: hardmaxImpl<short>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_32S: hardmaxImpl<int>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_32F: hardmaxImpl<float>(src, dst, shape, strides, indices, count, axis); break;
-            case CV_64F: hardmaxImpl<double>(src, dst, shape, strides, indices, count, axis); break;
+            case CV_8U:  hardmaxImpl<uchar>(src, dst, shape, strides, indices, count); break;
+            case CV_8S:  hardmaxImpl<schar>(src, dst, shape, strides, indices, count); break;
+            case CV_16U: hardmaxImpl<ushort>(src, dst, shape, strides, indices, count); break;
+            case CV_16S: hardmaxImpl<short>(src, dst, shape, strides, indices, count); break;
+            case CV_32S: hardmaxImpl<int>(src, dst, shape, strides, indices, count); break;
+            case CV_32F: hardmaxImpl<float>(src, dst, shape, strides, indices, count); break;
+            case CV_64F: hardmaxImpl<double>(src, dst, shape, strides, indices, count); break;
             default:
                 CV_Error(Error::StsUnsupportedFormat, "Unsupported input data type");
         }
@@ -110,20 +110,24 @@ public:
 
     template<typename T>
     void hardmaxImpl(const Mat& src, Mat& dst, const MatShape& shape, const std::vector<size_t>& strides,
-                     std::vector<int>& indices, size_t count, int axis)
+                     std::vector<int>& indices, size_t count)
     {
         for (size_t i = 0; i < count; ++i)
         {
             // Find max element along the axis
             T max_val = std::numeric_limits<T>::lowest();
             int max_idx = -1;
+
+            size_t base_offset = 0;
+            for (int k = 0; k < src.dims; ++k) {
+                if (k != axis) {
+                    base_offset += indices[k] * strides[k];
+                }
+            }
+
             for (int j = 0; j < shape[axis]; ++j)
             {
-                indices[axis] = j;
-                size_t offset = 0;
-                for (int k = 0; k < src.dims; ++k)
-                    offset += indices[k] * strides[k];
-
+                size_t offset = base_offset + j * strides[axis];
                 T val = src.ptr<T>()[offset];
                 if (val > max_val)
                 {

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -1,0 +1,146 @@
+#include <inttypes.h>
+ #include <opencv2/dnn/shape_utils.hpp>
+ #include "../precomp.hpp"
+ #include "layers_common.hpp"
+
+namespace cv
+{
+namespace dnn
+{
+
+class LayerHardmaxImpl CV_FINAL : public HardmaxLayer
+{
+public:
+    int axis;
+    LayerHardmaxImpl(const LayerParams& params)
+    {
+        axis = params.get<int>("axis", -1);
+    }
+
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV ||
+               backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;
+    }
+
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        outputs.resize(1);
+        outputs[0] = inputs[0];
+        return true;
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        if (inputs_arr.depth() == CV_16F)
+        {
+            forward_fallback(inputs_arr, outputs_arr, internals_arr);
+            return;
+        }
+
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        Mat src = inputs[0];
+        Mat dst = outputs[0];
+        std::cout << "input shape: " << src.size << std::endl;
+        std::cout << "input type: " << src.type() << std::endl;
+
+        std::cout << "output shape: " << dst.size << std::endl;
+        std::cout << "output type: " << dst.type() << std::endl;
+
+        int dims = src.dims;
+        int real_axis = normalize_axis(axis, dims);
+        std::cout << "axis: " << axis << std::endl;
+        std::cout << "dims: " << dims << std::endl;
+        std::cout << "actual_axis: " << real_axis << std::endl;
+        MatShape shape(src.size.p, src.size.p + src.dims);
+
+        // print all elements of src
+        for (int i = 0; i < src.total(); ++i)
+        {
+            std::cout << src.ptr<float>()[i] << " ";
+        }
+        std::cout << std::endl;
+
+        // Calculate strides for efficient iteration
+        std::vector<size_t> strides(src.dims);
+        size_t total = 1;
+        for (int i = src.dims - 1; i >= 0; --i)
+        {
+            strides[i] = total;
+            total *= shape[i];
+        }
+        std::cout << "strides: " << strides << std::endl;
+        std::cout << "shape: " << shape << std::endl;
+        std::cout << "total: " << total << std::endl;
+
+        // Prepare output
+        dst.create(shape, src.type());
+        dst = Scalar(0);
+
+
+
+        // Iterate over all elements except the axis dimension
+        std::vector<int> indices(src.dims, 0);
+        size_t count = total / shape[real_axis];
+        for (size_t i = 0; i < count; ++i)
+        {
+            // Find max element along the axis
+            float max_val = -std::numeric_limits<float>::max();
+            int max_idx = -1;
+            for (int j = 0; j < shape[real_axis]; ++j)
+            {
+                indices[real_axis] = j;
+                size_t offset = 0;
+                for (int k = 0; k < src.dims; ++k)
+                    offset += indices[k] * strides[k];
+                float val = src.ptr<float>()[offset];
+                if (val > max_val)
+                {
+                    max_val = val;
+                    max_idx = j;
+                }
+            }
+
+            // Set the max element to 1, others to 0
+            indices[real_axis] = max_idx;
+            size_t offset = 0;
+            for (int k = 0; k < src.dims; ++k)
+                offset += indices[k] * strides[k];
+
+            dst.ptr<float>()[offset] = 1.0f;
+
+            // Update indices for the next iteration
+            for (int j = src.dims - 1; j >= 0; --j)
+            {
+                if (j == real_axis) continue;
+                if (++indices[j] < shape[j]) break;
+                indices[j] = 0;
+            }
+        }
+
+
+    }
+
+
+};
+
+
+Ptr<HardmaxLayer> HardmaxLayer::create(const LayerParams& params)
+{
+    return Ptr<HardmaxLayer>(new LayerHardmaxImpl(params));
+}
+
+}}

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -138,17 +138,12 @@ public:
                     if (src_ptr[src_idx] > max_val)
                     {
                         max_val = src_ptr[src_idx];
-                        max_idx = mid;
+                        max_idx = src_idx;
                     }
                 }
 
                 // Set 1 for max, 0 for others
-                for (size_t mid = 0; mid < mid_size; ++mid)
-                {
-                    const size_t dst_idx = dst_offset + mid * inner_size + inner;
-                    if (mid == max_idx)
-                        dst_ptr[dst_idx] = 1;
-                }
+                dst_ptr[max_idx] = 1;
             }
         }
     }

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -73,13 +73,11 @@ public:
         Mat src = inputs[0];
         Mat dst = outputs[0];
 
-        int dims = src.dims;
-        axis = normalize_axis(axis, dims);
+        axis = normalize_axis(axis, src.dims);
         MatShape shape(src.size.p, src.size.p + src.dims);
 
         // Prepare output
-        dst.create(shape, src.type());
-        dst = Scalar(0);
+        dst = Mat::zeros(src.dims, src.size, src.type());
 
         switch (src.depth())
         {
@@ -104,9 +102,7 @@ public:
         const size_t outer_size = src.total(0, axis);
         const auto mid_size = static_cast<size_t>(src.size[axis]);
         const size_t inner_size = src.total(axis + 1);
-
         const size_t outer_step = src.total(axis);
-        const size_t dst_step = dst.total(axis);
 
         for (size_t outer = 0; outer < outer_size; ++outer)
         {

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -77,22 +77,9 @@ public:
         axis = normalize_axis(axis, dims);
         MatShape shape(src.size.p, src.size.p + src.dims);
 
-        // Calculate strides for efficient iteration
-        std::vector<size_t> strides(src.dims);
-        size_t total = 1;
-        for (int i = src.dims - 1; i >= 0; --i)
-        {
-            strides[i] = total;
-            total *= shape[i];
-        }
-
         // Prepare output
         dst.create(shape, src.type());
         dst = Scalar(0);
-
-        // Iterate over all elements except the axis dimension
-        std::vector<int> indices(src.dims, 0);
-        size_t count = total / shape[axis];
 
         switch (src.depth())
         {
@@ -124,7 +111,6 @@ public:
         for (size_t outer = 0; outer < outer_size; ++outer)
         {
             const size_t outer_offset = outer * outer_step;
-            const size_t dst_offset = outer * dst_step;
 
             for (size_t inner = 0; inner < inner_size; ++inner)
             {

--- a/modules/dnn/src/layers/harmax.cpp
+++ b/modules/dnn/src/layers/harmax.cpp
@@ -146,7 +146,8 @@ public:
                 for (size_t mid = 0; mid < mid_size; ++mid)
                 {
                     const size_t dst_idx = dst_offset + mid * inner_size + inner;
-                    dst_ptr[dst_idx] = (mid == max_idx) ? 1 : 0;
+                    if (mid == max_idx)
+                        dst_ptr[dst_idx] = 1;
                 }
             }
         }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -197,6 +197,7 @@ private:
     void parseLayerNorm            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSimpleLayers         (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseEinsum               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseHardmax              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
 
     // Domain: com.microsoft
     // URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
@@ -3190,6 +3191,20 @@ void ONNXImporter::parseSimpleLayers(LayerParams& layerParams, const opencv_onnx
     addLayer(layerParams, node_proto);
 }
 
+void ONNXImporter::parseHardmax(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "Hardmax";
+
+    // hadnle parameter axis
+    int axis = layerParams.get<int>("axis", -1);
+    if (axis == -1) {
+        axis = static_cast<int>(outShapes[node_proto.input(0)].size()) - 1;
+    }
+    layerParams.set("axis", axis);
+
+    addLayer(layerParams, node_proto);
+}
+
 void ONNXImporter::parseEinsum(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     std::vector<MatShape> einsumInpShapes;
@@ -3981,6 +3996,7 @@ void ONNXImporter::buildDispatchMap_ONNX_AI(int opset_version)
     dispatch["Where"] = &ONNXImporter::parseElementWise;
     dispatch["Range"] = &ONNXImporter::parseRange;
     dispatch["Einsum"] = &ONNXImporter::parseEinsum;
+    dispatch["Hardmax"] = &ONNXImporter::parseHardmax;
 
     std::vector<std::string> simpleLayers{"Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",
                                           "Cosh", "Dropout", "Erf", "Exp", "Floor", "HardSigmoid", "HardSwish",

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3194,14 +3194,6 @@ void ONNXImporter::parseSimpleLayers(LayerParams& layerParams, const opencv_onnx
 void ONNXImporter::parseHardmax(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "Hardmax";
-
-    // hadnle parameter axis
-    int axis = layerParams.get<int>("axis", -1);
-    if (axis == -1) {
-        axis = static_cast<int>(outShapes[node_proto.input(0)].size()) - 1;
-    }
-    layerParams.set("axis", axis);
-
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -128,13 +128,6 @@
 "test_gru_defaults", // ---- same as above ---
 "test_gru_seq_length", // ---- same as above ---
 "test_gru_with_initial_bias", // ---- same as above ---
-"test_hardmax_axis_0", // Issues::Layer::Can't create layer "onnx_node_output_0!y" of type "Hardmax" in function 'getLayerInstance'
-"test_hardmax_axis_1",  // ---- same as above ---
-"test_hardmax_axis_2",  // ---- same as above ---
-"test_hardmax_default_axis",  // ---- same as above ---
-"test_hardmax_example",  // ---- same as above ---
-"test_hardmax_negative_axis",  // ---- same as above ---
-"test_hardmax_one_hot",  // ---- same as above ---
 "test_identity_opt", //  23221 illegal hardware instruction
 "test_identity_sequence",  // Issue:: Unkonwn error
 "test_if", // Issue::'Graph' is not supported in function 'getLayerParams'


### PR DESCRIPTION
This PR add support for `Hardmax` layer, which as previously listed in conformance deny list. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
