### PR TITLE
change default CV_YIELD to nop

### DIFF
--- a/modules/core/src/parallel_impl.cpp
+++ b/modules/core/src/parallel_impl.cpp
@@ -30,8 +30,7 @@
 DECLARE_CV_YIELD
 #endif
 #ifndef CV_YIELD
-# include <thread>
-# define CV_YIELD() std::this_thread::yield()
+# define CV_YIELD() __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
 #endif // CV_YIELD
 
 // Spin lock's CPU-level yield (required for Hyper-Threading)


### PR DESCRIPTION
As modern chip has multi-cpu and multi-core,when execute  parallel calculation,it could let WorkerThread::thread_body try to run on current CPU to wait other thread complete ,other than yield the cpu to cause context switch

It will reduce the overhead of schedule in and out in WorkerThread::thread_body,and get  the performance improvement of cache misses whenthe thread_body's thread is scheduled to another cpu.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
