### PR TITLE
Multiple calibrateMultiview improvements.

### DIFF
--- a/modules/calib/include/opencv2/calib.hpp
+++ b/modules/calib/include/opencv2/calib.hpp
@@ -1288,14 +1288,22 @@ points in all the available views from all cameras.
 @sa findChessboardCorners, findCirclesGrid, calibrateCamera, fisheye::calibrate, registerCameras
 */
 
+CV_EXPORTS_AS(calibrateMultiviewExtended) double calibrateMultiview (
+        InputArrayOfArrays objPoints, const std::vector<std::vector<Mat>> &imagePoints,
+        const std::vector<cv::Size>& imageSize, InputArray detectionMask, InputArray models,
+        InputOutputArrayOfArrays Ks, InputOutputArrayOfArrays distortions,
+        InputOutputArrayOfArrays Rs, InputOutputArrayOfArrays Ts,
+        OutputArray initializationPairs, OutputArrayOfArrays rvecs0,
+        OutputArrayOfArrays tvecs0, OutputArray perFrameErrors,
+        InputArray flagsForIntrinsics=noArray(), int flags = 0);
+
+/// @overload
 CV_EXPORTS_W double calibrateMultiview (
         InputArrayOfArrays objPoints, const std::vector<std::vector<Mat>> &imagePoints,
         const std::vector<cv::Size>& imageSize, InputArray detectionMask, InputArray models,
-        InputOutputArrayOfArrays Rs, InputOutputArrayOfArrays Ts,
         InputOutputArrayOfArrays Ks, InputOutputArrayOfArrays distortions,
-        int flags = 0, InputArray flagsForIntrinsics=noArray(),
-        OutputArrayOfArrays rvecs0=noArray(), OutputArrayOfArrays tvecs0=noArray(),
-        OutputArray perFrameErrors=noArray(), OutputArray initializationPairs=noArray());
+        InputOutputArrayOfArrays Rs, InputOutputArrayOfArrays Ts,
+        InputArray flagsForIntrinsics=noArray(), int flags = 0);
 
 
 /** @brief Computes Hand-Eye calibration: \f$_{}^{g}\textrm{T}_c\f$

--- a/modules/calib/test/test_cameracalibration.cpp
+++ b/modules/calib/test/test_cameracalibration.cpp
@@ -2485,7 +2485,7 @@ double CV_MultiviewCalibrationTest_CPP::calibrateStereoCamera( const vector<vect
     std::vector<uchar> models(2, cv::CALIB_MODEL_PINHOLE);
     std::vector<int> all_flags(2, flags);
     double rms = calibrateMultiview(objectPoints, image_points_all, image_sizes, visibility_mat, models,
-                                    Rs, Ts, Ks, distortions, 0, all_flags, rvecs, tvecs, errors_mat);
+                                    Ks, distortions, Rs, Ts, /*pairs*/ noArray(), rvecs, tvecs, errors_mat, all_flags);
 
     if (perViewErrors1.size() != (size_t)numImgs)
     {

--- a/modules/calib/test/test_fisheye.cpp
+++ b/modules/calib/test/test_fisheye.cpp
@@ -616,17 +616,12 @@ TEST_F(fisheyeTest, multiview_calibration)
     }
     std::vector<cv::Size> image_sizes(2, imageSize);
     cv::Mat visibility_mat = cv::Mat_<uchar>::ones(2, (int)leftPoints.size());
-    std::vector<cv::Mat> Rs, Ts, Ks, distortions, rvecs0, tvecs0;
+    std::vector<cv::Mat> Rs, Ts, Ks, distortions;
     std::vector<uchar> models(2, cv::CALIB_MODEL_FISHEYE);
-    int flag = 0;
-    flag |= cv::CALIB_RECOMPUTE_EXTRINSIC;
-    flag |= cv::CALIB_CHECK_COND;
-    flag |= cv::CALIB_FIX_SKEW;
+    std::vector<int> all_flags(2, cv::CALIB_RECOMPUTE_EXTRINSIC | cv::CALIB_CHECK_COND | cv::CALIB_FIX_SKEW);
 
-    std::vector<int> all_flags(2, flag);
-
-    calibrateMultiview(objectPoints, image_points_all, image_sizes, visibility_mat, models,
-                       Rs, Ts, Ks, distortions, 0, all_flags, rvecs0, tvecs0);
+    calibrateMultiview(objectPoints, image_points_all, image_sizes, visibility_mat,
+                       models, Ks, distortions, Rs, Ts, all_flags);
     cv::Matx33d R_correct(   0.9975587205950972,   0.06953016383322372, 0.006492709911733523,
                            -0.06956823121068059,    0.9975601387249519, 0.005833595226966235,
                           -0.006071257768382089, -0.006271040135405457, 0.9999619062167968);

--- a/modules/calib/test/test_multiview_calib.cpp
+++ b/modules/calib/test/test_multiview_calib.cpp
@@ -133,7 +133,7 @@ TEST(multiview_calibration, accuracy) {
 
     std::vector<cv::Mat> Ks, distortions, Rs, Ts;
     calibrateMultiview(objPoints, image_points_all, image_sizes, visibility_mat,
-                       models, Rs, Ts, Ks, distortions);
+                       models, Ks, distortions, Rs, Ts);
 
     const double K_err_tol = 1e1, dist_tol = 5e-2, R_tol = 1e-2, T_tol = 1e-2;
     for (int c = 0; c < num_cameras; c++) {
@@ -169,7 +169,7 @@ struct MultiViewTest : public ::testing::Test
                          std::vector<std::vector<cv::Mat>>& image_points_all, cv::Mat& visibility)
     {
         image_points_all.clear();
-        visibility.create(static_cast<int>(cameras.size()), frameCount, CV_8UC1);
+        visibility.create(static_cast<int>(cameras.size()), frameCount, CV_BoolC1);
         for (int c = 0; c < static_cast<int>(cameras.size()); c++)
         {
             std::vector<cv::Mat> camera_image_points;
@@ -183,7 +183,7 @@ struct MultiViewTest : public ::testing::Test
                 if (!node.empty())
                 {
                     camera_image_points.push_back(node.mat().reshape(2, 1));
-                    visibility.at<uchar>(c, i) = 255;
+                    visibility.at<uchar>(c, i) = 1;
                 }
                 else
                 {
@@ -315,7 +315,7 @@ TEST_F(MultiViewTest, OneLine)
 
     std::vector<cv::Mat> Ks, distortions, Rs, Rs_rvec, Ts;
     double rms = calibrateMultiview(objPoints, image_points_all, image_sizes, visibility, models,
-                                    Rs_rvec, Ts, Ks, distortions, 0, flagsForIntrinsics);
+                                    Ks, distortions, Rs_rvec, Ts, flagsForIntrinsics);
     CV_LOG_INFO(NULL, "RMS: "  << rms);
 
     EXPECT_LE(rms, .3);
@@ -420,7 +420,7 @@ TEST_F(MultiViewTest, OneLineInitialGuess)
 
     int flags = cv::CALIB_USE_EXTRINSIC_GUESS | cv::CALIB_USE_INTRINSIC_GUESS | cv::CALIB_STEREO_REGISTRATION;
     double rms = calibrateMultiview(objPoints, image_points_all, image_sizes, visibility, models,
-                                    Rs_rvec, Ts, Ks, distortions, flags, flagsForIntrinsics);
+                                    Ks, distortions, Rs_rvec, Ts, flagsForIntrinsics, flags);
     CV_LOG_INFO(NULL, "RMS: "  << rms);
 
     EXPECT_LE(rms, .3);
@@ -486,7 +486,7 @@ TEST_F(MultiViewTest, CamsToFloor)
 
     std::vector<cv::Mat> Ks, distortions, Rs, Rs_rvec, Ts;
     double rms = calibrateMultiview(objPoints, image_points_all, image_sizes, visibility, models,
-                                    Rs_rvec, Ts, Ks, distortions, 0, flagsForIntrinsics);
+                                    Ks, distortions, Rs_rvec, Ts, flagsForIntrinsics);
     CV_LOG_INFO(NULL, "RMS: "  << rms);
 
     EXPECT_LE(rms, 1.);
@@ -555,7 +555,7 @@ TEST_F(MultiViewTest, Hetero)
 
     std::vector<cv::Mat> Ks, distortions, Rs, Rs_rvec, Ts;
     double rms = calibrateMultiview(objPoints, image_points_all, image_sizes, visibility, models,
-                                    Rs_rvec, Ts, Ks, distortions, 0, flagsForIntrinsics);
+                                    Ks, distortions, Rs_rvec, Ts, flagsForIntrinsics);
     CV_LOG_INFO(NULL, "RMS: "  << rms);
 
     EXPECT_LE(rms, 2.5);

--- a/samples/cpp/multiview_calibration_sample.cpp
+++ b/samples/cpp/multiview_calibration_sample.cpp
@@ -163,7 +163,7 @@ static void detectPointsAndCalibrate (cv::Size pattern_size, float pattern_dista
 // ! [multiview_calib]
 
     const double rmse = calibrateMultiview(objPoints, image_points_all, image_sizes, visibility,
-                                           models, Rs, Ts, Ks, distortions);
+                                           models, Ks, distortions, Rs, Ts);
 // ! [multiview_calib]
     std::cout << "average RMSE over detection mask " << rmse << "\n";
     for (int c = 0; c < (int)Rs.size(); c++) {

--- a/samples/python/multiview_calibration.py
+++ b/samples/python/multiview_calibration.py
@@ -423,7 +423,7 @@ def calibrateFromPoints(
 #    try:
 # [multiview_calib]
     rmse, Rs, Ts, Ks, distortions, rvecs0, tvecs0, errors_per_frame, output_pairs = \
-            cv.calibrateMultiview(
+            cv.calibrateMultiviewExtended(
                 objPoints=pattern_points_all,
                 imagePoints=image_points,
                 imageSize=image_sizes,


### PR DESCRIPTION
- Added function overload for the simple case
- Added CV_Bool type support for masks
- `parallel_for_` for intrinsics calibration for faster inference
- Homogenize parameters order with other calibrateXXX functions

4 tests from MultiViewTest 298912 ms total before and 234068 ms total after the patch.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
