### PR TITLE
Modified TFLite parser for the new dnn engine

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1109,7 +1109,7 @@ CV__DNN_INLINE_NS_BEGIN
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model, int engine=ENGINE_AUTO);
+    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model, EngineType engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @param bufferModel buffer containing the content of the tflite file
@@ -1117,7 +1117,7 @@ CV__DNN_INLINE_NS_BEGIN
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel, int engine=ENGINE_AUTO);
+    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel, EngineType engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @details This is an overloaded member function, provided for convenience.
@@ -1127,7 +1127,7 @@ CV__DNN_INLINE_NS_BEGIN
       * @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       */
-    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel, int engine=ENGINE_AUTO);
+    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel, EngineType engine=ENGINE_AUTO);
 
      /**
       * @brief Read deep learning network represented in one of the supported formats.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1105,23 +1105,29 @@ CV__DNN_INLINE_NS_BEGIN
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @param model  path to the .tflite file with binary flatbuffers description of the network architecture
+      * @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model);
+    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @param bufferModel buffer containing the content of the tflite file
+      * @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel);
+    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @details This is an overloaded member function, provided for convenience.
       * It differs from the above function only in what argument(s) it accepts.
       * @param bufferModel buffer containing the content of the tflite file
       * @param lenModel length of bufferModel
+      * @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
+      * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       */
-    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel);
+    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel, int engine=ENGINE_AUTO);
 
      /**
       * @brief Read deep learning network represented in one of the supported formats.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1109,7 +1109,7 @@ CV__DNN_INLINE_NS_BEGIN
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model, EngineType engine=ENGINE_AUTO);
+    CV_EXPORTS_W Net readNetFromTFLite(CV_WRAP_FILE_PATH const String &model, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @param bufferModel buffer containing the content of the tflite file
@@ -1117,7 +1117,7 @@ CV__DNN_INLINE_NS_BEGIN
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel, EngineType engine=ENGINE_AUTO);
+    CV_EXPORTS_W Net readNetFromTFLite(const std::vector<uchar>& bufferModel, int engine=ENGINE_AUTO);
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/lite">TFLite</a> framework's format.
       * @details This is an overloaded member function, provided for convenience.
@@ -1127,7 +1127,7 @@ CV__DNN_INLINE_NS_BEGIN
       * @param engine select DNN engine to be used. With auto selection the new engine is used first and falls back to classic.
       * Please pay attention that the new DNN does not support non-CPU back-ends for now.
       */
-    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel, EngineType engine=ENGINE_AUTO);
+    CV_EXPORTS Net readNetFromTFLite(const char *bufferModel, size_t lenModel, int engine=ENGINE_AUTO);
 
      /**
       * @brief Read deep learning network represented in one of the supported formats.

--- a/modules/dnn/misc/objc/gen_dict.json
+++ b/modules/dnn/misc/objc/gen_dict.json
@@ -9,8 +9,8 @@
             "(Net*)readNetFromONNX:(ByteVector*)buffer engine:(int)engine" : { "readNetFromONNX" : {"name" : "readNetFromONNXBuffer"} },
             "(Net*)readNetFromTensorflow:(NSString*)model config:(NSString*)config" : { "readNetFromTensorflow" : {"name" : "readNetFromTensorflowFile"} },
             "(Net*)readNetFromTensorflow:(ByteVector*)bufferModel bufferConfig:(ByteVector*)bufferConfig" : { "readNetFromTensorflow" : {"name" : "readNetFromTensorflowBuffer"} },
-            "(Net*)readNetFromTFLite:(NSString*)model" : { "readNetFromTFLite" : {"name" : "readNetFromTFLiteFile"} },
-            "(Net*)readNetFromTFLite:(ByteVector*)buffer" : { "readNetFromTFLite" : {"name" : "readNetFromTFLiteBuffer"} }
+            "(Net*)readNetFromTFLite:(NSString*)model engine:(int)engine" : { "readNetFromTFLite" : {"name" : "readNetFromTFLiteFile"} },
+            "(Net*)readNetFromTFLite:(ByteVector*)buffer engine:(int)engine" : { "readNetFromTFLite" : {"name" : "readNetFromTFLiteBuffer"} }
         },
         "Net": {
             "(void)forward:(NSMutableArray<Mat*>*)outputBlobs outputName:(NSString*)outputName" : { "forward" : {"name" : "forwardOutputBlobs"} },

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -1310,8 +1310,8 @@ void TFLiteImporter::getQuantParams(const Operator& op, float& inpScale, int& in
     }
 }
 
-Net readNetFromTFLite(const String &modelPath, EngineType engine) {
-    static const EngineType engine_forced = (EngineType)utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO);
+Net readNetFromTFLite(const String &modelPath, int engine) {
+    static const int engine_forced = utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO);
     if(engine_forced != ENGINE_AUTO)
         engine = engine_forced;
 
@@ -1337,12 +1337,12 @@ Net readNetFromTFLite(const String &modelPath, EngineType engine) {
     return net;
 }
 
-Net readNetFromTFLite(const std::vector<uchar>& bufferModel, EngineType engine) {
+Net readNetFromTFLite(const std::vector<uchar>& bufferModel, int engine) {
     return readNetFromTFLite((const char*)bufferModel.data(), bufferModel.size());
 }
 
-Net readNetFromTFLite(const char *bufferModel, size_t bufSize, EngineType engine) {
-    static const EngineType engine_forced = (EngineType)utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO);
+Net readNetFromTFLite(const char *bufferModel, size_t bufSize, int engine) {
+    static const int engine_forced = utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO);
     if(engine_forced != ENGINE_AUTO)
         engine = engine_forced;
 
@@ -1355,15 +1355,15 @@ Net readNetFromTFLite(const char *bufferModel, size_t bufSize, EngineType engine
 
 #define DNN_TFLITE_UNSUPPORTED() CV_Error(Error::StsError, "DNN/TFLite: Build OpenCV with FlatBuffers to import TFLite models: https://github.com/opencv/opencv/pull/23161")
 
-Net readNetFromTFLite(const String &, EngineType) {
+Net readNetFromTFLite(const String &, int) {
     DNN_TFLITE_UNSUPPORTED();
 }
 
-Net readNetFromTFLite(const std::vector<uchar>&, EngineType) {
+Net readNetFromTFLite(const std::vector<uchar>&, int) {
     DNN_TFLITE_UNSUPPORTED();
 }
 
-Net readNetFromTFLite(const char *, size_t, EngineType) {
+Net readNetFromTFLite(const char *, size_t, int) {
     DNN_TFLITE_UNSUPPORTED();
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -80,7 +80,7 @@ private:
     void parseFusedActivation(const Operator& op, ActivationFunctionType activ);
     void parseActivation(const Operator& op, const std::string& opcode, LayerParams& layerParams, bool isFused);
     void addLayer(LayerParams& layerParams, const Operator& op, bool additionalPreLayer = false, bool additionalPostLayer = false);
-    void addLayer(LayerParams& layerParams, std::vector<std::string> inputTensors, std::vector<std::string> outputTensors);
+    void addLayer(LayerParams& layerParams, const std::vector<std::string>& inputTensors, const std::vector<std::string>& outputTensors);
     int addPermuteLayer(const std::vector<int>& order, const std::string& permName, const std::pair<int, int>& inpId, int dtype, int inpTensorId);
     int addReshapeLayer(const std::vector<int>& shape, int axis, int num_axes,
                         const std::string& name, const std::pair<int, int>& inpId, int dtype, int inpTensorId);
@@ -454,7 +454,7 @@ void TFLiteImporter::addLayer(LayerParams& layerParams, const Operator& op, bool
         addLayer(layerParams, inputTensors, outputTensors);
 }
 
-void TFLiteImporter::addLayer(LayerParams& layerParams, std::vector<std::string> inputTensors, std::vector<std::string> outputTensors) {
+void TFLiteImporter::addLayer(LayerParams& layerParams, const std::vector<std::string>& inputTensors, const std::vector<std::string>& outputTensors) {
     Ptr<Layer> layer = LayerFactory::createLayerInstance(layerParams.type, layerParams);
     if (!layer)
         CV_Error(Error::StsError, "Can't create layer " + layerParams.name + " with type " + layerParams.type);

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -155,6 +155,9 @@ TEST_P(Test_TFLite, max_unpooling)
     net.setPreferableBackend(backend);
     net.setPreferableTarget(target);
 
+    if (net.getMainGraph())
+        throw SkipTestException("The new dnn engine doesn't support forward to specified layers");
+
     Mat input = imread(findDataFile("cv/shared/lena.png"));
     cvtColor(input, input, COLOR_BGR2RGBA);
     input = input.mul(Scalar(1, 1, 1, 0));

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -156,7 +156,7 @@ TEST_P(Test_TFLite, max_unpooling)
     net.setPreferableTarget(target);
 
     if (net.getMainGraph())
-        throw SkipTestException("The new dnn engine doesn't support forward to specified layers");
+        throw SkipTestException("The new dnn engine doesn't support forward to specified layers"); // https://github.com/opencv/opencv/issues/26349
 
     Mat input = imread(findDataFile("cv/shared/lena.png"));
     cvtColor(input, input, COLOR_BGR2RGBA);


### PR DESCRIPTION
The new dnn graph is creating just by defining input and output names of each layer.
Some TFLite layers has fused activation, which doesn't have layer name and input and output names. Also some layers require additional preprocessing layers (e.g. NHWC -> NCHW). All these layers should be added to the graph with some unique layer and input and output names. 

I solve this problem by adding additionalPreLayer and additionalPostLayer layers.

If a layer has a fused activation, I add additionalPostLayer and change input and output names this way:
**original**: conv_relu(conv123, conv123_input, conv123_output)
**new**: conv(conv123, conv123_input, conv123_output_additional_post_layer) + relu(conv123_relu,  conv1_output_additional_post_layer, conv123_output)

If a layer has additional preprocessing layer, I change input and output names this way:
**original**: permute_reshape(reshape345, reshape345_input, reshape345_output)
**new**: permute(reshape345_permute, reshape345_input, reshape345_input_additional_pre_layer) + reshape(reshape345, reshape345_input_additional_pre_layer, reshape345_output)


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
