### PR TITLE
fixed issue when std::vector<T> is wrapped into Mat with explicit step.

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -895,7 +895,7 @@ Mat::Mat(Size _sz, int _type, void* _data, size_t _step)
 
     size_t esz = CV_ELEM_SIZE(_type), esz1 = CV_ELEM_SIZE1(_type);
     size_t minstep = cols*esz;
-    if( _step == AUTO_STEP )
+    if( _step == AUTO_STEP || (_step < minstep && rows == 1))
     {
         _step = minstep;
     }

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1204,7 +1204,6 @@ TEST(Imgproc_Resize, issue_26497)
 {
     std::vector<float> vec = {0.f, 1.f, 2.f, 3.f};
     Mat A(vec), B;
-    std::cout << A.size() << std::endl;
     resize(A, B, Size(2,2), 0, 0, INTER_LINEAR);
     double minv = 0, maxv = 0;
     cvtest::minMaxIdx(B, &minv, &maxv, nullptr, nullptr, noArray());

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1200,5 +1200,18 @@ TEST(Imgproc_Remap, issue_23562)
     }
 }
 
+TEST(Imgproc_Resize, issue_26497)
+{
+    std::vector<float> vec = {0.f, 1.f, 2.f, 3.f};
+    Mat A(vec), B;
+    std::cout << A.size() << std::endl;
+    resize(A, B, Size(2,2), 0, 0, INTER_LINEAR);
+    double minv = 0, maxv = 0;
+    cvtest::minMaxIdx(B, &minv, &maxv, nullptr, nullptr, noArray());
+    EXPECT_EQ(B.size(), Size(2, 2));
+    EXPECT_LE(0., minv);
+    EXPECT_LE(maxv, 3.);
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
Hopefully, fixes #26497

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
