### PR TITLE
Fixed cv::Mat type constants in ObjC and Swift.

### DIFF
--- a/modules/core/misc/objc/common/CvTypeExt.swift
+++ b/modules/core/misc/objc/common/CvTypeExt.swift
@@ -53,7 +53,7 @@ public extension CvType {
     static let CV_16FC4: Int32 = CV_16FC(4)
 
     static let CV_CN_MAX = 512
-    static let CV_CN_SHIFT = 3
+    static let CV_CN_SHIFT = 5
     static let CV_DEPTH_MAX = 1 << CV_CN_SHIFT
 
     static func CV_8UC(_ channels:Int32) -> Int32 {

--- a/modules/core/misc/objc/test/MatTestObjc.m
+++ b/modules/core/misc/objc/test/MatTestObjc.m
@@ -8,14 +8,20 @@
 #import <OpenCV/OpenCV.h>
 
 #define CV_8U 0
+#define CV_8S 1
+#define CV_16U 2
 #define CV_16S 3
 #define CV_32S 4
 #define CV_32F 5
-#define CV_CN_SHIFT 3
+#define CV_64F 6
+#define CV_16F 7
+
+#define CV_CN_SHIFT 5
 #define CV_DEPTH_MAX (1 << CV_CN_SHIFT)
 #define CV_MAT_DEPTH_MASK (CV_DEPTH_MAX - 1)
 #define CV_MAT_DEPTH(flags) ((flags) & CV_MAT_DEPTH_MASK)
 #define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
+
 #define CV_8UC3 CV_MAKETYPE(CV_8U,3)
 #define CV_32FC3 CV_MAKETYPE(CV_32F,3)
 #define CV_32SC3 CV_MAKETYPE(CV_32S,3)


### PR DESCRIPTION
Fixes #26552
Fixes #26549

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
