### PR TITLE
Update haveCUDA() to detect CUDA support at runtime

### DIFF
--- a/modules/dnn/src/op_cuda.cpp
+++ b/modules/dnn/src/op_cuda.cpp
@@ -107,3 +107,18 @@ void Net::Impl::initCUDABackend(const std::vector<LayerPin>& blobsToKeep_)
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn
 #endif  // HAVE_CUDA
+
+namespace cv { namespace dnn {
+
+bool haveCUDA()
+{
+#ifdef HAVE_CUDA
+    int dev = 0;
+    static bool ret = (cudaGetDevice(&dev) == cudaSuccess);
+    return ret;
+#else
+    return false;
+#endif
+}
+
+}}  // namespace cv::dnn

--- a/modules/dnn/src/op_cuda.hpp
+++ b/modules/dnn/src/op_cuda.hpp
@@ -29,13 +29,7 @@ namespace cv { namespace dnn {
         return id == DNN_TARGET_CUDA_FP16 || id == DNN_TARGET_CUDA;
     }
 
-    constexpr bool haveCUDA() {
-#ifdef HAVE_CUDA
-        return true;
-#else
-        return false;
-#endif
-    }
+    bool haveCUDA();
 
 #ifdef HAVE_CUDA
     namespace cuda4dnn { namespace csl {


### PR DESCRIPTION
A minor improvement regarding the CUDA support is required. Currently, `haveCUDA()` is equivalent to using the `HAVE_CUDA` define. However, existing code combines both checks, which implies that it is intended to do a runtime instead of a compile time check. For example:

https://github.com/opencv/opencv/blob/f503890c2b2ba73f4f94971c1845ead941143262/modules/dnn/src/net_impl.cpp#L173

Instead, we should use a runtime check in `haveCUDA()`, similar to `haveVulkan()`. Doing so, we can use CUDA by default whenever available by setting `OPENCV_DNN_BACKEND_DEFAULT = DNN_BACKEND_CUDA`, cf. #25112. The feature is implemented by simply checking for a valid CUDA device using `cudaGetDevice()` and saving its return value such that this function is only called once.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
