### PR TITLE
RISC-V: fix installation process

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -423,9 +423,6 @@ elseif(RISCV)
 
   ocv_update(CPU_RVV_FLAGS_CONFLICT "-march=[^ ]*")
 
-  if(NOT ${BUILD_SHARED_LIBS}) # static build for k230
-    add_extra_compiler_option("-static -static-libgcc -static-libstdc++")
-  endif()
   set(CPU_DISPATCH "FP16;RVV_ZVFH" CACHE STRING "${HELP_CPU_DISPATCH}")
   set(CPU_BASELINE "DETECT" CACHE STRING "${HELP_CPU_BASELINE}")
 


### PR DESCRIPTION
Installation process has been broken due to extra options added for RISC-V in #25743. Weekly builds failed because the are using `ninja install` (https://github.com/opencv/ci-gha-workflow/actions/runs/10640797355).

It should be possible to add extra options in custom build by modifying `CMAKE_CXX_FLAGS` or `OPENCV_EXTRA_CXX_FLAGS`. 