### PR TITLE
Enhance cv::TickMeter to be able to get the last elapsed time

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -309,11 +309,12 @@ public:
     //! stops counting ticks.
     CV_WRAP void stop()
     {
-        int64 time = cv::getTickCount();
+        const int64 time = cv::getTickCount();
         if (startTime == 0)
             return;
         ++counter;
-        sumTime += (time - startTime);
+        lastTime = time - startTime;
+        sumTime += lastTime;
         startTime = 0;
     }
 
@@ -336,9 +337,33 @@ public:
     }
 
     //! returns passed time in seconds.
-    CV_WRAP double getTimeSec()   const
+    CV_WRAP double getTimeSec() const
     {
         return (double)getTimeTicks() / getTickFrequency();
+    }
+
+    //! returns counted ticks of the last iteration.
+    CV_WRAP int64 getLastTimeTicks() const
+    {
+        return lastTime;
+    }
+
+    //! returns passed time of the last iteration in microseconds.
+    CV_WRAP double getLastTimeMicro() const
+    {
+        return getLastTimeMilli()*1e3;
+    }
+
+    //! returns passed time of the last iteration in milliseconds.
+    CV_WRAP double getLastTimeMilli() const
+    {
+        return getLastTimeSec()*1e3;
+    }
+
+    //! returns passed time of the last iteration in seconds.
+    CV_WRAP double getLastTimeSec() const
+    {
+        return (double)getLastTimeTicks() / getTickFrequency();
     }
 
     //! returns internal counter value.
@@ -373,15 +398,17 @@ public:
     //! resets internal values.
     CV_WRAP void reset()
     {
-        startTime = 0;
-        sumTime = 0;
         counter = 0;
+        sumTime = 0;
+        startTime = 0;
+        lastTime = 0;
     }
 
 private:
     int64 counter;
     int64 sumTime;
     int64 startTime;
+    int64 lastTime;
 };
 
 /** @brief output operator

--- a/samples/cpp/tutorial_code/snippets/core_various.cpp
+++ b/samples/cpp/tutorial_code/snippets/core_various.cpp
@@ -78,6 +78,7 @@ int main()
             tm.start();
             // do something ...
             tm.stop();
+            cout << "Last iteration: " << tm.getLastTimeSec() << endl;
         }
         cout << "Average time per iteration in seconds: " << tm.getAvgTimeSec() << endl;
         cout << "Average FPS: " << tm.getFPS() << endl;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [N/A] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


## Proposal
This PR introduces a new interface to collect the last iteration time of the `cv::TickMeter` class.
Besides, two more minor changes are included:
1. Reorder the variables inside the `cv::TickeMeter::reset()` method so that the order matches the declaration of the variables, which makes visual inspection easier.
2. `const` correctness inside the `cv::TickMeter::stop()` method.

### Motivation
When using the `cv::TickMeter` in a loop or in a continuous processing application, it is sometimes useful to also know the time that the last iteration took, not only the average. For example, if the user wants to report extraordinary deviations from the average, or to debug the application.

In this use case, the current implementation requires that the user implements complicated code externally that could be simply provided by the class in a more elegant way. 

### Related work
#6821 - Addition of the `cv::TickMeter` class.
#17071 - Addition of methods to get the FPS and average time to the `cv::TickMeter` class.


### Other
I could not find any tests for the `cv::TickMeter` class. Now that there is increasingly more functionality, not sure if it may now be desirable to start testing this class. I could do so, if desired. We could test:
1. The consistency between the several getters in different units (i.e., that micro is milli * 1e3, etc.).
2. That in the first iteration the last iteration needs to be equal to the total time.
3. Any other ideas?

This is my very first PR and I have read over the different documents on how to contribute. I hope I did not miss any detail, but let me know otherwise :)