### PR TITLE
core: C-API cleanup: RNG algorithms in core(4.x)

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1225,6 +1225,31 @@ CVAPI(int)  cvCheckArr( const CvArr* arr, int flags CV_DEFAULT(0),
                         double min_val CV_DEFAULT(0), double max_val CV_DEFAULT(0));
 #define cvCheckArray cvCheckArr
 
+#define CV_RAND_UNI      0
+#define CV_RAND_NORMAL   1
+
+/** @brief Fills an array with random numbers and updates the RNG state.
+
+The function fills the destination array with uniformly or normally distributed random numbers.
+@param rng CvRNG state initialized by cvRNG
+@param arr The destination array
+@param dist_type Distribution type
+> -   **CV_RAND_UNI** uniform distribution
+> -   **CV_RAND_NORMAL** normal or Gaussian distribution
+@param param1 The first parameter of the distribution. In the case of a uniform distribution it is
+the inclusive lower boundary of the random numbers range. In the case of a normal distribution it
+is the mean value of the random numbers.
+@param param2 The second parameter of the distribution. In the case of a uniform distribution it
+is the exclusive upper boundary of the random numbers range. In the case of a normal distribution
+it is the standard deviation of the random numbers.
+@sa randu, randn, RNG::fill.
+ */
+CVAPI(void) cvRandArr( CvRNG* rng, CvArr* arr, int dist_type,
+                      CvScalar param1, CvScalar param2 );
+
+CVAPI(void) cvRandShuffle( CvArr* mat, CvRNG* rng,
+                           double iter_factor CV_DEFAULT(1.));
+
 #define CV_SORT_EVERY_ROW 0
 #define CV_SORT_EVERY_COLUMN 1
 #define CV_SORT_ASCENDING 0

--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1225,31 +1225,6 @@ CVAPI(int)  cvCheckArr( const CvArr* arr, int flags CV_DEFAULT(0),
                         double min_val CV_DEFAULT(0), double max_val CV_DEFAULT(0));
 #define cvCheckArray cvCheckArr
 
-#define CV_RAND_UNI      0
-#define CV_RAND_NORMAL   1
-
-/** @brief Fills an array with random numbers and updates the RNG state.
-
-The function fills the destination array with uniformly or normally distributed random numbers.
-@param rng CvRNG state initialized by cvRNG
-@param arr The destination array
-@param dist_type Distribution type
-> -   **CV_RAND_UNI** uniform distribution
-> -   **CV_RAND_NORMAL** normal or Gaussian distribution
-@param param1 The first parameter of the distribution. In the case of a uniform distribution it is
-the inclusive lower boundary of the random numbers range. In the case of a normal distribution it
-is the mean value of the random numbers.
-@param param2 The second parameter of the distribution. In the case of a uniform distribution it
-is the exclusive upper boundary of the random numbers range. In the case of a normal distribution
-it is the standard deviation of the random numbers.
-@sa randu, randn, RNG::fill.
- */
-CVAPI(void) cvRandArr( CvRNG* rng, CvArr* arr, int dist_type,
-                      CvScalar param1, CvScalar param2 );
-
-CVAPI(void) cvRandShuffle( CvArr* mat, CvRNG* rng,
-                           double iter_factor CV_DEFAULT(1.));
-
 #define CV_SORT_EVERY_ROW 0
 #define CV_SORT_EVERY_COLUMN 1
 #define CV_SORT_ASCENDING 0

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -409,7 +409,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
                (((_param2.rows == 1 || _param2.cols == 1) &&
                 (_param2.rows + _param2.cols - 1 == cn || _param2.rows + _param2.cols - 1 == 1 ||
                 (_param1.size() == Size(1, 4) && _param1.type() == CV_64F && cn <= 4))) ||
-                (_param2.rows == cn && _param2.cols == cn && disttype == NORMAL)));
+                (_param2.rows == cn && _param2.cols == cn && disttype == RNG::NORMAL)));
 
     Vec2i* ip = 0;
     Vec2d* dp = 0;
@@ -421,7 +421,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
     int n1 = (int)_param1.total();
     int n2 = (int)_param2.total();
 
-    if( disttype == UNIFORM )
+    if( disttype == RNG::UNIFORM )
     {
         _parambuf.allocate(cn*8 + n1 + n2);
         double* parambuf = _parambuf.data();
@@ -535,7 +535,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
         }
         CV_Assert( func != 0 );
     }
-    else if( disttype == CV_RAND_NORMAL )
+    else if( disttype == RNG::NORMAL )
     {
         _parambuf.allocate(MAX(n1, cn) + MAX(n2, cn));
         double* parambuf = _parambuf.data();
@@ -586,7 +586,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
     float* nbuf = 0;
     float* tmpbuf = 0;
 
-    if( disttype == UNIFORM )
+    if( disttype == RNG::UNIFORM )
     {
         buf.allocate(blockSize*cn*4);
         param = (uchar*)(double*)buf.data();
@@ -637,7 +637,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
         {
             int len = std::min(total - j, blockSize);
 
-            if( disttype == CV_RAND_UNI )
+            if( disttype == RNG::UNIFORM )
                 func( ptr, len*cn, &state, param, tmpbuf, smallFlag );
             else
             {
@@ -749,28 +749,6 @@ void cv::randShuffle( InputOutputArray _dst, double iterFactor, RNG* _rng )
     CV_Assert( func != 0 );
     func( dst, rng, iterFactor );
 }
-
-
-#ifndef OPENCV_EXCLUDE_C_API
-
-CV_IMPL void
-cvRandArr( CvRNG* _rng, CvArr* arr, int disttype, CvScalar param1, CvScalar param2 )
-{
-    cv::Mat mat = cv::cvarrToMat(arr);
-    // !!! this will only work for current 64-bit MWC RNG !!!
-    cv::RNG& rng = _rng ? (cv::RNG&)*_rng : cv::theRNG();
-    rng.fill(mat, disttype == CV_RAND_NORMAL ?
-        cv::RNG::NORMAL : cv::RNG::UNIFORM, cv::Scalar(param1), cv::Scalar(param2) );
-}
-
-CV_IMPL void cvRandShuffle( CvArr* arr, CvRNG* _rng, double iter_factor )
-{
-    cv::Mat dst = cv::cvarrToMat(arr);
-    cv::RNG& rng = _rng ? (cv::RNG&)*_rng : cv::theRNG();
-    cv::randShuffle( dst, iter_factor, &rng );
-}
-
-#endif  // OPENCV_EXCLUDE_C_API
 
 
 // Mersenne Twister random number generator.

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -751,6 +751,28 @@ void cv::randShuffle( InputOutputArray _dst, double iterFactor, RNG* _rng )
 }
 
 
+#ifndef OPENCV_EXCLUDE_C_API
+
+CV_IMPL void
+cvRandArr( CvRNG* _rng, CvArr* arr, int disttype, CvScalar param1, CvScalar param2 )
+{
+    cv::Mat mat = cv::cvarrToMat(arr);
+    // !!! this will only work for current 64-bit MWC RNG !!!
+    cv::RNG& rng = _rng ? (cv::RNG&)*_rng : cv::theRNG();
+    rng.fill(mat, disttype == CV_RAND_NORMAL ?
+        cv::RNG::NORMAL : cv::RNG::UNIFORM, cv::Scalar(param1), cv::Scalar(param2) );
+}
+
+CV_IMPL void cvRandShuffle( CvArr* arr, CvRNG* _rng, double iter_factor )
+{
+    cv::Mat dst = cv::cvarrToMat(arr);
+    cv::RNG& rng = _rng ? (cv::RNG&)*_rng : cv::theRNG();
+    cv::randShuffle( dst, iter_factor, &rng );
+}
+
+#endif  // OPENCV_EXCLUDE_C_API
+
+
 // Mersenne Twister random number generator.
 // Inspired by http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/CODES/mt19937ar.c
 

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -118,12 +118,12 @@ protected:
             int cn = cvtest::randInt(rng) % 4 + 1;
             Mat test_mat(cvtest::randInt(rng)%30+1, cvtest::randInt(rng)%30+1, CV_MAKETYPE(depth, cn));
 
-            rng0.fill(test_mat, CV_RAND_UNI, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
+            rng0.fill(test_mat, RNG::UNIFORM, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
             if( depth >= CV_32F )
             {
                 exp(test_mat, test_mat);
                 Mat test_mat_scale(test_mat.size(), test_mat.type());
-                rng0.fill(test_mat_scale, CV_RAND_UNI, Scalar::all(-1), Scalar::all(1));
+                rng0.fill(test_mat_scale, RNG::UNIFORM, Scalar::all(-1), Scalar::all(1));
                 cv::multiply(test_mat, test_mat_scale, test_mat);
             }
 
@@ -136,12 +136,12 @@ protected:
             };
             MatND test_mat_nd(3, sz, CV_MAKETYPE(depth, cn));
 
-            rng0.fill(test_mat_nd, CV_RAND_UNI, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
+            rng0.fill(test_mat_nd, RNG::UNIFORM, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
             if( depth >= CV_32F )
             {
                 exp(test_mat_nd, test_mat_nd);
                 MatND test_mat_scale(test_mat_nd.dims, test_mat_nd.size, test_mat_nd.type());
-                rng0.fill(test_mat_scale, CV_RAND_UNI, Scalar::all(-1), Scalar::all(1));
+                rng0.fill(test_mat_scale, RNG::UNIFORM, Scalar::all(-1), Scalar::all(1));
                 cv::multiply(test_mat_nd, test_mat_scale, test_mat_nd);
             }
 

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -650,8 +650,8 @@ void Core_ArrayOpTest::run( int /* start_from */)
         MatND A(3, sz3, CV_32F), B(3, sz3, CV_16SC4);
         CvMatND matA = cvMatND(A), matB = cvMatND(B);
         RNG rng;
-        rng.fill(A, CV_RAND_UNI, Scalar::all(-10), Scalar::all(10));
-        rng.fill(B, CV_RAND_UNI, Scalar::all(-10), Scalar::all(10));
+        rng.fill(A, RNG::UNIFORM, Scalar::all(-10), Scalar::all(10));
+        rng.fill(B, RNG::UNIFORM, Scalar::all(-10), Scalar::all(10));
 
         int idx0[] = {3,4,5}, idx1[] = {0, 9, 7};
         float val0 = 130;
@@ -807,7 +807,7 @@ void Core_ArrayOpTest::run( int /* start_from */)
         all_vals.resize(nz0);
         all_vals2.resize(nz0);
         Mat_<double> _all_vals(all_vals), _all_vals2(all_vals2);
-        rng.fill(_all_vals, CV_RAND_UNI, Scalar(-1000), Scalar(1000));
+        rng.fill(_all_vals, RNG::UNIFORM, Scalar(-1000), Scalar(1000));
         if( depth == CV_32F )
         {
             Mat _all_vals_f;

--- a/modules/core/test/test_rand.cpp
+++ b/modules/core/test/test_rand.cpp
@@ -48,7 +48,7 @@ bool Core_RandTest::check_pdf(const Mat& hist, double scale,
         sum += H[i];
     CV_Assert( fabs(1./sum - scale) < FLT_EPSILON );
 
-    if( dist_type == CV_RAND_UNI )
+    if( dist_type == RNG::UNIFORM )
     {
         float scale0 = (float)(1./hsz);
         for( i = 0; i < hsz; i++ )
@@ -79,7 +79,7 @@ bool Core_RandTest::check_pdf(const Mat& hist, double scale,
     }
     realval = chi2;
 
-    double chi2_pval = chi2_p95(hsz - 1 - (dist_type == CV_RAND_NORMAL ? 2 : 0));
+    double chi2_pval = chi2_p95(hsz - 1 - (dist_type == RNG::NORMAL ? 2 : 0));
     refval = chi2_pval*0.01;
     return realval <= refval;
 }
@@ -108,7 +108,7 @@ void Core_RandTest::run( int )
         int depth = cvtest::randInt(rng) % (CV_64F+1);
         int c, cn = (cvtest::randInt(rng) % 4) + 1;
         int type = CV_MAKETYPE(depth, cn);
-        int dist_type = cvtest::randInt(rng) % (CV_RAND_NORMAL+1);
+        int dist_type = cvtest::randInt(rng) % (RNG::NORMAL+1);
         int i, k, SZ = N/cn;
         Scalar A, B;
 
@@ -116,18 +116,18 @@ void Core_RandTest::run( int )
         if (depth == CV_64F)
             eps = 1.e-7;
 
-        bool do_sphere_test = dist_type == CV_RAND_UNI;
+        bool do_sphere_test = dist_type == RNG::UNIFORM;
         Mat arr[2], hist[4];
         int W[] = {0,0,0,0};
 
         arr[0].create(1, SZ, type);
         arr[1].create(1, SZ, type);
-        bool fast_algo = dist_type == CV_RAND_UNI && depth < CV_32F;
+        bool fast_algo = dist_type == RNG::UNIFORM && depth < CV_32F;
 
         for( c = 0; c < cn; c++ )
         {
             int a, b, hsz;
-            if( dist_type == CV_RAND_UNI )
+            if( dist_type == RNG::UNIFORM )
             {
                 a = (int)(cvtest::randInt(rng) % (_ranges[depth][1] -
                                               _ranges[depth][0])) + _ranges[depth][0];
@@ -188,8 +188,8 @@ void Core_RandTest::run( int )
             const uchar* data = arr[0].ptr();
             int* H = hist[c].ptr<int>();
             int HSZ = hist[c].cols;
-            double minVal = dist_type == CV_RAND_UNI ? A[c] : A[c] - B[c]*4;
-            double maxVal = dist_type == CV_RAND_UNI ? B[c] : A[c] + B[c]*4;
+            double minVal = dist_type == RNG::UNIFORM ? A[c] : A[c] - B[c]*4;
+            double maxVal = dist_type == RNG::UNIFORM ? B[c] : A[c] + B[c]*4;
             double scale = HSZ/(maxVal - minVal);
             double delta = -minVal*scale;
 
@@ -210,7 +210,7 @@ void Core_RandTest::run( int )
                     H[ival]++;
                     W[c]++;
                 }
-                else if( dist_type == CV_RAND_UNI )
+                else if( dist_type == RNG::UNIFORM )
                 {
                     if( (minVal <= val && val < maxVal) || (depth >= CV_32F && val == maxVal) )
                     {
@@ -224,14 +224,14 @@ void Core_RandTest::run( int )
                 }
             }
 
-            if( dist_type == CV_RAND_UNI && W[c] != SZ )
+            if( dist_type == RNG::UNIFORM && W[c] != SZ )
             {
                 ts->printf( cvtest::TS::LOG, "Uniform RNG gave values out of the range [%g,%g) on channel %d/%d\n",
                            A[c], B[c], c, cn);
                 ts->set_failed_test_info( cvtest::TS::FAIL_INVALID_OUTPUT );
                 return;
             }
-            if( dist_type == CV_RAND_NORMAL && W[c] < SZ*.90)
+            if( dist_type == RNG::NORMAL && W[c] < SZ*.90)
             {
                 ts->printf( cvtest::TS::LOG, "Normal RNG gave too many values out of the range (%g+4*%g,%g+4*%g) on channel %d/%d\n",
                            A[c], B[c], A[c], B[c], c, cn);

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -558,7 +558,7 @@ int CV_WarpAffineTest::prepare_test_case( int test_case_idx )
     angle = cvtest::randReal(rng)*360;
     scale = ((double)dst.rows/src.rows + (double)dst.cols/src.cols)*0.5;
     getRotationMatrix2D(center, angle, scale).convertTo(mat, mat.depth());
-    rng.fill( tmp, CV_RAND_NORMAL, Scalar::all(1.), Scalar::all(0.01) );
+    rng.fill( tmp, RNG::NORMAL, Scalar::all(1.), Scalar::all(0.01) );
     cv::max(tmp, 0.9, tmp);
     cv::min(tmp, 1.1, tmp);
     cv::multiply(tmp, mat, mat, 1.);
@@ -673,7 +673,7 @@ int CV_WarpPerspectiveTest::prepare_test_case( int test_case_idx )
     float bufer[16];
     Mat tmp( 1, 16, CV_32FC1, bufer );
 
-    rng.fill( tmp, CV_RAND_NORMAL, Scalar::all(0.), Scalar::all(0.1) );
+    rng.fill( tmp, RNG::NORMAL, Scalar::all(0.), Scalar::all(0.1) );
 
     for( i = 0; i < 4; i++ )
     {


### PR DESCRIPTION
- replace CV_RAND_UNI and NORMAL to cv::RNG::UNIFORM and cv::RNG::NORMAL.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
