### PR TITLE
VideoCapture open camera slow

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3360,7 +3360,7 @@ namespace cv
 {
 videoInput VideoCapture_DShow::g_VI;
 
-VideoCapture_DShow::VideoCapture_DShow(int index)
+VideoCapture_DShow::VideoCapture_DShow(int index, const VideoCaptureParameters& params)
     : m_index(-1)
     , m_width(-1)
     , m_height(-1)
@@ -3370,6 +3370,16 @@ VideoCapture_DShow::VideoCapture_DShow(int index)
     , m_convertRGBSet(true)
 {
     CoInitialize(0);
+
+    if (!params.empty()) {
+        int tmpW = params.get<int>(CV_CAP_PROP_FRAME_WIDTH, -1);
+        int tmpH = params.get<int>(CV_CAP_PROP_FRAME_HEIGHT, -1);
+        int tmpFOURCC = params.get<int>(CV_CAP_PROP_FOURCC, -1);
+        if (tmpW != -1 && tmpH != -1) {
+            g_VI.setupDeviceFourcc(index, tmpW, tmpH, tmpFOURCC);
+        }
+    }
+
     open(index);
 }
 VideoCapture_DShow::~VideoCapture_DShow()
@@ -3675,9 +3685,9 @@ void VideoCapture_DShow::close()
     m_convertRGBSet = true;
 }
 
-Ptr<IVideoCapture> create_DShow_capture(int index)
+Ptr<IVideoCapture> create_DShow_capture(int index, const VideoCaptureParameters& params)
 {
-    return makePtr<VideoCapture_DShow>(index);
+    return makePtr<VideoCapture_DShow>(index, params);
 }
 
 

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -21,7 +21,7 @@ namespace cv
 class VideoCapture_DShow : public IVideoCapture
 {
 public:
-    VideoCapture_DShow(int index);
+    VideoCapture_DShow(int index, const VideoCaptureParameters& params);
     virtual ~VideoCapture_DShow();
 
     virtual double getProperty(int propIdx) const CV_OVERRIDE;

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -355,7 +355,7 @@ Ptr<IVideoWriter> cvCreateVideoWriter_MSMF(const std::string& filename, int four
                                            double fps, const Size& frameSize,
                                            const VideoWriterParameters& params);
 
-Ptr<IVideoCapture> create_DShow_capture(int index);
+Ptr<IVideoCapture> create_DShow_capture(int index, const VideoCaptureParameters& params);
 
 Ptr<IVideoCapture> create_V4L_capture_cam(int index);
 Ptr<IVideoCapture> create_V4L_capture_file(const std::string &filename);


### PR DESCRIPTION
Resolve the issue of slow camera opening when using dshow as the backend for VideoCapture.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work : https://github.com/opencv/opencv/issues/17687 , about DSHOW slow.
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
[dshow-code.zip](https://github.com/user-attachments/files/18070514/dshow-code.zip)
[DSHOW_test.docx](https://github.com/user-attachments/files/18070504/DSHOW_test.docx)
