### PR TITLE
Fixed several cases of unaligned pointer cast

### DIFF
--- a/modules/core/src/stat.simd.hpp
+++ b/modules/core/src/stat.simd.hpp
@@ -48,12 +48,16 @@ int normHamming(const uchar* a, int n)
 #  if defined CV_POPCNT_U64
         for(; i <= n - 8; i += 8)
         {
-            result += (int)CV_POPCNT_U64(*(uint64*)(a + i));
+            uint64_t val;
+            std::memcpy(&val, a + i, sizeof(val));
+            result += (int)CV_POPCNT_U64(val);
         }
 #  endif
         for(; i <= n - 4; i += 4)
         {
-            result += CV_POPCNT_U32(*(uint*)(a + i));
+            uint32_t val;
+            std::memcpy(&val, a + i, sizeof(val));
+            result += CV_POPCNT_U32(val);
         }
     }
 #endif
@@ -92,12 +96,18 @@ int normHamming(const uchar* a, const uchar* b, int n)
 #  if defined CV_POPCNT_U64
         for(; i <= n - 8; i += 8)
         {
-            result += (int)CV_POPCNT_U64(*(uint64*)(a + i) ^ *(uint64*)(b + i));
+            uint64_t val_a, val_b;
+            std::memcpy(&val_a, a + i, sizeof(val_a));
+            std::memcpy(&val_b, b + i, sizeof(val_b));
+            result += (int)CV_POPCNT_U64(val_a ^ val_b);
         }
 #  endif
         for(; i <= n - 4; i += 4)
         {
-            result += CV_POPCNT_U32(*(uint*)(a + i) ^ *(uint*)(b + i));
+            uint32_t val_a, val_b;
+            std::memcpy(&val_a, a + i, sizeof(val_a));
+            std::memcpy(&val_b, b + i, sizeof(val_b));
+            result += (int)CV_POPCNT_U32(val_a ^ val_b);
         }
     }
 #endif

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -137,7 +137,11 @@ uchar* FillGrayRow1( uchar* data, uchar* indices, int len, uchar* palette );
 
 CV_INLINE bool  isBigEndian( void )
 {
-    return (((const int*)"\0\x1\x2\x3\x4\x5\x6\x7")[0] & 255) != 0;
+#ifdef WORDS_BIGENDIAN
+    return true;
+#else
+    return false;
+#endif
 }
 
 }  // namespace

--- a/modules/imgproc/src/smooth.simd.hpp
+++ b/modules/imgproc/src/smooth.simd.hpp
@@ -1324,7 +1324,9 @@ void vlineSmooth3N<uint8_t, ufixedpoint16>(const ufixedpoint16* const * src, con
         ufixedpoint32 val[] = { (m[0] + m[1] + m[2]) * ufixedpoint16((uint8_t)128) };
         v_128_4 = vx_setall_s32(*((int32_t*)val));
     }
-    v_int16 v_mul01 = v_reinterpret_as_s16(vx_setall_u32(*((uint32_t*)m)));
+    uint32_t val01;
+    std::memcpy(&val01, m, sizeof(val01));
+    v_int16 v_mul01 = v_reinterpret_as_s16(vx_setall_u32(val01));
     v_int16 v_mul2 = v_reinterpret_as_s16(vx_setall_u16(*((uint16_t*)(m + 2))));
     for (; i <= len - 4*VECSZ; i += 4*VECSZ)
     {


### PR DESCRIPTION
Fixed several cases of casting from `uchar*` to wider pointer type (e.g. `uint64_t*`) which can cause unaligned access.