### PR TITLE
test: fix technical issue with min_element in reduce tests

### DIFF
--- a/modules/core/test/ref_reduce_arg.impl.hpp
+++ b/modules/core/test/ref_reduce_arg.impl.hpp
@@ -12,6 +12,21 @@
 
 namespace cvtest {
 
+// Standard library (technically) forbids using std::min_element
+// with non-strict std::less_equal, so we make our own min_element
+template <typename Iter, typename Comp>
+Iter custom_min_element(Iter begin, Iter end, Comp cmp_less)
+{
+    if (begin == end)
+        return begin;
+    Iter result = begin;
+    while (++begin != end)
+        if (cmp_less(*begin, *result))
+            result = begin;
+    return result;
+}
+
+
 template <class Cmp, typename T>
 struct reduceMinMaxImpl
 {
@@ -30,7 +45,7 @@ struct reduceMinMaxImpl
             cv::Mat sub = src(idx);
 
             auto begin = sub.begin<T>();
-            auto it = std::min_element(begin, sub.end<T>(), cmp);
+            auto it = custom_min_element(begin, sub.end<T>(), cmp);
             *dst(idx).ptr<int32_t>() = static_cast<int32_t>(std::distance(begin, it));
 
             for (int j = static_cast<int>(idx.size()) - 1; j >= 0; --j)


### PR DESCRIPTION
Compiling  and running core tests with libc++ with debug hardening mode produces following error (`Core_reduceArgMinMax`):
```
/usr/local/include/c++/v1/__algorithm/comp_ref_type.h:47: 
    assertion !__comp_(__l, __r) failed: Comparator does not induce a strict weak ordering
```

Perhaps we should not [use](https://github.com/opencv/opencv/blob/fb422a62d28faeed5b97ee7da7e8272f8fab250a/modules/core/test/test_arithm.cpp#L1517-L1524) `std::min_element` with `std::less_equal`. E.g. C++-17 (?) (N4659) standard says:
> 28.7
>
> 3. For all algorithms that take Compare, there is a version that uses operator< instead.
> That is, comp(*i, *j) != false defaults to *i < *j != false. For algorithms other than those
> described in 28.7.3 (binary_search etc.), comp shall induce a strict weak ordering on the values.

This might look a bit pedantic, but since this is just test I think we can fix this problem.