### PR TITLE
int64 data type support for FileStorage. 1d and empty Mat with exact dimensions

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -365,6 +365,8 @@ public:
      */
     CV_WRAP void write(const String& name, int val);
     /// @overload
+    CV_WRAP void write(const String& name, int64_t val);
+    /// @overload
     CV_WRAP void write(const String& name, double val);
     /// @overload
     CV_WRAP void write(const String& name, const String& val);
@@ -530,6 +532,8 @@ public:
     CV_WRAP size_t rawSize() const;
     //! returns the node content as an integer. If the node stores floating-point number, it is rounded.
     operator int() const;
+    //! returns the node content as a signed 64bit integer. If the node stores floating-point number, it is rounded.
+    operator int64_t() const;
     //! returns the node content as float
     operator float() const;
     //! returns the node content as double
@@ -654,6 +658,7 @@ protected:
 /////////////////// XML & YAML I/O implementation //////////////////
 
 CV_EXPORTS void write( FileStorage& fs, const String& name, int value );
+CV_EXPORTS void write( FileStorage& fs, const String& name, int64_t value );
 CV_EXPORTS void write( FileStorage& fs, const String& name, float value );
 CV_EXPORTS void write( FileStorage& fs, const String& name, double value );
 CV_EXPORTS void write( FileStorage& fs, const String& name, const String& value );
@@ -665,11 +670,13 @@ CV_EXPORTS void write( FileStorage& fs, const String& name, const std::vector<DM
 #endif
 
 CV_EXPORTS void writeScalar( FileStorage& fs, int value );
+CV_EXPORTS void writeScalar( FileStorage& fs, int64_t value );
 CV_EXPORTS void writeScalar( FileStorage& fs, float value );
 CV_EXPORTS void writeScalar( FileStorage& fs, double value );
 CV_EXPORTS void writeScalar( FileStorage& fs, const String& value );
 
 CV_EXPORTS void read(const FileNode& node, int& value, int default_value);
+CV_EXPORTS void read(const FileNode& node, int64_t& value, int64_t default_value);
 CV_EXPORTS void read(const FileNode& node, float& value, float default_value);
 CV_EXPORTS void read(const FileNode& node, double& value, double default_value);
 CV_EXPORTS void read(const FileNode& node, std::string& value, const std::string& default_value);

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -56,6 +56,28 @@ char* itoa( int _val, char* buffer, int /*radix*/ )
     return ptr;
 }
 
+char* itoa( int64_t _val, char* buffer, int /*radix*/, bool _signed)
+{
+    const int radix = 10;
+    char* ptr=buffer + 23 /* enough even for 64-bit integers */;
+    int sign = _signed && _val < 0 ? -1 : 1;
+    uint64_t val = !_signed ? (uint64_t)_val : abs(_val);
+
+    *ptr = '\0';
+    do
+    {
+        uint64_t r = val / radix;
+        *--ptr = (char)(val - (r*radix) + '0');
+        val = r;
+    }
+    while( val != 0 );
+
+    if( sign < 0 )
+        *--ptr = '-';
+
+    return ptr;
+}
+
 char* doubleToString( char* buf, size_t bufSize, double value, bool explicitZero )
 {
     Cv64suf val;
@@ -2634,7 +2656,7 @@ FileNodeIterator& FileNodeIterator::readRaw( const String& fmt, void* _data0, si
                 offset = alignSize( offset, elem_size );
                 uchar* data = data0 + offset;
 
-                for( int i = 0; i < count; i++ )
+                for( int i = 0; i < count; i++, ++(*this) )
                 {
                     FileNode node = *(*this);
                     if( node.isInt() )
@@ -2722,11 +2744,6 @@ FileNodeIterator& FileNodeIterator::readRaw( const String& fmt, void* _data0, si
                     }
                     else
                         CV_Error( Error::StsError, "readRawData can only be used to read plain sequences of numbers" );
-                    ++(*this);
-                    if (elem_type == CV_64S)
-                    {
-                        ofs += 4;
-                    }
                 }
                 offset = (int)(data - data0);
             }

--- a/modules/core/src/persistence.hpp
+++ b/modules/core/src/persistence.hpp
@@ -86,6 +86,7 @@ namespace fs
 {
 int strcasecmp(const char* str1, const char* str2);
 char* itoa( int _val, char* buffer, int /*radix*/ );
+char* itoa( int64_t _val, char* buffer, int /*radix*/, bool _signed );
 char* floatToString( char* buf, size_t bufSize, float value, bool halfprecision, bool explicitZero );
 char* doubleToString( char* buf, size_t bufSize, double value, bool explicitZero );
 

--- a/modules/core/src/persistence.hpp
+++ b/modules/core/src/persistence.hpp
@@ -193,6 +193,7 @@ public:
                                           int struct_flags, const char* type_name=0 ) = 0;
     virtual void endWriteStruct(const FStructData& current_struct) = 0;
     virtual void write(const char* key, int value) = 0;
+    virtual void write(const char* key, int64_t value) = 0;
     virtual void write(const char* key, double value) = 0;
     virtual void write(const char* key, const char* value, bool quote) = 0;
     virtual void writeScalar(const char* key, const char* value) = 0;

--- a/modules/core/src/persistence_impl.hpp
+++ b/modules/core/src/persistence_impl.hpp
@@ -69,6 +69,8 @@ public:
 
     void write( const String& key, int value );
 
+    void write( const String& key, int64_t value );
+
     void write( const String& key, double value );
 
     void write( const String& key, const String& value );

--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -81,6 +81,12 @@ public:
         writeScalar( key, fs::itoa( value, buf, 10 ));
     }
 
+    void write(const char* key, int64_t value)
+    {
+        char buf[128];
+        writeScalar( key, fs::itoa( value, buf, 10, true ));
+    }
+
     void write( const char* key, double value )
     {
         char buf[128];
@@ -596,7 +602,7 @@ public:
             }
             else
             {
-                int ival = (int)strtol( beg, &ptr, 0 );
+                int64_t ival = strtoll( beg, &ptr, 0 );
                 CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG_CPP();
 
                 node.setValue(FileNode::INT, &ival);
@@ -623,7 +629,7 @@ public:
             else if( (len == 4 && memcmp( beg, "true", 4 ) == 0) ||
                      (len == 5 && memcmp( beg, "false", 5 ) == 0) )
             {
-                int ival = *beg == 't' ? 1 : 0;
+                int64_t ival = *beg == 't' ? 1 : 0;
                 node.setValue(FileNode::INT, &ival);
             }
             else

--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -151,8 +151,6 @@ void read(const FileNode& node, Mat& m, const Mat& default_mat)
     CV_Assert(!data_node.empty());
 
     size_t nelems = data_node.size();
-    if (nelems == 0)
-        m = Mat();
     CV_Assert(nelems == m.total()*m.channels());
 
     data_node.readRaw(dt, (uchar*)m.ptr(), m.total()*m.elemSize());

--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -12,7 +12,7 @@ void write( FileStorage& fs, const String& name, const Mat& m )
 {
     char dt[22];
 
-    if( m.dims <= 2 )
+    if( m.dims == 2 || m.empty() )
     {
         fs.startWriteStruct(name, FileNode::MAP, String("opencv-matrix"));
         fs << "rows" << m.rows;
@@ -151,6 +151,8 @@ void read(const FileNode& node, Mat& m, const Mat& default_mat)
     CV_Assert(!data_node.empty());
 
     size_t nelems = data_node.size();
+    if (nelems == 0)
+        m = Mat();
     CV_Assert(nelems == m.total()*m.channels());
 
     data_node.readRaw(dt, (uchar*)m.ptr(), m.total()*m.elemSize());

--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -12,7 +12,7 @@ void write( FileStorage& fs, const String& name, const Mat& m )
 {
     char dt[22];
 
-    if( m.dims == 2 || m.empty() )
+    if( m.dims <= 2 )
     {
         fs.startWriteStruct(name, FileNode::MAP, String("opencv-matrix"));
         fs << "rows" << m.rows;

--- a/modules/core/src/persistence_xml.cpp
+++ b/modules/core/src/persistence_xml.cpp
@@ -145,6 +145,12 @@ public:
         writeScalar( key, ptr);
     }
 
+    void write(const char* key, int64_t value)
+    {
+        char buf[128], *ptr = fs::itoa( value, buf, 10, true );
+        writeScalar( key, ptr);
+    }
+
     void write( const char* key, double value )
     {
         char buf[128];
@@ -556,7 +562,7 @@ public:
                     }
                     else
                     {
-                        int ival = (int)strtol( ptr, &endptr, 0 );
+                        int64_t ival = strtoll( ptr, &endptr, 0 );
                         elem->setValue(FileNode::INT, &ival);
                     }
 

--- a/modules/core/src/persistence_yml.cpp
+++ b/modules/core/src/persistence_yml.cpp
@@ -107,6 +107,12 @@ public:
         writeScalar( key, fs::itoa( value, buf, 10 ));
     }
 
+    void write(const char* key, int64_t value)
+    {
+        char buf[128];
+        writeScalar( key, fs::itoa( value, buf, 10, true ));
+    }
+
     void write( const char* key, double value )
     {
         char buf[128];
@@ -567,7 +573,7 @@ public:
             else
             {
             force_int:
-                int ival = (int)strtol( ptr, &endptr, 0 );
+                int64_t ival = strtoll( ptr, &endptr, 0 );
                 node.setValue(FileNode::INT, &ival);
             }
 

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2018,11 +2018,27 @@ T fsWriteRead(const T& expectedValue, const char* ext)
     return value;
 }
 
+void testExactMat(const Mat& src, const char* ext)
+{
+    bool srcIsEmpty = src.empty();
+    Mat dst = fsWriteRead(src, ext);
+    EXPECT_EQ(dst.empty(), srcIsEmpty);
+    EXPECT_EQ(src.dims, dst.dims);
+    EXPECT_EQ(src.size, dst.size);
+    EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
+}
+
 typedef testing::TestWithParam<const char*> FileStorage_exact_type;
 TEST_P(FileStorage_exact_type, empty_mat)
 {
     testExactMat(Mat(), GetParam());
 }
+
+TEST_P(FileStorage_exact_type, mat_1d)
+{
+    testExactMat(Mat({1}, CV_32S, Scalar(8)), GetParam());
+}
+
 TEST_P(FileStorage_exact_type, long_int)
 {
     for (const int64_t expected : std::vector<int64_t>{INT64_MAX, INT64_MIN, -1, 1, 0})
@@ -2031,6 +2047,7 @@ TEST_P(FileStorage_exact_type, long_int)
         EXPECT_EQ(value, expected);
     }
 }
+
 INSTANTIATE_TEST_CASE_P(Core_InputOutput,
     FileStorage_exact_type, Values(".yml", ".xml", ".json")
 );

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2003,4 +2003,36 @@ TEST(Core_InputOutput, FileStorage_invalid_attribute_value_regression_25946)
     ASSERT_EQ(0, std::remove(fileName.c_str()));
 }
 
+template <typename T>
+T fsWriteRead(const T& expectedValue, const char* ext)
+{
+    std::string fname = cv::tempfile(ext);
+    FileStorage fs_w(fname, FileStorage::WRITE);
+    fs_w << "value" << expectedValue;
+    fs_w.release();
+
+    FileStorage fs_r(fname, FileStorage::READ);
+
+    T value;
+    fs_r["value"] >> value;
+    return value;
+}
+
+typedef testing::TestWithParam<const char*> FileStorage_exact_type;
+TEST_P(FileStorage_exact_type, empty_mat)
+{
+    testExactMat(Mat(), GetParam());
+}
+TEST_P(FileStorage_exact_type, long_int)
+{
+    for (const int64_t expected : std::vector<int64_t>{INT64_MAX, INT64_MIN, -1, 1, 0})
+    {
+        int64_t value = fsWriteRead(expected, GetParam());
+        EXPECT_EQ(value, expected);
+    }
+}
+INSTANTIATE_TEST_CASE_P(Core_InputOutput,
+    FileStorage_exact_type, Values(".yml", ".xml", ".json")
+);
+
 }} // namespace

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2018,27 +2018,7 @@ T fsWriteRead(const T& expectedValue, const char* ext)
     return value;
 }
 
-void testExactMat(const Mat& src, const char* ext)
-{
-    bool srcIsEmpty = src.empty();
-    Mat dst = fsWriteRead(src, ext);
-    EXPECT_EQ(dst.empty(), srcIsEmpty);
-    EXPECT_EQ(src.dims, dst.dims);
-    EXPECT_EQ(src.size, dst.size);
-    EXPECT_EQ(cv::norm(src, dst, NORM_INF), 0.0);
-}
-
 typedef testing::TestWithParam<const char*> FileStorage_exact_type;
-TEST_P(FileStorage_exact_type, empty_mat)
-{
-    testExactMat(Mat(), GetParam());
-}
-
-TEST_P(FileStorage_exact_type, mat_1d)
-{
-    testExactMat(Mat({1}, CV_32S, Scalar(8)), GetParam());
-}
-
 TEST_P(FileStorage_exact_type, long_int)
 {
     for (const int64_t expected : std::vector<int64_t>{INT64_MAX, INT64_MIN, -1, 1, 0})

--- a/modules/python/src2/typing_stubs_generation/predefined_types.py
+++ b/modules/python/src2/typing_stubs_generation/predefined_types.py
@@ -27,6 +27,7 @@ _PREDEFINED_TYPES = (
     PrimitiveTypeNode.int_("int32_t"),
     PrimitiveTypeNode.int_("uint32_t"),
     PrimitiveTypeNode.int_("size_t"),
+    PrimitiveTypeNode.int_("int64_t"),
     PrimitiveTypeNode.float_("float"),
     PrimitiveTypeNode.float_("double"),
     PrimitiveTypeNode.bool_("bool"),


### PR DESCRIPTION
### Pull Request Readiness Checklist

Port of https://github.com/opencv/opencv/pull/26399 to 4.x branch

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
