### PR TITLE
build: enable RISC-V FP16 support in the toolchain

### DIFF
--- a/platforms/linux/flags-riscv64.cmake
+++ b/platforms/linux/flags-riscv64.cmake
@@ -1,6 +1,10 @@
 # see https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html#index-march-14
 function(ocv_set_platform_flags VAR)
-  if(ENABLE_RVV OR RISCV_RVV_SCALABLE)
+  if(ENABLE_RVV_ZVFH OR  ENABLE_RVV_FP16)
+    set(flags "-march=rv64gc_v_zvfh")
+  elseif(ENABLE_RVV_ZVFHMIN OR ENABLE_FP16)
+    set(flags "-march=rv64gc_v_zvfhmin")
+  elseif(ENABLE_RVV OR RISCV_RVV_SCALABLE)
     set(flags "-march=rv64gcv")
   else()
     set(flags "-march=rv64gc")


### PR DESCRIPTION
Support RISC-V RVV FP16 after corresponding build changes from 4.x has been merged (shift options related to CPU features to the RISC-V/AArch64 toolchain files).

**Note:** option names are up to discussion

**Note:** [zvfhmin](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#184-zvfhmin-vector-extension-for-minimal-half-precision-floating-point) - conversions only, [zvfh](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#185-zvfh-vector-extension-for-half-precision-floating-point) - full arithmetic support.