### PR TITLE
C-API cleanup: use AutoBuffer in MSER (5.x)

### DIFF
--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -46,7 +46,6 @@
 #include "precomp.hpp"
 #include <limits>
 #include "../3rdparty/mscr/chi_table.h"
-#include "opencv2/core/core_c.h"
 
 namespace cv
 {
@@ -873,10 +872,13 @@ extractMSER_8uC3( const Mat& src,
                   const MSER_Impl::Params& params )
 {
     bboxvec.clear();
-    MSCRNode* map = (MSCRNode*)cvAlloc( src.cols*src.rows*sizeof(map[0]) );
+    AutoBuffer<MSCRNode> mapBuf(src.cols*src.rows);
+    MSCRNode* map = mapBuf.data();
     int Ne = src.cols*src.rows*2-src.cols-src.rows;
-    MSCREdge* edge = (MSCREdge*)cvAlloc( Ne*sizeof(edge[0]) );
-    TempMSCR* mscr = (TempMSCR*)cvAlloc( src.cols*src.rows*sizeof(mscr[0]) );
+    AutoBuffer<MSCREdge> edgeBuf(Ne);
+    MSCREdge* edge = edgeBuf.data();
+    AutoBuffer<TempMSCR> mscrBuf(src.cols*src.rows);
+    TempMSCR* mscr = mscrBuf.data();
     double emean = 0;
     Mat dx( src.rows, src.cols-1, CV_64FC1 );
     Mat dy( src.rows-1, src.cols, CV_64FC1 );
@@ -987,9 +989,6 @@ extractMSER_8uC3( const Mat& src,
             }
             bboxvec.push_back(Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1));
         }
-    cvFree( &mscr );
-    cvFree( &edge );
-    cvFree( &map );
 }
 
 void MSER_Impl::detectRegions( InputArray _src, vector<vector<Point> >& msers, vector<Rect>& bboxes )


### PR DESCRIPTION
cvAlloc/cvFree was the only use of C-API in _features2d_ source code.