### PR TITLE
Fix ORB inconsistency for masks with values 255 and 1.

### DIFF
--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -1133,15 +1133,12 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
             if( !mask.empty() )
             {
                 resize(prevMask, currMask, sz, 0, 0, INTER_LINEAR_EXACT);
-                if( level > firstLevel )
-                    threshold(currMask, currMask, 254, 0, THRESH_TOZERO);
+                copyMakeBorder(currMask, extMask, border, border, border, border,
+                               BORDER_CONSTANT + BORDER_ISOLATED);
             }
 
             copyMakeBorder(currImg, extImg, border, border, border, border,
-                           BORDER_REFLECT_101+BORDER_ISOLATED);
-            if (!mask.empty())
-                copyMakeBorder(currMask, extMask, border, border, border, border,
-                               BORDER_CONSTANT+BORDER_ISOLATED);
+                           BORDER_REFLECT_101 + BORDER_ISOLATED);
         }
         else
         {

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -1036,7 +1036,11 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
     bool useOCL = false;
 #endif
 
-    Mat image = _image.getMat(), mask = _mask.getMat();
+    Mat image = _image.getMat(), mask;
+    if (!_mask.empty())
+    {
+        cv::threshold(_mask.getMat(), mask, 0, 255, cv::THRESH_BINARY);
+    }
     if( image.type() != CV_8UC1 )
         cvtColor(_image, image, COLOR_BGR2GRAY);
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -1039,7 +1039,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
     Mat image = _image.getMat(), mask;
     if (!_mask.empty())
     {
-        cv::threshold(_mask.getMat(), mask, 0, 255, cv::THRESH_BINARY);
+        threshold(_mask, mask, 0, 255, THRESH_BINARY);
     }
     if( image.type() != CV_8UC1 )
         cvtColor(_image, image, COLOR_BGR2GRAY);

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -170,7 +170,7 @@ BIGDATA_TEST(Features2D_ORB, regression_opencv_python_537)  // memory usage: ~3 
 
 TEST(Features2D_ORB, MaskValue)
 {
-    Mat gray = imread("features2d/tsukuba.png", IMREAD_GRAYSCALE);
+    Mat gray = imread(cvtest::findDataFile("features2d/tsukuba.png"), IMREAD_GRAYSCALE);
     ASSERT_FALSE(gray.empty());
 
     cv::Rect roi(gray.cols/4, gray.rows/4, gray.cols/2, gray.rows/2);

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -188,24 +188,11 @@ TEST(Features2D_ORB, MaskValue)
     orb->detectAndCompute(gray, mask255, keypoints_mask255, descriptors_mask255, false);
     orb->detectAndCompute(gray, mask1, keypoints_mask1, descriptors_mask1, false);
 
-    std::cout << "keypoints_mask255.size(): " << keypoints_mask255.size() << std::endl;
-    std::cout << "descriptors_mask255.size(): " << descriptors_mask255.size() << std::endl;
-    std::cout << "keypoints_mask1.size(): " << keypoints_mask1.size() << std::endl;
-    std::cout << "descriptors_mask1.size(): " << descriptors_mask1.size() << std::endl;
-
     ASSERT_EQ(keypoints_mask255.size(), keypoints_mask1.size())
         << "Number of keypoints differs between mask values 255 and 1";
 
-    if (keypoints_mask255.size() == keypoints_mask1.size())
-    {
-        ASSERT_EQ(descriptors_mask255.size, descriptors_mask1.size)
-            << "Descriptor sizes do not match";
-        ASSERT_EQ(descriptors_mask255.type(), descriptors_mask1.type())
-            << "Descriptor types do not match";
-
-        Mat diff = descriptors_mask255 != descriptors_mask1;
-        ASSERT_EQ(countNonZero(diff), 0)
-            << "Descriptors are not identical";
-    }
+    Mat diff = descriptors_mask255 != descriptors_mask1;
+    ASSERT_EQ(countNonZero(diff), 0);
 }
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

The PR fixes : [25974](https://github.com/opencv/opencv/issues/25974)

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
