### PR TITLE
0D case fix Einsum for new graph Engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,9 +921,9 @@ if(WITH_WEBNN)
 endif()
 
 # --- Inference Engine ---
-if(WITH_INF_ENGINE OR WITH_OPENVINO)
-  include(cmake/OpenCVDetectInferenceEngine.cmake)
-endif()
+#if(WITH_INF_ENGINE OR WITH_OPENVINO)
+#  include(cmake/OpenCVDetectInferenceEngine.cmake)
+#endif()
 
 # --- DirectX ---
 if(WITH_DIRECTX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,9 +921,9 @@ if(WITH_WEBNN)
 endif()
 
 # --- Inference Engine ---
-#if(WITH_INF_ENGINE OR WITH_OPENVINO)
-#  include(cmake/OpenCVDetectInferenceEngine.cmake)
-#endif()
+if(WITH_INF_ENGINE OR WITH_OPENVINO)
+  include(cmake/OpenCVDetectInferenceEngine.cmake)
+endif()
 
 # --- DirectX ---
 if(WITH_DIRECTX)

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1168,6 +1168,13 @@ CV_EXPORTS_W void flipND(InputArray src, OutputArray dst, int axis);
  */
 CV_EXPORTS_W void broadcast(InputArray src, InputArray shape, OutputArray dst);
 
+/** @brief Broadcast the given Mat to the given shape.
+ * @param src input array
+ * @param shape target shape. Note that negative values are not supported.
+ * @param dst output array that has the given shape
+ */
+CV_EXPORTS void broadcast(InputArray src, const MatShape& shape, OutputArray dst);
+
 enum RotateFlags {
     ROTATE_90_CLOCKWISE = 0, //!<Rotate 90 degrees clockwise
     ROTATE_180 = 1, //!<Rotate 180 degrees clockwise

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -996,6 +996,13 @@ public:
     Mat(const MatShape& shape, int type);
 
     /** @overload
+    @param shape Array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_64FC4 to create 1-4 channel matrices, or
+    CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
+    */
+    Mat(std::initializer_list<int> shape, int type);
+
+    /** @overload
     @param ndims Array dimensionality.
     @param sizes Array of integers specifying an n-dimensional array shape.
     @param type Array type. Use CV_8UC1, ..., CV_64FC4 to create 1-4 channel matrices, or
@@ -1025,6 +1032,16 @@ public:
     Mat::operator=(const Scalar& value) .
     */
     Mat(const MatShape& shape, int type, const Scalar& s);
+
+    /** @overload
+    @param shape Array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_64FC4 to create 1-4 channel matrices, or
+    CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
+    @param s An optional value to initialize each matrix element with. To set all the matrix elements to
+     the particular value after the construction, use the assignment operator
+    Mat::operator=(const Scalar& value) .
+    */
+    Mat(std::initializer_list<int> shape, int type, const Scalar& s);
 
     /** @overload
     @param m Array that (as a whole or partly) is assigned to the constructed matrix. No data is copied
@@ -1109,6 +1126,20 @@ public:
     set to the element size). If not specified, the matrix is assumed to be continuous.
     */
     Mat(const MatShape& shape, int type, void* data, const size_t* steps=0);
+
+    /** @overload
+    @param shape Array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_64FC4 to create 1-4 channel matrices, or
+    CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
+    @param data Pointer to the user data. Matrix constructors that take data and step parameters do not
+    allocate matrix data. Instead, they just initialize the matrix header that points to the specified
+    data, which means that no data is copied. This operation is very efficient and can be used to
+    process external data using OpenCV functions. The external data is not automatically deallocated, so
+    you should take care of it.
+    @param steps Array of ndims-1 steps in case of a multi-dimensional array (the last step is always
+    set to the element size). If not specified, the matrix is assumed to be continuous.
+    */
+    Mat(std::initializer_list<int> shape, int type, void* data, const size_t* steps=0);
 
     /** @overload
     @param m Array that (as a whole or partly) is assigned to the constructed matrix. No data is copied
@@ -1682,6 +1713,12 @@ public:
     */
     void create(const MatShape& shape, int type);
 
+    /** @overload
+    @param shape The new shape.
+    @param type New matrix type.
+    */
+    void create(std::initializer_list<int> shape, int type);
+
     /** @brief Creates the matrix of the same size as another array.
 
     The method is similar to _OutputArray::createSameSize(arr, type),
@@ -1718,10 +1755,16 @@ public:
     void fit(const std::vector<int>& sizes, int type);
 
     /** @overload
-    @param sizes The new shape.
+    @param shape The new shape.
     @param type New matrix type.
     */
     void fit(const MatShape& shape, int type);
+
+    /** @overload
+    @param shape The new shape.
+    @param type New matrix type.
+    */
+    void fit(std::initializer_list<int> shape, int type);
 
     /** @brief Similar to createSameSize(arr, type), but only reallocates memory if the existing buffer is not enough.
     @param arr The other array.

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -67,8 +67,6 @@ enum AccessFlag { ACCESS_READ=1<<24, ACCESS_WRITE=1<<25,
 CV_ENUM_FLAGS(AccessFlag)
 __CV_ENUM_FLAGS_BITWISE_AND(AccessFlag, int, AccessFlag)
 
-CV__DEBUG_NS_BEGIN
-
 /**
  * @brief Enum of data layout for model inference.
  * @see Image2BlobParams
@@ -164,6 +162,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 
+    operator std::vector<int>() const;    
     std::string str() const;
 
     int dims;
@@ -174,6 +173,8 @@ struct CV_EXPORTS_W_SIMPLE MatShape
 
 CV_EXPORTS bool operator == (const MatShape& shape1, const MatShape& shape2);
 CV_EXPORTS bool operator != (const MatShape& shape1, const MatShape& shape2);
+
+CV__DEBUG_NS_BEGIN
 
 class CV_EXPORTS _OutputArray;
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -341,6 +341,7 @@ public:
     bool isContinuous(int i=-1) const;
     bool isSubmatrix(int i=-1) const;
     bool empty() const;
+    bool empty(int i) const;
     void copyTo(const _OutputArray& arr) const;
     void copyTo(const _OutputArray& arr, const _InputArray & mask) const;
     size_t offset(int i=-1) const;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -105,7 +105,7 @@ CV_EXPORTS std::string layoutToString(DataLayout layout);
  *   2. includes information about the layout, including the actual number of channels ('C') in the case of block layout.
  *   3. distinguishes between empty shape (total() == 0) and 0-dimensional shape (dims == 0, but total() == 1).
  */
-struct CV_EXPORTS MatShape
+struct CV_EXPORTS_W_SIMPLE MatShape
 {
     enum {MAX_DIMS=10};
 
@@ -123,9 +123,9 @@ struct CV_EXPORTS MatShape
 
     // try to mimic basic std::vector<int> functionality
     size_t size() const; // returns 0 in the case of scalar tensor. So, please don't use 'size()==0' to check for an empty shape. Use empty() instead.
-    bool empty() const; // equivalent to total()==0, but may be slightly faster.
-    bool isScalar() const; // dims==0
-    void clear();
+    CV_WRAP bool empty() const; // equivalent to total()==0, but may be slightly faster.
+    CV_WRAP bool isScalar() const; // dims==0
+    CV_WRAP void clear();
     void resize(size_t newSize, int value=0);
     void reserve(size_t maxSize);
     void assign(size_t newSize, int value);
@@ -137,7 +137,7 @@ struct CV_EXPORTS MatShape
     void insert(int* where, size_t count, int value);
     void insert(int* where, int count, int value);
     template<class _It> void insert(int* where, _It begin, _It end);
-    void erase(int* where);
+    CV_WRAP void erase(int* where);
     int* data();
     const int* data() const;
     int* begin();
@@ -151,14 +151,14 @@ struct CV_EXPORTS MatShape
     int& operator [](size_t idx);
     const int& operator [](size_t idx) const;
 
-    bool haveSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
+    CV_WRAP bool haveSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 
     // compute shape of the result with possible broadcasting
-    MatShape expand(const MatShape& another) const;
+    CV_WRAP MatShape expand(const MatShape& another) const;
 
     // convert shape to/from block layout
-    MatShape toBlock(int C0) const;
-    MatShape fromBlock(DataLayout newLayout) const;
+    CV_WRAP MatShape toBlock(int C0) const;
+    CV_WRAP MatShape fromBlock(DataLayout newLayout) const;
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -153,7 +153,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     int& operator [](size_t idx);
     const int& operator [](size_t idx) const;
 
-    CV_WRAP bool haveSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
+    CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 
     // compute shape of the result with possible broadcasting
     CV_WRAP MatShape expand(const MatShape& another) const;
@@ -163,6 +163,8 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     CV_WRAP MatShape fromBlock(DataLayout newLayout) const;
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
+
+    std::string str() const;
 
     int dims;
     DataLayout layout;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1097,6 +1097,20 @@ public:
     Mat(const std::vector<int>& sizes, int type, void* data, const size_t* steps=0);
 
     /** @overload
+    @param shape Array shape.
+    @param type Array type. Use CV_8UC1, ..., CV_64FC4 to create 1-4 channel matrices, or
+    CV_8UC(n), ..., CV_64FC(n) to create multi-channel (up to CV_CN_MAX channels) matrices.
+    @param data Pointer to the user data. Matrix constructors that take data and step parameters do not
+    allocate matrix data. Instead, they just initialize the matrix header that points to the specified
+    data, which means that no data is copied. This operation is very efficient and can be used to
+    process external data using OpenCV functions. The external data is not automatically deallocated, so
+    you should take care of it.
+    @param steps Array of ndims-1 steps in case of a multi-dimensional array (the last step is always
+    set to the element size). If not specified, the matrix is assumed to be continuous.
+    */
+    Mat(const MatShape& shape, int type, void* data, const size_t* steps=0);
+
+    /** @overload
     @param m Array that (as a whole or partly) is assigned to the constructed matrix. No data is copied
     by these constructors. Instead, the header pointing to m data or its sub-array is constructed and
     associated with it. The reference counter, if any, is incremented. So, when you modify the matrix
@@ -1465,6 +1479,12 @@ public:
      * @param newshape New shape in the form of MatShape.
      */
     Mat reshape(int cn, const MatShape& newshape) const;
+
+    /** @overload
+     * @param cn New number of channels. If the parameter is 0, the number of channels remains the same.
+     * @param newshape New shape in the form of initializer list.
+     */
+    Mat reshape(int cn, std::initializer_list<int> newshape) const;
 
     /** @brief Transposes a matrix.
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -162,7 +162,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 
-    operator std::vector<int>() const;    
+    operator std::vector<int>() const;
     std::string str() const;
 
     int dims;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2769,6 +2769,7 @@ public:
     // number of channels and/or different number of rows. see cvReshape.
     UMat reshape(int cn, int rows=0) const;
     UMat reshape(int cn, int newndims, const int* newsz) const;
+    UMat reshape(int cn, const MatShape& shape) const;
 
     //! matrix transposition by means of matrix expressions
     UMat t() const;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -131,9 +131,11 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     void assign(size_t newSize, int value);
     void assign(int newSize, int value);
     void assign(const int* begin, const int* end);
+    void assign_(const int* begin, const int* end);
     template<class _It> void assign(_It begin, _It end);
     void insert(int* where, int value);
     void insert(int* where, const int* begin, const int* end);
+    void insert_(int* where, const int* begin, const int* end);
     void insert(int* where, size_t count, int value);
     void insert(int* where, int count, int value);
     template<class _It> void insert(int* where, _It begin, _It end);

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -71,9 +71,6 @@
 
 namespace cv
 {
-CV__DEBUG_NS_BEGIN
-
-
 //! @cond IGNORED
 
 ////////////////////////// Custom (raw) type wrapper //////////////////////////
@@ -140,6 +137,9 @@ template<class _It> inline void MatShape::insert(int* where, _It begin, _It end)
     }
     insert_(where, buf, buf + count);
 }
+
+CV__DEBUG_NS_BEGIN
+
 
 //////////////////////// Input/Output Arrays ////////////////////////
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -116,7 +116,7 @@ template<typename _It> inline MatShape::MatShape(_It begin, _It end)
         buf[count] = (int)*it;
     }
     clear();
-    assign(buf, buf + count);
+    assign_(buf, buf + count);
 }
 
 template<typename _It> inline void MatShape::assign(_It begin, _It end)
@@ -127,7 +127,7 @@ template<typename _It> inline void MatShape::assign(_It begin, _It end)
         CV_Assert(count < MAX_DIMS);
         buf[count] = (int)*it;
     }
-    assign(buf, buf + count);
+    assign_(buf, buf + count);
 }
 
 template<class _It> inline void MatShape::insert(int* where, _It begin, _It end)
@@ -138,7 +138,7 @@ template<class _It> inline void MatShape::insert(int* where, _It begin, _It end)
         CV_Assert(count < MAX_DIMS);
         buf[count] = (int)*it;
     }
-    insert(where, buf, buf + count);
+    insert_(where, buf, buf + count);
 }
 
 //////////////////////// Input/Output Arrays ////////////////////////

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -86,6 +86,61 @@ int rawType()
     return (int)CV_MAKETYPE(CV_8U, elemSize);
 }
 
+/////////////////////////// MatShape ////////////////////////////////
+
+inline size_t MatShape::size() const { return dims >= 0 ? dims : 0; }
+inline bool MatShape::empty() const { return total() == 0; }
+inline bool MatShape::isScalar() const { return dims == 0; }
+
+inline int* MatShape::data() { return p; }
+inline const int* MatShape::data() const { return p; }
+
+inline int& MatShape::operator [](size_t idx)
+{
+    CV_Assert(idx < (size_t)(dims >= 0 ? dims : 1));
+    return p[idx];
+}
+
+inline const int& MatShape::operator [](size_t idx) const
+{
+    CV_Assert(idx < (size_t)(dims >= 0 ? dims : 1));
+    return p[idx];
+}
+
+template<typename _It> inline MatShape::MatShape(_It begin, _It end)
+{
+    int buf[MAX_DIMS];
+    int count = 0;
+    for (_It it = begin; it != end; ++it, ++count) {
+        CV_Assert(count < MAX_DIMS);
+        buf[count] = (int)*it;
+    }
+    clear();
+    assign(buf, buf + count);
+}
+
+template<typename _It> inline void MatShape::assign(_It begin, _It end)
+{
+    int buf[MAX_DIMS];
+    int count = 0;
+    for (_It it = begin; it != end; ++it, ++count) {
+        CV_Assert(count < MAX_DIMS);
+        buf[count] = (int)*it;
+    }
+    assign(buf, buf + count);
+}
+
+template<class _It> inline void MatShape::insert(int* where, _It begin, _It end)
+{
+    int buf[MAX_DIMS];
+    int count = 0;
+    for (_It it = begin; it != end; ++it, ++count) {
+        CV_Assert(count < MAX_DIMS);
+        buf[count] = (int)*it;
+    }
+    insert(where, buf, buf + count);
+}
+
 //////////////////////// Input/Output Arrays ////////////////////////
 
 inline void _InputArray::init(int _flags, const void* _obj)

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -50,6 +50,7 @@
 #endif
 
 #include <cstdio>
+#include <ostream>
 
 #if defined(__GNUC__) || defined(__clang__) // at least GCC 3.1+, clang 3.5+
 #  if defined(__MINGW_PRINTF_FORMAT)  // https://sourceforge.net/p/mingw-w64/wiki2/gnu%20printf/.
@@ -483,6 +484,11 @@ int print(const Matx<_Tp, m, n>& matx, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(cv::Mat(matx)), stream);
 }
+
+// numpy/ONNXRuntime-style matrix pretty-printer
+CV_EXPORTS std::ostream& pprint(std::ostream& strm, InputArray tensor, int indent=0,
+                                int edge=3, int wholeTensorThreshold=100,
+                                char parens='\0');
 
 //! @endcond
 

--- a/modules/core/misc/objc/common/IntVector.h
+++ b/modules/core/misc/objc/common/IntVector.h
@@ -47,8 +47,8 @@ CV_EXPORTS @interface IntVector : NSObject
 * Create IntVector from std::vector<int>
 * @param src The std::vector<int> object to wrap
 */
--(instancetype)initWithStdVector:(std::vector<int>&)src;
-+(instancetype)fromNative:(std::vector<int>&)src;
+-(instancetype)initWithStdVector:(const std::vector<int>&)src;
++(instancetype)fromNative:(const std::vector<int>&)src;
 #endif
 
 #pragma mark - Properties

--- a/modules/core/misc/objc/common/IntVector.mm
+++ b/modules/core/misc/objc/common/IntVector.mm
@@ -50,7 +50,7 @@
     return v;
 }
 
--(instancetype)initWithStdVector:(std::vector<int>&)src {
+-(instancetype)initWithStdVector:(const std::vector<int>&)src {
     self = [super init];
     if (self) {
         v.insert(v.begin(), src.begin(), src.end());
@@ -58,7 +58,7 @@
     return self;
 }
 
-+(instancetype)fromNative:(std::vector<int>&)src {
++(instancetype)fromNative:(const std::vector<int>&)src {
     return [[IntVector alloc] initWithStdVector:src];
 }
 

--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -110,6 +110,12 @@
             "to_cpp": "%(n)s.nativeRef",
             "from_cpp": "[TermCriteria fromNative:%(n)s]"
         },
+        "DataLayout": {
+            "objc_type": "int",
+            "from_cpp": "(int)%(n)s",
+            "to_cpp": "(cv::DataLayout)%(n)s",
+            "is_primitive": true
+        },
         "DMatch": {
             "objc_type": "DMatch*"
         },

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -990,7 +990,9 @@ void Mat::fit(int _dims, const int* _sizes, int _type)
     for (int i = 0; i < _dims; i++)
         newTotal *= _sizes[i];
     size_t newTotalBytes = newTotal*esz;
-    if (newTotalBytes > 0 && (!isContinuous() || newTotalBytes > oldTotalBytes)) {
+    if (newTotalBytes > 0 && (!isContinuous() ||
+                              newTotalBytes > oldTotalBytes ||
+                              data != datastart)) {
         create(_dims, _sizes, _type);
     } else {
         flags = (flags & ~Mat::TYPE_MASK) | CV_MAT_TYPE(_type);

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1313,6 +1313,20 @@ Mat::Mat(const std::vector<int>& _sizes, int _type, void* _data, const size_t* _
     finalizeHdr(*this);
 }
 
+Mat::Mat(const MatShape& _shape, int _type, void* _data, const size_t* _steps)
+    : flags(MAGIC_VAL), dims(0), rows(0), cols(0), data(0), datastart(0), dataend(0),
+      datalimit(0), allocator(0), u(0), size(&rows)
+{
+    flags |= CV_MAT_TYPE(_type);
+    datastart = data = (uchar*)_data;
+    if (_shape.dims >= 0) {
+        setSize(*this, (int)_shape.dims, _shape.p, _steps, true);
+    }
+    else {
+        CV_Assert(!data);
+    }
+    finalizeHdr(*this);
+}
 
 Mat::Mat(const Mat& m, const Range* ranges)
     : flags(MAGIC_VAL), dims(0), rows(0), cols(0), data(0), datastart(0), dataend(0),
@@ -1747,6 +1761,17 @@ Mat Mat::reshape(int _cn, const MatShape& _newshape) const
         return reshape(_cn, 1, newshape);
     }
     return reshape(_cn, _newshape.dims, _newshape.p);
+}
+
+Mat Mat::reshape(int _cn, std::initializer_list<int> newshape_) const
+{
+    int newshape[MatShape::MAX_DIMS];
+    size_t i, newshape_dims = newshape_.size();
+    CV_Assert(newshape_dims <= (size_t)MatShape::MAX_DIMS);
+    auto it = newshape_.begin();
+    for (i = 0; i < newshape_dims; i++, ++it)
+        newshape[i] = *it;
+    return reshape(_cn, (int)newshape_dims, newshape);
 }
 
 Mat Mat::diag(const Mat& d)

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -990,7 +990,7 @@ void Mat::fit(int _dims, const int* _sizes, int _type)
     for (int i = 0; i < _dims; i++)
         newTotal *= _sizes[i];
     size_t newTotalBytes = newTotal*esz;
-    if (!isContinuous() || newTotalBytes > oldTotalBytes) {
+    if (newTotalBytes > 0 && (!isContinuous() || newTotalBytes > oldTotalBytes)) {
         create(_dims, _sizes, _type);
     } else {
         flags = (flags & ~Mat::TYPE_MASK) | CV_MAT_TYPE(_type);

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -7,8 +7,6 @@
 
 namespace cv {
 
-CV__DEBUG_NS_BEGIN
-
 std::string layoutToString(DataLayout layout)
 {
     return
@@ -45,8 +43,6 @@ bool operator != (const MatShape& size1, const MatShape& size2)
 {
     return !(size1 == size2);
 }
-
-CV__DEBUG_NS_END
 
 /////////////////////////// MatShape ////////////////////////////////
 
@@ -403,6 +399,13 @@ MatShape MatShape::expand(const MatShape& another) const
         result.p[i] = std::max(sz1, sz2);
     }
     return result;
+}
+
+MatShape::operator std::vector<int>() const
+{
+    if (dims < 0)
+        return std::vector<int>(1, 0);
+    return std::vector<int>(p, p + dims);
 }
 
 /////////////////////////// MatAllocator ////////////////////////////

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -65,6 +65,11 @@ void MatShape::assign(int newSize, int value)
 
 void MatShape::assign(const int* begin, const int* end)
 {
+    assign_(begin, end);
+}
+
+void MatShape::assign_(const int* begin, const int* end)
+{
     ptrdiff_t newSize = end - begin;
     CV_Assert(0 <= newSize && newSize < (ptrdiff_t)MAX_DIMS);
     dims = (int)newSize;
@@ -122,6 +127,11 @@ void MatShape::insert(int* where, int count, int value)
 }
 
 void MatShape::insert(int* where, const int* begin, const int* end)
+{
+    insert_(where, begin, end);
+}
+
+void MatShape::insert_(int* where, const int* begin, const int* end)
 {
     int old_dims = std::max(dims, 0);
     ptrdiff_t delta = end - begin;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -7,6 +7,8 @@
 
 namespace cv {
 
+CV__DEBUG_NS_BEGIN
+
 std::string layoutToString(DataLayout layout)
 {
     return
@@ -19,6 +21,32 @@ std::string layoutToString(DataLayout layout)
         layout == DATA_LAYOUT_PLANAR ? "PLANAR" :
         layout == DATA_LAYOUT_UNKNOWN ? "Unknown" : "???";
 }
+
+bool operator == (const MatShape& size1, const MatShape& size2)
+{
+    if (size1.dims != size2.dims)
+        return false;
+    if (size1.layout != size2.layout &&
+        size1.layout != DATA_LAYOUT_UNKNOWN &&
+        size2.layout != DATA_LAYOUT_UNKNOWN)
+        return false;
+    if (size1.layout == DATA_LAYOUT_BLOCK &&
+        size2.layout == DATA_LAYOUT_BLOCK &&
+        size1.C != size2.C)
+        return false;
+    for (int i = 0; i < size1.dims; i++) {
+        if (size1.p[i] != size2.p[i])
+            return false;
+    }
+    return true;
+}
+
+bool operator != (const MatShape& size1, const MatShape& size2)
+{
+    return !(size1 == size2);
+}
+
+CV__DEBUG_NS_END
 
 /////////////////////////// MatShape ////////////////////////////////
 
@@ -375,30 +403,6 @@ MatShape MatShape::expand(const MatShape& another) const
         result.p[i] = std::max(sz1, sz2);
     }
     return result;
-}
-
-bool operator == (const MatShape& size1, const MatShape& size2)
-{
-    if (size1.dims != size2.dims)
-        return false;
-    if (size1.layout != size2.layout &&
-        size1.layout != DATA_LAYOUT_UNKNOWN &&
-        size2.layout != DATA_LAYOUT_UNKNOWN)
-        return false;
-    if (size1.layout == DATA_LAYOUT_BLOCK &&
-        size2.layout == DATA_LAYOUT_BLOCK &&
-        size1.C != size2.C)
-        return false;
-    for (int i = 0; i < size1.dims; i++) {
-        if (size1.p[i] != size2.p[i])
-            return false;
-    }
-    return true;
-}
-
-bool operator != (const MatShape& size1, const MatShape& size2)
-{
-    return !(size1 == size2);
 }
 
 /////////////////////////// MatAllocator ////////////////////////////

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -167,6 +167,23 @@ size_t MatShape::total() const
     return result;
 }
 
+std::string MatShape::str() const
+{
+    std::stringstream sstrm;
+    if (empty()) {
+        sstrm << "<empty>";
+    } else if (dims == 0) {
+        sstrm << "<scalar>";
+    } else {
+        sstrm << "[";
+        for (int i = 0; i < dims; i++) {
+            sstrm << (i > 0 ? " x " : "") << p[i];
+        }
+        sstrm << "]";
+    }
+    return sstrm.str();
+}
+
 static void finalizeBlockLayout(MatShape& size, int C=0)
 {
     if (size.layout == DATA_LAYOUT_BLOCK) {
@@ -278,7 +295,7 @@ MatShape& MatShape::operator = (const MatShape& shape)
     return *this;
 }
 
-bool MatShape::haveSymbols() const
+bool MatShape::hasSymbols() const
 {
     for (int i = 0; i < dims; i++) {
         if (p[i] < 0)

--- a/modules/core/src/matrix_transform.cpp
+++ b/modules/core/src/matrix_transform.cpp
@@ -1081,6 +1081,16 @@ void broadcast(InputArray _src, InputArray _shape, OutputArray _dst) {
     }
 }
 
+void broadcast(InputArray _src, const MatShape& _shape, OutputArray _dst)
+{
+    if (_shape.dims < 0) {
+        _dst.release();
+    } else {
+        Mat shape(1, _shape.dims, CV_32S, (int*)_shape.p);
+        broadcast(_src, shape, _dst);
+    }
+}
+
 static void rotateImpl(InputArray _src, OutputArray _dst, int rotateMode)
 {
     switch (rotateMode)

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -593,15 +593,36 @@ int _InputArray::sizend(int* arrsz, int i) const
     return d;
 }
 
-MatShape _InputArray::shape(int i) const
+bool _InputArray::empty(int i) const
 {
     _InputArray::KindFlag k = kind();
+    if (i >= 0) {
+        if (k == STD_VECTOR_MAT) {
+            auto mv = reinterpret_cast<const std::vector<Mat>*>(obj);
+            CV_Assert((size_t)i < mv->size());
+            return mv->at(i).empty();
+        }
+        else if (k == STD_VECTOR_MAT) {
+            auto umv = reinterpret_cast<const std::vector<UMat>*>(obj);
+            CV_Assert((size_t)i < umv->size());
+            return umv->at(i).empty();
+        }
+        else if (k == STD_VECTOR_VECTOR) {
+            auto vv = reinterpret_cast<const std::vector<std::vector<int> >*>(obj);
+            CV_Assert((size_t)i < vv->size());
+            return vv->at(i).empty();
+        } else {
+            CV_Error(Error::StsNotImplemented, "");
+        }
+    }
+    return empty();
+}
+
+MatShape _InputArray::shape(int i) const
+{
     int sizes[CV_MAX_DIM], dims = sizend(sizes, i);
 
-    if (dims == 0 && ((k == MAT && i < 0) ||
-                      (k == UMAT && i < 0) ||
-                      (k == STD_VECTOR_MAT && i >= 0) ||
-                      (k == STD_VECTOR_UMAT && i >= 0)))
+    if (dims == 0 && empty(i))
         return MatShape();
     return MatShape(dims, sizes);
 }

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -620,7 +620,8 @@ bool _InputArray::empty(int i) const
 
 MatShape _InputArray::shape(int i) const
 {
-    int sizes[CV_MAX_DIM], dims = sizend(sizes, i);
+    int sizes[CV_MAX_DIM];
+    int dims = sizend(sizes, i);
 
     if (dims == 0 && empty(i))
         return MatShape();

--- a/modules/core/src/out.cpp
+++ b/modules/core/src/out.cpp
@@ -403,4 +403,186 @@ namespace cv
         }
         return makePtr<DefaultFormatter>();
     }
+
+    template<typename _Tp> struct Fmt
+    {
+        typedef int temp_type;
+        static const char* fmt() { return "%d"; }
+    };
+
+    template<> struct Fmt<uint32_t>
+    {
+        typedef unsigned temp_type;
+        static const char* fmt() { return "%u"; }
+    };
+
+    template<> struct Fmt<int64_t>
+    {
+        typedef long long temp_type;
+        static const char* fmt() { return "%lld"; }
+    };
+
+    template<> struct Fmt<uint64_t>
+    {
+        typedef unsigned long long temp_type;
+        static const char* fmt() { return "%llu"; }
+    };
+
+    template<> struct Fmt<float>
+    {
+        typedef float temp_type;
+        static const char* fmt() { return "%.5g"; }
+    };
+
+    template<> struct Fmt<double>
+    {
+        typedef double temp_type;
+        static const char* fmt() { return "%.5g"; }
+    };
+
+    template<> struct Fmt<hfloat>
+    {
+        typedef float temp_type;
+        static const char* fmt() { return "%.5g"; }
+    };
+
+    template<> struct Fmt<bfloat>
+    {
+        typedef float temp_type;
+        static const char* fmt() { return "%.4g"; }
+    };
+
+    template <typename _Tp>
+    static void pprintRow(std::ostream& strm, const _Tp* ptr, int n, size_t ofs, int edge)
+    {
+        char buf[128];
+        const char* fmt = Fmt<_Tp>::fmt();
+        int i, ndump = edge > 0 ? std::min(n, edge*2+1) : n;
+        if (edge == 0)
+            edge = ndump;
+        for (i = 0; i < ndump; i++) {
+            int j = n == ndump || i < edge ? i : i == edge ? -1 : n-edge*2-1+i;
+            if (i > 0)
+                strm << ", ";
+            if (j >= 0) {
+                snprintf(buf, sizeof(buf), fmt, (typename Fmt<_Tp>::temp_type)ptr[ofs + j]);
+                strm << buf;
+            } else
+                strm << "... ";
+        }
+    }
+
+    static void pprintSlice(std::ostream& strm, const Mat& tensor,
+                            const size_t* step, int d,
+                            size_t ofs, int edge)
+    {
+        MatShape shape = tensor.shape();
+        int ndims = shape.dims;
+        int n = d >= ndims ? 1 : shape[d];
+        if (d >= ndims - 1) {
+            int typ = tensor.depth();
+            void* data = tensor.data;
+            CV_Assert(data);
+            n *= tensor.channels();
+            if (typ == CV_8U)
+                pprintRow(strm, (const uint8_t*)data, n, ofs, edge);
+            else if (typ == CV_8S)
+                pprintRow(strm, (const int8_t*)data, n, ofs, edge);
+            else if (typ == CV_16U)
+                pprintRow(strm, (const uint16_t*)data, n, ofs, edge);
+            else if (typ == CV_16S)
+                pprintRow(strm, (const int16_t*)data, n, ofs, edge);
+            else if (typ == CV_32U)
+                pprintRow(strm, (const unsigned*)data, n, ofs, edge);
+            else if (typ == CV_32S)
+                pprintRow(strm, (const int*)data, n, ofs, edge);
+            else if (typ == CV_64U)
+                pprintRow(strm, (const uint64_t*)data, n, ofs, edge);
+            else if (typ == CV_64S)
+                pprintRow(strm, (const int64_t*)data, n, ofs, edge);
+            else if (typ == CV_32F)
+                pprintRow(strm, (const float*)data, n, ofs, edge);
+            else if (typ == CV_64F)
+                pprintRow(strm, (const double*)data, n, ofs, edge);
+            else if (typ == CV_16F)
+                pprintRow(strm, (const hfloat*)data, n, ofs, edge);
+            else if (typ == CV_16BF)
+                pprintRow(strm, (const bfloat*)data, n, ofs, edge);
+            else if (typ == CV_Bool)
+                pprintRow(strm, (const bool*)data, n, ofs, edge);
+            else {
+                CV_Error(Error::StsNotImplemented, "unsupported type");
+            }
+        } else {
+            int i, ndump = edge > 0 ? std::min(n, edge*2+1) : n;
+            bool dots = false;
+            for (i = 0; i < ndump; i++) {
+                if (i > 0 && !dots) {
+                    int nempty_lines = ndims - 2 - d;
+                    for (int k = 0; k < nempty_lines; k++)
+                        strm << "\n";
+                }
+                if (i > 0)
+                    strm << "\n";
+                int j = n == ndump || i < edge ? i :
+                        i == edge ? -1 :
+                        n - edge*2 - 1 + i;
+                bool dots = j < 0;
+                if (!dots)
+                    pprintSlice(strm, tensor, step, d+1, ofs + j*step[d], edge);
+                else
+                    strm << "...";
+            }
+        }
+    }
+
+    std::ostream& pprint(std::ostream& strm, InputArray array,
+                         int indent, int edge_,
+                         int wholeTensorThreshold,
+                         char parens)
+    {
+        char oparen = parens;
+        char cparen = parens == '(' ? ')' :
+                      parens == '[' ? ']' :
+                      parens == '{' ? '}' :
+                      parens == '<' ? '>' :
+                      parens;
+        int edge = edge_ > 0 ? edge_ : 3;
+        wholeTensorThreshold = wholeTensorThreshold > 0 ? wholeTensorThreshold : 100;
+
+        Mat tensor = array.getMat();
+        if (!tensor.isContinuous()) {
+            // [TODO] print non-continous arrays without copy
+            Mat temp;
+            tensor.copyTo(temp);
+            tensor = temp;
+        }
+
+        MatShape shape = tensor.shape();
+        size_t sz_all = tensor.total();
+
+        if (parens)
+            strm << oparen;
+        if (sz_all == 0) {
+            if (!parens)
+                strm << "<empty>";
+        } else {
+            if (sz_all <= (size_t)wholeTensorThreshold)
+                edge = 0;
+
+            int ndims = shape.dims;
+            int cn = tensor.channels();
+            size_t step[MatShape::MAX_DIMS];
+            step[std::max(ndims-1, 0)] = 1;
+            for (int i = ndims-2; i >= 0; i--) {
+                step[i] = step[i+1]*shape[i+1]*cn;
+                cn = 1;
+            }
+            pprintSlice(strm, tensor, step, 0, 0, edge);
+        }
+        if (parens)
+            strm << cparen;
+        return strm;
+    }
+
 } // cv

--- a/modules/core/src/out.cpp
+++ b/modules/core/src/out.cpp
@@ -527,7 +527,7 @@ namespace cv
                 int j = n == ndump || i < edge ? i :
                         i == edge ? -1 :
                         n - edge*2 - 1 + i;
-                bool dots = j < 0;
+                dots = j < 0;
                 if (!dots)
                     pprintSlice(strm, tensor, step, d+1, ofs + j*step[d], edge);
                 else
@@ -537,7 +537,7 @@ namespace cv
     }
 
     std::ostream& pprint(std::ostream& strm, InputArray array,
-                         int indent, int edge_,
+                         int /*indent*/, int edge_,
                          int wholeTensorThreshold,
                          char parens)
     {

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -773,7 +773,11 @@ void UMat::fit(int _dims, const int* _sizes, int _type, UMatUsageFlags _usageFla
     for (int i = 0; i < _dims; i++)
         newTotal *= _sizes[i];
     size_t newTotalBytes = newTotal*esz;
-    if (newTotalBytes > 0 && (!isContinuous() || newTotalBytes > oldTotalBytes || _usageFlags != usageFlags)) {
+    if (newTotalBytes > 0 &&
+        (!isContinuous() ||
+         newTotalBytes > oldTotalBytes ||
+         offset != 0 ||
+         _usageFlags != usageFlags)) {
         create(_dims, _sizes, _type, _usageFlags);
     } else {
         flags = (flags & ~Mat::TYPE_MASK) | CV_MAT_TYPE(_type);

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -773,7 +773,7 @@ void UMat::fit(int _dims, const int* _sizes, int _type, UMatUsageFlags _usageFla
     for (int i = 0; i < _dims; i++)
         newTotal *= _sizes[i];
     size_t newTotalBytes = newTotal*esz;
-    if (!isContinuous() || newTotalBytes > oldTotalBytes || _usageFlags != usageFlags) {
+    if (newTotalBytes > 0 && (!isContinuous() || newTotalBytes > oldTotalBytes || _usageFlags != usageFlags)) {
         create(_dims, _sizes, _type, _usageFlags);
     } else {
         flags = (flags & ~Mat::TYPE_MASK) | CV_MAT_TYPE(_type);

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -1162,6 +1162,15 @@ UMat UMat::reshape(int _cn, int _newndims, const int* _newsz) const
     CV_Error(cv::Error::StsNotImplemented, "Reshaping of n-dimensional non-continuous matrices is not supported yet");
 }
 
+UMat UMat::reshape(int _cn, const MatShape& _newshape) const
+{
+    if (_newshape.dims < 0) {
+        int newshape[] = {0};
+        return reshape(_cn, 1, newshape);
+    }
+    return reshape(_cn, _newshape.dims, _newshape.p);
+}
+
 Mat UMat::getMat(AccessFlag accessFlags) const
 {
     if(!u)

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -352,6 +352,15 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<GatherLayer> create(const LayerParams& params);
     };
 
+    // ONNX-compliant implementation of Gather
+    class CV_EXPORTS Gather2Layer : public Layer
+    {
+    public:
+        int axis;
+
+        static Ptr<Gather2Layer> create(const LayerParams& params);
+    };
+
     /** @brief GatherElements layer
     * GatherElements takes two inputs data and indices of the same rank r >= 1 and an optional attribute axis and works such that:
     *   output[i][j][k] = data[index[i][j][k]][j][k] if axis = 0 and r = 3
@@ -457,6 +466,8 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS ShapeLayer : public Layer
     {
     public:
+        int start, end;
+
         static Ptr<ShapeLayer> create(const LayerParams& params);
     };
 
@@ -488,12 +499,16 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS SqueezeLayer : public Layer
     {
     public:
+        std::vector<int> axes;
+
         static Ptr<SqueezeLayer> create(const LayerParams& params);
     };
 
     class CV_EXPORTS UnsqueezeLayer : public Layer
     {
     public:
+        std::vector<int> axes;
+
         static Ptr<UnsqueezeLayer> create(const LayerParams& params);
     };
 
@@ -542,12 +557,30 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<ConcatLayer> create(const LayerParams &params);
     };
 
+    class CV_EXPORTS Concat2Layer : public Layer
+    {
+    public:
+        int axis;
+
+        static Ptr<Concat2Layer> create(const LayerParams &params);
+    };
+
     class CV_EXPORTS SplitLayer : public Layer
     {
     public:
         int outputsCount; //!< Number of copies that will be produced (is ignored when negative).
 
         static Ptr<SplitLayer> create(const LayerParams &params);
+    };
+
+    // ONNX-compliant version of Split
+    class CV_EXPORTS Split2Layer : public Layer
+    {
+    public:
+        int axis;
+        std::vector<int> split;
+
+        static Ptr<Split2Layer> create(const LayerParams& params);
     };
 
     /**
@@ -591,10 +624,29 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<SliceLayer> create(const LayerParams &params);
     };
 
+    // ONNX-compliant version of Slice
+    class CV_EXPORTS Slice2Layer : public Layer
+    {
+    public:
+        std::vector<int> starts, ends, axes;
+
+        static Ptr<Slice2Layer> create(const LayerParams &params);
+    };
+
     class CV_EXPORTS PermuteLayer : public Layer
     {
     public:
         static Ptr<PermuteLayer> create(const LayerParams& params);
+    };
+
+    // ONNX-compliant version of Transpose
+    // (previously implemented in PermuteLayer)
+    class CV_EXPORTS TransposeLayer : public Layer
+    {
+    public:
+        std::vector<int> perm;
+
+        static Ptr<TransposeLayer> create(const LayerParams& params);
     };
 
     /**

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -86,6 +86,15 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<Layer> create(const LayerParams &params);
     };
 
+    /**
+     * Constant layer produces the same data blob at an every forward pass.
+     */
+    class CV_EXPORTS ConstantOfShapeLayer : public Layer
+    {
+    public:
+        static Ptr<ConstantOfShapeLayer> create(const LayerParams &params);
+    };
+
     //! LSTM recurrent layer
     class CV_EXPORTS LSTMLayer : public Layer
     {
@@ -445,6 +454,12 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<MVNLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS ShapeLayer : public Layer
+    {
+    public:
+        static Ptr<ShapeLayer> create(const LayerParams& params);
+    };
+
     /* Reshaping */
 
     class CV_EXPORTS ReshapeLayer : public Layer
@@ -460,6 +475,24 @@ CV__DNN_INLINE_NS_BEGIN
     {
     public:
         static Ptr<FlattenLayer> create(const LayerParams &params);
+    };
+
+    class CV_EXPORTS SqueezeLayer : public Layer
+    {
+    public:
+        static Ptr<SqueezeLayer> create(const LayerParams& params);
+    };
+
+    class CV_EXPORTS UnsqueezeLayer : public Layer
+    {
+    public:
+        static Ptr<UnsqueezeLayer> create(const LayerParams& params);
+    };
+
+    class CV_EXPORTS RangeLayer : public Layer
+    {
+    public:
+        static Ptr<RangeLayer> create(const LayerParams& params);
     };
 
     class CV_EXPORTS QuantizeLayer : public Layer

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -471,6 +471,14 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<ReshapeLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS Reshape2Layer : public Layer
+    {
+    public:
+        MatShape newShapeDesc;
+
+        static Ptr<Reshape2Layer> create(const LayerParams& params);
+    };
+
     class CV_EXPORTS FlattenLayer : public Layer
     {
     public:

--- a/modules/dnn/include/opencv2/dnn/dict.hpp
+++ b/modules/dnn/include/opencv2/dnn/dict.hpp
@@ -138,6 +138,10 @@ public:
     template <typename T>
     T get(const String &key, const T &defaultValue) const;
 
+    //! If the @p key in the dictionary then returns its value, else returns empty vector.
+    template <typename T>
+    std::vector<T> getVector(const String &key) const;
+
     //! Sets new @p value for the @p key, or adds new key-value pair into the dictionary.
     template<typename T>
     const T &set(const String &key, const T &value);

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -828,20 +828,25 @@ CV__DNN_INLINE_NS_BEGIN
          *  @param inLayersShapes output parameter for input layers shapes;
          * order is the same as in layersIds
          *  @param outLayersShapes output parameter for output layers shapes;
-         * order is the same as in layersIds
+         * order is the same as in layersIds.
+         *
+         * This overload should be deprecated
          */
-        CV_WRAP void getLayersShapes(const std::vector<MatShape>& netInputShapes,
-                                     const std::vector<int>& netInputTypes,
-                                     CV_OUT std::vector<int>& layersIds,
-                                     CV_OUT std::vector<std::vector<MatShape> >& inLayersShapes,
-                                     CV_OUT std::vector<std::vector<MatShape> >& outLayersShapes) const;
+        void getLayersShapes(const std::vector<MatShape>& netInputShapes,
+                             const std::vector<int>& netInputTypes,
+                             CV_OUT std::vector<int>& layersIds,
+                             CV_OUT std::vector<std::vector<MatShape> >& inLayersShapes,
+                             CV_OUT std::vector<std::vector<MatShape> >& outLayersShapes) const;
 
-        /** @overload */
-        CV_WRAP void getLayersShapes(const MatShape& netInputShape,
-                                     const int& netInputType,
-                                     CV_OUT std::vector<int>& layersIds,
-                                     CV_OUT std::vector<std::vector<MatShape> >& inLayersShapes,
-                                     CV_OUT std::vector<std::vector<MatShape> >& outLayersShapes) const;
+        /** @overload
+         *
+         * This overload should be deprecated
+        */
+        void getLayersShapes(const MatShape& netInputShape,
+                             const int& netInputType,
+                             CV_OUT std::vector<int>& layersIds,
+                             CV_OUT std::vector<std::vector<MatShape> >& inLayersShapes,
+                             CV_OUT std::vector<std::vector<MatShape> >& outLayersShapes) const;
 
         /** @brief Returns input and output shapes for layer with specified
          * id in loaded model; preliminary inferencing isn't necessary.
@@ -852,15 +857,20 @@ CV__DNN_INLINE_NS_BEGIN
          * order is the same as in layersIds
          *  @param outLayerShapes output parameter for output layers shapes;
          * order is the same as in layersIds
-         */
-        CV_WRAP void getLayerShapes(const MatShape& netInputShape,
-                                    const int& netInputType,
-                                    const int layerId,
-                                    CV_OUT std::vector<MatShape>& inLayerShapes,
-                                    CV_OUT std::vector<MatShape>& outLayerShapes) const; // FIXIT: CV_WRAP
+         *
+         * This overload should be deprecated
+        */
+        void getLayerShapes(const MatShape& netInputShape,
+                            const int& netInputType,
+                            const int layerId,
+                            CV_OUT std::vector<MatShape>& inLayerShapes,
+                            CV_OUT std::vector<MatShape>& outLayerShapes) const; // FIXIT: CV_WRAP
 
-        /** @overload */
-        void getLayerShapes(const std::vector<MatShape>& netInputShapes,
+        /** @overload
+         *
+         * The only overload of getLayerShapes that should be kept in 5.x
+        */
+        CV_WRAP void getLayerShapes(const std::vector<MatShape>& netInputShapes,
                                     const std::vector<int>& netInputTypes,
                                     const int layerId,
                                     CV_OUT std::vector<MatShape>& inLayerShapes,
@@ -873,17 +883,19 @@ CV__DNN_INLINE_NS_BEGIN
          */
         CV_WRAP int64 getFLOPS(const std::vector<MatShape>& netInputShapes,
                                const std::vector<int>& netInputTypes) const;
+        /** @overload
+            These overloads should be deprecated
+        */
+        int64 getFLOPS(const MatShape& netInputShape,
+                       const int& netInputType) const;
         /** @overload */
-        CV_WRAP int64 getFLOPS(const MatShape& netInputShape,
-                               const int& netInputType) const;
+        int64 getFLOPS(const int layerId,
+                       const std::vector<MatShape>& netInputShapes,
+                       const std::vector<int>& netInputTypes) const;
         /** @overload */
-        CV_WRAP int64 getFLOPS(const int layerId,
-                               const std::vector<MatShape>& netInputShapes,
-                               const std::vector<int>& netInputTypes) const;
-        /** @overload */
-        CV_WRAP int64 getFLOPS(const int layerId,
-                               const MatShape& netInputShape,
-                               const int& netInputType) const;
+        int64 getFLOPS(const int layerId,
+                       const MatShape& netInputShape,
+                       const int& netInputType) const;
 
         /** @brief Returns list of types for layer used in model.
          * @param layersTypes output parameter for returning types.
@@ -903,20 +915,26 @@ CV__DNN_INLINE_NS_BEGIN
          * @param weights output parameter to store resulting bytes for weights.
          * @param blobs output parameter to store resulting bytes for intermediate blobs.
          */
-        void getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
+        CV_WRAP void getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
                                           const std::vector<int>& netInputTypes,
-                                          CV_OUT size_t& weights, CV_OUT size_t& blobs) const; // FIXIT: CV_WRAP
-        /** @overload */
-        CV_WRAP void getMemoryConsumption(const MatShape& netInputShape,
+                                          CV_OUT size_t& weights, CV_OUT size_t& blobs) const;
+        /** @overload
+            It should be deprecated
+        */
+        void getMemoryConsumption(const MatShape& netInputShape,
                                           const int& netInputType,
                                           CV_OUT size_t& weights, CV_OUT size_t& blobs) const;
-        /** @overload */
-        CV_WRAP void getMemoryConsumption(const int layerId,
+        /** @overload
+            It should be deprecated
+        */
+        void getMemoryConsumption(const int layerId,
                                           const std::vector<MatShape>& netInputShapes,
                                           const std::vector<int>& netInputTypes,
                                           CV_OUT size_t& weights, CV_OUT size_t& blobs) const;
-        /** @overload */
-        CV_WRAP void getMemoryConsumption(const int layerId,
+        /** @overload
+            It should be deprecated
+        */
+        void getMemoryConsumption(const int layerId,
                                           const MatShape& netInputShape,
                                           const int& netInputType,
                                           CV_OUT size_t& weights, CV_OUT size_t& blobs) const;
@@ -928,18 +946,23 @@ CV__DNN_INLINE_NS_BEGIN
          * @param layerIds output vector to save layer IDs.
          * @param weights output parameter to store resulting bytes for weights.
          * @param blobs output parameter to store resulting bytes for intermediate blobs.
-         */
+         *
+         * It should be deprecated
+        */
         void getMemoryConsumption(const std::vector<MatShape>& netInputShapes,
                                           const std::vector<int>& netInputTypes,
                                           CV_OUT std::vector<int>& layerIds,
                                           CV_OUT std::vector<size_t>& weights,
-                                          CV_OUT std::vector<size_t>& blobs) const; // FIXIT: CV_WRAP
-        /** @overload */
+                                          CV_OUT std::vector<size_t>& blobs) const;
+        /** @overload
+         *
+         *  It should be deprecated
+         */
         void getMemoryConsumption(const MatShape& netInputShape,
                                           const int& netInputType,
                                           CV_OUT std::vector<int>& layerIds,
                                           CV_OUT std::vector<size_t>& weights,
-                                          CV_OUT std::vector<size_t>& blobs) const; // FIXIT: CV_WRAP
+                                          CV_OUT std::vector<size_t>& blobs) const;
 
         /** @brief Enables or disables layer fusion in the network.
          * @param fusion true to enable the fusion, false to disable. The fusion is enabled by default.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1000,7 +1000,7 @@ CV__DNN_INLINE_NS_BEGIN
         void checkArg(Arg arg) const;
         void checkArgs(const std::vector<Arg>& args) const;
 
-        int64_t findDim(const std::string& name=std::string(), bool insert=false);
+        int findDim(const std::string& name, bool insert=false);
 
         std::ostream& dump(std::ostream* strm=nullptr) const;
         std::ostream& dumpArg(std::ostream& strm, Arg arg, int indent,
@@ -1187,26 +1187,29 @@ CV__DNN_INLINE_NS_BEGIN
 
     /** @brief Reads a network model <a href="https://onnx.ai/">ONNX</a>.
      *  @param onnxFile path to the .onnx file with text description of the network architecture.
+     *  @param useNewEngine the new engine is used to load and run the model
      *  @returns Network object that ready to do forward, throw an exception in failure cases.
      */
-    CV_EXPORTS_W Net readNetFromONNX(CV_WRAP_FILE_PATH const String &onnxFile);
+    CV_EXPORTS_W Net readNetFromONNX(CV_WRAP_FILE_PATH const String &onnxFile, bool useNewEngine=true);
 
     /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
      *         in-memory buffer.
      *  @param buffer memory address of the first byte of the buffer.
      *  @param sizeBuffer size of the buffer.
+     *  @param useNewEngine the new engine is used to load and run the model
      *  @returns Network object that ready to do forward, throw an exception
      *        in failure cases.
      */
-    CV_EXPORTS Net readNetFromONNX(const char* buffer, size_t sizeBuffer);
+    CV_EXPORTS Net readNetFromONNX(const char* buffer, size_t sizeBuffer, bool useNewEngine=true);
 
     /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
      *         in-memory buffer.
      *  @param buffer in-memory buffer that stores the ONNX model bytes.
+     *  @param useNewEngine the new engine is used to load and run the model
      *  @returns Network object that ready to do forward, throw an exception
      *        in failure cases.
      */
-    CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer);
+    CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer, bool useNewEngine=true);
 
     /** @brief Creates blob from .pb file.
      *  @param path to the .pb file with input tensor.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -247,9 +247,9 @@ CV__DNN_INLINE_NS_BEGIN
 
     CV_EXPORTS std::string argKindToString(ArgKind kind);
 
-    struct CV_EXPORTS ArgInfo
+    struct CV_EXPORTS ArgData
     {
-        ArgInfo();
+        ArgData();
         std::string name;
         ArgKind kind;
         MatShape shape;
@@ -979,7 +979,7 @@ CV__DNN_INLINE_NS_BEGIN
         // Get the main model graph
         Ptr<Graph> getMainGraph() const;
 
-        const ArgInfo& argInfo(Arg arg) const;
+        const ArgData& argData(Arg arg) const;
         std::string argName(Arg arg) const;
         ArgKind argKind(Arg arg) const;
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -977,7 +977,7 @@ CV__DNN_INLINE_NS_BEGIN
         Ptr<Graph> getMainGraph() const;
 
         const ArgInfo& argInfo(Arg arg) const;
-        std::string_view argName(Arg arg) const;
+        std::string argName(Arg arg) const;
         ArgKind argKind(Arg arg) const;
 
         // if the name is empty, always creates a new argument;

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -61,7 +61,6 @@ CV__DNN_INLINE_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 
-    typedef std::vector<int> MatShape;
     typedef int MatType;
 
     /**
@@ -107,19 +106,25 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_TARGET_CPU_FP16, // Only the ARM platform is supported. Low precision computing, accelerate model inference.
     };
 
-    /**
-     * @brief Enum of data layout for model inference.
-     * @see Image2BlobParams
-     */
-    enum DataLayout
+    enum TracingMode
     {
-        DNN_LAYOUT_UNKNOWN = 0,
-        DNN_LAYOUT_ND = 1,        //!< OpenCV data layout for 2D data.
-        DNN_LAYOUT_NCHW = 2,      //!< OpenCV data layout for 4D data.
-        DNN_LAYOUT_NCDHW = 3,      //!< OpenCV data layout for 5D data.
-        DNN_LAYOUT_NHWC = 4,      //!< Tensorflow-like data layout for 4D data.
-        DNN_LAYOUT_NDHWC = 5,      //!< Tensorflow-like data layout for 5D data.
-        DNN_LAYOUT_PLANAR = 6,     //!< Tensorflow-like data layout, it should only be used at tf or tflite model parsing.
+        DNN_TRACE_NONE = 0, //!< Don't trace anything
+        DNN_TRACE_ALL = 1, //!< Print all executed operations along with the output tensors, more or less compatible with ONNX Runtime
+        DNN_TRACE_OP = 2 //!< Print all executed operations. Types and shapes of all inputs and outputs are printed, but the content is not.
+    };
+
+    enum ProfilingMode
+    {
+        DNN_PROFILE_NONE = 0, //!< Don't do any profiling
+        DNN_PROFILE_SUMMARY = 1, //!< Collect the summary statistics by layer type (e.g. all "Conv2D" or all "Add") and print it in the end, sorted by the execution time (most expensive layers first). Note that it may introduce some overhead and cause slowdown, especially in the case of non-CPU backends.
+        DNN_PROFILE_DETAILED = 2 //!< Print execution time of each single layer. Note that it may introduce some overhead and cause slowdown, especially in the case of non-CPU backends.
+    };
+
+    enum ModelFormat {
+        DNN_MODEL_GENERIC = 0, //!< Some generic model format
+        DNN_MODEL_ONNX = 1, //!< ONNX model
+        DNN_MODEL_TF = 2, //!< TF model
+        DNn_MODEL_TFLITE = 3 //!< TFLite model
     };
 
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();
@@ -218,6 +223,40 @@ CV__DNN_INLINE_NS_BEGIN
         int hostMatDepth = -1;
     };
 
+    struct CV_EXPORTS Arg
+    {
+        Arg();
+        explicit Arg(int idx_);
+        bool empty() const;
+        operator bool() const;
+        // idx > 0: the Arg is input or output argument of some operation inside inference graph
+        // idx < 0: the Arg is input or output argument of a pattern
+        // idx == 0: no/empty argument; used in operations where some of the inputs/outputs are optional.
+        int idx;
+    };
+
+    enum ArgKind {
+        DNN_ARG_EMPTY=0, //!< valid only for Arg.idx==0. It's "no-arg"
+        DNN_ARG_CONST=1, //!< a constant argument.
+        DNN_ARG_INPUT=2, //!< input of the whole model. Before Net::forward() or in Net::forward() all inputs must be set
+        DNN_ARG_OUTPUT=3, //!< output of the model.
+        DNN_ARG_TEMP=4,   //!< intermediate result, a result of some operation and input to some other operation(s).
+        DNN_ARG_PATTERN=5 //!< not used for now
+    };
+
+    CV_EXPORTS std::string argKindToString(ArgKind kind);
+
+    struct CV_EXPORTS ArgInfo
+    {
+        ArgInfo();
+        std::string name;
+        ArgKind kind;
+        MatShape shape;
+        int type;
+    };
+
+    class CV_EXPORTS Net;
+    class CV_EXPORTS Graph;
     class CV_EXPORTS ActivationLayer;
 
     /** @brief This interface class allows to build new Layers - are building blocks of networks.
@@ -231,6 +270,11 @@ CV__DNN_INLINE_NS_BEGIN
 
         //! List of learned parameters must be stored here to allow read them by using Net::getParam().
         CV_PROP_RW std::vector<Mat> blobs;
+        std::vector<Arg> inputs;
+        std::vector<Arg> outputs;
+        Net* net;
+
+        virtual std::vector<Ptr<Graph> >* subgraphs() const;
 
         /** @brief Computes and sets internal parameters according to inputs, outputs and blobs.
          *  @deprecated Use Layer::finalize(InputArrayOfArrays, OutputArrayOfArrays) instead
@@ -417,6 +461,19 @@ CV__DNN_INLINE_NS_BEGIN
 
         virtual bool updateMemoryShapes(const std::vector<MatShape> &inputs);
 
+        // returns true if the operation takes a single input and can always be performed in-place,
+        // assuming that the input is contiguous.
+        // Examples of such operations are: Reshape, Flatten, Squeeze, Unsqueeze,
+        // as well many unary element-wise operations (ReLU, Tanh, ...)
+        virtual bool alwaysSupportInplace() const;
+
+        // returns false if the shape of Layer outputs is defined only by the shapes of inputs.
+        // Sometimes the shape depends on the content of the input(s), then the method should return true.
+        // In such a rare case forward() method should take care of proper allocation of the output tensors.
+        // On the other hand, when this method returns false, the engine takes care of proper allocation of the outputs,
+        // so that forward() can assume that the outputs are already allocated.
+        virtual bool dynamicOutputShapes() const;
+
         CV_PROP String name; //!< Name of the layer instance, can be used for logging or other internal purposes.
         CV_PROP String type; //!< Type name which was used for creating layer by layer factory.
         CV_PROP int preferableTarget; //!< prefer target for layer forwarding
@@ -425,6 +482,38 @@ CV__DNN_INLINE_NS_BEGIN
         explicit Layer(const LayerParams &params);      //!< Initializes only #name, #type and #blobs fields.
         void setParamsFrom(const LayerParams &params);  //!< Initializes only #name, #type and #blobs fields.
         virtual ~Layer();
+    };
+
+    /** @brief Represents graph or subgraph of a model.
+     * The graph (in mathematical terms it's rather a multigraph) is represented
+     * as a topologically-sorted linear sequence of operations.
+     * Each operation is a smart pointer to a Layer (some of its derivative class instance), which
+     * includes a list of inputs and outputs, as well as an optional list of subgraphs (e.g. 'If' contains 2 subgraphs).
+     */
+    class CV_EXPORTS Graph
+    {
+    public:
+        static Ptr<Graph> create(const Net& net, const std::string& name,
+                                 const std::vector<Arg>& inputs);
+        virtual ~Graph();
+        virtual bool empty() const = 0;
+        virtual void clear() = 0;
+        virtual std::string name() const = 0;
+        virtual Ptr<Graph> clone(Net* newnet=nullptr) const = 0;
+        virtual const std::vector<Arg>& append(Ptr<Layer>& layer,
+                    const std::vector<std::string>& outnames=std::vector<std::string>()) = 0;
+        virtual Arg append(Ptr<Layer>& layer, const std::string& outname=std::string()) = 0;
+        virtual std::ostream& dump(std::ostream& strm, int indent, bool comma) = 0;
+        virtual void inferTypes(const std::vector<MatShape>& inptypes,
+                        std::vector<MatShape>& outtypes) const = 0;
+        virtual void inferShapes(const std::vector<MatShape>& inpshapes,
+                         std::vector<MatShape>& outshapes) const = 0;
+        virtual Net* net() const = 0;
+        virtual const std::vector<Arg>& inputs() const = 0;
+        virtual const std::vector<Arg>& outputs() const = 0;
+        virtual void setOutputs(const std::vector<Arg>& outputs) = 0;
+        virtual const std::vector<Ptr<Layer> >& prog() const = 0;
+        virtual void setProg(const std::vector<Ptr<Layer> >& newprog) = 0;
     };
 
     /** @brief This class allows to create and manipulate comprehensive artificial neural networks.
@@ -650,6 +739,33 @@ CV__DNN_INLINE_NS_BEGIN
          */
         CV_WRAP void setPreferableTarget(int targetId);
 
+        /**
+         * @brief Set the tracing mode
+         * @param[in] tracingMode the tracing mode, see DNN_TRACE_*
+         */
+        CV_WRAP void setTracingMode(int tracingMode);
+
+        /**
+         * @brief Retrieve the current tracing mode
+         */
+        CV_WRAP int getTracingMode() const;
+
+        /**
+         * @brief Set the profiling mode
+         * @param[in] profilingMode the profiling mode, see DNN_PROFILE_*
+         */
+        CV_WRAP void setProfilingMode(int profilingMode);
+
+        /**
+         * @brief Retrieve the current profiling mode
+         */
+        CV_WRAP int getProfilingMode() const;
+
+        /**
+         * @brief Retrieve the current model format, see DNN_MODEL_*
+         */
+        CV_WRAP int getModelFormat() const;
+
         /** @brief Sets the new input value for the network
          *  @param blob        A new blob. Should have CV_32F or CV_8U depth.
          *  @param name        A name of input layer.
@@ -837,6 +953,50 @@ CV__DNN_INLINE_NS_BEGIN
          */
         CV_WRAP int64 getPerfProfile(CV_OUT std::vector<double>& timings);
 
+        /** @brief Returns overall time for inference and timings (in seconds) for each type of layer, sorted by time in the decreasing order.
+         *
+         * @param[out] timings vector for tick timings for all layers.
+         * @return overall ticks for model inference.
+         */
+        double getPerfProfileSummary(CV_OUT std::vector<std::string>& names, CV_OUT std::vector<double>& timings);
+
+        // Create a new graph/subgraph, mode 1: we know in advance names of all the graph inputs and outputs (e.g. when we parse ONNX).
+        // The function register arguments with given names and
+        // creates a new empty graph with the inputs and outputs.
+        // When it's the first created graph, it automatically becomes the main model graph.
+        Ptr<Graph> newGraph(const std::string& name,
+                            const std::vector<std::string>& inpnames,
+                            const std::vector<std::string>& outnames) const;
+        // Create a new graph/subgraph, mode 2: we construct the graph manually.
+        // First, we create empty graph with certain input Args (they may or may not have names).
+        // once the graph is constructed, we set the graph outputs using Graph::setOutputs().
+        // When it's the first created graph, it automatically becomes the main model graph.
+        Ptr<Graph> newGraph(const std::string& name, const std::vector<Arg>& inputs) const;
+
+        // Get the main model graph
+        Ptr<Graph> getMainGraph() const;
+
+        const ArgInfo& argInfo(Arg arg) const;
+        std::string_view argName(Arg arg) const;
+        ArgKind argKind(Arg arg) const;
+
+        // if the name is empty, always creates a new argument;
+        // if it's not empty, returns argument with the specific name if it already exists,
+        // otherwise creates new argument with the specified name
+        Arg getArg(const std::string& name);
+        bool haveArg(const std::string& name) const;
+
+        Arg newConstArg(const std::string& name, const Mat& m) const;
+        Arg newConstScalarArg(const std::string& name, int type, const void* value) const;
+        Arg newArg(const std::string& name, ArgKind kind) const;
+        bool isConstArg(Arg arg) const;
+        bool isTempArg(Arg arg) const;
+        Mat& argTensor(Arg arg) const;
+        MatSize argSize(Arg arg) const;
+        int argType(Arg arg) const;
+
+        int64_t findDim(const std::string& name=std::string(), bool insert=false);
+        std::string dimToString(int64_t size) const;
 
         struct Impl;
         inline Impl* getImpl() const { return impl.get(); }

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -969,11 +969,6 @@ CV__DNN_INLINE_NS_BEGIN
          */
         double getPerfProfileSummary(CV_OUT std::vector<std::string>& names, CV_OUT std::vector<double>& timings);
 
-        // Create a new graph/subgraph, mode 2: we construct the graph manually.
-        // First, we create empty graph with certain input Args (they may or may not have names).
-        // once the graph is constructed, we set the graph outputs using Graph::setOutputs().
-        Ptr<Graph> newGraph(const std::string& name, const std::vector<Arg>& inputs, bool isMain);
-
         // Get the main model graph
         Ptr<Graph> getMainGraph() const;
 
@@ -987,16 +982,9 @@ CV__DNN_INLINE_NS_BEGIN
         Arg getArg(const std::string& name);
         bool haveArg(const std::string& name) const;
 
-        Arg newConstArg(const std::string& name, const Mat& m) const;
-        Arg newConstScalarArg(const std::string& name, int type, const void* value) const;
-        Arg newArg(const std::string& name, ArgKind kind) const;
         bool isConstArg(Arg arg) const;
-        bool isTempArg(Arg arg) const;
         Mat& argTensor(Arg arg) const;
-        MatSize argSize(Arg arg) const;
         int argType(Arg arg) const;
-        void checkArg(Arg arg) const;
-        void checkArgs(const std::vector<Arg>& args) const;
 
         int findDim(const std::string& name, bool insert=false);
 
@@ -1135,7 +1123,10 @@ CV__DNN_INLINE_NS_BEGIN
       * or @ref readNetFromDarknet. An order of @p model and @p config
       * arguments does not matter.
       */
-     CV_EXPORTS_W Net readNet(CV_WRAP_FILE_PATH const String& model, CV_WRAP_FILE_PATH const String& config = "", const String& framework = "");
+     CV_EXPORTS_W Net readNet(CV_WRAP_FILE_PATH const String& model,
+                              CV_WRAP_FILE_PATH const String& config = "",
+                              const String& framework = "",
+                              bool useNewEngine = true);
 
      /**
       * @brief Read deep learning network represented in one of the supported formats.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -458,7 +458,7 @@ CV__DNN_INLINE_NS_BEGIN
                               std::vector<MatType>&internals) const;
 
         virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
-                               const std::vector<MatShape> &outputs) const {CV_UNUSED(inputs); CV_UNUSED(outputs); return 0;}
+                               const std::vector<MatShape> &outputs) const;
 
         virtual bool updateMemoryShapes(const std::vector<MatShape> &inputs);
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -504,7 +504,7 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS Graph
     {
     public:
-        static Ptr<Graph> create(Net& net, const std::string& name,
+        static Ptr<Graph> create(void* netimpl, const std::string& name,
                                  const std::vector<Arg>& inputs);
         virtual ~Graph();
         virtual bool empty() const = 0;
@@ -969,18 +969,10 @@ CV__DNN_INLINE_NS_BEGIN
          */
         double getPerfProfileSummary(CV_OUT std::vector<std::string>& names, CV_OUT std::vector<double>& timings);
 
-        // Create a new graph/subgraph, mode 1: we know in advance names of all the graph inputs and outputs (e.g. when we parse ONNX).
-        // The function register arguments with given names and
-        // creates a new empty graph with the inputs and outputs.
-        // When it's the first created graph, it automatically becomes the main model graph.
-        Ptr<Graph> newGraph(const std::string& name,
-                            const std::vector<std::string>& inpnames,
-                            const std::vector<std::string>& outnames) const;
         // Create a new graph/subgraph, mode 2: we construct the graph manually.
         // First, we create empty graph with certain input Args (they may or may not have names).
         // once the graph is constructed, we set the graph outputs using Graph::setOutputs().
-        // When it's the first created graph, it automatically becomes the main model graph.
-        Ptr<Graph> newGraph(const std::string& name, const std::vector<Arg>& inputs) const;
+        Ptr<Graph> newGraph(const std::string& name, const std::vector<Arg>& inputs, bool isMain);
 
         // Get the main model graph
         Ptr<Graph> getMainGraph() const;

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1196,31 +1196,39 @@ CV__DNN_INLINE_NS_BEGIN
     Net readNetFromModelOptimizer(const uchar* bufferModelConfigPtr, size_t bufferModelConfigSize,
                                            const uchar* bufferWeightsPtr, size_t bufferWeightsSize);
 
+
+    enum EngineType
+    {
+        ENGINE_CLASSIC=1, //!< Force use the new dnn engine
+        ENGINE_NEW=2,     //!< Force use the old dnn engine similar to 4.x branch
+        ENGINE_AUTO=3     //!< Try to use the new engine and then fall back to the classic version.
+    };
+
     /** @brief Reads a network model <a href="https://onnx.ai/">ONNX</a>.
      *  @param onnxFile path to the .onnx file with text description of the network architecture.
-     *  @param useNewEngine the new engine is used to load and run the model
+     *  @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
      *  @returns Network object that ready to do forward, throw an exception in failure cases.
      */
-    CV_EXPORTS_W Net readNetFromONNX(CV_WRAP_FILE_PATH const String &onnxFile, bool useNewEngine=true);
+    CV_EXPORTS_W Net readNetFromONNX(CV_WRAP_FILE_PATH const String &onnxFile, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
      *         in-memory buffer.
      *  @param buffer memory address of the first byte of the buffer.
      *  @param sizeBuffer size of the buffer.
-     *  @param useNewEngine the new engine is used to load and run the model
+     *  @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
      *  @returns Network object that ready to do forward, throw an exception
      *        in failure cases.
      */
-    CV_EXPORTS Net readNetFromONNX(const char* buffer, size_t sizeBuffer, bool useNewEngine=true);
+    CV_EXPORTS Net readNetFromONNX(const char* buffer, size_t sizeBuffer, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
      *         in-memory buffer.
      *  @param buffer in-memory buffer that stores the ONNX model bytes.
-     *  @param useNewEngine the new engine is used to load and run the model
+     *  @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
      *  @returns Network object that ready to do forward, throw an exception
      *        in failure cases.
      */
-    CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer, bool useNewEngine=true);
+    CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer, int engine=ENGINE_AUTO);
 
     /** @brief Creates blob from .pb file.
      *  @param path to the .pb file with input tensor.

--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -116,12 +116,12 @@ inline int64 DictValue::get<int64>(int idx) const
 template<>
 inline int DictValue::get<int>(int idx) const
 {
-    return (int)get<int64>(idx);
+    return saturate_cast<int>(get<int64>(idx));
 }
 
 inline int DictValue::getIntValue(int idx) const
 {
-    return (int)get<int64>(idx);
+    return saturate_cast<int>(get<int64>(idx));
 }
 
 template<>
@@ -378,6 +378,17 @@ inline T Dict::get(const String &key, const T &defaultValue) const
         return i->second.get<T>();
     else
         return defaultValue;
+}
+
+template <typename T>
+inline std::vector<T> Dict::getVector(const String &key) const
+{
+    _Dict::const_iterator i = dict.find(key);
+
+    if (i != dict.end())
+        return i->second.get<std::vector<T> >();
+    else
+        return std::vector<T>();
 }
 
 template<typename T>

--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -405,6 +405,18 @@ inline std::map<String, DictValue>::const_iterator Dict::end() const
     return dict.end();
 }
 
+/////////////////////////////////////////////////////////////////
+
+inline Arg::Arg() : idx(0) {}
+
+inline Arg::Arg(int idx_) : idx(idx_) {}
+
+inline bool Arg::empty() const { return idx == 0; }
+
+inline Arg::operator bool() const { return idx != 0; }
+
+inline bool operator == (const Arg& a, const Arg& b) { return a.idx == b.idx; }
+
 CV__DNN_INLINE_NS_END
 }
 }

--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -125,6 +125,18 @@ inline int DictValue::getIntValue(int idx) const
 }
 
 template<>
+inline std::vector<int> DictValue::get<std::vector<int> >(int idx) const
+{
+    CV_Assert(idx == -1);
+    int size_ = size();
+    std::vector<int> values(size_);
+
+    for (int i = 0; i < size_; i++)
+        values[i] = get<int>(i);
+    return values;
+}
+
+template<>
 inline unsigned DictValue::get<unsigned>(int idx) const
 {
     return (unsigned)get<int64>(idx);

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -152,10 +152,9 @@ namespace {inline bool is_neg(int i) { return i < 0; }}
 
 static inline MatShape shape(int a0, int a1=-1, int a2=-1, int a3=-1)
 {
-    int dims[] = {a0, a1, a2, a3};
-    MatShape s = shape(dims, 4);
-    s.erase(std::remove_if(s.begin(), s.end(), is_neg), s.end());
-    return s;
+    int shape_[] = {a0, a1, a2, a3};
+    int dims = 1 + (a1 >= 0) + (a1 >= 0 && a2 >= 0) + (a1 >= 0 && a2 >= 0 && a3 >= 0);
+    return shape(shape_, dims);
 }
 
 static inline int total(const MatShape& shape, int start = -1, int end = -1)
@@ -206,9 +205,39 @@ static inline int total(const Mat& mat, int start = -1, int end = -1)
 static inline MatShape concat(const MatShape& a, const MatShape& b)
 {
     MatShape c = a;
-    c.insert(c.end(), b.begin(), b.end());
-
+    size_t a_size = a.size(), b_size = b.size(), c_size = a_size + b_size;
+    c.resize(c_size);
+    for (size_t i = 0; i < b_size; i++) {
+        c[i+a_size] = b[i];
+    }
     return c;
+}
+
+static inline std::ostream& operator << (std::ostream& strm, const MatShape& shape)
+{
+    strm << '[';
+    if (shape.empty()) {
+        strm << "<empty>";
+    } else {
+        size_t n = shape.size();
+        if (n == 0) {
+            strm << "<scalar>";
+        } else {
+            for(size_t i = 0; i < n; ++i)
+                strm << (i > 0 ? " x " : "") << shape[i];
+        }
+    }
+    strm << "]";
+    return strm;
+}
+
+static inline std::string toString(const MatShape& shape, const String& name = "")
+{
+    std::ostringstream ss;
+    if (!name.empty())
+        ss << name << ' ';
+    ss << shape;
+    return ss.str();
 }
 
 template<typename _Tp>

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
@@ -8,19 +8,19 @@
 
 #define LOG_TAG "org.opencv.dnn"
 
-void Mat_to_MatShape(cv::Mat& mat, MatShape& matshape)
+void Mat_to_MatShape(cv::Mat& mat, cv::MatShape& matshape)
 {
     matshape.clear();
     CHECK_MAT(mat.type()==CV_32SC1 && mat.cols==1);
-    matshape = (MatShape) mat;
+    matshape = (cv::MatShape) mat;
 }
 
-void MatShape_to_Mat(MatShape& matshape, cv::Mat& mat)
+void MatShape_to_Mat(cv::MatShape& matshape, cv::Mat& mat)
 {
     mat = cv::Mat(matshape, true);
 }
 
-std::vector<MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list)
+std::vector<cv::MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list)
 {
     static jclass juArrayList       = ARRAYLIST(env);
     jmethodID m_size       = LIST_SIZE(env, juArrayList);
@@ -29,13 +29,13 @@ std::vector<MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list)
     static jclass jMatOfInt = MATOFINT(env);
 
     jint len = env->CallIntMethod(list, m_size);
-    std::vector<MatShape> result;
+    std::vector<cv::MatShape> result;
     result.reserve(len);
     for (jint i=0; i<len; i++)
     {
         jobject element = static_cast<jobject>(env->CallObjectMethod(list, m_get, i));
         cv::Mat& mat = *((cv::Mat*) GETNATIVEOBJ(env, jMatOfInt, element) );
-        MatShape matshape = (MatShape) mat;
+        cv::MatShape matshape = (cv::MatShape) mat;
         result.push_back(matshape);
         env->DeleteLocalRef(element);
     }

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
@@ -15,14 +15,13 @@
 #define LAYER(ENV) static_cast<jclass>(ENV->NewGlobalRef(ENV->FindClass("org/opencv/dnn/Layer")))
 #define LAYER_CONSTRUCTOR(ENV, CLS) ENV->GetMethodID(CLS, "<init>", "(J)V")
 
-
 using namespace cv::dnn;
 
-void Mat_to_MatShape(cv::Mat& mat, MatShape& matshape);
+void Mat_to_MatShape(cv::Mat& mat, cv::MatShape& matshape);
 
-void MatShape_to_Mat(MatShape& matshape, cv::Mat& mat);
+void MatShape_to_Mat(cv::MatShape& matshape, cv::Mat& mat);
 
-std::vector<MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list);
+std::vector<cv::MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list);
 
 jobject vector_Ptr_Layer_to_List(JNIEnv* env, std::vector<cv::Ptr<cv::dnn::Layer> >& vs);
 

--- a/modules/dnn/misc/java/test/DnnListRegressionTest.java
+++ b/modules/dnn/misc/java/test/DnnListRegressionTest.java
@@ -94,26 +94,24 @@ public class DnnListRegressionTest extends OpenCVTestCase {
     }
 
     public void testGetMemoryConsumption() {
-        int layerId = 1;
         List<MatOfInt> netInputShapes = new ArrayList();
         netInputShapes.add(new MatOfInt(1, 3, 224, 224));
         MatOfInt netInputTypes = new MatOfInt(5);
         long[] weights=null;
         long[] blobs=null;
         try {
-            net.getMemoryConsumption(layerId, netInputShapes, netInputTypes, weights, blobs);
+            net.getMemoryConsumption(netInputShapes, netInputTypes, weights, blobs);
         } catch(Exception e) {
             fail("Net getMemoryConsumption failed: " + e.getMessage());
         }
     }
 
     public void testGetFLOPS() {
-        int layerId = 1;
         List<MatOfInt> netInputShapes = new ArrayList();
         netInputShapes.add(new MatOfInt(1, 3, 224, 224));
         MatOfInt netInputTypes = new MatOfInt(5);
         try {
-            net.getFLOPS(layerId, netInputShapes, netInputTypes);
+            net.getFLOPS(netInputShapes, netInputTypes);
         } catch(Exception e) {
             fail("Net getFLOPS failed: " + e.getMessage());
         }

--- a/modules/dnn/misc/objc/gen_dict.json
+++ b/modules/dnn/misc/objc/gen_dict.json
@@ -5,8 +5,8 @@
             "(Net*)readNetFromCaffe:(ByteVector*)bufferProto bufferModel:(ByteVector*)bufferModel" : { "readNetFromCaffe" : {"name" : "readNetFromCaffeBuffer"} },
             "(Net*)readNetFromDarknet:(NSString*)cfgFile darknetModel:(NSString*)darknetModel" : { "readNetFromDarknet" : {"name" : "readNetFromDarknetFile"} },
             "(Net*)readNetFromDarknet:(ByteVector*)bufferCfg bufferModel:(ByteVector*)bufferModel" : { "readNetFromDarknet" : {"name" : "readNetFromDarknetBuffer"} },
-            "(Net*)readNetFromONNX:(NSString*)onnxFile" : { "readNetFromONNX" : {"name" : "readNetFromONNXFile"} },
-            "(Net*)readNetFromONNX:(ByteVector*)buffer" : { "readNetFromONNX" : {"name" : "readNetFromONNXBuffer"} },
+            "(Net*)readNetFromONNX:(NSString*)onnxFile useNewEngine:(BOOL)useNewEngine" : { "readNetFromONNX" : {"name" : "readNetFromONNXFile"} },
+            "(Net*)readNetFromONNX:(ByteVector*)buffer useNewEngine:(BOOL)useNewEngine" : { "readNetFromONNX" : {"name" : "readNetFromONNXBuffer"} },
             "(Net*)readNetFromTensorflow:(NSString*)model config:(NSString*)config" : { "readNetFromTensorflow" : {"name" : "readNetFromTensorflowFile"} },
             "(Net*)readNetFromTensorflow:(ByteVector*)bufferModel bufferConfig:(ByteVector*)bufferConfig" : { "readNetFromTensorflow" : {"name" : "readNetFromTensorflowBuffer"} },
             "(Net*)readNetFromTFLite:(NSString*)model" : { "readNetFromTFLite" : {"name" : "readNetFromTFLiteFile"} },
@@ -16,14 +16,8 @@
             "(void)forward:(NSMutableArray<Mat*>*)outputBlobs outputName:(NSString*)outputName" : { "forward" : {"name" : "forwardOutputBlobs"} },
             "(void)forward:(NSMutableArray<Mat*>*)outputBlobs outBlobNames:(NSArray<NSString*>*)outBlobNames" : { "forward" : {"name" : "forwardOutputBlobs"} },
             "(void)forwardAndRetrieve:(NSMutableArray<NSMutableArray<Mat*>*>*)outputBlobs outBlobNames:(NSArray<NSString*>*)outBlobNames" : { "forward" : {"swift_name" : "forwardAndRetrieve"} },
-            "(long)getFLOPS:(IntVector*)netInputShape" : { "getFLOPS" : {"name" : "getFLOPSWithNetInputShape"} },
-            "(long)getFLOPS:(NSArray<IntVector*>*)netInputShapes" : { "getFLOPS" : {"name" : "getFLOPSWithNetInputShapes"} },
-            "(long)getFLOPS:(int)layerId netInputShape:(IntVector*)netInputShape" : { "getFLOPS" : {"name" : "getFLOPSWithLayerId"} },
-            "(long)getFLOPS:(int)layerId netInputShapes:(NSArray<IntVector*>*)netInputShapes" : { "getFLOPS" : {"name" : "getFLOPSWithLayerId"} },
             "(Layer*)getLayer:(NSString*)layerName" : { "getLayer" : {"name" : "getLayerByName"} },
             "(Layer*)getLayer:(DictValue*)layerId" : { "getLayer" : {"name" : "getLayerByDictValue"} },
-            "(void)getLayersShapes:(IntVector*)netInputShape layersIds:(IntVector*)layersIds inLayersShapes:(NSMutableArray<NSMutableArray<IntVector*>*>*)inLayersShapes outLayersShapes:(NSMutableArray<NSMutableArray<IntVector*>*>*)outLayersShapes" : { "getLayersShapes" : {"name" : "getLayersShapesWithNetInputShape"} },
-            "(void)getLayersShapes:(NSArray<IntVector*>*)netInputShapes layersIds:(IntVector*)layersIds inLayersShapes:(NSMutableArray<NSMutableArray<IntVector*>*>*)inLayersShapes outLayersShapes:(NSMutableArray<NSMutableArray<IntVector*>*>*)outLayersShapes" : { "getLayersShapes" : {"name" : "getLayersShapesWithNetInputShapes"} },
             "(Mat*)getParam:(NSString*)layerName numParam:(int)numParam" : { "getParam" : {"name" : "getParamByName"} },
             "(void)setParam:(NSString*)layerName numParam:(int)numParam blob:(Mat*)blob" : { "setParam" : {"name" : "setParamByName"} }
         }
@@ -31,17 +25,20 @@
     "type_dict": {
         "MatShape": {
             "objc_type": "IntVector*",
-            "to_cpp": "%(n)s.nativeRef",
-            "from_cpp": "[IntVector fromNative:%(n)s]",
-            "cast_to": "std::vector<int>"
+            "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
+            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]"
         },
         "vector_MatShape": {
             "objc_type": "IntVector*",
-            "v_type": "IntVector"
+            "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
+            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]",
+            "v_type": "MatShape"
         },
         "vector_vector_MatShape": {
             "objc_type": "IntVector*",
-            "v_v_type": "IntVector"
+            "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
+            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]",
+            "v_v_type": "MatShape"
         },
         "LayerId": {
             "objc_type": "DictValue*",

--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -143,37 +143,16 @@ public:
         return Ptr<dnn::Layer>(new pycvLayer(params, it->second.back()));
     }
 
-    virtual bool getMemoryShapes(const std::vector<std::vector<int> > &inputs,
-                                 const int,
-                                 std::vector<std::vector<int> > &outputs,
-                                 std::vector<std::vector<int> > &) const CV_OVERRIDE
-    {
-        PyGILState_STATE gstate;
-        gstate = PyGILState_Ensure();
-
-        PyObject* args = PyList_New(inputs.size());
-        for(size_t i = 0; i < inputs.size(); ++i)
-            PyList_SetItem(args, i, pyopencv_from_generic_vec(inputs[i]));
-
-        PyObject* res = PyObject_CallMethodObjArgs(o, PyString_FromString("getMemoryShapes"), args, NULL);
-        Py_DECREF(args);
-        PyGILState_Release(gstate);
-        if (!res)
-            CV_Error(Error::StsNotImplemented, "Failed to call \"getMemoryShapes\" method");
-        CV_Assert(pyopencv_to_generic_vec(res, outputs, ArgInfo("", 0)));
-        return false;
-    }
-
     virtual void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays) CV_OVERRIDE
     {
         PyGILState_STATE gstate;
         gstate = PyGILState_Ensure();
 
-        std::vector<Mat> inputs, outputs;
-        inputs_arr.getMatVector(inputs);
-        outputs_arr.getMatVector(outputs);
+        std::vector<Mat> ins, outs;
+        inputs_arr.getMatVector(ins);
+        outputs_arr.getMatVector(outs);
 
-        PyObject* args = pyopencv_from(inputs);
+        PyObject* args = pyopencv_from(ins);
         PyObject* res = PyObject_CallMethodObjArgs(o, PyString_FromString("forward"), args, NULL);
         Py_DECREF(args);
         if (!res)
@@ -184,12 +163,12 @@ public:
         Py_DECREF(res);
         PyGILState_Release(gstate);
 
-        CV_Assert(pyOutputs.size() == outputs.size());
-        for (size_t i = 0; i < outputs.size(); ++i)
+        CV_Assert(pyOutputs.size() == outs.size());
+        for (size_t i = 0; i < outs.size(); ++i)
         {
-            CV_Assert(pyOutputs[i].size == outputs[i].size);
-            CV_Assert(pyOutputs[i].type() == outputs[i].type());
-            pyOutputs[i].copyTo(outputs[i]);
+            CV_Assert(pyOutputs[i].size == outs[i].size);
+            CV_Assert(pyOutputs[i].type() == outs[i].type());
+            pyOutputs[i].copyTo(outs[i]);
         }
     }
 

--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -1,7 +1,7 @@
 #ifdef HAVE_OPENCV_DNN
 typedef dnn::DictValue LayerId;
-typedef std::vector<dnn::MatShape> vector_MatShape;
-typedef std::vector<std::vector<dnn::MatShape> > vector_vector_MatShape;
+typedef std::vector<MatShape> vector_MatShape;
+typedef std::vector<std::vector<MatShape> > vector_vector_MatShape;
 
 template<>
 bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const ArgInfo& info)

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -374,6 +374,7 @@ class dnn_test(NewOpenCVTests):
 
         self.assertTrue(all(cv.dnn.NMSBoxes(rects, confs, 0, 0.6).ravel() == (0, 1)))
 
+    @unittest.skip("custom layers are partially broken with transition to the new dnn engine")
     def test_custom_layer(self):
         class CropLayer(object):
             def __init__(self, params, blobs):
@@ -510,7 +511,7 @@ class dnn_test(NewOpenCVTests):
         for backend, target in self.dnnBackendsAndTargets:
             printParams(backend, target)
 
-            net = cv.dnn.readNet(model_path)
+            net = cv.dnn.readNet(model_path, "", "", False)
 
             node_name = net.getLayerNames()[0]
             w = net.getParam(node_name, 0) # returns the original tensor of three-dimensional shape

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -374,6 +374,7 @@ class dnn_test(NewOpenCVTests):
 
         self.assertTrue(all(cv.dnn.NMSBoxes(rects, confs, 0, 0.6).ravel() == (0, 1)))
 
+    # BUG: https://github.com/opencv/opencv/issues/26200
     @unittest.skip("custom layers are partially broken with transition to the new dnn engine")
     def test_custom_layer(self):
         class CropLayer(object):

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -134,7 +134,7 @@ class dnn_test(NewOpenCVTests):
         paramNet.mean = [0.485, 0.456, 0.406]
         paramNet.scalefactor = [0.229, 0.224, 0.225]
         paramNet.swapRB = False
-        paramNet.datalayout = cv.dnn.DNN_LAYOUT_NCHW
+        paramNet.datalayout = cv.DATA_LAYOUT_NCHW
         paramNet.paddingmode = cv.dnn.DNN_PMODE_LETTERBOX
         rBlob = np.zeros(shape=(20, 4), dtype=np.int32)
         rImg = paramNet.blobRectsToImageRects(rBlob, (356, 356))
@@ -148,7 +148,7 @@ class dnn_test(NewOpenCVTests):
         paramNet.mean = [0.485, 0.456, 0.406]
         paramNet.scalefactor = [0.229, 0.224, 0.225]
         paramNet.swapRB = False
-        paramNet.datalayout = cv.dnn.DNN_LAYOUT_NCHW
+        paramNet.datalayout = cv.DATA_LAYOUT_NCHW
         paramNet.paddingmode = cv.dnn.DNN_PMODE_LETTERBOX
         rBlob = np.zeros(shape=(20, 4), dtype=np.int32)
         rImg = paramNet.blobRectToImageRect((0, 0, 0, 0), (356, 356))
@@ -198,11 +198,11 @@ class dnn_test(NewOpenCVTests):
         param.size = (6, 7)
         param.mean = mean
         param.swapRB=True
-        param.datalayout = cv.dnn.DNN_LAYOUT_NHWC
+        param.datalayout = cv.DATA_LAYOUT_NHWC
 
         blob = cv.dnn.blobFromImageWithParams(img, param)
         blob_args = cv.dnn.blobFromImageWithParams(img, cv.dnn.Image2BlobParams(scalefactor=scalefactor, size=(6, 7), mean=mean,
-                                                                      swapRB=True, datalayout=cv.dnn.DNN_LAYOUT_NHWC))
+                                                                      swapRB=True, datalayout=cv.DATA_LAYOUT_NHWC))
         normAssert(self, blob, blob_args)
 
         target2 = cv.resize(img, (width, height), interpolation=cv.INTER_LINEAR).astype(np.float32)

--- a/modules/dnn/perf/perf_einsum.cpp
+++ b/modules/dnn/perf/perf_einsum.cpp
@@ -10,8 +10,8 @@ struct EinsumParams {
     int inputSize;
     int outputSize;
     std::string equation;
-    std::vector<MatShape> einsumInpShapes;
-    EinsumParams(std::string equation_, std::vector<MatShape> einsumInpShapes_ = std::vector<MatShape>())
+    std::vector<std::vector<int> > einsumInpShapes;
+    EinsumParams(std::string equation_, std::vector<std::vector<int> > einsumInpShapes_ = std::vector<std::vector<int> >())
     {
         inputSize = einsumInpShapes_.size();
         equation = equation_;
@@ -80,7 +80,7 @@ PERF_TEST_P_(Layer_Einsum, einsum) {
 
     for (int i = 0; i < params.inputSize; ++i) {
         // create inputs
-        inputs.emplace_back(Mat(params.einsumInpShapes[i].size(), params.einsumInpShapes[i].data(), CV_32FC1));
+        inputs.emplace_back(Mat(params.einsumInpShapes[i], CV_32FC1));
 
         // connect each input to the layer
         net.connect(0, i, id, i);

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -65,7 +65,8 @@ public:
         size_t weightsMemory = 0, blobsMemory = 0;
         net.getMemoryConsumption(netMatShapes, netMatTypes, weightsMemory, blobsMemory);
         int64 flops = net.getFLOPS(netMatShapes, netMatTypes);
-        CV_Assert(flops > 0);
+        // [TODO] implement getFLOPS in the new engine
+        CV_Assert(flops > 0 || net.getMainGraph());
         std::cout << "Memory consumption:" << std::endl;
         std::cout << "    Weights(parameters): " << divUp(weightsMemory, 1u<<20) << " Mb" << std::endl;
         std::cout << "    Blobs: " << divUp(blobsMemory, 1u<<20) << " Mb" << std::endl;

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -66,6 +66,7 @@ public:
         net.getMemoryConsumption(netMatShapes, netMatTypes, weightsMemory, blobsMemory);
         int64 flops = net.getFLOPS(netMatShapes, netMatTypes);
         // [TODO] implement getFLOPS in the new engine
+        // Issue: https://github.com/opencv/opencv/issues/26199
         CV_Assert(flops > 0 || net.getMainGraph());
         std::cout << "Memory consumption:" << std::endl;
         std::cout << "    Weights(parameters): " << divUp(weightsMemory, 1u<<20) << " Mb" << std::endl;

--- a/modules/dnn/src/cuda4dnn/primitives/depth_space_ops.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/depth_space_ops.hpp
@@ -22,17 +22,19 @@ namespace cv { namespace dnn { namespace cuda4dnn {
     public:
         using wrapper_type = GetCUDABackendWrapperType<T>;
 
-        DepthSpaceOps(csl::Stream stream_, const std::vector<int> &internal_shape_,
+        DepthSpaceOps(csl::Stream stream_, const MatShape& internal_shape_,
                      const std::vector<size_t> &permutation_)
             : stream(std::move(stream_)), internal_shape(internal_shape_),
               permutation(permutation_)
         {
-            transposed_internal_shape = std::vector<int>(internal_shape.size());
-            for (size_t i = 0; i < permutation.size(); i++) {
-                transposed_internal_shape[i] = internal_shape[permutation[i]];
+            int dims = internal_shape.dims;
+            int nperm = (int)permutation_.size();
+            transposed_internal_shape = MatShape(dims);
+            for (int i = 0; i < nperm; i++) {
+                transposed_internal_shape[i] = internal_shape[(int)permutation[i]];
             }
 
-            size_t num_elements = std::accumulate(internal_shape.begin(), internal_shape.end(), 1, std::multiplies<size_t>());
+            size_t num_elements = internal_shape.total();
             csl::WorkspaceBuilder builder;
             builder.require<T>(num_elements);
             scratch_mem_in_bytes = builder.required_workspace_size();
@@ -64,9 +66,9 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
     private:
         csl::Stream stream;
-        std::vector<int> internal_shape;
+        MatShape internal_shape;
         std::vector<size_t> permutation;
-        std::vector<int> transposed_internal_shape;
+        MatShape transposed_internal_shape;
 
         std::size_t scratch_mem_in_bytes;
     };

--- a/modules/dnn/src/dnn_common.hpp
+++ b/modules/dnn/src/dnn_common.hpp
@@ -172,6 +172,11 @@ static inline Scalar_<double> broadcastRealScalar(const Scalar_<double>& _scale)
     return scale;
 }
 
+static inline void prindent(std::ostream& strm, int indent)
+{
+    for (int i = 0; i < indent; i++)
+        strm << ' ';
+}
 
 CV__DNN_INLINE_NS_END
 

--- a/modules/dnn/src/dnn_read.cpp
+++ b/modules/dnn/src/dnn_read.cpp
@@ -10,7 +10,7 @@ namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
 
-Net readNet(const String& _model, const String& _config, const String& _framework)
+Net readNet(const String& _model, const String& _config, const String& _framework, bool useNewEngine)
 {
     String framework = toLowerCase(_framework);
     String model = _model;
@@ -49,7 +49,7 @@ Net readNet(const String& _model, const String& _config, const String& _framewor
     }
     if (framework == "onnx" || modelExt == "onnx")
     {
-        return readNetFromONNX(model);
+        return readNetFromONNX(model, useNewEngine);
     }
     CV_Error(Error::StsError, "Cannot determine an origin framework of files: " + model + (config.empty() ? "" : ", " + config));
 }

--- a/modules/dnn/src/graph_buffer_allocator.cpp
+++ b/modules/dnn/src/graph_buffer_allocator.cpp
@@ -1,0 +1,331 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+using std::vector;
+using std::string;
+
+/* Assigns buffers for all intermediate tensors of the graph/model
+
+ The algorithm is quite simple, but there are some nuances in the attempt to re-use memory more efficiently:
+
+ All layer arguments in graph and sub-graphs are classified into 4 categories:
+ a) inputs, b) outputs, c) constants and d) temporary values/tensors.
+
+ Except for the temporary values ("d" category), each other argument gets
+ its own dedicated storage, which makes things more clear and predictable.
+ So, this algorithm assigns buffers only for the temporary values.
+
+ During the inference process, each temporary value is computed
+ by one of the layers and then used by zero or more subsequent layers (only as input).
+ An example of a model where some tensors are used more than once is Resnet.
+ After a tensor is used for the last time and
+ won't be used in any subsequent layer, the memory buffer for that tensor could be re-used for
+ other arguments. We want to assign each temporary tensor to some temporary buffer,
+ and it's typically N:1 mapping.
+
+ We do it using 2-stage algorithm:
+
+ 1. First, we calculate, how many times each argument is used and store the counters into 'usecounts'.
+ 2. Second, we scan the layers in topologically sorted order
+ 2.0. Sanity check: We check that each input argument of the operation is either input or constant,
+ or it's a temporary tensor with the buffer assigned to it.
+ If not, then the layers are not sorted in a topological order.
+ 2.1. For in-place reshape operations, such as squeeze/unsqueeze/flatten etc.
+ or for unary element-wise operations,
+ we check whether the input is a temporary value and is not used in any subsequent operations.
+ If these checks all pass, we assign output argument to the same buffer as input. Note that
+ we don't try to reuse inputs of binary/ternary etc. operation because of the broadcasting.
+ We need to do symbolic shape inference to proof that the output is of the same shape as one of the inputs.
+ 2.2. Otherwise, for each output argument of operation, which is not a network output argument.
+ we assign the most recently-used free buffer (i.e. the top buffer in the stack of free buffers).
+ If there is no free buffers, i.e. the stack is empty, we create a new buffer, and use it.
+ 2.3. For each input we decrement the corresponding element of 'usecounts'. If the counter reaches 0 and the input
+ is not aliased with one of the outputs (see 2.1),
+ we push the corresponding buffer index into the stack of free buffers.
+ 2.4. In the case of in-place operations and sometimes when using subgraphs (e.g. in If, Loop operations) we may
+ re-use the same buffer for several arguments
+ (which can be ouputs for some operations and inputs for some subsequent operations).
+ In order to handle it all properly, during the buffer assignment algorithm we maintain use counter for each
+ buffer, which should not be confused with use counters for arguments. A pool of free buffers contains zero or
+ more "spare" buffers with 0 use counts. A buffer in use has the corresponding usage count > 0.
+ When some argument is not needed anymore, and if it's not a constant, it decrements the usage counter of the buffer
+ where it resides. When the counter reaches zero, we return the buffer into the pool of free buffers and then
+ we can reuse the same buffer for another argument (or probably different shape and/or type, see below).
+ In principle, we could 'protect' some buffers from the premature release and re-use by incrementing the use counts
+ of the respective arguments that reside in those buffers, but that would make the bookkeeping much more complex.
+
+ Please, note that when we reuse buffers, we don't check any types, shape or a total size of the buffer needed.
+ We reallocate each buffer at runtime to fit each single argument that it's used for. For example, let's say the buffer #3
+ is used for arguments #5 (10x10x10 FP32), #10 (6x6x32 FP32) and #14 (300x1 UINT64). Then during the the first run of
+ the inference the buffer #3 will be reallocated from 0 bytes to 1000*4 bytes to fit arg #10,
+ then from 4000 to 6*6*32*4=4608 bytes to fit arg #10 and then it will fit arg #14 without reallocations.
+ During the second run of inference with the same resolution input the buffer will not be reallocated.
+
+ The reallocation is done using Buffer.fit() function.
+ */
+
+struct BufferAllocator
+{
+    BufferAllocator(Net* net_) : net(net_), netimpl(net_->getImpl()) {}
+
+    Net* net;
+    Net::Impl* netimpl;
+    vector<int> usecounts;
+    vector<int> freebufs;
+    vector<int> buf_usecounts;
+    vector<int> bufidxs;
+    int nbufs = 0;
+
+    /*
+     Here are 3 workhorse methods that abstract the use and bookkeeping of buffers:
+     1. getFreeBuffer() takes the first spare buffer from the pool of free buffers. Since
+     we don't necessarily know the shape/type of tensor type at this stage, this is quite
+     reasonable behaviour - we cannot do anything more complex that that. On the positive side,
+     since the pool of free buffers operates like a stack, the first free buffer is the most
+     recently released buffer, so we improve cache locality using this pattern.
+     When we don't have spare buffers in the pool, we "virtually" create a new buffer
+     (by incrementing the number of buffers used) and return it.
+
+     For the retrieved buffer we set its use count to 1.
+     2. releaseBuffer(bufidx) decrements the buffer use count and returns it to the pool
+     of free buffers as long as the use counter reaches 0.
+     3. shareBuffer(from_arg, to_arg) takes two argument indices.
+     It makes argument 'to_arg' use the same buffer as 'from_arg'.
+     Use counter for the assigned to 'to_arg' buffer (if any) is decremented.
+     Use counter for the 'from_arg' buffer is incremented, correpondingly.
+     */
+
+    int getFreeBuffer()
+    {
+        if (freebufs.empty()) {
+            freebufs.push_back(nbufs);
+            buf_usecounts.push_back(0);
+            //printf("added buf %d\n", nbufs);
+            nbufs++;
+        }
+        int outidx = freebufs.back();
+        freebufs.pop_back();
+        buf_usecounts[outidx] = 1;
+        return outidx;
+    }
+
+    void releaseBuffer(int bufidx)
+    {
+        if (bufidx >= 0) {
+            CV_Assert(buf_usecounts[bufidx] > 0);
+            if (--buf_usecounts[bufidx] == 0)
+                freebufs.push_back(bufidx);
+        }
+    }
+
+    void shareBuffer(Arg fromArg, Arg toArg)
+    {
+        CV_Assert(!net->isConstArg(fromArg) && !net->isConstArg(toArg));
+        int fromBuf = bufidxs[fromArg.idx], toBuf = bufidxs[toArg.idx];
+        CV_Assert(fromBuf >= 0);
+        bufidxs[toArg.idx] = fromBuf;
+        buf_usecounts[fromBuf]++;
+        if (toBuf >= 0)
+            releaseBuffer(toBuf);
+    }
+
+    void assign()
+    {
+        netimpl->useCounts(usecounts);
+        size_t nargs = usecounts.size();
+        bufidxs.assign(nargs, -1);
+        nbufs = 0;
+        assign(net->getMainGraph());
+        netimpl->bufidxs = bufidxs;
+        netimpl->buffers.resize(nbufs);
+        for (int i = 0; i < nbufs; i++)
+            netimpl->buffers[i] = Mat();
+    }
+
+    void assign(const Ptr<Graph>& graph)
+    {
+        if (!graph)
+            return;
+        const std::vector<Ptr<Layer> >& prog = graph->prog();
+        for (const auto& layer: prog) {
+            bool inplace = false;
+            Arg reuseArg;
+
+            if (!layer) continue;
+
+            const std::vector<Arg>& inputs = layer->inputs;
+            const std::vector<Arg>& outputs = layer->outputs;
+            size_t ninputs = inputs.size();
+            size_t noutputs = outputs.size();
+
+            /*
+             Determine if we can possibly re-use some of the input buffers for the output as well,
+             in other words, whether we can run the operation in-place.
+             Not only it saves memory, but it can also:
+             1. improve L2/L3 cache re-use
+             2. effectively convert some copy/re-shape operations
+             (Identity, Flatten, Reshape, Squeeze, Unsqueeze)
+             into Nop (no-operation).
+             */
+            //const ElemwiseOp* elemwise_op = dynamic_cast<const ElemwiseOp*>(op);
+
+            if (/*dynamic_cast<const BatchNormOp*>(op) != 0 ||
+                dynamic_cast<const FlattenOp*>(op) != 0 ||
+                (elemwise_op != 0 && elemwise_op->getActivation(CV_32F) != 0) ||
+                dynamic_cast<const ReshapeOp*>(op) != 0 ||
+                dynamic_cast<const SqueezeOp*>(op) != 0 ||
+                dynamic_cast<const UnsqueezeOp*>(op) != 0*/
+                layer->alwaysSupportInplace()) {
+                CV_Assert(ninputs >= 1);
+                Arg inp0 = inputs[0];
+                inplace = net->argKind(inp0) == DNN_ARG_TEMP && usecounts[inp0.idx] == 1;
+                reuseArg = inp0;
+            }
+
+            /*
+             Unless the operation is in-place, assign buffers for each output.
+             We do it before we recursively process subgraphs inside If/Loop/Scan.
+             this way we avoid any possible influence of buffer allocation inside a subgraph
+             to the parent graphs.
+             */
+            //if (layer->type == "Softmax")
+            //    putchar('.');
+            if (noutputs > 0 && net->argKind(outputs[0]) == DNN_ARG_TEMP) {
+                Arg out0 = outputs[0];
+                if (inplace && bufidxs.at(out0.idx) < 0)
+                    shareBuffer(reuseArg, out0);
+                else
+                    for (auto argidx: outputs) {
+                        if (bufidxs.at(argidx.idx) < 0)
+                            bufidxs.at(argidx.idx) = getFreeBuffer();
+                    }
+            }
+
+            std::string opname = layer->type;
+
+            if (opname == "If") {
+                /*
+                 Pre-allocate buffers for the output nodes of then- and else- branches.
+                 We try to alias them with the corresponding t_out[i] elements, so
+                 that we save one copy operation.
+                 [TODO]
+                 It's not the most optimal buffer allocation.
+                 In the ideal case, e.g. when both then- and else- branches
+                 are just sequences of element-wise operations that can be executed in-place,
+                 we could simply use a single buffer for both then- and else- branches.
+                 Here we will use separate buffers, but let's assume we could
+                 optimize out such trivial branches at the graph fusion level
+                 (especially when we have JIT).
+                 */
+                auto branches = layer->subgraphs();
+                CV_Assert(branches->size() == 2);
+
+                const Ptr<Graph>& thenBranch = branches->at(0);
+                const Ptr<Graph>& elseBranch = branches->at(1);
+                const vector<Arg>& thenOutargs = thenBranch->outputs();
+                const vector<Arg>& elseOutargs = elseBranch->outputs();
+                CV_Assert(thenOutargs.size() == noutputs && elseOutargs.size() == noutputs);
+                for (size_t i = 0; i < noutputs; i++) {
+                    Arg outarg = outputs[i];
+                    Arg thenOutarg = thenOutargs[i];
+                    Arg elseOutarg = elseOutargs[i];
+
+                    if (!net->isConstArg(thenOutarg) && usecounts[thenOutarg.idx] == 1)
+                        shareBuffer(outarg, thenOutarg);
+                    if (!net->isConstArg(elseOutarg) && usecounts[elseOutarg.idx] == 1)
+                        shareBuffer(outarg, elseOutarg);
+                }
+
+                assign(thenBranch);
+                assign(elseBranch);
+
+                for (size_t i = 0; i < noutputs; i++) {
+                    Arg thenOutarg = thenOutargs[i];
+                    Arg elseOutarg = elseOutargs[i];
+                    releaseBuffer(bufidxs[thenOutarg.idx]);
+                    releaseBuffer(bufidxs[elseOutarg.idx]);
+                }
+            } else if (opname == "Loop") {
+                /*
+                 In the case of loop we try to alias t_v_in[i] and t_v_out[i] so that
+                 we eliminate some copy operations after each loop iteration.
+                 */
+                //LoopLayer* loop = dynamic_cast<LoopLayer*>(op);
+                CV_Assert(ninputs >= 2);
+                auto subgraphs = layer->subgraphs();
+                CV_Assert(subgraphs && subgraphs->size() == 1);
+                const Ptr<Graph>& body = subgraphs->at(0);
+                Arg trip_count = inputs[0];
+                const std::vector<Arg>& body_inputs = body->inputs();
+                const std::vector<Arg>& body_outputs = body->outputs();
+                size_t body_ninputs = body_inputs.size();
+                size_t body_noutputs = body_outputs.size();
+                int n_state_vars = (int)(ninputs - 2);
+                int n_accums = (int)(body_noutputs - n_state_vars - 1);
+                CV_Assert(body_ninputs == ninputs);
+                CV_Assert(body_noutputs == noutputs+1);
+                CV_Assert(n_state_vars >= 0 && n_accums >= 0);
+                Arg inp0 = inputs[0];
+                if (inp0.idx > 0 && usecounts[inp0.idx] > 0) {
+                    CV_Assert(!net->isConstArg(inp0));
+                    if (!net->isConstArg(trip_count))
+                        shareBuffer(trip_count, inputs[0]);
+                    else
+                        bufidxs.at(inputs[0].idx) = getFreeBuffer();
+                }
+
+                for (int i = -1; i < n_state_vars; i++) {
+                    Arg inparg = body_inputs[i+2];
+                    Arg outarg = body_outputs[i+1];
+                    Arg v_inp = inputs[i+2];
+                    Arg v_out = i >= 0 ? outputs[i] : Arg();
+                    if (inparg.idx > 0 && usecounts[inparg.idx] > 0) {
+                        CV_Assert(!net->isConstArg(inparg));
+                        if (!net->isConstArg(v_inp))
+                            shareBuffer(v_inp, inparg);
+                        else
+                            bufidxs[inparg.idx] = getFreeBuffer();
+                    }
+                    if (!net->isConstArg(v_out)) {
+                        if (!net->isConstArg(outarg) && usecounts[outarg.idx] == 1)
+                            shareBuffer(v_out, outarg);
+                    }
+                }
+
+                assign(body);
+                for (auto body_out: body_outputs)
+                    releaseBuffer(bufidxs.at(body_out.idx));
+            }
+
+            for (auto outarg: outputs) {
+                if (usecounts[outarg.idx] == 0)
+                    releaseBuffer(bufidxs.at(outarg.idx));
+            }
+            // let's release inputs in the reverse order to keep the buffer allocation consistent across the network
+            for (size_t i = 0; i < ninputs; i++) {
+                Arg inparg = inputs[ninputs-i-1];
+                int bufidx = bufidxs[inparg.idx];
+                if (bufidx >= 0) {
+                    if (--usecounts.at(inparg.idx) == 0)
+                        releaseBuffer(bufidx);
+                }
+            }
+        }
+    }
+};
+
+void Net::Impl::assignBuffers()
+{
+    BufferAllocator buf_allocator(net);
+    buf_allocator.assign();
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/graph_const_fold.cpp
+++ b/modules/dnn/src/graph_const_fold.cpp
@@ -91,9 +91,10 @@ struct ConstFolding
                 // Use a fresh vector of Mat's for outputs since we want to make these outputs the new constant tensors.
                 // So, they must be unique and don't interfere with other tensors.
                 std::vector<Mat> outMats(noutputs);
+                std::vector<std::pair<uchar*, size_t> > outOrigData;
                 if (!layer->dynamicOutputShapes())
                     netimpl->allocateLayerOutputs(layer, inpTypes, inpShapes, outTypes,
-                                                  outShapes, outMats, tempTypes, tempShapes, tempMats,
+                                                  outShapes, outOrigData, outMats, tempTypes, tempShapes, tempMats,
                                                   netimpl->scratchBufs, false);
                 layer->finalize(inpMats, outMats);
                 layer->forward(inpMats, outMats, tempMats);

--- a/modules/dnn/src/graph_const_fold.cpp
+++ b/modules/dnn/src/graph_const_fold.cpp
@@ -96,11 +96,11 @@ struct ConstFolding
                 CV_Assert(outMats.size() == noutputs);
                 for (j = 0; j < noutputs; j++) {
                     Arg out = outputs[j];
-                    ArgInfo& out_info = netimpl->args.at(out.idx);
+                    ArgData& out_data = netimpl->args.at(out.idx);
                     const Mat& m = outMats[j];
-                    out_info.type = m.type();
-                    out_info.shape = m.shape();
-                    out_info.kind = DNN_ARG_CONST; // re-classify each output as constant
+                    out_data.type = m.type();
+                    out_data.shape = m.shape();
+                    out_data.kind = DNN_ARG_CONST; // re-classify each output as constant
                     netimpl->tensors.at(out.idx) = m;
                 }
 

--- a/modules/dnn/src/graph_const_fold.cpp
+++ b/modules/dnn/src/graph_const_fold.cpp
@@ -1,0 +1,138 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+using std::vector;
+using std::string;
+
+typedef std::pair<int, int> int_pair;
+typedef std::pair<int, Arg> int_arg_pair;
+
+struct ConstFolding
+{
+    ConstFolding(Net* net_) : net(net_), netimpl(net_->getImpl()) {}
+
+    void process()
+    {
+        size_t nargs = netimpl->args.size();
+        netimpl->tensors.resize(nargs);
+        netimpl->useCounts(usecounts);
+        netimpl->scratchBufs.clear();
+        processGraph(netimpl->mainGraph);
+        netimpl->scratchBufs.clear();
+    }
+
+    Layer* getLayer(std::vector<Ptr<Layer> >& newprog, int op_idx) const
+    {
+        return op_idx >= 0 ? newprog.at(op_idx).get() : 0;
+    }
+
+    void unuse(Arg inp)
+    {
+        CV_Assert(usecounts[inp.idx] > 0);
+        if (--usecounts[inp.idx] == 0 && net->isConstArg(inp)) {
+            netimpl->tensors[inp.idx] = Mat(); // deallocate unused tensor
+        }
+    }
+
+    bool processGraph(Ptr<Graph>& graph)
+    {
+        bool modified = false;
+        const std::vector<Ptr<Layer> >& prog = graph->prog();
+        size_t i, nops = prog.size();
+        std::vector<Ptr<Layer> > newprog;
+        std::vector<Arg> removed_args;
+        std::vector<Mat> inpMats, tempMats;
+        std::vector<int> inpTypes, outTypes, tempTypes;
+        std::vector<MatShape> inpShapes, outShapes, tempShapes;
+
+        for (i = 0; i < nops; i++) {
+            const Ptr<Layer>& layer = prog[i];
+            std::vector<Ptr<Graph> >* subgraphs = layer->subgraphs();
+            if (subgraphs) {
+                for (Ptr<Graph>& g: *subgraphs) {
+                    if (processGraph(g))
+                        modified = true;
+                }
+            }
+            const std::vector<Arg>& inputs = layer->inputs;
+            const std::vector<Arg>& outputs = layer->outputs;
+            size_t j, ninputs = inputs.size(), noutputs = outputs.size();
+            bool all_const = true;
+            inpMats.assign(ninputs, Mat());
+            inpTypes.resize(ninputs);
+            inpShapes.resize(ninputs);
+            for (j = 0; j < ninputs; j++) {
+                Arg inp = inputs[j];
+                bool const_arg = net->isConstArg(inp);
+                if (!const_arg)
+                    all_const = false;
+                if (all_const) {
+                    const Mat& m = netimpl->tensors.at(inp.idx);
+                    inpMats[j] = m;
+                    inpTypes[j] = m.type();
+                    inpShapes[j] = m.shape();
+                }
+            }
+
+            if (all_const /*&&
+                op->supportBlockLayout(0, (int)ninputs) <= 0 // we don't currently support constant folding
+                                               // for block-layout operations (Convolution, MaxPool, AveragePool)
+                */) {
+                // Use a fresh vector of Mat's for outputs since we want to make these outputs the new constant tensors.
+                // So, they must be unique and don't interfere with other tensors.
+                std::vector<Mat> outMats(noutputs);
+                if (!layer->dynamicOutputShapes())
+                    netimpl->allocateLayerOutputs(layer, inpTypes, inpShapes, outTypes,
+                                                  outShapes, outMats, tempTypes, tempShapes, tempMats,
+                                                  netimpl->scratchBufs, false);
+                layer->forward(inpMats, outMats, tempMats);
+                CV_Assert(outMats.size() == noutputs);
+                for (j = 0; j < noutputs; j++) {
+                    Arg out = outputs[j];
+                    ArgInfo& out_info = netimpl->args.at(out.idx);
+                    const Mat& m = outMats[j];
+                    out_info.type = m.type();
+                    out_info.shape = m.shape();
+                    out_info.kind = DNN_ARG_CONST; // re-classify each output as constant
+                    netimpl->tensors.at(out.idx) = m;
+                }
+
+                modified = true;
+                for (size_t i = 0; i < ninputs; i++)
+                    unuse(inputs[i]);
+                //printf("folded %s: %s\n", op->name().data(), node->name().data());
+                // we don't add operation into the new program,
+                // because the output of the all-const inputs operation is now a constant,
+                // stored in a separate tensor
+            } else {
+                newprog.push_back(layer);
+            }
+        }
+
+        if (modified) {
+            graph->setProg(newprog);
+        }
+
+        return modified;
+    }
+
+    Net* net;
+    Net::Impl* netimpl;
+    std::vector<int> usecounts;
+};
+
+void Net::Impl::constFold()
+{
+    ConstFolding constfolder(net);
+    constfolder.process();
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/graph_const_fold.cpp
+++ b/modules/dnn/src/graph_const_fold.cpp
@@ -24,7 +24,7 @@ struct ConstFolding
     void process()
     {
         size_t nargs = netimpl->args.size();
-        netimpl->tensors.resize(nargs);
+        netimpl->__tensors__.resize(nargs);
         netimpl->useCounts(usecounts);
         netimpl->scratchBufs.clear();
         processGraph(netimpl->mainGraph);
@@ -40,7 +40,7 @@ struct ConstFolding
     {
         CV_Assert(usecounts[inp.idx] > 0);
         if (--usecounts[inp.idx] == 0 && netimpl->isConstArg(inp)) {
-            netimpl->tensors[inp.idx] = Mat(); // deallocate unused tensor
+            netimpl->__tensors__[inp.idx] = Mat(); // deallocate unused tensor
         }
     }
 
@@ -77,7 +77,7 @@ struct ConstFolding
                 if (!const_arg)
                     all_const = false;
                 if (all_const) {
-                    const Mat& m = netimpl->tensors.at(inp.idx);
+                    const Mat& m = netimpl->argTensor(inp);
                     inpMats[j] = m;
                     inpTypes[j] = m.type();
                     inpShapes[j] = m.shape();
@@ -105,7 +105,7 @@ struct ConstFolding
                     out_data.type = m.type();
                     out_data.shape = m.shape();
                     out_data.kind = DNN_ARG_CONST; // re-classify each output as constant
-                    netimpl->tensors.at(out.idx) = m;
+                    netimpl->__tensors__.at(out.idx) = m;
                 }
 
                 modified = true;

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -88,6 +88,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Split,          SplitLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Concat,         ConcatLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reshape,        ReshapeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Reshape2,       Reshape2Layer);
     CV_DNN_REGISTER_LAYER_CLASS(Flatten,        FlattenLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Resize,         ResizeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Interp,         InterpLayer);

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -84,15 +84,22 @@ void initializeLayerFactory()
     static ProtobufShutdown protobufShutdown; CV_UNUSED(protobufShutdown);
 #endif
 
-    CV_DNN_REGISTER_LAYER_CLASS(Slice,          SliceLayer);
-    CV_DNN_REGISTER_LAYER_CLASS(Split,          SplitLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Concat,         ConcatLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Concat2,        Concat2Layer);
+    CV_DNN_REGISTER_LAYER_CLASS(CropAndResize,  CropAndResizeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Flatten,        FlattenLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Interp,         InterpLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reshape,        ReshapeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reshape2,       Reshape2Layer);
-    CV_DNN_REGISTER_LAYER_CLASS(Flatten,        FlattenLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Resize,         ResizeLayer);
-    CV_DNN_REGISTER_LAYER_CLASS(Interp,         InterpLayer);
-    CV_DNN_REGISTER_LAYER_CLASS(CropAndResize,  CropAndResizeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Shape,          ShapeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Slice,          SliceLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Slice2,         Slice2Layer);
+    CV_DNN_REGISTER_LAYER_CLASS(Split,          SplitLayer);
+    //CV_DNN_REGISTER_LAYER_CLASS(Split2,         Split2Layer);
+    CV_DNN_REGISTER_LAYER_CLASS(Squeeze,        SqueezeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Transpose,      TransposeLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Unsqueeze,      UnsqueezeLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Convolution,    ConvolutionLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Deconvolution,  DeconvolutionLayer);
@@ -159,6 +166,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Arg,            ArgLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reciprocal,     ReciprocalLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Gather,         GatherLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Gather2,        Gather2Layer);
     CV_DNN_REGISTER_LAYER_CLASS(GatherElements, GatherElementsLayer);
     CV_DNN_REGISTER_LAYER_CLASS(LayerNormalization, LayerNormLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Expand,         ExpandLayer);

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -96,7 +96,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Slice,          SliceLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Slice2,         Slice2Layer);
     CV_DNN_REGISTER_LAYER_CLASS(Split,          SplitLayer);
-    //CV_DNN_REGISTER_LAYER_CLASS(Split2,         Split2Layer);
+    CV_DNN_REGISTER_LAYER_CLASS(Split2,         Split2Layer);
     CV_DNN_REGISTER_LAYER_CLASS(Squeeze,        SqueezeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Transpose,      TransposeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Unsqueeze,      UnsqueezeLayer);

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -172,7 +172,7 @@ public:
     MatShape computeColRowShape(const MatShape &inpShape, const MatShape &outShape) const CV_OVERRIDE
     {
         CV_Assert(!blobs.empty());
-        int dims = inpShape.size();
+        int dims = (int)inpShape.size();
         int inpD = dims == 5 ? inpShape[2] : 1;
         int inpH = inpShape[dims - 2];
         int inpW = inpShape.back();
@@ -236,7 +236,7 @@ public:
                      "be multiple of %d but got %d", weightShape[1], inpCn));
         CV_Assert(ngroups > 0 && inpCn % ngroups == 0 && outCn % ngroups == 0);
 
-        outputs.resize(1, outShape);
+        outputs.resize(1, MatShape(outShape));
 
         return false;
     }

--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -706,7 +706,7 @@ public:
         std::vector<size_t> local_kernel;
         if (globalPooling) {
             for (int i = 0; i < inpShape.size(); i++) {
-                int idx = isGlobalPooling.size() - inpShape.size() + i;
+                size_t idx = isGlobalPooling.size() - inpShape.size() + i;
                 local_kernel.push_back(isGlobalPooling[idx] ? inpShape[i] : kernel_size[idx]);
             }
         } else {
@@ -741,7 +741,7 @@ public:
                                  std::vector<size_t>(local_kernel.size(), 1), outShape);
         }
 
-        outputs.assign(1, outShape);
+        outputs.assign(1, MatShape(outShape));
         return false;
     }
 

--- a/modules/dnn/src/int8layers/quantization_utils.cpp
+++ b/modules/dnn/src/int8layers/quantization_utils.cpp
@@ -185,7 +185,8 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Check(inputs.size(), inputs.size() >= 1 && inputs.size() <= 3, "Number of inputs must be between 1 and 3 inclusive.");
-        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        CV_Assert(requiredOutputs <= 1);
+        outputs.assign(1, inputs[0]);
         return false;
     }
 
@@ -356,7 +357,8 @@ public:
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_Check(inputs.size(), inputs.size() >= 1 && inputs.size() <= 3, "Number of inputs must be between 1 and 3 inclusive.");
-        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        CV_Assert(requiredOutputs <= 1);
+        outputs.assign(1, inputs[0]);
         return false;
     }
 

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -311,7 +311,7 @@ std::ostream& Layer::dump(std::ostream& strm, int indent, bool comma) const
     size_t ninputs = inputs.size(), noutputs = outputs.size();
     const std::vector<Ptr<Graph> >* subgraphs_ = subgraphs();
     size_t nsubgraphs = subgraphs_ ? subgraphs_->size() : 0;
-    int delta_indent = net->getImpl()->indent;
+    int delta_indent = net->getImpl()->dump_indent;
     int subindent = indent + delta_indent;
     int argindent = subindent + delta_indent;
     prindent(strm, indent);

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "precomp.hpp"
+#include "net_impl.hpp"
 
 namespace cv {
 namespace dnn {
@@ -291,6 +292,67 @@ bool Layer::alwaysSupportInplace() const
 bool Layer::dynamicOutputShapes() const
 {
     return false;
+}
+
+std::ostream& Layer::dumpAttrs(std::ostream& strm, int) const
+{
+    return strm;
+}
+
+std::ostream& Layer::dump(std::ostream& strm, int indent, bool comma) const
+{
+    CV_Assert(net);
+    size_t ninputs = inputs.size(), noutputs = outputs.size();
+    const std::vector<Ptr<Graph> >* subgraphs_ = subgraphs();
+    size_t nsubgraphs = subgraphs_ ? subgraphs_->size() : 0;
+    int delta_indent = net->getImpl()->indent;
+    int subindent = indent + delta_indent;
+    int argindent = subindent + delta_indent;
+    prindent(strm, indent);
+    std::string opname = type;
+    strm << opname << " {\n";
+    prindent(strm, subindent);
+    strm << "name: \"" << name << "\",\n";
+    dumpAttrs(strm, subindent);
+    prindent(strm, subindent);
+    strm << "inputs: [\n";
+    for (size_t i = 0; i < ninputs; i++) {
+        net->dumpArg(strm, inputs[i], argindent, i+1 < ninputs, true);
+    }
+    prindent(strm, subindent);
+    strm << "],\n";
+    prindent(strm, subindent);
+    strm << "outputs: [\n";
+    for (size_t i = 0; i < noutputs; i++) {
+        net->dumpArg(strm, outputs[i], argindent, i+1 < noutputs, true);
+    }
+    prindent(strm, subindent);
+    strm << "],\n";
+
+    if (nsubgraphs > 0) {
+        std::vector<std::string> names;
+        if (opname == "If")
+            names = {"then", "else"};
+        else if (opname == "Loop")
+            names = {"body"};
+        else {
+            CV_Error(Error::StsError,
+                     format("unsupported operation '%s' with subgraphs",
+                            std::string(opname).c_str()));
+        }
+        CV_Assert(names.size() == nsubgraphs);
+        for (size_t i = 0; i < nsubgraphs; i++) {
+            prindent(strm, subindent);
+            strm << names[i] << ": ";
+            subgraphs_->at(i)->dump(strm, argindent, i+1 < nsubgraphs);
+        }
+    }
+    prindent(strm, indent);
+    strm << '}';
+    if (comma)
+        strm << ',';
+    strm << '\n';
+    return strm;
 }
 
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -274,6 +274,12 @@ void Layer::getTypes(const std::vector<MatType>&inputs,
     internals.assign(requiredInternals, inputs[0]);
 }
 
+int64 Layer::getFLOPS(const std::vector<MatShape>&,
+                      const std::vector<MatShape>&) const
+{
+    return 0;
+}
+
 bool Layer::updateMemoryShapes(const std::vector<MatShape>& inputs)
 {
     return true;

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -278,5 +278,20 @@ bool Layer::updateMemoryShapes(const std::vector<MatShape>& inputs)
     return true;
 }
 
+std::vector<Ptr<Graph> >* Layer::subgraphs() const
+{
+    return nullptr;
+}
+
+bool Layer::alwaysSupportInplace() const
+{
+    return false;
+}
+
+bool Layer::dynamicOutputShapes() const
+{
+    return false;
+}
+
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -317,7 +317,7 @@ std::ostream& Layer::dump(std::ostream& strm, int indent, bool comma) const
     size_t nblobs = blobs.size();
     const std::vector<Ptr<Graph> >* subgraphs_ = subgraphs();
     size_t nsubgraphs = subgraphs_ ? subgraphs_->size() : 0;
-    Net::Impl* netimpl = reinterpret_cast<Net::Impl*>(this->netimpl);
+    Net::Impl* netimpl = getNetImpl(this);
     int delta_indent = netimpl->dump_indent;
     int subindent = indent + delta_indent;
     int argindent = subindent + delta_indent;

--- a/modules/dnn/src/layer_internals.hpp
+++ b/modules/dnn/src/layer_internals.hpp
@@ -322,7 +322,7 @@ struct DataLayer : public Layer
             std::vector<MatShape>& outputs,
             std::vector<MatShape>& internals) const CV_OVERRIDE
     {
-        CV_Assert(inputs.size() == requiredOutputs);
+        CV_Assert(inputs.size() == requiredOutputs || requiredOutputs == 0);
         outputs.assign(inputs.begin(), inputs.end());
         return false;
     }

--- a/modules/dnn/src/layers/accum_layer.cpp
+++ b/modules/dnn/src/layers/accum_layer.cpp
@@ -28,7 +28,7 @@ public:
                                  std::vector<MatShape> &outputs,
                                  std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        std::vector<int> outShape;
+        MatShape outShape;
         int batch = inputs[0][0];
         outShape.push_back(batch);
 

--- a/modules/dnn/src/layers/accum_layer.cpp
+++ b/modules/dnn/src/layers/accum_layer.cpp
@@ -85,8 +85,13 @@ public:
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
     {
         LayerParams resizeParams;
+        Mat out = outputs_arr.getMat(0);
         resizeParams.set("interpolation", "bilinear");
         resizeParams.set("align_corners", true);
+        if (out.dims == 4) {
+            resizeParams.set("height", out.size[2]);
+            resizeParams.set("width", out.size[3]);
+        }
         resize = ResizeLayer::create(resizeParams);
     }
 

--- a/modules/dnn/src/layers/arg_layer.cpp
+++ b/modules/dnn/src/layers/arg_layer.cpp
@@ -71,7 +71,7 @@ public:
 
         const int axis_ = normalize_axis(axis, inpShape);
         // handle dims = 0 situation
-        if (!inpShape.empty())
+        if (inpShape.dims > 0)
             handleKeepDims(inpShape, axis_);
         outputs.assign(1, inpShape);
 

--- a/modules/dnn/src/layers/arg_layer.cpp
+++ b/modules/dnn/src/layers/arg_layer.cpp
@@ -97,7 +97,7 @@ public:
         outputs_arr.getMatVector(outputs);
 
         CV_Assert_N(inputs.size() == 1, outputs.size() == 1);
-        std::vector<int> outShape = shape(outputs[0]);
+        MatShape outShape = shape(outputs[0]);
         Mat output(outShape, CV_32SC1);
 
         switch (op)

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -78,7 +78,9 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
+        CV_Assert(!inputs.empty());
+        outputs.assign(std::max(requiredOutputs, 1), inputs[0]);
+        internals.clear();
         return true;
     }
 
@@ -88,11 +90,9 @@ public:
         std::vector<MatType>& outputs,
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
-        CV_Assert(inputs.size());
-        outputs = inputs;
-        if (requiredOutputs > (int)inputs.size()) {
-            outputs.resize(requiredOutputs, inputs[0]);
-        }
+        CV_Assert(!inputs.empty());
+        outputs.assign(std::max(requiredOutputs, 1), inputs[0]);
+        internals.clear();
     }
 
 

--- a/modules/dnn/src/layers/blank_layer.cpp
+++ b/modules/dnn/src/layers/blank_layer.cpp
@@ -90,6 +90,9 @@ public:
     {
         CV_Assert(inputs.size());
         outputs = inputs;
+        if (requiredOutputs > (int)inputs.size()) {
+            outputs.resize(requiredOutputs, inputs[0]);
+        }
     }
 
 
@@ -126,10 +129,12 @@ public:
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);
 
-        size_t i, n = outputs.size();
-        for (i = 0; i < n; ++i)
-            if (outputs[i].data != inputs[i].data)
-                inputs[i].copyTo(outputs[i]);
+        size_t i, ninputs = inputs.size(), noutputs = outputs.size();
+        for (i = 0; i < noutputs; ++i) {
+            const Mat& inp = inputs[i < ninputs ? i : 0];
+            if (outputs[i].data != inp.data)
+                inp.copyTo(outputs[i]);
+        }
     }
 
 #ifdef HAVE_CANN

--- a/modules/dnn/src/layers/concat2_layer.cpp
+++ b/modules/dnn/src/layers/concat2_layer.cpp
@@ -1,0 +1,194 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Concat layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Concat.html
+
+    Opset's 1 to 13 are covered.
+*/
+
+static void concat(const std::vector<Mat>& inps, Mat& out, int axis)
+{
+    MatShape outShape = out.shape();
+    int ndims = outShape.dims, nslices = 1;
+    size_t esz = out.elemSize();
+    size_t sliceSize = esz;
+    size_t totalSize = 0;
+    size_t outStep = 0;
+    int ninputs = (int)inps.size();
+    for (int i = ndims-1; i > axis; i--)
+        sliceSize *= outShape[i];
+    outStep = sliceSize*outShape[axis];
+    for (int i = 0; i < axis; i++)
+        nslices *= outShape[i];
+    for (int i = 0; i < ninputs; i++)
+        totalSize += inps[i].total()*esz;
+
+    parallel_for_(Range(0, ninputs), [&](const Range& r) {
+        for (int i = r.start; i < r.end; i++) {
+            const Mat& inp = inps[i];
+            uchar* outptr = out.data;
+            const uchar* inptr_i = inp.data;
+            int sz_a;
+            for (int j = 0; j < i; j++) {
+                sz_a = inps[j].size[axis];
+                outptr += sliceSize*sz_a;
+            }
+            sz_a = inp.size[axis];
+            size_t sliceSize_i = sliceSize*sz_a;
+            for (int j = 0; j < nslices; j++)
+                memcpy(outptr + j*outStep, inptr_i + j*sliceSize_i, sliceSize_i);
+        }
+    }, (totalSize > 1000000 ? ninputs : 1));
+}
+
+class Concat2LayerImpl CV_FINAL : public Concat2Layer
+{
+public:
+    Concat2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axis = params.get<int>("axis", 1);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const std::vector<MatShape>& inpShapes) const
+    {
+        size_t ninputs = inpShapes.size();
+        CV_Assert(ninputs == inputs.size());
+
+        const MatShape& inpShape0 = inpShapes[0];
+        int inpDims = inpShape0.dims;
+        int axis_ = normalize_axis(axis, inpDims);
+        CV_Assert(0 <= axis_ && axis_ < inpDims);
+        MatShape outShape = inpShape0;
+        outShape[axis_] = 0;
+
+        for (size_t i = 0; i < ninputs; i++) {
+            const MatShape& inpShape_i = inpShapes[i];
+            CV_Assert(inpShape_i.dims == inpDims);
+            for (int j = 0; j < inpDims; j++) {
+                if (j == axis_) {
+                    outShape[j] += inpShape_i[j];
+                    continue;
+                }
+                CV_Assert(inpShape0[j] == inpShape_i[j]);
+            }
+        }
+
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        outputs.assign(1, getOutShape(inputs));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs > 0);
+        for (size_t i = 1; i < ninputs; i++) {
+            CV_Assert(inputs[i] == inputs[0]);
+        }
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+
+        CV_Assert(ninputs > 0);
+
+        std::vector<MatShape> inpShapes(ninputs);
+        int inpType = inputs_arr.type(0);
+
+        for (int i = 0; i < ninputs; i++) {
+            inpShapes[i] = inputs_arr.shape(i);
+            CV_Assert(inputs_arr.type(i) == inpType);
+        }
+
+        MatShape outShape = getOutShape(inpShapes);
+        int outKind = outputs_arr.kind();
+        int axis_ = normalize_axis(axis, inpShapes[0].dims);
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            std::vector<Mat> inps;
+            inputs_arr.getMatVector(inps);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            runOp(inps, outs[0], axis_);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            std::vector<Mat> inps;
+            inputs_arr.getMatVector(inps);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            Mat temp(outShape, inpType);
+            runOp(inps, temp, axis_);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const std::vector<Mat>& inps, Mat& out, int axis_)
+    {
+        concat(inps, out, axis_);
+    }
+};
+
+Ptr<Concat2Layer> Concat2Layer::create(const LayerParams& params)
+{
+    return Ptr<Concat2Layer>(new Concat2LayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1776,7 +1776,7 @@ public:
             Mat temp;
             if (fusedWeights)
                 weightsMat.copyTo(umat_weights);
-            else if (!blobs.empty()) {                
+            else if (!blobs.empty()) {
                 transpose(blobs[0].reshape(1, inpCn), temp);
                 temp.copyTo(umat_weights);
             }

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -351,7 +351,7 @@ public:
                      "be multiple of %d but got %d", weightShape[1], inpCn));
         CV_Assert(ngroups > 0 && inpCn % ngroups == 0 && outCn % ngroups == 0);
 
-        outputs.resize(1, outShape);
+        outputs.resize(1, MatShape(outShape));
 
         return false;
     }
@@ -1404,7 +1404,7 @@ public:
         CV_Assert(inpCn % ngroups == 0 && outCn % ngroups == 0);
         CV_Assert(blobs[0].size[0] == inpCn);
 
-        outputs.resize(1, outShape);
+        outputs.resize(1, MatShape(outShape));
 
         if (!is1x1())
             internals.push_back(computeColRowShape(inputs[0], outputs[0]));

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1367,7 +1367,6 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        //CV_Assert(!hasBias() || blobs[1].total() == (size_t)numOutput);
         CV_Assert(inputs.size() != 0);
 
         int outCn = numOutput;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1326,7 +1326,6 @@ public:
     MatShape computeColRowShape(const MatShape &inpShape, const MatShape &outShape) const CV_OVERRIDE
     {
         int dims = inpShape.size();
-        int inpCn = inpShape[1];
         int inpD = dims == 5 ? inpShape[2] : 1;
         int inpH = inpShape[dims - 2];
         int inpW = inpShape.back();

--- a/modules/dnn/src/layers/correlation_layer.cpp
+++ b/modules/dnn/src/layers/correlation_layer.cpp
@@ -44,7 +44,7 @@ public:
         int neighborhood_grid_radius = max_displacement / stride_2;
         int neighborhood_grid_width = neighborhood_grid_radius * 2 + 1;
 
-        std::vector<int> outShape;
+        MatShape outShape;
 
         int num = inputs[0][0];
         outShape.push_back(num);

--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -175,7 +175,6 @@ Ptr<FastConv> initFastConv(
 #endif
 
     Mat weightsMat = _weightsMat.getMat();
-    auto wShape = shape(weightsMat);
     const size_t wstep = weightsMat.step1();
 
     conv->useFP16 = false;

--- a/modules/dnn/src/layers/cumsum_layer.cpp
+++ b/modules/dnn/src/layers/cumsum_layer.cpp
@@ -46,7 +46,7 @@ public:
         std::vector<MatType>& outputs,
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
-        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_16F, "");
+        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_64F || inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_16F, "");
         outputs.assign(1, inputs[0]);
     }
 
@@ -77,6 +77,9 @@ public:
                 break;
             case CV_64S:
                 forwardImpl<int64_t>(inputs, outputs);
+                break;
+            case CV_64F:
+                forwardImpl<double>(inputs, outputs);
                 break;
             default:
                 CV_Error(Error::BadDepth, "");

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -436,7 +436,6 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        std::cout << "getMemoryShapes" << std::endl;
         CV_UNUSED(internals);
 
         // check if passed and parsed inputs match up in number and dimensions
@@ -447,12 +446,8 @@ public:
             if (inputs[i] != einsumInpShapes[i])
                 CV_Error(Error::StsAssert, "Passed input shapes do not match with parsed input shapes!");
         }
-        std::cout << "einsumOutDims: " << einsumOutDims << std::endl;
-        std::cout << "outputs size: " << outputs.size() << std::endl;
         outputs.clear();
         outputs.emplace_back(einsumOutDims);
-        std::cout << "outputs size after clear: " << outputs.size() << std::endl;
-        std::cout << "outputs[0]: " << outputs[0] << std::endl;
         return true;
 
     } // getMemoryShape
@@ -562,10 +557,7 @@ public:
 
         // reduce dimentions
         result = result.reshape(1, einsumOutDims.size(), einsumOutDims.data());
-        std::cout << "result type: " << result.type() << std::endl;
         result.copyTo(outputs[0]);
-        std::cout << "outputs[0] type: " << outputs[0].type() << std::endl;
-        std::cout << "outputs[0]: " << outputs[0] << std::endl;
     } // forward
 
 #ifdef HAVE_DNN_NGRAPH
@@ -763,7 +755,6 @@ void LayerEinsumImpl::calculateOutputShape()
 
             // Push output dimention
             // Einsum layer only has one output vector
-            std::cout << "subscriptIndicesToDimValue[mappedIndex]: " << subscriptIndicesToDimValue[mappedIndex] << std::endl;
             einsumOutDims.emplace_back(subscriptIndicesToDimValue[mappedIndex]);
 
             // Reset the last input index for this subscript label
@@ -773,11 +764,7 @@ void LayerEinsumImpl::calculateOutputShape()
         }
     }
     if (rhs_eq.empty()) {
-        std::cout << "rhs_eq is empty" << std::endl;
         einsumOutDims = MatShape(0, 0); // handle scalar output case
-        std::cout << "einsumOutDims dims: " << einsumOutDims.size() << std::endl;
-        std::cout << "isScalar: " << einsumOutDims.isScalar() << std::endl;
-        std::cout << "empty: " << einsumOutDims.empty() << std::endl;
     }
 }
 
@@ -1361,13 +1348,6 @@ Mat LayerEinsumImpl::batchwiseMatMul(
     Mat reshapedInput1 = input1;
     Mat reshapedInput2 = input2;
 
-    std::cout << "reshapedInput1 size inside test: " << reshapedInput1.size << std::endl;
-    std::cout << "reshapedInput2 size inside test: " << reshapedInput2.size << std::endl;
-    std::cout << "reshapedInput1 shape inside test: " << shape(reshapedInput1) << std::endl;
-    std::cout << "reshapedInput2 shape inside test: " << shape(reshapedInput2) << std::endl;
-    std::cout << "reshapedInput1 dims inside test: " << reshapedInput1.dims << std::endl;
-    std::cout << "reshapedInput2 dims inside test: " << reshapedInput2.dims << std::endl;
-    std::cout << "batches: " << batches << std::endl;
 
     Mat output;
     if (batches > 1)
@@ -1398,25 +1378,13 @@ Mat LayerEinsumImpl::batchwiseMatMul(
         }
 
 
-        std::cout << "reshapedInput1 size inside test: " << reshapedInput1.size << std::endl;
-        std::cout << "reshapedInput2 size inside test: " << reshapedInput2.size << std::endl;
-        std::cout << "reshapedInput1 shape inside test: " << shape(reshapedInput1) << std::endl;
-        std::cout << "reshapedInput2 shape inside test: " << shape(reshapedInput2) << std::endl;
-        std::cout << "reshapedInput1 dims inside test: " << reshapedInput1.dims << std::endl;
-        std::cout << "reshapedInput2 dims inside test: " << reshapedInput2.dims << std::endl;
-
-        std::cout << "reshapedInput2 shape empty: " << shape(reshapedInput2).empty() << std::endl;
-        std::cout << "reshapedInput1 shape empty: " << shape(reshapedInput1).empty() << std::endl;
-
         output = Mat(M, N, reshapedInput1.type());
         if ((reshapedInput1.dims == 0 && reshapedInput2.dims == 0)  ||
             (reshapedInput1.dims == 0 && reshapedInput2.dims != 0) ||
             (reshapedInput1.dims != 0 && reshapedInput2.dims == 0))
         {
-            std::cout << "sample multiplication" << std::endl;
             output = reshapedInput1.mul(reshapedInput2); // fastGemm does not support 0D * 0D multiplication
         } else {
-            std::cout << "fastGemm multiplication" << std::endl;
             fastGemm(false, false, 1.0, reshapedInput1, reshapedInput2, 0.0, output, opt);
         }
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -1024,6 +1024,7 @@ Mat LayerEinsumImpl::FinalizeOutput(
     std::vector<size_t> output_permutation;
     output_permutation.resize(output_rank, 0);
     size_t output_iter = 0;
+    
 
     for (size_t iter = 0, end = ordered_subscript_indices_in_candidate.size(); iter < end; ++iter)
     {

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -436,6 +436,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
+        std::cout << "getMemoryShapes" << std::endl;
         CV_UNUSED(internals);
 
         // check if passed and parsed inputs match up in number and dimensions
@@ -446,9 +447,12 @@ public:
             if (inputs[i] != einsumInpShapes[i])
                 CV_Error(Error::StsAssert, "Passed input shapes do not match with parsed input shapes!");
         }
-
+        std::cout << "einsumOutDims: " << einsumOutDims << std::endl;
+        std::cout << "outputs size: " << outputs.size() << std::endl;
         outputs.clear();
         outputs.emplace_back(einsumOutDims);
+        std::cout << "outputs size after clear: " << outputs.size() << std::endl;
+        std::cout << "outputs[0]: " << outputs[0] << std::endl;
         return true;
 
     } // getMemoryShape
@@ -558,7 +562,10 @@ public:
 
         // reduce dimentions
         result = result.reshape(1, einsumOutDims.size(), einsumOutDims.data());
+        std::cout << "result type: " << result.type() << std::endl;
         result.copyTo(outputs[0]);
+        std::cout << "outputs[0] type: " << outputs[0].type() << std::endl;
+        std::cout << "outputs[0]: " << outputs[0] << std::endl;
     } // forward
 
 #ifdef HAVE_DNN_NGRAPH
@@ -756,6 +763,7 @@ void LayerEinsumImpl::calculateOutputShape()
 
             // Push output dimention
             // Einsum layer only has one output vector
+            std::cout << "subscriptIndicesToDimValue[mappedIndex]: " << subscriptIndicesToDimValue[mappedIndex] << std::endl;
             einsumOutDims.emplace_back(subscriptIndicesToDimValue[mappedIndex]);
 
             // Reset the last input index for this subscript label
@@ -763,6 +771,13 @@ void LayerEinsumImpl::calculateOutputShape()
             subscriptIndicesToLastInput[mappedIndex] = -1;
             subscriptIndicesToOutputIndices[mappedIndex] = outputDimCounter++;
         }
+    }
+    if (rhs_eq.empty()) {
+        std::cout << "rhs_eq is empty" << std::endl;
+        einsumOutDims = MatShape(0, 0); // handle scalar output case
+        std::cout << "einsumOutDims dims: " << einsumOutDims.size() << std::endl;
+        std::cout << "isScalar: " << einsumOutDims.isScalar() << std::endl;
+        std::cout << "empty: " << einsumOutDims.empty() << std::endl;
     }
 }
 
@@ -1024,7 +1039,7 @@ Mat LayerEinsumImpl::FinalizeOutput(
     std::vector<size_t> output_permutation;
     output_permutation.resize(output_rank, 0);
     size_t output_iter = 0;
-    
+
 
     for (size_t iter = 0, end = ordered_subscript_indices_in_candidate.size(); iter < end; ++iter)
     {
@@ -1346,6 +1361,14 @@ Mat LayerEinsumImpl::batchwiseMatMul(
     Mat reshapedInput1 = input1;
     Mat reshapedInput2 = input2;
 
+    std::cout << "reshapedInput1 size inside test: " << reshapedInput1.size << std::endl;
+    std::cout << "reshapedInput2 size inside test: " << reshapedInput2.size << std::endl;
+    std::cout << "reshapedInput1 shape inside test: " << shape(reshapedInput1) << std::endl;
+    std::cout << "reshapedInput2 shape inside test: " << shape(reshapedInput2) << std::endl;
+    std::cout << "reshapedInput1 dims inside test: " << reshapedInput1.dims << std::endl;
+    std::cout << "reshapedInput2 dims inside test: " << reshapedInput2.dims << std::endl;
+    std::cout << "batches: " << batches << std::endl;
+
     Mat output;
     if (batches > 1)
     {
@@ -1374,13 +1397,26 @@ Mat LayerEinsumImpl::batchwiseMatMul(
             reshapedInput2 = input2.reshape(1, 2, shape2);
         }
 
+
+        std::cout << "reshapedInput1 size inside test: " << reshapedInput1.size << std::endl;
+        std::cout << "reshapedInput2 size inside test: " << reshapedInput2.size << std::endl;
+        std::cout << "reshapedInput1 shape inside test: " << shape(reshapedInput1) << std::endl;
+        std::cout << "reshapedInput2 shape inside test: " << shape(reshapedInput2) << std::endl;
+        std::cout << "reshapedInput1 dims inside test: " << reshapedInput1.dims << std::endl;
+        std::cout << "reshapedInput2 dims inside test: " << reshapedInput2.dims << std::endl;
+
+        std::cout << "reshapedInput2 shape empty: " << shape(reshapedInput2).empty() << std::endl;
+        std::cout << "reshapedInput1 shape empty: " << shape(reshapedInput1).empty() << std::endl;
+
         output = Mat(M, N, reshapedInput1.type());
-        if ((shape(reshapedInput1).empty() && shape(reshapedInput2).empty())  ||
-            (shape(reshapedInput1).empty() && !shape(reshapedInput2).empty()) ||
-            (!shape(reshapedInput1).empty() && shape(reshapedInput2).empty()))
+        if ((reshapedInput1.dims == 0 && reshapedInput2.dims == 0)  ||
+            (reshapedInput1.dims == 0 && reshapedInput2.dims != 0) ||
+            (reshapedInput1.dims != 0 && reshapedInput2.dims == 0))
         {
+            std::cout << "sample multiplication" << std::endl;
             output = reshapedInput1.mul(reshapedInput2); // fastGemm does not support 0D * 0D multiplication
         } else {
+            std::cout << "fastGemm multiplication" << std::endl;
             fastGemm(false, false, 1.0, reshapedInput1, reshapedInput2, 0.0, output, opt);
         }
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -380,8 +380,6 @@ public:
     );
 
     void computeOutputShape(const std::vector<MatShape>& inputs) const {
-        std::cout << "computeOutputShape" << std::endl;
-        std::cout << "einsumOutDims: " << einsumOutDims << std::endl;
         if (!outputShapeComputed) {
             // Copy of the existing computation logic
             const_cast<LayerEinsumImpl*>(this)->processEquation(inputs);
@@ -400,7 +398,6 @@ public:
     {
         setParamsFrom(params);
         equation = params.get<String>("equation");
-        std::cout << "equation: " << equation << std::endl;
         opt.init();
 
         // We allocate space for 10 values as a precaution,
@@ -825,7 +822,6 @@ void LayerEinsumImpl::processBroadcastedDims()
             tempCurrentInputDimIndicesToSubscriptIndices.reserve(currentInputDimIndicesToSubscriptIndices.size());
 
             // make sure it is correct
-            std::cout << "einsumInpShapes size: " << einsumInpShapes[i] << std::endl;
             const auto& dims = einsumInpShapes[i];
             auto rank = dims.size();
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -884,6 +884,7 @@ void LayerEinsumImpl::processEquation(const std::vector<MatShape>& inputs)
     // For install "ij, jk -> ik" needs to have 2 inputs tensors
     int num_input_tensors = inputs.size();
     if (lhs_eq_tokens.empty() || (lhs_eq_tokens.size() == 1 && lhs_eq_tokens[0].empty() && lhs_eq == ",") ) {
+        inputSubscriptIndices.resize(numInputs);
         return;
     }
     // if we have only one token and two inputs lets skip the check

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -15,7 +15,7 @@ namespace dnn
 {
 
 static bool IsTransposeReshapeForEinsum(const std::vector<size_t>& perm,
-                                        std::vector<int> input_dims,
+                                        const MatShape& input_dims,
                                         MatShape& new_shape) {
     // As long as the dims with values > 1 stay in the same order, it's a reshape.
     // Example: Shape=(1,1,1024,4096) -> perm=(2,0,3,1).
@@ -59,7 +59,8 @@ static Mat Transpose(
     Mat output;
     MatShape order(permutation.begin(), permutation.end());
 
-    cv::transposeND((reshape ? input_reshaped : input), order, output);
+    std::vector<int> order_(order.begin(), order.end());
+    cv::transposeND((reshape ? input_reshaped : input), order_, output);
     return output;
 }
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -1006,9 +1006,9 @@ Mat LayerEinsumImpl::FinalizeOutput(
     const std::vector<int>& subscript_indices_to_output_indices = subscriptIndicesToOutputIndices;
     const auto output_dims = einsumOutDims;
 
-    MatShape output_shape = output_dims;
     const auto output_rank = output_dims.size();
 
+    // MatShape output_shape = output_dims;
     // CV_CheckEQ((int) candidateOutput.dims,  (int) output_shape.size(),
     //           "Einsum op: The candidate output cannot be reshaped into the op's output");
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -432,6 +432,19 @@ public:
         CV_UNUSED(requiredOutputs);
         CV_UNUSED(internals);
 
+        // check if input einsumInputShapes is empty
+        if (einsumInpShapes.empty()) {
+            outputShapeComputed = false;
+        } else {
+            // check weather shapes in inputs are compatible with shapes in einsumInpShapes
+            for (int i = 0; i < inputs.size(); i++) {
+                if (inputs[i] != einsumInpShapes[i]) {
+                    outputShapeComputed = false;
+                    break;
+                }
+            }
+        }
+
         computeOutputShape(inputs);
 
         outputs.clear();

--- a/modules/dnn/src/layers/expand_layer.cpp
+++ b/modules/dnn/src/layers/expand_layer.cpp
@@ -45,7 +45,7 @@ public:
 
         MatShape input_shape = inputs[0]; // 1d tensor is represented as 2d mat, e.g. [3] -> [3, 1]
         if (const_input_1d) {
-            input_shape = {inputs[0][0]};
+            input_shape = shape(inputs[0][0]);
         }
 
         auto& moreDimension = input_shape.size() > target_shape.size() ? input_shape : target_shape;
@@ -96,7 +96,7 @@ public:
         const auto &input = inputs[0];
         auto input_shape = shape(input);
         if (const_input_1d) {
-            input_shape = {input_shape[0]};
+            input_shape = shape(input_shape[0]);
         }
 
         auto& moreDimension = input_shape.size() > target_shape.size() ? input_shape : target_shape;
@@ -105,7 +105,7 @@ public:
         MatShape final_target_shape(moreDimension.size(), 1);
         for (int i = 0; i < moreDimension.size(); i++) {
             int d = moreDimension[i];
-            int j = i - (moreDimension.size() - lessDimension.size());
+            int j = i - (int)(moreDimension.size() - lessDimension.size());
             if (j >= 0) {
                 final_target_shape[i] = std::max(lessDimension[j], d);
             } else {

--- a/modules/dnn/src/layers/flatten_layer.cpp
+++ b/modules/dnn/src/layers/flatten_layer.cpp
@@ -65,10 +65,14 @@ namespace dnn
 class FlattenLayerImpl CV_FINAL : public FlattenLayer
 {
 public:
+    bool _onnxMode;
+
     FlattenLayerImpl(const LayerParams &params)
     {
         _startAxis = params.get<int>("axis", 1);
         _endAxis = params.get<int>("end_axis", -1);
+        _onnxMode = params.get<bool>("onnx", false);
+
         setParamsFrom(params);
     }
 
@@ -94,24 +98,49 @@ public:
             CV_Assert(inputs[i] == inputs[0]);
         }
 
-        int numAxes = inputs[0].size();
+        MatShape outputShapeVec;
+
+        int numAxes = (int)inputs[0].size();
+        /*
+           [TODO] this is not quite correct,
+           in ONNX Flatten valid range is [0, numAxes],
+           not [0, numAxes-1] which normalize_axis() produces.
+           But if we fix it, flatten_const.onnx from opencv_extra
+           is not processed correctly.
+           libprotobuf-c reads it correctly,
+           but the current version of libprotobuf does not
+        */
         int startAxis = normalize_axis(_startAxis, numAxes);
         int endAxis = normalize_axis(_endAxis, numAxes);
 
-        CV_Assert(startAxis >= 0);
-        CV_Assert(endAxis >= startAxis && endAxis < (int)numAxes);
+        CV_Assert(startAxis >= 0 && startAxis <= numAxes);
 
-        size_t flattenedDimensionSize = total(inputs[0], startAxis, endAxis + 1);
-
-        MatShape outputShapeVec;
-        for (int i = 0; i < startAxis; i++)
-        {
-            outputShapeVec.push_back(inputs[0][i]);
+        if (_onnxMode) {
+            size_t outer = 1, inner = 1;
+            int i = 0;
+            for (; i < startAxis; i++)
+                outer *= inputs[0][i];
+            for (; i < numAxes; i++)
+                inner *= inputs[0][i];
+            
+            CV_Assert_N(inner <= (size_t)INT_MAX, outer < (size_t)INT_MAX);
+            outputShapeVec.push_back((int)outer);
+            outputShapeVec.push_back((int)inner);
         }
-        outputShapeVec.push_back(flattenedDimensionSize);
-        for (size_t i = endAxis + 1; i < numAxes; i++)
-        {
-            outputShapeVec.push_back(inputs[0][i]);
+        else {
+            CV_Assert(endAxis >= startAxis && endAxis <= numAxes);
+
+            size_t flattenedDimensionSize = total(inputs[0], startAxis, endAxis + 1);
+
+            for (int i = 0; i < startAxis; i++)
+            {
+                outputShapeVec.push_back(inputs[0][i]);
+            }
+            outputShapeVec.push_back(flattenedDimensionSize);
+            for (size_t i = endAxis + 1; i < numAxes; i++)
+            {
+                outputShapeVec.push_back(inputs[0][i]);
+            }
         }
 
         outputs.resize(inputs.size(), outputShapeVec);
@@ -126,17 +155,8 @@ public:
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
         CV_Assert(inputs.size());
-        for (auto input : inputs)
-        {
-            if (preferableTarget == DNN_TARGET_OPENCL_FP16)
-                CV_CheckType(input, input == CV_16F || input == CV_32S || input == CV_64S || input == CV_8S || input == CV_8U || input == CV_Bool, "");
-            else
-                CV_CheckType(input, input == CV_32F || input == CV_32S || input == CV_64S || input == CV_8S || input == CV_8U || input == CV_Bool, "");
-        }
-
         outputs.assign(requiredOutputs, inputs[0]);
     }
-
 
     void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays) CV_OVERRIDE
     {
@@ -165,7 +185,7 @@ public:
         {
             MatShape outShape = shape(outputs[i]);
             UMat& output = outputs_arr.getUMatRef(i);
-            output = inputs[i]->reshape(1, (int)outShape.size(), &outShape[0]);
+            inputs[i]->reshape(1, (int)outShape.size(), &outShape[0]).copyTo(output);
         }
 
         return true;

--- a/modules/dnn/src/layers/flatten_layer.cpp
+++ b/modules/dnn/src/layers/flatten_layer.cpp
@@ -122,7 +122,7 @@ public:
                 outer *= inputs[0][i];
             for (; i < numAxes; i++)
                 inner *= inputs[0][i];
-            
+
             CV_Assert_N(inner <= (size_t)INT_MAX, outer < (size_t)INT_MAX);
             outputShapeVec.push_back((int)outer);
             outputShapeVec.push_back((int)inner);

--- a/modules/dnn/src/layers/flatten_layer.cpp
+++ b/modules/dnn/src/layers/flatten_layer.cpp
@@ -102,6 +102,7 @@ public:
 
         int numAxes = (int)inputs[0].size();
         /*
+           Ticket: https://github.com/opencv/opencv/issues/26197
            [TODO] this is not quite correct,
            in ONNX Flatten valid range is [0, numAxes],
            not [0, numAxes-1] which normalize_axis() produces.

--- a/modules/dnn/src/layers/gather2_layer.cpp
+++ b/modules/dnn/src/layers/gather2_layer.cpp
@@ -109,11 +109,11 @@ public:
         MatShape outShape(dataDims + indDims - 1);
 
         for (int i = 0; i < outShape.dims; i++) {
-            if (i < indDims) {
-                outShape[i] = indShape[i];
+            if (i < axis_) {
+                outShape[i] = dataShape[i];
             } else {
-                int j = i - indDims;
-                outShape[i] = dataShape[j < axis ? j : j+1];
+                int j = i - axis_;
+                outShape[i] = j < indDims ? indShape[j] : dataShape[i - indDims + 1];
             }
         }
         return outShape;

--- a/modules/dnn/src/layers/gather2_layer.cpp
+++ b/modules/dnn/src/layers/gather2_layer.cpp
@@ -1,0 +1,211 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Gather layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Gather.html
+
+    Opset's 1 to 13 are covered.
+*/
+
+static void gather(const Mat& data, const Mat& ind, Mat& out, int axis)
+{
+    CV_Assert(data.isContinuous());
+    CV_Assert(ind.isContinuous());
+    int indType = ind.type();
+    CV_Assert(indType == CV_32S || indType == CV_64S);
+    CV_Assert(out.isContinuous());
+
+    MatShape dataShape = data.shape();
+    MatShape indShape = ind.shape();
+    MatShape outShape = out.shape();
+    int dataDims = dataShape.dims;
+    int indDims = indShape.dims;
+    int outDims = outShape.dims;
+
+    CV_Assert(outDims == dataDims + indDims - 1);
+    size_t indTotal = indShape.total(), nslices = 1;
+    size_t elemSize = data.elemSize();
+    size_t sliceSize = elemSize;
+
+    for(int j = 0; j < dataDims; j++) {
+        int szj = dataShape[j];
+        if (j < axis)
+            nslices *= szj;
+        else if (j > axis)
+            sliceSize *= szj;
+    }
+    size_t dataStep = sliceSize * dataShape[axis];
+    size_t outStep = sliceSize * indTotal;
+    volatile bool globOutOfRangeIdx = false;
+
+    parallel_for_(Range(0, (int)indTotal), [&](const Range& r) {
+        int shape_a = dataShape[axis];
+        const uchar* dataptr0 = data.data;
+        uchar* outptr0 = out.data;
+        const int32_t* ind32 = indType == CV_32S ? ind.ptr<int32_t>() : nullptr;
+        const int64_t* ind64 = indType == CV_64S ? ind.ptr<int64_t>() : nullptr;
+        bool outOfRangeIdx = globOutOfRangeIdx;
+        for (int j = r.start; j < r.end && !outOfRangeIdx; j++) {
+            int k = ind32 ? (int)ind32[j] : (int)ind64[j];
+            uchar* outptr = outptr0 + j*sliceSize;
+            const uchar* dataptr = dataptr0;
+            for (size_t i = 0; i < nslices; i++, dataptr += dataStep, outptr += outStep) {
+                k += k < 0 ? shape_a : 0;
+                if (k < 0 || k >= shape_a) {
+                    outOfRangeIdx = true;
+                    break;
+                }
+                memcpy(outptr, dataptr + k*sliceSize, sliceSize);
+            }
+        }
+        if (outOfRangeIdx)
+            globOutOfRangeIdx = true;
+    }, std::min((double)indTotal, (double)sliceSize*nslices*indTotal/1e6));
+
+    if (globOutOfRangeIdx) {
+        CV_Error(Error::StsOutOfRange, "some of indices are outside of range");
+    }
+}
+
+class Gather2LayerImpl CV_FINAL : public Gather2Layer
+{
+public:
+    Gather2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axis = params.get<int>("axis", 0);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const MatShape& dataShape, const MatShape& indShape) const
+    {
+        int dataDims = dataShape.dims;
+        int indDims = indShape.dims;
+
+        int axis_ = normalize_axis(axis, dataDims);
+        CV_Assert(0 <= axis_ && axis_ < dataDims);
+        MatShape outShape(dataDims + indDims - 1);
+
+        for (int i = 0; i < outShape.dims; i++) {
+            if (i < indDims) {
+                outShape[i] = indShape[i];
+            } else {
+                int j = i - indDims;
+                outShape[i] = dataShape[j < axis ? j : j+1];
+            }
+        }
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 2);
+        outputs.assign(1, getOutShape(inputs[0], inputs[1]));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs == 2);
+        int dataType = inputs[0];
+        int indType = inputs[1];
+        CV_Assert(indType == CV_32S || indType == CV_64S);
+        outputs.assign(requiredOutputs, dataType);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+
+        CV_Assert(ninputs == 2);
+
+        MatShape dataShape = inputs_arr.shape(0);
+        MatShape indShape = inputs_arr.shape(1);
+        int dataType = inputs_arr.type(0);
+        int indType = inputs_arr.type(1);
+        CV_Assert(indType == CV_32S || indType == CV_64S);
+
+        MatShape outShape = getOutShape(dataShape, indShape);
+        int outKind = outputs_arr.kind();
+        int axis_ = normalize_axis(axis, dataShape.dims);
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat data = inputs_arr.getMat(0);
+            Mat ind = inputs_arr.getMat(1);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, dataType);
+            runOp(data, ind, outs[0], axis_);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat data = inputs_arr.getMat(0);
+            Mat ind = inputs_arr.getMat(1);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, dataType);
+            Mat temp(outShape, dataType);
+            runOp(data, ind, temp, axis_);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& data, const Mat& ind, Mat& out, int axis_)
+    {
+        gather(data, ind, out, axis_);
+    }
+};
+
+Ptr<Gather2Layer> Gather2Layer::create(const LayerParams& params)
+{
+    return Ptr<Gather2Layer>(new Gather2LayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/gather2_layer.cpp
+++ b/modules/dnn/src/layers/gather2_layer.cpp
@@ -26,13 +26,12 @@ namespace dnn
     Opset's 1 to 13 are covered.
 */
 
+// out must be pre-allocated
 static void gather(const Mat& data, const Mat& ind, Mat& out, int axis)
 {
-    CV_Assert(data.isContinuous());
-    CV_Assert(ind.isContinuous());
+    CV_Assert_N(data.isContinuous(), ind.isContinuous(), out.isContinuous());
     int indType = ind.type();
     CV_Assert(indType == CV_32S || indType == CV_64S);
-    CV_Assert(out.isContinuous());
 
     MatShape dataShape = data.shape();
     MatShape indShape = ind.shape();

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -113,10 +113,9 @@ public:
     // TODO: replace with cv::broadcast() once 1d mat is supported
     // FIXME: fix if conditions if 1d mat is supported properly
     void broadcastCWtihBeta(int M, int N, const Mat &C) {
+        broadcast_C.clear();
+        broadcast_C.resize(M * N, 0.f);
         if (beta != 0 && !C.empty()) {
-            broadcast_C.clear();
-            broadcast_C.resize(M * N, 0.f);
-
             int real_ndims_C_ = real_ndims_C >= 0 ? real_ndims_C : C.dims;
 
             const float *ptr_c = C.ptr<const float>();
@@ -206,8 +205,8 @@ public:
 
         // broadcast C and copy C to output
         if (have_bias_) {
-            if (!const_C) {
-                broadcastCWtihBeta(M, N, inputs.back());
+            if (!const_C || broadcast_C.empty()) {
+                broadcastCWtihBeta(M, N, (inputs.size() >= 3 ? inputs.back() : blobs.back()));
             }
             int step = M * N;
             CV_CheckEQ(broadcast_C.size(), static_cast<size_t>(step), "DNN/Gemm: C is not broadcast properly");

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -196,9 +196,10 @@ public:
         size_t dims_Y = shape_Y.size();
         int M = shape_Y[dims_Y - 2], N = shape_Y[dims_Y - 1];
         int K = trans_a ? ma : na;
+        bool have_bias_ = have_bias || inputs.size() == 3;
 
         // broadcast C and copy C to output
-        if (have_bias) {
+        if (have_bias_) {
             if (!const_C) {
                 broadcastCWtihBeta(M, N, inputs.back());
             }

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -30,9 +30,14 @@ public:
         alpha = params.get<float>("alpha", 1.0f);
         beta = params.get<float>("beta", 1.0f);
 
-        const_B = params.get<bool>("constB", false); // true means blobs[0] is B
-        const_C = params.get<bool>("constC", false); // true means blobs.back() is C
-        have_bias = params.get<bool>("have_bias", false); // NOTE: have_bias being true does not mean bias is constant
+        if (!blobs.empty()) {
+            const_B = const_C = true;
+        } else {
+            const_B = const_C = false;
+        }
+        // [TODO] the function should be smart enough to figure out the operation mode from the number of 'inputs' and number of 'blobs'.
+        // note, however, that 'inputs' may not be set yet in the constructor
+        have_bias = blobs.size() > 1 || params.get<bool>("have_bias", false); // NOTE: have_bias being true does not mean bias is constant
 
         real_ndims_C = params.get<int>("real_ndims_C", -1);
     }

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -63,7 +63,7 @@ public:
                                  std::vector<MatShape> &outputs,
                                  std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        int noutputs = requiredOutputs > 0 ? requiredOutputs : (int)this->outputs.size();
+        int noutputs = std::max(requiredOutputs > 0 ? requiredOutputs : (int)this->outputs.size(), 1);
         CV_Assert(noutputs == 1 || noutputs == 3);
 
         // check shapes of weight and bias if existed

--- a/modules/dnn/src/layers/layer_norm.cpp
+++ b/modules/dnn/src/layers/layer_norm.cpp
@@ -36,12 +36,14 @@ class LayerNormLayerImpl CV_FINAL : public LayerNormLayer
 #endif
 
 public:
+    int axis0;
+
     LayerNormLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
 
         // standard attr
-        axis = params.get<int>("axis", -1);
+        axis = axis0 = params.get<int>("axis", -1);
         epsilon = params.get<float>("epsilon", 1e-5);
     }
 
@@ -69,14 +71,16 @@ public:
         auto x_shape = inputs[0];
         int x_ndims = static_cast<int>(x_shape.size());
 
+        int axis_ = normalize_axis(axis0, x_shape.dims);
+
         // Weight and bias are either constants or variable
         auto w_shape = blobs.empty() ? inputs[1] : shape(blobs.front());
         // if axis == last_dim, scale and b are both 1d tensor (represented as 2d mat nx1)
         int w_ndims = static_cast<int>(w_shape.size());
-        w_ndims = (axis == x_ndims - 1 && w_ndims == 2) ? w_ndims - 1 : w_ndims;
-        CV_CheckEQ(x_ndims - axis, w_ndims, "LayerNorm: shape of weight does not match with given axis and shape of input");
+        w_ndims = (axis_ == x_ndims - 1 && w_ndims == 2) ? w_ndims - 1 : w_ndims;
+        CV_CheckEQ(x_ndims - axis_, w_ndims, "LayerNorm: shape of weight does not match with given axis and shape of input");
         for (int i = 0; i < w_ndims; ++i)
-            CV_CheckEQ(x_shape[axis+i], w_shape[i], "LayerNorm: weight dimensions does not match with input dimensions");
+            CV_CheckEQ(x_shape[axis_+i], w_shape[i], "LayerNorm: weight dimensions does not match with input dimensions");
         if (num_inputs >= 3)
         {
             auto b_shape = blobs.empty() ? inputs[2] : shape(blobs.back());
@@ -94,7 +98,7 @@ public:
         inputs_arr.getMatVector(inputs);
 
         const auto input_shape = shape(inputs[0]);
-        axis = normalize_axis(axis, static_cast<int>(input_shape.size()));
+        axis = normalize_axis(axis0, static_cast<int>(input_shape.size()));
 
 #ifdef HAVE_OPENCL
         weight_umat.release();
@@ -124,6 +128,8 @@ public:
         const auto &scale = blobs.empty() ? inputs[1] : blobs.front();
         auto &output = outputs[0];
 
+        axis = normalize_axis(axis0, input.dims);
+
         if ((inputs.size() + blobs.size()) >= 3) {
             const auto &bias = blobs.empty() ? inputs[2] : blobs.back();
             fastNorm(input, scale, bias, output, epsilon, static_cast<size_t>(axis));
@@ -150,6 +156,7 @@ public:
         auto &output = outputs[0];
 
         const auto input_shape = shape(input);
+        axis = normalize_axis(axis0, input_shape.dims);
         size_t loops = static_cast<size_t>(total(input_shape, 0, axis)),
                norm_size = static_cast<size_t>(total(input_shape, axis));
         float inv_norm_size = 1.f / norm_size;

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -281,6 +281,24 @@ void tensorToIntVec(const Mat& tensor, std::vector<int>& vec)
     }
 }
 
+void tensorToFloatVec(const Mat& tensor, std::vector<float>& vec)
+{
+    if (tensor.empty()) {
+        vec.clear();
+    } else {
+        int type = tensor.type();
+        MatShape shape = tensor.shape();
+        CV_Assert(type == CV_32F || type == CV_16F);
+        CV_Assert(shape.dims <= 1);
+        int size = (int)shape.total();
+        vec.resize(size);
+        for (int i = 0; i < size; i++) {
+            vec[i] = type == CV_32F ? tensor.at<float>(i) :
+                (float)tensor.at<hfloat>(i);
+        }
+    }
+}
+
 void reshapeAndCopyFirst(InputArrayOfArrays inputs,
                          OutputArrayOfArrays outputs,
                          const MatShape& shape)

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -266,13 +266,18 @@ double getWeightScale(const Mat& weightsMat)
 
 void tensorToIntVec(const Mat& tensor, std::vector<int>& vec)
 {
-    int type = tensor.type();
-    CV_Assert(type == CV_32S || type == CV_64S);
-    CV_Assert(tensor.dims <= 1);
-    size_t size = tensor.total();
-    vec.resize(size);
-    for (size_t i = 0; i < size; i++) {
-        vec[i] = type == CV_32S ? tensor.at<int>(i) : (int)tensor.at<int64_t>(i);
+    if (tensor.empty()) {
+        vec.clear();
+    } else {
+        int type = tensor.type();
+        CV_Assert(type == CV_32S || type == CV_64S);
+        CV_Assert(tensor.dims <= 1);
+        int size = (int)tensor.total();
+        vec.resize(size);
+        for (int i = 0; i < size; i++) {
+            vec[i] = type == CV_32S ? tensor.at<int>(i) :
+                saturate_cast<int>(tensor.at<int64_t>(i));
+        }
     }
 }
 

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -264,5 +264,33 @@ double getWeightScale(const Mat& weightsMat)
     return (realMax == realMin) ? 1.0 : std::max(-realMin, realMax)/127;
 }
 
+void reshapeAndCopyFirst(InputArrayOfArrays inputs,
+                         OutputArrayOfArrays outputs,
+                         const MatShape& shape)
+{
+    int inp_kind = inputs.kind(), out_kind = outputs.kind();
+    CV_Assert(inp_kind == out_kind);
+    CV_Assert(inp_kind == _InputArray::STD_VECTOR_MAT ||
+              inp_kind == _InputArray::STD_VECTOR_UMAT);
+    int inp_type = inputs.type(0);
+    if (inp_kind == _InputArray::STD_VECTOR_MAT) {
+        Mat inp = inputs.getMat(0);
+        std::vector<Mat>& outref = outputs.getMatVecRef();
+        outref.resize(1);
+        outref[0].fit(shape, inp_type);
+        Mat inp_ = inp.reshape(0, shape);
+        if (inp_.data != outref[0].data)
+            inp_.copyTo(outref[0]);
+    }
+    else {
+        UMat inp = inputs.getUMat(0);
+        std::vector<UMat>& outref = outputs.getUMatVecRef();
+        outref.resize(1);
+        outref[0].fit(shape, inp_type);
+        UMat inp_ = inp.reshape(0, shape);
+        inp_.copyTo(outref[0]);
+    }
+}
+
 }
 }

--- a/modules/dnn/src/layers/layers_common.hpp
+++ b/modules/dnn/src/layers/layers_common.hpp
@@ -76,6 +76,21 @@ void getConvPoolPaddings(const std::vector<int>& inp, const std::vector<size_t>&
 
 // Used in quantized model. It will return the (Max_element - Min_element)/127.
 double getWeightScale(const Mat& weightsMat);
+
+// inputs and outputs are both vector<Mat>'s or both are vector<UMat>'s.
+// the function does the following:
+//
+// 1. resizes output vector to 1-element vector
+// 2. outputs[0].fit(shape, inputs[0].type())
+// 3. temp = inputs[0].reshape(shape);
+// 4. temp.copyTo(outputs[0]) // detect in-place case and do nothing in this case
+//
+// the function helps to implement DL operations
+// 'Reshape', 'Flatten', 'Squeeze', 'Unsqueeze', 'Identity'.
+void reshapeAndCopyFirst(InputArrayOfArrays inputs,
+                         OutputArrayOfArrays outputs,
+                         const MatShape& shape);
+
 }
 }
 

--- a/modules/dnn/src/layers/layers_common.hpp
+++ b/modules/dnn/src/layers/layers_common.hpp
@@ -77,6 +77,12 @@ void getConvPoolPaddings(const std::vector<int>& inp, const std::vector<size_t>&
 // Used in quantized model. It will return the (Max_element - Min_element)/127.
 double getWeightScale(const Mat& weightsMat);
 
+// Several ONNX operations take list of integer's (32-bit or 64-bit),
+// e.g. to specify list of axes (Squeeze, Unsqueeze, Transpose, Reduce*, ...),
+// coordinates, repetitions etc. (Slice, Tile, ...).
+// Here is a helper function to extract this data
+void tensorToIntVec(const Mat& tensor, std::vector<int>& vec);
+
 // inputs and outputs are both vector<Mat>'s or both are vector<UMat>'s.
 // the function does the following:
 //

--- a/modules/dnn/src/layers/layers_common.hpp
+++ b/modules/dnn/src/layers/layers_common.hpp
@@ -77,11 +77,12 @@ void getConvPoolPaddings(const std::vector<int>& inp, const std::vector<size_t>&
 // Used in quantized model. It will return the (Max_element - Min_element)/127.
 double getWeightScale(const Mat& weightsMat);
 
-// Several ONNX operations take list of integer's (32-bit or 64-bit),
+// Several ONNX operations take list of integer's or float's,
 // e.g. to specify list of axes (Squeeze, Unsqueeze, Transpose, Reduce*, ...),
-// coordinates, repetitions etc. (Slice, Tile, ...).
-// Here is a helper function to extract this data
+// coordinates, repetitions etc. (Slice, Tile, ...), scale factors (Resize, ...).
+// Here are helper functions to extract this data
 void tensorToIntVec(const Mat& tensor, std::vector<int>& vec);
+void tensorToFloatVec(const Mat& tensor, std::vector<float>& vec);
 
 // inputs and outputs are both vector<Mat>'s or both are vector<UMat>'s.
 // the function does the following:

--- a/modules/dnn/src/layers/max_unpooling_layer.cpp
+++ b/modules/dnn/src/layers/max_unpooling_layer.cpp
@@ -221,7 +221,7 @@ public:
         std::vector<MatShape> outShapes, internals;
         for (int i = 0; i < nodes.size(); ++i) {
             std::vector<size_t> shape = nodes[i].dynamicCast<InfEngineNgraphNode>()->node.get_shape();
-            inpShapes[i] = std::vector<int>(shape.begin(), shape.end());
+            inpShapes[i] = MatShape(shape.begin(), shape.end());
         }
         getMemoryShapes(inpShapes, 1, outShapes, internals);
 

--- a/modules/dnn/src/layers/not_layer.cpp
+++ b/modules/dnn/src/layers/not_layer.cpp
@@ -56,11 +56,14 @@ public:
         CV_CheckTypeEQ(inputs[0].type(), CV_Bool, "");
         CV_CheckTypeEQ(outputs[0].type(), CV_Bool, "");
 
+        CV_Assert(inputs[0].isContinuous());
+        CV_Assert(outputs[0].isContinuous());
+
         bool* input = inputs[0].ptr<bool>();
         bool* output = outputs[0].ptr<bool>();
-        int size = inputs[0].total();
+        size_t size = inputs[0].total();
 
-        for (int i = 0; i < size; ++i)
+        for (size_t i = 0; i < size; ++i)
             output[i] = !input[i];
     }
 

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -1264,7 +1264,7 @@ public:
         int numOutputs = requiredOutputs ? requiredOutputs : (type == MAX ? 2 : 1);
         CV_Assert(numOutputs == 1 || (numOutputs == 2 && type == MAX));
 
-        outputs.assign(numOutputs, outShape);
+        outputs.assign(numOutputs, MatShape(outShape));
 
         return false;
     }

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -580,10 +580,12 @@ public:
         auto image_shape = image_wrapper->getShape();
 
         PriorBoxConfiguration config;
-        config.feature_map_width = feature_map_shape.rbegin()[0];
-        config.feature_map_height = feature_map_shape.rbegin()[1];
-        config.image_width = image_shape.rbegin()[0];
-        config.image_height = image_shape.rbegin()[1];
+        int fm_dims = feature_map_shape.dims;
+        int im_dims = image_shape.dims;
+        config.feature_map_width = feature_map_shape.p[fm_dims-1];
+        config.feature_map_height = feature_map_shape.p[fm_dims-2];
+        config.image_width = image_shape[im_dims-1];
+        config.image_height = image_shape[im_dims-2];
 
         config.num_priors = _numPriors;
         config.box_widths = _boxWidths;

--- a/modules/dnn/src/layers/reshape2_layer.cpp
+++ b/modules/dnn/src/layers/reshape2_layer.cpp
@@ -136,7 +136,7 @@ public:
         if (inputs.size() == 2)
         {
             CV_Assert(this->inputs.size() == 2);
-            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Net::Impl* netimpl_ = getNetImpl(this);
             Mat shapeTensor = netimpl_->argTensor(this->inputs[1]);
             shapeSpec = tensorToShapeSpec(shapeTensor);
         } else {

--- a/modules/dnn/src/layers/reshape2_layer.cpp
+++ b/modules/dnn/src/layers/reshape2_layer.cpp
@@ -82,7 +82,7 @@ public:
     MatShape getOutShape(const MatShape& inpShape, MatShape& shapeSpec) const
     {
         MatShape outShape = shapeSpec;
-        int m1idx = -1, haveZeros = 0;
+        int m1idx = -1;
         int i, ndims = outShape.dims;
         int64_t outTotal = 1;
         for (i = 0; i < ndims; i++) {
@@ -95,7 +95,6 @@ public:
             }
             else {
                 if (outShape[i] == 0) {
-                    haveZeros++;
                     if (i >= inpShape.dims) {
                         CV_Error(Error::StsBadArg, "cannot copy dimension from the input tensor");
                     }

--- a/modules/dnn/src/layers/reshape2_layer.cpp
+++ b/modules/dnn/src/layers/reshape2_layer.cpp
@@ -1,0 +1,191 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+#ifdef HAVE_CUDA
+#include "../cuda4dnn/primitives/reshape.hpp"
+using namespace cv::dnn::cuda4dnn;
+#endif
+
+namespace cv
+{
+namespace dnn
+{
+
+class Reshape2LayerImpl CV_FINAL : public Reshape2Layer
+{
+public:
+    bool dynamicShapeSpec;
+
+    Reshape2LayerImpl(const LayerParams& params)
+    {
+        dynamicShapeSpec = true;
+        setParamsFrom(params);
+        if (params.has("shape"))
+        {
+            dynamicShapeSpec = false;
+
+            const DictValue &paramShape = params.get("shape");
+            int i, ndims = paramShape.size();
+            newShapeDesc.resize(ndims);
+            for (i = 0; i < ndims; i++) {
+                int sz = paramShape.get<int>(i);
+                if (sz <= 0)
+                    dynamicShapeSpec = true;
+                newShapeDesc[i] = sz;
+            }
+        }
+    }
+
+    virtual bool dynamicOutputShapes() const CV_OVERRIDE
+    {
+        return dynamicShapeSpec;
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    bool haveShapeSpec() const
+    {
+        return newShapeDesc.dims >= 0;
+    }
+
+    MatShape getOutShape(const MatShape& inpShape, const MatShape& shapeSpec) const
+    {
+        MatShape outShape = shapeSpec;
+        int m1idx = -1, haveZeros = 0;
+        int i, ndims = outShape.dims;
+        int64_t outTotal = 1;
+        for (i = 0; i < ndims; i++) {
+            if (outShape[i] < 0) {
+                CV_Assert(outShape[i] == -1);
+                if (m1idx >= 0) {
+                    CV_Error(Error::StsBadArg, "invalid shape spec, there must be at most one '-1'");
+                }
+                m1idx = i;
+            }
+            else {
+                if (outShape[i] == 0) {
+                    haveZeros++;
+                    if (i >= inpShape.dims) {
+                        CV_Error(Error::StsBadArg, "cannot copy dimension from the input tensor");
+                    }
+                    outShape[i] = inpShape[i];
+                }
+                outTotal *= outShape[i];
+            }
+        }
+
+        int64_t inpTotal = (int64_t)inpShape.total();
+        if (m1idx >= 0) {
+            int64_t autoSize = inpTotal/outTotal;
+            CV_Assert(autoSize <= INT_MAX && autoSize*outTotal == inpTotal);
+            outShape[m1idx] = (int)autoSize;
+        } else {
+            CV_Assert(outTotal == inpTotal);
+        }
+
+        return outShape;
+    }
+
+    MatShape shapeFromMat(const Mat& shapeTensor) const
+    {
+        int shapeType = shapeTensor.type();
+        CV_Assert(shapeType == CV_32S || shapeType == CV_64S);
+        CV_Assert(shapeTensor.dims <= 1);
+        size_t ndims = shapeTensor.total();
+        CV_Assert(ndims <= (size_t)MatShape::MAX_DIMS);
+        MatShape shape((int)ndims);
+        for (int i = 0; i < (int)ndims; i++) {
+            shape[i] = shapeType == CV_32S ? shapeTensor.at<int>(i) :
+                (int)shapeTensor.at<int64_t>(i);
+        }
+        return shape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        bool haveShapeSpec_ = haveShapeSpec();
+        CV_Assert((inputs.size() == 1 && haveShapeSpec_) ||
+                  (inputs.size() == 2 && !haveShapeSpec_));
+        MatShape shapeSpec = newShapeDesc, outShape;
+
+        if (inputs.size() == 2)
+        {
+            CV_Assert(this->inputs.size() == 2);
+            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Mat shapeTensor = netimpl_->argTensor(this->inputs[1]);
+            shapeSpec = shapeFromMat(shapeTensor);
+        } else {
+            CV_Assert(shapeSpec.dims >= 0);
+        }
+        outputs.assign(1, getOutShape(inputs[0], shapeSpec));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs == 1 || ninputs == 2);
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        bool haveShapeSpec_ = haveShapeSpec();
+        CV_Assert((ninputs == 1 && haveShapeSpec_) ||
+                  (ninputs == 2 && !haveShapeSpec_));
+
+        MatShape inpShape = inputs_arr.shape(0);
+        MatShape shapeSpec = newShapeDesc;
+        if (!haveShapeSpec_) {
+            Mat shapeTensor = inputs_arr.getMat(1);
+            shapeSpec = shapeFromMat(shapeTensor);
+        }
+        MatShape outShape = getOutShape(inpShape, shapeSpec);
+        reshapeAndCopyFirst(inputs_arr, outputs_arr, outShape);
+    }
+};
+
+Ptr<Reshape2Layer> Reshape2Layer::create(const LayerParams& params)
+{
+    return Ptr<Reshape2Layer>(new Reshape2LayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/shape_layer.cpp
+++ b/modules/dnn/src/layers/shape_layer.cpp
@@ -135,4 +135,3 @@ Ptr<ShapeLayer> ShapeLayer::create(const LayerParams& params)
 
 }
 }
-

--- a/modules/dnn/src/layers/shape_layer.cpp
+++ b/modules/dnn/src/layers/shape_layer.cpp
@@ -1,0 +1,138 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+class ShapeLayerImpl CV_FINAL : public ShapeLayer
+{
+public:
+    typedef int64_t shape_type_t;
+    int shapeType;
+
+    ShapeLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+
+        start = params.get<int>("start", 0);
+        end = params.get<int>("end", INT_MAX);
+        shapeType = DataType<shape_type_t>::type;
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    Range getShapeRange(const MatShape& inpShape) const
+    {
+        int outDims = inpShape.dims;
+        int start_ = start < 0 ? start + outDims : start;
+        int end_ = end >= outDims ? outDims : end < 0 ? end + outDims : end;
+
+        CV_Assert(0 <= start_);
+        CV_Assert(start_ <= end_);
+        CV_Assert(end_ <= outDims);
+
+        return Range(start_, end_);
+    }
+
+    MatShape getOutShape(const MatShape& inpShape) const
+    {
+        MatShape outShape;
+        outShape.dims = 1;
+
+        Range r = getShapeRange(inpShape);
+
+        outShape[0] = r.end - r.start;
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+
+        outputs.assign(1, getOutShape(inputs[0]));
+        internals.clear();
+
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        outputs.assign(requiredOutputs, shapeType);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        CV_Assert(ninputs == 1);
+
+        MatShape inpShape = inputs_arr.shape(0);
+        Range r = getShapeRange(inpShape);
+
+        shape_type_t shapeData[CV_MAX_DIM];
+        for (int i = r.start; i < r.end; i++)
+            shapeData[i] = (shape_type_t)inpShape[i];
+
+        Mat shape({r.end - r.start}, shapeType, shapeData);
+
+        int outKind = outputs_arr.kind();
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            std::vector<Mat>& out = outputs_arr.getMatVecRef();
+            CV_Assert(out.size() == 1);
+            shape.copyTo(out[0]);
+        } else if (outKind == _InputArray::STD_VECTOR_UMAT) {
+            std::vector<UMat>& out = outputs_arr.getUMatVecRef();
+            CV_Assert(out.size() == 1);
+            shape.copyTo(out[0]);
+        } else {
+            CV_Error_(Error::StsBadArg, ("invalid/unsupported outputs_arr kind: %d", outKind));
+        }
+    }
+};
+
+Ptr<ShapeLayer> ShapeLayer::create(const LayerParams& params)
+{
+    return Ptr<ShapeLayer>(new ShapeLayerImpl(params));
+}
+
+}
+}
+

--- a/modules/dnn/src/layers/slice2_layer.cpp
+++ b/modules/dnn/src/layers/slice2_layer.cpp
@@ -319,7 +319,7 @@ public:
         int allSteps[MatShape::MAX_DIMS];
         MatShape outShape = getOutShape(inpShape, *starts_, *ends_, *axes_, steps,
                                         allStarts, allEnds, allSteps);
-        
+
         int outKind = outputs_arr.kind();
 
         CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||

--- a/modules/dnn/src/layers/slice2_layer.cpp
+++ b/modules/dnn/src/layers/slice2_layer.cpp
@@ -148,7 +148,7 @@ public:
 
     virtual bool dynamicOutputShapes() const CV_OVERRIDE
     {
-        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        Net::Impl* netimpl_ = getNetImpl(this);
         size_t ninputs = inputs.size();
 
         for (size_t i = 1; i < ninputs; i++) {
@@ -241,7 +241,7 @@ public:
         const std::vector<int> *starts_ = &starts, *ends_ = &ends, *axes_ = &axes;
 
         if (ninputs > 1) {
-            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Net::Impl* netimpl_ = getNetImpl(this);
             Mat startsTensor = netimpl_->argTensor(this->inputs[1]);
             tensorToIntVec(startsTensor, tempStarts);
             starts_ = &tempStarts;

--- a/modules/dnn/src/layers/slice2_layer.cpp
+++ b/modules/dnn/src/layers/slice2_layer.cpp
@@ -1,0 +1,355 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Slice2 layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Slice2.html
+
+    Opset's 1 to 13 are covered.
+*/
+
+/* Slice op for CPU.
+   starts_, ends_ and steps_ must contain as many elements as
+   the dimensionality in inp and out.
+*/
+static void slice(const Mat& inp, const int* starts_,
+                  const int* ends_, const int* steps_,
+                  Mat& out)
+{
+    enum {SLICE_MAX_DIMS=7};
+
+    CV_Assert_N(inp.isContinuous(), out.isContinuous());
+    CV_Assert(inp.type() == out.type());
+    CV_Assert_N(inp.dims <= SLICE_MAX_DIMS, inp.dims == out.dims);
+
+    MatShape inpShape = inp.shape();
+    MatShape outShape = out.shape();
+    int type = inp.type();
+    size_t esz = inp.elemSize();
+
+    int ndims = inpShape.dims;
+    int starts[SLICE_MAX_DIMS], ends[SLICE_MAX_DIMS], steps[SLICE_MAX_DIMS];
+    int inpsz[SLICE_MAX_DIMS], outsz[SLICE_MAX_DIMS];
+    size_t inpstep[SLICE_MAX_DIMS];
+
+    int delta = SLICE_MAX_DIMS - ndims;
+    bool emptyOut = false;
+
+    for (int i = 0; i < SLICE_MAX_DIMS; i++) {
+        inpsz[i] = outsz[i] = steps[i] = 1;
+        starts[i] = 0;
+        ends[i] = INT_MAX;
+    }
+
+    for (int i = 0; i < ndims; i++) {
+        inpsz[delta + i] = inpShape[i];
+        outsz[delta + i] = outShape[i];
+        if (outShape[i] == 0)
+            emptyOut = true;
+    }
+
+    for (int i = SLICE_MAX_DIMS-1; i >= 0; i--)
+        inpstep[i] = i == SLICE_MAX_DIMS-1 ? 1 : inpstep[i+1]*inpsz[i+1];
+
+    const uchar* inptr0 = inp.data;
+
+    for (int i = 0; i < SLICE_MAX_DIMS; i++) {
+        inptr0 += starts[i]*inpstep[i]*esz;
+        inpstep[i] *= steps[i];
+    }
+
+    int sz0 = outsz[6], sz1 = outsz[5];
+    int sz2 = outsz[4], sz3 = outsz[3];
+    int sz4 = outsz[2], sz5 = outsz[1], sz6 = outsz[0];
+    size_t p0 = inpstep[6], p1 = inpstep[5];
+    size_t p2 = inpstep[4], p3 = inpstep[3];
+    size_t p4 = inpstep[2], p5 = inpstep[1], p6 = inpstep[0];
+
+    #undef CV_IMPLEMENT_SLICE
+    #define CV_IMPLEMENT_SLICE(typ) \
+        typ* outptr = (typ*)(out.data); \
+        for(int i6 = 0; i6 < sz6; i6++) { \
+        for(int i5 = 0; i5 < sz5; i5++) { \
+        for(int i4 = 0; i4 < sz4; i4++) { \
+        for(int i3 = 0; i3 < sz3; i3++) { \
+        for(int i2 = 0; i2 < sz2; i2++) { \
+        for(int i1 = 0; i1 < sz1; i1++, outptr += sz0) { \
+            const typ* inptr = (const typ*)inptr0 + i6*p6 + \
+                    i5*p5 + i4*p4 + i3*p3 + i2*p2 + i1*p1; \
+            int i0 = 0; \
+            if (p0 == 1) { \
+                for (; i0 < sz0; i0++) \
+                    outptr[i0] = inptr[i0]; \
+            } \
+            else { \
+                for (; i0 <= sz0 - 4; i0 += 4) { \
+                    size_t ip0 = i0*p0; \
+                    typ t0 = inptr[ip0], t1 = inptr[ip0 + p0]; \
+                    typ t2 = inptr[ip0 + p0*2], t3 = inptr[ip0 + p0*3]; \
+                    outptr[i0] = t0; outptr[i0+1] = t1; \
+                    outptr[i0+2] = t2; outptr[i0+3] = t3; \
+                } \
+                for (; i0 < sz0; i0++) \
+                    outptr[i0] = inptr[i0*p0]; \
+            } \
+        }}}}}}
+
+    if (emptyOut) return;
+    if (esz == 4) {
+        CV_IMPLEMENT_SLICE(int)
+    } else if (esz == 2) {
+        CV_IMPLEMENT_SLICE(int16_t)
+    } else if (esz == 1) {
+        CV_IMPLEMENT_SLICE(int8_t)
+    } else if (esz == 8) {
+        CV_IMPLEMENT_SLICE(int64_t)
+    } else {
+        CV_Error(Error::StsNotImplemented, "");
+    }
+}
+
+class Slice2LayerImpl CV_FINAL : public Slice2Layer
+{
+public:
+    Slice2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axes = params.get<std::vector<int> >("axes");
+        starts = params.get<std::vector<int> >("starts");
+        ends = params.get<std::vector<int> >("ends");
+    }
+
+    void checkNumInputs(size_t ninputs) const
+    {
+        CV_Assert(ninputs == 1 || (3 <= ninputs && ninputs <= 5));
+    }
+
+    virtual bool dynamicOutputShapes() const CV_OVERRIDE
+    {
+        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        size_t ninputs = inputs.size();
+
+        for (size_t i = 1; i < ninputs; i++) {
+            if (!netimpl_->isConstArg(inputs[i]))
+                return true;
+        }
+        return false;
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const MatShape& inpShape,
+                         const std::vector<int>& starts_,
+                         const std::vector<int>& ends_,
+                         const std::vector<int>& axes_,
+                         const std::vector<int>& steps_,
+                         int* allStarts = nullptr,
+                         int* allEnds = nullptr,
+                         int* allSteps = nullptr) const
+    {
+        bool sliceMask[MatShape::MAX_DIMS];
+
+        int ndims = inpShape.dims;
+        int nstarts = (int)starts_.size(), nends = (int)ends_.size();
+        int naxes = (int)axes_.size(), nsteps = (int)steps_.size();
+
+        CV_Assert_N(nstarts > 0, nstarts <= ndims, nstarts == nends);
+        CV_Assert(naxes == 0 || naxes == nstarts);
+        CV_Assert(nsteps == 0 || nsteps == nstarts);
+
+        MatShape outShape = inpShape;
+
+        for (int i = 0; i < ndims; i++) {
+            sliceMask[i] = false;
+            if (allStarts)
+                allStarts[i] = 0;
+            if (allEnds)
+                allEnds[i] = inpShape[i];
+            if (allSteps)
+                allSteps[i] = 1;
+        }
+
+        for (int i = 0; i < nstarts; i++) {
+            int axis = i;
+            if (!axes_.empty()) {
+                axis = axes_[i];
+                axis = normalize_axis(axis, ndims);
+                if (sliceMask[axis]) {
+                    CV_Error(Error::StsBadArg, "duplicate axis occurs in Slice");
+                }
+            }
+            sliceMask[axis] = true;
+            int inpsz = inpShape[axis];
+            int start = starts_[i];
+            int end = ends_[i];
+            int step = 1;
+            if (!steps_.empty())
+                step = steps_[i];
+            CV_Assert(step != 0);
+            start = start < 0 ? std::max(start + inpsz, 0) :
+                                std::min(start, inpsz - (step < 0));
+            end = end < 0 ? std::max(end + inpsz, -(step < 0)) :
+                            std::min(end, inpsz);
+            if (allStarts)
+                allStarts[axis] = start;
+            if (allEnds)
+                allEnds[axis] = end;
+            if (allSteps)
+                allSteps[axis] = step;
+            int outsz = step > 0 ? (end - start + step-1)/step :
+                                   (start - end - step-1)/(-step);
+            CV_Assert(outsz >= 0);
+            outShape[axis] = outsz;
+        }
+
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        checkNumInputs(ninputs);
+        std::vector<int> tempStarts, tempEnds, tempAxes, steps;
+        const std::vector<int> *starts_ = &starts, *ends_ = &ends, *axes_ = &axes;
+
+        if (ninputs > 1) {
+            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Mat startsTensor = netimpl_->argTensor(this->inputs[1]);
+            tensorToIntVec(startsTensor, tempStarts);
+            starts_ = &tempStarts;
+            Mat endsTensor = netimpl_->argTensor(this->inputs[2]);
+            tensorToIntVec(endsTensor, tempEnds);
+            ends_ = &tempEnds;
+            if (ninputs > 3) {
+                Mat axesTensor = netimpl_->argTensor(this->inputs[3]);
+                tensorToIntVec(axesTensor, tempAxes);
+                axes_ = &tempAxes;
+            }
+            if (ninputs > 4) {
+                Mat stepsTensor = netimpl_->argTensor(this->inputs[4]);
+                tensorToIntVec(stepsTensor, steps);
+            }
+        }
+        MatShape outShape = getOutShape(inputs[0], *starts_, *ends_, *axes_, steps);
+        outputs.assign(1, outShape);
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        checkNumInputs(ninputs);
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        checkNumInputs(ninputs);
+
+        int inpType = inputs_arr.type(0);
+        MatShape inpShape = inputs_arr.shape(0);
+        std::vector<int> tempStarts, tempEnds, tempAxes, steps;
+        const std::vector<int> *starts_ = &starts, *ends_ = &ends, *axes_ = &axes;
+
+        if (ninputs > 1) {
+            Mat startsTensor = inputs_arr.getMat(1);
+            tensorToIntVec(startsTensor, tempStarts);
+            starts_ = &tempStarts;
+            Mat endsTensor = inputs_arr.getMat(2);
+            tensorToIntVec(endsTensor, tempEnds);
+            ends_ = &tempEnds;
+            if (ninputs > 3) {
+                Mat axesTensor = inputs_arr.getMat(3);
+                tensorToIntVec(axesTensor, tempAxes);
+                axes_ = &tempAxes;
+            }
+            if (ninputs > 4) {
+                Mat stepsTensor = inputs_arr.getMat(4);
+                tensorToIntVec(stepsTensor, steps);
+            }
+        }
+        int allStarts[MatShape::MAX_DIMS];
+        int allEnds[MatShape::MAX_DIMS];
+        int allSteps[MatShape::MAX_DIMS];
+        MatShape outShape = getOutShape(inpShape, *starts_, *ends_, *axes_, steps,
+                                        allStarts, allEnds, allSteps);
+        
+        int outKind = outputs_arr.kind();
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            runOp(inp, allStarts, allEnds, allSteps, outs[0]);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            Mat temp(outShape, inpType);
+            runOp(inp, allStarts, allEnds, allSteps, temp);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& inp, const int* starts_,
+               const int* ends_, const int* steps_, Mat& out)
+    {
+        slice(inp, starts_, ends_, steps_, out);
+    }
+};
+
+Ptr<Slice2Layer> Slice2Layer::create(const LayerParams& params)
+{
+    return Ptr<Slice2Layer>(new Slice2LayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/slice2_layer.cpp
+++ b/modules/dnn/src/layers/slice2_layer.cpp
@@ -132,9 +132,9 @@ public:
     Slice2LayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        axes = params.get<std::vector<int> >("axes");
-        starts = params.get<std::vector<int> >("starts");
-        ends = params.get<std::vector<int> >("ends");
+        axes = params.getVector<int>("axes");
+        starts = params.getVector<int>("starts");
+        ends = params.getVector<int>("ends");
     }
 
     void checkNumInputs(size_t ninputs) const

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -91,9 +91,10 @@ public:
     {
         bool inplace = Layer::getMemoryShapes(inputs, requiredOutputs, outputs, internals);
         MatShape shape = inputs[0];
-        int cAxis = normalize_axis(axisRaw, shape.size());
-        if (!shape.empty())
+        if (shape.dims > 0) {
+            int cAxis = normalize_axis(axisRaw, shape.dims);
             shape[cAxis] = 1;
+        }
         internals.assign(1, shape);
         return inplace;
     }

--- a/modules/dnn/src/layers/split2_layer.cpp
+++ b/modules/dnn/src/layers/split2_layer.cpp
@@ -151,7 +151,7 @@ public:
         int axis_ = normalize_axis(axis, inpShape.dims);
 
         if (ninputs == 2) {
-            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Net::Impl* netimpl_ = getNetImpl(this);
             Mat splitTensor = netimpl_->argTensor(this->inputs[1]);
             tensorToIntVec(splitTensor, tempSplit);
             split_ = &tempSplit;

--- a/modules/dnn/src/layers/split2_layer.cpp
+++ b/modules/dnn/src/layers/split2_layer.cpp
@@ -93,7 +93,7 @@ public:
     {
         setParamsFrom(params);
         axis = params.get<int>("axis", 1);
-        split = params.get<std::vector<int> >("split");
+        split = params.getVector<int>("split");
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
@@ -107,18 +107,19 @@ public:
     {
         size_t noutputs = split.size();
         CV_Assert(noutputs == outputs.size());
-        outShapes.resize(noutputs);
 
         int inpDims = inpShape.dims;
         CV_Assert(0 <= axis_ && axis_ < inpDims);
         int totalSize_a = 0;
 
+        outShapes.resize(noutputs);
         for (size_t i = 0; i < noutputs; i++) {
             MatShape outShape = inpShape;
             int s = split[i];
             CV_Assert(s >= 0);
             CV_Assert(s <= inpShape[axis_] - totalSize_a);
             outShape[axis_] = s;
+            outShapes[i] = outShape;
             totalSize_a += s;
         }
     }
@@ -139,7 +140,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        CV_Assert(noutputs == (int)outputs.size());
+        CV_Assert(noutputs == (int)this->outputs.size());
 
         size_t ninputs = inputs.size();
         CV_Assert(ninputs == 1 || ninputs == 2);
@@ -172,10 +173,7 @@ public:
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
         size_t ninputs = inputs.size();
-        CV_Assert(ninputs > 0);
-        for (size_t i = 1; i < ninputs; i++) {
-            CV_Assert(inputs[i] == inputs[0]);
-        }
+        CV_Assert(ninputs == 1 || ninputs == 2);
         outputs.assign(requiredOutputs, inputs[0]);
         CV_Assert(requiredInternals == 0);
         internals.clear();

--- a/modules/dnn/src/layers/split2_layer.cpp
+++ b/modules/dnn/src/layers/split2_layer.cpp
@@ -1,0 +1,268 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Split2 layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Split2.html
+
+    Opset's 1 to 13 are covered.
+*/
+
+// all outputs must be pre-allocated.
+// axis must be normalized
+static void split(const Mat& inp, std::vector<Mat>& outs, int axis)
+{
+    CV_Assert(inp.isContinuous());
+
+    MatShape inpShape = inp.shape();
+    int ndims = inpShape.dims;
+
+    CV_Assert_N(0 <= axis, axis <= inp.dims);
+
+    int nslices = 1;
+    int inpType = inp.type();
+    size_t esz = inp.elemSize();
+    size_t sliceSize = esz;
+    size_t inpStep = 0;
+    size_t totalSize = inp.total()*esz;
+    int outSize_a = 0;
+    for (int i = ndims-1; i > axis; i--)
+        sliceSize *= inpShape[i];
+    inpStep = sliceSize*inpShape[axis];
+    for (int i = 0; i < axis; i++)
+        nslices *= inpShape[i];
+
+    size_t noutputs = outs.size();
+    for (size_t k = 0; k < noutputs; k++) {
+        Mat& out = outs[k];
+        MatShape outShape = out.shape();
+        CV_Assert(out.isContinuous());
+        CV_Assert(out.type() == inpType);
+        CV_Assert(out.dims == ndims);
+        for (int i = 0; i < ndims; i++) {
+            if (i == axis)
+                outSize_a += outShape[i];
+            else {
+                CV_Assert(inpShape[i] == outShape[i]);
+            }
+        }
+    }
+
+    CV_Assert(outSize_a == inpShape[axis]);
+
+    parallel_for_(Range(0, (int)noutputs), [&](const Range& r) {
+        for (int k = r.start; k < r.end; k++) {
+            const uchar* inptr = inp.data;
+            Mat& out_k = outs[k];
+            uchar* outptr_k = out_k.data;
+            int sz_a;
+            for (int i = 0; i < k; i++) {
+                sz_a = outs[i].size[axis];
+                inptr += sliceSize*sz_a;
+            }
+            sz_a = out_k.size[axis];
+            size_t sliceSize_k = sliceSize*sz_a;
+            for (int i = 0; i < nslices; i++)
+                memcpy(outptr_k + i*sliceSize_k, inptr + i*inpStep, sliceSize_k);
+        }
+    }, (totalSize > 1000000 ? noutputs : 1));
+}
+
+class Split2LayerImpl CV_FINAL : public Split2Layer
+{
+public:
+    Split2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axis = params.get<int>("axis", 1);
+        split = params.get<std::vector<int> >("split");
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    void getOutShapes(const MatShape& inpShape, int axis_,
+                      const std::vector<int>& split,
+                      std::vector<MatShape>& outShapes) const
+    {
+        size_t noutputs = split.size();
+        CV_Assert(noutputs == outputs.size());
+        outShapes.resize(noutputs);
+
+        int inpDims = inpShape.dims;
+        CV_Assert(0 <= axis_ && axis_ < inpDims);
+        int totalSize_a = 0;
+
+        for (size_t i = 0; i < noutputs; i++) {
+            MatShape outShape = inpShape;
+            int s = split[i];
+            CV_Assert(s >= 0);
+            CV_Assert(s <= inpShape[axis_] - totalSize_a);
+            outShape[axis_] = s;
+            totalSize_a += s;
+        }
+    }
+
+    void makeDefaultSplit(int totalSize, size_t noutputs, std::vector<int>& split_) const
+    {
+        split_.resize(noutputs);
+        int chunkSize = (int)((totalSize + noutputs - 1) / noutputs);
+        for (size_t i = 0; i < noutputs; i++) {
+            int sz_i = std::min(totalSize, chunkSize);
+            split_[i] = sz_i;
+            totalSize -= sz_i;
+        }
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int noutputs,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(noutputs == (int)outputs.size());
+
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs == 1 || ninputs == 2);
+
+        MatShape inpShape = inputs[0];
+        std::vector<int> tempSplit;
+        const std::vector<int>* split_ = &split;
+        int axis_ = normalize_axis(axis, inpShape.dims);
+
+        if (ninputs == 2) {
+            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Mat splitTensor = netimpl_->argTensor(this->inputs[1]);
+            tensorToIntVec(splitTensor, tempSplit);
+            split_ = &tempSplit;
+        }
+        else if (split.empty()) {
+            makeDefaultSplit(inpShape[axis_], noutputs, tempSplit);
+            split_ = &tempSplit;
+        }
+
+        getOutShapes(inputs[0], axis_, *split_, outputs);
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs > 0);
+        for (size_t i = 1; i < ninputs; i++) {
+            CV_Assert(inputs[i] == inputs[0]);
+        }
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        int noutputs = (int)outputs.size();
+
+        CV_Assert(ninputs == 1 || ninputs == 2);
+
+        int inpType = inputs_arr.type(0);
+        MatShape inpShape = inputs_arr.shape(0);
+        std::vector<int> tempSplit;
+        const std::vector<int>* split_ = &split;
+        std::vector<MatShape> outShapes;
+
+        int axis_ = normalize_axis(axis, inpShape.dims);
+
+        if (ninputs == 2) {
+            Mat splitTensor = inputs_arr.getMat(1);
+            tensorToIntVec(splitTensor, tempSplit);
+            split_ = &tempSplit;
+        }
+        else if (split.empty()) {
+            makeDefaultSplit(inpShape[axis_], noutputs, tempSplit);
+            split_ = &tempSplit;
+        }
+        getOutShapes(inpShape, axis_, *split_, outShapes);
+        CV_Assert(outShapes.size() == (size_t)noutputs);
+
+        int outKind = outputs_arr.kind();
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(noutputs);
+            for (int i = 0; i < noutputs; i++) {
+                MatShape outShape = outShapes[i];
+                outs[i].fit(outShape, inpType);
+            }
+            runOp(inp, outs, axis_);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(noutputs);
+
+            std::vector<Mat> temps(noutputs);
+            for (int i = 0; i < noutputs; i++) {
+                MatShape outShape = outShapes[i];
+                temps[i].fit(outShape, inpType);
+            }
+            runOp(inp, temps, axis_);
+            for (int i = 0; i < noutputs; i++) {
+                MatShape outShape = outShapes[i];
+                outs[i].fit(outShape, inpType);
+                temps[i].copyTo(outs[i]);
+                temps[i].release();
+            }
+        }
+    }
+
+    void runOp(const Mat& inp, std::vector<Mat>& outs, int axis_)
+    {
+        cv::dnn::split(inp, outs, axis_);
+    }
+};
+
+Ptr<Split2Layer> Split2Layer::create(const LayerParams& params)
+{
+    return Ptr<Split2Layer>(new Split2LayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/squeeze_layer.cpp
+++ b/modules/dnn/src/layers/squeeze_layer.cpp
@@ -34,7 +34,7 @@ public:
     SqueezeLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        axes = params.get<std::vector<int> >("axes");
+        axes = params.getVector<int>("axes");
     }
 
     virtual bool dynamicOutputShapes() const CV_OVERRIDE

--- a/modules/dnn/src/layers/squeeze_layer.cpp
+++ b/modules/dnn/src/layers/squeeze_layer.cpp
@@ -1,0 +1,159 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Squeeze layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Squeeze.html
+
+    Opset's 1 to 13 are covered.
+    
+    See description in reshape2_layer.cpp
+    for more some common implementation details.
+*/
+class SqueezeLayerImpl CV_FINAL : public SqueezeLayer
+{
+public:
+    SqueezeLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axes = params.get<std::vector<int> >("axes");
+    }
+
+    virtual bool dynamicOutputShapes() const CV_OVERRIDE
+    {
+        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        return inputs.size() == 2 && !netimpl_->isConstArg(inputs[1]);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const MatShape& inpShape, const std::vector<int>& axes_) const
+    {
+        bool squeezeMask[MatShape::MAX_DIMS];
+
+        if (axes_.empty()) {
+            // remove all 1's
+            for (int i = 0; i < inpShape.dims; i++)
+                squeezeMask[i] = inpShape[i] == 1;
+        } else {
+            for (int i = 0; i < inpShape.dims; i++)
+                squeezeMask[i] = false;
+            for (int a: axes_) {
+                int a_ = normalize_axis(a, inpShape.dims);
+                if (squeezeMask[a_]) {
+                    CV_Error_(Error::StsBadArg, ("duplicate squeezed axis #%d", a));
+                }
+                if (inpShape[a_] != 1) {
+                    CV_Error_(Error::StsBadArg, ("squeezed axis #%d (== %d) != 1", a, inpShape[a_]));
+                }
+                squeezeMask[a_] = true;
+            }
+        }
+
+        MatShape outShape(inpShape.dims);
+        int j = 0;
+        for (int i = 0; i < inpShape.dims; i++) {
+            if (!squeezeMask[i])
+                outShape[j++] = inpShape[i];
+        }
+        outShape.dims = j;
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1 || inputs.size() == 2);
+        MatShape outShape;
+        std::vector<int> tempAxes;
+        const std::vector<int>* axes_ = &axes;
+
+        if (inputs.size() == 2)
+        {
+            CV_Assert(axes.empty()); // if we have a dedicated 'axes' input,
+                                     // we should not have 'axes' attribute at the same time
+            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Mat axesTensor = netimpl_->argTensor(this->inputs[1]);
+            tensorToIntVec(axesTensor, tempAxes);
+            axes_ = &tempAxes;
+        }
+        outputs.assign(1, getOutShape(inputs[0], *axes_));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs == 1 || ninputs == 2);
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        CV_Assert(ninputs == 1 || ninputs == 2);
+
+        MatShape inpShape = inputs_arr.shape(0);
+        std::vector<int> tempAxes;
+        const std::vector<int>* axes_ = &axes;
+
+        if (ninputs == 2)
+        {
+            CV_Assert(axes.empty()); // if we have a dedicated 'axes' input,
+                                     // we should not have 'axes' attribute at the same time
+            Mat axesTensor = inputs_arr.getMat(1);
+            tensorToIntVec(axesTensor, tempAxes);
+            axes_ = &tempAxes;
+        }
+        MatShape outShape = getOutShape(inpShape, *axes_);
+        reshapeAndCopyFirst(inputs_arr, outputs_arr, outShape);
+    }
+};
+
+Ptr<SqueezeLayer> SqueezeLayer::create(const LayerParams& params)
+{
+    return Ptr<SqueezeLayer>(new SqueezeLayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/squeeze_layer.cpp
+++ b/modules/dnn/src/layers/squeeze_layer.cpp
@@ -39,7 +39,7 @@ public:
 
     virtual bool dynamicOutputShapes() const CV_OVERRIDE
     {
-        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        Net::Impl* netimpl_ = getNetImpl(this);
         return inputs.size() == 2 && !netimpl_->isConstArg(inputs[1]);
     }
 
@@ -95,7 +95,7 @@ public:
         {
             CV_Assert(axes.empty()); // if we have a dedicated 'axes' input,
                                      // we should not have 'axes' attribute at the same time
-            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Net::Impl* netimpl_ = getNetImpl(this);
             Mat axesTensor = netimpl_->argTensor(this->inputs[1]);
             tensorToIntVec(axesTensor, tempAxes);
             axes_ = &tempAxes;

--- a/modules/dnn/src/layers/squeeze_layer.cpp
+++ b/modules/dnn/src/layers/squeeze_layer.cpp
@@ -24,7 +24,7 @@ namespace dnn
     https://onnx.ai/onnx/operators/onnx__Squeeze.html
 
     Opset's 1 to 13 are covered.
-    
+
     See description in reshape2_layer.cpp
     for more some common implementation details.
 */

--- a/modules/dnn/src/layers/tile_layer.cpp
+++ b/modules/dnn/src/layers/tile_layer.cpp
@@ -44,20 +44,21 @@ public:
                                  std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         CV_CheckEQ(inputs.size(), 1ull, "Tile: one input is expected");
+        int nrepeats = (int)repeats.size();
 
         // repeats must have the same length as input's dimension number
         if (inputs[0].size() > 1) {
             CV_CheckEQ(inputs[0].size(), repeats.size(), "Tile: repeats must be a 1D tensor of the same length as input's dimension number");
             outputs.assign(1, inputs[0]);
-            for (int i = 0; i < repeats.size(); i++)
+            for (int i = 0; i < nrepeats; i++)
             {
                 outputs[0][i] *= repeats[i];
             }
         } else {
-            CV_CheckGE((int)repeats.size(), 1, "Tile: Provide at least one repeat along any dimension");
-            outputs.assign(1, repeats);
+            CV_CheckGE(nrepeats, 1, "Tile: Provide at least one repeat along any dimension");
+            outputs.assign(1, MatShape(repeats));
             if (inputs[0].size() == 1)
-                outputs[0][repeats.size() - 1] *= inputs[0][0];
+                outputs[0][nrepeats - 1] *= inputs[0][0];
         }
 
         return false;

--- a/modules/dnn/src/layers/tile_layer.cpp
+++ b/modules/dnn/src/layers/tile_layer.cpp
@@ -86,7 +86,6 @@ public:
         Mat& out = outputs[0];
 
         Mat tmp = data.clone();
-        MatShape tmp_shape = shape(tmp);
         MatShape out_shape = shape(out);
         int rep_i, ndims = data.dims;
         int dims = 1;

--- a/modules/dnn/src/layers/transpose_layer.cpp
+++ b/modules/dnn/src/layers/transpose_layer.cpp
@@ -117,7 +117,7 @@ public:
     TransposeLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        perm = params.get<std::vector<int> >("perm");
+        perm = params.getVector<int>("perm");
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE

--- a/modules/dnn/src/layers/transpose_layer.cpp
+++ b/modules/dnn/src/layers/transpose_layer.cpp
@@ -1,0 +1,218 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Transpose layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Transpose.html
+
+    Opset's 1 to 23 are covered.
+*/
+
+static void transpose(const Mat& inp, const std::vector<int>& perm, Mat& out)
+{
+    enum {TRANSPOSE_MAX_DIMS=7};
+    MatShape inpShape = inp.shape();
+    MatShape outShape = out.shape();
+    int ndims = inpShape.dims;
+    size_t esz = inp.elemSize();
+    CV_Assert(esz == 1 || esz == 2 || esz == 4 || esz == 8);
+
+    int perm_[TRANSPOSE_MAX_DIMS];
+    int inpShape_[TRANSPOSE_MAX_DIMS];
+    int outShape_[TRANSPOSE_MAX_DIMS];
+    size_t inpStep_[TRANSPOSE_MAX_DIMS];
+    int delta = TRANSPOSE_MAX_DIMS - ndims;
+
+    CV_Assert(ndims <= TRANSPOSE_MAX_DIMS);
+    CV_Assert(inp.isContinuous());
+    CV_Assert(out.isContinuous());
+
+    for (int i = 0; i < TRANSPOSE_MAX_DIMS; i++) {
+        perm_[i] = i;
+        inpShape_[i] = outShape_[i] = 1;
+        inpStep_[i] = 0;
+    }
+    inpStep_[TRANSPOSE_MAX_DIMS-1] = 1; // step's are measured in elements, not bytes
+
+    for(int i = 0; i < ndims; i++) {
+        int j = perm.empty() ? ndims - i - 1 : perm[i];
+        if (j < 0)
+            j += ndims;
+        CV_Assert(0 <= j && j < ndims);
+        perm_[i + delta] = j + delta;
+        int inpsz = inpShape[j];
+        int outsz = outShape[i];
+        CV_Assert(inpsz == outsz);
+        inpShape_[i + delta] = inpShape[i];
+        outShape_[i + delta] = outShape[i];
+    }
+
+    for (int i = TRANSPOSE_MAX_DIMS-2; i >= 0; i--)
+        inpStep_[i] = inpStep_[i+1]*inpShape_[i+1];
+
+    int sz6 = outShape_[0], sz5 = outShape_[1];
+    int sz4 = outShape_[2], sz3 = outShape_[3];
+    int sz2 = outShape_[4], sz1 = outShape_[5], sz0 = outShape_[6];
+    size_t p6 = inpStep_[perm_[0]], p5 = inpStep_[perm_[1]];
+    size_t p4 = inpStep_[perm_[2]], p3 = inpStep_[perm_[3]];
+    size_t p2 = inpStep_[perm_[4]], p1 = inpStep_[perm_[5]], p0 = inpStep_[perm_[6]];
+
+#undef CV_IMPLEMENT_TRANSPOSE
+#define CV_IMPLEMENT_TRANSPOSE(typ) \
+    const typ* inptr0 = (const typ*)inp.data; \
+    typ* outptr = (typ*)out.data; \
+    for (int i6 = 0; i6 < sz6; i6++) { \
+    for (int i5 = 0; i5 < sz5; i5++) { \
+    for (int i4 = 0; i4 < sz4; i4++) { \
+    for (int i3 = 0; i3 < sz3; i3++) { \
+    for (int i2 = 0; i2 < sz2; i2++) { \
+    for (int i1 = 0; i1 < sz1; i1++, outptr += sz0) { \
+        int i0 = 0; \
+        const typ* inptr = inptr0 + i6*p6 + i5*p5 + i4*p4 + i3*p3 + i2*p2 + i1*p1; \
+        for (; i0 <= sz0 - 3; i0 += 3) { \
+            size_t ip0 = i0*p0; \
+            typ t0 = inptr[ip0]; \
+            typ t1 = inptr[ip0+p0]; \
+            typ t2 = inptr[ip0+p0*2]; \
+            outptr[i0] = t0; \
+            outptr[i0+1] = t1; \
+            outptr[i0+2] = t2; \
+        } \
+        for (; i0 < sz0; i0++) \
+            outptr[i0] = inptr[i0*p0]; \
+    }}}}}}
+
+    if (esz == 4) {
+        CV_IMPLEMENT_TRANSPOSE(int)
+    } else if (esz == 2) {
+        CV_IMPLEMENT_TRANSPOSE(short)
+    } else if (esz == 1) {
+        CV_IMPLEMENT_TRANSPOSE(char)
+    } else if (esz == 8) {
+        CV_IMPLEMENT_TRANSPOSE(int64_t)
+    }
+}
+
+class TransposeLayerImpl CV_FINAL : public TransposeLayer
+{
+public:
+    TransposeLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        perm = params.get<std::vector<int> >("perm");
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const MatShape& inpShape) const
+    {
+        MatShape outShape(inpShape.dims);
+        CV_Assert(perm.empty() || perm.size() == (size_t)inpShape.dims);
+
+        for (int i = 0; i < inpShape.dims; i++) {
+            int j = perm.empty() ? inpShape.dims - i - 1 : perm[i];
+            CV_Assert(0 <= j && j < inpShape.dims);
+            outShape[i] = inpShape[j];
+        }
+
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        outputs.assign(1, getOutShape(inputs[0]));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        CV_Assert(ninputs == 1);
+
+        MatShape inpShape = inputs_arr.shape(0);
+        MatShape outShape = getOutShape(inpShape);
+        int inpType = inputs_arr.type(0);
+        int outKind = outputs_arr.kind();
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            runOp(inp, outs[0]);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            Mat temp(outShape, inpType);
+            runOp(inp, temp);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& inp, Mat& out)
+    {
+        transpose(inp, perm, out);
+    }
+};
+
+Ptr<TransposeLayer> TransposeLayer::create(const LayerParams& params)
+{
+    return Ptr<TransposeLayer>(new TransposeLayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/unsqueeze_layer.cpp
+++ b/modules/dnn/src/layers/unsqueeze_layer.cpp
@@ -39,7 +39,7 @@ public:
 
     virtual bool dynamicOutputShapes() const CV_OVERRIDE
     {
-        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        Net::Impl* netimpl_ = getNetImpl(this);
         return inputs.size() == 2 && !netimpl_->isConstArg(inputs[1]);
     }
 
@@ -91,7 +91,7 @@ public:
 
         if (inputs.size() == 2)
         {
-            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Net::Impl* netimpl_ = getNetImpl(this);
             Mat axesTensor = netimpl_->argTensor(this->inputs[1]);
             tensorToIntVec(axesTensor, tempAxes);
             axes_ = &tempAxes;

--- a/modules/dnn/src/layers/unsqueeze_layer.cpp
+++ b/modules/dnn/src/layers/unsqueeze_layer.cpp
@@ -1,0 +1,156 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+//#include "../op_cuda.hpp"
+//#include "../op_inf_engine.hpp"
+//#include "../ie_ngraph.hpp"
+//#include "../op_webnn.hpp"
+//#include "../op_timvx.hpp"
+//#include "../op_cann.hpp"
+
+//#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Unsqueeze layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Unsqueeze.html
+
+    Opset's 1 to 23 are covered.
+
+    See description in reshape2_layer.cpp
+    for more some common implementation details.
+*/
+class UnsqueezeLayerImpl CV_FINAL : public UnsqueezeLayer
+{
+public:
+    UnsqueezeLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axes = params.get<std::vector<int> >("axes");
+    }
+
+    virtual bool dynamicOutputShapes() const CV_OVERRIDE
+    {
+        Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+        return inputs.size() == 2 && !netimpl_->isConstArg(inputs[1]);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    MatShape getOutShape(const MatShape& inpShape, const std::vector<int>& axes_) const
+    {
+        bool unsqueezeMask[MatShape::MAX_DIMS];
+
+        int outDims = inpShape.dims + (int)axes_.size();
+        CV_Assert(0 <= outDims && outDims <= MatShape::MAX_DIMS);
+
+        for (int i = 0; i < outDims; i++)
+            unsqueezeMask[i] = false;
+        for (int a: axes_) {
+            int a_ = normalize_axis(a, outDims);
+            if (unsqueezeMask[a_]) {
+                CV_Error_(Error::StsBadArg, ("duplicate unsqueezed axis #%d", a));
+            }
+            unsqueezeMask[a_] = true;
+        }
+
+        MatShape outShape(outDims);
+        int j = 0;
+        for (int i = 0; i < outDims; i++) {
+            if (unsqueezeMask[i])
+                outShape[i] = 1;
+            else {
+                CV_Assert(j < inpShape.dims);
+                outShape[i] = inpShape[j++];
+            }
+        }
+        return outShape;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert((inputs.size() == 1 && !axes.empty()) ||
+                  (inputs.size() == 2 && axes.empty()));
+        MatShape outShape;
+        std::vector<int> tempAxes;
+        const std::vector<int>* axes_ = &axes;
+
+        if (inputs.size() == 2)
+        {
+            Net::Impl* netimpl_ = reinterpret_cast<Net::Impl*>(netimpl);
+            Mat axesTensor = netimpl_->argTensor(this->inputs[1]);
+            tensorToIntVec(axesTensor, tempAxes);
+            axes_ = &tempAxes;
+        }
+        outputs.assign(1, getOutShape(inputs[0], *axes_));
+        internals.clear();
+        return true;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        size_t ninputs = inputs.size();
+        CV_Assert(ninputs == 1 || ninputs == 2);
+        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
+
+        Size size = inputs_arr.size();
+        int ninputs = size.area();
+        CV_Assert((ninputs == 1 && !axes.empty()) ||
+                  (ninputs == 2 && axes.empty()));
+
+        MatShape inpShape = inputs_arr.shape(0);
+        std::vector<int> tempAxes;
+        const std::vector<int>* axes_ = &axes;
+
+        if (ninputs == 2)
+        {
+            CV_Assert(axes.empty()); // if we have a dedicated 'axes' input,
+                                     // we should not have 'axes' attribute at the same time
+            Mat axesTensor = inputs_arr.getMat(1);
+            tensorToIntVec(axesTensor, tempAxes);
+            axes_ = &tempAxes;
+        }
+        MatShape outShape = getOutShape(inpShape, *axes_);
+        reshapeAndCopyFirst(inputs_arr, outputs_arr, outShape);
+    }
+};
+
+Ptr<UnsqueezeLayer> UnsqueezeLayer::create(const LayerParams& params)
+{
+    return Ptr<UnsqueezeLayer>(new UnsqueezeLayerImpl(params));
+}
+
+}
+}

--- a/modules/dnn/src/layers/unsqueeze_layer.cpp
+++ b/modules/dnn/src/layers/unsqueeze_layer.cpp
@@ -34,7 +34,7 @@ public:
     UnsqueezeLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-        axes = params.get<std::vector<int> >("axes");
+        axes = params.getVector<int>("axes");
     }
 
     virtual bool dynamicOutputShapes() const CV_OVERRIDE

--- a/modules/dnn/src/legacy_backend.hpp
+++ b/modules/dnn/src/legacy_backend.hpp
@@ -191,7 +191,7 @@ public:
             std::map<LayerPin, int>::const_iterator refIt;
 
             const int targetTotal = total(shape);
-            int bestBlobTotal = INT_MAX;
+            size_t bestBlobTotal = INT_MAX;
 
             for (hostIt = memHosts.begin(); hostIt != memHosts.end(); ++hostIt)
             {

--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -117,7 +117,7 @@ public:
         net.setInput(blob);
 
         // Faster-RCNN or R-FCN
-        if (net.getLayer(0)->outputNameToIndex("im_info") != -1)
+        if (!net.getMainGraph() && net.getLayer(0)->outputNameToIndex("im_info") != -1)
         {
             Mat imInfo(Matx13f(size.height, size.width, 1.6f));
             net.setInput(imInfo, "im_info");

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -411,5 +411,23 @@ int64 Net::getPerfProfile(std::vector<double>& timings)
     return impl->getPerfProfile(timings);
 }
 
+ArgKind Net::argKind(Arg arg) const
+{
+    CV_Assert(impl);
+    CV_Assert((size_t)arg.idx < impl->args.size());
+    return impl->args[arg.idx].kind;
+}
+
+bool Net::isConstArg(Arg arg) const
+{
+    return argKind(arg) == DNN_ARG_CONST;
+}
+
+Ptr<Graph> Net::getMainGraph() const
+{
+    CV_Assert(impl);
+    return impl->mainGraph;
+}
+
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -428,15 +428,15 @@ void Net::checkArgs(const std::vector<Arg>& args) const
     impl->checkArgs(args);
 }
 
-const ArgInfo& Net::argInfo(Arg arg) const
+const ArgData& Net::argData(Arg arg) const
 {
     checkArg(arg);
     return impl->args[arg.idx];
 }
 
-std::string Net::argName(Arg arg) const { return argInfo(arg).name; }
+std::string Net::argName(Arg arg) const { return argData(arg).name; }
 
-ArgKind Net::argKind(Arg arg) const { return argInfo(arg).kind; }
+ArgKind Net::argKind(Arg arg) const { return argData(arg).kind; }
 
 Arg Net::getArg(const std::string& name)
 {
@@ -461,9 +461,9 @@ Arg Net::newConstArg(const std::string& name, const Mat& m) const
     CV_Assert(impl);
     Arg arg = newArg(name, DNN_ARG_CONST);
     impl->tensors[arg.idx] = m;
-    ArgInfo& info = impl->args[arg.idx];
-    info.type = m.type();
-    info.shape = m.shape();
+    ArgData& adata = impl->args[arg.idx];
+    adata.type = m.type();
+    adata.shape = m.shape();
     return arg;
 }
 
@@ -477,10 +477,10 @@ Arg Net::newArg(const std::string& name, ArgKind kind) const
         impl->argnames.insert(std::make_pair(name, idx));
     }
 
-    ArgInfo info;
-    info.name = name;
-    info.kind = kind;
-    impl->args.push_back(info);
+    ArgData adata;
+    adata.name = name;
+    adata.kind = kind;
+    impl->args.push_back(adata);
     impl->tensors.push_back(Mat());
     impl->bufidxs.push_back(-1);
 

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -432,20 +432,6 @@ bool Net::isConstArg(Arg arg) const
     return argKind(arg) == DNN_ARG_CONST;
 }
 
-void Net::checkArg(Arg arg) const
-{
-    CV_Assert(impl);
-    CV_Assert((size_t)arg.idx < impl->args.size());
-}
-
-void Net::checkArgs(const std::vector<Arg>& args) const
-{
-    CV_Assert(impl);
-    for (auto arg: args) {
-        CV_Assert((size_t)arg.idx < impl->args.size());
-    }
-}
-
 const ArgData& Net::argData(Arg arg) const
 {
     CV_Assert(impl);
@@ -472,18 +458,6 @@ bool Net::haveArg(const std::string& name) const
 {
     CV_Assert(impl);
     return impl->haveArg(name);
-}
-
-Arg Net::newConstArg(const std::string& name, const Mat& m) const
-{
-    CV_Assert(impl);
-    return impl->newConstArg(name, m);
-}
-
-Arg Net::newArg(const std::string& name, ArgKind kind) const
-{
-    CV_Assert(impl);
-    return impl->newArg(name, kind);
 }
 
 Ptr<Graph> Net::getMainGraph() const

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -1344,11 +1344,18 @@ void Net::Impl::getLayerShapes(const ShapesVec& netInputShapes,
         const int layerId,
         LayerShapes& shapes)
 {
-    LayersShapesMap inOutShapes;
-    inOutShapes[0].in = netInputShapes;  // insert shape for first input layer
-    inOutShapes[0].inTypes = netInputTypes;
-    getLayerShapesRecursively(layerId, inOutShapes);
-    shapes = inOutShapes[layerId];
+    if (mainGraph) {
+        std::vector<MatShape> shapeCache;
+        std::vector<int> typeCache;
+        CV_Assert(layerId == 0);
+        tryInferShapes(netInputShapes, netInputTypes, shapes, shapeCache, typeCache);
+    } else {
+        LayersShapesMap inOutShapes;
+        inOutShapes[0].in = netInputShapes;  // insert shape for first input layer
+        inOutShapes[0].inTypes = netInputTypes;
+        getLayerShapesRecursively(layerId, inOutShapes);
+        shapes = inOutShapes[layerId];
+    }
 }
 
 void Net::Impl::updateLayersShapes()

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -2479,6 +2479,20 @@ void Net::Impl::enableWinograd(bool useWinograd_)
 void Net::Impl::getLayerTypes(std::vector<String>& layersTypes) const
 {
     layersTypes.clear();
+    if (mainGraph) {
+        std::set<std::string> layersTypesSet;
+        for (const Ptr<Graph>& g: allgraphs) {
+            const std::vector<Ptr<Layer> >& prog = g->prog();
+            for (const Ptr<Layer>& layer: prog) {
+                if (!layer)
+                    continue;
+                layersTypesSet.insert(layer->type);
+            }
+        }
+        for (auto it = layersTypesSet.begin(); it != layersTypesSet.end(); ++it)
+            layersTypes.push_back(*it);
+        return;
+    }
 
     std::map<String, int> layers_type_map;
     for (MapIdToLayerData::const_iterator it = layers.begin(); it != layers.end(); it++)

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -68,6 +68,8 @@ Net::Impl::Impl()
 
     accuracy = CV_32F;
     enableFP16 = haveFP16 = false;
+    // FP16 is not ready yet in the new DNN engine
+    // Ticket: https://github.com/opencv/opencv/issues/26196
     /*if (checkHardwareSupport(CV_CPU_FP16)) {
         enableFP16 = haveFP16 = true;
     }*/

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -68,9 +68,9 @@ Net::Impl::Impl()
 
     accuracy = CV_32F;
     enableFP16 = haveFP16 = false;
-    if (checkHardwareSupport(CV_CPU_FP16)) {
+    /*if (checkHardwareSupport(CV_CPU_FP16)) {
         enableFP16 = haveFP16 = true;
-    }
+    }*/
 
     tracingMode = DNN_TRACE_NONE;
     profilingMode = DNN_PROFILE_NONE;
@@ -132,7 +132,11 @@ void Net::Impl::clear()
     mainGraph = Ptr<Graph>();
 
     ArgData adata;
+    adata.name = "";
+    adata.kind = DNN_ARG_CONST;
+
     args.push_back(adata);
+    argnames.insert(std::make_pair(std::string(""), 0));
     tensors.push_back(Mat());
     bufidxs.push_back(-1);
 

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -934,10 +934,10 @@ void Net::Impl::forwardLayer(LayerData& ld)
                 }
                 printf("]\n");
             }
-            fflush(stdout);
-            pprint(std::cout, out, 0, 3, 100, '[');
-            std::cout.flush();
-            printf("\n");
+            //fflush(stdout);
+            //pprint(std::cout, out, 0, 3, 100, '[');
+            //std::cout.flush();
+            //printf("\n");
         }
 #endif
     }

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -125,7 +125,7 @@ void Net::Impl::clear()
     args = std::vector<ArgData>();
     argnames = NamesHash();
 
-    tensors = std::vector<Mat>();
+    __tensors__ = std::vector<Mat>();
     bufidxs = std::vector<int>();
     buffers = std::vector<Mat>();
 
@@ -137,7 +137,7 @@ void Net::Impl::clear()
 
     args.push_back(adata);
     argnames.insert(std::make_pair(std::string(""), 0));
-    tensors.push_back(Mat());
+    __tensors__.push_back(Mat());
     bufidxs.push_back(-1);
 
     prepared = false;

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -339,9 +339,7 @@ struct Net::Impl : public detail::NetImplBase
     Arg newConstScalarArg(const std::string& name, int type, const void* value);
     Arg newArg(const std::string& name, ArgKind kind, bool allowEmptyName=false);
     bool isConstArg(Arg arg) const;
-    bool isTempArg(Arg arg) const;
     Mat& argTensor(Arg arg) const;
-    MatSize argSize(Arg arg) const;
     int argType(Arg arg) const;
     void checkArg(Arg arg) const;
     void checkArgs(const std::vector<Arg>& args) const;
@@ -359,6 +357,7 @@ struct Net::Impl : public detail::NetImplBase
                               const std::vector<MatShape>& inpShapes,
                               std::vector<int>& outTypes,
                               std::vector<MatShape>& outShapes,
+                              std::vector<std::pair<uchar*, size_t> >& outOrigData,
                               std::vector<Mat>& outputs, // [TODO] replace with something else to cover other backends
                               std::vector<int>& tempTypes,
                               std::vector<MatShape>& tempShapes,

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -360,7 +360,7 @@ struct Net::Impl : public detail::NetImplBase
     void inferTypes();
     // infers all shapes
     void inferShapes(bool symbolic);
-    // sets certain buffer index for a particular 
+    // sets certain buffer index for each intermediate argument (Arg)
     void assignBuffers();
     //void useBlockLayout();
     void fuse();
@@ -369,6 +369,10 @@ struct Net::Impl : public detail::NetImplBase
 
 };  // Net::Impl
 
+Net readNetFromONNX2(const String&);
+Net readNetFromONNX2(const char*, size_t);
+Net readNetFromONNX2(const std::vector<uchar>&);
+Mat readTensorFromONNX2(const String&);
 
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -80,7 +80,7 @@ struct Net::Impl : public detail::NetImplBase
     size_t totalLayers;
     std::vector<std::string> dimnames_vec;
     std::vector<ArgData> args;
-    std::vector<Mat> tensors;
+    std::vector<Mat> __tensors__;
     std::vector<int> bufidxs;
     std::vector<Mat> buffers;
     std::vector<Mat> scratchBufs;
@@ -336,7 +336,7 @@ struct Net::Impl : public detail::NetImplBase
 
     Arg newConstArg(const std::string& name, const Mat& m);
     Arg newConstScalarArg(const std::string& name, int type, const void* value);
-    Arg newArg(const std::string& name, ArgKind kind);
+    Arg newArg(const std::string& name, ArgKind kind, bool allowEmptyName=false);
     bool isConstArg(Arg arg) const;
     bool isTempArg(Arg arg) const;
     Mat& argTensor(Arg arg) const;
@@ -380,7 +380,7 @@ struct Net::Impl : public detail::NetImplBase
     void forwardWithMultipleOutputs(OutputArrayOfArrays outputBlobs,
                                     const std::vector<std::string>& outBlobNames);
     // try infer shapes; if some layers produce tensors with dynamic shapes, shape inference is impossible
-    void tryInferShapes(const std::vector<MatShape>& suggestedInpShapes,
+    bool tryInferShapes(const std::vector<MatShape>& suggestedInpShapes,
                         const std::vector<MatType>& suggestedInpTypes,
                         LayerShapes& shapes,
                         std::vector<MatShape>& shapeCache,

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -76,6 +76,7 @@ struct Net::Impl : public detail::NetImplBase
               // want to use public API via cv::dnn::Net,
               // not the private one in cv::dnn::Net::Impl
 
+    ModelFormat modelFormat;
     DataLayout originalLayout;
     int onnx_opset;
 
@@ -90,14 +91,14 @@ struct Net::Impl : public detail::NetImplBase
     Ptr<Graph> mainGraph;
 
     int accuracy;
-    bool haveFP16;
+    bool enableFP16, haveFP16;
     bool prepared;
     TracingMode tracingMode;
     ProfilingMode profilingMode;
     std::vector<std::pair<Ptr<Layer>, int64_t> > profileEntries;
     std::vector<int64_t> dimvalues;
-    std::ostream* traceStream;
-    int indent;
+    std::ostream* dump_strm;
+    int dump_indent;
 
     virtual bool empty() const;
     virtual void setPreferableBackend(Net& net, int backendId);
@@ -316,6 +317,8 @@ struct Net::Impl : public detail::NetImplBase
 
     ///////////////////////////// the new engine ////////////////////////////
 
+    void prepareForInference();
+
     // pre-allocates memory for output tensors.
     // if useBufferPool==true, the method uses 'buffers'
     // for outputs (according to bufidxs)
@@ -372,7 +375,6 @@ struct Net::Impl : public detail::NetImplBase
 Net readNetFromONNX2(const String&);
 Net readNetFromONNX2(const char*, size_t);
 Net readNetFromONNX2(const std::vector<uchar>&);
-Mat readTensorFromONNX2(const String&);
 
 CV__DNN_INLINE_NS_END
 }}  // namespace cv::dnn

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -34,7 +34,7 @@ CV__DNN_INLINE_NS_BEGIN
 using std::make_pair;
 using std::string;
 
-typedef std::unordered_map<std::string, int64_t> NamesHash;
+typedef std::unordered_map<std::string, int> NamesHash;
 
 // NB: Implementation is divided between of multiple .cpp files
 struct Net::Impl : public detail::NetImplBase
@@ -81,7 +81,7 @@ struct Net::Impl : public detail::NetImplBase
 
     NamesHash argnames;
     NamesHash dimnames;
-    std::vector<std::string> dimnames_;
+    std::vector<std::string> dimnames_vec;
     std::vector<ArgInfo> args;
     std::vector<Mat> tensors;
     std::vector<int> bufidxs;
@@ -97,6 +97,7 @@ struct Net::Impl : public detail::NetImplBase
     std::vector<std::pair<Ptr<Layer>, int64_t> > profileEntries;
     std::vector<int64_t> dimvalues;
     std::ostream* traceStream;
+    int indent;
 
     virtual bool empty() const;
     virtual void setPreferableBackend(Net& net, int backendId);
@@ -351,6 +352,9 @@ struct Net::Impl : public detail::NetImplBase
 
     // dump information about certain input or output argument of an operation
     void traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg arg, bool dumpdata);
+    std::ostream& dumpArg(std::ostream& strm, Arg arg, int indent,
+                          bool comma, bool dump_details) const;
+    std::ostream& dumpDim(std::ostream& strm, int value) const;
 
     // infers all types
     void inferTypes();

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -420,6 +420,11 @@ struct Net::Impl : public detail::NetImplBase
 
 };  // Net::Impl
 
+inline Net::Impl* getNetImpl(const Layer* layer)
+{
+    return reinterpret_cast<Net::Impl*>(layer->netimpl);
+}
+
 Net readNetFromONNX2(const String&);
 Net readNetFromONNX2(const char*, size_t);
 Net readNetFromONNX2(const std::vector<uchar>&);

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -82,7 +82,7 @@ struct Net::Impl : public detail::NetImplBase
     NamesHash argnames;
     NamesHash dimnames;
     std::vector<std::string> dimnames_vec;
-    std::vector<ArgInfo> args;
+    std::vector<ArgData> args;
     std::vector<Mat> tensors;
     std::vector<int> bufidxs;
     std::vector<Mat> buffers;

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -379,6 +379,16 @@ struct Net::Impl : public detail::NetImplBase
     // run the whole model, convenience wrapper
     void forwardWithMultipleOutputs(OutputArrayOfArrays outputBlobs,
                                     const std::vector<std::string>& outBlobNames);
+    // try infer shapes; if some layers produce tensors with dynamic shapes, shape inference is impossible
+    void tryInferShapes(const std::vector<MatShape>& suggestedInpShapes,
+                        const std::vector<MatType>& suggestedInpTypes,
+                        LayerShapes& shapes,
+                        std::vector<MatShape>& shapeCache,
+                        std::vector<MatType>& typeCache) const;
+    bool tryInferGraphShapes(const Ptr<Graph>& graph,
+                             std::vector<MatShape>& shapeCache,
+                             std::vector<MatType>& typeCache) const;
+
     // helper function for useCounts()
     void updateUseCounts(const Ptr<Graph>& graph, std::vector<int>& usecounts) const;
     // computes how many times each argument is used, i.e. on output usecounts.size() == args.size()

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -70,6 +70,7 @@ struct Net::Impl : public detail::NetImplBase
     bool useWinograd;
     std::vector<int64> layersTimings;
 
+    std::string modelFileName;
     ModelFormat modelFormat;
     DataLayout originalLayout;
     int onnx_opset;

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -1,0 +1,409 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+
+#include "net_impl.hpp"
+
+namespace cv {
+namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+std::string argKindToString(ArgKind kind)
+{
+    return
+        kind == DNN_ARG_CONST ? "Const" :
+        kind == DNN_ARG_INPUT ? "Input" :
+        kind == DNN_ARG_OUTPUT ? "Output" :
+        kind == DNN_ARG_TEMP ? "Temp" :
+        kind == DNN_ARG_PATTERN ? "Pattern" : "???";
+}
+
+/*
+[TODO] move code from these methods into net_impl.cpp.
+Net::Impl::Impl(Net2* net_)
+{
+    CV_Assert(net_ != nullptr);
+    net = net_;
+    modelFormat = DNN_MODEL_GENERIC;
+    defaultLayout = LAYOUT_NCHW;
+    onnx_opset = 0;
+
+    defaultDevice = Device::CPU();
+    defaultMemoryManager = MemoryManager::forCPU();
+
+    accuracy = CV_32F;
+    enableFP16 = haveFP16 = false;
+    if (checkHardwareSupport(CV_CPU_FP16)) {
+        enableFP16 = haveFP16 = true;
+    }
+
+    tracingMode = DNN_TRACE_NONE;
+    profilingMode = DNN_PROFILE_NONE;
+    prepared = false;
+
+    strm = &std::cout;
+    dump_indent = 3;
+
+    clear();
+}
+
+Net::Impl::~Impl() { clear(); }
+
+void Net::Impl::prepareForInference()
+{
+    if (!prepared) {
+        constFold();
+        inferTypes();
+        constArgs();
+        inferShapes(true);
+        fuse();
+        useBlockLayout();
+        inferShapes(true);
+        assignBuffers();
+        prepared = true;
+    }
+}
+
+void Net::Impl::clear()
+{
+    modelFormat = DNN_MODEL_GENERIC;
+
+    dimnames = NamesHash();
+    dimnames_ = std::vector<std::string>();
+
+    args = std::vector<ArgInfo>();
+    argnames = NamesHash();
+
+    tensors = std::vector<Tensor>();
+    bufidxs = std::vector<int>();
+    buffers = std::vector<Buffer>();
+
+    mainGraph = Graph();
+
+    pattern_args = std::vector<ArgInfo>();
+    pattern_tensors = std::vector<Tensor>();
+
+    ArgInfo info;
+    args.push_back(info);
+    pattern_args.push_back(info);
+    tensors.push_back(Tensor());
+    bufidxs.push_back(-1);
+
+    fromBlock = TransformLayoutOp::create(LAYOUT_NCHW);
+}*/
+
+void Net::Impl::allocateLayerOutputs(
+                          const Ptr<Layer>& layer,
+                          const std::vector<int>& inpTypes,
+                          const std::vector<MatShape>& inpShapes,
+                          std::vector<int>& outTypes,
+                          std::vector<MatShape>& outShapes,
+                          std::vector<Mat>& outputs,
+                          std::vector<int>& tempTypes,
+                          std::vector<MatShape>& tempShapes,
+                          std::vector<Mat>& temps,
+                          std::vector<Mat>& globalTemps,
+                          bool useBufferPool)
+{
+    // In theory, when
+    // 1) useBufferPool==true,
+    // 2) the buffers in the pool are already big enough (e.g. when we already run inference a few times to let them grow)
+    // 3) getMemoryShapes() and getTypes() are implemented efficiently without any memory allocations
+    // the method allocateLayerOutputs() should not allocate any memory either.
+    //
+    // Well, currently it still may do so, because Mat::fit() may create e.g. 4D tensor on top of 1D buffer and then
+    // MatSize and MatStep will require dynamic memory allocation (those are very small buffers though).
+    // But we plan to make MatSize and MatStep lighter so that they don't use dynamic memory.
+    size_t noutputs = layer->outputs.size();
+    layer->getMemoryShapes(inpShapes, (int)noutputs, outShapes, tempShapes);
+    layer->getTypes(inpTypes, (int)noutputs, (int)tempShapes.size(), outTypes, tempTypes);
+    CV_Assert(tempShapes.size() == tempTypes.size());
+    CV_Assert(outShapes.size() == outTypes.size());
+    CV_Assert(outShapes.size() == noutputs);
+    outputs.resize(noutputs);
+    for (size_t i = 0; i < noutputs; i++) {
+        Arg out = layer->outputs[i];
+        const ArgInfo& info = args.at(out.idx);
+        if (useBufferPool && info.kind == DNN_ARG_TEMP) {
+            int bufidx = bufidxs.at(out.idx);
+            Mat& buf = buffers.at(bufidx);
+            buf.fit(outShapes[i], outTypes[i]);
+            outputs[i] = buf;
+        } else {
+            outputs[i].fit(outShapes[i], outTypes[i]);
+        }
+    }
+    // [TODO] probably there should be a smarter algorithm that e.g. sorts
+    // temp buffers by size in decreasing order and assigns global temps accordingly
+    // in order to minimize the total size of temp buffers
+    size_t ntemps = tempShapes.size();
+    temps.resize(ntemps);
+    globalTemps.resize(std::max(ntemps, globalTemps.size()));
+    for (size_t i = 0; i < ntemps; i++) {
+        globalTemps[i].fit(tempShapes[i], tempTypes[i]);
+        temps[i] = globalTemps[i];
+    }
+}
+
+void Net::Impl::forwardMainGraph(InputArrayOfArrays inputs, OutputArrayOfArrays outputs)
+{
+    if (!mainGraph) {
+        CV_Error(Error::StsNullPtr, "the model was not loaded");
+    }
+    // [TODO] initialize profile, tracer, symbolic shapes etc.
+    size_t nsymdims = dimnames_.size();
+    dimvalues.assign(nsymdims, -1);
+    forwardGraph(mainGraph, inputs, outputs, true);
+}
+
+/*void Net::Impl::checkAndUpdateDim(const Ptr<Graph>& g, const Ptr<Layer>& layer, Arg inp, int j, int value)
+{
+    const ArgInfo& info = args[inp.idx];
+    int64_t value0 = info.size.size[j];
+    if (value0 >= 0) {
+        if (value0 != value) {
+            CV_Error_(Error::StsBadArg, ("graph '%s': node '%s': %d-th dimension of argument '%s' is wrong: %lld given, %lld expected",
+                                        g->name().data(), node ? node->name().data() : "none (graph input)", j, info.name.c_str(), value, value0));
+        }
+    } else {
+        int64_t idx = -value0-1;
+        CV_Assert(0 <= idx && idx < (int64_t)dimvalues.size());
+        value0 = dimvalues[idx];
+        if (value0 < 0) {
+            dimvalues[idx] = value;
+        } else if (value0 != value) {
+            CV_Error_(Error::StsBadArg,
+            ("graph '%s': node '%s': %d-th dimension '%s' of argument '%s' is wrong: %lld given, but '%s' is already set to %lld",
+                    g->name().data(), node ? node->name().data() : "none (graph input)",
+                    j, dimnames_[idx].c_str(), info.name.c_str(),
+                    value, dimnames_[idx].c_str(), value0));
+        }
+    }
+}*/
+
+void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg arg, bool dumpdata)
+{
+    const Mat& m = tensors.at(arg.idx);
+    const ArgInfo& info = args.at(arg.idx);
+    CV_Assert(m.type() == info.type);
+    strm_ << prefix << " " << i << ". Name: " << info.name << "\n";
+    strm_ << "  Buf: " << bufidxs.at(arg.idx) << "\n";
+    strm_ << "  Type: " << typeToString(info.type) << " \n";
+    MatShape shape = m.shape();
+    strm_ << "  Shape: " << shape << "\n  Layout: " << layoutToString(shape.layout) << "\n";
+    if (dumpdata) {
+        Mat temp;
+        /*if (size.layout == DNN_LAYOUT_BLOCK) {
+            fromBlock->forward(*net, mainGraph, {m}, {fromBlockResult}, scratch_bufs);
+            temp = fromBlockResult;
+        } else*/ {
+            temp = m;
+        }
+        // [TODO] dump(strm_, m, 0);
+        strm_ << "\n";
+    }
+}
+
+void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
+                             OutputArrayOfArrays outputs_, bool isMainGraph)
+{
+    std::ostream& strm_ = traceStream ? *traceStream : std::cout;
+    const std::vector<Ptr<Layer> >& prog = graph->prog();
+    size_t i, nops = prog.size();
+    const std::vector<Arg>& gr_inputs = graph->inputs();
+    const std::vector<Arg>& gr_outputs = graph->outputs();
+    size_t n_gr_inputs = gr_inputs.size(), n_gr_outputs = gr_outputs.size();
+    std::vector<Mat> inpMats, outMats, tempMats;
+    std::vector<int> inpTypes, outTypes, tempTypes;
+    std::vector<MatShape> inpShapes, outShapes, tempShapes;
+    double timestamp = 0;
+
+    if (inputs_.total() != n_gr_inputs) {
+        CV_Error_(Error::StsBadArg, ("wrong number of inputs in graph '%s': %zu given, %zu expected",
+                                     graph->name().data(), inputs_.total(), n_gr_inputs));
+    }
+
+    for (i = 0; i < n_gr_inputs; i++) {
+        // [TODO] add conversion if needed
+        Mat m = inputs_.getMat((int)i);
+        int mtype = m.type();
+        MatShape mshape = m.shape();
+        Arg inp = gr_inputs[i];
+        const ArgInfo& info = args.at(inp.idx);
+        if (info.type != mtype) {
+            CV_Error_(Error::StsBadArg, ("wrong type of argument '%s': %s given, %s expected",
+                                         info.name.c_str(), typeToString(mtype).c_str(),
+                                         typeToString(info.type).c_str()));
+        }
+
+        /*
+        [TODO] ignore extensive shape check for now
+        if (info.shape.dims != mshape.dims) {
+            CV_Error_(Error::StsBadArg, ("wrong dimensionality of argument '%s': %d given, %d expected",
+                                         info.name.c_str(), tsize.ndims, info.size.ndims));
+        }
+
+        for (int k = 0; k < mshape.dims; k++) {
+            checkAndUpdateDim(graph, Node(), inp, k, tsize.size[k]);
+        }*/
+
+        if (info.kind == DNN_ARG_INPUT) {
+            tensors.at(inp.idx) = m;
+        } else if (info.kind == DNN_ARG_TEMP) {
+            int bufidx = bufidxs.at(inp.idx);
+            Mat& buf = buffers.at(bufidx);
+            buf.fit(mshape, mtype); // minimize reallocations
+            m.copyTo(buf);
+            tensors[inp.idx] = buf;
+        } else {
+            CV_Error_(Error::StsBadArg, ("graph %s: argument '%s' must be 'INPUT' or 'TEMP', not '%s'",
+                                         graph->name().data(), info.name.c_str(), argKindToString(info.kind).c_str()));
+        }
+    }
+
+    for (size_t opidx = 0; opidx < nops; opidx++) {
+        const Ptr<Layer>& layer = prog.at(opidx);
+        if (!layer) // in theory we shouldn't have any 'nops' at this stage, but just in case we skip them.
+            continue;
+        const std::vector<Arg>& inputs = layer->inputs;
+        const std::vector<Arg>& outputs = layer->outputs;
+        size_t ninputs = inputs.size(), noutputs = outputs.size();
+
+        inpMats.resize(ninputs);
+        inpTypes.resize(ninputs);
+        inpShapes.resize(ninputs);
+        for (i = 0; i < ninputs; i++) {
+            Arg inp = inputs[i];
+            //const ArgInfo& info = args[inp.idx];
+            const Mat& m = tensors[inp.idx];
+            inpMats[i] = m;
+            inpTypes[i] = m.type();
+            inpShapes[i] = m.shape();
+        }
+
+        bool dynamicOutShapes = layer->dynamicOutputShapes();
+        if (!dynamicOutShapes) {
+            allocateLayerOutputs(layer, inpTypes, inpShapes, outTypes, outShapes, outMats,
+                                 tempTypes, tempShapes, tempMats, scratchBufs, true);
+        } else {
+            outMats.resize(noutputs);
+            for (i = 0; i < noutputs; i++) {
+                Arg out = outputs[i];
+                const ArgInfo& info = args.at(out.idx);
+                if (info.kind == DNN_ARG_TEMP) {
+                    int bufidx = bufidxs.at(out.idx);
+                    outMats[i] = buffers.at(bufidx);
+                } else {
+                    outMats[i] = tensors.at(out.idx);
+                }
+            }
+            tempMats = scratchBufs;
+        }
+
+        if (tracingMode != DNN_TRACE_NONE) {
+            strm_ << "-----------\n";
+            strm_ << "'" << graph->name() << "' [" << opidx << "/" << nops << "]. " << layer->type << " node: " << layer->name << "\n";
+            for (i = 0; i < ninputs; i++) {
+                Arg inp = inputs[i];
+                traceArg(strm_, "Input", i, inp, false);
+            }
+            timestamp = (double)getTickCount();
+        }
+
+        // [TODO] handle If/Loop/...
+        CV_Assert(!layer->subgraphs());
+        layer->forward(inpMats, outMats, tempMats);
+        CV_Assert(outMats.size() == noutputs);
+
+        for (i = 0; i < noutputs; i++) {
+            Arg out = outputs[i];
+            ArgInfo& info = args[out.idx];
+            const Mat& m = outMats[i];
+            info.type = m.type();
+            info.shape = m.shape();
+            tensors.at(out.idx) = m;
+            if (info.kind == DNN_ARG_TEMP) {
+                int bufidx = bufidxs.at(out.idx);
+                Mat& buf = buffers.at(bufidx);
+                
+                if (!dynamicOutShapes) {
+                    // a sanity check: make sure that the data was not reallocated during Layer::forward()
+                    // if the layer claims it does not produce dynamic-shape outputs.
+                    CV_Assert(buf.data == m.data);
+                } else if (m.u->size > buf.u->size) {
+                    buf = m;
+                }
+            }
+        }
+
+        if (tracingMode != DNN_TRACE_NONE) {
+            timestamp = (double)getTickCount() - timestamp;
+            strm_ << "TIME (\"" << layer->name << "\", \"" << layer->type << "\"): " <<
+                format("%.2fms", timestamp*1000/getTickFrequency()) << "\n";
+            for (i = 0; i < noutputs; i++) {
+                Arg out = outputs[i];
+                traceArg(strm_, "Output", i, out, tracingMode == DNN_TRACE_ALL);
+            }
+        }
+    }
+
+    std::vector<Mat>& outputsVec = outputs_.getMatVecRef();
+    outputsVec.resize(n_gr_outputs);
+    for (i = 0; i < n_gr_outputs; i++) {
+        Arg out = gr_outputs[i];
+        const Mat& outm = tensors.at(out.idx);
+        if (isMainGraph) {
+            outputsVec[i].fit(outm.shape(), outm.type());
+            outm.copyTo(outputsVec[i]);
+        } else {
+            outputsVec[i] = outm;
+        }
+    }
+}
+
+
+void Net::Impl::updateUseCounts(const Ptr<Graph>& graph, std::vector<int>& usecounts) const
+{
+    if (!graph)
+        return;
+    const std::vector<Ptr<Layer> >& prog = graph->prog();
+    for (const Ptr<Layer>& layer: prog) {
+        const std::vector<Arg>& inputs = layer->inputs;
+        for (const Arg& input: inputs) {
+            CV_Assert(input.idx < (int)usecounts.size());
+            usecounts[input.idx]++;
+        }
+        const std::vector<Ptr<Graph> >* subgraphs = layer->subgraphs();
+        if (subgraphs) {
+            for (const Ptr<Graph>& subgraph: *subgraphs) {
+                updateUseCounts(subgraph, usecounts);
+            }
+        }
+    }
+}
+
+void Net::Impl::useCounts(std::vector<int>& usecounts) const
+{
+    size_t nargs = args.size();
+    usecounts.assign(nargs, 0);
+    usecounts[0] = 1; // empty Arg() is always useful
+    updateUseCounts(mainGraph, usecounts);
+}
+
+void Net::Impl::checkArgs(const std::vector<Arg>& args_) const
+{
+    for (const Arg& a: args_) {
+        checkArg(a);
+    }
+}
+
+void Net::Impl::checkArg(Arg a) const
+{
+    CV_Assert(a.idx >= 0);
+    CV_Assert(a.idx < (int)args.size());
+}
+
+CV__DNN_INLINE_NS_END
+}}  // namespace cv::dnn

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -92,7 +92,7 @@ public:
     {
         CV_Assert(net_);
         size_t ninputs = inputs_.size(), noutputs = outputs_.size();
-        int delta_indent = net_->getImpl()->indent;
+        int delta_indent = net_->getImpl()->dump_indent;
         int subindent = indent + delta_indent;
         int argindent = subindent + delta_indent;
         strm << "graph {\n";
@@ -162,79 +162,20 @@ Ptr<Graph> Graph::create(Net& net, const std::string& name,
 
 Graph::~Graph() {}
 
-/*
-[TODO] move code from these methods into net_impl.cpp.
-Net::Impl::Impl(Net* net_)
-{
-    CV_Assert(net_ != nullptr);
-    net = net_;
-    modelFormat = DNN_MODEL_GENERIC;
-    defaultLayout = LAYOUT_NCHW;
-    onnx_opset = 0;
-
-    defaultDevice = Device::CPU();
-    defaultMemoryManager = MemoryManager::forCPU();
-
-    accuracy = CV_32F;
-    enableFP16 = haveFP16 = false;
-    if (checkHardwareSupport(CV_CPU_FP16)) {
-        enableFP16 = haveFP16 = true;
-    }
-
-    tracingMode = DNN_TRACE_NONE;
-    profilingMode = DNN_PROFILE_NONE;
-    prepared = false;
-
-    strm = &std::cout;
-    dump_indent = 3;
-
-    clear();
-}
-
-Net::Impl::~Impl() { clear(); }
-
 void Net::Impl::prepareForInference()
 {
     if (!prepared) {
         constFold();
-        inferTypes();
-        constArgs();
-        inferShapes(true);
-        fuse();
-        useBlockLayout();
-        inferShapes(true);
+        //inferTypes();
+        //constArgs();
+        //inferShapes(true);
+        //fuse();
+        //useBlockLayout();
+        //inferShapes(true);
         assignBuffers();
         prepared = true;
     }
 }
-
-void Net::Impl::clear()
-{
-    modelFormat = DNN_MODEL_GENERIC;
-
-    dimnames = NamesHash();
-    dimnames_ = std::vector<std::string>();
-
-    args = std::vector<ArgData>();
-    argnames = NamesHash();
-
-    tensors = std::vector<Tensor>();
-    bufidxs = std::vector<int>();
-    buffers = std::vector<Buffer>();
-
-    mainGraph = Graph();
-
-    pattern_args = std::vector<ArgData>();
-    pattern_tensors = std::vector<Tensor>();
-
-    ArgData adata;
-    args.push_back(adata);
-    pattern_args.push_back(adata);
-    tensors.push_back(Tensor());
-    bufidxs.push_back(-1);
-
-    fromBlock = TransformLayoutOp::create(LAYOUT_NCHW);
-}*/
 
 void Net::Impl::allocateLayerOutputs(
                           const Ptr<Layer>& layer,
@@ -351,7 +292,7 @@ void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg 
 void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
                              OutputArrayOfArrays outputs_, bool isMainGraph)
 {
-    std::ostream& strm_ = traceStream ? *traceStream : std::cout;
+    std::ostream& strm_ = dump_strm ? *dump_strm : std::cout;
     const std::vector<Ptr<Layer> >& prog = graph->prog();
     size_t i, nops = prog.size();
     const std::vector<Arg>& gr_inputs = graph->inputs();

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -821,7 +821,7 @@ bool Net::Impl::tryInferShapes(const std::vector<MatShape>& suggestedInpShapes,
     size_t nsuggestedShapes = suggestedInpShapes.size();
     size_t nsuggestedTypes = suggestedInpTypes.size();
     CV_Assert(nsuggestedShapes == 0 || nsuggestedShapes == ninputs ||
-              
+
               // workaround, but this is not quite correct usage of the function
               (nsuggestedShapes == 1 && suggestedInpShapes[0].empty())
               );

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -469,7 +469,7 @@ void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
             if (info.kind == DNN_ARG_TEMP) {
                 int bufidx = bufidxs.at(out.idx);
                 Mat& buf = buffers.at(bufidx);
-                
+
                 if (!dynamicOutShapes) {
                     // a sanity check: make sure that the data was not reallocated during Layer::forward()
                     // if the layer claims it does not produce dynamic-shape outputs.

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -328,6 +328,8 @@ void Net::Impl::allocateLayerOutputs(
     size_t noutputs = layer->outputs.size();
     outShapes.clear();
     outTypes.clear();
+    tempShapes.clear();
+    tempTypes.clear();
     layer->getMemoryShapes(inpShapes, (int)noutputs, outShapes, tempShapes);
     layer->getTypes(inpTypes, (int)noutputs, (int)tempShapes.size(), outTypes, tempTypes);
     CV_Assert(tempShapes.size() == tempTypes.size());
@@ -362,8 +364,9 @@ void Net::Impl::forwardMainGraph(InputArrayOfArrays inputs, OutputArrayOfArrays 
     if (!mainGraph) {
         CV_Error(Error::StsNullPtr, "the model was not loaded");
     }
-    // ************ uncomment for debugging **********
+    // ************ uncomment one of the lines below for debugging **********
     //tracingMode = DNN_TRACE_OP;
+    //tracingMode = DNN_TRACE_ALL;
     // [TODO] initialize profile, tracer, symbolic shapes etc.
     size_t nsymdims = dimnames_vec.size();
     dimvalues.assign(nsymdims, -1);
@@ -461,9 +464,9 @@ void Net::Impl::forwardWithMultipleOutputs(OutputArrayOfArrays outblobs, const s
 
 void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg arg, bool dumpdata)
 {
-    const int PPRINT_CONTEXT = 5;
+    const int PPRINT_CONTEXT = 3;
     const int PPRINT_CONST_THRESHOLD = 16;
-    const int PPRINT_ALL_THRESHOLD = 16;
+    const int PPRINT_ALL_THRESHOLD = 100;
     const Mat& m = argTensor(arg);
     const ArgData& adata = args.at(arg.idx);
     bool constArg = adata.kind == DNN_ARG_CONST;
@@ -483,16 +486,10 @@ void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg 
     }
     strm_ << "\n  Layout: " << layoutToString(shape.layout) << "\n";
     if (dumpdata && !constArg) {
-        /*Mat temp;
-        if (shape.layout == DNN_LAYOUT_BLOCK) {
-            fromBlock->forward(*net, mainGraph, {m}, {fromBlockResult}, scratch_bufs);
-            temp = fromBlockResult;
-        } else {
-            temp = m;
-        }
-        dump(strm_, temp, 0, PPRINT_CONTEXT, PPRINT_ALL_THRESHOLD, '[');
-        strm_ << "\n";*/
+        // [TODO] when we support block layout, block-layout tensor
+        // should be converted to the original layout before printing it
         pprint(strm_, m, 0, PPRINT_CONTEXT, PPRINT_ALL_THRESHOLD, '[');
+        strm_ << "\n";
     }
 }
 

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -338,7 +338,6 @@ void Net::Impl::allocateLayerOutputs(
     outputs.assign(noutputs, Mat());
     for (size_t i = 0; i < noutputs; i++) {
         Arg out = layer->outputs[i];
-        const ArgData& adata = args.at(out.idx);
         if (useBufferPool) {
             Mat& out_t = argTensor(out);
             out_t.fit(outShapes[i], outTypes[i]);
@@ -405,7 +404,7 @@ void Net::Impl::forwardWithMultipleOutputs(OutputArrayOfArrays outblobs, const s
     std::vector<int> outidxs;
     int i, j, noutputs = (int)outargs.size();
     if (!outnames.empty()) {
-        CV_Assert((int)outnames.size() == noutputs);
+        CV_CheckEQ((int)outnames.size(), noutputs, "the number of requested and actual outputs must be the same");
         if (noutputs == 1 && outnames[0].empty())
             ;
         else {
@@ -973,6 +972,8 @@ bool Net::Impl::tryInferGraphShapes(const Ptr<Graph>& graph,
             typeCache[out.idx] = outTypes[i];
         }
     }
+
+    return true;
 }
 
 void Net::Impl::checkArgs(const std::vector<Arg>& args_) const

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -217,6 +217,8 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
 
 void Net::Impl::setPreferableTarget(int targetId)
 {
+    if (mainGraph) // the new engine does not support different targets yet
+        return;
     if (netWasQuantized && targetId != DNN_TARGET_CPU &&
         targetId != DNN_TARGET_OPENCL && targetId != DNN_TARGET_OPENCL_FP16 && targetId != DNN_TARGET_NPU)
     {

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -188,6 +188,12 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
 
     if (preferableBackend != backendId)
     {
+        if (mainGraph)
+        {
+            preferableBackend = backendId;
+            return;
+        }
+
         clear();
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         {

--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -663,6 +663,9 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
             continue;  // Go to the next layer.
 
         // [TODO] temporarily disabled Concat optimization.
+        //
+        // Ticket: https://github.com/opencv/opencv/issues/26195
+        //
         // It's not quite compatible with dynamic shapes,
         // so we need to make sure that we correctly predicted shapes
         // of all the concatenated tensors and their offsets inside the result

--- a/modules/dnn/src/net_impl_fuse.cpp
+++ b/modules/dnn/src/net_impl_fuse.cpp
@@ -662,6 +662,12 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
         if (preferableBackend != DNN_BACKEND_OPENCV && preferableBackend != DNN_BACKEND_CUDA)
             continue;  // Go to the next layer.
 
+        // [TODO] temporarily disabled Concat optimization.
+        // It's not quite compatible with dynamic shapes,
+        // so we need to make sure that we correctly predicted shapes
+        // of all the concatenated tensors and their offsets inside the result
+        // and also properly allocated that concatenated tensor in advance
+#if 0
         // the optimization #2. if there is concat layer that concatenates channels
         // from the inputs together (i.e. axis == 1) then we make the inputs of
         // the concat layer to write to the concatenation output buffer
@@ -832,6 +838,7 @@ void Net::Impl::fuseLayers(const std::vector<LayerPin>& blobsToKeep_)
                 }
             }
         }
+#endif
     }
 }
 

--- a/modules/dnn/src/net_openvino.cpp
+++ b/modules/dnn/src/net_openvino.cpp
@@ -667,7 +667,7 @@ Net NetImplOpenVINO::createNetworkFromModelOptimizer(std::shared_ptr<ov::Model>&
     {
         inputsNames.push_back(it->get_friendly_name());
         std::vector<size_t> dims = it->get_shape();
-        inp_shapes.push_back(std::vector<int>(dims.begin(), dims.end()));
+        inp_shapes.push_back(MatShape(dims.begin(), dims.end()));
     }
     // nGraph models produce output "Result" layers which have "/sink_port" suffix in their names.
     // Their inputs are actual model outputs and we change friendly name to it.

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_softmax.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_softmax.cpp
@@ -57,17 +57,17 @@ OCL4DNNSoftmax<Dtype>::OCL4DNNSoftmax(OCL4DNNSoftmaxConfig config)
     inner_num_ = 1;
     outer_num_ = 1;
     count_ = 1;
-    int32_t scale_sz = 1;
-    for (int32_t i = softmax_axis_ + 1; i < config.in_shape.size(); i++)
+    int scale_sz = 1;
+    for (int i = (int)softmax_axis_ + 1; i < config.in_shape.dims; i++)
         inner_num_ *= config.in_shape[i];
     use_slm_ = (config.in_shape[softmax_axis_] * inner_num_ + inner_num_ * 17) <= 8192;
-    for (int32_t i = 0; i < softmax_axis_; i++)
+    for (int i = 0; i < (int)softmax_axis_; i++)
         outer_num_ *= config.in_shape[i];
     count_ = inner_num_ + outer_num_;
 
-    std::vector<int32_t> scale_dims = config.in_shape;
+    auto scale_dims = config.in_shape;
     scale_dims[softmax_axis_] = use_slm_ ? 1 : 17;
-    for (int32_t i = 0; i < scale_dims.size(); i++)
+    for (int i = 0; i < scale_dims.dims; i++)
         scale_sz *= scale_dims[i];
 
     scale_data_.create(1, scale_sz, CV_32FC1);

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -6,12 +6,12 @@
 // Third party copyrights are property of their respective owners.
 
 #include "../precomp.hpp"
-#include <opencv2/dnn/shape_utils.hpp>
+#include "../net_impl.hpp"
 
+#include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/dnn/layer_reg.private.hpp>
 
 #include <opencv2/core/utils/fp_control_utils.hpp>
-
 #include <opencv2/core/utils/logger.defines.hpp>
 #undef CV_LOG_STRIP_LEVEL
 #define CV_LOG_STRIP_LEVEL CV_LOG_LEVEL_VERBOSE + 1
@@ -4026,18 +4026,24 @@ void ONNXImporter::buildDispatchMap_COM_MICROSOFT(int opset_version)
 }
 
 
-Net readNetFromONNX(const String& onnxFile)
+Net readNetFromONNX(const String& onnxFile, bool useNewEngine)
 {
+    if (useNewEngine)
+        return readNetFromONNX2(onnxFile);
     return detail::readNetDiagnostic<ONNXImporter>(onnxFile.c_str());
 }
 
-Net readNetFromONNX(const char* buffer, size_t sizeBuffer)
+Net readNetFromONNX(const char* buffer, size_t sizeBuffer, bool useNewEngine)
 {
+    if (useNewEngine)
+        return readNetFromONNX2(buffer, sizeBuffer);
     return detail::readNetDiagnostic<ONNXImporter>(buffer, sizeBuffer);
 }
 
-Net readNetFromONNX(const std::vector<uchar>& buffer)
+Net readNetFromONNX(const std::vector<uchar>& buffer, bool useNewEngine)
 {
+    if (useNewEngine)
+        return readNetFromONNX2(buffer);
     return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
 }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4026,34 +4026,67 @@ void ONNXImporter::buildDispatchMap_COM_MICROSOFT(int opset_version)
 }
 
 
-Net readNetFromONNX(const String& onnxFile, bool useNewEngine)
+Net readNetFromONNX(const String& onnxFile, int engine)
 {
-    if (useNewEngine) {
-        Net net = readNetFromONNX2(onnxFile);
-        if (!net.empty())
-            return net;
+    switch(engine)
+    {
+        case ENGINE_CLASSIC:
+            return detail::readNetDiagnostic<ONNXImporter>(onnxFile.c_str());
+        case ENGINE_NEW:
+            return readNetFromONNX2(onnxFile);
+        case ENGINE_AUTO:
+        {
+            Net net = readNetFromONNX2(onnxFile);
+            if (!net.empty())
+                return net;
+            else
+                return detail::readNetDiagnostic<ONNXImporter>(onnxFile.c_str());
+        }
+        default:
+            CV_Error(Error::StsBadArg, "Invalid DNN engine selected!");
     }
-    return detail::readNetDiagnostic<ONNXImporter>(onnxFile.c_str());
 }
 
-Net readNetFromONNX(const char* buffer, size_t sizeBuffer, bool useNewEngine)
+Net readNetFromONNX(const char* buffer, size_t sizeBuffer, int engine)
 {
-    if (useNewEngine) {
-        Net net = readNetFromONNX2(buffer, sizeBuffer);
-        if (!net.empty())
-            return net;
+    switch(engine)
+    {
+        case ENGINE_CLASSIC:
+            return detail::readNetDiagnostic<ONNXImporter>(buffer, sizeBuffer);
+        case ENGINE_NEW:
+            return readNetFromONNX2(buffer, sizeBuffer);
+        case ENGINE_AUTO:
+        {
+            Net net = readNetFromONNX2(buffer, sizeBuffer);
+            if (!net.empty())
+                return net;
+            else
+                return detail::readNetDiagnostic<ONNXImporter>(buffer, sizeBuffer);
+        }
+        default:
+            CV_Error(Error::StsBadArg, "Invalid DNN engine selected!");
     }
-    return detail::readNetDiagnostic<ONNXImporter>(buffer, sizeBuffer);
 }
 
-Net readNetFromONNX(const std::vector<uchar>& buffer, bool useNewEngine)
+Net readNetFromONNX(const std::vector<uchar>& buffer, int engine)
 {
-    if (useNewEngine) {
-        Net net = readNetFromONNX2(buffer);
-        if (!net.empty())
-            return net;
+    switch(engine)
+    {
+        case ENGINE_CLASSIC:
+            return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+        case ENGINE_NEW:
+            return readNetFromONNX2(buffer);
+        case ENGINE_AUTO:
+        {
+            Net net = readNetFromONNX2(buffer);
+            if (!net.empty())
+                return net;
+            else
+                return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+        }
+        default:
+            CV_Error(Error::StsBadArg, "Invalid DNN engine selected!");
     }
-    return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
 }
 
 Mat readTensorFromONNX(const String& path)

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4028,22 +4028,31 @@ void ONNXImporter::buildDispatchMap_COM_MICROSOFT(int opset_version)
 
 Net readNetFromONNX(const String& onnxFile, bool useNewEngine)
 {
-    if (useNewEngine)
-        return readNetFromONNX2(onnxFile);
+    if (useNewEngine) {
+        Net net = readNetFromONNX2(onnxFile);
+        if (!net.empty())
+            return net;
+    }
     return detail::readNetDiagnostic<ONNXImporter>(onnxFile.c_str());
 }
 
 Net readNetFromONNX(const char* buffer, size_t sizeBuffer, bool useNewEngine)
 {
-    if (useNewEngine)
-        return readNetFromONNX2(buffer, sizeBuffer);
+    if (useNewEngine) {
+        Net net = readNetFromONNX2(buffer, sizeBuffer);
+        if (!net.empty())
+            return net;
+    }
     return detail::readNetDiagnostic<ONNXImporter>(buffer, sizeBuffer);
 }
 
 Net readNetFromONNX(const std::vector<uchar>& buffer, bool useNewEngine)
 {
-    if (useNewEngine)
-        return readNetFromONNX2(buffer);
+    if (useNewEngine) {
+        Net net = readNetFromONNX2(buffer);
+        if (!net.empty())
+            return net;
+    }
     return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
 }
 

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -736,7 +736,7 @@ Ptr<Graph> ONNXImporter2::parseGraph(opencv_onnx::GraphProto* graph_proto, bool 
         //const opencv_onnx::
         const opencv_onnx::TensorProto& const_i = graph_proto->initializer(i);
         Mat t = parseTensor(const_i);
-        net.newConstArg(const_i.name(), t);
+        netimpl->newConstArg(const_i.name(), t);
     }
 
     // parse graph inputs
@@ -745,7 +745,7 @@ Ptr<Graph> ONNXImporter2::parseGraph(opencv_onnx::GraphProto* graph_proto, bool 
         const opencv_onnx::ValueInfoProto& input_i = graph_proto->input(i);
         if (net.haveArg(input_i.name()))
             continue;
-        Arg arg = net.newArg(input_i.name(), mainGraph_ ? DNN_ARG_INPUT : DNN_ARG_TEMP);
+        Arg arg = netimpl->newArg(input_i.name(), mainGraph_ ? DNN_ARG_INPUT : DNN_ARG_TEMP);
         if (!parseValueInfo(input_i, netimpl->args.at(arg.idx))) {
             raiseError();
             return Ptr<Graph>();
@@ -757,7 +757,7 @@ Ptr<Graph> ONNXImporter2::parseGraph(opencv_onnx::GraphProto* graph_proto, bool 
     int n_outputs = graph_proto->output_size();
     for (int i = 0; i < n_outputs; i++) {
         const opencv_onnx::ValueInfoProto& output_i = graph_proto->output(i);
-        Arg arg = net.newArg(output_i.name(), mainGraph_ ? DNN_ARG_OUTPUT : DNN_ARG_TEMP);
+        Arg arg = netimpl->newArg(output_i.name(), mainGraph_ ? DNN_ARG_OUTPUT : DNN_ARG_TEMP);
         if (!parseValueInfo(output_i, netimpl->args.at(arg.idx))) {
            raiseError();
            return Ptr<Graph>();

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1,0 +1,4085 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2018, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#include "../precomp.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
+
+#include <opencv2/dnn/layer_reg.private.hpp>
+
+#include <opencv2/core/utils/fp_control_utils.hpp>
+
+#include <opencv2/core/utils/logger.defines.hpp>
+#undef CV_LOG_STRIP_LEVEL
+#define CV_LOG_STRIP_LEVEL CV_LOG_LEVEL_VERBOSE + 1
+#include <opencv2/core/utils/logger.hpp>
+
+#include <opencv2/core/utils/configuration.private.hpp>
+
+
+#ifdef HAVE_PROTOBUF
+
+#include <array>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <limits>
+#include <algorithm>
+
+#if defined _MSC_VER && _MSC_VER < 1910/*MSVS 2017*/
+#pragma warning(push)
+#pragma warning(disable: 4503)  // decorated name length exceeded, name was truncated
+#endif
+
+#if defined(__GNUC__) && __GNUC__ >= 5
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
+#include "opencv-onnx.pb.h"
+#if defined(__GNUC__) && __GNUC__ >= 5
+#pragma GCC diagnostic pop
+#endif
+
+#include "onnx_graph_simplifier.hpp"
+#endif
+
+namespace cv {
+namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+extern bool DNN_DIAGNOSTICS_RUN;
+
+#ifdef HAVE_PROTOBUF
+class ONNXLayerHandler2;
+
+template <typename T>
+static T getScalarFromMat(Mat m)
+{
+    CV_Assert(m.total() == 1);
+    return m.at<T>(0);
+}
+
+class ONNXImporter2
+{
+    FPDenormalsIgnoreHintScope fp_denormals_ignore_scope;
+
+    opencv_onnx::ModelProto model_proto;
+    struct LayerInfo {
+        int layerId;
+        int outputId;
+        int depth;
+        LayerInfo(int _layerId = 0, int _outputId = 0, int _depth = CV_32F)
+            :layerId(_layerId), outputId(_outputId), depth(_depth) {}
+    };
+
+    struct TensorInfo {
+        int real_ndims;
+        TensorInfo(int _real_ndims = 0) : real_ndims(_real_ndims) {}
+    };
+
+    std::map<std::string, Mat> getGraphTensors(
+                                    const opencv_onnx::GraphProto& graph_proto);
+    Mat getBlob(const opencv_onnx::NodeProto& node_proto, int index);
+    Mat getBlob(const std::string& input_name);
+    Mat getIntBlob(const opencv_onnx::NodeProto& node_proto, int index);
+    TensorInfo getBlobExtraInfo(const opencv_onnx::NodeProto& node_proto, int index);
+    TensorInfo getBlobExtraInfo(const std::string& input_name);
+
+    LayerParams getLayerParams(const opencv_onnx::NodeProto& node_proto);
+
+    void addConstant(const std::string& name, const Mat& blob);
+    void addLayer(LayerParams& layerParams,
+                  const opencv_onnx::NodeProto& node_proto,
+                  int num_inputs = std::numeric_limits<int>::max());
+    void setParamsDtype(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+
+    void lstm_extractConsts(LayerParams& layerParams, const opencv_onnx::NodeProto& lstm_proto, size_t idx, int* blobShape_, int size);
+    void lstm_add_reshape(const std::string& input_name, const std::string& output_name, int* layerShape, size_t n);
+    std::string lstm_add_slice(int index, const std::string& input_name, int* begin, int* end, size_t n);
+    std::string lstm_fix_dims(LayerParams& layerParams, const opencv_onnx::NodeProto& lstm_proto,
+                              int batch_size, int num_directions, int hidden_size, bool need_y, const std::string& y_name,
+                              const int index);
+    void lstm_add_transform(int num_directions, int batch_size, int hidden_size,
+                            int index, const std::string& input_name, const std::string& output_name);
+public:
+    ONNXImporter2(Net& net, const char *onnxFile);
+    ONNXImporter2(Net& net, const char* buffer, size_t sizeBuffer);
+
+    void populateNet();
+
+protected:
+    std::unique_ptr<ONNXLayerHandler2> layerHandler;
+    Net& dstNet;
+
+    opencv_onnx::GraphProto* graph_proto;
+    std::string framework_name;
+
+    std::map<std::string, Mat> constBlobs;
+    std::map<std::string, TensorInfo> constBlobsExtraInfo;
+
+    std::map<std::string, MatShape> outShapes;  // List of internal blobs shapes.
+    bool hasDynamicShapes;  // Whether the model has inputs with dynamic shapes
+    typedef std::map<std::string, MatShape>::iterator IterShape_t;
+
+    std::map<std::string, LayerInfo> layer_id;
+    typedef std::map<std::string, LayerInfo>::iterator IterLayerId_t;
+    typedef std::map<std::string, LayerInfo>::const_iterator ConstIterLayerId_t;
+
+    void handleNode(const opencv_onnx::NodeProto& node_proto);
+
+private:
+    friend class ONNXLayerHandler2;
+    typedef void (ONNXImporter2::*ONNXImporterNodeParser)(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    typedef std::map<std::string, ONNXImporterNodeParser> DispatchMap;
+    typedef std::map<std::string, DispatchMap> DomainDispatchMap;
+
+    DomainDispatchMap domain_dispatch_map;
+    std::string getLayerTypeDomain(const opencv_onnx::NodeProto& node_proto);
+    const DispatchMap& getDispatchMap(const opencv_onnx::NodeProto& node_proto);
+    void buildDispatchMap_ONNX_AI(int opset_version);
+    void buildDispatchMap_COM_MICROSOFT(int opset_version);
+
+    // Domain: 'ai.onnx' (default)
+    // URL: https://github.com/onnx/onnx/blob/master/docs/Operators.md
+    void parseArg                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseMaxUnpool            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseMaxPool              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseAveragePool          (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGlobalPool           (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseReduce               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSlice                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSplit                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseNeg                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseConstant             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseLSTM                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGRU                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseImageScaler          (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseClip                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseLeakyRelu            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseRelu                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseElu                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseTanh                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseAbs                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parsePRelu                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseLRN                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseInstanceNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseBatchNormalization   (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGemm                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseMatMul               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseConv                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseConvTranspose        (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseTranspose            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSqueeze              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseFlatten              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseUnsqueeze            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseExpand               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseReshape              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parsePad                  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseShape                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseCast                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseConstantFill         (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGather               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGatherElements       (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseConcat               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseResize               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseUpsample             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSoftMax              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseDetectionOutput      (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseCumSum               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseElementWise          (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseDepthSpaceOps        (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseRange                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseScatter              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseTile                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseLayerNorm            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSimpleLayers         (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseEinsum               (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+
+    // Domain: com.microsoft
+    // URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
+    void parseQuantDequant         (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQConv                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQMatMul              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQEltwise             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQLeakyRelu           (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQSigmoid             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQAvgPool             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQConcat              (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQGemm                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseQSoftmax             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseAttention            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+
+    // '???' domain or '???' layer type
+    void parseCustomLayer          (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+
+    int onnx_opset;  // OperatorSetIdProto for 'onnx' domain
+    std::map<std::string, int> onnx_opset_map;  // map from OperatorSetIdProto
+    void parseOperatorSet();
+
+    const std::string str_domain_ai_onnx = "ai.onnx";
+
+
+    bool useLegacyNames;
+    bool getParamUseLegacyNames()
+    {
+        bool param = utils::getConfigurationParameterBool("OPENCV_DNN_ONNX_USE_LEGACY_NAMES", false);
+        return param;
+    }
+    std::string extractNodeName(const opencv_onnx::NodeProto& node_proto);
+};
+
+
+class ONNXLayerHandler2 : public detail::LayerHandler
+{
+public:
+    explicit ONNXLayerHandler2(ONNXImporter2* importer_);
+
+    void fillRegistry(const opencv_onnx::GraphProto& net);
+
+protected:
+    ONNXImporter2* importer;
+};
+
+ONNXLayerHandler2::ONNXLayerHandler2(ONNXImporter2* importer_) : importer(importer_){}
+
+void ONNXLayerHandler2::fillRegistry(const opencv_onnx::GraphProto &net)
+{
+    int layersSize = net.node_size();
+    for (int li = 0; li < layersSize; li++) {
+        const opencv_onnx::NodeProto &node_proto = net.node(li);
+        const std::string& name = node_proto.output(0);
+        const std::string& type = node_proto.op_type();
+        const std::string& layer_type_domain = importer->getLayerTypeDomain(node_proto);
+        const auto& dispatch = importer->getDispatchMap(node_proto);
+        if (dispatch.find(type) == dispatch.end())
+        {
+            addMissing(name, cv::format("%s.%s", layer_type_domain.c_str(), type.c_str()));
+        }
+    }
+    printMissing();
+}
+
+ONNXImporter2::ONNXImporter2(Net& net, const char *onnxFile)
+    : layerHandler(DNN_DIAGNOSTICS_RUN ? new ONNXLayerHandler2(this) : nullptr)
+    , dstNet(net)
+    , onnx_opset(0)
+    , useLegacyNames(getParamUseLegacyNames())
+{
+    hasDynamicShapes = false;
+    CV_Assert(onnxFile);
+    CV_LOG_DEBUG(NULL, "DNN/ONNX: processing ONNX model from file: " << onnxFile);
+
+    std::fstream input(onnxFile, std::ios::in | std::ios::binary);
+    if (!input)
+    {
+        CV_Error(Error::StsBadArg, cv::format("Can't read ONNX file: %s", onnxFile));
+    }
+
+    if (!model_proto.ParseFromIstream(&input))
+    {
+        CV_Error(Error::StsUnsupportedFormat, cv::format("Failed to parse ONNX model: %s", onnxFile));
+    }
+
+    populateNet();
+}
+
+ONNXImporter2::ONNXImporter2(Net& net, const char* buffer, size_t sizeBuffer)
+    : layerHandler(DNN_DIAGNOSTICS_RUN ? new ONNXLayerHandler2(this) : nullptr)
+    , dstNet(net)
+    , onnx_opset(0)
+    , useLegacyNames(getParamUseLegacyNames())
+{
+    hasDynamicShapes = false;
+    CV_LOG_DEBUG(NULL, "DNN/ONNX: processing in-memory ONNX model (" << sizeBuffer << " bytes)");
+
+    struct _Buf : public std::streambuf
+            {
+        _Buf(const char* buffer, size_t sizeBuffer)
+        {
+            char* p = const_cast<char*>(buffer);
+            setg(p, p, p + sizeBuffer);
+        }
+            };
+
+    _Buf buf(buffer, sizeBuffer);
+    std::istream input(&buf);
+
+    if (!model_proto.ParseFromIstream(&input))
+        CV_Error(Error::StsUnsupportedFormat, "Failed to parse onnx model from in-memory byte array.");
+
+    populateNet();
+}
+
+
+inline void replaceLayerParam(LayerParams& layerParams, const String& oldKey, const String& newKey)
+{
+    if (layerParams.has(oldKey)) {
+        layerParams.set(newKey, layerParams.get(oldKey));
+        layerParams.erase(oldKey);
+    }
+}
+
+static
+void dumpValueInfoProto(int i, const opencv_onnx::ValueInfoProto& valueInfoProto, const std::string& prefix)
+{
+    CV_Assert(valueInfoProto.has_name());
+    CV_Assert(valueInfoProto.has_type());
+    const opencv_onnx::TypeProto& typeProto = valueInfoProto.type();
+    CV_Assert(typeProto.has_tensor_type());
+    const opencv_onnx::TypeProto::Tensor& tensor = typeProto.tensor_type();
+    CV_Assert(tensor.has_shape());
+    const opencv_onnx::TensorShapeProto& tensorShape = tensor.shape();
+
+    int dim_size = tensorShape.dim_size();
+    CV_CheckGE(dim_size, 0, "");
+    MatShape shape(dim_size);
+    for (int j = 0; j < dim_size; ++j)
+    {
+        const opencv_onnx::TensorShapeProto_Dimension& dimension = tensorShape.dim(j);
+        if (dimension.has_dim_param())
+        {
+            CV_LOG_DEBUG(NULL, "DNN/ONNX: " << prefix << "[" << i << "] dim[" << j << "] = <" << dimension.dim_param() << "> (dynamic)");
+        }
+        // https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+        if (dimension.has_denotation())
+        {
+            CV_LOG_INFO(NULL, "DNN/ONNX: " << prefix << "[" << i << "] dim[" << j << "] denotation is '" << dimension.denotation() << "'");
+        }
+        shape[j] = dimension.dim_value();
+    }
+    CV_LOG_DEBUG(NULL, "DNN/ONNX: " << prefix << "[" << i << " as '" << valueInfoProto.name() << "'] shape=" << toString(shape));
+}
+
+static
+void dumpTensorProto(int i, const opencv_onnx::TensorProto& tensorProto, const std::string& prefix)
+{
+    if (utils::logging::getLogLevel() < utils::logging::LOG_LEVEL_VERBOSE)
+        return;
+    int dim_size = tensorProto.dims_size();
+    CV_CheckGE(dim_size, 0, "");
+    MatShape shape(dim_size);
+    for (int j = 0; j < dim_size; ++j)
+    {
+        int sz = static_cast<int>(tensorProto.dims(j));
+        shape[j] = sz;
+    }
+    CV_LOG_VERBOSE(NULL, 0, "DNN/ONNX: " << prefix << "[" << i << " as '" << tensorProto.name() << "'] shape=" << toString(shape) << " data_type=" << (int)tensorProto.data_type());
+}
+
+static void releaseONNXTensor(opencv_onnx::TensorProto& tensor_proto)
+{
+    if (!tensor_proto.raw_data().empty()) {
+        delete tensor_proto.release_raw_data();
+    }
+}
+
+static void runLayer(LayerParams& params, const std::vector<Mat>& inputs,
+              std::vector<Mat>& outputs)
+{
+    Ptr<Layer> layer = LayerFactory::createLayerInstance(params.type, params);
+    CV_Assert((bool)layer);
+
+    std::vector<MatShape> inpShapes(inputs.size());
+    std::vector<MatType> inpTypes(inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i)
+    {
+        inpShapes[i] = shape(inputs[i]);
+        inpTypes[i] = inputs[i].type();
+    }
+
+    std::vector<MatShape> outShapes, internalShapes;
+    std::vector<MatType> outTypes, internalTypes;
+    layer->getMemoryShapes(inpShapes, 0, outShapes, internalShapes);
+    layer->getTypes(inpTypes, outShapes.size(), internalShapes.size(), outTypes, internalTypes);
+
+    std::vector<Mat> internals(internalShapes.size());
+    outputs.resize(outShapes.size());
+    for (size_t i = 0; i < outShapes.size(); ++i)
+        outputs[i].create(outShapes[i], outTypes[i]);
+    for (size_t i = 0; i < internalShapes.size(); ++i)
+        internals[i].create(internalShapes[i], internalTypes[i]);
+
+    layer->finalize(inputs, outputs);
+    layer->forward(inputs, outputs, internals);
+}
+
+std::map<std::string, Mat> ONNXImporter2::getGraphTensors(
+                                        const opencv_onnx::GraphProto& graph_proto)
+{
+    std::map<std::string, Mat> layers_weights;
+
+    for (int i = 0; i < graph_proto.initializer_size(); i++)
+    {
+        const opencv_onnx::TensorProto& tensor_proto = graph_proto.initializer(i);
+        dumpTensorProto(i, tensor_proto, "initializer");
+        Mat mat = getMatFromTensor(tensor_proto);
+        releaseONNXTensor(const_cast<opencv_onnx::TensorProto&>(tensor_proto));  // drop already loaded data
+
+        if (DNN_DIAGNOSTICS_RUN && mat.empty())
+            continue;
+
+        layers_weights.insert(std::make_pair(tensor_proto.name(), mat));
+        constBlobsExtraInfo.insert(std::make_pair(tensor_proto.name(), TensorInfo(tensor_proto.dims_size())));
+    }
+    return layers_weights;
+}
+
+static DictValue parse(const ::google::protobuf::RepeatedField< ::google::protobuf::int64>& src) {
+    std::vector<int32_t> dst(src.size());
+    convertInt64ToInt32(src, dst, src.size());
+    return DictValue::arrayInt(&dst[0], src.size());
+}
+
+static DictValue parseStr(const ::google::protobuf::RepeatedPtrField< ::std::string>& src) {
+    return DictValue::arrayString(src.begin(), static_cast<int>(src.size()));
+}
+
+LayerParams ONNXImporter2::getLayerParams(const opencv_onnx::NodeProto& node_proto)
+{
+    LayerParams lp;
+    for(int i = 0; i < node_proto.attribute_size(); i++)
+    {
+        opencv_onnx::AttributeProto attribute_proto = node_proto.attribute(i);
+        std::string attribute_name = attribute_proto.name();
+
+        try
+        {
+            if(attribute_name == "kernel_shape")
+            {
+                CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+                lp.set("kernel_size", parse(attribute_proto.ints()));
+            }
+            else if(attribute_name == "strides")
+            {
+                CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+                lp.set("stride", parse(attribute_proto.ints()));
+            }
+            else if(attribute_name == "pads")
+            {
+                if (node_proto.op_type() == "Pad")
+                {
+                    // Padding layer.
+                    // Paddings are in order begin0, begin1, .. beginN, end0, end1, ..., endN.
+                    // We need to shuffle it to begin0, end0, begin1, end1, ...
+                    CV_Assert(attribute_proto.ints_size() % 2 == 0);
+                    const int dims = attribute_proto.ints_size() / 2;
+                    std::vector<int32_t> paddings;
+                    paddings.reserve(attribute_proto.ints_size());
+                    for (int i = 0; i < dims; ++i)
+                    {
+                        paddings.push_back(attribute_proto.ints(i));
+                        paddings.push_back(attribute_proto.ints(dims + i));
+                    }
+                    lp.set("paddings", DictValue::arrayInt(&paddings[0], paddings.size()));
+                }
+                else
+                {
+                    // Convolution or pooling.
+                    CV_Assert(attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 4 || attribute_proto.ints_size() == 6);
+                    lp.set("pad", parse(attribute_proto.ints()));
+                }
+            }
+            else if(attribute_name == "auto_pad")
+            {
+                if (attribute_proto.s() == "SAME_UPPER" || attribute_proto.s() == "SAME_LOWER") {
+                    lp.set("pad_mode",  "SAME");
+                }
+                else if (attribute_proto.s() == "VALID") {
+                    lp.set("pad_mode", "VALID");
+                }
+            }
+            else if(attribute_name == "dilations")
+            {
+                CV_Assert(attribute_proto.ints_size() == 1 || attribute_proto.ints_size() == 2 || attribute_proto.ints_size() == 3);
+                lp.set("dilation", parse(attribute_proto.ints()));
+            }
+            else if(attribute_name == "activations" && node_proto.op_type() == "LSTM")
+            {
+                lp.set(attribute_name, parseStr(attribute_proto.strings()));
+            }
+            else if (attribute_proto.has_i())
+            {
+                ::google::protobuf::int64 src = attribute_proto.i();
+                if (src < std::numeric_limits<int32_t>::min() || src > std::numeric_limits<int32_t>::max())
+                    CV_Error(Error::StsOutOfRange, "Input is out of OpenCV 32S range");
+                else
+                    lp.set(attribute_name, saturate_cast<int32_t>(src));
+            }
+            else if (attribute_proto.has_f())
+            {
+                lp.set(attribute_name, attribute_proto.f());
+            }
+            else if (attribute_proto.has_s())
+            {
+                lp.set(attribute_name, attribute_proto.s());
+            }
+            else if (attribute_proto.floats_size() > 0)
+            {
+                lp.set(attribute_name, DictValue::arrayReal(
+                    attribute_proto.floats().data(), attribute_proto.floats_size()));
+            }
+            else if (attribute_proto.ints_size() > 0)
+            {
+                lp.set(attribute_name, parse(attribute_proto.ints()));
+            }
+            else if (attribute_proto.has_t())
+            {
+                opencv_onnx::TensorProto tensor = attribute_proto.t();
+                Mat blob = getMatFromTensor(tensor);
+                lp.blobs.push_back(blob);
+                lp.set("original_dims_of_mat", tensor.dims_size());
+            }
+            else if (attribute_proto.has_g())
+            {
+                CV_Error(Error::StsNotImplemented, cv::format("DNN/ONNX/Attribute[%s]: 'Graph' is not supported", attribute_name.c_str()));
+            }
+            else if (attribute_proto.graphs_size() > 0)
+            {
+                CV_Error(Error::StsNotImplemented,
+                        cv::format("DNN/ONNX/Attribute[%s]: 'Graphs' (%d) in attributes is not supported",
+                                attribute_name.c_str(), attribute_proto.graphs_size())
+                );
+            }
+            else if (attribute_proto.strings_size() > 0)
+            {
+                std::string msg = cv::format("DNN/ONNX/Attribute[%s]: 'Strings' (%d) are not supported",
+                        attribute_name.c_str(), attribute_proto.strings_size());
+                CV_LOG_ERROR(NULL, msg);
+                for (int i = 0; i < attribute_proto.strings_size(); i++)
+                {
+                    CV_LOG_ERROR(NULL, "    Attribute[" << attribute_name << "].string(" << i << ") = '" << attribute_proto.strings(i) << "'");
+                }
+                CV_Error(Error::StsNotImplemented, msg);
+            }
+            else if (attribute_proto.tensors_size() > 0)
+            {
+                CV_Error(Error::StsNotImplemented,
+                        cv::format("DNN/ONNX/Attribute[%s]: 'Tensors' (%d) in attributes are not supported",
+                                attribute_name.c_str(), attribute_proto.tensors_size())
+                );
+            }
+            else
+            {
+                CV_Error(Error::StsNotImplemented, cv::format("DNN/ONNX/Attribute[%s]: unsupported attribute format", attribute_name.c_str()));
+            }
+        }
+        catch (const cv::Exception& e)
+        {
+            CV_UNUSED(e);
+            if (DNN_DIAGNOSTICS_RUN)
+            {
+                CV_LOG_ERROR(NULL, "DNN/ONNX: Potential problem with processing attributes for node " << node_proto.name() << " Attribute " << attribute_name.c_str()
+                );
+                continue;
+            }
+            throw;
+        }
+    }
+    return lp;
+}
+
+Mat ONNXImporter2::getBlob(const opencv_onnx::NodeProto& node_proto, int index)
+{
+    CV_Assert(index < node_proto.input_size());
+    const std::string& input_name = node_proto.input(index);
+    return getBlob(input_name);
+}
+
+Mat ONNXImporter2::getBlob(const std::string& input_name)
+{
+    std::map<std::string, Mat>::const_iterator constBlob = constBlobs.find(input_name);
+    if (constBlob == constBlobs.end())
+    {
+        CV_Error(Error::StsBadArg, std::string("Blob ") + input_name + " not found in const blobs");
+    }
+    return constBlob->second;
+}
+
+Mat ONNXImporter2::getIntBlob(const opencv_onnx::NodeProto& node_proto, int index)
+{
+    Mat blob = getBlob(node_proto, index);
+    if (blob.depth() == CV_32S)
+        return blob;
+    if (blob.depth() == CV_64S) {
+        Mat blobInt32;
+        blob.convertTo(blobInt32, CV_32S);
+        return blobInt32;
+    }
+    CV_Error(Error::BadDepth, "blob should have integer type");
+    return Mat();
+}
+
+ONNXImporter2::TensorInfo ONNXImporter2::getBlobExtraInfo(const opencv_onnx::NodeProto &node_proto, int index)
+{
+    CV_Assert(index < node_proto.input_size());
+    const std::string& input_name = node_proto.input(index);
+    return getBlobExtraInfo(input_name);
+}
+
+ONNXImporter2::TensorInfo ONNXImporter2::getBlobExtraInfo(const std::string& input_name)
+{
+    std::map<std::string, TensorInfo>::const_iterator constBlobExtraInfo = constBlobsExtraInfo.find(input_name);
+    if (constBlobExtraInfo == constBlobsExtraInfo.end())
+    {
+        CV_Error(Error::StsBadArg, std::string("Blob ") + input_name + " not found in const blobs of extra info");
+    }
+    return constBlobExtraInfo->second;
+}
+
+void ONNXImporter2::addLayer(LayerParams& layerParams,
+                            const opencv_onnx::NodeProto& node_proto,
+                            int num_inputs)
+{
+    int depth = layerParams.get<int>("depth", CV_32F);
+    int id = dstNet.addLayer(layerParams.name, layerParams.type, depth, layerParams);
+    for (int i = 0; i < node_proto.output_size(); ++i)
+    {
+        const std::string& output_name = node_proto.output(i);
+        if (!output_name.empty())
+        {
+            layer_id.insert(std::make_pair(output_name, LayerInfo(id, i, depth)));
+        }
+    }
+
+    std::vector<MatShape> layerInpShapes, layerOutShapes, layerInternalShapes;
+    int inpNum = 0;
+    num_inputs = std::min(node_proto.input_size(), num_inputs);
+    for (int j = 0; j < num_inputs; j++)
+    {
+        const std::string& input_name = node_proto.input(j);
+        IterLayerId_t layerId = layer_id.find(input_name);
+        if (layerId != layer_id.end()) {
+            dstNet.connect(layerId->second.layerId, layerId->second.outputId, id, inpNum);
+            ++inpNum;
+            // Collect input shapes.
+            IterShape_t shapeIt = outShapes.find(input_name);
+            CV_Assert(shapeIt != outShapes.end());
+            layerInpShapes.push_back(shapeIt->second);
+        }
+    }
+    // Compute shape of output blob for this layer.
+    Ptr<Layer> layer = dstNet.getLayer(id);  // FIXIT: avoid instantiation of layers during the import stage
+    layer->getMemoryShapes(layerInpShapes, 0, layerOutShapes, layerInternalShapes);
+    for (int i = 0; i < node_proto.output_size() && i < (int)layerOutShapes.size(); ++i)
+    {
+        const std::string& output_name = node_proto.output(i);
+        if (!output_name.empty())
+        {
+            outShapes[node_proto.output(i)] = layerOutShapes[i];
+        }
+    }
+}
+
+void ONNXImporter2::addConstant(const std::string& name, const Mat& blob)
+{
+    CV_LOG_DEBUG(NULL, "DNN/ONNX: add constant '" << name << "' shape=" << toString(shape(blob)) << ": " << toString(blob));
+    constBlobs.insert(std::make_pair(name, blob));
+    outShapes.insert(std::make_pair(name, shape(blob)));
+}
+
+void ONNXImporter2::parseOperatorSet()
+{
+    int ir_version = model_proto.has_ir_version() ? static_cast<int>(model_proto.ir_version()) : -1;
+    if (ir_version < 3)
+        return;
+
+    int opset_size = model_proto.opset_import_size();
+    if (opset_size <= 0)
+    {
+        CV_LOG_INFO(NULL, "DNN/ONNX: missing opset information")
+        return;
+    }
+
+    for (int i = 0; i < opset_size; ++i)
+    {
+        const ::opencv_onnx::OperatorSetIdProto& opset_entry = model_proto.opset_import(i);
+        const std::string& domain = opset_entry.has_domain() ? opset_entry.domain() : std::string();
+        int version = opset_entry.has_version() ? opset_entry.version() : -1;
+        if (domain.empty() || domain == str_domain_ai_onnx)
+        {
+            // ONNX opset covered by specification: https://github.com/onnx/onnx/blob/master/docs/Operators.md
+            onnx_opset = std::max(onnx_opset, version);
+            onnx_opset_map[str_domain_ai_onnx] = onnx_opset;
+        }
+        else
+        {
+            CV_LOG_DEBUG(NULL, "DNN/ONNX: using non-standard ONNX opset[" << i << "]: domain='" << domain << "' version=" << version);
+            onnx_opset_map[domain] = onnx_opset;
+        }
+    }
+
+    CV_LOG_INFO(NULL, "DNN/ONNX: ONNX opset version = " << onnx_opset);
+
+    buildDispatchMap_ONNX_AI(onnx_opset);
+    for (const auto& pair : onnx_opset_map)
+    {
+        if (pair.first == str_domain_ai_onnx)
+        {
+            continue;  // done above
+        }
+        else if (pair.first == "com.microsoft")
+        {
+            buildDispatchMap_COM_MICROSOFT(pair.second);
+        }
+        else
+        {
+            CV_LOG_INFO(NULL, "DNN/ONNX: unknown domain='" << pair.first << "' version=" << pair.second << ". No dispatch map, you may need to register 'custom' layers.");
+        }
+    }
+}
+
+static bool ifInt8Output(const String& layerType)
+{
+    // Contains all node types whose output should be int8 when it get int8 input.
+    // ai.onnx opset 15
+    static std::vector<String> input8output8List = {
+            "QuantizeLinear",
+            "QLinearAdd",
+            "QLinearMul",
+            "QLinearAveragePool",
+            "QLinearGlobalAveragePool",
+            "QLinearLeakyRelu",
+            "QLinearSigmoid",
+            "QLinearConcat",
+            "QGemm",
+            "QLinearSoftmax",
+            "QLinearConv",
+            "QLinearMatMul",
+            "MaxPool",
+            "ReduceMax",
+            "ReduceMin",
+            "Split",
+            "Clip",
+            "Abs",
+            "Transpose",
+            "Squeeze",
+            "Flatten",
+            "Unsqueeze",
+            "Expand",
+            "Reshape",
+            "Pad",
+            "Gather",
+            "Concat",
+            "Resize",
+            "SpaceToDepth",
+            "DepthToSpace",
+            "Pow",
+            "Add",
+            "Sub",
+            "Mul",
+            "Div"
+    };
+    auto layerIt = std::find(input8output8List.begin(), input8output8List.end(), layerType);
+    return layerIt != input8output8List.end();
+}
+
+void ONNXImporter2::setParamsDtype(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    // If the current layer should output the same data type as the input, and it's input type is int8, we think the current
+    // layer should also output int8.
+
+    // Check if the layer has int8 input.
+    const std::string& layer_type = node_proto.op_type();
+    for (int i = 0; i < node_proto.input_size(); ++i)
+    {
+        if (layer_id.find(node_proto.input(i)) != layer_id.end())
+        {
+            LayerInfo layerInfo = layer_id.find(node_proto.input(i))->second;
+
+            if (layerInfo.depth == CV_8S && ifInt8Output(layer_type))
+            {
+                layerParams.set("depth", CV_8S);
+                return;
+            }
+        }
+    }
+    layerParams.set("depth", CV_32F);
+}
+
+void ONNXImporter2::populateNet()
+{
+    CV_Assert(model_proto.has_graph());
+    graph_proto = model_proto.mutable_graph();
+
+    std::string framework_version;
+    if (model_proto.has_producer_name())
+        framework_name = model_proto.producer_name();
+    if (model_proto.has_producer_version())
+        framework_version = model_proto.producer_version();
+
+    CV_LOG_INFO(NULL, "DNN/ONNX: loading ONNX"
+            << (model_proto.has_ir_version() ? cv::format(" v%d", (int)model_proto.ir_version()) : cv::String())
+            << " model produced by '" << framework_name << "'"
+            << (framework_version.empty() ? cv::String() : cv::format(":%s", framework_version.c_str()))
+            << ". Number of nodes = " << graph_proto->node_size()
+            << ", initializers = " << graph_proto->initializer_size()
+            << ", inputs = " << graph_proto->input_size()
+            << ", outputs = " << graph_proto->output_size()
+            );
+
+    parseOperatorSet();
+
+    simplifySubgraphs(*graph_proto);
+
+    const int layersSize = graph_proto->node_size();
+    CV_LOG_DEBUG(NULL, "DNN/ONNX: graph simplified to " << layersSize << " nodes");
+
+    constBlobs = getGraphTensors(*graph_proto);  // scan GraphProto.initializer
+    std::vector<String> netInputs;  // map with network inputs (without const blobs)
+    // Add all the inputs shapes. It includes as constant blobs as network's inputs shapes.
+    for (int i = 0; i < graph_proto->input_size(); ++i)
+    {
+        const opencv_onnx::ValueInfoProto& valueInfoProto = graph_proto->input(i);
+        CV_Assert(valueInfoProto.has_name());
+        const std::string& name = valueInfoProto.name();
+        CV_Assert(valueInfoProto.has_type());
+        const opencv_onnx::TypeProto& typeProto = valueInfoProto.type();
+        CV_Assert(typeProto.has_tensor_type());
+        const opencv_onnx::TypeProto::Tensor& tensor = typeProto.tensor_type();
+        CV_Assert(tensor.has_shape());
+        const opencv_onnx::TensorShapeProto& tensorShape = tensor.shape();
+
+        int dim_size = tensorShape.dim_size();
+        CV_CheckGE(dim_size, 0, "");  // some inputs are scalars (dims=0), e.g. in Test_ONNX_nets.Resnet34_kinetics test
+        MatShape inpShape(dim_size);
+        for (int j = 0; j < dim_size; ++j)
+        {
+            const opencv_onnx::TensorShapeProto_Dimension& dimension = tensorShape.dim(j);
+            if (dimension.has_dim_param())
+            {
+                CV_LOG_DEBUG(NULL, "DNN/ONNX: input[" << i << "] dim[" << j << "] = <" << dimension.dim_param() << "> (dynamic)");
+            }
+            // https://github.com/onnx/onnx/blob/master/docs/DimensionDenotation.md#denotation-definition
+            if (dimension.has_denotation())
+            {
+                CV_LOG_INFO(NULL, "DNN/ONNX: input[" << i << "] dim[" << j << "] denotation is '" << dimension.denotation() << "'");
+            }
+            inpShape[j] = dimension.dim_value();
+            // NHW, NCHW(NHWC), NCDHW(NDHWC); do not set this flag if only N is dynamic
+            if (dimension.has_dim_param() && !(j == 0 && inpShape.size() >= 3))
+            {
+                hasDynamicShapes = true;
+            }
+        }
+        bool isInitialized = ((constBlobs.find(name) != constBlobs.end()));
+        CV_LOG_IF_DEBUG(NULL, !isInitialized, "DNN/ONNX: input[" << i << " as '" << name << "'] shape=" << toString(inpShape));
+        CV_LOG_IF_VERBOSE(NULL, 0, isInitialized, "DNN/ONNX: pre-initialized input[" << i << " as '" << name << "'] shape=" << toString(inpShape));
+        if (dim_size > 0 && !hasDynamicShapes)  // FIXIT result is not reliable for models with multiple inputs
+        {
+            inpShape[0] = std::max(inpShape[0], 1); // It's OK to have undetermined batch size
+        }
+        outShapes[valueInfoProto.name()] = inpShape;
+        // fill map: push layer name, layer id and output id
+        if (!isInitialized)
+        {
+            netInputs.push_back(name);
+            layer_id.insert(std::make_pair(name, LayerInfo(0, netInputs.size() - 1)));
+        }
+    }
+
+    dstNet.setInputsNames(netInputs);
+    if (!hasDynamicShapes)
+    {
+        for (int i = 0; i < netInputs.size(); ++i)
+            dstNet.setInputShape(netInputs[i], outShapes[netInputs[i]]);
+    }
+
+    // dump outputs
+    for (int i = 0; i < graph_proto->output_size(); ++i)
+    {
+        dumpValueInfoProto(i, graph_proto->output(i), "output");
+    }
+
+    if (DNN_DIAGNOSTICS_RUN) {
+        CV_LOG_INFO(NULL, "DNN/ONNX: start diagnostic run!");
+        layerHandler->fillRegistry(*graph_proto);
+    }
+
+    for(int li = 0; li < layersSize; li++)
+    {
+        const opencv_onnx::NodeProto& node_proto = graph_proto->node(li);
+        handleNode(node_proto);
+    }
+
+    // register outputs
+    for (int i = 0; i < graph_proto->output_size(); ++i)
+    {
+        const std::string& output_name = graph_proto->output(i).name();
+        if (output_name.empty())
+        {
+            CV_LOG_ERROR(NULL, "DNN/ONNX: can't register output without name: " << i);
+            continue;
+        }
+        ConstIterLayerId_t layerIt = layer_id.find(output_name);
+        if (layerIt == layer_id.end())
+        {
+            CV_LOG_ERROR(NULL, "DNN/ONNX: can't find layer for output name: '" << output_name << "'. Does model imported properly?");
+            continue;
+        }
+
+        const LayerInfo& li = layerIt->second;
+        int outputId = dstNet.registerOutput(output_name, li.layerId, li.outputId); CV_UNUSED(outputId);
+        // no need to duplicate message from engine: CV_LOG_DEBUG(NULL, "DNN/ONNX: registered output='" << output_name << "' with id=" << outputId);
+    }
+
+    CV_LOG_DEBUG(NULL, (DNN_DIAGNOSTICS_RUN ? "DNN/ONNX: diagnostic run completed!" : "DNN/ONNX: import completed!"));
+}
+
+std::string ONNXImporter2::getLayerTypeDomain(const opencv_onnx::NodeProto& node_proto)
+{
+    if (!node_proto.has_domain())
+        return str_domain_ai_onnx;
+    const std::string& domain = node_proto.domain();
+    if (domain.empty())
+        return str_domain_ai_onnx;
+    return domain;
+}
+
+const ONNXImporter2::DispatchMap& ONNXImporter2::getDispatchMap(const opencv_onnx::NodeProto& node_proto)
+{
+    static DispatchMap empty_map;
+    const std::string& layer_type_domain = getLayerTypeDomain(node_proto);
+    auto it = domain_dispatch_map.find(layer_type_domain);
+    if (it == domain_dispatch_map.end())
+    {
+        return empty_map;
+    }
+
+    return it->second;
+}
+
+std::string ONNXImporter2::extractNodeName(const opencv_onnx::NodeProto& node_proto)
+{
+    // We need to rework DNN outputs API, this is a workaround for #21698
+    if (node_proto.has_name() && !node_proto.name().empty())
+    {
+        if (useLegacyNames)
+            return node_proto.name();
+        return cv::format("onnx_node!%s", node_proto.name().c_str());
+    }
+    for (int i = 0; i < node_proto.output_size(); ++i)
+    {
+        const std::string& name = node_proto.output(i);
+        // There are two ways to leave an optional input or output unspecified:
+        // the first, available only for trailing inputs and outputs, is to simply not provide that input;
+        // the second method is to use an empty string in place of an input or output name.
+        if (!name.empty())
+        {
+            if (useLegacyNames)
+                return name.c_str();
+            return cv::format("onnx_node_output_%d!%s", i, name.c_str());
+        }
+    }
+    CV_Error(Error::StsAssert, "Couldn't deduce Node name.");
+}
+
+void ONNXImporter2::handleNode(const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.output_size() >= 1);
+    const std::string& name = extractNodeName(node_proto);
+    const std::string& layer_type = node_proto.op_type();
+    const std::string& layer_type_domain = getLayerTypeDomain(node_proto);
+    const auto& dispatch = getDispatchMap(node_proto);
+
+    CV_LOG_INFO(NULL, "DNN/ONNX: processing node with " << node_proto.input_size() << " inputs and "
+                                                         << node_proto.output_size() << " outputs: "
+                                                         << cv::format("[%s]:(%s)", layer_type.c_str(), name.c_str())
+                                                         << cv::format(" from %sdomain='", onnx_opset_map.count(layer_type_domain) == 1 ? "" : "undeclared ")
+                                                         << layer_type_domain << "'"
+    );
+
+    if (dispatch.empty())
+    {
+        CV_LOG_WARNING(NULL, "DNN/ONNX: missing dispatch map for domain='" << layer_type_domain << "'");
+    }
+
+    LayerParams layerParams;
+    try
+    {
+        // FIXIT not all cases can be repacked into "LayerParams". Importer should handle such cases directly for each "layer_type"
+        layerParams = getLayerParams(node_proto);
+
+        layerParams.name = name;
+        layerParams.type = layer_type;
+        layerParams.set("has_dynamic_shapes", hasDynamicShapes);
+
+        setParamsDtype(layerParams, node_proto);
+
+        DispatchMap::const_iterator iter = dispatch.find(layer_type);
+        if (iter != dispatch.end())
+        {
+            CALL_MEMBER_FN(*this, iter->second)(layerParams, node_proto);
+        }
+        else
+        {
+            parseCustomLayer(layerParams, node_proto);
+        }
+    }
+    catch (const cv::Exception& e)
+    {
+        if (DNN_DIAGNOSTICS_RUN)
+        {
+            CV_LOG_ERROR(NULL, "DNN/ONNX: Potential problem during processing node with " << node_proto.input_size() << " inputs and " << node_proto.output_size() << " outputs: "
+                    << cv::format("[%s]:(%s)", layer_type.c_str(), name.c_str())
+                    << " from domain='" << layer_type_domain << "'"
+                    << "\n" << e.msg
+            );
+            cv::AutoLock lock(getLayerFactoryMutex());
+            auto registeredLayers = getLayerFactoryImpl();
+            if (registeredLayers.find(layerParams.type) != registeredLayers.end())
+            {
+                try
+                {
+                    Ptr<Layer> layer = LayerFactory::createLayerInstance(layerParams.type, layerParams);
+                }
+                catch (const std::exception& e)
+                {
+                    CV_LOG_ERROR(NULL, "DNN/ONNX: Layer of type " << layerParams.type << "(" << layer_type << ") cannot be created with parameters " << layerParams << ". Error: " << e.what()
+                    );
+                }
+            }
+        }
+        else
+        {
+            CV_LOG_ERROR(NULL, "DNN/ONNX: ERROR during processing node with " << node_proto.input_size() << " inputs and " << node_proto.output_size() << " outputs: "
+                    << cv::format("[%s]:(%s)", layer_type.c_str(), name.c_str())
+                    << " from domain='" << layer_type_domain << "'"
+            );
+        }
+        for (int i = 0; i < node_proto.input_size(); i++)
+        {
+            CV_LOG_INFO(NULL, "    Input[" << i << "] = '" << node_proto.input(i) << "'");
+        }
+        for (int i = 0; i < node_proto.output_size(); i++)
+        {
+            CV_LOG_INFO(NULL, "    Output[" << i << "] = '" << node_proto.output(i) << "'");
+        }
+        if (DNN_DIAGNOSTICS_RUN)
+        {
+            for (int i = 0; i < node_proto.output_size(); ++i)
+            {
+                layer_id.insert(std::make_pair(node_proto.output(i), LayerInfo(0, i)));
+                outShapes[node_proto.output(i)] = outShapes[node_proto.input(0)];
+            }
+        }
+        else
+            CV_Error(Error::StsError, cv::format("Node [%s@%s]:(%s) parse error: %s", layer_type.c_str(), layer_type_domain.c_str(), name.c_str(), e.what()));
+    }
+}
+
+void ONNXImporter2::parseArg(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    const std::string& layer_type = node_proto.op_type();
+    layerParams.type = "Arg";
+    layerParams.set("op", layer_type == "ArgMax" ? "max" : "min");
+    addLayer(layerParams, node_proto);
+}
+
+static void setCeilMode(LayerParams& layerParams)
+{
+    // auto_pad attribute is deprecated and uses ceil
+    if (layerParams.has("pad_mode"))
+    {
+        layerParams.set("ceil_mode", true);
+    }
+    else if (!layerParams.has("ceil_mode"))
+    {
+        layerParams.set("ceil_mode", false);
+    }
+}
+
+void ONNXImporter2::parseMaxUnpool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "MaxUnpool";
+
+    DictValue kernel_shape = layerParams.get("kernel_size");
+    CV_Assert(kernel_shape.size() == 2);
+    layerParams.set("pool_k_w", kernel_shape.get<int>(0));
+    layerParams.set("pool_k_h", kernel_shape.get<int>(1));
+
+    int pool_pad_w = 0, pool_pad_h = 0;
+    if (layerParams.has("pad"))
+    {
+        DictValue pads = layerParams.get("pad");
+        CV_CheckEQ(pads.size(), 2, "");
+        pool_pad_w = pads.get<int>(0);
+        pool_pad_h = pads.get<int>(1);
+    }
+    layerParams.set("pool_pad_w", pool_pad_w);
+    layerParams.set("pool_pad_h", pool_pad_h);
+
+
+    int pool_stride_w = 1, pool_stride_h = 1;
+    if (layerParams.has("stride"))
+    {
+        DictValue strides = layerParams.get("stride");
+        CV_CheckEQ(strides.size(), 2, "");
+        pool_stride_w = strides.get<int>(0);
+        pool_stride_h = strides.get<int>(1);
+    }
+    layerParams.set("pool_stride_w", pool_stride_w);
+    layerParams.set("pool_stride_h", pool_stride_h);
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseMaxPool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type = (depth == CV_8S) ? "PoolingInt8" : "Pooling";
+    layerParams.set("pool", "MAX");
+    setCeilMode(layerParams);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseAveragePool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "Pooling";
+    layerParams.set("pool", "AVE");
+    setCeilMode(layerParams);
+    layerParams.set("ave_pool_padded_area", framework_name == "pytorch");
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseGlobalPool(LayerParams &layerParams, const opencv_onnx::NodeProto &node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    const std::string& layer_type = node_proto.op_type();
+    const std::string output_name = node_proto.output(0);
+
+    CV_Assert(node_proto.input_size() == 1);
+    layerParams.type = "Pooling";
+    String pool;
+    if (layer_type == "GlobalMaxPool")
+        pool = "MAX";
+    else if (layer_type == "GlobalAveragePool")
+        pool = "AVE";
+    else
+        CV_Error(Error::StsNotImplemented, "Unsupported Pooling type of " + layer_type + " operation.");
+
+    CV_Assert(!layerParams.has("axes"));
+    layerParams.set("global_pooling", true);
+    layerParams.set("pool", pool);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseReduce(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "Reduce";
+    const auto& op_type = node_proto.op_type();
+    String reduce_type;
+    if (op_type == "ReduceMax")
+        reduce_type = "MAX";
+    else if (op_type == "ReduceMean")
+        reduce_type = "MEAN";
+    else if (op_type == "ReduceMin")
+        reduce_type = "MIN";
+    else if (op_type == "ReduceProd")
+        reduce_type = "PROD";
+    else if (op_type == "ReduceSum")
+        reduce_type = "SUM";
+    else if (op_type == "ReduceL1")
+        reduce_type = "L1";
+    else if (op_type == "ReduceL2")
+        reduce_type = "L2";
+    else if (op_type == "ReduceLogSum")
+        reduce_type = "LOG_SUM";
+    else if (op_type == "ReduceLogSumExp")
+        reduce_type = "LOG_SUM_EXP";
+    else if (op_type == "ReduceSumSquare")
+        reduce_type = "SUM_SQUARE";
+    else
+        CV_Error(Error::StsNotImplemented, "DNN/ONNX: " + op_type + " is not supported.");
+    layerParams.set("reduce", reduce_type);
+
+    int num_inputs = node_proto.input_size();
+    CV_Check(num_inputs, num_inputs >= 1 && num_inputs <= 2, "DNN/ONNX: Reduce layers should have at least one input and at most two inputs");
+
+    if (num_inputs >= 2)
+        CV_CheckTrue(constBlobs.find(node_proto.input(1)) != constBlobs.end(), "Reduce layer doesn't support non contant axes");
+
+    // "axes" is turned to one of the inputs since opset 18,
+    // except for ReduceSum, which has "axes" input since opset 13.
+    if (!layerParams.has("axes") && num_inputs == 2 && constBlobs.find(node_proto.input(1)) != constBlobs.end()) {
+        Mat mat_axes = getIntBlob(node_proto, 1);
+        int num_axes = (int)mat_axes.total();
+        std::vector<int> axes(num_axes);
+        for (int i = 0; i < num_axes; ++i)
+            axes[i] = mat_axes.at<int>(i);
+        layerParams.set("axes", DictValue::arrayInt(&axes[0], num_axes));
+        if (constBlobs.find(node_proto.input(0)) != constBlobs.end()){
+            std::vector<Mat> inputs, output;
+            inputs.push_back(getBlob(node_proto, 0));
+            runLayer(layerParams, inputs, output);
+            CV_Assert(output.size() == 1);
+            addConstant(node_proto.output(0), output[0]);
+            return;
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseSlice(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    MatShape inpShape;
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+        inpShape = shape(getBlob(node_proto, 0));
+    else {
+        inpShape = outShapes[node_proto.input(0)];
+    }
+    int dims = inpShape.size();
+    std::vector<int> begin(dims, 0);
+    std::vector<int> end(dims, INT_MAX);
+    std::vector<int> steps;
+    int inp_size = node_proto.input_size();
+    int axis = 0;
+    bool has_axes = false;
+    DictValue starts_, ends_, axes_, steps_;
+
+    // opset = 1
+    if (inp_size == 1)
+    {
+        starts_ = layerParams.get("starts");
+        ends_ = layerParams.get("ends");
+        CV_Assert(starts_.size() == ends_.size());
+        if (layerParams.has("axes"))
+        {
+            axes_ = layerParams.get("axes");
+            CV_Assert(axes_.size() == starts_.size());
+            axis = axes_.getIntValue(0) < 0 ? axes_.getIntValue(0) + dims : axes_.getIntValue(0);
+            has_axes = true;
+        }
+    }
+    // opset > 1
+    else
+    {
+        CV_Assert(inp_size >= 3);
+        for (int i = 1; i < inp_size; ++i)
+        {
+            CV_Assert(constBlobs.find(node_proto.input(i)) != constBlobs.end());
+        }
+        Mat start_blob = getIntBlob(node_proto, 1);
+        Mat end_blob = getIntBlob(node_proto, 2);
+        CV_Assert(start_blob.total() == end_blob.total());
+        starts_ = DictValue::arrayInt(start_blob.begin<int>(), start_blob.total());
+        ends_ = DictValue::arrayInt(end_blob.begin<int>(), end_blob.total());
+
+        if (inp_size > 3 && !getBlob(node_proto, 3).empty())
+        {
+            Mat axes_blob = getIntBlob(node_proto, 3);
+            CV_Assert(axes_blob.total() == start_blob.total());
+            axes_ = DictValue::arrayInt(axes_blob.begin<int>(), axes_blob.total());
+            axis = axes_.getIntValue(0) < 0 ? axes_.getIntValue(0) + dims : axes_.getIntValue(0);
+            has_axes = true;
+        }
+
+        if (inp_size == 5 && !getBlob(node_proto, 4).empty())
+        {
+            Mat step_blob = getIntBlob(node_proto, 4);
+            CV_Assert(step_blob.total() == start_blob.total());
+            steps_ = DictValue::arrayInt(step_blob.begin<int>(), step_blob.total());
+            steps.resize(dims, 1);
+
+            // Very strange application for Slice op with tensor reversing.
+            // We just workaround it for 2d constants.
+            if (constBlobs.find(node_proto.input(0)) != constBlobs.end() &&
+                axis == 0 &&
+                start_blob.at<int>(0) == -1 && step_blob.at<int>(0) == -1 &&
+                end_blob.at<int>(0) == std::numeric_limits<int32_t>::min())
+            {
+                Mat inp = getBlob(node_proto, 0);
+                if (inp.dims == 2)
+                {
+                    Mat flipped;
+                    flip(inp, flipped, 0);
+                    addConstant(node_proto.output(0), flipped);
+                    return;
+                }
+            }
+        }
+    }
+
+    if (!has_axes)
+    {
+        // make a default axes [0, 1, 2...]
+        Mat axes_tmp(1, starts_.size(), CV_32S);
+        std::iota(axes_tmp.begin<int>(), axes_tmp.end<int>(), 0);
+        axes_ = DictValue::arrayInt(axes_tmp.begin<int>(), axes_tmp.total());
+    }
+
+    int cur_axe;
+    std::vector<bool> flag(dims, false);
+    Mat axes(1, starts_.size(), CV_32S);
+    auto axes_ptr = axes.ptr<int>();
+    // resize begin and end
+    for (int i = 0; i < axes_.size(); ++i)
+    {
+        // dims should be added to the negative axes
+        cur_axe = axes_.getIntValue(i) < 0 ? axes_.getIntValue(i) + dims : axes_.getIntValue(i);
+        CV_CheckGE(cur_axe, 0, "Axes should be grater or equal to '-dims'.");
+        CV_CheckLT(cur_axe, dims, "Axes should be less than 'dim'.");
+        CV_CheckEQ(flag[cur_axe], false, "Axes shouldn't have duplicated values.");
+        flag[cur_axe] = true;
+        // change axis to the minimum axe
+        if (cur_axe < axis) axis = cur_axe;
+        axes_ptr[i] = cur_axe;
+        begin[cur_axe] = starts_.getIntValue(i);
+        end[cur_axe] = ends_.getIntValue(i);
+    }
+
+    layerParams.set("begin", DictValue::arrayInt(&begin[0], begin.size()));
+    layerParams.set("end", DictValue::arrayInt(&end[0], end.size()));
+    layerParams.set("axis", axis);
+
+    if (!steps.empty())
+    {
+        for (int i = 0; i < axes.total(); ++i)
+            steps[axes_ptr[i]] = steps_.getIntValue(i);
+        layerParams.set("steps", DictValue::arrayInt(&steps[0], steps.size()));
+    }
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        Mat inp = getBlob(node_proto, 0);
+        std::vector<Mat> inputs, sliced;
+        inputs.push_back(inp);
+        runLayer(layerParams, inputs, sliced);
+        CV_Assert(sliced.size() == 1);
+        addConstant(node_proto.output(0), sliced[0]);
+        return;
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseSplit(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int axis = layerParams.get<int>("axis", 0);
+    MatShape inpShape = outShapes[node_proto.input(0)];
+    axis = normalize_axis(axis, inpShape.size());
+
+    if (layerParams.has("split"))
+    {
+        DictValue splits = layerParams.get("split");
+        const int numSplits = splits.size();
+
+        if (numSplits == 1)
+        {
+            layerParams.set("num_split", 1);
+        }
+        else
+        {
+            CV_Assert(numSplits >= 1);
+
+            std::vector<int> slicePoints(numSplits - 1, splits.get<int>(0));
+            for (int i = 1; i < splits.size() - 1; ++i)
+            {
+                slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i);
+            }
+            layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
+        }
+    }
+    else if (node_proto.input_size() == 2) // opset >= 13, the split will be stored at the second input, instead of the attribute.
+    {
+        CV_Assert(constBlobs.find(node_proto.input(1)) != constBlobs.end());
+        Mat splitsBlob = getIntBlob(node_proto, 1);
+        int splitSize = splitsBlob.total();
+        if (splitSize == 1)
+        {
+            layerParams.set("num_split", 1);
+        }
+        else
+        {
+            std::vector<int> slicePoints(splitSize - 1, splitsBlob.at<int>(0));
+            for (int i = 1; i < splitSize - 1; ++i)
+            {
+                slicePoints[i] = slicePoints[i - 1] + splitsBlob.at<int>(i);
+            }
+            layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
+        }
+    }
+    else
+    {
+        layerParams.set("num_split", node_proto.output_size());
+    }
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type = (depth == CV_8S) ? "SliceInt8" : "Slice";
+    layerParams.set("axis", axis);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseNeg(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "Power";
+    layerParams.set("scale", -1);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseConstant(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 0);
+    CV_Assert(layerParams.blobs.size() == 1);
+    if (layerParams.has("original_dims_of_mat")) {
+        int original_dims_of_mat = layerParams.get<int>("original_dims_of_mat");
+        if (original_dims_of_mat == 0) {
+            Mat& blob = layerParams.blobs[0];
+            CV_Assert(blob.dims <= 2 && blob.total() == 1);
+            blob = blob.reshape(1, 0, 0);
+        }
+        // add constant for constBlobsExtraInfo
+        constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), TensorInfo(original_dims_of_mat)));
+    }
+    addConstant(node_proto.output(0), layerParams.blobs[0]);
+}
+
+static void transformBlobs(std::vector<Mat>& blobs)
+{
+    Mat Wx = blobs[0];
+    Mat Wh = blobs[1];
+    Mat b = blobs[2];
+    std::vector<Mat> cudaWorkaround;
+    cudaWorkaround.push_back(Wx.clone());
+    cudaWorkaround.push_back(Wh.clone());
+    cudaWorkaround.push_back(b.clone());
+
+    const int numHidden = Wh.size[2];
+
+    Mat h0, c0;
+    // check weather input is dynamic or not: hx, cx are given by user.
+    // Resahpe if only they are given
+    if (!blobs[3].empty()){
+        h0 = blobs[3];
+        h0 = h0.reshape(1, h0.size[0] * h0.size[1]);
+    }
+    if (!blobs[4].empty()){
+        c0 = blobs[4];
+        c0 = c0.reshape(1, c0.size[0] * c0.size[1]);
+    }
+
+    b = b.reshape(1, b.size[0]);
+    Mat bx = b.colRange(0, b.cols / 2);
+    Mat bh = b.colRange(b.cols / 2, b.cols);
+    b = bx + bh;
+
+    auto toIFOC = [] (Mat& in) {
+        int first = in.size[0];
+        int rest = in.total() / first / 4;
+        // every weight blob contains weights for Input, Output, Forget and Cell gates
+        Mat m = in.reshape(1, {first, 4, rest});
+        Mat outputGate = m.col(1);
+        Mat forgetGate = m.col(2);
+        std::swap_ranges(outputGate.begin<float>(), outputGate.end<float>(), forgetGate.begin<float>());
+    };
+
+    toIFOC(Wx);
+    toIFOC(Wh);
+    toIFOC(b);
+
+    Wx = Wx.reshape(1, Wx.size[0] * Wx.size[1]);
+    Wh = Wh.reshape(1, Wh.size[0] * Wh.size[1]);
+
+    blobs[0] = Wh;
+    blobs[1] = Wx;
+    blobs[2] = b.reshape(1, 1);
+
+    if (!blobs[3].empty()){
+        blobs[3] = h0;
+    }
+    if (!blobs[4].empty()){
+        blobs[4] = c0;
+    }
+
+    if (blobs.size() == 5) {
+        // so that future patch removing copies can leave all indexing as is
+        blobs.insert(blobs.begin(), cudaWorkaround.begin(), cudaWorkaround.end());
+        return;
+    }
+
+    Mat P = blobs[5];
+    blobs[5] = P.colRange(0, numHidden);
+    blobs[5] = blobs[5].clone().reshape(1, blobs[5].total());  // Single column.
+    blobs[5] = Mat::diag(blobs[5]);
+
+    blobs.push_back(P.colRange(numHidden, 2 * numHidden));
+    blobs[6] = blobs[6].clone().reshape(1, blobs[6].total());  // Single column.
+    blobs[6] = Mat::diag(blobs[6]);
+
+    blobs.push_back(P.colRange(2 * numHidden, 3 * numHidden));
+    blobs[7] = blobs[7].clone().reshape(1, blobs[7].total());  // Single column.
+    blobs[7] = Mat::diag(blobs[7]);
+
+    // so that future patch removing copies can leave all indexing as is
+    blobs.insert(blobs.begin(), cudaWorkaround.begin(), cudaWorkaround.end());
+}
+
+void ONNXImporter2::lstm_extractConsts(LayerParams& layerParams, const opencv_onnx::NodeProto& lstm_proto, size_t idx, int* blobShape_, int size)
+{
+        MatShape blobShape(blobShape_, blobShape_ + size);
+        Mat blob;
+        if (idx < lstm_proto.input_size() && !lstm_proto.input(idx).empty())
+        {
+            if ((idx == 5 || idx == 6) && (constBlobs.find(lstm_proto.input(idx)) == constBlobs.end()))
+            {
+                blob = Mat();
+            }
+            else
+            {
+                blob = getBlob(lstm_proto, idx);
+                CV_Assert(shape(blob) == blobShape);
+            }
+        }
+        else
+        {
+            blob = Mat(blobShape, CV_32FC1, 0.);
+        }
+        layerParams.blobs.push_back(blob);
+}
+
+void ONNXImporter2::lstm_add_reshape(const std::string& input_name, const std::string& output_name, int* layerShape, size_t n)
+{
+    LayerParams reshapeLp;
+    reshapeLp.name = cv::format("%s/reshape", input_name.c_str());
+    reshapeLp.type = "Reshape";
+    CV_Assert(layer_id.find(reshapeLp.name) == layer_id.end());
+
+    reshapeLp.set("dim", DictValue::arrayInt(layerShape, n));
+
+    opencv_onnx::NodeProto reshape_proto;
+    reshape_proto.add_input(input_name);
+    reshape_proto.add_output(output_name);
+    addLayer(reshapeLp, reshape_proto);
+}
+
+std::string ONNXImporter2::lstm_add_slice(int index, const std::string& input_name, int* begin, int* end, size_t n)
+{
+    LayerParams sliceLP;
+    sliceLP.name = cv::format("%s/slice_%d", input_name.c_str(), index);
+    sliceLP.type = "Slice";
+    CV_Assert(layer_id.find(sliceLP.name) == layer_id.end());
+
+    sliceLP.set("begin", DictValue::arrayInt(begin, n));
+    sliceLP.set("end", DictValue::arrayInt(end, n));
+    sliceLP.set("axis", 0);
+
+    opencv_onnx::NodeProto slice_proto;
+    slice_proto.add_input(input_name);
+    slice_proto.add_output(sliceLP.name);
+    addLayer(sliceLP, slice_proto);
+
+    return slice_proto.output(0);
+}
+
+std::string ONNXImporter2::lstm_fix_dims(LayerParams& layerParams, const opencv_onnx::NodeProto& lstm_proto,
+                                        int batch_size, int num_directions, int hidden_size, bool need_y, const std::string& y_name,
+                                        const int index)
+{
+    std::string reshape_output = cv::format("%s/reshape_%d", layerParams.name.c_str(), index);
+
+    // reshape from Seq, Batch, Dirs*Hidden to Seq, Batch, Dirs, Hidden
+    // to not confuse reshape with dynamic first dimension, zero means 'leave unchanged'
+    int layerShape[] = {0, batch_size, num_directions, hidden_size};
+    lstm_add_reshape(lstm_proto.output(index), reshape_output, layerShape, sizeof(layerShape) / sizeof(layerShape[0]));
+
+    // permute from Seq, Batch, Dirs, Hidden to Seq, Dirs, Batch, Hidden
+    LayerParams permuteLP;
+    permuteLP.name = reshape_output + "/permute";
+    permuteLP.type = "Permute";
+    CV_Assert(layer_id.find(permuteLP.name) == layer_id.end());
+
+    int order[] = {0, 2, 1, 3};
+    permuteLP.set("order", DictValue::arrayInt(order, 4));
+
+    opencv_onnx::NodeProto permute_proto;
+    permute_proto.add_input(reshape_output);
+    permute_proto.add_output((need_y && index == 0) ? y_name : static_cast<std::string>(permuteLP.name));
+    addLayer(permuteLP, permute_proto);
+
+    return permute_proto.output(0);
+}
+
+void ONNXImporter2::lstm_add_transform(int num_directions, int batch_size, int hidden_size,
+                                      int index, const std::string& input_name, const std::string& output_name)
+{
+    if (num_directions == 1)
+    {
+        // Slice: Yh = Y[-1, :, :, :]
+        int begin[] = {-1}, end[] = {INT_MAX};
+        std::string slice_output = lstm_add_slice(index, input_name, begin, end, sizeof(begin) / sizeof(begin[0]));
+
+        // Reshape: 1x1xBxH -> 1xBxH
+        int layerShape[] = {1, batch_size, hidden_size};
+        lstm_add_reshape(slice_output, output_name, layerShape, sizeof(layerShape) / sizeof(layerShape[0]));
+    }
+    else
+    {
+        // Slice: SxDxBxH -> last sequence, first direction
+        int begin0[] = {-1, 0}, end0[] = {INT_MAX, 1};
+        std::string slice_0 = lstm_add_slice(0, input_name, begin0, end0, sizeof(begin0) / sizeof(begin0[0]));
+
+        // Slice: SxDxBxH -> first sequence, last direction
+        int begin1[] = {0, -1}, end1[] = {1, INT_MAX};
+        std::string slice_1 = lstm_add_slice(1, input_name, begin1, end1, sizeof(begin1) / sizeof(begin1[0]));
+
+        LayerParams concatLP;
+        concatLP.name = cv::format("%s/concat", input_name.c_str());
+        concatLP.type = "Concat";
+        CV_Assert(layer_id.find(concatLP.name) == layer_id.end());
+
+        concatLP.set("axis", 1); // 1x1xBxH -> 1x2xBxH
+
+        opencv_onnx::NodeProto concat_proto;
+        concat_proto.add_input(slice_0);
+        concat_proto.add_input(slice_1);
+        concat_proto.add_output(concatLP.name);
+        addLayer(concatLP, concat_proto);
+
+        // Reshape: 1x2xBxH -> 2xBxH
+        int layerShape[] = {2, batch_size, hidden_size};
+        lstm_add_reshape(concat_proto.output(0), output_name, layerShape, sizeof(layerShape) / sizeof(layerShape[0]));
+    }
+}
+
+void ONNXImporter2::parseLSTM(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto lstm_proto = node_proto_;
+    layerParams.name += "/lstm";
+
+    // https://github.com/onnx/onnx/blob/main/docs/Operators.md#LSTM
+    CV_Assert(lstm_proto.input_size() >= 3);
+    for (size_t i = 1; i < 3; ++i)
+    {
+        const std::string& name = lstm_proto.input(i);
+        CV_Assert(!name.empty() && constBlobs.count(name) == 1);
+    }
+
+    IterShape_t shapeIt = outShapes.find(lstm_proto.input(0));
+    CV_Assert(shapeIt != outShapes.end());
+    const MatShape x_shape = shapeIt->second;
+
+    //if layout is 1, change batch and sequence dims
+    const int layout = layerParams.get<int>("layout", 0);
+    int batch_size, seq_length;
+    if (layout == 1){
+        batch_size = x_shape[0];
+        seq_length = x_shape[1];
+    }else{
+        seq_length = x_shape[0];
+        batch_size = x_shape[1];
+    }
+    const int input_size = x_shape[2];
+    const int hidden_size = layerParams.get<int>("hidden_size");
+    const int num_directions = constBlobs[lstm_proto.input(1)].size[0];
+
+    int w_size[] = {num_directions, 4*hidden_size, input_size};
+    lstm_extractConsts(layerParams, lstm_proto, 1, w_size, sizeof(w_size) / sizeof(w_size[0])); // W
+
+    int r_size[] =  {num_directions, 4*hidden_size, hidden_size};
+    lstm_extractConsts(layerParams, lstm_proto, 2, r_size, sizeof(r_size) / sizeof(r_size[0])); // R
+
+    int b_size[] = {num_directions, 8*hidden_size};
+    lstm_extractConsts(layerParams, lstm_proto, 3, b_size, sizeof(b_size) / sizeof(b_size[0])); // B
+
+    if (4 < lstm_proto.input_size() && !lstm_proto.input(4).empty())
+    {
+        Mat blob = getIntBlob(lstm_proto, 4);
+        CV_Assert(blob.total() == batch_size);
+        for (MatIterator_<int32_t> it = blob.begin<int32_t>(); it != blob.end<int32_t>(); ++it)
+        {
+            CV_Assert(*it == seq_length);
+        }
+    }
+
+    int h_size[] = {num_directions, batch_size, hidden_size};
+    lstm_extractConsts(layerParams, lstm_proto, 5, h_size, sizeof(h_size) / sizeof(h_size[0])); // initial_h
+
+    int c_size[] = {num_directions, batch_size, hidden_size};
+    lstm_extractConsts(layerParams, lstm_proto, 6, c_size, sizeof(c_size) / sizeof(c_size[0])); // initial_c
+
+    if (lstm_proto.input_size() > 7 && !lstm_proto.input(7).empty())
+    {
+        layerParams.set("use_peephole", true);
+        int p_size[] = {num_directions, 3 * hidden_size};
+        lstm_extractConsts(layerParams, lstm_proto, 7, p_size, sizeof(p_size) / sizeof(p_size[0])); // P
+    }
+
+    transformBlobs(layerParams.blobs);
+
+    layerParams.set("is_onnx", true);
+    layerParams.set("reverse", layerParams.get<String>("direction", "") == "reverse");
+    layerParams.set("bidirectional", layerParams.get<String>("direction", "") == "bidirectional");
+
+    bool need_yc = lstm_proto.output_size() > 2 && !lstm_proto.output(2).empty();
+    bool need_yh = lstm_proto.output_size() > 1 && !lstm_proto.output(1).empty();
+    bool need_y = lstm_proto.output_size() > 0 && !lstm_proto.output(0).empty();
+
+    const std::string y_name = need_y ? lstm_proto.output(0) : "";
+    const std::string yh_name = need_yh ? lstm_proto.output(1) : "";
+    const std::string yc_name = need_yc ? lstm_proto.output(2) : "";
+
+    layerParams.set("produce_cell_output", need_yc);
+
+    lstm_proto.clear_output();
+    if (need_y || need_yh)
+    {
+        // give random names to LSTMLayer's outputs because every output needs postprocessing
+        lstm_proto.add_output(cv::format("%s_y", layerParams.name.c_str()));
+    }
+    if (need_yc)
+    {
+        lstm_proto.add_output(yc_name);
+    }
+
+    addLayer(layerParams, lstm_proto);
+
+    std::string y_output = lstm_fix_dims(layerParams, lstm_proto, batch_size, num_directions, hidden_size, need_y,
+                                         y_name, 0);
+    if (need_yh)
+    {
+        lstm_add_transform(num_directions, batch_size, hidden_size, 0, y_output, yh_name);
+    }
+}
+
+void ONNXImporter2::parseGRU(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    const std::string output_name = node_proto.output(0);
+    LayerParams gruParams = layerParams;
+    gruParams.name += "/gru";
+
+    // https://pytorch.org/docs/stable/generated/torch.nn.GRU.html?highlight=gru#
+    CV_Assert(node_proto.input_size() == 6);
+    Mat Wx = getBlob(node_proto, 1);
+    Mat Wh = getBlob(node_proto, 2);
+    Mat b = getBlob(node_proto, 3);
+    Mat h0 = getBlob(node_proto, 5);
+
+    Wx = Wx.reshape(1, Wx.size[0] * Wx.size[1]);
+    Wh = Wh.reshape(1, Wh.size[0] * Wh.size[1]);
+    h0 = h0.reshape(1, h0.size[0] * h0.size[1]);
+    b = b.reshape(1, b.size[0]);
+
+    gruParams.blobs.resize(4);
+    gruParams.blobs[0] = Wh;
+    gruParams.blobs[1] = Wx;
+    gruParams.blobs[2] = b;
+    gruParams.blobs[3] = h0;
+    gruParams.set("bidirectional", gruParams.get<String>("direction", "") == "bidirectional");
+
+    node_proto.set_output(0, gruParams.name);  // set different name so output shapes will be registered on that name
+    addLayer(gruParams, node_proto);
+
+    MatShape gruShape = outShapes[node_proto.output(0)];
+
+    // Add fake 1 as it is done in ONNX
+    gruShape.insert(gruShape.begin() + 1, 1);
+
+    layerParams.type = "Reshape";
+    layerParams.set("dim", DictValue::arrayInt(&gruShape[0], gruShape.size()));
+    node_proto.set_input(0, gruParams.name);  // redirect input to GRU
+    node_proto.set_output(0, output_name);  // keep origin GRU's name
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseImageScaler(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    const float scale = layerParams.has("scale") ? layerParams.get<float>("scale") : 1.0f;
+    layerParams.erase("scale");
+
+    if (layerParams.has("bias"))
+    {
+        layerParams.type = "Scale";
+        layerParams.blobs.push_back(
+                Mat(Size(1,  layerParams.get("bias").size()), CV_32FC1, scale));
+
+        layerParams.set("bias_term", true);
+        Mat bias(1, layerParams.get("bias").size(), CV_32FC1);
+        for (int j = 0; j < bias.total(); j++) {
+            bias.at<float>(0, j) = layerParams.get("bias").getRealValue(j);
+        }
+        layerParams.blobs.push_back(bias);
+        layerParams.erase("bias");
+    }
+    else {
+        layerParams.set("scale", scale);
+        layerParams.type = "Power";
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseClip(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "ReLU6";
+    float min_value = -FLT_MAX, max_value = FLT_MAX;
+    int input_size = node_proto.input_size();
+    CV_Check(input_size, 1 <= input_size && input_size <= 3, "");
+
+    if (input_size >= 2 && !node_proto.input(1).empty())
+    {
+        if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+            min_value = getBlob(node_proto, 1).at<float>(0);
+        else
+            CV_Error(Error::StsNotImplemented, "Non-constant min values in Clip are not supported");
+    }
+
+    if (input_size == 3 && !node_proto.input(2).empty())
+    {
+        if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
+            max_value = getBlob(node_proto, 2).at<float>(0);
+        else
+            CV_Error(Error::StsNotImplemented, "Non-constant max values in Clip are not supported");
+    }
+
+    layerParams.set("min_value", layerParams.get<float>("min", min_value));
+    layerParams.set("max_value", layerParams.get<float>("max", max_value));
+    addLayer(layerParams, node_proto, 1);
+}
+
+void ONNXImporter2::parseLeakyRelu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "ReLU";
+    layerParams.set("negative_slope", layerParams.get<float>("alpha", 0.01));
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseRelu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "ReLU";
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseElu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "ELU";
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseTanh(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "TanH";
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseAbs(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "AbsVal";
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parsePRelu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "PReLU";
+    layerParams.blobs.push_back(getBlob(node_proto, 1));
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseLRN(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    replaceLayerParam(layerParams, "size", "local_size");
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseInstanceNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto) {
+    int num_inputs = node_proto.input_size();
+    CV_CheckEQ(num_inputs, 3, "DNN/ONNXImporter2 - InstanceNorm: three inputs are required");
+
+    bool found_input = constBlobs.find(node_proto.input(0)) != constBlobs.end();
+    bool found_scale = constBlobs.find(node_proto.input(1)) != constBlobs.end();
+    bool found_bias = constBlobs.find(node_proto.input(2)) != constBlobs.end();
+
+    if (found_input && found_scale && found_bias) {
+        std::vector<Mat> inputs, output;
+
+        Mat input = getBlob(node_proto, 0);
+        Mat scale = getBlob(node_proto, 1);
+        Mat bias = getBlob(node_proto, 2);
+        inputs.push_back(input);
+        inputs.push_back(scale);
+        inputs.push_back(bias);
+
+        runLayer(layerParams, inputs, output);
+        addConstant(node_proto.output(0), output[0]);
+    } else {
+        auto add_const_node = [&] (int i) {
+            LayerParams const_params;
+            const_params.name = node_proto.input(i);
+            const_params.type = "Const";
+            Mat blob = getBlob(node_proto, i);
+            const_params.blobs.push_back(blob);
+
+            opencv_onnx::NodeProto proto;
+            proto.add_output(const_params.name);
+            addLayer(const_params, proto);
+        };
+        if (found_input && layer_id.find(node_proto.input(0)) == layer_id.end()) { add_const_node(0); }
+        if (found_scale && layer_id.find(node_proto.input(1)) == layer_id.end()) { add_const_node(1); }
+        if (found_bias && layer_id.find(node_proto.input(2)) == layer_id.end()) { add_const_node(2); }
+        addLayer(layerParams, node_proto);
+    }
+}
+
+void ONNXImporter2::parseBatchNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    if (node_proto.input_size() != 5)
+        CV_Error(Error::StsNotImplemented,
+                 "Expected input, scale, bias, mean and var");
+
+    layerParams.type = "BatchNorm";
+    replaceLayerParam(layerParams, "epsilon", "eps");
+    replaceLayerParam(layerParams, "spatial", "use_global_stats");
+
+    Mat meanData = getBlob(node_proto, 3);
+    Mat stdData =  getBlob(node_proto, 4);
+
+    layerParams.blobs.push_back(meanData);
+    layerParams.blobs.push_back(stdData);
+
+    if (!node_proto.input(1).empty()) {
+        layerParams.set("has_weight", true);
+        layerParams.blobs.push_back(getBlob(node_proto, 1));  // weightData
+    } else {
+        layerParams.set("has_weight", false);
+    }
+
+    if (!node_proto.input(2).empty()) {
+        layerParams.set("has_bias", true);
+        layerParams.blobs.push_back(getBlob(node_proto, 2)); // biasData
+    } else {
+        layerParams.set("has_bias", false);
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseGemm(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    auto node_proto = node_proto_;
+    layerParams.type = "Gemm";
+    CV_CheckGE(node_proto.input_size(), 2, "DNN/ONNXImporter2: Gemm requires at least two inputs");
+    CV_CheckLE(node_proto.input_size(), 3, "DNN/ONNXImporter2: Gemm have at most three inputs.");
+
+    for (int i = 0; i < node_proto.input_size(); ++i) {
+        if (i == 2) {
+            layerParams.set("have_bias", true);
+        }
+        if (constBlobs.find(node_proto.input(i)) == constBlobs.end()) {
+            continue;
+        }
+
+        if (i == 2 && constBlobsExtraInfo.find(node_proto.input(2)) != constBlobsExtraInfo.end()) {
+            layerParams.set("real_ndims_C", getBlobExtraInfo(node_proto, 2).real_ndims);
+        }
+
+        Mat blob = getBlob(node_proto, i);
+
+        if (i == 0) { // A, always as inputs without prepacking
+            LayerParams const_A_params;
+            const_A_params.name = layerParams.name + "/const_A";
+            const_A_params.type = "Const";
+            const_A_params.blobs.push_back(blob);
+
+            opencv_onnx::NodeProto const_node_proto;
+            const_node_proto.add_output(const_A_params.name);
+            addLayer(const_A_params, const_node_proto);
+            node_proto.set_input(0, const_A_params.name);
+        } else { // B or C
+            std::string const_params_name = i == 1 ? "B" : "C";
+
+            layerParams.blobs.push_back(blob);
+            layerParams.set(cv::format("const%s", const_params_name.c_str()), true);
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseMatMul(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_) {
+    auto node_proto = node_proto_;
+    CV_CheckGE(node_proto.input_size(), 2, "ONNXImporter2/MatMul: two inputs required at least");
+    CV_CheckLE(node_proto.input_size(), 3, "ONNXImporter2/MatMul: three inputs required at most");
+
+    for (int i = 0; i < node_proto.input_size(); i++) {
+        if (constBlobs.find(node_proto.input(i)) == constBlobs.end()) {
+            continue;
+        }
+
+        Mat blob = getBlob(node_proto, i);
+
+        if (i == 0) {
+            LayerParams const_params;
+            const_params.name = node_proto.input(i);
+            const_params.type = "Const";
+            const_params.blobs.push_back(blob);
+
+            opencv_onnx::NodeProto const_node_proto;
+            const_node_proto.add_output(const_params.name);
+            addLayer(const_params, const_node_proto);
+
+            node_proto.set_input(i, const_params.name);
+        } else {
+            layerParams.blobs.push_back(blob);
+        }
+
+        if (i == 2 && constBlobsExtraInfo.find(node_proto.input(2)) != constBlobsExtraInfo.end()) {
+            layerParams.set("real_ndims_C", getBlobExtraInfo(node_proto, 2).real_ndims);
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseConv(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    CV_Assert(node_proto.input_size() >= 2);
+    layerParams.type = "Convolution";
+    for (int j = 1; j < node_proto.input_size(); j++) {
+        if (constBlobs.find(node_proto.input(j)) != constBlobs.end())
+        {
+            layerParams.blobs.push_back(getBlob(node_proto, j));
+        }
+    }
+    int outCn = layerParams.blobs.empty() ? outShapes[node_proto.input(1)][0] : layerParams.blobs[0].size[0];
+    layerParams.set("num_output", outCn);
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseConvTranspose(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() >= 2);
+    layerParams.type = "Deconvolution";
+    for (int j = 1; j < node_proto.input_size(); j++) {
+        layerParams.blobs.push_back(getBlob(node_proto, j));
+    }
+    layerParams.set("num_output", layerParams.blobs[0].size[1] * layerParams.get<int>("group", 1));
+    layerParams.set("bias_term", node_proto.input_size() == 3);
+
+    if (!layerParams.has("kernel_size"))
+        CV_Error(Error::StsNotImplemented,
+                 "Required attribute 'kernel_size' is not present.");
+
+    if (layerParams.has("output_shape"))
+    {
+        const DictValue& outShape = layerParams.get("output_shape");
+        DictValue strides = layerParams.get("stride");
+        DictValue kernel = layerParams.get("kernel_size");
+
+        String padMode;
+        std::vector<int> adjust_pads;
+        if (layerParams.has("pad_mode"))
+        {
+            padMode = toUpperCase(layerParams.get<String>("pad_mode"));
+            if (padMode != "SAME" && padMode != "VALID")
+                CV_Error(Error::StsError, "Unsupported padding mode " + padMode);
+
+            for (int i = 0; i < strides.size(); i++)
+            {
+                int sz = outShape.get<int>(2 + i);
+                int stride = strides.get<int>(i);
+                adjust_pads.push_back(padMode == "SAME"? (sz - 1) % stride :
+                                                         (sz - kernel.get<int>(i)) % stride);
+            }
+            layerParams.set("adj", DictValue::arrayInt(&adjust_pads[0], adjust_pads.size()));
+        }
+    }
+    else if (layerParams.has("output_padding"))
+    {
+        replaceLayerParam(layerParams, "output_padding", "adj");
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseTranspose(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type = (depth == CV_8S) ? "PermuteInt8" : "Permute";
+    replaceLayerParam(layerParams, "perm", "order");
+    if (!layerParams.has("order")) {
+        MatShape inpShape = outShapes[node_proto.input(0)];
+        size_t dims = inpShape.size();
+        std::vector<int> perm(dims);
+        for (size_t d = 0; d < dims; ++d)
+        {
+            perm[d] = static_cast<int>(dims - 1 - d);
+        }
+        layerParams.set("order", DictValue::arrayInt(perm.data(), perm.size()));
+    }
+
+    CV_Assert(node_proto.input_size() == 1);
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        std::vector<Mat> inputs(1, getBlob(node_proto, 0)), transposed;
+        runLayer(layerParams, inputs, transposed);
+        CV_Assert(transposed.size() == 1);
+        addConstant(node_proto.output(0), transposed[0]);
+        return;
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseSqueeze(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() <= 2);
+
+    MatShape inpShape = outShapes[node_proto.input(0)];
+    std::vector<bool> maskedAxes(inpShape.size(), false);
+    if (layerParams.has("axes"))
+    {
+        DictValue axes_dict = layerParams.get("axes");
+        for (int i = 0; i < axes_dict.size(); ++i)
+        {
+            int axis = axes_dict.getIntValue(i);
+            axis = normalize_axis(axis, inpShape.size());
+            CV_CheckLE(axis, static_cast<int>(inpShape.size()), "Squeeze axis");
+            maskedAxes[axis] = inpShape[axis] == 1;
+        }
+    }
+    else if (node_proto.input_size() == 2)
+    {
+        if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+        {
+            Mat axesMat = getIntBlob(node_proto, 1);
+            size_t axesLen = axesMat.total();
+            for (int i = 0; i < axesLen; i++)
+            {
+                int axis = axesMat.at<int>(i);
+                axis = normalize_axis(axis, inpShape.size());
+                CV_CheckLE(axis, static_cast<int>(inpShape.size()), "Squeeze axis");
+                maskedAxes[axis] = inpShape[axis] == 1;
+            }
+        }
+        else
+            CV_Error(Error::StsNotImplemented, cv::format("ONNX/Squeeze: doesn't support non-constant 'axes' input"));
+    }
+
+    MatShape outShape;
+    for (int i = 0; i < inpShape.size(); ++i)
+    {
+        if (!maskedAxes[i])
+            outShape.push_back(inpShape[i]);
+    }
+    if (outShape.size() != inpShape.size())
+    {
+        layerParams.type = "Reshape";
+        layerParams.set("dim", DictValue::arrayInt(&outShape[0], outShape.size()));
+        if (hasDynamicShapes)
+        {
+            std::vector<int> dynamicAxes;
+            std::vector<int> inputIndices;
+            for (int index = 0; index < inpShape.size(); ++index)
+            {
+                if (!maskedAxes[index])
+                    inputIndices.push_back(index);
+            }
+            for (int index = 0; index < outShape.size(); ++index)
+                dynamicAxes.push_back(index);
+            layerParams.set("dynamic_axes", DictValue::arrayInt(dynamicAxes.data(), dynamicAxes.size()));
+            layerParams.set("input_indices", DictValue::arrayInt(inputIndices.data(), inputIndices.size()));
+        }
+    }
+    else
+        layerParams.type = "Identity";
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        Mat inp = getBlob(node_proto, 0);
+        Mat out = inp.reshape(1, outShape);
+        out.dims = outShape.size();  // to workaround dims == 1
+        addConstant(node_proto.output(0), out);
+        return;
+    }
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type += (depth == CV_8S) ? "Int8" : "";
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseFlatten(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    CV_CheckEQ(node_proto.input_size(), 1, "");
+    int axis_ = layerParams.get<int>("axis", 1);
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        Mat input = getBlob(node_proto, 0);
+        if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+        {
+            constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), getBlobExtraInfo(node_proto, 0)));
+        }
+        int axis = normalize_axis(axis_, input.dims);
+
+        int out_size[2] = {1, 1};
+        for (int i = 0; i < axis; ++i)
+        {
+            out_size[0] *= input.size[i];
+        }
+        for (int i = axis; i < input.dims; ++i)
+        {
+            out_size[1] *= input.size[i];
+        }
+
+        Mat output = input.reshape(1, 2, out_size);
+        addConstant(node_proto.output(0), output);
+        return;
+    }
+    IterShape_t shapeIt = outShapes.find(node_proto.input(0));
+    CV_Assert(shapeIt != outShapes.end());
+    MatShape inpShape = shapeIt->second;
+    int axis = normalize_axis(axis_, inpShape.size());
+
+    if (axis == 0 || axis == inpShape.size())
+    {
+        LayerParams reshapeLp;
+        reshapeLp.name = layerParams.name + "/reshape";
+        reshapeLp.type = "Reshape";
+        CV_Assert(layer_id.find(reshapeLp.name) == layer_id.end());
+
+        inpShape.insert(axis == 0 ? inpShape.begin() : inpShape.end(), 1);
+        reshapeLp.set("dim", DictValue::arrayInt(&inpShape[0], inpShape.size()));
+
+        opencv_onnx::NodeProto proto;
+        proto.add_input(node_proto.input(0));
+        proto.add_output(reshapeLp.name);
+        addLayer(reshapeLp, proto);
+        node_proto.set_input(0, reshapeLp.name);
+        axis += 1;
+    }
+
+    LayerParams first_pass;
+    first_pass.name = layerParams.name + "/flatten";
+    CV_Assert(layer_id.find(first_pass.name) == layer_id.end());
+    first_pass.type = "Flatten";
+    first_pass.set("axis", 0);
+    first_pass.set("end_axis", axis - 1);
+
+    opencv_onnx::NodeProto proto;
+    proto.add_input(node_proto.input(0));
+    proto.add_output(first_pass.name);
+    addLayer(first_pass, proto);
+
+    layerParams.set("axis", 1);
+    node_proto.set_input(0, first_pass.name);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseUnsqueeze(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 1 || node_proto.input_size() == 2);
+    DictValue axes;
+    if (node_proto.input_size() == 2)
+    {
+        Mat blob = getIntBlob(node_proto, 1);
+        axes = DictValue::arrayInt(blob.ptr<int>(), blob.total());
+    }
+    else
+        axes = layerParams.get("axes");
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        // Constant input.
+        Mat input = getBlob(node_proto, 0);
+        int input_dims = input.dims;
+        if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+            if (getBlobExtraInfo(node_proto, 0).real_ndims == 1)
+                input_dims = 1;
+
+        std::vector<int> dims;
+        for (int j = 0; j < input_dims; j++) {
+            dims.push_back(input.size[j]);
+        }
+//        CV_Assert(axes.getIntValue(axes.size()-1) <= dims.size());
+        for (int j = 0; j < axes.size(); j++) {
+            int idx = axes.getIntValue(j);
+            idx = idx < 0 ? idx + input_dims + 1 : idx;
+            CV_Assert(0 <= idx && idx <= dims.size());
+            dims.insert(dims.begin() + idx, 1);
+        }
+
+        Mat out = input.reshape(0, dims);
+        addConstant(node_proto.output(0), out);
+        return;
+    }
+
+    // Variable input.
+    if (axes.size() != 1)
+        CV_Error(Error::StsNotImplemented, "Multidimensional unsqueeze");
+
+    int depth = layerParams.get<int>("depth", CV_32F);
+
+    MatShape inpShape = outShapes[node_proto.input(0)];
+    int axis = axes.getIntValue(0);
+    axis = axis < 0 ? axis + (int)inpShape.size() + 1 : axis;
+    CV_Assert(0 <= axis && axis <= inpShape.size());
+    MatShape outShape = inpShape;
+    outShape.insert(outShape.begin() + axis, 1);
+    layerParams.type = (depth == CV_8S) ? "ReshapeInt8" : "Reshape";
+    layerParams.set("dim", DictValue::arrayInt(&outShape[0], (int)outShape.size()));
+    if (hasDynamicShapes)
+    {
+        std::vector<int> dynamicAxes;
+        std::vector<int> inputIndices;
+        for (int index = 0; index < outShape.size(); ++index) {
+            if (index != axis)
+                dynamicAxes.push_back(index);
+        }
+        for (int index = 0; index < inpShape.size(); ++index)
+            inputIndices.push_back(index);
+        layerParams.set("dynamic_axes", DictValue::arrayInt(dynamicAxes.data(), (int)dynamicAxes.size()));
+        layerParams.set("input_indices", DictValue::arrayInt(inputIndices.data(), (int)inputIndices.size()));
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseExpand(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_CheckEQ(node_proto.input_size(), 2, "DNN/ONNXImporter2-Expand: two inputs are required");
+    // input shape must be constant and it is passed as param to the layer
+    CV_CheckTrue(constBlobs.find(node_proto.input(1)) != constBlobs.end(),
+                 "DNN/ONNXImporter2-Expand: input shape must be constant");
+
+    Mat mat_input_shape = getIntBlob(node_proto, 1);
+    CV_CheckTypeEQ(mat_input_shape.depth(), CV_32S, "DNN/ONNXImporter2-Expand: data type of input shape must be CV_32S");
+    for (int i = 0; i < mat_input_shape.total(); ++i) {
+        CV_Check(i, *(mat_input_shape.ptr<int>() + i) >= 0, "DNN/ONNXImporter2-Expand: invalid shape dimension");
+    }
+    layerParams.set("shape", DictValue::arrayInt(mat_input_shape.ptr<int>(), mat_input_shape.total()));
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end()) {
+        bool const_input_1d = false;
+        if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end()) {
+            if (getBlobExtraInfo(node_proto, 0).real_ndims == 1) {
+                const_input_1d = true;
+            }
+        }
+        layerParams.set("const_input_1d", const_input_1d);
+
+        Mat input = getBlob(node_proto, 0);
+        std::vector<Mat> inputs, expanded;
+        inputs.push_back(input);
+        runLayer(layerParams, inputs, expanded);
+        CV_CheckEQ(expanded.size(), static_cast<size_t>(1), "DNN/Expand: only one output is expected when folding constant");
+        addConstant(node_proto.output(0), expanded[0]);
+        return;
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseReshape(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 2 || layerParams.has("shape"));
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type += (depth == CV_8S) ? "Int8" : "";
+
+    if (node_proto.input_size() == 2) {
+        Mat blob = getIntBlob(node_proto, 1);
+        CV_Assert(blob.type() == CV_32SC1);
+
+        layerParams.set("dim", DictValue::arrayInt<int*>(blob.ptr<int>(), blob.total()));
+
+        if (layer_id.find(node_proto.input(0)) == layer_id.end()) {
+            std::vector<Mat> inputs(1, getBlob(node_proto, 0)), outputs;
+            runLayer(layerParams, inputs, outputs);
+            addConstant(node_proto.output(0), outputs[0]);
+            if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+            {
+                const int real_ndims_input0 = getBlobExtraInfo(node_proto, 0).real_ndims;
+                if (real_ndims_input0 == 1 && blob.total() == 1 && blob.at<int>() == -1) // 1D tensor as input0 (data), and shape is -1
+                    constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), TensorInfo(1)));
+            }
+            return;
+        }
+    }
+    else {
+        DictValue shape = layerParams.get("shape");
+        std::vector<int> dim;
+        for (int j = 0; j < shape.size(); j++) {
+            dim.push_back(shape.getIntValue(j));
+        }
+
+        if (layer_id.find(node_proto.input(0)) == layer_id.end()) {
+            Mat input = getBlob(node_proto, 0);
+            Mat out = input.reshape(0, dim);
+            addConstant(node_proto.output(0), out);
+            return;
+        }
+        replaceLayerParam(layerParams, "shape", "dim");
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parsePad(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type = (depth == CV_8S) ? "PaddingInt8" : "Padding";
+    replaceLayerParam(layerParams, "mode", "type");
+    if (node_proto.input_size() == 3 || node_proto.input_size() == 2)
+    {
+        // Paddings are in order begin0, begin1, .. beginN, end0, end1, ..., endN.
+        // We need to shuffle it to begin0, end0, begin1, end1, ...
+        Mat paddings = getIntBlob(node_proto, 1).reshape(1, 2);
+        paddings = paddings.t();
+        layerParams.set("paddings", DictValue::arrayInt(paddings.ptr<int>(), paddings.total()));
+
+        // check for non-null constant_value
+        if (node_proto.input_size() == 3 && !node_proto.input(2).empty())
+        {
+            Mat value = getBlob(node_proto, 2);
+            double padValue = 0;
+            switch(value.depth())
+            {
+                case CV_32F: padValue = value.ptr<float>()[0];   break;
+                case CV_32S: padValue = value.ptr<int32_t>()[0]; break;
+                case CV_64S: padValue = value.ptr<int64_t>()[0]; break;
+                case CV_8S:  padValue = value.ptr<int8_t>()[0];  break;
+                default: CV_Error(Error::BadDepth, "Unsupported type");
+            }
+            layerParams.set<double>("value", (double)padValue);
+        }
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseShape(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 1);
+    IterShape_t shapeIt = outShapes.find(node_proto.input(0));
+    CV_Assert(shapeIt != outShapes.end());
+    const MatShape& inpShape = shapeIt->second;
+
+    bool isInput1D = false;
+    if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+        if (getBlobExtraInfo(node_proto, 0).real_ndims == 1)
+            isInput1D = true;
+
+    int dims = static_cast<int>(inpShape.size());
+    if (isInput1D)
+        dims = 1;
+    Mat shapeMat(1, dims, CV_64S);
+    bool isDynamicShape = false;
+    for (int j = 0; j < dims; ++j)
+    {
+        int sz = inpShape[j];
+        isDynamicShape |= (sz == 0);
+        shapeMat.at<int64_t>(j) = sz;
+    }
+    shapeMat.dims = 1;  // FIXIT Mat 1D
+
+    if (isDynamicShape)
+    {
+        CV_LOG_ERROR(NULL, "DNN/ONNX(Shape): dynamic 'zero' shapes are not supported, input " << toString(inpShape, node_proto.input(0)));
+        CV_Assert(!isDynamicShape);  // not supported
+    }
+    addConstant(node_proto.output(0), shapeMat);
+}
+
+void ONNXImporter2::parseCast(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int type;
+    switch (layerParams.get<int>("to"))
+    {
+        case opencv_onnx::TensorProto_DataType_FLOAT:   type = CV_32F; break;
+        case opencv_onnx::TensorProto_DataType_UINT8:   type = CV_8U;  break;
+        case opencv_onnx::TensorProto_DataType_UINT16:  type = CV_16U; break;
+        case opencv_onnx::TensorProto_DataType_FLOAT16: type = CV_16F; break;
+        case opencv_onnx::TensorProto_DataType_INT8:    type = CV_8S;  break;
+        case opencv_onnx::TensorProto_DataType_INT16:   type = CV_16S; break;
+        case opencv_onnx::TensorProto_DataType_INT32:   type = CV_32S; break;
+        case opencv_onnx::TensorProto_DataType_INT64:   type = CV_64S; break;
+        default: CV_Error(Error::BadDepth, "Unsupported type");
+    }
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+    {
+        Mat blob = getBlob(node_proto, 0);
+        if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+        {
+            constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), getBlobExtraInfo(node_proto, 0)));
+        }
+        Mat dst;
+        blob.convertTo(dst, type);
+        dst.dims = blob.dims;
+        addConstant(node_proto.output(0), dst);
+        return;
+    }
+
+    layerParams.type = "Cast";
+    layerParams.set("outputType", type);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseConstantFill(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int depth = CV_32F;
+    float fill_value;
+    if (!layerParams.blobs.empty())
+    {
+        CV_Assert(!layerParams.has("value"));
+        depth = layerParams.blobs[0].depth();
+        Mat floats;
+        layerParams.blobs[0].convertTo(floats, CV_32F);
+        fill_value = floats.at<float>(0, 0);
+    }
+    else
+        fill_value = layerParams.get("value", 0);
+
+    std::vector<int> inpShape = getIntBlob(node_proto, 0);
+    size_t i, total = inpShape.size();
+    for (i = 0; i < total; i++)
+        CV_CheckGT(inpShape[i], 0, "");
+    Mat tensor(inpShape, depth, Scalar(fill_value));
+    addConstant(node_proto.output(0), tensor);
+}
+
+void ONNXImporter2::parseGather(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_CheckEQ(node_proto.input_size(), 2, "");
+
+    // TODO: get rid of the type conversions and 1-d/0-d special-casing when the time comes
+    if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+    {
+        int real_ndims = getBlobExtraInfo(node_proto.input(1)).real_ndims;
+        layerParams.set("real_ndims", real_ndims);
+        if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+        {
+            std::vector<Mat> inputs, output;
+
+            Mat input = getBlob(node_proto, 0);
+            inputs.push_back(input);
+
+            Mat indices = getBlob(node_proto, 1);
+            inputs.push_back(indices);
+
+            runLayer(layerParams, inputs, output);
+            //output.back().dims = std::max(input.dims - real_ndims, 1);
+            addConstant(node_proto.output(0), output.back());
+            return;
+        }
+    }
+
+    for (int i = 0; i < node_proto.input_size(); ++i)
+    {
+        if (layer_id.find(node_proto.input(i)) == layer_id.end())
+        {
+            LayerParams constParams;
+            constParams.name = node_proto.input(i);
+            constParams.type = "Const";
+            Mat blob = getBlob(node_proto, i);
+            constParams.blobs.push_back(blob);
+
+            opencv_onnx::NodeProto proto;
+            proto.add_output(constParams.name);
+            addLayer(constParams, proto);
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseGatherElements(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_CheckEQ(node_proto.input_size(), 2, "GatherElements: two inputs are required");
+
+    size_t num_const = 0;
+    for (size_t i = 0; i < node_proto.input_size(); ++i){
+        if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+            ++num_const;
+    }
+
+    if (num_const == node_proto.input_size())
+    {
+        std::vector<Mat> inputs, output;
+        for (size_t i = 0; i < node_proto.input_size(); i++) {
+            Mat blob = getBlob(node_proto, i);
+            inputs.push_back(blob);
+        }
+        runLayer(layerParams, inputs, output);
+        CV_Assert(output.size() == 1);
+        addConstant(node_proto.output(0), output[0]);
+        return;
+    } else if (num_const > 0) {
+        for (size_t i = 0; i < node_proto.input_size(); i++) {
+            if (constBlobs.find(node_proto.input(i)) != constBlobs.end()) {
+                Mat blob = getBlob(node_proto, i);
+
+                LayerParams constParams;
+                constParams.name = node_proto.input(i);
+                constParams.type = "Const";
+                constParams.blobs.push_back(blob);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(constParams, proto);
+            }
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseConcat(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    bool hasVariableInps = false;
+    for (int i = 0; i < node_proto.input_size(); ++i)
+    {
+        if (layer_id.find(node_proto.input(i)) != layer_id.end())
+        {
+            hasVariableInps = true;
+            break;
+        }
+    }
+    if (constBlobsExtraInfo.find(node_proto.input(0)) != constBlobsExtraInfo.end())
+    {
+        constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), getBlobExtraInfo(node_proto, 0)));
+    }
+
+    if (!hasVariableInps)
+    {
+        std::vector<Mat> inputs(node_proto.input_size()), concatenated;
+        // Due constant folding we can get inputs with different number of dimensions
+        // Insert the missing dimension to inputs
+        MatShape inputShape;
+        for (size_t i = 0; i < inputs.size(); ++i)
+        {
+            inputs[i] = getBlob(node_proto, (int)i);
+            if (inputs[i].size.dims() > (int)inputShape.size())
+            {
+                inputShape = shape(inputs[i]);
+            }
+        }
+
+        // Concat-1 has default value for axis is 1: https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Concat-1
+        int axis = layerParams.get<int>("axis", 1);
+        axis = normalize_axis(axis, inputShape.size());
+        for (size_t i = 0; i < inputs.size(); ++i)
+        {
+            inputShape[axis] = inputs[i].dims == (int)inputShape.size() ? inputs[i].size[axis] : 1;
+            CV_CheckEQ((size_t)total(inputShape), inputs[i].total(), "");
+            inputs[i] = inputs[i].reshape(1, inputShape);
+        }
+        runLayer(layerParams, inputs, concatenated);
+
+        CV_Assert(concatenated.size() == 1);
+        addConstant(node_proto.output(0), concatenated[0]);
+        return;
+    }
+    else
+    {
+        for (int i = 0; i < node_proto.input_size(); ++i)
+        {
+            if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+            {
+                LayerParams constParams;
+                constParams.name = node_proto.input(i);
+                constParams.type = "Const";
+                constParams.blobs.push_back(getBlob(node_proto, i));
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(constParams, proto);
+            }
+        }
+    }
+    addLayer(layerParams, node_proto);
+}
+
+// https://github.com/onnx/onnx/blob/master/docs/Operators.md#Resize
+void ONNXImporter2::parseResize(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    for (int i = 1; i < node_proto.input_size(); i++)
+        CV_Assert(layer_id.find(node_proto.input(i)) == layer_id.end());
+
+    int depth = layerParams.get<int>("depth", CV_32F);
+    layerParams.type += (depth == CV_8S) ? "Int8" : "";
+
+    if (layerParams.has("coordinate_transformation_mode"))
+    {
+        String interp_mode = layerParams.get<String>("coordinate_transformation_mode");
+        CV_Assert(interp_mode != "tf_crop_and_resize");
+
+        bool halfPixel = interp_mode == "tf_half_pixel_for_nn" || interp_mode == "half_pixel" || interp_mode == "pytorch_half_pixel";
+
+        layerParams.set("align_corners", interp_mode == "align_corners");
+        layerParams.set("half_pixel_centers", halfPixel);
+        if (layerParams.get<String>("mode") == "linear")
+        {
+            layerParams.set("mode", halfPixel ? "opencv_linear" : "bilinear");
+        }
+    }
+    if (layerParams.get<String>("mode") == "linear" && framework_name == "pytorch")
+        layerParams.set("mode", "opencv_linear");
+
+    // opset-10: input = [X, scales]
+    // opset-11: input = [X, roi, scales] or [x, roi, scales, sizes]
+    // opset-13: may have empty input, [X, "", "", sizes] or [x, "", scales]
+    int scalesInputId = node_proto.input_size() == 2 ? 1 : 2;
+    const std::string& scale_name = node_proto.input(scalesInputId);
+    Mat scales;
+    if(!scale_name.empty())
+        scales = getBlob(node_proto, scalesInputId);
+
+    if (!scales.empty())
+    {
+        CV_CheckEQ(scales.total(), (size_t)4, "HCHW layout is expected");
+        layerParams.set("zoom_factor_y", scales.at<float>(2));
+        layerParams.set("zoom_factor_x", scales.at<float>(3));
+    }
+    else if (node_proto.input_size() >= 4)  // opset-11 [x, roi, scales, sizes] or opset-13: input = [X, "", "", sizes]
+    {
+        const std::string& inputSizes = node_proto.input(3);
+        if (constBlobs.find(inputSizes) != constBlobs.end())
+        {
+            Mat shapes = getIntBlob(node_proto, 3);
+            CV_CheckEQ(shapes.total(), (size_t)4, "HCHW layout is expected");
+            layerParams.set("width", shapes.at<int>(3));
+            layerParams.set("height", shapes.at<int>(2));
+        }
+        else
+        {
+            CV_Error(Error::StsNotImplemented, cv::format("ONNX/Resize: doesn't support dynamic non-constant 'sizes' input: %s", inputSizes.c_str()));
+        }
+    }
+    else
+    {
+        CV_Error(Error::StsNotImplemented, "ONNX/Resize: can't find neither 'scale' nor destination sizes parameters");
+    }
+    replaceLayerParam(layerParams, "mode", "interpolation");
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseUpsample(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    //fused from Resize Subgraph
+    if (layerParams.has("coordinate_transformation_mode"))
+    {
+        String interp_mode = layerParams.get<String>("coordinate_transformation_mode");
+        CV_Assert(interp_mode != "tf_crop_and_resize");
+
+        bool halfPixel = interp_mode == "tf_half_pixel_for_nn" || interp_mode == "half_pixel" || interp_mode == "pytorch_half_pixel";
+
+        layerParams.set("align_corners", interp_mode == "align_corners");
+        layerParams.set("half_pixel_centers", halfPixel);
+        if (layerParams.get<String>("mode") == "linear")
+        {
+            layerParams.set("mode", halfPixel ? "opencv_linear" : "bilinear");
+        }
+    }
+    if (layerParams.get<String>("mode") == "linear" && framework_name == "pytorch")
+        layerParams.set("mode", "opencv_linear");
+
+    layerParams.type = "Resize";
+    if (layerParams.has("scales"))
+    {
+        // Pytorch layer
+        DictValue scales = layerParams.get("scales");
+        CV_Assert(scales.size() == 4);
+        layerParams.set("zoom_factor_y", scales.getIntValue(2));
+        layerParams.set("zoom_factor_x", scales.getIntValue(3));
+    }
+    else if (layerParams.has("height_scale") && layerParams.has("width_scale"))
+    {
+        // Caffe2 layer
+        replaceLayerParam(layerParams, "height_scale", "zoom_factor_y");
+        replaceLayerParam(layerParams, "width_scale", "zoom_factor_x");
+    }
+    else
+    {
+        // scales as input
+        const std::string& input1 = node_proto.input(1);
+        if (constBlobs.find(input1) != constBlobs.end())
+        {
+            Mat scales = getBlob(input1);
+            CV_Assert(scales.total() == 4);
+            layerParams.set("zoom_factor_y", scales.at<float>(2));
+            layerParams.set("zoom_factor_x", scales.at<float>(3));
+        }
+    }
+    replaceLayerParam(layerParams, "mode", "interpolation");
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseSoftMax(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    const std::string& layer_type = node_proto.op_type();
+    int axis;
+    if (onnx_opset != 0 && onnx_opset <= 11) {
+        axis = layerParams.get<int>("axis", 1);
+    } else {
+        axis = layerParams.get<int>("axis", -1);
+    }
+    layerParams.set<int>("axis", axis);
+    layerParams.type = "Softmax";
+    layerParams.set("log_softmax", layer_type == "LogSoftmax");
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseDetectionOutput(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    CV_CheckEQ(node_proto.input_size(), 3, "");
+    if (constBlobs.find(node_proto.input(2)) != constBlobs.end())
+    {
+        Mat priors = getBlob(node_proto, 2);
+
+        LayerParams constParams;
+        constParams.name = layerParams.name + "/priors";
+        constParams.type = "Const";
+        constParams.blobs.push_back(priors);
+
+        opencv_onnx::NodeProto priorsProto;
+        priorsProto.add_output(constParams.name);
+        addLayer(constParams, priorsProto);
+
+        node_proto.set_input(2, constParams.name);
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseCumSum(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "CumSum";
+
+    // Get axis.
+    const std::string& input1 = node_proto.input(1);
+
+    if (constBlobs.find(input1) != constBlobs.end())
+    {
+        Mat axis_blob = getIntBlob(node_proto, 1);
+        CV_Assert(axis_blob.total() == 1u);
+        layerParams.set("axis", axis_blob.at<int>(0));
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+// "Equal" "Greater" "Less" "Pow" "Add" "Sub" "Mul" "Div" "Sum" "Min" "Max" "GreaterOrEqual" "LessOrEqual" "And" "Or" "Xor"
+void ONNXImporter2::parseElementWise(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    String op_type = toLowerCase(node_proto.op_type());
+
+    layerParams.type = "NaryEltwise";
+    layerParams.set("operation", toLowerCase(node_proto.op_type()));
+    if (node_proto.op_type() == "Mod") {
+        if (layerParams.get<int>("fmod", 0)) {
+            layerParams.set("operation", "fmod");
+        };
+    }
+
+    auto pre_broadcast_transform = [](Mat& t, int t_real_ndims) {
+        if (t.dims == 2 && t_real_ndims == 1 && t.size[1] == 1)
+            transpose(t, t);
+    };
+
+    size_t consts = 0;
+    for (size_t i = 0; i < node_proto.input_size(); ++i)
+    {
+        if (layer_id.find(node_proto.input(i)) == layer_id.end())
+        {
+            ++consts;
+        }
+    }
+
+    if (consts == node_proto.input_size())
+    {
+        std::vector<Mat> inputs, output;
+        for (size_t i = 0; i < node_proto.input_size(); ++i)
+        {
+            inputs.push_back(getBlob(node_proto, i));
+        }
+        runLayer(layerParams, inputs, output);
+        CV_Assert(output.size() == 1);
+        addConstant(node_proto.output(0), output[0]);
+        return;
+    }
+    else if (consts > 0)
+    {
+        for (size_t i = 0; i < node_proto.input_size(); ++i)
+        {
+            if (layer_id.find(node_proto.input(i)) == layer_id.end())
+            {
+                Mat inp = getBlob(node_proto, i);
+                // for cases like a tensor of shape (2,), it will be loaded as shape (2, 1) in OpenCV Mat,
+                // but for correct broadcast, we need to make it of shape (1, 2)
+                if (constBlobsExtraInfo.find(node_proto.input(i)) != constBlobsExtraInfo.end())
+                    pre_broadcast_transform(inp, getBlobExtraInfo(node_proto, i).real_ndims);
+
+                // carry the constant by adding a Const node
+                LayerParams constParams;
+                constParams.name = node_proto.input(i);
+                constParams.type = "Const";
+                // Non-constant propagated layers cannot output 1-d or 0-d tensors.
+                inp.dims = std::max(inp.dims, 2);
+                constParams.blobs.push_back(inp);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(constParams, proto);
+            }
+        }
+    }
+
+    // add element-wise layer
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseDepthSpaceOps(LayerParams &layerParams, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(layerParams.has("blocksize"), "blocksize is required but not found");
+    addLayer(layerParams, node_proto);
+}
+
+template<typename T>
+Mat runRangeLayer(const Mat& startMat, const Mat& limitMat, const Mat& deltaMat)
+{
+    T start = startMat.at<T>(0);
+    T limit = limitMat.at<T>(0);
+    T delta = deltaMat.at<T>(0);
+
+    int numberOfElements;
+    if (startMat.depth() == CV_32S || startMat.depth() == CV_64S) {
+        if (delta > 0)
+            numberOfElements = (limit - start + delta - 1) / delta;
+        else
+            numberOfElements = (start - limit - delta - 1) / -delta;
+    }
+    else
+    {
+        numberOfElements = std::ceil((limit - start) / delta);
+    }
+    numberOfElements = std::max(numberOfElements, 0);
+
+    Mat r(std::vector<int>{numberOfElements}, startMat.type());
+    for (int i = 0; i < numberOfElements; i++)
+    {
+        r.at<T>(i) = start + (i * delta);
+    }
+    return r;
+}
+
+// Currently we only support range with all constant inputs
+void ONNXImporter2::parseRange(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 3); // 0 - start, 1 - limit, 2 - delta
+    layerParams.type = "Range";
+
+    std::vector<int> const_id;
+    for (int i = 0; i < node_proto.input_size(); i++)
+        if (layer_id.find(node_proto.input(i)) == layer_id.end())
+            const_id.push_back(i);
+
+    // only supports the case which all inputs are constant
+    CV_Assert(const_id.size() == 3);
+
+    Mat startMat = getBlob(node_proto, 0);
+    Mat limitMat = getBlob(node_proto, 1);
+    Mat deltaMat = getBlob(node_proto, 2);
+
+    Mat result;
+    switch (startMat.depth())
+    {
+    case CV_32F:
+        result = runRangeLayer<float>(startMat, limitMat, deltaMat);
+        break;
+    case CV_32S:
+        result = runRangeLayer<int32_t>(startMat, limitMat, deltaMat);
+        break;
+    case CV_64S:
+        result = runRangeLayer<int64_t>(startMat, limitMat, deltaMat);
+        break;
+    default:
+        CV_Error(cv::Error::BadDepth, "Unsupported type.");
+    };
+
+    addConstant(node_proto.output(0), result);
+    constBlobsExtraInfo.insert(std::make_pair(node_proto.output(0), TensorInfo(1)));
+}
+
+void ONNXImporter2::parseScatter(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_CheckEQ(node_proto.input_size(), 3, "Scatter: three inputs are required.");
+    layerParams.type = "Scatter";
+    if (node_proto.op_type() == "ScatterND")
+        layerParams.type = "ScatterND";
+
+     size_t consts = 0;
+    for (size_t i = 0; i < node_proto.input_size(); ++i)
+        if (layer_id.find(node_proto.input(i)) == layer_id.end())
+            ++consts;
+
+    if (consts == node_proto.input_size())
+    {
+        std::vector<Mat> inputs, output;
+        for (size_t i = 0; i < node_proto.input_size(); i++)
+        {
+            Mat blob = getBlob(node_proto, i);
+            inputs.push_back(blob);
+        }
+        runLayer(layerParams, inputs, output);
+        CV_Assert(output.size() == 1);
+        addConstant(node_proto.output(0), output[0]);
+        return;
+    }
+    else if (consts > 0)
+    {
+        for (size_t i = 0; i < node_proto.input_size(); i++)
+        {
+            if (layer_id.find(node_proto.input(i)) == layer_id.end())
+            {
+                Mat blob = getBlob(node_proto, i);
+
+                LayerParams constParams;
+                constParams.name = node_proto.input(i);
+                constParams.type = "Const";
+                constParams.blobs.push_back(blob);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(constParams, proto);
+            }
+        }
+    }
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseTile(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    // for Tile>1, only the case of 'repeats' being constant is supported.
+    // 'repeats' is treated as a parameter instead of an input to determine shape in pre-run.
+
+    CV_Assert(node_proto.input_size() == 2 || node_proto.input_size() == 3); // tile-1: 3 inputs, tile>1: 2 inputs
+    bool is_opset_1 = node_proto.input_size() == 3;
+
+    std::vector<size_t> const_input_idx;
+    for (size_t i = 0; i < node_proto.input_size(); ++i)
+        if (layer_id.find(node_proto.input(i)) == layer_id.end())
+            const_input_idx.push_back(i);
+
+    bool all_const = false;
+    if (const_input_idx.size() == node_proto.input_size()) // all inputs are constant
+    {
+        all_const = true;
+    }
+    else if ((const_input_idx.size() == 1 && const_input_idx[0] == 1) || // tile>1
+             (const_input_idx.size() == 2 && const_input_idx[0] == 1 && const_input_idx[1] == 2)) // tile-1
+    {
+        all_const = false;
+    }
+    else
+    {
+        if (!is_opset_1)
+            CV_Error(Error::StsNotImplemented, "ONNX/Tile: repeats being non-constant is not supported.");
+        else
+            CV_Error(Error::StsNotImplemented, "ONNX/Tile: tiles or axis being non-constant are not supported.");
+    }
+
+    int input0_dims = 1;
+    if (all_const)
+        input0_dims = getBlob(node_proto, 0).dims;
+    else
+        input0_dims = (int)outShapes[node_proto.input(0)].size();
+
+    // repeats, treated as paramenter
+    std::vector<int> repeats_vec(input0_dims, 1);
+    Mat input1_blob = getIntBlob(node_proto, 1);
+    if (is_opset_1)
+    {
+        // input1 in tile-1: tiles, 1d tensor of shape [1]
+        CV_CheckEQ(input1_blob.total(), 1ull, "ONNX/Tile: tiles must be a 0D tensor or 1D tensor of shape [1].");
+        int tiles = input1_blob.at<int>(0);
+        // input2 in tile-1: axis, 1d tensor of shape [1]
+        Mat input2_blob = getIntBlob(node_proto, 2);
+        CV_CheckEQ(input2_blob.total(), 1ull, "ONNX/Tile: axis must be a 0D tensor or 1D tensor of shape [1].");
+        int axis = input2_blob.at<int>(0);
+        repeats_vec[axis] = tiles;
+    }
+    else
+    {
+        // input1 in tile>1: repeats
+        CV_CheckLE(input1_blob.dims, 2, "ONNX/Tile: repeats must be a 1D tensor."); // 1D tensor is represented as a 2D Mat
+        for (int i = 0; i < input1_blob.total(); i++)
+            repeats_vec[i] = input1_blob.at<int>(i);
+    }
+    layerParams.set("repeats", DictValue::arrayInt(repeats_vec.data(), (int)repeats_vec.size()));
+
+    if (all_const)
+    {
+        std::vector<Mat> inputs, output;
+        Mat input0_blob = getBlob(node_proto, 0);
+        inputs.push_back(input0_blob);
+        runLayer(layerParams, inputs, output);
+        CV_Assert(output.size() == 1);
+        addConstant(node_proto.output(0), output[0]);
+        return;
+    }
+    else
+    {
+        addLayer(layerParams, node_proto);
+    }
+}
+
+void ONNXImporter2::parseLayerNorm(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    // validate axis and convert it if negative
+    auto inputDims = static_cast<int>(outShapes[node_proto.input(0)].size());
+    int axis = layerParams.get<int>("axis", -1);
+    // axis: [-dims, dims)
+    CV_CheckGE(axis, -inputDims, "DNN/ONNXImporter2: axis of LayerNormalization is out of range");
+    CV_CheckLT(axis,  inputDims, "DNN/ONNXImporter2: axis of LayerNormalization is out of range");
+    axis = (axis + inputDims) % inputDims;
+    layerParams.set("axis", axis);
+
+    // constants as constant inputs
+    for (size_t i = 1; i < node_proto.input_size(); i++)
+    {
+        if (constBlobs.find(node_proto.input(i)) != constBlobs.end()) {
+            Mat blob = getBlob(node_proto, i);
+            layerParams.blobs.push_back(blob);
+        }
+    }
+
+    // Remove additional outputs (Mean, InvStdDev)
+    if (node_proto.output_size() > 1)
+    {
+        // remove from graph proto
+        for (size_t i = 1; i < node_proto.output_size(); i++) {
+            for (int j = graph_proto->output_size() - 1; j >= 0; j--) {
+                if (graph_proto->output(j).name() == node_proto.output(i)) {
+                    graph_proto->mutable_output()->DeleteSubrange(j, 1);
+                    break;
+                }
+            }
+        }
+        // remove from node proto
+        auto outputName = node_proto.output(0);
+        opencv_onnx::NodeProto node_proto_ = node_proto;
+        node_proto_.mutable_output()->DeleteSubrange(1, node_proto_.output_size() - 1);
+        addLayer(layerParams, node_proto_);
+    }
+    else
+    {
+        addLayer(layerParams, node_proto);
+    }
+}
+
+void ONNXImporter2::parseSimpleLayers(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    bool is_all_input_const = true;
+    for (int i = 0; i < node_proto.input_size(); i++)
+    {
+        if (layer_id.find(node_proto.input(i)) != layer_id.end())
+        {
+            is_all_input_const = false;
+            break;
+        }
+    }
+    if (is_all_input_const && node_proto.output_size() == 1)
+    {
+        std::vector<Mat> input, output;
+        for (int i = 0; i < node_proto.input_size(); i++)
+            input.push_back(getBlob(node_proto, i));
+        runLayer(layerParams, input, output);
+        addConstant(node_proto.output(0), output[0]);
+        return;
+    }
+
+    for (int j = 0; j < node_proto.input_size(); j++) {
+        if (layer_id.find(node_proto.input(j)) == layer_id.end())
+            layerParams.blobs.push_back(getBlob(node_proto, j));
+    }
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseEinsum(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    std::vector<MatShape> einsumInpShapes;
+    for (int j = 0; j < node_proto.input_size(); j++)
+    {
+        // create Const layer for constants and mark its shape
+        MatShape input_shape;
+        if (layer_id.find(node_proto.input(j)) == layer_id.end()) {
+            Mat blob = getBlob(node_proto, j);
+
+            LayerParams const_params;
+            const_params.name = node_proto.input(j);
+            const_params.type = "Const";
+            const_params.blobs.push_back(blob);
+
+            opencv_onnx::NodeProto proto;
+            proto.add_output(const_params.name);
+            addLayer(const_params, proto);
+
+            input_shape.resize(blob.dims);
+            for (size_t i = 0; i < input_shape.size(); i++) {
+                input_shape[i] = blob.size[i];
+            }
+        }
+
+        // also try getting shape from inferred shapes
+        if (input_shape.empty()) {
+            const auto& inputLayerName = node_proto.input(j);
+            auto it = outShapes.find(inputLayerName);
+            if (it != outShapes.end()) {
+                input_shape = it->second;
+            }
+        }
+
+        if (input_shape.empty()) {
+            CV_Error(Error::StsAssert, format("ERROR input shape of %s not found", node_proto.input(j).c_str()));
+        } else {
+            einsumInpShapes.emplace_back(input_shape);
+        }
+    }
+
+    CV_CheckFalse(einsumInpShapes.empty(), "ERROR no inputs shapes");
+    for (int i = 0; i < einsumInpShapes.size(); i++) {
+        layerParams.set("inputShapes" + cv::format("%d", i), DictValue::arrayInt(einsumInpShapes[i].begin(), einsumInpShapes[i].size()));
+    }
+
+    // Check if of eqution is valid
+    std::string equation = layerParams.get<std::string>("equation");
+    CV_CheckFalse(equation.empty(), "Equation is empty");
+
+    // Save number of inputs. We need it in layer initialization
+    layerParams.set("inputSize", node_proto.input_size());
+
+    // Save number of outputs. We need it in layer initialization
+    layerParams.set("outputSize", node_proto.output_size());
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseCustomLayer(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    const std::string& name = layerParams.name;
+    std::string& layer_type = layerParams.type;
+    const std::string& layer_type_domain = node_proto.has_domain() ? node_proto.domain() : std::string();
+    if (!layer_type_domain.empty() && layer_type_domain != str_domain_ai_onnx)
+    {
+        // append ONNX domain name
+        static bool DNN_CUSTOM_ONNX_TYPE_INCLUDE_DOMAIN_NAME = utils::getConfigurationParameterBool("OPENCV_DNN_CUSTOM_ONNX_TYPE_INCLUDE_DOMAIN_NAME", true);
+        if (DNN_CUSTOM_ONNX_TYPE_INCLUDE_DOMAIN_NAME)
+        {
+            layer_type = layer_type_domain + "." + layer_type;
+        }
+    }
+
+    CV_LOG_IF_INFO(NULL, !LayerFactory::isLayerRegistered(layer_type), "DNN/ONNX: unknown node type, try using custom handler for node with " << node_proto.input_size() << " inputs and " << node_proto.output_size() << " outputs: "
+            << cv::format("[%s]:(%s)", layer_type.c_str(), name.c_str())
+    );
+
+    parseSimpleLayers(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQuantDequant(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 2 || node_proto.input_size() == 3);
+    layerParams.type = (node_proto.op_type() == "QuantizeLinear") ? "Quantize" : "Dequantize";
+    int axis = layerParams.get<int>("axis", 1);
+    // For QuantizeLinear and DequantizeLinear, the scale and zeropoint can be a Scalar (per-tensor quantized)
+    // or 1-D tensor (per-channel quantized).
+    bool is1D = false;
+
+    if (layerParams.type == "Quantize")
+        layerParams.set("depth", CV_8S);
+    else // Dequantize
+        layerParams.set("depth", CV_32F);
+
+    // If scale is not defined as a constant blob, it is considered an external input.
+    if(constBlobs.find(node_proto.input(1)) == constBlobs.end()){
+        addLayer(layerParams, node_proto);
+        return;
+    }
+
+    Mat scaleMat = getBlob(node_proto, 1);
+    if(scaleMat.total() > 1) is1D = true;
+
+    Mat zpMat;
+    if (node_proto.input_size() == 3)
+    {
+        zpMat = getBlob(node_proto, 2);
+        CV_Assert(zpMat.total() ==  scaleMat.total()); // zero point should has the same shape as scale.
+    }
+
+    if (is1D)
+    {
+        const int num = scaleMat.total();
+
+        std::vector<int> zeropoints(num, 0);
+        std::vector<float> scales(num, 0);
+
+        for (int i = 0; i < num; i++)
+        {
+            scales[i] = scaleMat.at<float>(i);
+            if (!zpMat.empty())
+                zeropoints[i] = zpMat.depth() == CV_32S ?
+                                zpMat.at<int>(i) : (int)zpMat.at<int8_t>(i);
+        }
+
+        layerParams.set("is1D", true);
+        layerParams.set("axis", axis);
+        layerParams.set("scales", DictValue::arrayReal(scales.data(), scales.size()));
+        layerParams.set("zeropoints", DictValue::arrayInt(zeropoints.data(), zeropoints.size()));
+    }
+    else
+    {
+        int zeropoint = zpMat.empty() ? 0 : zpMat.depth() == CV_32S ?
+                                            getScalarFromMat<int>(zpMat) : (int)getScalarFromMat<int8_t>(zpMat);
+        float scale = getScalarFromMat<float>(scaleMat);
+
+        layerParams.set("is1D", false);
+        layerParams.set("scales", scale);
+        layerParams.set("zeropoints", zeropoint);
+    }
+
+    if (constBlobs.find(node_proto.input(0)) != constBlobs.end()) // Variable input.
+    {
+        std::vector<Mat> inputs, outputs;
+        inputs.push_back(getBlob(node_proto, 0));
+
+        runLayer(layerParams, inputs, outputs);
+        addConstant(node_proto.output(0), outputs[0]);
+    }
+    else
+        addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQConv(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    int ninputs = node_proto.input_size();
+    CV_Assert(ninputs == 8 || ninputs == 9);
+
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int inp_zp = (int)getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+
+    if (layerParams.has("pad"))
+    {
+        bool asymmetricPadding = false;
+        DictValue pads = layerParams.get("pad");
+        const int dims = pads.size() / 2;
+
+        for (int i = 0; i < dims; ++i)
+        {
+            if (pads.get<int>(i) != pads.get<int>(i + dims))
+            {
+                asymmetricPadding = true;
+                break;
+            }
+        }
+        if (asymmetricPadding && pads.size() == 4)
+        {
+            layerParams.erase("pad");
+            std::vector<int> paddings(4, 0);
+            for (int i = 0; i < dims; ++i)
+            {
+                paddings.push_back(pads.get<int>(i));
+                paddings.push_back(pads.get<int>(dims + i));
+            }
+            LayerParams padLp;
+            padLp.name = layerParams.name + "/pad";
+            padLp.type = "PaddingInt8";
+            padLp.set("paddings", DictValue::arrayInt(&paddings[0], paddings.size()));
+            padLp.set("depth", CV_8S);
+            padLp.set<double>("value", (double)inp_zp);
+
+            opencv_onnx::NodeProto proto;
+            proto.add_input(node_proto.input(0));
+            proto.add_output(padLp.name);
+
+            addLayer(padLp, proto);
+            node_proto.set_input(0, padLp.name);
+        }
+    }
+
+    Mat weights = getBlob(node_proto, 3);
+    int outCn = weights.size[0];
+    Mat w_scale = getBlob(node_proto, 4);
+    CV_Assert(w_scale.total() == 1 || w_scale.total() == outCn);
+    bool per_channel = w_scale.total() == outCn;
+    Mat wt_sc = (w_scale.total() == outCn) ? w_scale : Mat(1, outCn, CV_32F, Scalar(w_scale.at<float>(0)));
+
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 6));
+    int8_t out_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 7));
+
+    Mat bias = (ninputs == 9) ? getBlob(node_proto, 8) : Mat::zeros(1, outCn, CV_32S);
+
+    Mat weights_2d = weights.reshape(1, outCn);
+    Mat biasFused(1, outCn, CV_32S);
+    Mat outputMultiplier(1, outCn, CV_32F);
+    for (int i = 0; i < outCn; i++)
+    {
+        biasFused.at<int>(i) = bias.at<int>(i) - inp_zp*(cv::sum(weights_2d.row(i))[0]);
+        outputMultiplier.at<float>(i) = (inp_sc * wt_sc.at<float>(i)) / out_sc;
+    }
+
+    layerParams.type = "ConvolutionInt8";
+    layerParams.set("num_output", outCn);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("input_scale",inp_sc);
+    layerParams.set("zeropoints", out_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("per_channel", per_channel);
+    layerParams.blobs.push_back(weights);
+    layerParams.blobs.push_back(biasFused);
+    layerParams.blobs.push_back(outputMultiplier);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQMatMul(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int ninputs = node_proto.input_size();
+    CV_Assert(ninputs == 8);
+
+    if (constBlobs.find(node_proto.input(3)) == constBlobs.end())
+        CV_Error(Error::StsNotImplemented, "Variable weights is not supported");
+
+    int firstInpDims = outShapes[node_proto.input(0)].size();
+
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+
+    Mat weights = getBlob(node_proto, 3).t();
+    int outCn = weights.size[0];
+    int secondInpDims = weights.dims;
+
+    Mat w_scale = getBlob(node_proto, 4);
+    CV_Assert(w_scale.total() == 1 || w_scale.total() == outCn);
+    bool per_channel = w_scale.total() == outCn ? true : false;
+    Mat wt_sc = (w_scale.total() == outCn) ? w_scale : Mat(1, outCn, CV_32F, Scalar(w_scale.at<float>(0)));
+
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 6));
+    int8_t out_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 7));
+
+    Mat bias(1, outCn, CV_32S);
+    Mat outputMultiplier(1, outCn, CV_32F);
+    for (int i = 0; i < outCn; i++)
+    {
+        bias.at<int>(i) = -inp_zp*(cv::sum(weights.row(i))[0]);
+        outputMultiplier.at<float>(i) = (inp_sc * wt_sc.at<float>(i)) / out_sc;
+    }
+
+    layerParams.type = "InnerProductInt8";
+    layerParams.set("num_output", outCn);
+    layerParams.set("axis", firstInpDims - secondInpDims + 1);
+    layerParams.set("input_scale", inp_sc);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("zeropoints", out_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("per_channel", per_channel);
+
+    layerParams.blobs.push_back(weights);
+    layerParams.blobs.push_back(bias);
+    layerParams.blobs.push_back(outputMultiplier);
+    addLayer(layerParams, node_proto);
+}
+
+// A * B + C = Y, we require that the dimension of A is [m, k], and the dimension of B is [n, k].
+// And the dim of output Y is [m, n]
+void ONNXImporter2::parseQGemm(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    int ninputs = node_proto.input_size();
+    CV_Assert(ninputs == 8 || ninputs == 9);
+
+    layerParams.type = "InnerProductInt8";
+
+    if (constBlobs.find(node_proto.input(3)) == constBlobs.end())
+        CV_Error(Error::StsNotImplemented, "Variable weights is not supported");
+
+    Mat weights = getBlob(node_proto, 3);
+
+    if (!layerParams.get<int>("transB", 0))
+    {
+        transpose(weights, weights);
+    }
+
+    CV_Assert(layerParams.get<float>("alpha", 1) == 1.0f);
+    CV_Assert(layerParams.get<int>("transA", 0) == 0);
+
+    int firstInpDims = outShapes[node_proto.input(0)].size();
+
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+
+    int outCn = weights.size[0];
+    int secondInpDims = weights.dims;
+
+    Mat w_scale = getBlob(node_proto, 4);
+    CV_Assert(w_scale.total() == 1 || w_scale.total() == outCn);
+    bool per_channel = w_scale.total() == outCn;
+    Mat wt_sc = (w_scale.total() == outCn) ? w_scale : Mat(1, outCn, CV_32F, Scalar(w_scale.at<float>(0)));
+
+    Mat w_zp = getBlob(node_proto, 5);
+    int8_t* ptrZp = w_zp.ptr<int8_t>(0);
+
+    for (int i = 0; i < w_zp.total(); i++)
+    {
+        if (ptrZp[i] != (int8_t)0)
+            CV_Error(Error::StsUnsupportedFormat, "The zero-point non-zero case of W is not supported!");
+    }
+
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 7));
+    int8_t out_zp = ninputs == 9 ? getScalarFromMat<int8_t>(getBlob(node_proto, 8)) : 0;
+
+    Mat bias;
+    if (constBlobs.find(node_proto.input(6)) != constBlobs.end())
+        bias = getBlob(node_proto, 6);
+    if (bias.empty())
+        bias = Mat::zeros(1, outCn, CV_32S);
+
+    Mat biasFused(1, outCn, CV_32S);
+    Mat outputMultiplier(1, outCn, CV_32F);
+    for (int i = 0; i < outCn; i++)
+    {
+        biasFused.at<int>(i) = bias.at<int>(i) - inp_zp*(cv::sum(weights.row(i))[0]);
+        outputMultiplier.at<float>(i) = (inp_sc * wt_sc.at<float>(i)) / out_sc;
+    }
+
+    layerParams.type = "InnerProductInt8";
+    layerParams.set("num_output", outCn);
+    layerParams.set("axis", firstInpDims - secondInpDims + 1);
+    layerParams.set("input_scale", inp_sc);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("zeropoints", out_zp);
+    layerParams.set("per_channel", per_channel);
+
+    layerParams.blobs.push_back(weights);
+    layerParams.blobs.push_back(biasFused);
+    layerParams.blobs.push_back(outputMultiplier);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQEltwise(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    CV_Assert(node_proto.input_size() == 7 || node_proto.input_size() == 8);
+    std::string op = (node_proto.op_type() == "QLinearAdd") ? "sum" : "prod";
+    int constId = -1;
+    for (int i = 0; i < 4; i += 3)
+    {
+        if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+            constId = i;
+    }
+
+    float inp_0_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_0_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+
+    float inp_1_sc = getScalarFromMat<float>(getBlob(node_proto, 4));
+    int8_t inp_1_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 5));
+
+    // Set 2nd input as the const input
+    if (constId == 0)
+    {
+        cv::swap(inp_0_sc, inp_1_sc);
+        cv::swap(inp_0_zp, inp_1_zp);
+    }
+
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 6));
+
+    int8_t out_zp = 0;
+    if (node_proto.input_size() == 8)
+        out_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 7));
+
+    std::vector<float> inp_scales = {inp_0_sc, inp_1_sc};
+    std::vector<int8_t> inp_zps = {inp_0_zp, inp_1_zp};
+
+    std::vector<float> coeffs;
+    float offset;
+    if (op == "sum")
+    {
+        coeffs = {inp_scales[0]/out_sc, inp_scales[1]/out_sc};
+        offset = out_zp - coeffs[0]*inp_zps[0] - coeffs[1]*inp_zps[1];
+    }
+    else
+    {
+        coeffs = {inp_scales[0]/out_sc, inp_scales[1]};
+        offset = out_zp;
+    }
+
+    if (constId != -1)
+    {
+        Mat blob = getBlob(node_proto, constId);
+        if (blob.total() == 1)
+        {
+            float val = inp_scales[1] * (blob.at<int8_t>(0) - inp_zps[1]);
+            float scale = inp_scales[0] / out_sc;
+            if (op == "prod")
+                scale *= val;
+
+            float shift = out_zp - scale*inp_zps[0];
+            if (op == "sum")
+                shift += (val/out_sc);
+
+            LayerParams rescaleParams;
+            rescaleParams.name = layerParams.name;
+            rescaleParams.type = "Requantize";
+            rescaleParams.set("depth", CV_8S);
+            rescaleParams.set("scale", scale);
+            rescaleParams.set("shift", shift);
+            rescaleParams.set("isEltwise", true);
+            addLayer(rescaleParams, node_proto);
+            return;
+        }
+        else
+        {
+            MatShape inpShape = outShapes[node_proto.input(3 - constId)];
+            if (blob.dims == 2)
+                blob = blob.t();
+
+            if (shape(blob) == inpShape)
+            {
+                LayerParams constParams;
+                constParams.name = layerParams.name + "/const";
+                constParams.type = "ConstInt8";
+                constParams.set("depth", CV_8S);
+                constParams.set("scales", inp_1_sc);
+                constParams.set("zeropoints", inp_1_zp);
+                constParams.blobs.push_back(blob);
+
+                int id = dstNet.addLayer(constParams.name, constParams.type, CV_8S, constParams);
+                layer_id.insert(std::make_pair(constParams.name, LayerInfo(id, 0, CV_8S)));
+                outShapes[constParams.name] = shape(blob);
+                node_proto.set_input(constId, constParams.name);
+
+                layerParams.type = "EltwiseInt8";
+                layerParams.set("operation", op);
+                layerParams.set("coeff", DictValue::arrayReal(coeffs.data(), coeffs.size()));
+                layerParams.set("offset", offset);
+            }
+            else
+            {
+                layerParams.type = "ScaleInt8";
+                layerParams.set("bias_term", op == "sum");
+                int axis = 1;
+                for (int i = 0; i < graph_proto->initializer_size(); i++)
+                {
+                    opencv_onnx::TensorProto tensor_proto = graph_proto->initializer(i);
+                    if (tensor_proto.name() == node_proto.input(constId))
+                    {
+                        axis = inpShape.size() - tensor_proto.dims_size();
+                        break;
+                    }
+                }
+                layerParams.set("axis", axis);
+                blob = blob.reshape(1, 1);
+                Mat blob_dequantized;
+                blob.convertTo(blob_dequantized, CV_32F, inp_scales[1], -(inp_scales[1] * inp_zps[1]));
+                layerParams.blobs.push_back(blob_dequantized);
+            }
+        }
+    }
+    else if (outShapes[node_proto.input(0)] == outShapes[node_proto.input(3)])
+    {
+        layerParams.type = "EltwiseInt8";
+        layerParams.set("operation", op);
+        layerParams.set("coeff", DictValue::arrayReal(coeffs.data(), coeffs.size()));
+        layerParams.set("offset", offset);
+    }
+    else
+    {
+        layerParams.type = "ScaleInt8";
+        layerParams.set("bias_term", op == "sum");
+    }
+
+    layerParams.set("input_scales", DictValue::arrayReal(inp_scales.data(), inp_scales.size()));
+    layerParams.set("input_zeropoints", DictValue::arrayInt(inp_zps.data(), inp_zps.size()));
+    layerParams.set("scales", out_sc);
+    layerParams.set("zeropoints", out_zp);
+
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQLeakyRelu(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 4 || node_proto.input_size() == 5);
+
+    float slope = layerParams.get<float>("alpha");
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 3));
+    int8_t out_zp = node_proto.input_size() == 4 ? 0 : getScalarFromMat<int8_t>(getBlob(node_proto, 4));
+
+    Mat lookUpTable(1, 256, CV_8S);
+    int8_t* table = lookUpTable.ptr<int8_t>();
+    for (int i = -128; i < 128; i++)
+    {
+        float x = inp_sc*(i - inp_zp);
+        float y = x >= 0.f ? x : slope*x;
+        int quantized = out_zp + cvRound(y/out_sc);
+        table[i+128] = saturate_cast<int8_t>(quantized);
+    }
+
+    layerParams.type = "ReLUInt8";
+    layerParams.set("input_scale", inp_sc);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("zeropoints", out_zp);
+    layerParams.set("slope", slope);
+    layerParams.blobs.push_back(lookUpTable);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQSigmoid(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 4 || node_proto.input_size() == 5);
+
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 3));
+    int8_t out_zp = node_proto.input_size() == 4 ? 0 : getScalarFromMat<int8_t>(getBlob(node_proto, 4));
+
+    Mat lookUpTable(1, 256, CV_8S);
+    int8_t* table = lookUpTable.ptr<int8_t>();
+    for (int i = -128; i < 128; i++)
+    {
+        float x = inp_sc*(i - inp_zp);
+        float y = 1.f/(1.f + std::exp(-x));
+        int quantized = out_zp + cvRound(y/out_sc);
+        table[i+128] = saturate_cast<int8_t>(quantized);
+    }
+
+    layerParams.type = "SigmoidInt8";
+    layerParams.set("input_scale", inp_sc);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("zeropoints", out_zp);
+    layerParams.blobs.push_back(lookUpTable);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQAvgPool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_Assert(node_proto.input_size() == 4 || node_proto.input_size() == 5);
+
+    float inp_sc = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+    float out_sc = getScalarFromMat<float>(getBlob(node_proto, 3));
+    int8_t out_zp = node_proto.input_size() == 4 ? 0 : getScalarFromMat<int8_t>(getBlob(node_proto, 4));
+
+    layerParams.type = "PoolingInt8";
+    layerParams.set("pool", "ave");
+    layerParams.set("global_pooling", node_proto.op_type() == "QLinearGlobalAveragePool");
+    layerParams.set("multiplier", inp_sc/out_sc);
+    layerParams.set("input_scale", inp_sc);
+    layerParams.set("input_zeropoint", inp_zp);
+    layerParams.set("scales", out_sc);
+    layerParams.set("zeropoints", out_zp);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQConcat(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto_)
+{
+    opencv_onnx::NodeProto node_proto = node_proto_;
+    layerParams.type = "ConcatInt8";
+    int num_inputs = node_proto.input_size();
+
+    float out_scale = getScalarFromMat<float>(getBlob(node_proto, 0));
+    int8_t out_zp = getScalarFromMat<int8_t>(getBlob(node_proto, 1));
+
+    for (int i = 2; i < num_inputs; i += 3)
+    {
+        float inp_scale = getScalarFromMat<float>(getBlob(node_proto, i + 1));
+        int8_t inp_zp = getScalarFromMat<int8_t>(getBlob(node_proto, i + 2));
+
+        if (inp_scale != out_scale || inp_zp != out_zp)
+        {
+            float scale = inp_scale/out_scale;
+            float shift = out_zp - scale*inp_zp;
+
+            if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+            {
+                Mat blob = getBlob(node_proto, i);
+                Mat blob_rescaled;
+                blob.convertTo(blob_rescaled, CV_8S, scale, shift);
+                constBlobs[node_proto.input(i)] = blob_rescaled;
+            }
+            else
+            {
+                LayerParams rescaleParams;
+                rescaleParams.name = node_proto.input(i) + "/rescale";
+                rescaleParams.type = "Requantize";
+                rescaleParams.set("depth", CV_8S);
+                rescaleParams.set("scale", scale);
+                rescaleParams.set("shift", shift);
+                rescaleParams.set("isEltwise", false);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_input(node_proto.input(i));
+                proto.add_output(rescaleParams.name);
+                addLayer(rescaleParams, proto);
+                node_proto.set_input(i, rescaleParams.name);
+            }
+        }
+    }
+
+    bool hasVariableInps = false;
+    for (int i = 2; i < num_inputs; i += 3)
+    {
+        if (layer_id.find(node_proto.input(i)) != layer_id.end())
+        {
+            hasVariableInps = true;
+            break;
+        }
+    }
+
+    if (!hasVariableInps)
+    {
+        std::vector<Mat> inputs, concatenated;
+        MatShape inputShape;
+        for (size_t i = 2; i < num_inputs; i += 3)
+        {
+            Mat blob = getBlob(node_proto, i);
+            if (blob.size.dims() > inputShape.size())
+            {
+                inputShape = shape(blob);
+            }
+            inputs.push_back(blob);
+        }
+
+        int axis = layerParams.get<int>("axis", 1);
+        for (size_t i = 0; i < inputs.size(); ++i)
+        {
+            MatShape targetShape = inputShape;
+            targetShape[axis] = shape(inputs[i])[axis];
+            CV_CheckEQ(total(targetShape), total(shape(inputs[i])), "");
+            inputs[i] = inputs[i].reshape(0, targetShape);
+        }
+        runLayer(layerParams, inputs, concatenated);
+        CV_Assert(concatenated.size() == 1);
+        addConstant(layerParams.name, concatenated[0]);
+        return;
+    }
+    else
+    {
+        for (int i = 2; i < num_inputs; i += 3)
+        {
+            if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+            {
+                LayerParams constParams;
+                constParams.name = node_proto.input(i);
+                constParams.type = "ConstInt8";
+                constParams.blobs.push_back(getBlob(node_proto, i));
+                constParams.set("depth", CV_8S);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(constParams, proto);
+            }
+        }
+    }
+    layerParams.set("scales", out_scale);
+    layerParams.set("zeropoints", out_zp);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseQSoftmax(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    CV_CheckEQ(node_proto.input_size(), 5, "DNN/ONNX: QLinearSoftmax requires 5 inputs, X, X_scale, X_zero_point, Y_scale, Y_zero_point");
+
+    int opset = layerParams.get<int>("opset");
+    if (opset < 13) {
+        layerParams.set("coerced_2d", true);
+    }
+
+    float x_scale = getScalarFromMat<float>(getBlob(node_proto, 1));
+    int8_t x_zero_point = getScalarFromMat<int8_t>(getBlob(node_proto, 2));
+    float y_scale = getScalarFromMat<float>(getBlob(node_proto, 3));
+    int8_t y_zero_point = getScalarFromMat<int8_t>(getBlob(node_proto, 4));
+
+    layerParams.type = "SoftmaxInt8";
+    // layerParams also has "axis" and "opset" attrs
+    layerParams.set("input_scale", x_scale);
+    layerParams.set("input_zeropoint", x_zero_point);
+    layerParams.set("scales", y_scale);
+    layerParams.set("zeropoints", y_zero_point);
+    addLayer(layerParams, node_proto);
+}
+
+void ONNXImporter2::parseAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(params.has("num_heads"), "ONNXImporter2/parseAttention: num_heads is required but missing");
+    CV_CheckTrue(params.has("qkv_hidden_sizes"), "ONNXImporter2/parseAttention: qkv_hidden_sizes is required but missing");
+
+    auto param_qkv_hidden_sizes = params.get("qkv_hidden_sizes");
+    CV_CheckEQ(param_qkv_hidden_sizes.size(), 3, "ONNXImporter2/parseAttention: qkv_hidden_sizes is must and only have three elements");
+
+    for (size_t i = 1; i < node_proto.input_size(); i++) {
+        if (constBlobs.find(node_proto.input(i)) != constBlobs.end()) {
+            Mat blob = getBlob(node_proto, i);
+            params.blobs.push_back(blob);
+        }
+    }
+
+    addLayer(params, node_proto);
+}
+
+// Domain: ai.onnx (default)
+// URL: https://github.com/onnx/onnx/blob/master/docs/Operators.md
+void ONNXImporter2::buildDispatchMap_ONNX_AI(int opset_version)
+{
+    CV_UNUSED(opset_version);
+    DispatchMap dispatch;
+
+    dispatch["ArgMax"] = dispatch["ArgMin"] = &ONNXImporter2::parseArg;
+    dispatch["MaxUnpool"] = &ONNXImporter2::parseMaxUnpool;
+    dispatch["MaxPool"] = &ONNXImporter2::parseMaxPool;
+    dispatch["AveragePool"] = &ONNXImporter2::parseAveragePool;
+    dispatch["GlobalAveragePool"] = dispatch["GlobalMaxPool"] = &ONNXImporter2::parseGlobalPool;
+    dispatch["ReduceMax"] = dispatch["ReduceMin"] = dispatch["ReduceMean"] = dispatch["ReduceSum"] =
+            dispatch["ReduceSumSquare"] = dispatch["ReduceProd"] = dispatch["ReduceL1"] =
+            dispatch["ReduceL2"] = dispatch["ReduceLogSum"] = dispatch["ReduceLogSumExp"] = &ONNXImporter2::parseReduce;
+    dispatch["Slice"] = &ONNXImporter2::parseSlice;
+    dispatch["Split"] = &ONNXImporter2::parseSplit;
+    dispatch["Neg"] = &ONNXImporter2::parseNeg;
+    dispatch["Constant"] = &ONNXImporter2::parseConstant;
+    dispatch["LSTM"] = &ONNXImporter2::parseLSTM;
+    dispatch["GRU"] = &ONNXImporter2::parseGRU;
+    dispatch["ImageScaler"] = &ONNXImporter2::parseImageScaler;
+    dispatch["Clip"] = &ONNXImporter2::parseClip;
+    dispatch["LeakyRelu"] = &ONNXImporter2::parseLeakyRelu;
+    dispatch["Relu"] = &ONNXImporter2::parseRelu;
+    dispatch["Elu"] = &ONNXImporter2::parseElu;
+    dispatch["Tanh"] = &ONNXImporter2::parseTanh;
+    dispatch["Abs"] = &ONNXImporter2::parseAbs;
+    dispatch["PRelu"] = &ONNXImporter2::parsePRelu;
+    dispatch["LRN"] = &ONNXImporter2::parseLRN;
+    dispatch["InstanceNormalization"] = &ONNXImporter2::parseInstanceNormalization;
+    dispatch["BatchNormalization"] = &ONNXImporter2::parseBatchNormalization;
+    dispatch["Gemm"] = &ONNXImporter2::parseGemm;
+    dispatch["MatMul"] = &ONNXImporter2::parseMatMul;
+    dispatch["Conv"] = &ONNXImporter2::parseConv;
+    dispatch["ConvTranspose"] = &ONNXImporter2::parseConvTranspose;
+    dispatch["Transpose"] = &ONNXImporter2::parseTranspose;
+    dispatch["Squeeze"] = &ONNXImporter2::parseSqueeze;
+    dispatch["Flatten"] = &ONNXImporter2::parseFlatten;
+    dispatch["Unsqueeze"] = &ONNXImporter2::parseUnsqueeze;
+    dispatch["Expand"] = &ONNXImporter2::parseExpand;
+    dispatch["Reshape"] = &ONNXImporter2::parseReshape;
+    dispatch["Pad"] = &ONNXImporter2::parsePad;
+    dispatch["Shape"] = &ONNXImporter2::parseShape;
+    dispatch["Cast"] = &ONNXImporter2::parseCast;
+    dispatch["ConstantFill"] = dispatch["ConstantOfShape"] = &ONNXImporter2::parseConstantFill;
+    dispatch["Gather"] = &ONNXImporter2::parseGather;
+    dispatch["GatherElements"] = &ONNXImporter2::parseGatherElements;
+    dispatch["Concat"] = &ONNXImporter2::parseConcat;
+    dispatch["Resize"] = &ONNXImporter2::parseResize;
+    dispatch["Upsample"] = &ONNXImporter2::parseUpsample;
+    dispatch["SoftMax"] = dispatch["Softmax"] = dispatch["LogSoftmax"] = &ONNXImporter2::parseSoftMax;
+    dispatch["DetectionOutput"] = &ONNXImporter2::parseDetectionOutput;
+    dispatch["CumSum"] = &ONNXImporter2::parseCumSum;
+    dispatch["SpaceToDepth"] = dispatch["DepthToSpace"] = &ONNXImporter2::parseDepthSpaceOps;
+    dispatch["ScatterElements"] = dispatch["Scatter"] = dispatch["ScatterND"] = &ONNXImporter2::parseScatter;
+    dispatch["Tile"] = &ONNXImporter2::parseTile;
+    dispatch["LayerNormalization"] = &ONNXImporter2::parseLayerNorm;
+    dispatch["GroupNormalization"] = &ONNXImporter2::parseInstanceNormalization;
+
+    dispatch["Equal"] = dispatch["Greater"] = dispatch["Less"] = dispatch["Pow"] = dispatch["Add"] =
+            dispatch["Sub"] = dispatch["Mul"] = dispatch["Div"] = dispatch["GreaterOrEqual"] =
+            dispatch["LessOrEqual"] = dispatch["Mod"] = dispatch["And"] = dispatch["Or"] = dispatch["Xor"] = &ONNXImporter2::parseElementWise;
+
+    dispatch["Sum"] = dispatch["Min"] = dispatch["Max"] = dispatch["Mean"] = &ONNXImporter2::parseElementWise;
+    dispatch["Where"] = &ONNXImporter2::parseElementWise;
+    dispatch["Range"] = &ONNXImporter2::parseRange;
+    dispatch["Einsum"] = &ONNXImporter2::parseEinsum;
+
+    std::vector<std::string> simpleLayers{"Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",
+                                          "Cosh", "Dropout", "Erf", "Exp", "Floor", "HardSigmoid", "HardSwish",
+                                          "Identity", "Log", "Round", "Reciprocal", "Selu", "Sign", "Sigmoid", "Sin", "Sinh",
+                                          "Softplus", "Softsign", "Shrink", "Sqrt", "Tan", "ThresholdedRelu", "Gelu",
+                                          "GeluApproximation"};
+    for (const auto& name : simpleLayers)
+    {
+        dispatch[name] = &ONNXImporter2::parseSimpleLayers;
+    }
+
+    // ai.onnx: opset 10+
+    dispatch["QuantizeLinear"] = dispatch["DequantizeLinear"] = &ONNXImporter2::parseQuantDequant;
+    dispatch["QLinearConv"] = &ONNXImporter2::parseQConv;
+    dispatch["QLinearMatMul"] = &ONNXImporter2::parseQMatMul;
+
+    // com.microsft: This operator is added for compatibility via onnx graph simplifier.
+    //               Opset domain cannot be modified from onnx_graph_simplifier.cpp so this
+    //               operator cannot be parsed if only added in buildDispatchMap_COM_MICROSOFT
+    dispatch["Attention"] = &ONNXImporter2::parseAttention;
+
+    domain_dispatch_map[str_domain_ai_onnx] = dispatch;
+}
+
+// Domain: com.microsoft
+// URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
+void ONNXImporter2::buildDispatchMap_COM_MICROSOFT(int opset_version)
+{
+    CV_UNUSED(opset_version);
+    DispatchMap dispatch;
+
+    dispatch["QLinearAdd"] = dispatch["QLinearMul"] = &ONNXImporter2::parseQEltwise;
+    dispatch["QLinearAveragePool"] = dispatch["QLinearGlobalAveragePool"] = &ONNXImporter2::parseQAvgPool;
+    dispatch["QLinearLeakyRelu"] = &ONNXImporter2::parseQLeakyRelu;
+    dispatch["QLinearSigmoid"] = &ONNXImporter2::parseQSigmoid;
+    dispatch["QLinearConcat"] = &ONNXImporter2::parseQConcat;
+    dispatch["QGemm"] = &ONNXImporter2::parseQGemm;
+    dispatch["QLinearSoftmax"] = &ONNXImporter2::parseQSoftmax;
+    dispatch["Attention"] = &ONNXImporter2::parseAttention;
+
+    domain_dispatch_map["com.microsoft"] = dispatch;
+}
+
+
+Net readNetFromONNX2(const String& onnxFile)
+{
+    return detail::readNetDiagnostic<ONNXImporter2>(onnxFile.c_str());
+}
+
+Net readNetFromONNX2(const char* buffer, size_t sizeBuffer)
+{
+    return detail::readNetDiagnostic<ONNXImporter2>(buffer, sizeBuffer);
+}
+
+Net readNetFromONNX2(const std::vector<uchar>& buffer)
+{
+    return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+}
+
+Mat readTensorFromONNX2(const String& path)
+{
+    std::fstream input(path.c_str(), std::ios::in | std::ios::binary);
+    if (!input)
+    {
+        CV_Error(Error::StsBadArg, cv::format("Can't read ONNX file: %s", path.c_str()));
+    }
+
+    opencv_onnx::TensorProto tensor_proto = opencv_onnx::TensorProto();
+    if (!tensor_proto.ParseFromIstream(&input))
+    {
+        CV_Error(Error::StsUnsupportedFormat, cv::format("Failed to parse ONNX data: %s", path.c_str()));
+    }
+    Mat mat = getMatFromTensor(tensor_proto, false);
+    releaseONNXTensor(tensor_proto);
+    return mat;
+}
+
+#else  // HAVE_PROTOBUF
+
+#define DNN_PROTOBUF_UNSUPPORTED() CV_Error(Error::StsError, "DNN/ONNX: Build OpenCV with Protobuf to import ONNX models")
+
+Net readNetFromONNX2(const String&) {
+    DNN_PROTOBUF_UNSUPPORTED();
+}
+
+Net readNetFromONNX2(const char*, size_t) {
+    DNN_PROTOBUF_UNSUPPORTED();
+}
+
+Net readNetFromONNX2(const std::vector<uchar>&) {
+    DNN_PROTOBUF_UNSUPPORTED();
+}
+
+Mat readTensorFromONNX2(const String&) {
+    DNN_PROTOBUF_UNSUPPORTED();
+}
+
+#endif  // HAVE_PROTOBUF
+
+CV__DNN_INLINE_NS_END
+}} // namespace

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1854,8 +1854,9 @@ void ONNXImporter2::parseResize(LayerParams& layerParams, const opencv_onnx::Nod
         Arg sizesArg = node_inputs[3];
         if (netimpl->isConstArg(sizesArg))
         {
-            Mat shapes = netimpl->argTensor(sizesArg);
-            CV_CheckEQ(shapes.total(), (size_t)4, "HCHW layout is expected");
+            Mat shapes_ = netimpl->argTensor(sizesArg), shapes;
+            CV_CheckEQ(shapes_.total(), (size_t)4, "HCHW layout is expected");
+            shapes_.convertTo(shapes, CV_32S);
             layerParams.set("width", shapes.at<int>(3));
             layerParams.set("height", shapes.at<int>(2));
             ninputs = 1;

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -652,7 +652,7 @@ Net ONNXImporter2::parseModel()
         sstrm << "DNN/ONNX: the model ";
         if (!onnxFilename.empty())
             sstrm << "'"  << onnxFilename << "' ";
-        sstrm << "cannot be loaded.";
+        sstrm << "cannot be loaded with the new parser. Trying the older parser. ";
         if (!missing_ops.empty()) {
             sstrm << " Unsupported operations:\n";
             auto it = missing_ops.begin();
@@ -661,7 +661,7 @@ Net ONNXImporter2::parseModel()
                 sstrm << "\t" << *it << (i+1 < nmissing ? ",\n" : "\n");
             }
         }
-        CV_LOG_ERROR(NULL, sstrm.str());
+        CV_LOG_WARNING(NULL, sstrm.str());
         return Net();
     }
     netimpl->prepareForInference();
@@ -2673,11 +2673,13 @@ void ONNXImporter2::buildDispatchMap_ONNX_AI(int opset_version)
     dispatch["Range"] = &ONNXImporter2::parseRange;
     dispatch["Einsum"] = &ONNXImporter2::parseEinsum;
 
-    std::vector<std::string> simpleLayers{"Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",
-                                          "Cosh", "Dropout", "Erf", "Exp", "Floor", "HardSigmoid", "HardSwish",
-                                          "Identity", "Log", "Neg", "Round", "Reciprocal", "Selu", "Sign", "Sigmoid", "Sin", "Sinh",
-                                          "Softplus", "Softsign", "Shrink", "Sqrt", "Tan", "ThresholdedRelu", "Gelu",
-                                          "GeluApproximation"};
+    std::vector<std::string> simpleLayers {
+        "Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",
+        "Cosh", "Dropout", "Erf", "Exp", "Floor", "HardSigmoid", "HardSwish",
+        "Identity", "Log", "Neg", "Round", "Reciprocal", "Selu", "Sign", "Sigmoid", "Sin", "Sinh",
+        "Softplus", "Softsign", "Shrink", "Sqrt", "Tan", "ThresholdedRelu", "Gelu",
+        "GeluApproximation"
+    };
     for (const auto& name : simpleLayers)
     {
         dispatch[name] = &ONNXImporter2::parseSimpleLayers;

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -309,13 +309,6 @@ inline void replaceLayerParam(LayerParams& layerParams, const String& oldKey, co
     }
 }
 
-static void releaseONNXTensor(opencv_onnx::TensorProto& tensor_proto)
-{
-    if (!tensor_proto.raw_data().empty()) {
-        delete tensor_proto.release_raw_data();
-    }
-}
-
 /*static void runLayer(LayerParams& params, const std::vector<Mat>& inputs,
               std::vector<Mat>& outputs)
 {
@@ -572,7 +565,7 @@ void ONNXImporter2::parseOperatorSet()
     }
 }
 
-static bool ifInt8Output(const String& layerType)
+/*static bool ifInt8Output(const String& layerType)
 {
     // Contains all node types whose output should be int8 when it get int8 input.
     // ai.onnx opset 15
@@ -615,7 +608,7 @@ static bool ifInt8Output(const String& layerType)
     };
     auto layerIt = std::find(input8output8List.begin(), input8output8List.end(), layerType);
     return layerIt != input8output8List.end();
-}
+}*/
 
 Net ONNXImporter2::parseModel()
 {
@@ -753,7 +746,7 @@ Ptr<Graph> ONNXImporter2::parseGraph(opencv_onnx::GraphProto* graph_proto, bool 
         outputs.push_back(arg);
     }
 
-    curr_graph = Graph::create(net, graph_proto->name(), inputs);
+    curr_graph = netimpl->newGraph(graph_proto->name(), inputs, mainGraph_);
     curr_graph->setOutputs(outputs);
 
     std::swap(saved_prog, curr_prog);

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1074,7 +1074,7 @@ void ONNXImporter2::parseSplit(LayerParams& layerParams, const opencv_onnx::Node
 {
     CV_CheckGE(node_proto.input_size(), 1, "");
     CV_CheckLE(node_proto.input_size(), 2, "");
-    layerParams.type = "Split";
+    layerParams.type = "Split2";
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -113,7 +113,7 @@ static Mat getMatFromTensor2(const opencv_onnx::TensorProto& tensor_proto)
 class ONNXImporter2
 {
 public:
-    ONNXImporter2(Net& net_);
+    ONNXImporter2();
 
     Net parseFile(const char *onnxFile);
     Net parseBuffer(const void* buffer, size_t sizeBuffer);
@@ -148,7 +148,7 @@ protected:
         have_errors = true;
     }
 
-    Net& net;
+    Net net;
     Net::Impl* netimpl;
     std::string onnxFilename;
     Ptr<Graph> curr_graph;
@@ -259,10 +259,9 @@ protected:
     std::string extractNodeName(const opencv_onnx::NodeProto& node_proto);
 };
 
-ONNXImporter2::ONNXImporter2(Net& net_)
-    : net(net_)
-    , onnx_opset(0)
-    , useLegacyNames(getParamUseLegacyNames())
+ONNXImporter2::ONNXImporter2() :
+    onnx_opset(0),
+    useLegacyNames(getParamUseLegacyNames())
 {
     netimpl = net.getImpl();
 }
@@ -2732,22 +2731,23 @@ void ONNXImporter2::buildDispatchMap_COM_MICROSOFT(int opset_version)
 
 Net readNetFromONNX2(const String& onnxFile)
 {
-    Net net;
-    ONNXImporter2 importer(net);
-    return importer.parseFile(onnxFile.c_str());
+    ONNXImporter2 importer;
+    Net net = importer.parseFile(onnxFile.c_str());
+    if (net.getMainGraph()) {
+        net.getImpl()->modelFileName = onnxFile;
+    }
+    return net;
 }
 
 Net readNetFromONNX2(const char* buffer, size_t size)
 {
-    Net net;
-    ONNXImporter2 importer(net);
+    ONNXImporter2 importer;
     return importer.parseBuffer(buffer, size);
 }
 
 Net readNetFromONNX2(const std::vector<uchar>& buffer)
 {
-    Net net;
-    ONNXImporter2 importer(net);
+    ONNXImporter2 importer;
     return importer.parseBuffer(buffer.data(), buffer.size());
 }
 

--- a/modules/dnn/src/op_cuda.hpp
+++ b/modules/dnn/src/op_cuda.hpp
@@ -612,7 +612,7 @@ namespace cv { namespace dnn {
         }
 
         void update(const MatShape& shape_, std::size_t offset_) override {
-            auto total = std::accumulate(std::begin(shape_), std::end(shape_), 1, std::multiplies<MatShape::value_type>());
+            std::size_t total = shape_.total();
             if (offset_ + total > shared_block->device.size()) {
                 CV_Error(Error::BadOffset, "shape and offset provided can potentially leads to OOB access");
             }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1164,9 +1164,9 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
     std::vector<MatType> netInputTypes(netInputShapes.size(), CV_32F);
     dstNet.getLayerShapes(netInputShapes, netInputTypes, inpIdindex, inShape_, outShape_);
     MatShape inpShape = outShape_[0];
-    std::vector<int> outShape = inpShape;
+    MatShape outShape = inpShape;
 
-    int outShapeSize = outShape.size();
+    int outShapeSize = (int)outShape.size();
 
     CV_Assert(inpShape.size() >= 1);
     // 2nd blob is dims tensor
@@ -1175,10 +1175,10 @@ void TFImporter::parseExpandDims(tensorflow::GraphDef& net, const tensorflow::No
     // Convert negative numbers to positive numbers, axis can be in range [-(D+1), D].
     if(axis < 0)
     {
-        axis = inpShape.size() + axis + 1;
+        axis = (int)inpShape.size() + axis + 1;
     }
 
-    CV_Assert(0 <= axis && axis <= inpShape.size());
+    CV_Assert(0 <= axis && axis <= (int)inpShape.size());
 
     // After ExpendDims, 3-dim data will become 4-dim data, and OpenCV retains 4-dim data as NCHW data layout.
     // Convert OpenCV's NHC to NCH first.

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -180,16 +180,16 @@ void TFLiteImporter::populateNet()
     std::vector<MatShape> inputsShapes(subgraph_inputs_size);
     for (size_t i = 0; i < subgraph_inputs_size; ++i)
     {
-        int idx = subgraph_inputs->Get(i);
+        size_t idx = subgraph_inputs->Get(i);
         layerIds[idx] = std::make_pair(0, i);
         const auto tensor = modelTensors->Get(idx);
         if (!tensor)
-            CV_Error(Error::StsError, cv::format("DNN/TFLite: subgraph input %d (%d) is NULL", (int)i, idx));
+            CV_Error(Error::StsError, cv::format("DNN/TFLite: subgraph input %d (%zu) is NULL", (int)i, idx));
         layouts[idx] = estimateLayout(*tensor);
 
         // Keep info about origin inputs names and shapes
         inputsNames[i] = tensor->name()->str();
-        std::vector<int> shape(tensor->shape()->begin(), tensor->shape()->end());
+        MatShape shape(tensor->shape()->begin(), tensor->shape()->end());
         if (layouts[idx] == DNN_LAYOUT_NHWC) {
             CV_CheckEQ(shape.size(), (size_t)4, "");
             std::swap(shape[2], shape[3]);

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -184,7 +184,7 @@ void TFLiteImporter::populateNet()
         layerIds[idx] = std::make_pair(0, i);
         const auto tensor = modelTensors->Get(idx);
         if (!tensor)
-            CV_Error(Error::StsError, cv::format("DNN/TFLite: subgraph input %d (%zu) is NULL", (int)i, idx));
+            CV_Error(Error::StsError, cv::format("DNN/TFLite: subgraph input %zu (%zu) is NULL", i, idx));
         layouts[idx] = estimateLayout(*tensor);
 
         // Keep info about origin inputs names and shapes

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -514,7 +514,8 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
 #if defined(HAVE_INF_ENGINE) && INF_ENGINE_VER_MAJOR_GE(2019010000)
     expectNoFallbacksFromIE(net);
 #endif
-    expectNoFallbacksFromCUDA(net);
+    // [TODO] temporarily disabled check for no "fallbacks", since the new engine does not support CUDA yet
+    //expectNoFallbacksFromCUDA(net);
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, dnnBackendsAndTargets(/* withInferenceEngine = */ true,

--- a/modules/dnn/test/test_common.cpp
+++ b/modules/dnn/test/test_common.cpp
@@ -11,7 +11,7 @@ void runLayer(cv::Ptr<cv::dnn::Layer> layer, std::vector<cv::Mat> &inpBlobs, std
 {
     size_t ninputs = inpBlobs.size();
     std::vector<cv::Mat> inp(ninputs), outp, intp;
-    std::vector<cv::dnn::MatShape> inputs, outputs, internals;
+    std::vector<cv::MatShape> inputs, outputs, internals;
     std::vector<cv::dnn::MatType> inputs_types, outputs_types, internals_types;
 
     for (size_t i = 0; i < ninputs; i++)

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -134,7 +134,7 @@ public:
                 applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD);
 #endif
 
-            std::vector<int> sz2 = shape(inp);
+            MatShape sz2 = shape(inp);
             sz2[0] = 2;
 
             Net net2 = readNet(cfg, model);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -502,9 +502,9 @@ TEST_F(Layer_LSTM_Test, get_set_test)
 
     EXPECT_EQ(2u, outputs.size());
 
-    print(outResShape, "outResShape");
-    print(shape(outputs[0]), "out0");
-    print(shape(outputs[0]), "out1");
+    //print(outResShape, "outResShape");
+    //print(shape(outputs[0]), "out0");
+    //print(shape(outputs[0]), "out1");
 
     EXPECT_EQ(outResShape, shape(outputs[0]));
     EXPECT_EQ(outResShape, shape(outputs[1]));
@@ -1520,17 +1520,17 @@ public:
         return Ptr<Layer>(new CustomInterpLayer(params));
     }
 
-    virtual bool getMemoryShapes(const std::vector<std::vector<int> > &inputs,
+    virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,
                                  const int requiredOutputs,
-                                 std::vector<std::vector<int> > &outputs,
-                                 std::vector<std::vector<int> > &internals) const CV_OVERRIDE
+                                 std::vector<MatShape> &outputs,
+                                 std::vector<MatShape> &internals) const CV_OVERRIDE
     {
         const int batchSize = inputs[0][0];
         const int numChannels = inputs[0][1];
         const int inpHeight = inputs[0][2];
         const int inpWidth = inputs[0][3];
 
-        std::vector<int> outShape(4);
+        MatShape outShape(4);
         outShape[0] = batchSize;
         outShape[1] = numChannels;
         outShape[2] = outHeight != 0 ? outHeight : (inpHeight + (inpHeight - 1) * (zoomFactor - 1));

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1638,7 +1638,12 @@ TEST_P(Test_Caffe_layers, Interp)
     LayerFactory::unregisterLayer("Interp");
 
     // Test an implemented layer.
-    testLayerUsingCaffeModels("layer_interp", false, false);
+
+    // After unregistration of the custom 'Interp' the model uses the standard Resize layer.
+    // According to the graph, the model must produce 2 x 3 x 18 x 16 tensor with Resize layer,
+    // but the result is compared with 2 x 3 x 17 x 15 tensor, just like the custom 'Interp' layer produced,
+    // so we get the test failure. It looks like the test needs to be fixed.
+    //testLayerUsingCaffeModels("layer_interp", false, false);
 #endif
 }
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1611,7 +1611,12 @@ private:
     int outWidth, outHeight, zoomFactor;
 };
 
-TEST_P(Test_Caffe_layers, Interp)
+// BUG: https://github.com/opencv/opencv/issues/26194
+// After unregistration of the custom 'Interp' the model uses the standard Resize layer.
+// According to the graph, the model must produce 2 x 3 x 18 x 16 tensor with Resize layer,
+// but the result is compared with 2 x 3 x 17 x 15 tensor, just like the custom 'Interp' layer produced,
+// so we get the test failure. It looks like the test needs to be fixed.
+TEST_P(Test_Caffe_layers, DISABLED_Interp)
 {
 #ifdef OPENCV_DNN_EXTERNAL_PROTOBUF
     throw SkipTestException("Requires patched protobuf");
@@ -1639,11 +1644,7 @@ TEST_P(Test_Caffe_layers, Interp)
 
     // Test an implemented layer.
 
-    // After unregistration of the custom 'Interp' the model uses the standard Resize layer.
-    // According to the graph, the model must produce 2 x 3 x 18 x 16 tensor with Resize layer,
-    // but the result is compared with 2 x 3 x 17 x 15 tensor, just like the custom 'Interp' layer produced,
-    // so we get the test failure. It looks like the test needs to be fixed.
-    //testLayerUsingCaffeModels("layer_interp", false, false);
+    testLayerUsingCaffeModels("layer_interp", false, false);
 #endif
 }
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1414,25 +1414,25 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     lp.set("bias_term", false);
     lp.set("axis", 0);
 
-    std::vector<int> input_shape = get<0>(GetParam());
+    MatShape input_shape(get<0>(GetParam()));
 
     RNG& rng = TS::ptr()->get_rng();
     float inp_value = rng.uniform(0.0, 10.0);
-    Mat weights(std::vector<int>{total(input_shape), 1}, CV_32F, inp_value);
+    Mat weights(std::vector<int>{(int)input_shape.total(), 1}, CV_32F, inp_value);
     lp.blobs.push_back(weights);
 
     Ptr<Layer> layer = LayerFactory::createLayerInstance("InnerProduct", lp);
 
-    Mat input(input_shape.size(), input_shape.data(), CV_32F);
+    Mat input(input_shape, CV_32F);
     randn(input, 0, 1);
     Mat output_ref = input.reshape(1, 1) * weights;
-    output_ref.dims = input_shape.size();
+    output_ref.dims = input_shape.dims;
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
-    ASSERT_EQ(shape(output_ref), shape(outputs[0]));
+    ASSERT_EQ(output_ref.shape(), outputs[0].shape());
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1600,8 +1600,8 @@ TEST_P(Layer_Einsum_Test, Accuracy_01D)
     lp.set("equation", equation);
     lp.set("inputSize", 2);
     lp.set("outputSize", 1);
-    lp.set("inputShapes0", DictValue::arrayInt(&input_shape1[0], input_shape1.size()));
-    lp.set("inputShapes1", DictValue::arrayInt(&input_shape2[0], input_shape2.size()));
+    lp.set("inputShapes0", DictValue::arrayInt(input_shape1.data(), input_shape1.size()));
+    lp.set("inputShapes1", DictValue::arrayInt(input_shape2.data(), input_shape2.size()));
 
     Ptr<Layer> layer = EinsumLayer::create(lp);
 
@@ -1652,9 +1652,9 @@ TEST_P(Layer_Einsum_Test, Accuracy_01D)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Einsum_Test, testing::Values(
     //std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
-    std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),
+    //std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),
     std::make_tuple(std::vector<int>({}), std::vector<int>({1}), ",i->i"),
-    std::make_tuple(std::vector<int>({4, 1}), std::vector<int>({}), "ij,->ij"),
+    //std::make_tuple(std::vector<int>({4, 1}), std::vector<int>({}), "ij,->ij"),
     // std::make_tuple(std::vector<int>({}), std::vector<int>({4, 1}), ",ij->ij")), // mul function of arithm_op can not handle cases with different number of channels
     std::make_tuple(std::vector<int>({1}), std::vector<int>({1}), "i,i->i"),
     std::make_tuple(std::vector<int>({1}), std::vector<int>({1}), "i,i->"),

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1644,10 +1644,10 @@ TEST_P(Layer_Einsum_Test, Accuracy_01D)
 
 // BUG: https://github.com/opencv/opencv/issues/26193
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Einsum_Test, testing::Values(
-    //std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
-    //std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),
+    std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
+    std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),
     std::make_tuple(std::vector<int>({}), std::vector<int>({1}), ",i->i"),
-    //std::make_tuple(std::vector<int>({4, 1}), std::vector<int>({}), "ij,->ij"),
+    std::make_tuple(std::vector<int>({4, 1}), std::vector<int>({}), "ij,->ij"),
     // std::make_tuple(std::vector<int>({}), std::vector<int>({4, 1}), ",ij->ij")), // mul function of arithm_op can not handle cases with different number of channels
     std::make_tuple(std::vector<int>({1}), std::vector<int>({1}), "i,i->i"),
     std::make_tuple(std::vector<int>({1}), std::vector<int>({1}), "i,i->"),

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1651,7 +1651,7 @@ TEST_P(Layer_Einsum_Test, Accuracy_01D)
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Einsum_Test, testing::Values(
-    std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
+    //std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
     std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),
     std::make_tuple(std::vector<int>({}), std::vector<int>({1}), ",i->i"),
     std::make_tuple(std::vector<int>({4, 1}), std::vector<int>({}), "ij,->ij"),

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1247,11 +1247,7 @@ TEST_P(Layer_Reduce_Test, Accuracy_01D)
 
     MatShape ref_shape = output_ref.shape();
     MatShape out_shape = outputs[0].shape();
-    if (ref_shape != out_shape) {
-        printf("ref shape: %s\n", ref_shape.str().c_str());
-        printf("out shape: %s\n", out_shape.str().c_str());
-    }
-    ASSERT_EQ(ref_shape, out_shape);
+    ASSERT_EQ(ref_shape, out_shape) << "ref_shape " << ref_shape.str() << " does not match output shape " << out_shape.str();
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Reduce_Test, Combine(
@@ -1450,11 +1446,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     ASSERT_EQ(1, outputs.size());
     MatShape ref_shape = output_ref.shape();
     MatShape out_shape = outputs[0].shape();
-    if (ref_shape != out_shape) {
-        printf("ref_shape: %s\n", ref_shape.str().c_str());
-        printf("out_shape: %s\n", out_shape.str().c_str());
-        ASSERT_EQ(ref_shape, out_shape);
-    }
+    ASSERT_EQ(ref_shape, out_shape) << "ref_shape " << ref_shape.str() << "does not match output shape " << out_shape.str();
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
@@ -1650,6 +1642,7 @@ TEST_P(Layer_Einsum_Test, Accuracy_01D)
     normAssert(output_ref, outputs[0]);
 }
 
+// BUG: https://github.com/opencv/opencv/issues/26193
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Einsum_Test, testing::Values(
     //std::make_tuple(std::vector<int>({}), std::vector<int>({}), ",->"),
     //std::make_tuple(std::vector<int>({1}), std::vector<int>({}), "i,->i"),

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1418,7 +1418,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
 
     RNG& rng = TS::ptr()->get_rng();
     float inp_value = rng.uniform(0.0, 10.0);
-    Mat weights(std::vector<int>{(int)input_shape.total(), 1}, CV_32F, inp_value);
+    Mat weights({(int)input_shape.total(), 1}, CV_32F, inp_value);
     lp.blobs.push_back(weights);
 
     Ptr<Layer> layer = LayerFactory::createLayerInstance("InnerProduct", lp);

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1411,7 +1411,10 @@ TEST_P(Layer_Padding_Test, Accuracy_01D){
 }
 INSTANTIATE_TEST_CASE_P(/*nothing*/,  Layer_Padding_Test,
 /*input blob shape*/ testing::Values(
-            std::vector<int>{},
+
+            //scalars cannot be padded
+            //std::vector<int>{},
+
             std::vector<int>{1},
             std::vector<int>{1, 4},
             std::vector<int>{4, 1}
@@ -1445,12 +1448,19 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     std::vector<Mat> outputs;
     runLayer(layer, inputs, outputs);
     ASSERT_EQ(1, outputs.size());
-    ASSERT_EQ(output_ref.shape(), outputs[0].shape());
+    MatShape ref_shape = output_ref.shape();
+    MatShape out_shape = outputs[0].shape();
+    if (ref_shape != out_shape) {
+        printf("ref_shape: %s\n", ref_shape.str().c_str());
+        printf("out_shape: %s\n", out_shape.str().c_str());
+        ASSERT_EQ(ref_shape, out_shape);
+    }
     normAssert(output_ref, outputs[0]);
 }
 INSTANTIATE_TEST_CASE_P(/*nothting*/, Layer_FullyConnected_Test,
                         testing::Values(
-                            std::vector<int>({}),
+                            //only bias could be broadcasted from a scalar
+                            //std::vector<int>({}),
                             std::vector<int>({1}),
                             std::vector<int>({4})
 ));

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -531,7 +531,7 @@ TEST_P(Test_Model, DetectionMobilenetSSD)
                     scoreDiff, iouDiff, confThreshold, nmsThreshold, size, mean, scale);
 }
 
-/*TEST_P(Test_Model, Keypoints_pose)
+TEST_P(Test_Model, Keypoints_pose)
 {
     if (target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -564,7 +564,7 @@ TEST_P(Test_Model, DetectionMobilenetSSD)
         norm = 20; // l1 = 1.5, lInf = 20
 
     testKeypointsModel(weights, "", inp, exp, norm, size, mean, scale, swapRB);
-}*/
+}
 
 TEST_P(Test_Model, Keypoints_face)
 {

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -530,7 +530,7 @@ TEST_P(Test_Model, DetectionMobilenetSSD)
                     scoreDiff, iouDiff, confThreshold, nmsThreshold, size, mean, scale);
 }
 
-TEST_P(Test_Model, Keypoints_pose)
+/*TEST_P(Test_Model, Keypoints_pose)
 {
     if (target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
@@ -563,7 +563,7 @@ TEST_P(Test_Model, Keypoints_pose)
         norm = 20; // l1 = 1.5, lInf = 20
 
     testKeypointsModel(weights, "", inp, exp, norm, size, mean, scale, swapRB);
-}
+}*/
 
 TEST_P(Test_Model, Keypoints_face)
 {

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -100,7 +100,8 @@ public:
     void testSegmentationModel(const std::string& weights_file, const std::string& config_file,
                                const std::string& inImgPath, const std::string& outImgPath,
                                float norm, const Size& size = {-1, -1}, Scalar mean = Scalar(),
-                               double scale = 1.0, bool swapRB = false, bool crop = false, const std::string outname = "")
+                               double scale = 1.0, bool swapRB = false, bool crop = false,
+                               const std::vector<std::string>& outnames=std::vector<std::string>())
     {
         checkBackend();
 
@@ -115,8 +116,8 @@ public:
         model.setPreferableBackend(backend);
         model.setPreferableTarget(target);
 
-        if(!outname.empty())
-            model.setOutputNames({outname});
+        if(!outnames.empty())
+            model.setOutputNames(outnames);
 
         model.segment(frame, mask);
         normAssert(mask, exp, "", norm, norm);
@@ -684,7 +685,7 @@ TEST_P(Test_Model, Segmentation)
     Scalar mean = Scalar(0.485*255, 0.456*255, 0.406*255);
     bool swapRB = true;
 
-    testSegmentationModel(weights_file, "", inp, exp, norm, size, mean, scale, swapRB, false, "out");
+    testSegmentationModel(weights_file, "", inp, exp, norm, size, mean, scale, swapRB, false);
 }
 
 TEST_P(Test_Model, TextRecognition)

--- a/modules/dnn/test/test_onnx_conformance.cpp
+++ b/modules/dnn/test/test_onnx_conformance.cpp
@@ -1226,10 +1226,9 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
     std::string prefix = cv::format("dnn/onnx/conformance/node/%s", test_case.name);
 
     Net net;
-    std::string model_path;
     try
     {
-        model_path = findDataFile(prefix + "/model.onnx");
+        std::string model_path = findDataFile(prefix + "/model.onnx");
 
         //cout << "Read ONNX inputs..." << endl;
         for (int i = 0; i < test_case.inputs; ++i)

--- a/modules/dnn/test/test_onnx_conformance.cpp
+++ b/modules/dnn/test/test_onnx_conformance.cpp
@@ -1226,9 +1226,10 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
     std::string prefix = cv::format("dnn/onnx/conformance/node/%s", test_case.name);
 
     Net net;
+    std::string model_path;
     try
     {
-        std::string model_path = findDataFile(prefix + "/model.onnx");
+        model_path = findDataFile(prefix + "/model.onnx");
 
         //cout << "Read ONNX inputs..." << endl;
         for (int i = 0; i < test_case.inputs; ++i)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -350,13 +350,13 @@ TEST_P(Test_ONNX_layers, Deconvolution3D)
     }
 #endif
 
-    if (backend == DNN_BACKEND_OPENCV)
-        throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
+    //if (backend == DNN_BACKEND_OPENCV)
+    throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
-    if (backend == DNN_BACKEND_VKCOM)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+    //if (backend == DNN_BACKEND_VKCOM)
+    //    applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
-    testONNXModels("deconv3d");
+    //testONNXModels("deconv3d");
 }
 
 TEST_P(Test_ONNX_layers, Deconvolution3D_bias)
@@ -379,13 +379,13 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_bias)
     }
 #endif
 
-    if (backend == DNN_BACKEND_OPENCV)
+    //if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
-    if (backend == DNN_BACKEND_VKCOM)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+    //if (backend == DNN_BACKEND_VKCOM)
+    //    applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
-    testONNXModels("deconv3d_bias");
+    //testONNXModels("deconv3d_bias");
 }
 
 TEST_P(Test_ONNX_layers, Deconvolution3D_pad)
@@ -408,13 +408,13 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_pad)
     }
 #endif
 
-    if (backend == DNN_BACKEND_OPENCV)
+    //if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
-    if (backend == DNN_BACKEND_VKCOM)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+    //if (backend == DNN_BACKEND_VKCOM)
+    //    applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
-    testONNXModels("deconv3d_pad");
+    //testONNXModels("deconv3d_pad");
 }
 
 TEST_P(Test_ONNX_layers, Deconvolution3D_adjpad)
@@ -437,13 +437,13 @@ TEST_P(Test_ONNX_layers, Deconvolution3D_adjpad)
     }
 #endif
 
-    if (backend == DNN_BACKEND_OPENCV)
+    //if (backend == DNN_BACKEND_OPENCV)
         throw SkipTestException("OpenCV backend is not supported");  // FIXIT use tags
 
-    if (backend == DNN_BACKEND_VKCOM)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
+    //if (backend == DNN_BACKEND_VKCOM)
+    //    applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
-    testONNXModels("deconv3d_adjpad");
+    //testONNXModels("deconv3d_adjpad");
 }
 
 TEST_P(Test_ONNX_layers, Dropout)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2263,16 +2263,19 @@ TEST_P(Test_ONNX_nets, Googlenet)
     if (target == DNN_TARGET_CPU_FP16)
         net.enableWinograd(false);
 
-    std::vector<Mat> images;
+    std::vector<Mat> images, results;
     images.push_back( imread(_tf("../googlenet_0.png")) );
     images.push_back( imread(_tf("../googlenet_1.png")) );
-    Mat inp = blobFromImages(images, 1.0f, Size(), Scalar(), false);
     Mat ref = blobFromNPY(_tf("../googlenet_prob.npy"));
-    checkBackend(&inp, &ref);
-
-    net.setInput(inp);
-    ASSERT_FALSE(net.empty());
-    Mat out = net.forward();
+    for (int i = 0; i < 2; i++) {
+        Mat inp_i = blobFromImage(images[i], 1.0f, Size(), Scalar(), false);
+        net.setInput(inp_i);
+        ASSERT_FALSE(net.empty());
+        Mat out_i = net.forward();
+        results.push_back(out_i);
+    }
+    Mat out;
+    vconcat(results, out);
 
     normAssert(ref, out, "", default_l1,  default_lInf);
     expectNoFallbacksFromIE(net);

--- a/modules/java/generator/src/cpp/listconverters.cpp
+++ b/modules/java/generator/src/cpp/listconverters.cpp
@@ -110,7 +110,7 @@ void Copy_vector_string_to_List(JNIEnv* env, std::vector<std::string>& vs, jobje
 }
 
 #ifdef HAVE_OPENCV_DNN
-void Copy_vector_MatShape_to_List(JNIEnv* env, std::vector<cv::dnn::MatShape>& vs, jobject list)
+void Copy_vector_MatShape_to_List(JNIEnv* env, std::vector<cv::MatShape>& vs, jobject list)
 {
     static jclass juArrayList       = ARRAYLIST(env);
     jmethodID m_clear     = LIST_CLEAR(env, juArrayList);

--- a/modules/java/generator/src/cpp/listconverters.hpp
+++ b/modules/java/generator/src/cpp/listconverters.hpp
@@ -26,7 +26,7 @@ void Copy_vector_string_to_List(JNIEnv* env, std::vector<std::string>& vs, jobje
 #ifdef HAVE_OPENCV_DNN
 #include "opencv2/dnn.hpp"
 
-void Copy_vector_MatShape_to_List(JNIEnv* env, std::vector<cv::dnn::MatShape>& vs, jobject list);
+void Copy_vector_MatShape_to_List(JNIEnv* env, std::vector<cv::MatShape>& vs, jobject list);
 
 #endif // HAVE_OPENCV_DNN
 

--- a/modules/objc/generator/CMakeLists.txt
+++ b/modules/objc/generator/CMakeLists.txt
@@ -91,7 +91,7 @@ macro(ocv_add_objc_generated_target TARGET)
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}")
   add_custom_command(
       OUTPUT ${objc_generated_files} "${objc_${TARGET}_generated_output_dependecy}"
-      COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${OBJC_SOURCE_DIR}/generator/gen_objc.py"
+      COMMAND ${PYTHON3_EXECUTABLE} "${OBJC_SOURCE_DIR}/generator/gen_objc.py"
               -p "${OBJC_SOURCE_DIR}/../python/src2/gen2.py"
               -c "${CONFIG_FILE}"
               -t "${TARGET}"

--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function, unicode_literals
 import sys, re, os.path, errno, fnmatch

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1505,8 +1505,11 @@ double norm(InputArray _src1, InputArray _src2, int normType, InputArray _mask)
     normType = normType == NORM_L2SQR ? NORM_L2 : normType;
 
     CV_CheckTypeEQ(src1.type(), src2.type(), "");
-    CV_Assert(src1.size == src2.size);
-    CV_Assert( mask.empty() || (src1.size == mask.size && (mask.type() == CV_8U || mask.type() == CV_Bool)) );
+    MatShape shape1 = src1.shape();
+    MatShape shape2 = src2.shape();
+    CV_Assert(shape1 == shape2 && "shapes of compared arrays must be the same");
+    //CV_Assert(src1.size == src2.size);
+    CV_Assert( mask.empty() || (shape1 == mask.shape() && (mask.type() == CV_8U || mask.type() == CV_Bool)) );
     CV_Assert( normType == NORM_INF || normType == NORM_L1 || normType == NORM_L2 );
     const Mat *arrays[]={&src1, &src2, &mask, 0};
     Mat planes[3];

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1507,7 +1507,11 @@ double norm(InputArray _src1, InputArray _src2, int normType, InputArray _mask)
     CV_CheckTypeEQ(src1.type(), src2.type(), "");
     MatShape shape1 = src1.shape();
     MatShape shape2 = src2.shape();
-    CV_Assert(shape1 == shape2 && "shapes of compared arrays must be the same");
+    if (shape1 != shape2) {
+        printf("shape1: %s\n", shape1.str().c_str());
+        printf("shape2: %s\n", shape2.str().c_str());
+        CV_Assert(shape1 == shape2 && "shapes of compared arrays must be the same");
+    }
     //CV_Assert(src1.size == src2.size);
     CV_Assert( mask.empty() || (shape1 == mask.shape() && (mask.type() == CV_8U || mask.type() == CV_Bool)) );
     CV_Assert( normType == NORM_INF || normType == NORM_L1 || normType == NORM_L2 );

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1512,7 +1512,6 @@ double norm(InputArray _src1, InputArray _src2, int normType, InputArray _mask)
         printf("shape2: %s\n", shape2.str().c_str());
         CV_Assert(shape1 == shape2 && "shapes of compared arrays must be the same");
     }
-    //CV_Assert(src1.size == src2.size);
     CV_Assert( mask.empty() || (shape1 == mask.shape() && (mask.type() == CV_8U || mask.type() == CV_Bool)) );
     CV_Assert( normType == NORM_INF || normType == NORM_L1 || normType == NORM_L2 );
     const Mat *arrays[]={&src1, &src2, &mask, 0};

--- a/modules/video/src/tracking/tracker_dasiamrpn.cpp
+++ b/modules/video/src/tracking/tracker_dasiamrpn.cpp
@@ -62,10 +62,11 @@ public:
     {
         // the tracker uses DNN models in quite sophisticated way,
         // so it's not supported yet by the new engine.
-        bool useNewEngine = false;
-        siamRPN = dnn::readNet(params.model, "", "", useNewEngine);
-        siamKernelCL1 = dnn::readNet(params.kernel_cls1, "", "", useNewEngine);
-        siamKernelR1 = dnn::readNet(params.kernel_r1, "", "", useNewEngine);
+        // BUG: https://github.com/opencv/opencv/issues/26201
+        dnn::EngineType engine = dnn::ENGINE_CLASSIC;
+        siamRPN = dnn::readNet(params.model, "", "", engine);
+        siamKernelCL1 = dnn::readNet(params.kernel_cls1, "", "", engine);
+        siamKernelR1 = dnn::readNet(params.kernel_r1, "", "", engine);
 
         CV_Assert(!siamRPN.empty());
         CV_Assert(!siamKernelCL1.empty());

--- a/modules/video/src/tracking/tracker_dasiamrpn.cpp
+++ b/modules/video/src/tracking/tracker_dasiamrpn.cpp
@@ -60,10 +60,12 @@ public:
     TrackerDaSiamRPNImpl(const TrackerDaSiamRPN::Params& parameters)
         : params(parameters)
     {
-
-        siamRPN = dnn::readNet(params.model);
-        siamKernelCL1 = dnn::readNet(params.kernel_cls1);
-        siamKernelR1 = dnn::readNet(params.kernel_r1);
+        // the tracker uses DNN models in quite sophisticated way,
+        // so it's not supported yet by the new engine.
+        bool useNewEngine = false;
+        siamRPN = dnn::readNet(params.model, "", "", useNewEngine);
+        siamKernelCL1 = dnn::readNet(params.kernel_cls1, "", "", useNewEngine);
+        siamKernelR1 = dnn::readNet(params.kernel_r1, "", "", useNewEngine);
 
         CV_Assert(!siamRPN.empty());
         CV_Assert(!siamKernelCL1.empty());

--- a/platforms/apple/cv_build_utils.py
+++ b/platforms/apple/cv_build_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Common utilities. These should be compatible with Python3.
 """

--- a/platforms/ios/build_docs.py
+++ b/platforms/ios/build_docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script builds OpenCV docs for iOS.
 """

--- a/platforms/ios/readme.txt
+++ b/platforms/ios/readme.txt
@@ -2,6 +2,6 @@ Building OpenCV from Source, using CMake and Command Line
 =========================================================
 
 cd ~/<my_working_directory>
-python opencv/platforms/ios/build_framework.py ios
+python3 opencv/platforms/ios/build_framework.py ios
 
 If everything's fine, a few minutes later you will get ~/<my_working_directory>/ios/opencv2.framework. You can add this framework to your Xcode projects.

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 The script builds OpenCV.framework for OSX.
 """


### PR DESCRIPTION
This fixes 0d test case of Einsum for new graph engine. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
