### PR TITLE
Fix incorrect string format in js build script

### DIFF
--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -254,7 +254,7 @@ if __name__ == "__main__":
     parser.add_argument('--cmake_option', action='append', help="Append CMake options")
     # Use flag --build_flags="-s USE_PTHREADS=0 -Os" for one and more arguments as in the example
     parser.add_argument('--build_flags', help="Append Emscripten build options")
-    parser.add_argument('--build_wasm_intrin_test', default=False, action="store_true", help="Build WASM intrin tests")
+    parser.add_argument('--build_wasm_intrin_test', action="store_true", help="Build WASM intrin tests")
     # Write a path to modify file like argument of this flag
     parser.add_argument('--config', help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
     parser.add_argument('--config', help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
 
-    transformed_args = ["--cmake_option=%s".format(arg) if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
+    transformed_args = ["--cmake_option={}".format(arg) if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
     args = parser.parse_args(transformed_args)
 
     log.debug("Args: %s", args)


### PR DESCRIPTION
I accidentally met this small problem mentioned in https://github.com/opencv/opencv/pull/25084#discussion_r1710838120 when play with wasm build. It seems https://github.com/EDVTAZ didn't fix it yet, so I create this tiny pr.

Additionally, I remove a redundant argument in `add_argument` call. `'store_true'` already set the default, see https://docs.python.org/3/library/argparse.html#action.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
