### PR TITLE
Made fastNlMeansDenoisingMulti support 16 bit types

### DIFF
--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -249,16 +249,16 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
     int hn = (int)h.size();
     double granularity = (double)std::max(1., (double)dst.total()/(1 << 16));
 
-    switch (srcImgs[0].type())
-    {
-        case CV_8U:
+
+    switch (CV_MAT_CN(srcImgs[0].type())) {
+        case 1:
             parallel_for_(cv::Range(0, srcImgs[0].rows),
-                          FastNlMeansMultiDenoisingInvoker<uchar, IT, UIT, D, int>(
+                          FastNlMeansMultiDenoisingInvoker<ST, IT, UIT, D, int>(
                               srcImgs, imgToDenoiseIndex, temporalWindowSize,
                               dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
             break;
-        case CV_8UC2:
+        case 2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
@@ -272,7 +272,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC3:
+        case 3:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
@@ -286,7 +286,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC4:
+        case 4:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
@@ -300,9 +300,9 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        default:
+       default:
             CV_Error(Error::StsBadArg,
-                "Unsupported image format! Only CV_8U, CV_8UC2, CV_8UC3 and CV_8UC4 are supported");
+                     "Unsupported number of channels! Only 1, 2, 3, and 4 are supported");
     }
 }
 


### PR DESCRIPTION
This PR adds support for 16 bit types for fastNlMeansDenoisingMulti, fixing the bug reported in
#26582 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
