### PR TITLE
Make undistortImagePoints default criteria undistortPoints consistent

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -3770,8 +3770,7 @@ CV_64FC2) (or vector\<Point2f\> ).
 CV_EXPORTS_W
 void undistortImagePoints(InputArray src, OutputArray dst, InputArray cameraMatrix,
                           InputArray distCoeffs,
-                          TermCriteria = TermCriteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 5,
-                                                      0.01));
+                          TermCriteria = TermCriteria(TermCriteria::MAX_ITER, 5, 0.01));
 
 //! @} calib3d
 


### PR DESCRIPTION
- `undistortPoints` default termination criteria: `TermCriteria(TermCriteria::MAX_ITER, 5, 0.01)`.
- `undistortImagePoints` default termination criteria: `TermCriteria(TermCriteria::MAX_ITER + TermCriteria::EPS, 5, 0.01))`.

The difference in default arguments for two such similar functions seems to me to be confusing enough to be considered a bug to be fixed in 4.x.

The proposed change in this PR uses the termination criteria for `undistortPoints` for `undistortImagePoints` also. This makes the default values consistent between the functions, retains the behaviour of the older function while changing only the newer function default argument.

5.x behaviour is currently indentical to 4.x. As the change is an API change (of a presumably incorrectly chosen default value), the change may possibly be more suited for 5.x.

- `TermCriteria` support for `undistortPoints` was introduced in 3.3.1 and the chosen default value mirrored the old hard coded behaviour (5 iterations, no error termination). https://github.com/opencv/opencv/pull/9560

- `undistortImagePoints` was introduced in 4.6.0. https://github.com/opencv/opencv/pull/21931

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
