### PR TITLE
Support string_view in caffe_importer

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -126,8 +126,8 @@ public:
             const google::protobuf::UnknownField& field = unknownFields.field(i);
             CV_Assert(field.type() == google::protobuf::UnknownField::TYPE_GROUP);
             CV_CheckGE(field.group().field_count(), 2, "UnknownField should have at least 2 items: name and value");
-            std::string fieldName = field.group().field(0).length_delimited();
-            std::string fieldValue = field.group().field(1).length_delimited();
+            std::string fieldName(field.group().field(0).length_delimited());
+            std::string fieldValue(field.group().field(1).length_delimited());
             params.set(fieldName, fieldValue);
         }
     }
@@ -137,7 +137,7 @@ public:
         const Reflection *refl = msg.GetReflection();
         int type = field->cpp_type();
         bool isRepeated = field->is_repeated();
-        const std::string &name = field->name();
+        const std::string name(field->name());
 
         #define SET_UP_FILED(getter, arrayConstr, gtype)                                    \
             if (isRepeated) {                                                               \
@@ -189,7 +189,7 @@ public:
                 params.set(name, DictValue::arrayString(buf.begin(), size));
             }
             else {
-                params.set(name, refl->GetEnum(msg, field)->name());
+                params.set(name, std::string(refl->GetEnum(msg, field)->name()));
             }
             break;
         default:
@@ -212,7 +212,7 @@ public:
         {
             const FieldDescriptor *fd = msgDesc->field(fieldId);
 
-            if (!isInternal && !ends_with_param(fd->name()))
+            if (!isInternal && !ends_with_param(std::string(fd->name())))
                 continue;
 
             const google::protobuf::UnknownFieldSet& unknownFields = msgRefl->GetUnknownFields(msg);


### PR DESCRIPTION
An upcoming change in Protobuf will change the return types of various methods like `Descriptor::name()` and `Message::GetTypeName()` from `const std::string&` or `std::string` to `absl::string_view`. This CL fixes users of those methods to work both before and after the change.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
