### PR TITLE
Add an optional suffix to the generated libraries to avoid conflicts …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,7 +532,8 @@ endif()
 
 if(WIN32)
   # Postfix of DLLs:
-  ocv_update(OPENCV_DLLVERSION "${OPENCV_VERSION_MAJOR}${OPENCV_VERSION_MINOR}${OPENCV_VERSION_PATCH}")
+  set(BUILD_LIBS_SUFFIX "" CACHE STRING "Set a library extension to avoid conflicts in your application with other libraries.")
+  ocv_update(OPENCV_DLLVERSION "${OPENCV_VERSION_MAJOR}${OPENCV_VERSION_MINOR}${OPENCV_VERSION_PATCH}${BUILD_LIBS_SUFFIX}")
   ocv_update(OPENCV_DEBUG_POSTFIX d)
 else()
   # Postfix of so's:


### PR DESCRIPTION
…with 3dparty libraries using customized opencv dlls in your own application.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
