### PR TITLE
fixed FP16 mat comparison in tests

### DIFF
--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1391,7 +1391,7 @@ norm_flt_(const _Tp* src1, const _Tp* src2, size_t total, int cn, int normType, 
             for( int c = 0; c < cn; c++ )
             {
                 for( i = 0; i < total; i++ )
-                    if( mask[i] && isrc1[i] != isrc2[i] )
+                    if( mask[i] && isrc1[i*cn + c] != isrc2[i*cn + c] )
                         result = std::max(result, std::abs((double)src1[i*cn + c] - (double)src2[i*cn + c]));
             }
     }
@@ -1407,7 +1407,7 @@ norm_flt_(const _Tp* src1, const _Tp* src2, size_t total, int cn, int normType, 
             for( int c = 0; c < cn; c++ )
             {
                 for( i = 0; i < total; i++ )
-                    if( mask[i] && isrc1[i] != isrc2[i] )
+                    if( mask[i] && isrc1[i*cn + c] != isrc2[i*cn + c] )
                         result += std::abs((double)src1[i*cn + c] - (double)src2[i*cn + c]);
             }
     }
@@ -1425,7 +1425,7 @@ norm_flt_(const _Tp* src1, const _Tp* src2, size_t total, int cn, int normType, 
             for( int c = 0; c < cn; c++ )
             {
                 for( i = 0; i < total; i++ )
-                    if( mask[i] && isrc1[i] != isrc2[i] )
+                    if( mask[i] && isrc1[i*cn + c] != isrc2[i*cn + c] )
                     {
                         double v = (double)src1[i*cn + c] - (double)src2[i*cn + c];
                         result += v*v;

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1411,7 +1411,7 @@ norm_flt_(const _Tp* src1, const _Tp* src2, size_t total, int cn, int normType, 
                         result += std::abs((double)src1[i*cn + c] - (double)src2[i*cn + c]);
             }
     }
-    else
+    else if( normType == NORM_L2 )
     {
         if( !mask )
             for( i = 0; i < total; i++ )
@@ -1432,6 +1432,11 @@ norm_flt_(const _Tp* src1, const _Tp* src2, size_t total, int cn, int normType, 
                     }
             }
     }
+    else
+    {
+        CV_Error(Error::StsBadArg, "Unexpected normType value in test");
+    }
+
     return result;
 }
 


### PR DESCRIPTION
make sure that if both compared FP16/BF16 values are bitwise-equal, assume their difference to be 0 (zero), just like in the case of FP32 and FP64, don't try to compare them as floating-point numbers, because they can be NaN's.

**fixes** #24894

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
