### PR TITLE
Support 0d/1d Mat in FileStorage

### DIFF
--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -151,6 +151,8 @@ void read(const FileNode& node, Mat& m, const Mat& default_mat)
     CV_Assert(!data_node.empty());
 
     size_t nelems = data_node.size();
+    if (nelems == 0)
+        m = Mat();
     CV_Assert(nelems == m.total()*m.channels());
 
     data_node.readRaw(dt, (uchar*)m.ptr(), m.total()*m.elemSize());

--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -12,7 +12,7 @@ void write( FileStorage& fs, const String& name, const Mat& m )
 {
     char dt[22];
 
-    if( m.dims <= 2 )
+    if( m.dims == 2 || m.empty() )
     {
         fs.startWriteStruct(name, FileNode::MAP, String("opencv-matrix"));
         fs << "rows" << m.rows;

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2025,4 +2025,44 @@ TEST(Core_InputOutput, FileStorage_invalid_attribute_value_regression_25946)
     ASSERT_EQ(0, std::remove(fileName.c_str()));
 }
 
+template <typename T>
+T fsWriteRead(const T& expectedValue, const char* ext)
+{
+    std::string fname = cv::tempfile(ext);
+    FileStorage fs_w(fname, FileStorage::WRITE);
+    fs_w << "value" << expectedValue;
+    fs_w.release();
+
+    FileStorage fs_r(fname, FileStorage::READ);
+
+    T value;
+    fs_r["value"] >> value;
+    return value;
+}
+
+typedef testing::TestWithParam<const char*> FileStorage_exact_type;
+TEST_P(FileStorage_exact_type, mat_0d)
+{
+    Mat src({}, CV_32S, Scalar(8));
+    CV_CheckEQ(src.dims, 0, "");
+    Mat dst = fsWriteRead(src, GetParam());
+    EXPECT_EQ(src.dims, dst.dims);
+    EXPECT_EQ(src.size, dst.size);
+    EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
+}
+
+TEST_P(FileStorage_exact_type, mat_1d)
+{
+    Mat src({1}, CV_32S, Scalar(8));
+    CV_CheckEQ(src.dims, 1, "");
+    Mat dst = fsWriteRead(src, GetParam());
+    EXPECT_EQ(src.dims, dst.dims);
+    EXPECT_EQ(src.size, dst.size);
+    EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
+}
+
+INSTANTIATE_TEST_CASE_P(Core_InputOutput,
+    FileStorage_exact_type, Values(".yml", ".xml", ".json")
+);
+
 }} // namespace

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2040,25 +2040,30 @@ T fsWriteRead(const T& expectedValue, const char* ext)
     return value;
 }
 
-typedef testing::TestWithParam<const char*> FileStorage_exact_type;
-TEST_P(FileStorage_exact_type, mat_0d)
+void testExactMat(const Mat& src, const char* ext)
 {
-    Mat src({}, CV_32S, Scalar(8));
-    CV_CheckEQ(src.dims, 0, "");
-    Mat dst = fsWriteRead(src, GetParam());
+    bool srcIsEmpty = src.empty();
+    Mat dst = fsWriteRead(src, ext);
+    EXPECT_EQ(dst.empty(), srcIsEmpty);
     EXPECT_EQ(src.dims, dst.dims);
     EXPECT_EQ(src.size, dst.size);
     EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
 }
 
+typedef testing::TestWithParam<const char*> FileStorage_exact_type;
+TEST_P(FileStorage_exact_type, empty_mat)
+{
+    testExactMat(Mat(), GetParam());
+}
+
+TEST_P(FileStorage_exact_type, mat_0d)
+{
+    testExactMat(Mat({}, CV_32S, Scalar(8)), GetParam());
+}
+
 TEST_P(FileStorage_exact_type, mat_1d)
 {
-    Mat src({1}, CV_32S, Scalar(8));
-    CV_CheckEQ(src.dims, 1, "");
-    Mat dst = fsWriteRead(src, GetParam());
-    EXPECT_EQ(src.dims, dst.dims);
-    EXPECT_EQ(src.size, dst.size);
-    EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
+    testExactMat(Mat({1}, CV_32S, Scalar(8)), GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(Core_InputOutput,


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
