### PR TITLE
calib: mark some multiview tests verylong

### DIFF
--- a/modules/calib/test/test_multiview_calib.cpp
+++ b/modules/calib/test/test_multiview_calib.cpp
@@ -333,6 +333,7 @@ TEST_F(MultiViewTest, OneLine)
 
 TEST_F(MultiViewTest, OneLineInitialGuess)
 {
+    applyTestTag(CV_TEST_TAG_VERYLONG);
     const string root = cvtest::TS::ptr()->get_data_path() + "cv/cameracalibration/multiview/3cams-one-line/";
     const std::vector<std::string> cam_names = {"cam_0", "cam_1", "cam_3"};
     const std::vector<cv::Size> image_sizes = {{1920, 1080}, {1920, 1080}, {1920, 1080} };
@@ -438,6 +439,7 @@ TEST_F(MultiViewTest, OneLineInitialGuess)
 
 TEST_F(MultiViewTest, CamsToFloor)
 {
+    applyTestTag(CV_TEST_TAG_VERYLONG);
     const string root = cvtest::TS::ptr()->get_data_path() + "cv/cameracalibration/multiview/3cams-to-floor/";
     const std::vector<std::string> cam_names = {"cam_0", "cam_1", "cam_2"};
     std::vector<cv::Size> image_sizes = {{1920, 1080}, {1920, 1080}, {1280, 720}};


### PR DESCRIPTION
Two cases takes too much time especially on slower devices. Skipping them reduces total test duration from 147 to 55 seconds (Linux, Release build, i5-11600).

Related RISC-V weekly build failure: https://github.com/opencv/ci-gha-workflow/actions/runs/11188809334/job/31165424632