### PR TITLE
detect Python libs inside Xcode.app properly

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -127,6 +127,23 @@ if(NOT ${found})
       if(NOT ${${include_dir_env}} STREQUAL "")
           set(PYTHON_INCLUDE_DIR "${${include_dir_env}}")
       endif()
+      if (APPLE AND NOT CMAKE_CROSSCOMPILING)
+          if (NOT PYTHON_LIBRARY AND NOT PYTHON_INCLUDE_DIR)
+              execute_process(COMMAND ${_executable} -c "from sysconfig import *; print(get_config_var('INCLUDEPY'))"
+                              RESULT_VARIABLE _cvpy_process
+                              OUTPUT_VARIABLE _include_dir
+                              OUTPUT_STRIP_TRAILING_WHITESPACE)
+              execute_process(COMMAND ${_executable} -c "from sysconfig import *; print('%s/%s' % (get_config_var('LIBDIR'), get_config_var('LIBRARY').replace('.a', '.dylib' if get_platform().startswith('macos') else '.so')))"
+                              RESULT_VARIABLE _cvpy_process
+                              OUTPUT_VARIABLE _library
+                              OUTPUT_STRIP_TRAILING_WHITESPACE)
+              if (_include_dir AND _library AND EXISTS "${_include_dir}/Python.h" AND EXISTS "${_library}")
+                  set(PYTHON_INCLUDE_PATH "${_include_dir}")
+                  set(PYTHON_INCLUDE_DIR "${_include_dir}")
+                  set(PYTHON_LIBRARY "${_library}")
+              endif()
+          endif()
+      endif()
 
       # not using _version_string here, because it might not conform to the CMake version format
       if(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
For many months already the default Python installation on macOS (together with the header files and numpy, which come with Xcode) cannot be properly detected by OpenCV CMake configuration script. Now the only way to build python bindings on macos is to install alternative distribution of Python, e.g. using brew.

However, the default Python (e.g. 3.9.6 in the case of macOS 15.1) is good enough for OpenCV 5.

It took just a few lines of code in OpenCVDetectPython.cmake script to solve the problem. The solution also works properly on Linux (Ubuntu 24.04-x64) if the condition

```
if (APPLE AND NOT CMAKE_CROSSCOMPILING)
...
``` 

is reduced to

```
if (NOT CMAKE_CROSSCOMPILING)
...
``` 

But I decided to limit it to macOS for now to minimize possible damage. On Linux the current/old solution works well too.
On Windows the proposed solution does not work, because there are no `LIBDIR` and `LIBRARY` entries in sysconfig, but a similar code can be provided to detect Python3 import library on native Windows (not WSL) without looking into the registry:

```
from sysconfig import *
print('%s\\libs\\python%s.lib' % (get_config_var('prefix'), get_config_var('py_version_nodot')))
```

**Note 1:** 
*Don't replace `INCLUDEPY` with `INCLUDEDIR`*! The second one points to the parent directory.

**Note 2:** also tried #26403, and no, as-is that solution cannot find Python files inside Xcode either. I think, it should be possible to combine the two solutions together, because this solution relies on the standard CMake 'find python' function, whatever it is, current one or `findpython3()`, but it provides extra hints on where to look for Python.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
