### PR TITLE
Fixed GpuMat::empty() function

### DIFF
--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -364,7 +364,8 @@ Size GpuMat::size() const
 inline
 bool GpuMat::empty() const
 {
-    return data == 0;
+    //return data == 0;
+    return 0 == cols || 0 == rows;
 }
 
 inline


### PR DESCRIPTION
Check GpuMat 'rows' and 'cols' fields instead of 'data' field. 'data' field can be NOT NULL while getting roi with empty rect.

// example usage
cv::cuda::GpuMat x(100, 100, CV_8UC1);
cv::Rect roi; // lets keep it empty
cv::cuda::GpuMat y = x(roi); // this is empty now, but y.data == x.data
y.empty() -> returns false

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
