### PR TITLE
objdetect: fix invalid vector access in QR de/encoder

### DIFF
--- a/modules/objdetect/src/qrcode_encoder.cpp
+++ b/modules/objdetect/src/qrcode_encoder.cpp
@@ -711,17 +711,17 @@ void QRCodeEncoderImpl::padBitStream()
     else if (pad_num <= 4)
     {
         int payload_size = (int)payload.size();
-        writeDecNumber(0, payload_size, payload);
+        payload.insert(payload.end(), payload_size, 0);
     }
     else
     {
-        writeDecNumber(0, 4, payload);
+        payload.insert(payload.end(), 4, 0);
 
         int i = payload.size() % bits;
 
         if (i != 0)
         {
-            writeDecNumber(0, bits - i, payload);
+            payload.insert(payload.end(), bits - i, 0);
         }
         pad_num = total_data - (int)payload.size();
 
@@ -1329,11 +1329,12 @@ private:
 
             int val = 0;
             while (bits >= actualBits) {
+                CV_CheckLT(idx, data.size(), "Not enough bits in the bitstream");
                 val |= data[idx++] << (bits - actualBits);
                 bits -= actualBits;
                 actualBits = 8;
             }
-            if (bits) {
+            if (bits && idx < data.size()) {
                 val |= data[idx] >> (actualBits - bits);
                 actualBits -= bits;
                 data[idx] &= 255 >> (8 - actualBits);


### PR DESCRIPTION
There might be cases when more bits are requested than available in the bitstream.
Partial stacktrace:
```
    frame #6: 0x00007ffff7c598f8 libopencv_objdetect.so.410`std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>::operator[][abi:de190104](this=0x00005555557a9338 size=19, __n=19) at vector:1436:3
    frame #7: 0x00007ffff7d51fe6 libopencv_objdetect.so.410`cv::QRCodeDecoderImpl::Bitstream::next(this=0x00005555557a9338, bits=3) at qrcode_encoder.cpp:1337:24
    frame #8: 0x00007ffff7d50a89 libopencv_objdetect.so.410`cv::QRCodeDecoderImpl::decodeSymbols(this=0x00005555557a9318, result="59147068325914706832591470683259147068325") at qrcode_encoder.cpp:1739:74
    frame #9: 0x00007ffff7d4f03e libopencv_objdetect.so.410`cv::QRCodeDecoderImpl::run(this=0x00005555557a9318, straight=0x00007fffffffaaa8, decoded_info="59147068325914706832591470683259147068325") at qrcode_encoder.cpp:1472:5
    frame #10: 0x00007ffff7d4ed4b libopencv_objdetect.so.410`cv::QRCodeDecoderImpl::decode(this=0x00005555557a9318, _straight=0x00007fffffffbe68, decoded_info="59147068325914706832591470683259147068325") at qrcode_encoder.cpp:1379:20
    frame #11: 0x00007ffff7d0ccea libopencv_objdetect.so.410`cv::QRDecode::decodingProcess(this=0x00007fffffffbcc8) at qrcode.cpp:2844:19
    frame #12: 0x00007ffff7d0e450 libopencv_objdetect.so.410`cv::QRDecode::straightDecodingProcess(this=0x00007fffffffbcc8) at qrcode.cpp:2922:10### Pull Request Readiness Checklist
    frame #13: 0x00007ffff7d0ed71 libopencv_objdetect.so.410`cv::ImplContour::decode(this=0x00005555557a8e08, in=0x00007fffffffc490, points=0x00007fffffffc478, straight_qrcode=0x00007fffffffc460) const at qrcode.cpp:2955:21
    frame #14: 0x00007ffff7cdd4b3 libopencv_objdetect.so.410`cv::GraphicalCodeDetector::decode(this=0x00007fffffffc4a8, img=0x00007fffffffc490, points=0x00007fffffffc478, straight_code=0x00007fffffffc460) const at graphical_code_detector.cpp:20:15
    frame #15: 0x000055555564ff99 opencv_test_objdetect`opencv_test::(anonymous namespace)::Objdetect_QRCode_Encode_Decode_regression_Test::Body(this=0x00005555557a9610) at test_qrcode_encode.cpp:298:60
```
~I'm not sure if we should fix decode process or just ignore extra bits which do not fit the bitstream. We can print some message to the log, but currently it is disabled.~
**cc** @dkurt 

Two changes in this PR:
* Since bitstream doesn't count exact number of bits stored it is possible for client code to request more bits than actually available. We've added to checks for this scenario: strict check in the `while` loop and soft check in the last bits processing.
* `writeDecNumber` has been used to append zero values to vector, in some cases it caused too large bit-shifts (>32bit). We replaced several such cases with explicit zero insertion.
