### PR TITLE
Support CV_32U, CV_64U and CV_64S for TIFF

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -332,7 +332,10 @@ can be saved using this function, with these exceptions:
     8-bit (or 16-bit) 4-channel image BGRA, where the alpha channel goes last. Fully transparent pixels
     should have alpha set to 0, fully opaque pixels should have alpha set to 255/65535 (see the code sample below).
 - With PGM/PPM encoder, 8-bit unsigned (CV_8U) and 16-bit unsigned (CV_16U) images can be saved.
-- With TIFF encoder, 8-bit unsigned (CV_8U), 16-bit unsigned (CV_16U),
+- With TIFF encoder, 8-bit unsigned (CV_8U), 8-bit signed (CV_8S),
+                     16-bit unsigned (CV_16U), 16-bit signed (CV_16S),
+                     32-bit unsigned (CV_32U), 32-bit signed (CV_32S),
+                     64-bit unsigned (CV_64U), 64-bit signed (CV_64S),
                      32-bit float (CV_32F) and 64-bit float (CV_64F) images can be saved.
   - Multiple images (vector of Mat) can be saved in TIFF format (see the code sample below).
   - 32-bit float 3-channel (CV_32FC3) TIFF images will be saved

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -55,6 +55,7 @@
 
 #include "tiff.h"
 #include "tiffio.h"
+#include "tiffvers.h" // For TIFFLIB_VERSION
 
 namespace cv
 {
@@ -1338,6 +1339,16 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
                 return false;
             }
         }
+
+// Predictor 2 for 64-bit is supported at v4.4.0 or later.
+// See https://libtiff.gitlab.io/libtiff/releases/v4.4.0.html
+#if TIFFLIB_VERSION < 20220520 /* Magic number of libtiff v4.4.0 */
+        if ( (bitsPerChannel == 64) && (predictor == PREDICTOR_HORIZONTAL /* 2 */) )
+        {
+            CV_LOG_ONCE_WARNING(NULL, "Predictor 2(HORIZONTAL) for 64-bit is supported at v4.4.0 or later, so it is fallbacked to 0(NONE)");
+            predictor = PREDICTOR_NONE;
+        }
+#endif
 
         const int bitsPerByte = 8;
         size_t fileStep = (width * channels * bitsPerChannel) / bitsPerByte;

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -951,7 +951,10 @@ Imgcodes_Tiff_TypeAndComp all_types[] = {
     { CV_8SC1,  true  }, { CV_8SC3,  true  }, { CV_8SC4,  true  },
     { CV_16UC1, true  }, { CV_16UC3, true  }, { CV_16UC4, true  },
     { CV_16SC1, true  }, { CV_16SC3, true  }, { CV_16SC4, true  },
+    { CV_32UC1, true  }, { CV_32UC3, true  }, { CV_32UC4, true  },
     { CV_32SC1, true  }, { CV_32SC3, true  }, { CV_32SC4, true  },
+    { CV_64UC1, true  }, { CV_64UC3, true  }, { CV_64UC4, true  },
+    { CV_64SC1, true  }, { CV_64SC3, true  }, { CV_64SC4, true  },
     { CV_32FC1, false }, { CV_32FC3, false }, { CV_32FC4, false }, // No compression
     { CV_64FC1, false }, { CV_64FC3, false }, { CV_64FC4, false }  // No compression
 };


### PR DESCRIPTION
Closed https://github.com/opencv/opencv/issues/26507

Note: Predictor 2 for 64-bit is only supported after libtiff 4.4.0. But Linux x64 Debug uses libtiff 4.1.0 (releases at 2019/11/3). I append fallback fix to NONE. I hope It works well.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
