### PR TITLE
Stronger warpAffine test threshold after CPU and OpenCL branches sync.

### DIFF
--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -73,9 +73,7 @@ OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
     const Size srcSize = get<0>(params);
     const int type = get<1>(params), interpolation = get<2>(params);
 
-    // BUG: OpenCL and CPU version diverges a bit
-    // Ticket: https://github.com/opencv/opencv/issues/26235
-    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 2 : interpolation == INTER_CUBIC ? 2e-3 : 3e-2;
+    const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : interpolation == INTER_CUBIC ? 2e-3 : 3e-2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 


### PR DESCRIPTION
Closes https://github.com/opencv/opencv/issues/26235
OpenCV extra: https://github.com/opencv/opencv_extra/pull/1216

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux OpenCL
```
