### PR TITLE
Remove useless cmake policy after upgrading cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,58 +20,6 @@ cmake_minimum_required(VERSION "${MIN_VER_CMAKE}" FATAL_ERROR)
 #
 # Configure CMake policies
 #
-if(POLICY CMP0026)
-  cmake_policy(SET CMP0026 NEW)
-endif()
-
-if(POLICY CMP0042)
-  cmake_policy(SET CMP0042 NEW)  # CMake 3.0+ (2.8.12): MacOS "@rpath" in target's install name
-endif()
-
-if(POLICY CMP0046)
-  cmake_policy(SET CMP0046 NEW)  # warn about non-existed dependencies
-endif()
-
-if(POLICY CMP0051)
-  cmake_policy(SET CMP0051 NEW)
-endif()
-
-if(POLICY CMP0054)  # CMake 3.1: Only interpret if() arguments as variables or keywords when unquoted.
-  cmake_policy(SET CMP0054 NEW)
-endif()
-
-if(POLICY CMP0056)
-  cmake_policy(SET CMP0056 NEW)  # try_compile(): link flags
-endif()
-
-if(POLICY CMP0057)
-  cmake_policy(SET CMP0057 NEW)  # CMake 3.3: if(IN_LIST) support
-endif()
-
-if(POLICY CMP0066)
-  cmake_policy(SET CMP0066 NEW)  # CMake 3.7: try_compile(): use per-config flags, like CMAKE_CXX_FLAGS_RELEASE
-endif()
-
-if(POLICY CMP0067)
-  cmake_policy(SET CMP0067 NEW)  # CMake 3.8: try_compile(): honor language standard variables (like C++11)
-endif()
-
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 NEW)  # CMake 3.9+: `RPATH` settings on macOS do not affect `install_name`.
-endif()
-
-if(POLICY CMP0071)
-  cmake_policy(SET CMP0071 NEW)  # CMake 3.10+: Let `AUTOMOC` and `AUTOUIC` process `GENERATED` files.
-endif()
-
-if(POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)  # CMake 3.12+: Include file check macros honor `CMAKE_REQUIRED_LIBRARIES`
-endif()
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)  # CMake 3.13+: option() honors normal variables.
-endif()
-
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW) # CMake 3.15+: leave MSVC runtime selection out of default CMAKE_<LANG>_FLAGS_<CONFIG> flags
 endif()


### PR DESCRIPTION
Several explicitly set cmake policy can be removed after upgrading cmake_minimum_required to 3.13

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
