### PR TITLE
fixed typo in bfloat<=>float conversion test

### DIFF
--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3432,7 +3432,7 @@ TEST(Core_BFloat, convert)
     int vlanes = VTraits<v_float32>::vlanes();
     for (size_t i = 0; i < N; i += vlanes)
     {
-        v_float32 x = v_load(&bigdata[i]);
+        v_float32 x = vx_load(&bigdata[i]);
         v_pack_store(&bfdata[i], x);
     }
 


### PR DESCRIPTION
see https://github.com/opencv/opencv/pull/26321#issuecomment-2443960075

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
