### PR TITLE
Fixing drawContours() function to correctly draw child contours

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -39,6 +39,7 @@
 //
 //M*/
 #include "precomp.hpp"
+#include<limits>
 #include<stack>
 #include<vector>
 using namespace cv;
@@ -2477,10 +2478,14 @@ namespace cv
                                  const Scalar &color, int thickness, int lineType,
                                  InputArray _hierarchy, Point offset)
     {
-        // Ensure the hierarchy is not empty
-        CV_Assert(!_hierarchy.empty());
-        Mat hierarchy = _hierarchy.getMat();
+        // Check if hierarchy is empty and return if it is
+        if (_hierarchy.empty())
+        {
+            CV_Error(Error::StsBadArg, "Hierarchy is empty");
+            return;
+        }
 
+        Mat hierarchy = _hierarchy.getMat();
         std::stack<int> contourStack;
         contourStack.push(idx);
 


### PR DESCRIPTION
## Fixing drawContours() function to correctly draw child contours

### Steps Followed

1. **Recursive Drawing**: Implemented a recursive function to draw child contours, ensuring no redundant fillings occur.
2. **Thickness Issue Resolved**: Fixed the inability to draw child contours when `thickness >= 0`.

#### Previously, when `thickness = 2`:

![Previous Contour Error](https://github.com/user-attachments/assets/0b340c10-8aef-4bec-b584-f4761caa17ce)

#### After the Fix, when `thickness = 2`:

![Positive Thick](https://github.com/user-attachments/assets/906054c6-d317-4313-a104-66f0e199a2f9)

#### After the Fix, when `thickness = 0`:

<img width="1256" alt="thickness = 0" src="https://github.com/user-attachments/assets/b9437968-1bfc-4176-9f11-d1e9115577a7">

#### After the Fix, when `thickness = -2`:

<img width="1265" alt="thickness =  -2" src="https://github.com/user-attachments/assets/06daea51-6379-48a1-ae8b-db111bcc916f">

### Other Details

- **Tested on**: macOS
- **OpenCV Version**: 4.10.0
- **Link to the Issue**: [Issue #26264](https://github.com/opencv/opencv/issues/26264)

Please review the code and provide any suggestions for improvements or feedback.

## Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
