### PR TITLE
Add note for people debugging DirectML detection failures to check their Windows SDK version.

### DIFF
--- a/cmake/OpenCVDetectDirectML.cmake
+++ b/cmake/OpenCVDetectDirectML.cmake
@@ -6,7 +6,7 @@ if(WIN32)
     OUTPUT_VARIABLE TRY_OUT
   )
   if(NOT __VALID_DIRECTML)
-    message(STATUS "No support for DirectML (d3d12, dxcore, directml libs are required)")
+    message(STATUS "No support for DirectML. d3d12, dxcore, directml libs are required, first bundled with Windows SDK 10.0.19041.0.")
     return()
   endif()
   set(HAVE_DIRECTML ON)


### PR DESCRIPTION
DirectML was first included with 10.0.18362.0, but dxcore.lib necessary to make the check pass was first in 10.0.19041.0.

I authored this PR because an internal customer was complaining about vcpkg failing to build OpenCV, but they were using Windows SDK 10.0.18362.0, causing this error:

```console
-- No support for DirectML (d3d12, dxcore, directml libs are required)
[...]
-- Verifying WITH_DIRECTML=ON => 'HAVE_DIRECTML'=FALSE
CMake Warning at cmake/OpenCVUtils.cmake:785 (message):
  Option WITH_DIRECTML is enabled but corresponding dependency have not been
  found: "HAVE_DIRECTML" is FALSE
Call Stack (most recent call first):
  CMakeLists.txt:1907 (ocv_verify_config)
[...]
CMake Error at cmake/OpenCVUtils.cmake:797 (message):
  Some dependencies have not been found or have been forced, unset
  ENABLE_CONFIG_VERIFICATION option to ignore these failures or change
  following options:

  WITH_DIRECTML
Call Stack (most recent call first):
  CMakeLists.txt:1907 (ocv_verify_config)


-- Configuring incomplete, errors occurred!
```

I tested that the check fails on 10.0.18362.0 but passes on 10.0.19041.0, below:

```console
D:\vcpkg\buildtrees\opencv4\src\4.9.0-de6494b280.clean\cmake\checks>set LIB=C:\Program Files\Microsoft Visual Studio\2022\Dogfood\VC\Tools\MSVC\14.43.34604\ATLMFC\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Dogfood\VC\Tools\MSVC\14.43.34604\lib\x64;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.18362.0\um\x64

D:\vcpkg\buildtrees\opencv4\src\4.9.0-de6494b280.clean\cmake\checks>cl "/IC:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um" .\directml.cpp dxcore.lib d3d12.lib directml.lib
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34604 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

directml.cpp
Microsoft (R) Incremental Linker Version 14.43.34604.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:directml.exe
directml.obj
dxcore.lib
d3d12.lib
directml.lib
LINK : fatal error LNK1181: cannot open input file 'dxcore.lib'

D:\vcpkg\buildtrees\opencv4\src\4.9.0-de6494b280.clean\cmake\checks>set LIB=C:\Program Files\Microsoft Visual Studio\2022\Dogfood\VC\Tools\MSVC\14.43.34604\ATLMFC\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Dogfood\VC\Tools\MSVC\14.43.34604\lib\x64;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64;C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64

D:\vcpkg\buildtrees\opencv4\src\4.9.0-de6494b280.clean\cmake\checks>cl "/IC:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um" .\directml.cpp dxcore.lib d3d12.lib directml.lib
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34604 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

directml.cpp
Microsoft (R) Incremental Linker Version 14.43.34604.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:directml.exe
directml.obj
dxcore.lib
d3d12.lib
directml.lib

D:\vcpkg\buildtrees\opencv4\src\4.9.0-de6494b280.clean\cmake\checks>
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch **I think so but am not positive**
- [ ] There is a reference to the original bug report and related work
<s>- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake</s>
