### PR TITLE
Added buffer-based model loading to FaceRecognizerSF

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/face.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/face.hpp
@@ -155,6 +155,22 @@ public:
      *  @param target_id the id of target device
      */
     CV_WRAP static Ptr<FaceRecognizerSF> create(CV_WRAP_FILE_PATH const String& model, CV_WRAP_FILE_PATH const String& config, int backend_id = 0, int target_id = 0);
+
+    /**
+     *  @brief Creates an instance of this class from a buffer containing the model weights and configuration.
+     *  @param framework Name of the framework (ONNX, etc.)
+     *  @param bufferModel A buffer containing the binary model weights.
+     *  @param bufferConfig A buffer containing the network configuration.
+     *  @param backend_id The id of the backend.
+     *  @param target_id The id of the target device.
+     *
+     *  @return A pointer to the created instance of FaceRecognizerSF.
+     */
+    CV_WRAP static Ptr<FaceRecognizerSF> create(const String& framework,
+                                                const std::vector<uchar>& bufferModel,
+                                                const std::vector<uchar>& bufferConfig,
+                                                int backend_id = 0,
+                                                int target_id = 0);
 };
 
 //! @}

--- a/modules/objdetect/src/face_recognize.cpp
+++ b/modules/objdetect/src/face_recognize.cpp
@@ -26,6 +26,19 @@ public:
         net.setPreferableBackend(backend_id);
         net.setPreferableTarget(target_id);
     }
+
+    FaceRecognizerSFImpl(const String& framework,
+                         const std::vector<uchar>& bufferModel,
+                         const std::vector<uchar>& bufferConfig,
+                         int backend_id, int target_id)
+    {
+        net = dnn::readNet(framework, bufferModel, bufferConfig);
+        CV_Assert(!net.empty());
+
+        net.setPreferableBackend(backend_id);
+        net.setPreferableTarget(target_id);
+    }
+
     void alignCrop(InputArray _src_img, InputArray _face_mat, OutputArray _aligned_img) const override
     {
         Mat face_mat = _face_mat.getMat();
@@ -185,6 +198,19 @@ Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& model, const String
     return makePtr<FaceRecognizerSFImpl>(model, config, backend_id, target_id);
 #else
     CV_UNUSED(model); CV_UNUSED(config); CV_UNUSED(backend_id); CV_UNUSED(target_id);
+    CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
+#endif
+}
+
+Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& framework,
+                                               const std::vector<uchar>& bufferModel,
+                                               const std::vector<uchar>& bufferConfig,
+                                               int backend_id, int target_id)
+{
+#ifdef HAVE_OPENCV_DNN
+    return makePtr<FaceRecognizerSFImpl>(framework, bufferModel, bufferConfig, backend_id, target_id);
+#else
+    CV_UNUSED(bufferModel); CV_UNUSED(bufferConfig); CV_UNUSED(backend_id); CV_UNUSED(target_id);
     CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
 #endif
 }


### PR DESCRIPTION
- Implemented a new `create` method in `FaceRecognizerSF` to allow model and configuration loading from memory buffers (std::vector<uchar>), similar to the existing functionality in `FaceDetectorYN`.
- Updated `face_recognize.cpp` with a new constructor in `FaceRecognizerSFImpl` that supports buffer-based loading for both model weights and network configuration.
- Ensured compatibility with both file-based and buffer-based model loading by maintaining consistent backend and target settings across both constructors.
- This change improves flexibility, allowing FaceRecognizerSF to be instantiated from memory buffers, which is useful for dynamic model loading scenarios such as embedded systems or applications where models are loaded in-memory.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
