### PR TITLE
Make STD_VECTOR and STD_VECTOR_VECTOR processing in Input/OutputArray more robust

### DIFF
--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -1418,13 +1418,91 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
         size_t len = size0*size1 > 0 ? size0 + size1 - 1 : 0;
         std::vector<uchar>* v = (std::vector<uchar>*)obj;
 
+        int type0 = CV_MAT_TYPE(flags);
+        int esz = CV_ELEM_SIZE(type0);
+
         if( k == STD_VECTOR_VECTOR )
         {
             std::vector<std::vector<uchar> >& vv = *(std::vector<std::vector<uchar> >*)obj;
             if( i < 0 )
             {
                 CV_Assert(!fixedSize() || len == vv.size());
-                vv.resize(len);
+
+                switch( esz )
+                {
+                case 1:
+                    ((std::vector<uchar>*)v)->resize(len);
+                    break;
+                case 2:
+                    ((std::vector<Vec2b>*)v)->resize(len);
+                    break;
+                case 3:
+                    ((std::vector<Vec3b>*)v)->resize(len);
+                    break;
+                case 4:
+                    ((std::vector<int>*)v)->resize(len);
+                    break;
+                case 6:
+                    ((std::vector<Vec3s>*)v)->resize(len);
+                    break;
+                case 8:
+                    ((std::vector<Vec2i>*)v)->resize(len);
+                    break;
+                case 12:
+                    ((std::vector<Vec3i>*)v)->resize(len);
+                    break;
+                case 16:
+                    ((std::vector<Vec4i>*)v)->resize(len);
+                    break;
+                case 20:
+                    ((std::vector<Vec<int, 5> >*)v)->resize(len);
+                    break;
+                case 24:
+                    ((std::vector<Vec6i>*)v)->resize(len);
+                    break;
+                case 28:
+                    ((std::vector<Vec<int, 7> >*)v)->resize(len);
+                    break;
+                case 32:
+                    ((std::vector<Vec8i>*)v)->resize(len);
+                    break;
+                case 36:
+                    ((std::vector<Vec<int, 9> >*)v)->resize(len);
+                    break;
+                case 40:
+                    ((std::vector<Vec<int, 10> >*)v)->resize(len);
+                    break;
+                case 44:
+                    ((std::vector<Vec<int, 11> >*)v)->resize(len);
+                    break;
+                case 48:
+                    ((std::vector<Vec<int, 12> >*)v)->resize(len);
+                    break;
+                case 52:
+                    ((std::vector<Vec<int, 13> >*)v)->resize(len);
+                    break;
+                case 56:
+                    ((std::vector<Vec<int, 14> >*)v)->resize(len);
+                    break;
+                case 60:
+                    ((std::vector<Vec<int, 15> >*)v)->resize(len);
+                    break;
+                case 64:
+                    ((std::vector<Vec<int, 16> >*)v)->resize(len);
+                    break;
+                case 128:
+                    ((std::vector<Vec<int, 32> >*)v)->resize(len);
+                    break;
+                case 256:
+                    ((std::vector<Vec<int, 64> >*)v)->resize(len);
+                    break;
+                case 512:
+                    ((std::vector<Vec<int, 128> >*)v)->resize(len);
+                    break;
+                default:
+                    CV_Error_(cv::Error::StsBadArg, ("Vectors with element size %d are not supported. Please, modify OutputArray::create()\n", esz));
+                }
+
                 return;
             }
             CV_Assert( i < (int)vv.size() );
@@ -1433,10 +1511,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
         else
             CV_Assert( i < 0 );
 
-        int type0 = CV_MAT_TYPE(flags);
         CV_Assert( mtype == type0 || (CV_MAT_CN(mtype) == CV_MAT_CN(type0) && ((1 << type0) & fixedDepthMask) != 0) );
-
-        int esz = CV_ELEM_SIZE(type0);
         CV_Assert(!fixedSize() || len == ((std::vector<uchar>*)v)->size() / esz);
         switch( esz )
         {

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -1531,7 +1531,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
 
         if(fixedType())
         {
-            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_TYPE(flags)) & fixedDepthMask) != 0 )
+            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_DEPTH(flags)) & fixedDepthMask) != 0 )
                 mtype = m.type();
             else
                 CV_CheckTypeEQ(m.type(), CV_MAT_TYPE(mtype), "Can't reallocate UMat with locked type (probably due to misused 'const' modifier)");
@@ -1585,7 +1585,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
         int esz = CV_ELEM_SIZE(typ);
 
         CV_Assert( k == STD_VECTOR_VECTOR || i < 0 );
-        if (k == STD_VECTOR || i < 0) {
+        if (k == STD_VECTOR || i >= 0) {
             CV_Assert( mtype == typ || (CV_MAT_CN(mtype) == CV_MAT_CN(typ) && ((1 << depth) & fixedDepthMask) != 0) );
         }
 
@@ -1721,7 +1721,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
 
         if(fixedType())
         {
-            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_TYPE(flags)) & fixedDepthMask) != 0 )
+            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_DEPTH(flags)) & fixedDepthMask) != 0 )
                 mtype = m.type();
             else
                 CV_Assert(CV_MAT_TYPE(mtype) == m.type());
@@ -1779,7 +1779,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
 
         if(fixedType())
         {
-            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_TYPE(flags)) & fixedDepthMask) != 0 )
+            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_DEPTH(flags)) & fixedDepthMask) != 0 )
                 mtype = m.type();
             else
                 CV_Assert(CV_MAT_TYPE(mtype) == m.type());
@@ -1839,7 +1839,7 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
 
         if(fixedType())
         {
-            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_TYPE(flags)) & fixedDepthMask) != 0 )
+            if(CV_MAT_CN(mtype) == m.channels() && ((1 << CV_MAT_DEPTH(flags)) & fixedDepthMask) != 0 )
                 mtype = m.type();
             else
                 CV_Assert(CV_MAT_TYPE(mtype) == m.type());

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2914,7 +2914,7 @@ TEST(Core_InputOutputArray, std_vector_vector)
     _OutputArray oarr_s(cn_s);
     EXPECT_EQ((size_t)3, iarr_s.total(-1));
     size_t newsize_s = vv0_s.size()*2;
-    oarr_s.create(Size((int)newsize_s, 1), CV_64F, 2);
+    oarr_s.create(Size((int)newsize_s, 1), CV_16S, 2);
     EXPECT_EQ(newsize_s, cn_s[2].size());
     cn_s[1].clear();
     EXPECT_EQ(true, oarr_s.empty(1));

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2908,11 +2908,11 @@ TEST(Core_InputOutputArray, std_vector_vector)
     merge(cn_s, vv1_s);
 
     double err0 = cvtest::norm(vv0_s, vv1_s, NORM_INF);
-    EXPECT_EQ(0, err0);
+    EXPECT_EQ(0., err0);
 
     _InputArray iarr_s(cn_s);
     _OutputArray oarr_s(cn_s);
-    EXPECT_EQ(3, iarr_s.total(-1));
+    EXPECT_EQ((size_t)3, iarr_s.total(-1));
     size_t newsize_s = vv0_s.size()*2;
     oarr_s.create(Size((int)newsize_s, 1), CV_64F, 2);
     EXPECT_EQ(newsize_s, cn_s[2].size());
@@ -2927,11 +2927,11 @@ TEST(Core_InputOutputArray, std_vector_vector)
     merge(cn_d, vv1_d);
 
     double err1 = cvtest::norm(vv0_d, vv1_d, NORM_INF);
-    EXPECT_EQ(0, err1);
+    EXPECT_EQ(0., err1);
 
     _InputArray iarr_d(cn_d);
     _OutputArray oarr_d(cn_d);
-    EXPECT_EQ(4, iarr_d.total(-1));
+    EXPECT_EQ((size_t)4, iarr_d.total(-1));
     size_t newsize_d = vv0_d.size()*3;
     oarr_d.create(Size((int)newsize_d, 1), CV_64F, 3);
     EXPECT_EQ(newsize_d, cn_d[3].size());
@@ -2941,7 +2941,7 @@ TEST(Core_InputOutputArray, std_vector_vector)
 
     double err2 = cvtest::norm(m2, Mat(cn_d[2]), NORM_INF);
     EXPECT_EQ(m2.ptr<double>(), &cn_d[2][0]);
-    EXPECT_EQ(0, err2);
+    EXPECT_EQ(0., err2);
 }
 
 }} // namespace


### PR DESCRIPTION
Hopefully, fixes #26289.

In short, there have been some branches in _InputArray and _OutputArray methods that assumed that all instances of `std::vector<std::vector<T>>` for all primitive types `T` (i.e. POD types in C++ terms) are organized in the same way, which is not necessarily true.

In the patch those branches are refactored. However, we still assume that if for 2 primitive types `T1` and `T2` we have `sizeof(T1) == sizeof(T2)`, then `std::vector<std::vector<T1>>` can be processed in the same way (i.e. by reinterpreting pointer) as `std::vector<std::vector<T2>>`.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] (let's start with 5.x; maybe need to make a patch to 4.x instead, or in addition to this PR) The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
