### PR TITLE
Added HAL documentation note for out-of-bound hack in optical flow LK.

### DIFF
--- a/modules/video/src/hal_replacement.hpp
+++ b/modules/video/src/hal_replacement.hpp
@@ -27,7 +27,9 @@
 //! @{
 
 /**
-@brief Lucas-Kanade optical flow for single pyramid layer. See calcOpticalFlowPyrLK
+@brief Lucas-Kanade optical flow for single pyramid layer. See calcOpticalFlowPyrLK.
+@note OpenCV builds pyramid levels with `win_size` padding. Out-of-bound access to source
+image data is legal within `+-win_size` range.
 @param prev_data previous frame image data
 @param prev_data_step previous frame image data step
 @param prev_deriv_data previous frame Schaar derivatives
@@ -69,6 +71,8 @@ inline int hal_ni_LKOpticalFlowLevel(const uchar *prev_data, size_t prev_data_st
 
 /**
 @brief Computes Schaar derivatives with inteleaved layout xyxy...
+@note OpenCV builds pyramid levels with `win_size` padding. Out-of-bound access to source
+image data is legal within `+-win_size` range.
 @param src_data source image data
 @param src_step source image step
 @param dst_data destination buffer data


### PR DESCRIPTION
- OpenCV and OpenCV/Carotene implementations are derived from the same root and expect +- winsize border around the actual image and its derivatives. The functions get cv::Mat with the padded buffer like ROI.
- OpenCV and OpenCV/Carotene Scharr derivatives have the same assumption in design and use +1 pixel border of the input image.
- The border is already taken into account during pyramid allocation. It's filled by the image pixels, if available or with copyMakeBorder. [CopyMakeBorder](https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga2ac1049c2c3dd25c2b41bffe17658a36) call has ticky logic and allows passing ROI of the original image as destination.  The function recognizes it and fills the border, but does not make a copy. So the current implementation is efficient in this term.

Relates to:
- https://github.com/opencv/opencv/pull/26143
- https://github.com/opencv/opencv/pull/26163

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
