### PR TITLE
Update trackbar documentation and tutorial

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -70,13 +70,14 @@ It provides easy interface to:
     @defgroup highgui_opengl OpenGL support
     @defgroup highgui_qt Qt New Functions
 
+
     ![image](pics/qtgui.png)
 
     This figure explains new functionality implemented with Qt\* GUI. The new GUI provides a statusbar,
     a toolbar, and a control panel. The control panel can have trackbars and buttonbars attached to it.
     If you cannot see the control panel, press Ctrl+P or right-click any Qt window and select **Display
     properties window**.
-
+    - 
     -   To attach a trackbar, the window name parameter must be NULL.
 
     -   To attach a buttonbar, a button must be created. If the last bar attached to the control panel
@@ -125,8 +126,13 @@ It provides easy interface to:
         cv::createTrackbar("Twin brother", windowName, &state, 100, callbackTwin);
     }
     @endcode
+
+    -   @note In modern usage, it is recommended to pass `nullptr` for the value pointer if you do not need
+        to update it directly. Instead, handle the trackbar position manually in the callback function.
+        See the updated trackbar tutorial for more details.
 @}
 */
+
 
 ///////////////////////// graphical user interface //////////////////////////
 namespace cv
@@ -530,17 +536,19 @@ control panel.
 
 Clicking the label of each trackbar enables editing the trackbar values manually.
 
-@param trackbarname Name of the created trackbar.
-@param winname Name of the window that will be used as a parent of the created trackbar.
-@param value Optional pointer to an integer variable whose value reflects the position of the
-slider. Upon creation, the slider position is defined by this variable.
-@param count Maximal position of the slider. The minimal position is always 0.
-@param onChange Pointer to the function to be called every time the slider changes position. This
-function should be prototyped as void Foo(int,void\*); , where the first parameter is the trackbar
-position and the second parameter is the user data (see the next parameter). If the callback is
-the NULL pointer, no callbacks are called, but only value is updated.
-@param userdata User data that is passed as is to the callback. It can be used to handle trackbar
-events without using global variables.
+ * @param trackbarname Name of the created trackbar.
+ * @param winname Name of the window that will contain the trackbar.
+ * @param value Pointer to the integer value that will be changed by the trackbar.
+ *              Pass `nullptr` if the value pointer is not used. In this case, manually handle
+ *              the trackbar position in the callback function.
+ * @param count Maximum position of the trackbar.
+ * @param onChange Pointer to the function to be called when the value changes.
+ * @param userdata Optional user data that is passed to the callback.
+ *
+ * @note If the value pointer is `nullptr`, the trackbar position must be manually managed.
+ *       Call the callback function manually with the desired initial value to avoid runtime warnings.
+ *
+ * @see [Trackbar Tutorial](https://docs.opencv.org/4.x/d7/dfc/tutorial_trackbar.html)
  */
 CV_EXPORTS int createTrackbar(const String& trackbarname, const String& winname,
                               int* value, int count,

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -694,6 +694,21 @@ int cv::pollKey()
 #endif
 }
 
+/**
+ * @brief Creates a trackbar and attaches it to the specified window.
+ *
+ * @param trackbarname Name of the created trackbar.
+ * @param winname Name of the window that will contain the trackbar.
+ * @param value Pointer to the integer value that will be changed by the trackbar. Pass `nullptr` if not used.
+ * @param count Maximum position of the trackbar.
+ * @param onChange Pointer to the function to be called when the value changes.
+ * @param userdata Optional user data that is passed to the callback.
+ *
+ * @note If the value pointer is not used (e.g., `nullptr` is passed), you must manually handle the value in the callback.
+ *       To set an initial value without using the pointer, manually call the callback function with the desired initial value.
+ */
+
+
 int cv::createTrackbar(const String& trackbarName, const String& winName,
                    int* value, int count, TrackbarCallback callback,
                    void* userdata)

--- a/samples/cpp/tutorial_code/HighGUI/AddingImagesTrackbar.cpp
+++ b/samples/cpp/tutorial_code/HighGUI/AddingImagesTrackbar.cpp
@@ -27,9 +27,21 @@ Mat dst;
  * @function on_trackbar
  * @brief Callback for trackbar
  */
-static void on_trackbar( int, void* )
+static void on_trackbar( int pos , void* userdata )
 {
-   alpha = (double) alpha_slider/alpha_slider_max ;
+   std::cout << "Trackbar position: " << pos << std::endl;
+   /**
+    * @note The trackbar value pointer is deprecated. Instead, directly
+    *       use the trackbar position in the callback function
+    *       as shown in this example. Initialize the blending manually by 
+    *       calling the callback function once after creating the trackbar.
+    */
+    if (userdata) {
+        // Example usage of userdata
+        int* data = static_cast<int*>(userdata);
+        std::cout << "User data: " << *data << std::endl;
+    }
+   alpha = (double) pos /alpha_slider_max ;
    beta = ( 1.0 - alpha );
    addWeighted( src1, alpha, src2, beta, 0.0, dst);
    imshow( "Linear Blend", dst );


### PR DESCRIPTION
This Fixes #26467 

Description:
This pull request aims to improve the OpenCV documentation regarding the Trackbar functionality. The current documentation does not provide clear guidance on certain aspects, such as handling the value pointer deprecation and utilizing callback arguments in C. This update addresses those gaps and provides an updated example for better clarity.

Changes:
Updated Documentation:

Clarified the usage of the value pointer and explained how to pass an initial value, since the value pointer is deprecated.
Added more detailed explanations about callback arguments in C, ensuring that users understand how to access and use them in Trackbar callbacks.
Added a note on how to properly handle initial value passing without relying on the deprecated value pointer.
Updated Tutorial Example:

Renamed and used callback function parameters to make them more understandable.
Included a demonstration on how to utilize userdata in the callback function.
Additional Notes:

Removed reliance on the value pointer for updating trackbar values. Users are now encouraged to use other mechanisms as per the current implementation to avoid the runtime warning.