### PR TITLE
added comprehensive test for countNonZero run on continuous and discontinuous 1D arrays

### DIFF
--- a/modules/core/test/test_countnonzero.cpp
+++ b/modules/core/test/test_countnonzero.cpp
@@ -308,7 +308,6 @@ TEST_P(CountNonZero1D, /**/)
     Mat mv;
     Mat(v).convertTo(mv, depth);
     EXPECT_EQ(mv.dims, 1);
-    EXPECT_EQ(mv.total(), M);
     size_t esz = mv.elemSize();
     // check countNonZero on a vector transformed to Mat inplace, e.g. on 1xM matrix
     int nz0 = countNonZero(mv);

--- a/modules/core/test/test_countnonzero.cpp
+++ b/modules/core/test/test_countnonzero.cpp
@@ -293,4 +293,50 @@ INSTANTIATE_TEST_CASE_P(Core, CountNonZeroBig,
     )
 );
 
+typedef testing::TestWithParam<int> CountNonZero1D;
+
+TEST_P(CountNonZero1D, /**/)
+{
+    const int depth = GetParam();
+    int i, M = 112 + depth, N = 3 + depth;
+    std::vector<uint8_t> v(M);
+    int nz_ref = 0;
+    for (i = 0; i < M; i++) {
+        v[i] = (uint8_t)(rand() % 7 == 0);
+        nz_ref += v[i] != 0;
+    }
+    Mat mv;
+    Mat(v).convertTo(mv, depth);
+    EXPECT_EQ(mv.dims, 1);
+    EXPECT_EQ(mv.total(), M);
+    size_t esz = mv.elemSize();
+    // check countNonZero on a vector transformed to Mat inplace, e.g. on 1xM matrix
+    int nz0 = countNonZero(mv);
+    EXPECT_EQ(nz0, nz_ref);
+    // another method to get 1xM matrix, this time 2D matrix
+    int nz0_ = countNonZero(Mat(Size(M, 1), depth, mv.data));
+    EXPECT_EQ(nz0_, nz_ref);
+    // let's now transpose it and get Mx1
+    Mat m1 = mv.t();
+    int nz1 = countNonZero(m1);
+    EXPECT_EQ(nz1, nz_ref);
+    Mat mwide(M, N, mv.type());
+    randu(mwide, 0, 3);
+    int colidx = rand()%N;
+    Mat mcol = mwide.col(colidx);
+    EXPECT_EQ(mcol.data, mwide.data + colidx*esz);
+    // let's now embed this column into a wider matrix
+    // make sure it's copied inside, not reallocated.
+    m1.copyTo(mcol);
+    EXPECT_EQ(mcol.data, mwide.data + colidx*esz);
+    // now it's not continuous
+    EXPECT_EQ(mcol.isContinuous(), false);
+    int nz2 = countNonZero(mcol);
+    EXPECT_EQ(nz2, nz_ref);
+}
+
+INSTANTIATE_TEST_CASE_P(Core, CountNonZero1D,
+    testing::Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32U, CV_32S, CV_64U, CV_64S, CV_32F, CV_64F, CV_16F, CV_16BF, CV_Bool)
+);
+
 }} // namespace


### PR DESCRIPTION
attempt to reproduce #24109

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
