### PR TITLE
Fix warnings on documentation built

### DIFF
--- a/modules/3d/src/pointcloud/load_point_cloud.cpp
+++ b/modules/3d/src/pointcloud/load_point_cloud.cpp
@@ -78,6 +78,7 @@ void loadPointCloud(const String &filename, OutputArray vertices, OutputArray no
     CV_UNUSED(filename);
     CV_UNUSED(vertices);
     CV_UNUSED(normals);
+    CV_UNUSED(rgb);
     CV_LOG_WARNING(NULL, "File system support is disabled in this OpenCV build!");
 #endif
 }
@@ -116,6 +117,7 @@ void savePointCloud(const String &filename, InputArray vertices, InputArray norm
     CV_UNUSED(filename);
     CV_UNUSED(vertices);
     CV_UNUSED(normals);
+    CV_UNUSED(rgb);
     CV_LOG_WARNING(NULL, "File system support is disabled in this OpenCV build!");
 #endif
 }
@@ -243,6 +245,7 @@ void loadMesh(const String &filename, OutputArray vertices, OutputArrayOfArrays 
     CV_UNUSED(normals);
     CV_UNUSED(colors);
     CV_UNUSED(indices);
+    CV_UNUSED(texCoords);
     CV_LOG_WARNING(NULL, "File system support is disabled in this OpenCV build!");
 #endif
 }
@@ -328,6 +331,7 @@ void saveMesh(const String &filename, InputArray vertices, InputArrayOfArrays in
     CV_UNUSED(colors);
     CV_UNUSED(normals);
     CV_UNUSED(indices);
+    CV_UNUSED(texCoords);
     CV_LOG_WARNING(NULL, "File system support is disabled in this OpenCV build!");
 #endif
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

fixes warnings on documentation built
```
/build/5_x_docs-lin64/opencv/modules/3d/src/pointcloud/load_point_cloud.cpp:52:100: warning: unused parameter 'rgb' [-Wunused-parameter]
/build/5_x_docs-lin64/opencv/modules/3d/src/pointcloud/load_point_cloud.cpp:85:97: warning: unused parameter 'rgb' [-Wunused-parameter]
/build/5_x_docs-lin64/opencv/modules/3d/src/pointcloud/load_point_cloud.cpp:124:68: warning: unused parameter 'texCoords' [-Wunused-parameter]
/build/5_x_docs-lin64/opencv/modules/3d/src/pointcloud/load_point_cloud.cpp:251:65: warning: unused parameter 'texCoords' [-Wunused-parameter]
```

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
