### PR TITLE
Fix default build type message for Visual Studio, Xcode, Unix Makefiles and other generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE)
     message(STATUS "'Debug' configuration will be used by default. Use the IDE to switch between configurations (Debug, Release, etc.).")
     # sets the default configurations for multi-configuration generators
     ocv_update(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configs" FORCE)
-  
+
   elseif(CMAKE_GENERATOR MATCHES "Unix Makefiles|Ninja|Watcom WMake")
     # for single-configuration generators
     if(CMAKE_GENERATOR MATCHES "Unix Makefiles")
@@ -121,9 +121,9 @@ if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE)
     elseif(CMAKE_GENERATOR MATCHES "Watcom WMake")
       message(STATUS "Watcom WMake = Generates Watcom WMake makefiles.")
     endif()
-    
+
     message(STATUS "'Release' build type is used by default for ${CMAKE_GENERATOR}. Use CMAKE_BUILD_TYPE to specify the build type (e.g., Release or Debug).")
-    
+
     # sets the default build type to Release for single-configuration generators
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,18 +104,39 @@ endif()
 ocv_cmake_hook(CMAKE_INIT)
 
 # must go before the project()/enable_language() commands
-ocv_update(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configs" FORCE)
-if(NOT DEFINED CMAKE_BUILD_TYPE
-    AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE
-)
-  message(STATUS "'Release' build type is used by default. Use CMAKE_BUILD_TYPE to specify build type (Release or Debug)")
-  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build")
+if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE)
+
+  # detects if the generator is a known multi-configuration generator
+  if(CMAKE_CONFIGURATION_TYPES OR CMAKE_GENERATOR MATCHES "Visual Studio|Xcode|Ninja Multi-Config")
+    message(STATUS "Using multi-configuration generator: ${CMAKE_GENERATOR}.")
+    message(STATUS "'Debug' configuration will be used by default. Use the IDE to switch between configurations (Debug, Release, etc.).")
+
+  elseif(CMAKE_GENERATOR MATCHES "Unix Makefiles|Ninja|Watcom WMake")
+    # single-configuration generators
+    if(CMAKE_GENERATOR MATCHES "Unix Makefiles")
+      message(STATUS "Unix Makefiles = Generates standard UNIX makefiles.")
+    elseif(CMAKE_GENERATOR MATCHES "Ninja")
+      message(STATUS "Ninja = Generates build.ninja files.")
+    elseif(CMAKE_GENERATOR MATCHES "Watcom WMake")
+      message(STATUS "Watcom WMake = Generates Watcom WMake makefiles.")
+    endif()
+    
+    message(STATUS "'Release' build type is used by default for ${CMAKE_GENERATOR}. Use CMAKE_BUILD_TYPE to specify the build type (e.g., Release or Debug).")
+    
+    # set the default build type to Release for single-configuration generators
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
+
+  else()
+    # to catch all the unrecognized or unsupported generators
+    message(WARNING "Unknown generator detected: ${CMAKE_GENERATOR}. Please check if this generator supports multi-configuration or single-configuration. No default behavior will be applied.")
+  endif()
+
 endif()
 if(DEFINED CMAKE_BUILD_TYPE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${CMAKE_CONFIGURATION_TYPES}")
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release")
 endif()
 
-option(ENABLE_PIC "Generate position independent code (necessary for shared libraries)" TRUE)
+option(ENABLE_PIC "Generate position-independent code for shared libraries" TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_PIC})
 
 ocv_cmake_hook(PRE_CMAKE_BOOTSTRAP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,14 +105,15 @@ ocv_cmake_hook(CMAKE_INIT)
 
 # must go before the project()/enable_language() commands
 if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE)
-
   # detects if the generator is a known multi-configuration generator
-  if(CMAKE_CONFIGURATION_TYPES OR CMAKE_GENERATOR MATCHES "Visual Studio|Xcode|Ninja Multi-Config")
+  if(CMAKE_GENERATOR MATCHES "Visual Studio|Xcode|Ninja Multi-Config")
     message(STATUS "Using multi-configuration generator: ${CMAKE_GENERATOR}.")
     message(STATUS "'Debug' configuration will be used by default. Use the IDE to switch between configurations (Debug, Release, etc.).")
-
+    # sets the default configurations for multi-configuration generators
+    ocv_update(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Configs" FORCE)
+  
   elseif(CMAKE_GENERATOR MATCHES "Unix Makefiles|Ninja|Watcom WMake")
-    # single-configuration generators
+    # for single-configuration generators
     if(CMAKE_GENERATOR MATCHES "Unix Makefiles")
       message(STATUS "Unix Makefiles = Generates standard UNIX makefiles.")
     elseif(CMAKE_GENERATOR MATCHES "Ninja")
@@ -123,15 +124,15 @@ if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT OPENCV_SKIP_DEFAULT_BUILD_TYPE)
     
     message(STATUS "'Release' build type is used by default for ${CMAKE_GENERATOR}. Use CMAKE_BUILD_TYPE to specify the build type (e.g., Release or Debug).")
     
-    # set the default build type to Release for single-configuration generators
+    # sets the default build type to Release for single-configuration generators
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
 
   else()
-    # to catch all the unrecognized or unsupported generators
+    # catches all unrecognized or unsupported generators
     message(WARNING "Unknown generator detected: ${CMAKE_GENERATOR}. Please check if this generator supports multi-configuration or single-configuration. No default behavior will be applied.")
   endif()
-
 endif()
+
 if(DEFINED CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release")
 endif()


### PR DESCRIPTION
### Description
This PR addresses the misleading message about the default build type in multi-configuration generators (Visual Studio, Xcode). The message now correctly states that 'Debug' is the default for these generators, while 'Release' remains the default for single-configuration generators (Unix Makefiles, Ninja).

### Fixes
- Added checks for multi-configuration generators and updated the message to reflect 'Debug' as the default.
- Kept 'Release' as the default for single-configuration generators.
- Added warnings for unsupported generators.
- Following the [CMake Documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html), I have set the `CMAKE_BUILD_TYPE` variable accordingly.

### Testing
I thoroughly tested this solution on macOS with OpenCV 4.10.0 using the following generators:
1. `cmake -G "Unix Makefiles" ..`
2. `cmake -G "Ninja" ..`
3. `cmake -G "Xcode" ..`

The changes work as intended. I appreciate any feedback regarding compatibility on Windows and Linux.

### Comparison
1. **Unix Makefiles**
   - **Before:**
     ![Unix Makefiles Previous](https://github.com/user-attachments/assets/57356660-a27d-4799-aaa7-bdbd299ef700)
   - **After:**
     ![Unix Makefiles Current](https://github.com/user-attachments/assets/121bfd72-19b5-4114-ab4f-cca548aaf65b)

2. **Xcode**
   - **Before:**
     ![Xcode Previous](https://github.com/user-attachments/assets/98253953-644a-4076-8c8f-882bd087247c)
   - **After:**
     ![Xcode Current](https://github.com/user-attachments/assets/fdb279f5-fc18-492b-8ba1-ab0165dbdb05)

3. **Ninja**
   - **Before:**
     ![Ninja Previous](https://github.com/user-attachments/assets/85935018-b6d6-4578-972f-9c62e5fc939c)
   - **After:**
     ![Ninja Current](https://github.com/user-attachments/assets/959b15e2-4d7f-4a3a-8e31-d3464f1be65d)

### **Related Issue:** [#26206](https://github.com/opencv/opencv/issues/26206)

### **Checklist**
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.
- [x] The PR is proposed to the proper branch.
- [x] There is a reference to the original bug report and related work.
- [ ] Accuracy, performance tests, and test data are provided if applicable, with a corresponding patch in the opencv_extra repository.
- [ ] The feature is documented and sample code can be built with the project’s CMake.