### PR TITLE
Fix #26322: construction of another Mat header for empty matrix

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1372,7 +1372,8 @@ Mat::Mat(int _dims, const int* _sizes, int _type, void* _data, const size_t* _st
 {
     flags |= CV_MAT_TYPE(_type);
     datastart = data = (uchar*)_data;
-    setSize(*this, _dims, _sizes, _steps, true);
+    if (_dims > 0 || _data != nullptr)
+        setSize(*this, _dims, _sizes, _steps, true);
     finalizeHdr(*this);
 }
 
@@ -1383,7 +1384,9 @@ Mat::Mat(const std::vector<int>& _sizes, int _type, void* _data, const size_t* _
 {
     flags |= CV_MAT_TYPE(_type);
     datastart = data = (uchar*)_data;
-    setSize(*this, (int)_sizes.size(), _sizes.data(), _steps, true);
+    int _dims = (int)_sizes.size();
+    if (_dims > 0 || _data != nullptr)
+        setSize(*this, _dims, _sizes.data(), _steps, true);
     finalizeHdr(*this);
 }
 
@@ -1407,15 +1410,16 @@ Mat::Mat(std::initializer_list<int> _shape, int _type, void* _data, const size_t
       datalimit(0), allocator(0), u(0), size(&rows)
 {
     int new_shape[MatShape::MAX_DIMS];
-    int new_ndims = (int)_shape.size();
-    CV_Assert(new_ndims <= MatShape::MAX_DIMS);
+    int _dims = (int)_shape.size();
+    CV_Assert(_dims <= MatShape::MAX_DIMS);
     auto it = _shape.begin();
-    for (int i = 0; i < new_ndims; i++, ++it)
+    for (int i = 0; i < _dims; i++, ++it)
         new_shape[i] = *it;
 
     flags |= CV_MAT_TYPE(_type);
     datastart = data = (uchar*)_data;
-    setSize(*this, new_ndims, new_shape, _steps, true);
+    if (_dims > 0 || _data != nullptr)
+        setSize(*this, _dims, new_shape, _steps, true);
     finalizeHdr(*this);
 }
 

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2647,4 +2647,26 @@ TEST(InputArray, dumpEmpty)
     EXPECT_EQ(s, "InputArray: empty()=true kind=0x00010000 flags=0x01010000 total(-1)=0 dims(-1)=0 size(-1)=0x0 type(-1)=CV_8UC1");
 }
 
+TEST(Mat, regression_26322)
+{
+    cv::Mat1b mat;
+    EXPECT_TRUE(mat.empty());
+    EXPECT_EQ(0, (int)mat.total());
+
+    cv::Mat mat2(mat.dims, mat.size.p, mat.type(), mat.data, mat.step.p);
+    EXPECT_TRUE(mat2.empty());
+    EXPECT_EQ(mat.cols, mat2.cols);
+    EXPECT_EQ(mat.rows, mat2.rows);
+    EXPECT_EQ(0, mat2.cols * mat2.rows * mat2.elemSize());
+    EXPECT_EQ(0, (int)mat2.total());
+
+    // the new way of doing the same in 5.x
+    cv::Mat mat3(mat.shape(), mat.type(), mat.data, mat.step.p);
+    EXPECT_TRUE(mat3.empty());
+    EXPECT_EQ(mat.cols, mat3.cols);
+    EXPECT_EQ(mat.rows, mat3.rows);
+    EXPECT_EQ(0, mat3.cols * mat3.rows * mat3.elemSize());
+    EXPECT_EQ(0, (int)mat3.total());
+}
+
 }} // namespace

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2657,7 +2657,7 @@ TEST(Mat, regression_26322)
     EXPECT_TRUE(mat2.empty());
     EXPECT_EQ(mat.cols, mat2.cols);
     EXPECT_EQ(mat.rows, mat2.rows);
-    EXPECT_EQ(0, mat2.cols * mat2.rows * mat2.elemSize());
+    EXPECT_EQ(0, (int)(mat2.cols * mat2.rows * mat2.elemSize()));
     EXPECT_EQ(0, (int)mat2.total());
 
     // the new way of doing the same in 5.x
@@ -2665,7 +2665,7 @@ TEST(Mat, regression_26322)
     EXPECT_TRUE(mat3.empty());
     EXPECT_EQ(mat.cols, mat3.cols);
     EXPECT_EQ(mat.rows, mat3.rows);
-    EXPECT_EQ(0, mat3.cols * mat3.rows * mat3.elemSize());
+    EXPECT_EQ(0, (int)(mat3.cols * mat3.rows * mat3.elemSize()));
     EXPECT_EQ(0, (int)mat3.total());
 }
 


### PR DESCRIPTION
The PR fixes #26322

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
