### PR TITLE
Added offset for HAL as ofs2idx expects 1-based index

### DIFF
--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -847,7 +847,7 @@ static MinMaxIdxFunc getMinmaxTab(int depth)
 }
 
 // The function expects 1-based indexing for ofs
-// Zero is trited as invalid offset (not found)
+// Zero is treated as invalid offset (not found)
 static void ofs2idx(const Mat& a, size_t ofs, int* idx)
 {
     int i, d = a.dims;

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -846,6 +846,8 @@ static MinMaxIdxFunc getMinmaxTab(int depth)
     return minmaxTab[depth];
 }
 
+// The function expects 1-based indexing for ofs
+// Zero is trited as invalid offset (not found)
 static void ofs2idx(const Mat& a, size_t ofs, int* idx)
 {
     int i, d = a.dims;
@@ -1524,9 +1526,9 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
         {
             // minIdx[0] and minIdx[0] are always 0 for "flatten" version
             if (minIdx)
-                ofs2idx(src, minIdx[1], minIdx);
+                ofs2idx(src, minIdx[1]+1, minIdx);
             if (maxIdx)
-                ofs2idx(src, maxIdx[1], maxIdx);
+                ofs2idx(src, maxIdx[1]+1, maxIdx);
             return;
         }
         else if (res != CV_HAL_ERROR_NOT_IMPLEMENTED)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
