### PR TITLE
videoio(test): filter unstable GStreamer tests

### DIFF
--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -47,6 +47,14 @@ public:
             throw SkipTestException(cv::String("Backend is not available/disabled: ") + cv::videoio_registry::getBackendName(apiPref));
         if (cvtest::skipUnstableTests && apiPref == CAP_MSMF && (ext == "h264" || ext == "h265" || ext == "mpg"))
             throw SkipTestException("Unstable MSMF test");
+#ifdef __linux__
+        if (cvtest::skipUnstableTests && apiPref == CAP_GSTREAMER &&
+            (ext == "avi" || ext == "mkv") &&
+            (video_file.find("MPEG") != std::string::npos))
+        {
+            throw SkipTestException("Unstable GSTREAMER test");
+        }
+#endif
         writeVideo();
         VideoCapture cap;
         ASSERT_NO_THROW(cap.open(video_file, apiPref));
@@ -852,6 +860,13 @@ TEST_P(videowriter_acceleration, write)
     std::string backend_name = cv::videoio_registry::getBackendName(backend);
     if (!videoio_registry::hasBackend(backend))
         throw SkipTestException(cv::String("Backend is not available/disabled: ") + backend_name);
+#ifdef __linux__
+    if (cvtest::skipUnstableTests && backend == CAP_GSTREAMER &&
+        (extension == "mkv") && (codecid == "MPEG"))
+    {
+        throw SkipTestException("Unstable GSTREAMER test");
+    }
+#endif
 
     const Size sz(640, 480);
     const int frameNum = 15;


### PR DESCRIPTION
- observed on Ubuntu 24.04

Fail or sporadically hang on these tests:

```
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] videoio/videoio_synthetic.write_read_position/9, where GetParam() = (640x480, FOURCC(MPEG), .avi, GSTREAMER, 28dB)
[  FAILED  ] videoio/videoio_synthetic.write_read_position/12, where GetParam() = (640x480, FOURCC(MPEG), .mkv, GSTREAMER, 28dB)
[  FAILED  ] videoio/videoio_synthetic.write_read_position/25, where GetParam() = (976x768, FOURCC(MPEG), .avi, GSTREAMER, 28dB)
[  FAILED  ] videoio/videoio_synthetic.write_read_position/28, where GetParam() = (976x768, FOURCC(MPEG), .mkv, GSTREAMER, 28dB)
[  FAILED  ] videoio/videowriter_acceleration.write/40, where GetParam() = (FOURCC(MPEG), .mkv, GSTREAMER, 29dB, NONE, false)
[  FAILED  ] videoio/videowriter_acceleration.write/42, where GetParam() = (FOURCC(MPEG), .mkv, GSTREAMER, 29dB, ANY, false)
```