### PR TITLE
build: made environment access a separate feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ OCV_OPTION(ENABLE_CONFIG_VERIFICATION "Fail build if actual configuration doesn'
 OCV_OPTION(OPENCV_ENABLE_MEMALIGN     "Enable posix_memalign or memalign usage" ON)
 OCV_OPTION(OPENCV_DISABLE_FILESYSTEM_SUPPORT "Disable filesystem support" OFF)
 OCV_OPTION(OPENCV_DISABLE_THREAD_SUPPORT "Build the library without multi-threaded code." OFF)
+OCV_OPTION(OPENCV_DISABLE_ENV_SUPPORT "Disable environment variables access (getenv)" (CMAKE_SYSTEM_NAME MATCHES "Windows(CE|Phone|Store)"))
 OCV_OPTION(OPENCV_SEMIHOSTING         "Build the library for semihosting target (Arm). See https://developer.arm.com/documentation/100863/latest." OFF)
 OCV_OPTION(ENABLE_CUDA_FIRST_CLASS_LANGUAGE "Enable CUDA as a first class language, if enabled dependant projects will need to use CMake >= 3.18" OFF
   VISIBLE_IF (WITH_CUDA AND NOT CMAKE_VERSION VERSION_LESS 3.18)

--- a/cmake/platforms/OpenCV-WinRT.cmake
+++ b/cmake/platforms/OpenCV-WinRT.cmake
@@ -1,6 +1,6 @@
 set(WINRT TRUE)
 
-add_definitions(-DWINRT -DNO_GETENV)
+add_definitions(-DWINRT)
 
 # Making definitions available to other configurations and
 # to filter dependency restrictions at compile time.

--- a/cmake/platforms/OpenCV-WindowsCE.cmake
+++ b/cmake/platforms/OpenCV-WindowsCE.cmake
@@ -1,1 +1,1 @@
-add_definitions(-DNO_GETENV)
+# empty

--- a/doc/tutorials/introduction/env_reference/env_reference.markdown
+++ b/doc/tutorials/introduction/env_reference/env_reference.markdown
@@ -59,7 +59,6 @@ import cv2 # variables set after this may not have effect
 
 ## Types
 
-- _non-null_ - set to anything to enable feature, in some cases can be interpreted as other types (e.g. path)
 - _bool_ - `1`, `True`, `true`, `TRUE` / `0`, `False`, `false`, `FALSE`
 - _number_/_size_ - unsigned number, suffixes `MB`, `Mb`, `mb`, `KB`, `Kb`, `kb`
 - _string_ - plain string or can have a structure
@@ -70,7 +69,7 @@ import cv2 # variables set after this may not have effect
 ## General, core
 | name | type | default | description |
 |------|------|---------|-------------|
-| OPENCV_SKIP_CPU_BASELINE_CHECK | non-null | | do not check that current CPU supports all features used by the build (baseline) |
+| OPENCV_SKIP_CPU_BASELINE_CHECK | bool | false | do not check that current CPU supports all features used by the build (baseline) |
 | OPENCV_CPU_DISABLE | `,` or `;`-separated | | disable code branches which use CPU features (dispatched code) |
 | OPENCV_SETUP_TERMINATE_HANDLER | bool | true (Windows) | use std::set_terminate to install own termination handler |
 | OPENCV_LIBVA_RUNTIME | file path | | libva for VA interoperability utils |
@@ -78,9 +77,9 @@ import cv2 # variables set after this may not have effect
 | OPENCV_BUFFER_AREA_ALWAYS_SAFE | bool | false | enable safe mode for multi-buffer allocations (each buffer separately) |
 | OPENCV_KMEANS_PARALLEL_GRANULARITY | num | 1000 | tune algorithm parallel work distribution parameter `parallel_for_(..., ..., ..., granularity)` |
 | OPENCV_DUMP_ERRORS | bool | true (Debug or Android), false (others) | print extra information on exception (log to Android) |
-| OPENCV_DUMP_CONFIG | non-null | | print build configuration to stderr (`getBuildInformation`) |
+| OPENCV_DUMP_CONFIG | bool | false | print build configuration to stderr (`getBuildInformation`) |
 | OPENCV_PYTHON_DEBUG | bool | false | enable extra warnings in Python bindings |
-| OPENCV_TEMP_PATH | non-null / path | `/tmp/` (Linux), `/data/local/tmp/` (Android), `GetTempPathA` (Windows) | directory for temporary files |
+| OPENCV_TEMP_PATH | path | `/tmp/` (Linux), `/data/local/tmp/` (Android), `GetTempPathA` (Windows) | directory for temporary files |
 | OPENCV_DATA_PATH_HINT | paths | | paths for findDataFile |
 | OPENCV_DATA_PATH | paths | | paths for findDataFile |
 | OPENCV_SAMPLES_DATA_PATH_HINT | paths | | paths for findDataFile |
@@ -272,7 +271,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 | ⭐ OPENCV_FFMPEG_CAPTURE_OPTIONS | string (see note) | | extra options for VideoCapture FFmpeg backend |
 | ⭐ OPENCV_FFMPEG_WRITER_OPTIONS | string (see note) | | extra options for VideoWriter FFmpeg backend |
 | OPENCV_FFMPEG_THREADS | num | | set FFmpeg thread count |
-| OPENCV_FFMPEG_DEBUG | non-null | | enable logging messages from FFmpeg |
+| OPENCV_FFMPEG_DEBUG | bool | false | enable logging messages from FFmpeg |
 | OPENCV_FFMPEG_LOGLEVEL | num | | set FFmpeg logging level |
 | OPENCV_FFMPEG_DLL_DIR | dir path | | directory with FFmpeg plugin (legacy) |
 | OPENCV_FFMPEG_IS_THREAD_SAFE | bool | false | enabling this option will turn off thread safety locks in the FFmpeg backend (use only if you are sure FFmpeg is built with threading support, tested on Linux) |
@@ -286,7 +285,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 | OPENCV_VIDEOIO_MFX_BITRATE_DIVISOR | num | 300 | this option allows to tune encoding bitrate (video quality/size) |
 | OPENCV_VIDEOIO_MFX_WRITER_TIMEOUT | num | 1 | timeout for encoding operation (in seconds) |
 | OPENCV_VIDEOIO_MSMF_ENABLE_HW_TRANSFORMS | bool | true | allow HW-accelerated transformations (DXVA) in MediaFoundation processing graph (may slow down camera probing process) |
-| OPENCV_DSHOW_DEBUG | non-null | | enable verbose logging in the DShow backend |
+| OPENCV_DSHOW_DEBUG | bool | false | enable verbose logging in the DShow backend |
 | OPENCV_DSHOW_SAVEGRAPH_FILENAME | file path | | enable processing graph tump in the DShow backend |
 | OPENCV_VIDEOIO_V4L_RANGE_NORMALIZED | bool | false | use (0, 1) range for properties (V4L) |
 | OPENCV_VIDEOIO_V4L_SELECT_TIMEOUT | num | 10 | timeout for select call (in seconds) (V4L) |
@@ -297,7 +296,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 ### videoio tests
 | name | type | default | description |
 |------|------|---------|-------------|
-| OPENCV_TEST_VIDEOIO_BACKEND_REQUIRE_FFMPEG | | | test app will exit if no FFmpeg backend is available |
+| OPENCV_TEST_VIDEOIO_BACKEND_REQUIRE_FFMPEG | bool | false | test app will exit if no FFmpeg backend is available |
 | OPENCV_TEST_V4L2_VIVID_DEVICE | file path | | path to VIVID virtual camera device for V4L2 test (e.g. `/dev/video5`) |
 | OPENCV_TEST_PERF_CAMERA_LIST | paths | | cameras to use in performance test (waitAny_V4L test) |
 | OPENCV_TEST_CAMERA_%d_FPS | num | | fps to set for N-th camera (0-based index) (waitAny_V4L test) |
@@ -327,7 +326,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 
 | name | type | default | description |
 |------|------|---------|-------------|
-| OPENCV_LEGACY_WAITKEY | non-null | | switch `waitKey` return result (default behavior: `return code & 0xff` (or -1), legacy behavior: `return code`) |
+| OPENCV_LEGACY_WAITKEY | bool | false | switch `waitKey` return result (default behavior: `return code & 0xff` (or -1), legacy behavior: `return code`) |
 | $XDG_RUNTIME_DIR | | | Wayland backend specific - create shared memory-mapped file for interprocess communication (named `opencv-shared-??????`) |
 | OPENCV_HIGHGUI_FB_MODE | string | `FB` | Selects output mode for the framebuffer backend (`FB` - regular frambuffer, `EMU` - emulation, perform internal checks but does nothing, `XVFB` - compatible with _xvfb_ virtual frambuffer) |
 | OPENCV_HIGHGUI_FB_DEVICE | file path | | Path to frambuffer device to use (will be checked first) |

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -182,6 +182,10 @@ if(OPENCV_DISABLE_THREAD_SUPPORT)
   ocv_target_compile_definitions(${the_module} PUBLIC "OPENCV_DISABLE_THREAD_SUPPORT=1")
 endif()
 
+if(OPENCV_DISABLE_ENV_SUPPORT)
+  ocv_append_source_file_compile_definitions(${CMAKE_CURRENT_SOURCE_DIR}/src/system.cpp "NO_GETENV")
+endif()
+
 if(OPENCV_SEMIHOSTING)
   ocv_target_compile_definitions(${the_module} PRIVATE "-DOPENCV_SEMIHOSTING")
 endif(OPENCV_SEMIHOSTING)

--- a/modules/core/include/opencv2/core/utils/configuration.private.hpp
+++ b/modules/core/include/opencv2/core/utils/configuration.private.hpp
@@ -12,9 +12,9 @@
 namespace cv { namespace utils {
 
 typedef std::vector<std::string> Paths;
-CV_EXPORTS bool getConfigurationParameterBool(const char* name, bool defaultValue);
-CV_EXPORTS size_t getConfigurationParameterSizeT(const char* name, size_t defaultValue);
-CV_EXPORTS cv::String getConfigurationParameterString(const char* name, const char* defaultValue);
+CV_EXPORTS bool getConfigurationParameterBool(const char* name, bool defaultValue = false);
+CV_EXPORTS size_t getConfigurationParameterSizeT(const char* name, size_t defaultValue = 0);
+CV_EXPORTS std::string getConfigurationParameterString(const char* name, const std::string & defaultValue = std::string());
 CV_EXPORTS Paths getConfigurationParameterPaths(const char* name, const Paths &defaultValue = Paths());
 
 }} // namespace

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1170,10 +1170,10 @@ bool haveOpenCL()
     if (!g_isOpenCLInitialized)
     {
         CV_TRACE_REGION("Init_OpenCL_Runtime");
-        const char* envPath = getenv("OPENCV_OPENCL_RUNTIME");
-        if (envPath)
+        std::string envPath = utils::getConfigurationParameterString("OPENCV_OPENCL_RUNTIME");
+        if (!envPath.empty())
         {
-            if (cv::String(envPath) == "disabled")
+            if (envPath == "disabled")
             {
                 g_isOpenCLAvailable = false;
                 g_isOpenCLInitialized = true;
@@ -2119,24 +2119,18 @@ static bool parseOpenCLDeviceConfiguration(const std::string& configurationStr,
     return true;
 }
 
-#if defined WINRT || defined _WIN32_WCE
-static cl_device_id selectOpenCLDevice(const char* configuration = NULL)
-{
-    CV_UNUSED(configuration)
-    return NULL;
-}
-#else
-static cl_device_id selectOpenCLDevice(const char* configuration = NULL)
+static cl_device_id selectOpenCLDevice(const std::string & configuration_ = std::string())
 {
     std::string platform, deviceName;
     std::vector<std::string> deviceTypes;
 
-    if (!configuration)
-        configuration = getenv("OPENCV_OPENCL_DEVICE");
+    std::string configuration(configuration_);
+    if (configuration.empty())
+        configuration = utils::getConfigurationParameterString("OPENCV_OPENCL_DEVICE");
 
-    if (configuration &&
-            (strcmp(configuration, "disabled") == 0 ||
-             !parseOpenCLDeviceConfiguration(std::string(configuration), platform, deviceTypes, deviceName)
+    if (!configuration.empty() &&
+            (configuration == "disabled" ||
+             !parseOpenCLDeviceConfiguration(configuration, platform, deviceTypes, deviceName)
             ))
         return NULL;
 
@@ -2204,7 +2198,7 @@ static cl_device_id selectOpenCLDevice(const char* configuration = NULL)
         if (!isID)
         {
             deviceTypes.push_back("GPU");
-            if (configuration)
+            if (!configuration.empty())
                 deviceTypes.push_back("CPU");
         }
         else
@@ -2272,7 +2266,7 @@ static cl_device_id selectOpenCLDevice(const char* configuration = NULL)
     }
 
 not_found:
-    if (!configuration)
+    if (configuration.empty())
         return NULL; // suppress messages on stderr
 
     std::ostringstream msg;
@@ -2287,7 +2281,6 @@ not_found:
     CV_LOG_ERROR(NULL, msg.str());
     return NULL;
 }
-#endif
 
 #ifdef HAVE_OPENCL_SVM
 namespace svm {
@@ -2340,12 +2333,12 @@ static unsigned int getSVMCapabilitiesMask()
     static unsigned int mask = 0;
     if (!initialized)
     {
-        const char* envValue = getenv("OPENCV_OPENCL_SVM_CAPABILITIES_MASK");
-        if (envValue == NULL)
+        const std::string envValue = utils::getConfigurationParameterString("OPENCV_OPENCL_SVM_CAPABILITIES_MASK");
+        if (envValue.empty())
         {
             return ~0U; // all bits 1
         }
-        mask = atoi(envValue);
+        mask = atoi(envValue.c_str());
         initialized = true;
     }
     return mask;
@@ -2482,8 +2475,8 @@ public:
         std::string configuration = configuration_;
         if (configuration_.empty())
         {
-            const char* c = getenv("OPENCV_OPENCL_DEVICE");
-            if (c)
+            const std::string c = utils::getConfigurationParameterString("OPENCV_OPENCL_DEVICE");
+            if (!c.empty())
                 configuration = c;
         }
         Impl* impl = findContext(configuration);
@@ -2494,7 +2487,7 @@ public:
             return impl;
         }
 
-        cl_device_id d = selectOpenCLDevice(configuration.empty() ? NULL : configuration.c_str());
+        cl_device_id d = selectOpenCLDevice(configuration);
         if (d == NULL)
             return NULL;
 

--- a/modules/core/src/parallel/registry_parallel.impl.hpp
+++ b/modules/core/src/parallel/registry_parallel.impl.hpp
@@ -111,7 +111,7 @@ protected:
     bool readPrioritySettings()
     {
         bool hasChanges = false;
-        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_PARALLEL_PRIORITY_LIST", NULL);
+        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_PARALLEL_PRIORITY_LIST");
         if (prioritized_backends.empty())
             return hasChanges;
         CV_LOG_INFO(NULL, "core(parallel): Configured priority list (OPENCV_PARALLEL_PRIORITY_LIST): " << prioritized_backends);

--- a/modules/core/src/utils/datafile.cpp
+++ b/modules/core/src/utils/datafile.cpp
@@ -60,7 +60,7 @@ static std::vector<cv::String>& _getDataSearchSubDirectory()
 
 CV_EXPORTS void addDataSearchPath(const cv::String& path)
 {
-    if (utils::fs::isDirectory(path))
+    if (!path.empty() && utils::fs::isDirectory(path))
         _getDataSearchPath().push_back(path);
 }
 CV_EXPORTS void addDataSearchSubDirectory(const cv::String& subdir)

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -447,8 +447,8 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
 #elif defined __ANDROID__
         // no defaults
 #elif defined __APPLE__
-        const char* tmpdir_env = getenv("TMPDIR");
-        if (tmpdir_env && utils::fs::isDirectory(tmpdir_env))
+        const std::string tmpdir_env = utils::getConfigurationParameterString("TMPDIR");
+        if (!tmpdir_env.empty() && utils::fs::isDirectory(tmpdir_env))
         {
             default_cache_path = tmpdir_env;
         }
@@ -461,16 +461,16 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
         // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
         if (default_cache_path.empty())
         {
-            const char* xdg_cache_env = getenv("XDG_CACHE_HOME");
-            if (xdg_cache_env && xdg_cache_env[0] && utils::fs::isDirectory(xdg_cache_env))
+            const std::string xdg_cache_env = utils::getConfigurationParameterString("XDG_CACHE_HOME");
+            if (!xdg_cache_env.empty() && utils::fs::isDirectory(xdg_cache_env))
             {
                 default_cache_path = xdg_cache_env;
             }
         }
         if (default_cache_path.empty())
         {
-            const char* home_env = getenv("HOME");
-            if (home_env && home_env[0] && utils::fs::isDirectory(home_env))
+            const std::string home_env = utils::getConfigurationParameterString("HOME");
+            if (!home_env.empty() && utils::fs::isDirectory(home_env))
             {
                 cv::String home_path = home_env;
                 cv::String home_cache_path = utils::fs::join(home_path, ".cache/");

--- a/modules/core/src/va_wrapper.impl.hpp
+++ b/modules/core/src/va_wrapper.impl.hpp
@@ -7,6 +7,7 @@
 //
 
 #include "opencv2/core/utils/plugin_loader.private.hpp"  // DynamicLib
+#include "opencv2/core/utils/configuration.private.hpp"
 
 namespace cv { namespace detail {
 
@@ -47,8 +48,8 @@ static FN_vaGetImage fn_vaGetImage = NULL;
 static std::shared_ptr<cv::plugin::impl::DynamicLib> loadLibVA()
 {
     std::shared_ptr<cv::plugin::impl::DynamicLib> lib;
-    const char* envPath = getenv("OPENCV_LIBVA_RUNTIME");
-    if (envPath)
+    const std::string envPath = utils::getConfigurationParameterString("OPENCV_LIBVA_RUNTIME");
+    if (!envPath.empty())
     {
         lib = std::make_shared<cv::plugin::impl::DynamicLib>(envPath);
         return lib;

--- a/modules/dnn/perf/perf_main.cpp
+++ b/modules/dnn/perf/perf_main.cpp
@@ -1,16 +1,7 @@
 #include "perf_precomp.hpp"
 
-static const char* extraTestDataPath =
-#ifdef WINRT
-        NULL;
-#else
-        getenv("OPENCV_DNN_TEST_DATA_PATH");
-#endif
-
 #if defined(HAVE_HPX)
     #include <hpx/hpx_main.hpp>
 #endif
 
-CV_PERF_TEST_MAIN(dnn,
-    extraTestDataPath ? (void)cvtest::addDataSearchPath(extraTestDataPath) : (void)0
-)
+CV_PERF_TEST_MAIN(dnn, cvtest::addDataSearchEnv("OPENCV_DNN_TEST_DATA_PATH"))

--- a/modules/dnn/src/precomp.hpp
+++ b/modules/dnn/src/precomp.hpp
@@ -47,6 +47,7 @@
 #endif
 
 #include <opencv2/core.hpp>
+#include "opencv2/core/utils/configuration.private.hpp"
 
 #ifndef CV_OCL4DNN
 #define CV_OCL4DNN 0

--- a/modules/dnn/src/vkcom/vulkan/vk_loader.cpp
+++ b/modules/dnn/src/vkcom/vulkan/vk_loader.cpp
@@ -115,21 +115,12 @@ bool loadVulkanLibrary()
     if (handle != nullptr)
         return true;
 
-    const char* path;
-    const char* envPath = getenv("OPENCV_VULKAN_RUNTIME");
-    if (envPath)
-    {
-        path = envPath;
-    }
-    else
-    {
-        path = DEFAULT_VK_LIBRARY_PATH;
-    }
+    const std::string path = cv::utils::getConfigurationParameterString("OPENCV_VULKAN_RUNTIME", DEFAULT_VK_LIBRARY_PATH);
 
-    handle = LOAD_VK_LIBRARY(path);
+    handle = LOAD_VK_LIBRARY(path.c_str());
     if( handle == nullptr )
     {
-        fprintf(stderr, "Could not load Vulkan library: %s!\n", path);
+        fprintf(stderr, "Could not load Vulkan library: %s!\n", path.c_str());
         fprintf(stderr, "Please download the Vulkan SDK and set the environment variable of OPENCV_VULKAN_RUNTIME according "
                         "to your system environment.\n");
         fprintf(stderr, "For M1 Mac and IOS, we use MoltenVK to map the Vulkan code to native apple Metal code.\n");

--- a/modules/dnn/test/test_common.impl.hpp
+++ b/modules/dnn/test/test_common.impl.hpp
@@ -437,14 +437,7 @@ bool validateVPUType()
 
 void initDNNTests()
 {
-    const char* extraTestDataPath =
-#ifdef WINRT
-        NULL;
-#else
-        getenv("OPENCV_DNN_TEST_DATA_PATH");
-#endif
-    if (extraTestDataPath)
-        cvtest::addDataSearchPath(extraTestDataPath);
+    cvtest::addDataSearchEnv("OPENCV_DNN_TEST_DATA_PATH");
 
     registerGlobalSkipTag(
         CV_TEST_TAG_DNN_SKIP_OPENCV_BACKEND,

--- a/modules/dnn/test/test_ie_models.cpp
+++ b/modules/dnn/test/test_ie_models.cpp
@@ -40,15 +40,11 @@ static void initDLDTDataPath()
     if (!initialized)
     {
 #if INF_ENGINE_RELEASE <= 2018050000
-        const char* dldtTestDataPath = getenv("INTEL_CVSDK_DIR");
-        if (dldtTestDataPath)
-            cvtest::addDataSearchPath(dldtTestDataPath);
+        cvtest::addDataSearchEnv("INTEL_CVSDK_DIR");
 #else
-        const char* omzDataPath = getenv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
-        if (omzDataPath)
-            cvtest::addDataSearchPath(omzDataPath);
-        const char* dnnDataPath = getenv("OPENCV_DNN_TEST_DATA_PATH");
-        if (dnnDataPath)
+        cvtest::addDataSearchEnv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
+        const std::string dnnDataPath = cv::utils::getConfigurationParameterString("OPENCV_DNN_TEST_DATA_PATH");
+        if (!dnnDataPath.empty())
             cvtest::addDataSearchPath(std::string(dnnDataPath) + "/omz_intel_models");
 #endif
         initialized = true;

--- a/modules/dnn/test/test_precomp.hpp
+++ b/modules/dnn/test/test_precomp.hpp
@@ -45,6 +45,7 @@
 #include "opencv2/ts/ts_perf.hpp"
 #include "opencv2/core/utility.hpp"
 #include "opencv2/core/ocl.hpp"
+#include "opencv2/core/utils/configuration.private.hpp"
 
 #include "opencv2/dnn.hpp"
 #include "test_common.hpp"

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -99,9 +99,9 @@ namespace
         auto dump_info = cv::gapi::getCompileArg<cv::graph_dump_path>(args);
         if (!dump_info.has_value())
         {
-            const char* path = std::getenv("GRAPH_DUMP_PATH");
-            return path
-                ? cv::util::make_optional(std::string(path))
+            const std::string path = cv::utils::getConfigurationParameterString("GRAPH_DUMP_PATH");
+            return !path.empty()
+                ? cv::util::make_optional(path)
                 : cv::util::optional<std::string>();
         }
         else

--- a/modules/gapi/src/precomp.hpp
+++ b/modules/gapi/src/precomp.hpp
@@ -10,6 +10,7 @@
 
 #if !defined(GAPI_STANDALONE)
 #  include <opencv2/core.hpp>
+#  include <opencv2/core/utils/configuration.private.hpp>
 #  include <opencv2/imgproc.hpp>
 #  include <opencv2/gapi/core.hpp>
 #  include <opencv2/gapi/imgproc.hpp>

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -101,22 +101,18 @@ public:
 // FIXME: taken from DNN module
 static void initDLDTDataPath()
 {
-#ifndef WINRT
     static bool initialized = false;
     if (!initialized)
     {
-        const char* omzDataPath = getenv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
-        if (omzDataPath)
-            cvtest::addDataSearchPath(omzDataPath);
-        const char* dnnDataPath = getenv("OPENCV_DNN_TEST_DATA_PATH");
-        if (dnnDataPath) {
+        cvtest::addDataSearchEnv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
+        const std::string dnnDataPath = cv::utils::getConfigurationParameterString("OPENCV_DNN_TEST_DATA_PATH");
+        if (!dnnDataPath.empty()) {
             // Add the dnnDataPath itself - G-API is using some images there directly
             cvtest::addDataSearchPath(dnnDataPath);
             cvtest::addDataSearchPath(dnnDataPath + std::string("/omz_intel_models"));
         }
         initialized = true;
     }
-#endif // WINRT
 }
 
 #if INF_ENGINE_RELEASE >= 2020010000

--- a/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_onnx_test.cpp
@@ -58,10 +58,7 @@ public:
 };
 struct ONNXInitPath {
     ONNXInitPath() {
-        const char* env_path = getenv("OPENCV_GAPI_ONNX_MODEL_PATH");
-        if (env_path) {
-            cvtest::addDataSearchPath(env_path);
-        }
+        cvtest::addDataSearchEnv("OPENCV_GAPI_ONNX_MODEL_PATH");
     }
 };
 static ONNXInitPath g_init_path;

--- a/modules/gapi/test/infer/gapi_infer_ov_tests.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ov_tests.cpp
@@ -25,11 +25,9 @@ void initDLDTDataPath()
     static bool initialized = false;
     if (!initialized)
     {
-        const char* omzDataPath = getenv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
-        if (omzDataPath)
-            cvtest::addDataSearchPath(omzDataPath);
-        const char* dnnDataPath = getenv("OPENCV_DNN_TEST_DATA_PATH");
-        if (dnnDataPath) {
+        cvtest::addDataSearchEnv("OPENCV_OPEN_MODEL_ZOO_DATA_PATH");
+        const std::string dnnDataPath = cv::utils::getConfigurationParameterString("OPENCV_DNN_TEST_DATA_PATH");
+        if (!dnnDataPath.empty()) {
             // Add the dnnDataPath itself - G-API is using some images there directly
             cvtest::addDataSearchPath(dnnDataPath);
             cvtest::addDataSearchPath(dnnDataPath + std::string("/omz_intel_models"));

--- a/modules/gapi/test/test_precomp.hpp
+++ b/modules/gapi/test/test_precomp.hpp
@@ -16,6 +16,8 @@
 
 #include <opencv2/ts.hpp>
 
+#include <opencv2/core/utils/configuration.private.hpp>
+
 #include <opencv2/gapi.hpp>
 #include <opencv2/gapi/core.hpp>
 #include <opencv2/gapi/imgproc.hpp>

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -54,6 +54,7 @@
 #include "opencv2/core/utility.hpp"
 #if defined(__OPENCV_BUILD)
 #include "opencv2/core/private.hpp"
+#include "opencv2/core/utils/configuration.private.hpp"
 #endif
 
 #include "opencv2/imgproc.hpp"

--- a/modules/highgui/src/registry.impl.hpp
+++ b/modules/highgui/src/registry.impl.hpp
@@ -133,7 +133,7 @@ protected:
     bool readPrioritySettings()
     {
         bool hasChanges = false;
-        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_UI_PRIORITY_LIST", NULL);
+        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_UI_PRIORITY_LIST");
         if (prioritized_backends.empty())
             return hasChanges;
         CV_LOG_INFO(NULL, "UI: Configured priority list (OPENCV_UI_PRIORITY_LIST): " << prioritized_backends);

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -662,7 +662,7 @@ int cv::waitKey(int delay)
     static int use_legacy = -1;
     if (use_legacy < 0)
     {
-        use_legacy = getenv("OPENCV_LEGACY_WAITKEY") != NULL ? 1 : 0;
+        use_legacy = utils::getConfigurationParameterBool("OPENCV_LEGACY_WAITKEY");
     }
     if (use_legacy > 0)
         return code;

--- a/modules/highgui/src/window_wayland.cpp
+++ b/modules/highgui/src/window_wayland.cpp
@@ -1378,7 +1378,7 @@ int cv_wl_buffer::create_tmpfile(std::string const &tmpname) {
 }
 
 int cv_wl_buffer::create_anonymous_file(off_t size) {
-    auto path = getenv("XDG_RUNTIME_DIR") + std::string("/opencv-shared-XXXXXX");
+    auto path = cv::utils::getConfigurationParameterString("XDG_RUNTIME_DIR") + std::string("/opencv-shared-XXXXXX");
     int fd = create_tmpfile(path);
 
     int ret = posix_fallocate(fd, 0, size);

--- a/modules/objdetect/test/test_main.cpp
+++ b/modules/objdetect/test/test_main.cpp
@@ -11,14 +11,7 @@ static
 void initTests()
 {
 #ifdef HAVE_OPENCV_DNN
-    const char* extraTestDataPath =
-#ifdef WINRT
-        NULL;
-#else
-        getenv("OPENCV_DNN_TEST_DATA_PATH");
-#endif
-    if (extraTestDataPath)
-        cvtest::addDataSearchPath(extraTestDataPath);
+    cvtest::addDataSearchEnv("OPENCV_DNN_TEST_DATA_PATH");
 #endif  // HAVE_OPENCV_DNN
 }
 

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -754,6 +754,7 @@ void smoothBorder(Mat& img, const Scalar& color, int delta = 3);
 // Utility functions
 
 void addDataSearchPath(const std::string& path);
+void addDataSearchEnv(const std::string& env_name);
 void addDataSearchSubDirectory(const std::string& subdir);
 
 /*! @brief Try to find requested data file

--- a/modules/ts/src/precomp.hpp
+++ b/modules/ts/src/precomp.hpp
@@ -1,5 +1,6 @@
 #include "opencv2/ts.hpp"
 #include <opencv2/core/utils/logger.hpp>
+#include "opencv2/core/utils/configuration.private.hpp"
 #include "opencv2/core/utility.hpp"
 #if !defined(__EMSCRIPTEN__)
 #include "opencv2/core/private.hpp"

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -553,13 +553,9 @@ static int tsErrorCallback( int status, const char* func_name, const char* err_m
 void TS::init( const string& modulename )
 {
     data_search_subdir.push_back(modulename);
-#ifndef WINRT
-    char* datapath_dir = getenv("OPENCV_TEST_DATA_PATH");
-#else
-    char* datapath_dir = OPENCV_TEST_DATA_PATH;
-#endif
+    std::string datapath_dir = cv::utils::getConfigurationParameterString("OPENCV_TEST_DATA_PATH");
 
-    if( datapath_dir )
+    if( !datapath_dir.empty() )
     {
         data_path = path_join(path_join(datapath_dir, modulename), "");
     }
@@ -903,11 +899,7 @@ void parseCustomOptions(int argc, char **argv)
 
     test_ipp_check = parser.get<bool>("test_ipp_check");
     if (!test_ipp_check)
-#ifndef WINRT
-        test_ipp_check = getenv("OPENCV_IPP_CHECK") != NULL;
-#else
-        test_ipp_check = false;
-#endif
+        test_ipp_check = cv::utils::getConfigurationParameterBool("OPENCV_IPP_CHECK");
 
     param_seed = parser.get<unsigned int>("test_seed");
 
@@ -953,8 +945,13 @@ static bool isDirectory(const std::string& path)
 
 void addDataSearchPath(const std::string& path)
 {
-    if (isDirectory(path))
+    if (!path.empty() && isDirectory(path))
         TS::ptr()->data_search_path.push_back(path);
+}
+void addDataSearchEnv(const std::string& env_name)
+{
+    const std::string val = cv::utils::getConfigurationParameterString(env_name.c_str());
+    cvtest::addDataSearchPath(val);
 }
 void addDataSearchSubDirectory(const std::string& subdir)
 {
@@ -1001,14 +998,10 @@ static std::string findData(const std::string& relative_path, bool required, boo
 
     const std::vector<std::string>& search_subdir = TS::ptr()->data_search_subdir;
 
-#ifndef WINRT
-    char* datapath_dir = getenv("OPENCV_TEST_DATA_PATH");
-#else
-    char* datapath_dir = OPENCV_TEST_DATA_PATH;
-#endif
+    std::string datapath_dir = cv::utils::getConfigurationParameterString("OPENCV_TEST_DATA_PATH");
 
     std::string datapath;
-    if (datapath_dir)
+    if (!datapath_dir.empty())
     {
         datapath = datapath_dir;
         //CV_Assert(isDirectory(datapath) && "OPENCV_TEST_DATA_PATH is specified but it doesn't exist");

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -192,22 +192,18 @@ void Regression::init(const std::string& testSuitName, const std::string& ext)
         return;
     }
 
-#ifndef WINRT
-    const char *data_path_dir = getenv("OPENCV_TEST_DATA_PATH");
-#else
-    const char *data_path_dir = OPENCV_TEST_DATA_PATH;
-#endif
+    const std::string data_path_dir = utils::getConfigurationParameterString("OPENCV_TEST_DATA_PATH");
 
     cvtest::addDataSearchSubDirectory("");
     cvtest::addDataSearchSubDirectory(testSuitName);
 
     const char *path_separator = "/";
 
-    if (data_path_dir)
+    if (!data_path_dir.empty())
     {
-        int len = (int)strlen(data_path_dir)-1;
+        int len = (int)data_path_dir.size()-1;
         if (len < 0) len = 0;
-        std::string path_base = (data_path_dir[0] == 0 ? std::string(".") : std::string(data_path_dir))
+        std::string path_base = (data_path_dir[0] == 0 ? std::string(".") : data_path_dir)
                 + (data_path_dir[len] == '/' || data_path_dir[len] == '\\' ? "" : path_separator)
                 + "perf"
                 + path_separator;
@@ -1042,7 +1038,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
     param_verify_sanity = args.get<bool>("perf_verify_sanity");
 
 #ifdef HAVE_IPP
-    test_ipp_check      = !args.get<bool>("perf_ipp_check") ? getenv("OPENCV_IPP_CHECK") != NULL : true;
+    test_ipp_check      = !args.get<bool>("perf_ipp_check") ? utils::getConfigurationParameterBool("OPENCV_IPP_CHECK") : true;
 #endif
     testThreads         = args.get<int>("perf_threads");
 #ifdef CV_COLLECT_IMPL_DATA
@@ -1125,12 +1121,11 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
 #endif
 
     {
-#ifndef WINRT
-        const char* path = getenv("OPENCV_PERF_VALIDATION_DIR");
-#else
-        const char* path = OPENCV_PERF_VALIDATION_DIR;
+        std::string path = utils::getConfigurationParameterString("OPENCV_PERF_VALIDATION_DIR");
+#ifdef WINRT
+        path = OPENCV_PERF_VALIDATION_DIR;
 #endif
-        if (path)
+        if (!path.empty())
             perf_validation_results_directory = path;
     }
 
@@ -1888,17 +1883,16 @@ std::string TestBase::getDataPath(const std::string& relativePath)
         throw PerfEarlyExitException();
     }
 
-#ifndef WINRT
-    const char *data_path_dir = getenv("OPENCV_TEST_DATA_PATH");
-#else
-    const char *data_path_dir = OPENCV_TEST_DATA_PATH;
+    std::string data_path_dir = utils::getConfigurationParameterString("OPENCV_TEST_DATA_PATH");
+#ifdef WINRT
+    data_path_dir = OPENCV_TEST_DATA_PATH;
 #endif
     const char *path_separator = "/";
 
     std::string path;
-    if (data_path_dir)
+    if (!data_path_dir.empty())
     {
-        int len = (int)strlen(data_path_dir) - 1;
+        int len = (int)data_path_dir.size() - 1;
         if (len < 0) len = 0;
         path = (data_path_dir[0] == 0 ? std::string(".") : std::string(data_path_dir))
                 + (data_path_dir[len] == '/' || data_path_dir[len] == '\\' ? "" : path_separator);

--- a/modules/video/perf/perf_main.cpp
+++ b/modules/video/perf/perf_main.cpp
@@ -7,15 +7,7 @@
 static
 void initTests()
 {
-    const char* extraTestDataPath =
-#ifdef WINRT
-        NULL;
-#else
-        getenv("OPENCV_DNN_TEST_DATA_PATH");
-#endif
-    if (extraTestDataPath)
-        cvtest::addDataSearchPath(extraTestDataPath);
-
+    cvtest::addDataSearchEnv("OPENCV_DNN_TEST_DATA_PATH");
     cvtest::addDataSearchSubDirectory("");  // override "cv" prefix below to access without "../dnn" hacks
 }
 

--- a/modules/video/perf/perf_precomp.hpp
+++ b/modules/video/perf/perf_precomp.hpp
@@ -7,6 +7,7 @@
 #include "opencv2/ts.hpp"
 #include <opencv2/video.hpp>
 #include "opencv2/ts/ts_perf.hpp"
+#include "opencv2/core/utils/configuration.private.hpp"
 
 namespace cvtest
 {

--- a/modules/video/test/test_main.cpp
+++ b/modules/video/test/test_main.cpp
@@ -10,15 +10,7 @@
 static
 void initTests()
 {
-    const char* extraTestDataPath =
-#ifdef WINRT
-        NULL;
-#else
-        getenv("OPENCV_DNN_TEST_DATA_PATH");
-#endif
-    if (extraTestDataPath)
-        cvtest::addDataSearchPath(extraTestDataPath);
-
+    cvtest::addDataSearchEnv("OPENCV_DNN_TEST_DATA_PATH");
     cvtest::addDataSearchSubDirectory("");  // override "cv" prefix below to access without "../dnn" hacks
 }
 

--- a/modules/video/test/test_precomp.hpp
+++ b/modules/video/test/test_precomp.hpp
@@ -7,6 +7,7 @@
 #include "opencv2/ts.hpp"
 #include "opencv2/video.hpp"
 #include <opencv2/ts/ts_perf.hpp>
+#include "opencv2/core/utils/configuration.private.hpp"
 
 namespace opencv_test {
 using namespace perf;

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -332,16 +332,14 @@ std::vector<FileSystemPath_t> getPluginCandidates(const std::string& baseName)
     std::vector<FileSystemPath_t> results;
 #ifdef _WIN32
     FileSystemPath_t moduleName = toFileSystemPath(libraryPrefix() + "opencv_videoio_" + baseName_l + librarySuffix());
-#ifndef WINRT
     if (baseName_u == "FFMPEG")  // backward compatibility
     {
-        const wchar_t* ffmpeg_env_path = _wgetenv(L"OPENCV_FFMPEG_DLL_DIR");
-        if (ffmpeg_env_path)
+        const std::string ffmpeg_env_path = cv::utils::getConfigurationParameterString("OPENCV_FFMPEG_DLL_DIR");
+        if (!ffmpeg_env_path.empty())
         {
-            results.push_back(FileSystemPath_t(ffmpeg_env_path) + L"\\" + moduleName);
+            results.push_back(toFileSystemPath(ffmpeg_env_path + "\\" + toPrintablePath(moduleName)));
         }
     }
-#endif
     if (plugin_expr != default_expr)
     {
         moduleName = toFileSystemPath(plugin_expr);

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -303,15 +303,7 @@ interface ISampleGrabber : public IUnknown
 
 static void DebugPrintOut(const char *format, ...)
 {
-    static int gs_verbose = -1;
-    if (gs_verbose < 0)
-    {
-        // Fetch initial debug state from environment - defaults to disabled
-        const char* s = getenv("OPENCV_DSHOW_DEBUG");
-        gs_verbose = s != NULL && atoi(s) != 0;
-    }
-
-
+    static const bool gs_verbose = utils::getConfigurationParameterBool("OPENCV_DSHOW_DEBUG");
     if (gs_verbose)
     {
         va_list args;
@@ -2982,18 +2974,18 @@ int videoInput::start(int deviceID, videoDevice *VD){
     VD->readyToCapture = true;
 
     // check for optional saving the direct show graph to a file
-    const char* graph_filename = getenv("OPENCV_DSHOW_SAVEGRAPH_FILENAME");
-    if (graph_filename) {
-        size_t filename_len = strlen(graph_filename);
+    std::string graph_filename = utils::getConfigurationParameterString("OPENCV_DSHOW_SAVEGRAPH_FILENAME");
+    if (!graph_filename.empty()) {
+        size_t filename_len = graph_filename.size();
         std::vector<WCHAR> wfilename(filename_len + 1);
-        size_t len = mbstowcs(&wfilename[0], graph_filename, filename_len  + 1);
+        size_t len = mbstowcs(&wfilename[0], &graph_filename[0], filename_len  + 1);
         CV_Assert(len == filename_len);
 
         HRESULT res = SaveGraphFile(VD->pGraph, &wfilename[0]);
         if (SUCCEEDED(res)) {
-            DebugPrintOut("Saved DSHOW graph to %s\n", graph_filename);
+            DebugPrintOut("Saved DSHOW graph to %s\n", graph_filename.c_str());
         } else {
-            DebugPrintOut("Failed to save DSHOW graph to %s\n", graph_filename);
+            DebugPrintOut("Failed to save DSHOW graph to %s\n", graph_filename.c_str());
         }
     }
 

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -259,7 +259,7 @@ protected:
     bool readPrioritySettings()
     {
         bool hasChanges = false;
-        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_VIDEOIO_PRIORITY_LIST", NULL);
+        cv::String prioritized_backends = utils::getConfigurationParameterString("OPENCV_VIDEOIO_PRIORITY_LIST");
         if (prioritized_backends.empty())
             return hasChanges;
         CV_LOG_INFO(NULL, "VIDEOIO: Configured priority list (OPENCV_VIDEOIO_PRIORITY_LIST): " << prioritized_backends);

--- a/modules/videoio/test/test_main.cpp
+++ b/modules/videoio/test/test_main.cpp
@@ -11,15 +11,13 @@
 static
 void initTests()
 {
-#ifndef WINRT  // missing getenv
     const std::vector<cv::VideoCaptureAPIs> backends = cv::videoio_registry::getStreamBackends();
-    const char* requireFFmpeg = getenv("OPENCV_TEST_VIDEOIO_BACKEND_REQUIRE_FFMPEG");
+    bool requireFFmpeg = cv::utils::getConfigurationParameterBool("OPENCV_TEST_VIDEOIO_BACKEND_REQUIRE_FFMPEG");
     if (requireFFmpeg && !isBackendAvailable(cv::CAP_FFMPEG, backends))
     {
         CV_LOG_FATAL(NULL, "OpenCV-Test: required FFmpeg backend is not available (broken plugin?). STOP.");
         exit(1);
     }
-#endif
 }
 
 CV_TEST_MAIN("highgui", initTests())

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -13,6 +13,7 @@
 #include "opencv2/videoio.hpp"
 #include "opencv2/videoio/registry.hpp"
 #include "opencv2/core/private.hpp"
+#include "opencv2/core/utils/configuration.private.hpp"
 
 namespace cv {
 


### PR DESCRIPTION
- changed second argument of the `getConfigurationParameterString` to `std::string` from `const char*`, technically this breaks the ABI, but the function is private
- added `cvtest::addDataSearchEnv` function to replace repetative blocks with `getenv + addDataSearchPath`
- added call to `getConfigurationParameterString` to the gapi module, this change presumably conflicts with standalone build, but can be fixed if needed
- in some cases "unset" and empty environment variables could be treated differently, but I haven't found where it is really useful. Both paths essentially produced the same effect, so I beleive processing them as a single case `var.isEmpty()` should be OK.
- in some cases we just checked environment variables for non-null (i.e. set), this has changed to bool processing (e.g. `1`, `true` - turn ON, `0`, `false` - turn OFF). This is also changed beokhavior.
- changed videoio plugin code for loading FFmpeg on Windows (`OPENCV_FFMPEG_DLL_DIR`) - it used `_wgetenv` with `wchar_t*` result, but I've changed it to our function returning `std::string`, I'm not sure if it affects unicode paths support (they might use UTF-8)
- when new option `OPENCV_DISABLE_ENV_SUPPORT` is set to `ON`, just one file will be compiled with `NO_GETENV` macro enabled, all 3rdparty libraries will not be affected, I'm not sure if it is OK behavior or not.
