### PR TITLE
calib3d: fix vector access in USAC (5.x)

### DIFF
--- a/modules/3d/src/usac/fundamental_solver.cpp
+++ b/modules/3d/src/usac/fundamental_solver.cpp
@@ -579,7 +579,7 @@ public:
         CameraPose pose;
         pose.R = corr_idx < 2 ? R1 : R2;
         pose.t = corr_idx % 2 == 1 ? -t : t;
-        refine_relpose(calib_points, sample, sample_size, &pose, opt, &weights[0]);
+        refine_relpose(calib_points, sample, sample_size, &pose, opt, weights.empty() ? nullptr : &weights[0]);
         Matx33d model_new = Math::getSkewSymmetric(pose.t) * pose.R;
         if (is_fundamental)
             model_new = K2_inv_t * model_new * K1_inv;


### PR DESCRIPTION
Port of #26530 to 5.x
