### PR TITLE
`cuda` - update npp calls to use the new NppStreamContext API if available

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -134,6 +134,36 @@ namespace cv { namespace cuda
     template<> struct NPPTypeTraits<CV_32F> { typedef Npp32f npp_type; };
     template<> struct NPPTypeTraits<CV_64F> { typedef Npp64f npp_type; };
 
+#define nppSafeCall(expr)  cv::cuda::checkNppError(expr, __FILE__, __LINE__, CV_Func)
+// NppStreamContext is introduced in NPP version 10100 included in CUDA toolkit 10.1 (CUDA_VERSION == 10010) however not all of the NPP functions called internally by OpenCV
+// - have an NppStreamContext argument (e.g. nppiHistogramEvenGetBufferSize_8u_C1R_Ctx in CUDA 12.3) and/or
+// - have a corresponding function in the supplied library (e.g. nppiEvenLevelsHost_32s_Ctx is not present in nppist.lib or libnppist.so as of CUDA 12.6)
+// Because support for these functions has gradually been introduced without being mentioned in the release notes this flag is set to a version of NPP (version 12205 included in CUDA toolkit 12.4) which is known to work.
+#define USE_NPP_STREAM_CTX NPP_VERSION >= 12205
+#if USE_NPP_STREAM_CTX
+    class NppStreamHandler
+    {
+    public:
+        inline explicit NppStreamHandler(cudaStream_t newStream)
+        {
+            nppStreamContext = {};
+            nppSafeCall(nppGetStreamContext(&nppStreamContext));
+            nppStreamContext.hStream = newStream;
+            cudaSafeCall(cudaStreamGetFlags(nppStreamContext.hStream, &nppStreamContext.nStreamFlags));
+        }
+
+        inline explicit NppStreamHandler(Stream& newStream) : NppStreamHandler(StreamAccessor::getStream(newStream)) {}
+
+        inline operator NppStreamContext() const {
+            return nppStreamContext;
+        }
+
+        inline NppStreamContext get() { return nppStreamContext; }
+
+    private:
+        NppStreamContext nppStreamContext;
+    };
+#else
     class NppStreamHandler
     {
     public:
@@ -157,9 +187,9 @@ namespace cv { namespace cuda
     private:
         cudaStream_t oldStream;
     };
+#endif
 }}
 
-#define nppSafeCall(expr)  cv::cuda::checkNppError(expr, __FILE__, __LINE__, CV_Func)
 #define cuSafeCall(expr)  cv::cuda::checkCudaDriverApiError(expr, __FILE__, __LINE__, CV_Func)
 
 #endif // HAVE_CUDA


### PR DESCRIPTION
Update calls to Nvidia's NPP library to use the newer NppStreamContext API introduced in CUDA 10.1 ([release notes](https://docs.nvidia.com/cuda/archive/10.1/cuda-toolkit-release-notes/index.html#npp-new-features))

Although this was introduced in CUDA 10.1 at that point not all of the functions either had a `_Ctx` version which took a `NppStreamContext` or an implementation present in the NPP library.  Therefore in this PR the `USE_NPP_STREAM_CTX` flag which selects the new API is only enabled for versions of NPP >= 12205 (the version included with CUDA toolkit 12.4) which I have verified as working.  Currently the only function called inside OpenCV which does not work with the new API is `nppiEvenLevelsHost_32s_Ctx` which doesn't have an implementation inside _nppist.lib_ or _libnppist.so_ as of CUDA 12.6.

Tested locally on Ubuntu 20.04 with both CUDA toolkits 12.3 and 12.4.

Adds changes discussed in https://github.com/opencv/opencv_contrib/pull/3338 to all Npp functions called by OpenCV.
Fixes https://github.com/opencv/opencv_contrib/issues/3798

@tomoaki0705 I have re-introduced streaming in https://github.com/tomoaki0705/opencv/blob/f4e5d777e856f751c4318f0c633dcce37cfa66f2/modules/cudaarithm/src/reductions.cpp#L161 which you disabled in https://github.com/opencv/opencv/pull/11064 because it looks like you fixed it with https://github.com/opencv/opencv/pull/11550 is this correct?

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
