### PR TITLE
build: set cmake policy for if(IN_LIST) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ if(POLICY CMP0056)
   cmake_policy(SET CMP0056 NEW)  # try_compile(): link flags
 endif()
 
+if(POLICY CMP0057)
+  cmake_policy(SET CMP0057 NEW)  # CMake 3.3: if(IN_LIST) support
+endif()
+
 if(POLICY CMP0066)
   cmake_policy(SET CMP0066 NEW)  # CMake 3.7: try_compile(): use per-config flags, like CMAKE_CXX_FLAGS_RELEASE
 endif()


### PR DESCRIPTION
I've got a warning and an error with cmake 3.29 from MSVC:

Warning:
```
1> [CMake] CMake Warning (dev) at modules/python/python_loader.cmake:104 (if):
1> [CMake]   Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
1> [CMake]   --help-policy CMP0057" for policy details.  Use the cmake_policy command to
1> [CMake]   set the policy and suppress this warning.
1> [CMake] 
1> [CMake]   IN_LIST will be interpreted as an operator when the policy is set to NEW.
1> [CMake]   Since the policy is not set the OLD behavior will be used.
1> [CMake] Call Stack (most recent call first):
1> [CMake]   modules/python/python_loader.cmake:118 (ocv_add_python_files_from_path)
1> [CMake]   modules/python/bindings/CMakeLists.txt:12 (include)
1> [CMake] This warning is for project developers.  Use -Wno-dev to suppress it.
```

Following error:
```
1> [CMake] CMake Error at modules/python/python_loader.cmake:104 (if):
1> [CMake]   if given arguments:
1> [CMake] 
1> [CMake]     "NOT" "misc" "IN_LIST" "extra_modules"
1> [CMake] 
1> [CMake]   Unknown arguments specified
```