### PR TITLE
build: disable clang  warning in clapack 3rdparty

### DIFF
--- a/3rdparty/clapack/CMakeLists.txt
+++ b/3rdparty/clapack/CMakeLists.txt
@@ -23,7 +23,8 @@ set(the_target "libclapack")
 add_library(${the_target} STATIC ${lapack_srcs} ${runtime_srcs} ${lib_hdrs})
 
 ocv_warnings_disable(CMAKE_C_FLAGS -Wno-parentheses -Wno-uninitialized -Wno-array-bounds
-    -Wno-implicit-function-declaration -Wno-unused -Wunused-parameter -Wstringop-truncation) # gcc/clang warnings
+    -Wno-implicit-function-declaration -Wno-unused -Wunused-parameter -Wstringop-truncation
+    -Wtautological-negation-compare) # gcc/clang warnings
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4244 /wd4554 /wd4723 /wd4819) # visual studio warnings
 
 set_target_properties(${the_target}


### PR DESCRIPTION
**Compiler**: LLVM/Clang 19
**Warning**:
```
/home/ubuntu/opencv/3rdparty/clapack/runtime/cblas_wrap.c:286:13: warning: '&&' of a value and its negation always evaluates to false [-Wtautological-negation-compare]
```
**Location**:
https://github.com/opencv/opencv/blob/f7483cd97809217676bedf524c42c6ea064364e6/3rdparty/clapack/runtime/cblas_wrap.c#L286-L287
