### PR TITLE
Modified Caffe parser to support the new dnn engine

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1051,17 +1051,24 @@ CV__DNN_INLINE_NS_BEGIN
     /** @brief Reads a network model stored in <a href="http://caffe.berkeleyvision.org">Caffe</a> framework's format.
       * @param prototxt   path to the .prototxt file with text description of the network architecture.
       * @param caffeModel path to the .caffemodel file with learned network.
+      * @param engine select DNN engine to be used. With auto selection the new engine is used.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromCaffe(CV_WRAP_FILE_PATH const String &prototxt, CV_WRAP_FILE_PATH const String &caffeModel = String());
+    CV_EXPORTS_W Net readNetFromCaffe(CV_WRAP_FILE_PATH const String &prototxt,
+                                      CV_WRAP_FILE_PATH const String &caffeModel = String(),
+                                      int engine = ENGINE_AUTO);
 
     /** @brief Reads a network model stored in Caffe model in memory.
       * @param bufferProto buffer containing the content of the .prototxt file
       * @param bufferModel buffer containing the content of the .caffemodel file
+      * @param engine select DNN engine to be used. With auto selection the new engine is used.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
     CV_EXPORTS_W Net readNetFromCaffe(const std::vector<uchar>& bufferProto,
-                                      const std::vector<uchar>& bufferModel = std::vector<uchar>());
+                                      const std::vector<uchar>& bufferModel = std::vector<uchar>(),
+                                      int engine = ENGINE_AUTO);
 
     /** @brief Reads a network model stored in Caffe model in memory.
       * @details This is an overloaded member function, provided for convenience.
@@ -1070,10 +1077,13 @@ CV__DNN_INLINE_NS_BEGIN
       * @param lenProto length of bufferProto
       * @param bufferModel buffer containing the content of the .caffemodel file
       * @param lenModel length of bufferModel
+      * @param engine select DNN engine to be used. With auto selection the new engine is used.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
     CV_EXPORTS Net readNetFromCaffe(const char *bufferProto, size_t lenProto,
-                                    const char *bufferModel = NULL, size_t lenModel = 0);
+                                    const char *bufferModel = NULL, size_t lenModel = 0,
+                                    int engine = ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/">TensorFlow</a> framework's format.
       * @param model  path to the .pb file with binary protobuf description of the network architecture

--- a/modules/dnn/misc/objc/gen_dict.json
+++ b/modules/dnn/misc/objc/gen_dict.json
@@ -1,8 +1,8 @@
 {
     "func_arg_fix" : {
         "Dnn": {
-            "(Net*)readNetFromCaffe:(NSString*)prototxt caffeModel:(NSString*)caffeModel" : { "readNetFromCaffe" : {"name" : "readNetFromCaffeFile"} },
-            "(Net*)readNetFromCaffe:(ByteVector*)bufferProto bufferModel:(ByteVector*)bufferModel" : { "readNetFromCaffe" : {"name" : "readNetFromCaffeBuffer"} },
+            "(Net*)readNetFromCaffe:(NSString*)prototxt caffeModel:(NSString*)caffeModel engine:(int)engine" : { "readNetFromCaffe" : {"name" : "readNetFromCaffeFile"} },
+            "(Net*)readNetFromCaffe:(ByteVector*)bufferProto bufferModel:(ByteVector*)bufferModel engine:(int)engine" : { "readNetFromCaffe" : {"name" : "readNetFromCaffeBuffer"} },
             "(Net*)readNetFromDarknet:(NSString*)cfgFile darknetModel:(NSString*)darknetModel" : { "readNetFromDarknet" : {"name" : "readNetFromDarknetFile"} },
             "(Net*)readNetFromDarknet:(ByteVector*)bufferCfg bufferModel:(ByteVector*)bufferModel" : { "readNetFromDarknet" : {"name" : "readNetFromDarknetBuffer"} },
             "(Net*)readNetFromONNX:(NSString*)onnxFile engine:(int)engine" : { "readNetFromONNX" : {"name" : "readNetFromONNXFile"} },

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -324,6 +324,9 @@ class dnn_test(NewOpenCVTests):
                                  testScores, testBoxes, 0.5)
 
     def test_async(self):
+        # bug: https://github.com/opencv/opencv/issues/26376
+        raise unittest.SkipTest("The new dnn engine does not support async inference")
+
         timeout = 10*1000*10**6  # in nanoseconds (10 sec)
         proto = self.find_dnn_file('dnn/layers/layer_convolution.prototxt')
         model = self.find_dnn_file('dnn/layers/layer_convolution.caffemodel')

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -463,7 +463,7 @@ class dnn_test(NewOpenCVTests):
         for backend, target in self.dnnBackendsAndTargets:
             printParams(backend, target)
 
-            net = cv.dnn.readNet(model)
+            net = cv.dnn.readNet(model, engine=cv.dnn.ENGINE_CLASSIC)
 
             net.setPreferableBackend(backend)
             net.setPreferableTarget(target)

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -112,7 +112,7 @@ class dnn_test(NewOpenCVTests):
     def checkIETarget(self, backend, target):
         proto = self.find_dnn_file('dnn/layers/layer_convolution.prototxt')
         model = self.find_dnn_file('dnn/layers/layer_convolution.caffemodel')
-        net = cv.dnn.readNet(proto, model)
+        net = cv.dnn.readNet(proto, model, engine=cv.dnn.ENGINE_CLASSIC)
         try:
             net.setPreferableBackend(backend)
             net.setPreferableTarget(target)

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -337,7 +337,7 @@ class dnn_test(NewOpenCVTests):
 
             printParams(backend, target)
 
-            netSync = cv.dnn.readNet(proto, model)
+            netSync = cv.dnn.readNet(proto, model, engine=cv.dnn.ENGINE_CLASSIC)
             netSync.setPreferableBackend(backend)
             netSync.setPreferableTarget(target)
 

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -324,8 +324,8 @@ public:
     }
 
     Ptr<Layer> addLayer(Net& dstNet,
-                        String type,
-                        String name,
+                        const String& type,
+                        const String& name,
                         LayerParams& layerParams,
                         const std::vector<String>& inputs,
                         const std::vector<String>& outputs)
@@ -367,8 +367,11 @@ public:
         layerCounter.clear();
 
         // OLD ENGINE
-        addedBlobs.clear();
-        addedBlobs.reserve(layersSize + 1);
+        if(!newEngine)
+        {
+            addedBlobs.clear();
+            addedBlobs.reserve(layersSize + 1);
+        }
         std::vector<String> netInputs(net.input_size());
         std::vector<MatShape> inp_shapes;
 
@@ -674,7 +677,7 @@ public:
 
         if (newEngine)
         {
-            Ptr<Graph> curr_graph = netImpl->newGraph("GRAPH_NAME_TODO", modelInputs, true);
+            Ptr<Graph> curr_graph = netImpl->newGraph(net.name(), modelInputs, true);
             curr_graph->setOutputs(modelOutputs);
             curr_graph->setProg(curr_prog);
 

--- a/modules/dnn/src/dnn_read.cpp
+++ b/modules/dnn/src/dnn_read.cpp
@@ -21,7 +21,7 @@ Net readNet(const String& _model, const String& _config, const String& _framewor
     {
         if (modelExt == "prototxt" || configExt == "caffemodel")
             std::swap(model, config);
-        return readNetFromCaffe(config, model);
+        return readNetFromCaffe(config, model, engine);
     }
     if (framework == "tensorflow" || modelExt == "pb" || configExt == "pb" || modelExt == "pbtxt" || configExt == "pbtxt")
     {
@@ -61,7 +61,7 @@ Net readNet(const String& _framework, const std::vector<uchar>& bufferModel,
     if (framework == "onnx")
         return readNetFromONNX(bufferModel, engine);
     else if (framework == "caffe")
-        return readNetFromCaffe(bufferConfig, bufferModel);
+        return readNetFromCaffe(bufferConfig, bufferModel, engine);
     else if (framework == "tensorflow")
         return readNetFromTensorflow(bufferModel, bufferConfig);
     else if (framework == "darknet")

--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -114,14 +114,17 @@ public:
         }
         Mat blob = dnn::blobFromImageWithParams(frame, param); // [1, 10, 10, 4]
 
-        net.setInput(blob);
-
         // Faster-RCNN or R-FCN
         if ((net.getMainGraph() && net.haveArg("im_info") && net.argKind(net.getArg("im_info")) == DNN_ARG_INPUT) ||
             (!net.getMainGraph() && net.getLayer(0)->outputNameToIndex("im_info") != -1))
         {
+            net.setInput(blob, "data");
             Mat imInfo(Matx13f(size.height, size.width, 1.6f));
             net.setInput(imInfo, "im_info");
+        }
+        else
+        {
+            net.setInput(blob);
         }
 
         net.forward(outs, outNames);

--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -117,7 +117,8 @@ public:
         net.setInput(blob);
 
         // Faster-RCNN or R-FCN
-        if (!net.getMainGraph() && net.getLayer(0)->outputNameToIndex("im_info") != -1)
+        if ((net.getMainGraph() && net.haveArg("im_info") && net.argKind(net.getArg("im_info")) == DNN_ARG_INPUT) ||
+            (!net.getMainGraph() && net.getLayer(0)->outputNameToIndex("im_info") != -1))
         {
             Mat imInfo(Matx13f(size.height, size.width, 1.6f));
             net.setInput(imInfo, "im_info");
@@ -507,7 +508,12 @@ void DetectionModel::detect(InputArray frame, CV_OUT std::vector<int>& classIds,
 
     int frameWidth  = frame.cols();
     int frameHeight = frame.rows();
-    if (getNetwork_().getLayer(0)->outputNameToIndex("im_info") != -1)
+    if ((getNetwork_().getMainGraph() &&
+         getNetwork_().haveArg("im_info") &&
+         getNetwork_().argKind(getNetwork_().getArg("im_info")) == DNN_ARG_INPUT)
+        ||
+        (!getNetwork_().getMainGraph() &&
+         getNetwork_().getLayer(0)->outputNameToIndex("im_info") != -1))
     {
         frameWidth = impl->size.width;
         frameHeight = impl->size.height;

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -41,7 +41,13 @@ public:
         Net netDefault = readNet(weights, proto);
         netDefault.setPreferableBackend(DNN_BACKEND_OPENCV);
         netDefault.setInput(inp);
-        Mat outDefault = netDefault.forward(outputLayer).clone();
+
+        // BUG: https://github.com/opencv/opencv/issues/26349
+        Mat outDefault;
+        if(netDefault.getMainGraph())
+            outDefault = netDefault.forward().clone();
+        else
+            outDefault = netDefault.forward(outputLayer).clone();
 
         net = readNet(weights, proto);
         net.setInput(inp);
@@ -51,7 +57,12 @@ public:
         if (target == DNN_TARGET_CPU_FP16)
             net.enableWinograd(false);
 
-        Mat out = net.forward(outputLayer).clone();
+        // BUG: https://github.com/opencv/opencv/issues/26349
+        Mat out;
+        if(net.getMainGraph())
+            out = net.forward().clone();
+        else
+            out = net.forward(outputLayer).clone();
 
         check(outDefault, out, outputLayer, l1, lInf, detectionConfThresh, "First run");
 
@@ -65,8 +76,17 @@ public:
         }
         netDefault.setInput(inp);
         net.setInput(inp);
-        outDefault = netDefault.forward(outputLayer).clone();
-        out = net.forward(outputLayer).clone();
+
+        if(netDefault.getMainGraph())
+            outDefault = netDefault.forward().clone();
+        else
+            outDefault = netDefault.forward(outputLayer).clone();
+
+        if(net.getMainGraph())
+            out = net.forward().clone();
+        else
+            out = net.forward(outputLayer).clone();
+
         check(outDefault, out, outputLayer, l1, lInf, detectionConfThresh, "Second run");
     }
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -534,9 +534,8 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
 #if defined(HAVE_INF_ENGINE) && INF_ENGINE_VER_MAJOR_GE(2019010000)
     expectNoFallbacksFromIE(net);
 #endif
-    // BUG: https://github.com/opencv/opencv/issues/26306
-    // Temporarily disabled check for no "fallbacks", since the new engine does not support CUDA yet
-    //expectNoFallbacksFromCUDA(net);
+
+    expectNoFallbacksFromCUDA(net);
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, dnnBackendsAndTargets(/* withInferenceEngine = */ true,

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -230,7 +230,14 @@ TEST_P(Reproducibility_AlexNet, Accuracy)
     ASSERT_TRUE(!sample.empty());
 
     net.setInput(blobFromImage(sample, 1.0f, Size(227, 227), Scalar(), false), "data");
-    Mat out = net.forward("prob");
+
+    Mat out;
+    // BUG: https://github.com/opencv/opencv/issues/26349
+    if (net.getMainGraph())
+        out = net.forward();
+    else
+        out = net.forward("prob");
+
     Mat ref = blobFromNPY(_tf("caffe_alexnet_prob.npy"));
     normAssert(ref, out, "", l1, lInf);
 }
@@ -259,7 +266,13 @@ TEST(Reproducibility_FCN, Accuracy)
     net.getMemoryConsumption(shape(1,3,227,227), CV_32F, layerIds, weights, blobs);
 
     net.setInput(blobFromImage(sample, 1.0f, Size(500, 500), Scalar(), false), "data");
-    Mat out = net.forward("score");
+
+    Mat out;
+    // BUG: https://github.com/opencv/opencv/issues/26349
+    if (net.getMainGraph())
+        out = net.forward();
+    else
+        out = net.forward("score");
 
     Mat refData = imread(_tf("caffe_fcn8s_prob.png"), IMREAD_ANYDEPTH);
     int shape[] = {1, 21, 500, 500};
@@ -292,7 +305,13 @@ TEST(Reproducibility_SSD, Accuracy)
 
     Mat in_blob = blobFromImage(sample, 1.0f, Size(300, 300), Scalar(), false);
     net.setInput(in_blob, "data");
-    Mat out = net.forward("detection_out");
+
+    // BUG: https://github.com/opencv/opencv/issues/26349
+    Mat out;
+    if(net.getMainGraph())
+        out = net.forward();
+    else
+        out = net.forward("detection_out");
 
     Mat ref = blobFromNPY(_tf("ssd_out.npy"));
     normAssertDetections(ref, out, "", 0.06);
@@ -495,7 +514,13 @@ TEST(Reproducibility_GoogLeNet_fp16, Accuracy)
     ASSERT_TRUE(!inpMats[0].empty() && !inpMats[1].empty());
 
     net.setInput(blobFromImages(inpMats, 1.0f, Size(), Scalar(), false), "data");
-    Mat out = net.forward("prob");
+
+    // BUG: https://github.com/opencv/opencv/issues/26349
+    Mat out;
+    if(net.getMainGraph())
+        out = net.forward();
+    else
+        out = net.forward("prob");
 
     Mat ref = blobFromNPY(_tf("googlenet_prob.npy"));
     normAssert(out, ref, "", l1, lInf);

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -195,6 +195,11 @@ public:
 
     void expectNoFallbacks(Net& net, bool raiseError = true)
     {
+        // The new DNN engine does not support back-ends for now
+        // bug: https://github.com/opencv/opencv/issues/26198
+        if (net.getMainGraph())
+            return;
+
         // Check if all the layers are supported with current backend and target.
         // Some layers might be fused so their timings equal to zero.
         std::vector<double> timings;

--- a/modules/dnn/test/test_googlenet.cpp
+++ b/modules/dnn/test/test_googlenet.cpp
@@ -80,7 +80,13 @@ TEST_P(Reproducibility_GoogLeNet, Batching)
     ASSERT_TRUE(!inpMats[0].empty() && !inpMats[1].empty());
 
     net.setInput(blobFromImages(inpMats, 1.0f, Size(), Scalar(), false), "data");
-    Mat out = net.forward("prob");
+
+    // BUG: https://github.com/opencv/opencv/issues/26349
+    Mat out;
+    if(net.getMainGraph())
+        out = net.forward();
+    else
+        out = net.forward("prob");
 
     Mat ref = blobFromNPY(_tf("googlenet_prob.npy"));
     normAssert(out, ref);

--- a/modules/dnn/test/test_googlenet.cpp
+++ b/modules/dnn/test/test_googlenet.cpp
@@ -99,8 +99,9 @@ TEST_P(Reproducibility_GoogLeNet, IntermediateBlobs)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (targetId == DNN_TARGET_CPU_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CPU_FP16);
+    // BUG: https://github.com/opencv/opencv/issues/26349
     Net net = readNetFromCaffe(findDataFile("dnn/bvlc_googlenet.prototxt"),
-                               findDataFile("dnn/bvlc_googlenet.caffemodel", false));
+                               findDataFile("dnn/bvlc_googlenet.caffemodel", false), ENGINE_CLASSIC);
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setPreferableTarget(targetId);
 
@@ -132,8 +133,9 @@ TEST_P(Reproducibility_GoogLeNet, SeveralCalls)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (targetId == DNN_TARGET_CPU_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CPU_FP16);
+    // BUG: https://github.com/opencv/opencv/issues/26349
     Net net = readNetFromCaffe(findDataFile("dnn/bvlc_googlenet.prototxt"),
-                               findDataFile("dnn/bvlc_googlenet.caffemodel", false));
+                               findDataFile("dnn/bvlc_googlenet.caffemodel", false), ENGINE_CLASSIC);
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setPreferableTarget(targetId);
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -864,7 +864,7 @@ TEST_P(Test_Caffe_layers, FasterRCNN_Proposal)
     std::vector<Mat> outs;
     net.setPreferableBackend(backend);
     net.setPreferableTarget(target);
-    net.forward(outs, "output");
+    net.forward(outs);
 
     for (int i = 0; i < 2; ++i)
     {

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -408,7 +408,11 @@ TEST_P(Test_Caffe_layers, Reshape_Split_Slice)
     rng.fill(input, RNG::UNIFORM, -1, 1);
 
     net.setInput(input, "input");
-    Mat output = net.forward("output");
+    Mat output;
+    if (net.getMainGraph())
+        output = net.forward();
+    else
+        output = net.forward("output");
 
     normAssert(input, output, "", default_l1, default_lInf);
 }

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -330,7 +330,10 @@ TEST_P(dump, Regression)
     Net net = readNet(findDataFile("dnn/squeezenet_v1.1.prototxt"),
                       findDataFile("dnn/squeezenet_v1.1.caffemodel", false));
 
-    ASSERT_EQ(net.getLayerInputs(net.getLayerId("fire2/concat")).size(), 2);
+    if (net.getMainGraph())
+        ASSERT_EQ(net.getLayer(net.getLayerId("fire2/concat"))->inputs.size(), 2);
+    else
+        ASSERT_EQ(net.getLayerInputs(net.getLayerId("fire2/concat")).size(), 2);
 
     int size[] = {1, 3, 227, 227};
     Mat input = cv::Mat::ones(4, size, CV_32F);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -605,7 +605,14 @@ TEST(Net, forwardAndRetrieve)
     outNames.push_back("testLayer");
     std::vector<std::vector<Mat> > outBlobs;
 
-    net.forward(outBlobs, outNames);
+    if (net.getMainGraph())
+    {
+        // Issue: https://github.com/opencv/opencv/issues/26349
+        outBlobs.push_back({});
+        net.forward(outBlobs[0]);
+    }
+    else
+        net.forward(outBlobs, outNames);
 
     EXPECT_EQ(outBlobs.size(), 1);
     EXPECT_EQ(outBlobs[0].size(), 2);


### PR DESCRIPTION
Now the Caffe parser supports both the old and the new engine. It can be selected using newEngine argument in PopulateNet.

All cpu Caffe tests work fine except:

- Test_Caffe_nets.Colorization
- Test_Caffe_layers.FasterRCNN_Proposal

Both these tests doesn't work because of the bug in the new net.forward function. The function takes the name of the desired target last layer, but uses this name as the name of the desired output tensor.
Also Colorization test contains a strange model with a Silence layer in the end, so it doesn't have outputs. The old parser just ignored it. I think, the proper solution is to run this model until the (number_of_layers - 2) layer using proper net.forward arguments in the test.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
