### PR TITLE
Disable SME2 branches in KleidiCV as it's incompatible with some CLang versions, e.g. NDK 28b1

### DIFF
--- a/3rdparty/kleidicv/CMakeLists.txt
+++ b/3rdparty/kleidicv/CMakeLists.txt
@@ -20,4 +20,5 @@ else()
   set(THE_ROOT "${OpenCV_BINARY_DIR}/3rdparty/kleidicv/kleidicv-${KLEIDICV_SRC_COMMIT}")
 endif()
 
+option(KLEIDICV_ENABLE_SME2 "" OFF) # not compatible with some CLang versions in NDK
 include("${THE_ROOT}/adapters/opencv/CMakeLists.txt")


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
