### PR TITLE
Drop remaning C CV_FUNCTION_NAME as it's not used any more.

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1830,27 +1830,6 @@ cv::error((status),(func),(context),__FILE__,__LINE__)
 Func;                                                           \
 }
 
-
-/** CV_FUNCNAME macro defines icvFuncName constant which is used by CV_ERROR macro */
-#ifdef CV_NO_FUNC_NAMES
-#define CV_FUNCNAME( Name )
-#define cvFuncName ""
-#else
-#define CV_FUNCNAME( Name )  \
-static char cvFuncName[] = Name
-#endif
-
-
-/**
- CV_ERROR macro unconditionally raises error with passed code and message.
- After raising error, control will be transferred to the exit label.
- */
-#define CV_ERROR( Code, Msg )                                       \
-{                                                                   \
-    cv::error( (Code), cvFuncName, Msg, __FILE__, __LINE__ );        \
-    __CV_EXIT__;                                                   \
-}
-
 /**
  CV_CHECK macro checks error status after CV (or IPL)
  function call. If error detected, control will be transferred to the exit

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -851,8 +851,6 @@ double cvGetOpenGlProp_W32(const char* name)
     double result = -1;
 
 #ifdef HAVE_OPENGL
-    CV_FUNCNAME("cvGetOpenGlProp_W32");
-
     AutoLock lock(getWindowMutex());
 
     if (!name)
@@ -894,8 +892,6 @@ namespace
 {
     void createGlContext(HWND hWnd, HDC& hGLDC, HGLRC& hGLRC, bool& useGl)
     {
-        CV_FUNCNAME("createGlContext");
-
         AutoLock lock(getWindowMutex());
 
         useGl = false;
@@ -947,8 +943,6 @@ namespace
 
     void releaseGlContext(CvWindow& window)
     {
-        //CV_FUNCNAME("releaseGlContext");
-
         AutoLock lock(getWindowMutex());
 
         if (window.hGLRC)
@@ -968,8 +962,6 @@ namespace
 
     void drawGl(CvWindow& window)
     {
-        CV_FUNCNAME("drawGl");
-
         AutoLock lock(getWindowMutex());
 
         if (!wglMakeCurrent(window.dc, window.hGLRC))
@@ -986,8 +978,6 @@ namespace
 
     void resizeGl(CvWindow& window)
     {
-        CV_FUNCNAME("resizeGl");
-
         AutoLock lock(getWindowMutex());
 
         if (!wglMakeCurrent(window.dc, window.hGLRC))
@@ -1119,8 +1109,6 @@ static std::shared_ptr<CvWindow> namedWindow_(const std::string& name, int flags
 
 void setOpenGLContextImpl(const char* name)
 {
-    CV_FUNCNAME("setOpenGLContextImpl");
-
     AutoLock lock(getWindowMutex());
 
     if (!name)
@@ -1139,8 +1127,6 @@ void setOpenGLContextImpl(const char* name)
 
 void updateWindowImpl(const char* name)
 {
-    CV_FUNCNAME("updateWindowImpl");
-
     AutoLock lock(getWindowMutex());
 
     if (!name)
@@ -1155,8 +1141,6 @@ void updateWindowImpl(const char* name)
 
 void setOpenGLDrawCallbackImpl(const char* name, CvOpenGlDrawCallback callback, void* userdata)
 {
-    CV_FUNCNAME("cvCreateOpenGLCallback");
-
     AutoLock lock(getWindowMutex());
 
     if (!name)

--- a/modules/highgui/src/window_winrt.cpp
+++ b/modules/highgui/src/window_winrt.cpp
@@ -48,8 +48,6 @@ void cv::winrt_initContainer(::Windows::UI::Xaml::Controls::Panel^ _container)
 
 void showImageImpl(const char* name, InputArray arr)
 {
-    CV_FUNCNAME("showImageImpl");
-
     __BEGIN__;
 
     if (!name)
@@ -72,8 +70,6 @@ void showImageImpl(const char* name, InputArray arr)
 
 int namedWindowImpl(const char* name, int flags)
 {
-    CV_FUNCNAME("namedWindowImpl");
-
     if (!name)
         CV_Error(cv::Error::StsNullPtr, "NULL name");
 
@@ -84,8 +80,6 @@ int namedWindowImpl(const char* name, int flags)
 
 void destroyWindowImpl(const char* name)
 {
-    CV_FUNCNAME("destroyWindowImpl");
-
     if (!name)
         CV_Error(cv::Error::StsNullPtr, "NULL name string");
 
@@ -100,8 +94,6 @@ void destroyAllWindowsImpl()
 int createTrackbar2Impl(const char* trackbar_name, const char* window_name,
     int* val, int count, CvTrackbarCallback2 on_notify, void* userdata)
 {
-    CV_FUNCNAME("createTrackbar2Impl");
-
     int pos = 0;
 
     if (!window_name || !trackbar_name)
@@ -124,8 +116,6 @@ int createTrackbar2Impl(const char* trackbar_name, const char* window_name,
 
 void setTrackbarPosImpl(const char* trackbar_name, const char* window_name, int pos)
 {
-    CV_FUNCNAME("setTrackbarPosImpl");
-
     CvTrackbar* trackbar = 0;
 
     if (trackbar_name == 0 || window_name == 0)
@@ -141,8 +131,6 @@ void setTrackbarPosImpl(const char* trackbar_name, const char* window_name, int 
 
 void setTrackbarMaxImpl(const char* trackbar_name, const char* window_name, int maxval)
 {
-    CV_FUNCNAME("setTrackbarMaxImpl");
-
     if (maxval >= 0)
     {
         if (trackbar_name == 0 || window_name == 0)
@@ -157,8 +145,6 @@ void setTrackbarMaxImpl(const char* trackbar_name, const char* window_name, int 
 
 void setTrackbarMinImpl(const char* trackbar_name, const char* window_name, int minval)
 {
-    CV_FUNCNAME("setTrackbarMinImpl");
-
     if (minval >= 0)
     {
         if (trackbar_name == 0 || window_name == 0)
@@ -174,8 +160,6 @@ void setTrackbarMinImpl(const char* trackbar_name, const char* window_name, int 
 int getTrackbarPosImpl(const char* trackbar_name, const char* window_name)
 {
     int pos = -1;
-
-    CV_FUNCNAME("getTrackbarPosImpl");
 
     if (trackbar_name == 0 || window_name == 0)
         CV_Error(cv::Error::StsNullPtr, "NULL trackbar or window name");
@@ -211,8 +195,6 @@ int waitKeyImpl(int delay)
 void setMouseCallbackImpl(const char* window_name, CvMouseCallback on_mouse, void* param)
 {
     CV_WINRT_NO_GUI_ERROR("setMouseCallbackImpl");
-
-    CV_FUNCNAME("setMouseCallbackImpl");
 
     if (!window_name)
         CV_Error(cv::Error::StsNullPtr, "NULL window name");


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/26142
Related to https://github.com/opencv/opencv/pull/26025

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
