### PR TITLE
C-API cleanup: rework ArrayTest to use new arrays only

### DIFF
--- a/modules/3d/test/test_undistort.cpp
+++ b/modules/3d/test/test_undistort.cpp
@@ -178,8 +178,8 @@ private:
 
     int matrix_type;
 
-    static const int MAX_X = 2048;
-    static const int MAX_Y = 2048;
+    static const int MAX_X = 2000;
+    static const int MAX_Y = 2000;
 };
 
 CV_GetOptimalNewCameraMatrixNoDistortionTest::CV_GetOptimalNewCameraMatrixNoDistortionTest()

--- a/modules/core/test/test_dxt.cpp
+++ b/modules/core/test/test_dxt.cpp
@@ -797,7 +797,7 @@ double CxCore_MulSpectrumsTest::get_success_error_level( int test_case_idx, int 
     CV_UNUSED(test_case_idx);
     CV_Assert(i == OUTPUT);
     CV_Assert(j == 0);
-    int elem_depth = CV_MAT_DEPTH(cvGetElemType(test_array[i][j]));
+    const int elem_depth = test_mat[i][j].depth();
     CV_Assert(elem_depth == CV_32F || elem_depth == CV_64F);
 
     element_wise_relative_error = false;
@@ -810,7 +810,7 @@ void CxCore_MulSpectrumsTest::run_func()
 {
     Mat& dst = !test_mat[TEMP].empty() && !test_mat[TEMP][0].empty() ?
         test_mat[TEMP][0] : test_mat[OUTPUT][0];
-    const Mat* src1 = &test_mat[INPUT][0], *src2 = &test_mat[INPUT][1];
+    Mat *src1 = &test_mat[INPUT][0], *src2 = &test_mat[INPUT][1];
 
     if( inplace )
     {


### PR DESCRIPTION
Base class `ArrayTest` had two parallel data storages: `test_array` (raw pointers) and `test_mat` (`cv::Mat`). In this PR we get rid of the first one and temporarily substitute class interface to catch all calls to `test_array` member and transform them to corresponding calls to `test_mat`. In future this proxy interface should be removed and replaced with separate methods. I did it this way to limit changes in this PR.

Other notable changes:
* removed SVD and Core_CovarMatrix tests - they have been set-up for C-API function and it would be easier to rewrite them completely to test new interface instead (see also: #24957)
* `mulTransposed` destination type depends on source type now, C-function additionally converted result to requested destination type
* `transform` doesn't have `shift` argument - removed
* `cv::invert` doesn't work as expected with larger arrays - limited random size
* changed max image size in GetOptimalNewCameraMatrixNoDistortionTest test to avoid random failure


See also: #26244 - my attempt to enable ROI in tests have failed
