### PR TITLE
Fix python re warning and remove python2 import

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function, unicode_literals
-import sys, re, os.path, errno, fnmatch
+import codecs
+import errno
+import fnmatch
+import io
 import json
 import logging
-import codecs
-import io
-from shutil import copyfile
+import os.path
+import re
+import sys
+from io import StringIO
 from pprint import pformat
+from shutil import copyfile
 from string import Template
 
 if sys.version_info >= (3, 8): # Python 3.8+
@@ -17,10 +21,6 @@ if sys.version_info >= (3, 8): # Python 3.8+
 else:
     from distutils.dir_util import copy_tree
 
-try:
-    from io import StringIO # Python 3
-except:
-    from io import BytesIO as StringIO
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -1121,7 +1121,7 @@ class ObjectiveCWrapperGenerator(object):
                         name = line[p0:p1]
                         for arg in args:
                             if arg.name == name:
-                                toWrite.append(re.sub('\*\s*@param ', '* @param ', line))
+                                toWrite.append(re.sub(r'\*\s*@param ', '* @param ', line))
                                 break
                     else:
                         s0 = line.find("@see")
@@ -1513,13 +1513,13 @@ def escape_underscore(str):
     return str.replace('_', '\\_')
 
 def escape_texttt(str):
-    return re.sub(re.compile('texttt{(.*?)\}', re.DOTALL), lambda x: 'texttt{' + escape_underscore(x.group(1)) + '}', str)
+    return re.sub(re.compile('texttt{(.*?)}', re.DOTALL), lambda x: 'texttt{' + escape_underscore(x.group(1)) + '}', str)
 
 def get_macros(tex):
     out = ""
-    if re.search("\\\\fork\s*{", tex):
+    if re.search(r"\\fork\s*{", tex):
         out += "\\newcommand{\\fork}[4]{ \\left\\{ \\begin{array}{l l} #1 & \\text{#2}\\\\\\\\ #3 & \\text{#4}\\\\\\\\ \\end{array} \\right.} "
-    if re.search("\\\\vecthreethree\s*{", tex):
+    if re.search(r"\\vecthreethree\s*{", tex):
         out += "\\newcommand{\\vecthreethree}[9]{ \\begin{bmatrix} #1 & #2 & #3\\\\\\\\ #4 & #5 & #6\\\\\\\\ #7 & #8 & #9 \\end{bmatrix} } "
     return out
 


### PR DESCRIPTION
There are four warnings when build objc with Python 3.12+

```
2024-12-05T10:16:37.8418499Z   C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\objc\generator\gen_objc.py:1124: SyntaxWarning: invalid escape sequence '\*'
2024-12-05T10:16:37.8420255Z     toWrite.append(re.sub('\*\s*@param ', '* @param ', line))
2024-12-05T10:16:37.8464005Z   C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\objc\generator\gen_objc.py:1516: SyntaxWarning: invalid escape sequence '\}'
2024-12-05T10:16:37.8469048Z     return re.sub(re.compile('texttt{(.*?)\}', re.DOTALL), lambda x: 'texttt{' + escape_underscore(x.group(1)) + '}', str)
2024-12-05T10:16:37.8471247Z   C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\objc\generator\gen_objc.py:1520: SyntaxWarning: invalid escape sequence '\s'
2024-12-05T10:16:37.8476158Z     if re.search("\\\\fork\s*{", tex):
2024-12-05T10:16:37.8478651Z   C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\objc\generator\gen_objc.py:1522: SyntaxWarning: invalid escape sequence '\s'
2024-12-05T10:16:37.8483224Z     if re.search("\\\\vecthreethree\s*{", tex):
```

https://docs.python.org/3/library/re.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
