### PR TITLE
Fix pyrDown inconsistency between different ROIs

### DIFF
--- a/modules/imgproc/test/test_pyramid.cpp
+++ b/modules/imgproc/test/test_pyramid.cpp
@@ -6,6 +6,45 @@
 
 namespace opencv_test { namespace {
 
+TEST(Imgproc_PyrDown, pyrDown_regression_custom)
+{
+    Mat src(16, 16, CV_16UC3, Scalar(0, 0, 0));
+    {
+        int swidth = src.cols;
+        int sheight = src.rows;
+        int cn = src.channels();
+        int count = 0;
+        ASSERT_NE(src.data, nullptr) << "src.data is null. Cannot proceed.";
+
+        for (int y = 0; y < sheight; y++)
+        {
+            ushort *src_c = src.ptr<ushort>(y);
+            ASSERT_NE(src_c, nullptr) << "src.ptr<ushort>(y) is null. Cannot proceed.";
+            for (int x = 0; x < swidth * cn; x++)
+            {
+                src_c[x] = (count++) % 10;
+            }
+        }
+    }
+
+    Size dstSize((src.cols + 1) / 2, (src.rows + 1) / 2);
+    Mat dst(dstSize, CV_16UC3, Scalar(0, 0, 0));
+    ASSERT_NE(dst.data, nullptr) << "dst.data is null. Cannot proceed.";
+
+    pyrDown(src, dst, dstSize);
+
+    Mat srcp = src(Rect(0, 0, 14, 14));
+    Size dstpSize((srcp.cols + 1) / 2, (srcp.rows + 1) / 2);
+    Mat dstp(dstpSize, CV_16UC3, Scalar(0, 0, 0));
+    ASSERT_NE(srcp.data, nullptr) << "srcp.data is null. Cannot proceed.";
+    ASSERT_NE(dstp.data, nullptr) << "dstp.data is null. Cannot proceed.";
+
+    pyrDown(srcp, dstp, dstpSize);
+
+    Mat diff = dst(Rect(Point(), dstp.size())) - dstp;
+    EXPECT_TRUE(cv::countNonZero(diff.reshape(1)) == 0) << "The difference between dst and dstp is not zero.";
+}
+
 TEST(Imgproc_PyrUp, pyrUp_regression_22184)
 {
     Mat src(100,100,CV_16UC3,Scalar(255,255,255));


### PR DESCRIPTION
### Pull Request Readiness Checklist

Issue Link : [25990](https://github.com/opencv/opencv/issues/25990)

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
