### PR TITLE
ts: add some missing override markers

### DIFF
--- a/modules/ts/include/opencv2/ts/ocl_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_perf.hpp
@@ -64,7 +64,7 @@ using namespace perf;
     public: \
         OCL##_##fixture##_##name() { } \
     protected: \
-        virtual void PerfTestBody(); \
+        virtual void PerfTestBody() CV_OVERRIDE; \
     }; \
     TEST_F(OCL##_##fixture##_##name, name) { CV_TRACE_REGION("PERF_TEST: " #fixture "_" #name); declare.strategy(OCL_PERF_STRATEGY); RunPerfTestBody(); } \
     void OCL##_##fixture##_##name::PerfTestBody()
@@ -76,7 +76,7 @@ using namespace perf;
     public: \
         OCL##_##fixture##_##name() { } \
     protected: \
-        virtual void PerfTestBody(); \
+        virtual void PerfTestBody() CV_OVERRIDE; \
     }; \
     TEST_P(OCL##_##fixture##_##name, name) { CV_TRACE_REGION("PERF_TEST_P: " #fixture "_" #name); declare.strategy(OCL_PERF_STRATEGY); RunPerfTestBody(); } \
     INSTANTIATE_TEST_CASE_P(/*none*/, OCL##_##fixture##_##name, params); \

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -85,7 +85,7 @@ struct SkipThisTest : public ::testing::Test {
     };\
     class test_case_name##test_name##_factory : public ::testing::internal::TestFactoryBase { \
      public:\
-      virtual ::testing::Test* CreateTest() { \
+      virtual ::testing::Test* CreateTest() CV_OVERRIDE { \
         try { \
           return new GTEST_TEST_CLASS_NAME_(test_case_name, test_name); \
         } catch (const cvtest::details::SkipTestExceptionBase& e) { \
@@ -150,7 +150,7 @@ struct SkipThisTest : public ::testing::Test {
     };\
     class test_fixture##test_name##_factory : public ::testing::internal::TestFactoryBase { \
      public:\
-      virtual ::testing::Test* CreateTest() { \
+      virtual ::testing::Test* CreateTest() CV_OVERRIDE { \
         try { \
           return new GTEST_TEST_CLASS_NAME_(test_fixture, test_name); \
         } catch (const cvtest::details::SkipTestExceptionBase& e) { \

--- a/modules/ts/include/opencv2/ts/ts_gtest.h
+++ b/modules/ts/include/opencv2/ts/ts_gtest.h
@@ -8458,7 +8458,7 @@ class TestFactoryBase {
 template <class TestClass>
 class TestFactoryImpl : public TestFactoryBase {
  public:
-  virtual Test* CreateTest() { return new TestClass; }
+  virtual Test* CreateTest() override { return new TestClass; }
 };
 
 #if GTEST_OS_WINDOWS
@@ -11927,7 +11927,7 @@ class ParameterizedTestFactory : public internal::TestFactoryBase {
   typedef typename TestClass::ParamType ParamType;
   explicit ParameterizedTestFactory(ParamType parameter) :
       parameter_(parameter) {}
-  virtual Test* CreateTest() {
+  virtual Test* CreateTest() override {
     TestClass::SetParam(&parameter_);
     return new TestClass();
   }
@@ -11968,7 +11968,7 @@ class TestMetaFactory
 
   TestMetaFactory() {}
 
-  virtual TestFactoryBase* CreateTestFactory(ParamType parameter) {
+  virtual TestFactoryBase* CreateTestFactory(ParamType parameter) override {
     return new ParameterizedTestFactory<TestCase>(parameter);
   }
 
@@ -12030,9 +12030,9 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
       : test_case_name_(name), code_location_(code_location) {}
 
   // Test case base name for display purposes.
-  virtual const std::string& GetTestCaseName() const { return test_case_name_; }
+  virtual const std::string& GetTestCaseName() const override { return test_case_name_; }
   // Test case id to verify identity.
-  virtual TypeId GetTestCaseTypeId() const { return GetTypeId<TestCase>(); }
+  virtual TypeId GetTestCaseTypeId() const override { return GetTypeId<TestCase>(); }
   // TEST_P macro uses AddTestPattern() to record information
   // about a single test in a LocalTestInfo structure.
   // test_case_name is the base name of the test case (without invocation
@@ -12061,7 +12061,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
   // This method should not be called more then once on any single
   // instance of a ParameterizedTestCaseInfoBase derived class.
   // UnitTest has a guard to prevent from calling this method more then once.
-  virtual void RegisterTests() {
+  virtual void RegisterTests() override {
     for (typename TestInfoContainer::iterator test_it = tests_.begin();
          test_it != tests_.end(); ++test_it) {
       linked_ptr<TestInfo> test_info = *test_it;

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -585,7 +585,7 @@ void PrintTo(const Size& sz, ::std::ostream* os);
       public:\
        fixture() {}\
       protected:\
-       virtual void PerfTestBody();\
+       virtual void PerfTestBody() CV_OVERRIDE;\
      };\
      TEST_F(fixture, testname){ CV__PERF_TEST_BODY_IMPL(#fixture "_" #testname); }\
     }\
@@ -626,7 +626,7 @@ void PrintTo(const Size& sz, ::std::ostream* os);
      public:\
       fixture##_##name() {}\
      protected:\
-      virtual void PerfTestBody();\
+      virtual void PerfTestBody() CV_OVERRIDE;\
     };\
     CV__TEST_P(fixture##_##name, name, PerfTestBodyDummy,, CV__PERF_TEST_BODY_IMPL){} \
     INSTANTIATE_TEST_CASE_P(/*none*/, fixture##_##name, params);\


### PR DESCRIPTION
Modified both OpenCV part and GTest.
Used C++11 `override` in GTest code - I believe it's OK.