### PR TITLE
More type constants for Java bindings too.

### DIFF
--- a/modules/core/misc/java/src/java/core+CvType.java
+++ b/modules/core/misc/java/src/java/core+CvType.java
@@ -1,5 +1,7 @@
 package org.opencv.core;
 
+//NOTE: Type constants and related functions are ported from modules/core/include/opencv2/core/hal/interface.h
+
 public final class CvType {
 
     // type depth constants
@@ -11,13 +13,13 @@ public final class CvType {
             CV_32S = 4,
             CV_32F = 5,
             CV_64F = 6,
-            CV_16F = 7;
-
-    /**
-     * @deprecated please use {@link #CV_16F}
-     */
-    @Deprecated
-    public static final int CV_USRTYPE1 = CV_16F;
+            CV_16F = 7,
+            CV_16BF = 8,
+            CV_Bool = 9,
+            CV_64U = 10,
+            CV_64S = 11,
+            CV_32U = 12
+            ;
 
     // predefined type constants
     public static final int
@@ -26,9 +28,14 @@ public final class CvType {
             CV_16UC1 = CV_16UC(1), CV_16UC2 = CV_16UC(2), CV_16UC3 = CV_16UC(3), CV_16UC4 = CV_16UC(4),
             CV_16SC1 = CV_16SC(1), CV_16SC2 = CV_16SC(2), CV_16SC3 = CV_16SC(3), CV_16SC4 = CV_16SC(4),
             CV_32SC1 = CV_32SC(1), CV_32SC2 = CV_32SC(2), CV_32SC3 = CV_32SC(3), CV_32SC4 = CV_32SC(4),
+            CV_32UC1 = CV_32UC(1), CV_32UC2 = CV_32UC(2), CV_32UC3 = CV_32UC(3), CV_32UC4 = CV_32UC(4),
+            CV_64SC1 = CV_64SC(1), CV_64SC2 = CV_64SC(2), CV_64SC3 = CV_64SC(3), CV_64SC4 = CV_64SC(4),
+            CV_64UC1 = CV_64UC(1), CV_64UC2 = CV_64UC(2), CV_64UC3 = CV_64UC(3), CV_64UC4 = CV_64UC(4),
             CV_32FC1 = CV_32FC(1), CV_32FC2 = CV_32FC(2), CV_32FC3 = CV_32FC(3), CV_32FC4 = CV_32FC(4),
             CV_64FC1 = CV_64FC(1), CV_64FC2 = CV_64FC(2), CV_64FC3 = CV_64FC(3), CV_64FC4 = CV_64FC(4),
-            CV_16FC1 = CV_16FC(1), CV_16FC2 = CV_16FC(2), CV_16FC3 = CV_16FC(3), CV_16FC4 = CV_16FC(4);
+            CV_16FC1 = CV_16FC(1), CV_16FC2 = CV_16FC(2), CV_16FC3 = CV_16FC(3), CV_16FC4 = CV_16FC(4),
+            CV_16BFC1 = CV_16BFC(1), CV_16BFC2 = CV_16BFC(2), CV_16BFC3 = CV_16BFC(3), CV_16BFC4 = CV_16BFC(4),
+            CV_BoolC1 = CV_BoolC(1), CV_BoolC2 = CV_BoolC(2), CV_BoolC3 = CV_BoolC(3), CV_BoolC4 = CV_BoolC(4);
 
     private static final int CV_CN_MAX = 128, CV_CN_SHIFT = 5, CV_DEPTH_MAX = (1 << CV_CN_SHIFT);
 
@@ -64,6 +71,18 @@ public final class CvType {
         return makeType(CV_32S, ch);
     }
 
+    public static final int CV_32UC(int ch) {
+        return makeType(CV_32U, ch);
+    }
+
+    public static final int CV_64SC(int ch) {
+        return makeType(CV_64S, ch);
+    }
+
+    public static final int CV_64UC(int ch) {
+        return makeType(CV_64U, ch);
+    }
+
     public static final int CV_32FC(int ch) {
         return makeType(CV_32F, ch);
     }
@@ -74,6 +93,14 @@ public final class CvType {
 
     public static final int CV_16FC(int ch) {
         return makeType(CV_16F, ch);
+    }
+
+    public static final int CV_16BFC(int ch) {
+        return makeType(CV_16BF, ch);
+    }
+
+    public static final int CV_BoolC(int ch) {
+        return makeType(CV_Bool, ch);
     }
 
     public static final int channels(int type) {
@@ -90,16 +117,21 @@ public final class CvType {
 
     public static final int ELEM_SIZE(int type) {
         switch (depth(type)) {
+        case CV_Bool:
         case CV_8U:
         case CV_8S:
             return channels(type);
         case CV_16U:
         case CV_16S:
         case CV_16F:
+        case CV_16BF:
             return 2 * channels(type);
         case CV_32S:
+        case CV_32U:
         case CV_32F:
             return 4 * channels(type);
+        case CV_64U:
+        case CV_64S:
         case CV_64F:
             return 8 * channels(type);
         default:
@@ -126,14 +158,29 @@ public final class CvType {
         case CV_32S:
             s = "CV_32S";
             break;
+        case CV_32U:
+            s = "CV_32U";
+            break;
         case CV_32F:
             s = "CV_32F";
+            break;
+        case CV_64U:
+            s = "CV_64U";
+            break;
+        case CV_64S:
+            s = "CV_64S";
             break;
         case CV_64F:
             s = "CV_64F";
             break;
         case CV_16F:
             s = "CV_16F";
+            break;
+        case CV_16BF:
+            s = "CV_16BF";
+            break;
+        case CV_Bool:
+            s = "CV_Bool";
             break;
         default:
             throw new UnsupportedOperationException(

--- a/modules/core/misc/java/test/CvTypeTest.java
+++ b/modules/core/misc/java/test/CvTypeTest.java
@@ -29,12 +29,24 @@ public class CvTypeTest extends OpenCVTestCase {
         assertEquals(CvType.CV_32SC4, CvType.CV_32SC(4));
     }
 
+    public void testCV_32UC() {
+        assertEquals(CvType.CV_32UC4, CvType.CV_32UC(4));
+    }
+
+    public void testCV_64SC() {
+        assertEquals(CvType.CV_64SC4, CvType.CV_64SC(4));
+    }
+
     public void testCV_32FC() {
         assertEquals(CvType.CV_32FC4, CvType.CV_32FC(4));
     }
 
     public void testCV_64FC() {
         assertEquals(CvType.CV_64FC4, CvType.CV_64FC(4));
+    }
+
+    public void testCV_BoolFC() {
+        assertEquals(CvType.CV_BoolC1, CvType.CV_BoolC(1));
     }
 
     public void testCV_16FC() {
@@ -66,6 +78,8 @@ public class CvTypeTest extends OpenCVTestCase {
         assertEquals("CV_32FC1", CvType.typeToString(CvType.CV_32F));
         assertEquals("CV_32FC3", CvType.typeToString(CvType.CV_32FC3));
         assertEquals("CV_32FC(127)", CvType.typeToString(CvType.CV_32FC(127)));
+        assertEquals("CV_64UC(12)", CvType.typeToString(CvType.CV_64UC(12)));
+        assertEquals("CV_16BFC1", CvType.typeToString(CvType.CV_16BFC(1)));
     }
 
 }


### PR DESCRIPTION
Analog of #26568 for Java

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
