### PR TITLE
more convenient GpuMatND constructor

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -413,8 +413,9 @@ public:
     data, which means that no data is copied. This operation is very efficient and can be used to
     process external data using OpenCV functions. The external data is not automatically deallocated, so
     you should take care of it.
-    @param step Array of _size.size()-1 steps in case of a multi-dimensional array (the last step is always
-    set to the element size). If not specified, the matrix is assumed to be continuous.
+    @param step Array of _size.size() or _size.size()-1 steps in case of a multi-dimensional array
+    (if specified, the last step must be equal to the element size, otherwise it will be added as such).
+    If not specified, the matrix is assumed to be continuous.
     */
     GpuMatND(SizeArray size, int type, void* data, StepArray step = StepArray());
 

--- a/modules/core/src/cuda_gpu_mat_nd.cpp
+++ b/modules/core/src/cuda_gpu_mat_nd.cpp
@@ -12,7 +12,8 @@ GpuMatND::~GpuMatND() = default;
 GpuMatND::GpuMatND(SizeArray _size, int _type, void* _data, StepArray _step) :
     flags(0), dims(0), data(static_cast<uchar*>(_data)), offset(0)
 {
-    CV_Assert(_step.empty() || _size.size() == _step.size() + 1);
+    CV_Assert(_step.empty() || _size.size() == _step.size() + 1 ||
+              (_size.size() == _step.size() && _step.back() == CV_ELEM_SIZE(type)));
 
     setFields(std::move(_size), _type, std::move(_step));
 }
@@ -106,7 +107,8 @@ void GpuMatND::setFields(SizeArray _size, int _type, StepArray _step)
     else
     {
         step = std::move(_step);
-        step.push_back(elemSize());
+        if (step.size() < size.size())
+          step.push_back(elemSize());
 
         flags = cv::updateContinuityFlag(flags, dims, size.data(), step.data());
     }


### PR DESCRIPTION
#26471

For convenience, GpuMatND can now accept a step.size() equal to size.size(), as long as the last step is equal to elemSize()

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
