### PR TITLE
Build Annoy index in parallel

### DIFF
--- a/modules/features2d/src/annoy.cpp
+++ b/modules/features2d/src/annoy.cpp
@@ -2,6 +2,8 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
 
+#define ANNOYLIB_MULTITHREADED_BUILD
+
 #include "precomp.hpp"
 #include "../3rdparty/annoy/annoylib.h"
 #include <opencv2/core/utils/logger.hpp>
@@ -48,7 +50,7 @@ class ANNIndexImpl : public ANNIndex
 public:
     ANNIndexImpl(int dimension) : dim(dimension)
     {
-        index = makePtr<::cvannoy::AnnoyIndex<int, DataType, DistanceType, Random, ::cvannoy::AnnoyIndexSingleThreadedBuildPolicy>>(dimension);
+        index = makePtr<::cvannoy::AnnoyIndex<int, DataType, DistanceType, Random, ::cvannoy::AnnoyIndexMultiThreadedBuildPolicy>>(dimension);
     }
 
     void addItems(InputArray _dataset) CV_OVERRIDE
@@ -234,7 +236,7 @@ public:
 
 private:
     int dim;
-    Ptr<::cvannoy::AnnoyIndex<int, DataType, DistanceType, Random, ::cvannoy::AnnoyIndexSingleThreadedBuildPolicy>> index;
+    Ptr<::cvannoy::AnnoyIndex<int, DataType, DistanceType, Random, ::cvannoy::AnnoyIndexMultiThreadedBuildPolicy>> index;
 };
 
 Ptr<ANNIndex> ANNIndex::create(int dim, ANNIndex::Distance distType)


### PR DESCRIPTION
#26287 raised the C++ standard, and Annoy's multi-threaded index building can be enabled now.