### PR TITLE
Guide to Handling PyLint Warnings with OpenCV

### DIFF
--- a/doc/pylint_guide.md
+++ b/doc/pylint_guide.md
@@ -1,0 +1,23 @@
+# Guide to Handling PyLint Warnings with OpenCV
+
+## Summary
+When using the OpenCV library (`cv2`), PyLint may not recognize certain members, resulting in false-positive warnings in the Problems tab.
+
+
+## Example Code
+Here is a Minimum Working Example (MWE) that demonstrates the issue:
+
+```python
+import cv2
+
+cap = cv2.VideoCapture("test.mp4")
+background_subtractor = cv2.createBackgroundSubtractorMOG2()
+
+ret, frame = cap.read()
+foreground_mask = background_subtractor.apply(frame)
+contours, hierarchy = cv2.findContours(
+    foreground_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+)
+
+cv2.destroyAllWindows()
+cap.release()


### PR DESCRIPTION

# Summary
Explain the problem of PyLint not recognizing certain cv2 members and how it can flood the Problems tab.


# Example Code
Include the Minimum Working Example (MWE) you shared.

# Solution:
Suggest a workaround, such as configuring PyLint to ignore specific warnings or updating PyLint settings.

# References: 
Link to the PyLint documentation for further reading.
## Example Code
```python
import cv2

cap = cv2.VideoCapture("test.mp4")
background_subtractor = cv2.createBackgroundSubtractorMOG2()

ret, frame = cap.read()
foreground_mask = background_subtractor.apply(frame)
contours, hierarchy = cv2.findContours(
    foreground_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
)

cv2.destroyAllWindows()
cap.release()
```


# Suggested Workaround
To ignore these warnings, you can configure PyLint with the following command:

```bash
pylint --disable=no-member
```
For more detailed information, refer to the PyLint documentation.

