### PR TITLE
RISC-V: fix build with RVV 0.7.1

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp
@@ -360,7 +360,7 @@ template <> inline v_##_Tp##x##num v_setzero_() { return v_setzero_##suffix(); }
 template <> inline v_##_Tp##x##num v_setall_(__Tp v) { return v_setall_##suffix(v); }
 
 OPENCV_HAL_IMPL_RISCVV_INIT_SET(uchar, uint8, u8, u8, 16)
-OPENCV_HAL_IMPL_RISCVV_INIT_SET(char, int8, s8, i8, 16)
+OPENCV_HAL_IMPL_RISCVV_INIT_SET(schar, int8, s8, i8, 16)
 OPENCV_HAL_IMPL_RISCVV_INIT_SET(ushort, uint16, u16, u16, 8)
 OPENCV_HAL_IMPL_RISCVV_INIT_SET(short, int16, s16, i16, 8)
 OPENCV_HAL_IMPL_RISCVV_INIT_SET(unsigned int, uint32, u32, u32, 4)


### PR DESCRIPTION
Issue introduced in #25891 (https://github.com/opencv/ci-gha-workflow/actions/runs/11188809334/job/31165423898)

```
/opencv/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp:360:36: error: template-id 'v_setall_<>' for 'cv::hal_baseline::v_int8x16 cv::hal_baseline::v_setall_(char)' does not match any template declaration
  360 | template <> inline v_##_Tp##x##num v_setall_(__Tp v) { return v_setall_##suffix(v); }
      |                                    ^~~~~~~~~
/opencv/modules/core/include/opencv2/core/hal/intrin_rvv071.hpp:363:1: note: in expansion of macro 'OPENCV_HAL_IMPL_RISCVV_INIT_SET'
  363 | OPENCV_HAL_IMPL_RISCVV_INIT_SET(char, int8, s8, i8, 16)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opencv/modules/core/src/precomp.hpp:88,
                 from /opencv/modules/core/src/array.cpp:49:
/opencv/modules/core/include/opencv2/core/hal/intrin.hpp:205:42: note: candidates are: 'template<class _VecTp> _VecTp cv::hal_baseline::v_setall_(double)'
  205 | template <typename _VecTp> inline _VecTp v_setall_(double);
      |                                          ^~~~~~~~~
/opencv/modules/core/include/opencv2/core/hal/intrin.hpp:204:42: note:                 'template<class _VecTp> _VecTp cv::hal_baseline::v_setall_(float)'
  204 | template <typename _VecTp> inline _VecTp v_setall_(float);
      |                                          ^~~~~~~~~
...
```