### PR TITLE
Relax CMake requirement in 5.x

### DIFF
--- a/cmake/OpenCVMinDepVersions.cmake
+++ b/cmake/OpenCVMinDepVersions.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED MIN_VER_CMAKE)
-  set(MIN_VER_CMAKE 3.13) # Debian 10
-  # set(MIN_VER_CMAKE 3.10) # Visual Studio 2017 15.7
+  # set(MIN_VER_CMAKE 3.13) # Debian 10
+  set(MIN_VER_CMAKE 3.10) # Visual Studio 2017 15.7
 endif()
 set(MIN_VER_CUDA 6.5)
 set(MIN_VER_CUDNN 7.5)


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/26287
Buildbot uses CMake 3.10. Reverted CMake version change to satisfy buildbot now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
