### PR TITLE
Adds roboflow interactive widgets to documentation with a feature-flag implementation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,6 +14,12 @@ endif()
 #     \                               -> doxygen_python* ->        /
 #      ---------------------------------------------------------->
 
+if(NOT DEFINED ENABLE_ROBOFLOW_IFRAMES)
+  set(ENABLE_ROBOFLOW_IFRAMES ON)
+endif()
+
+option(ENABLE_ROBOFLOW_IFRAMES "Enable Roboflow iframes in documentation" ${ENABLE_ROBOFLOW_IFRAMES})
+
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
   if (DOXYGEN_VERSION VERSION_LESS 1.9.8)
@@ -29,9 +35,14 @@ if(DOXYGEN_FOUND)
   unset(CMAKE_DOXYGEN_TUTORIAL_JS_ROOT)
 
   set(OPENCV_DOCS_EXCLUDE_CUDA ON)
+
   if(";${OPENCV_MODULES_EXTRA};" MATCHES ";cudev;")
     set(OPENCV_DOCS_EXCLUDE_CUDA OFF)
     list(APPEND CMAKE_DOXYGEN_ENABLED_SECTIONS "CUDA_MODULES")
+  endif()
+
+  if(ENABLE_ROBOFLOW_IFRAMES)
+    list(APPEND CMAKE_DOXYGEN_ENABLED_SECTIONS "ENABLE_ROBOFLOW_IFRAMES")
   endif()
 
   # gathering headers

--- a/doc/py_tutorials/py_feature2d/py_matcher/py_matcher.markdown
+++ b/doc/py_tutorials/py_feature2d/py_matcher/py_matcher.markdown
@@ -133,7 +133,13 @@ plt.imshow(img3),plt.show()
 @endcode
 See the result below:
 
+@if (ENABLE_ROBOFLOW_IFRAMES)
+\htmlonly
+<div style="height: 600px;"><iframe src="https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiM3ZqZklQZlRZZUppaUhQcVAwM0YiLCJ3b3Jrc3BhY2VJZCI6IjRPSUtuamRyMmczY21MUkl6ZEFEIiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyODA3NjA1N30.ySDSp40t2jx5FSdt9A4Xaj-9L-HEJvWwGatuwPNcgIw" loading="lazy" title="Roboflow Workflow for SIFT Brute Force" style="width: 100%; height: 100%; min-height: 400px; border: none;"></iframe></div>
+\endhtmlonly
+@else
 ![image](images/matcher_result2.jpg)
+@endif
 
 FLANN based Matcher
 -------------------
@@ -208,4 +214,10 @@ plt.imshow(img3,),plt.show()
 @endcode
 See the result below:
 
+@if (ENABLE_ROBOFLOW_IFRAMES)
+\htmlonly
+<div style="height: 600px;"><iframe src="https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoicEJkQ04yYXdFaUdwS1NXMW9sQVMiLCJ3b3Jrc3BhY2VJZCI6IjRPSUtuamRyMmczY21MUkl6ZEFEIiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyODA4MDI1MH0.kbJWXGD6E2jQcOIChyOFhDQm95rvNI8M2H473grJEF8" loading="lazy" title="Roboflow Workflow for SIFT FLANN" style="width: 100%; height: 100%; min-height: 400px; border: none;"></iframe></div>
+\endhtmlonly
+@else
 ![image](images/matcher_flann.jpg)
+@endif


### PR DESCRIPTION
This PR adds Roboflow interactive widgets to documentation with a feature-flag implementation.

You can check the live demo [here](https://fb1480eafdf2.ngrok.app/dc/dc3/tutorial_py_matcher.html).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
