### PR TITLE
TrackerVit: Add support for loading model from memory buffer

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -916,6 +916,7 @@ public:
     {
         CV_WRAP Params();
         CV_PROP_RW std::string net;
+        CV_PROP_RW std::vector<uchar> modelBuffer;
         CV_PROP_RW int backend;
         CV_PROP_RW int target;
         CV_PROP_RW Scalar meanvalue;

--- a/modules/video/src/tracking/tracker_vit.cpp
+++ b/modules/video/src/tracking/tracker_vit.cpp
@@ -24,6 +24,7 @@ TrackerVit::~TrackerVit()
 TrackerVit::Params::Params()
 {
     net = "vitTracker.onnx";
+    modelBuffer.clear(); // Initialize the buffer to empty
     meanvalue = Scalar{0.485, 0.456, 0.406}; // normalized mean (already divided by 255)
     stdvalue = Scalar{0.229, 0.224, 0.225};  // normalized std (already divided by 255)
 #ifdef HAVE_OPENCV_DNN
@@ -44,7 +45,17 @@ public:
     TrackerVitImpl(const TrackerVit::Params& parameters)
         : params(parameters)
     {
-        net = dnn::readNet(params.net);
+        if (!params.modelBuffer.empty())
+        {
+            // Load the model from memory if buffer is provided
+            net = dnn::readNetFromONNX(params.modelBuffer);
+        }
+        else
+        {
+            // Otherwise, load the model from the file path
+            net = dnn::readNet(params.net);
+        }
+
         CV_Assert(!net.empty());
 
         net.setPreferableBackend(params.backend);


### PR DESCRIPTION
- Extended the TrackerVit::Params structure to include an optional std::vector<uchar> `modelBuffer` for loading models directly from memory.
- Updated TrackerVitImpl to check if the `modelBuffer` is not empty, and if so, load the model from memory using `dnn::readNetFromONNX`.
- If the `modelBuffer` is empty, the model continues to be loaded from the file path specified in `Params::net`, ensuring backward compatibility.
- This enhancement provides flexibility for scenarios where models are loaded from in-memory sources rather than file paths.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
