### PR TITLE
Improved dumpVector, cv::Rect operator<< and exceptions

### DIFF
--- a/modules/core/src/bindings_utils.cpp
+++ b/modules/core/src/bindings_utils.cpp
@@ -18,7 +18,7 @@ namespace utils {
 
 String dumpInputArray(InputArray argument)
 {
-    if (argument.empty())
+    if (&argument == &noArray())
         return "InputArray: noArray()";
     std::ostringstream ss;
     ss << "InputArray:";
@@ -69,7 +69,7 @@ String dumpInputArray(InputArray argument)
 
 CV_EXPORTS_W String dumpInputArrayOfArrays(InputArrayOfArrays argument)
 {
-    if (argument.empty())
+    if (&argument == &noArray())
         return "InputArrayOfArrays: noArray()";
     std::ostringstream ss;
     ss << "InputArrayOfArrays:";
@@ -126,7 +126,7 @@ CV_EXPORTS_W String dumpInputArrayOfArrays(InputArrayOfArrays argument)
 
 CV_EXPORTS_W String dumpInputOutputArray(InputOutputArray argument)
 {
-    if (argument.empty())
+    if (&argument == &noArray())
         return "InputOutputArray: noArray()";
     std::ostringstream ss;
     ss << "InputOutputArray:";
@@ -177,7 +177,7 @@ CV_EXPORTS_W String dumpInputOutputArray(InputOutputArray argument)
 
 CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argument)
 {
-    if (argument.empty())
+    if (&argument == &noArray())
         return "InputOutputArrayOfArrays: noArray()";
     std::ostringstream ss;
     ss << "InputOutputArrayOfArrays:";

--- a/modules/core/src/bindings_utils.cpp
+++ b/modules/core/src/bindings_utils.cpp
@@ -9,11 +9,16 @@
 #include <opencv2/core/utils/filesystem.hpp>
 #include <opencv2/core/utils/filesystem.private.hpp>
 
-namespace cv { namespace utils {
+namespace cv {
+static inline std::ostream& operator<<(std::ostream& os, const Rect& rect)
+{
+    return os << "[x=" << rect.x << ", y=" << rect.y << ", w=" << rect.width << ", h=" << rect.height << ']';
+}
+namespace utils {
 
 String dumpInputArray(InputArray argument)
 {
-    if (&argument == &noArray())
+    if (argument.empty())
         return "InputArray: noArray()";
     std::ostringstream ss;
     ss << "InputArray:";
@@ -51,16 +56,20 @@ String dumpInputArray(InputArray argument)
             ss << " type(-1)=" << cv::typeToString(argument.type(-1));
         } while (0);
     }
+    catch (const std::exception& e)
+    {
+        ss << " ERROR: exception occurred: " << e.what();
+    }
     catch (...)
     {
-        ss << " ERROR: exception occurred, dump is non-complete";  // need to properly support different kinds
+        ss << " ERROR: unknown exception occurred, dump is non-complete";
     }
     return ss.str();
 }
 
 CV_EXPORTS_W String dumpInputArrayOfArrays(InputArrayOfArrays argument)
 {
-    if (&argument == &noArray())
+    if (argument.empty())
         return "InputArrayOfArrays: noArray()";
     std::ostringstream ss;
     ss << "InputArrayOfArrays:";
@@ -104,16 +113,20 @@ CV_EXPORTS_W String dumpInputArrayOfArrays(InputArrayOfArrays argument)
             }
         } while (0);
     }
+    catch (const std::exception& e)
+    {
+        ss << " ERROR: exception occurred: " << e.what();
+    }
     catch (...)
     {
-        ss << " ERROR: exception occurred, dump is non-complete";  // need to properly support different kinds
+        ss << " ERROR: unknown exception occurred, dump is non-complete";
     }
     return ss.str();
 }
 
 CV_EXPORTS_W String dumpInputOutputArray(InputOutputArray argument)
 {
-    if (&argument == &noArray())
+    if (argument.empty())
         return "InputOutputArray: noArray()";
     std::ostringstream ss;
     ss << "InputOutputArray:";
@@ -151,16 +164,20 @@ CV_EXPORTS_W String dumpInputOutputArray(InputOutputArray argument)
             ss << " type(-1)=" << cv::typeToString(argument.type(-1));
         } while (0);
     }
+    catch (const std::exception& e)
+    {
+        ss << " ERROR: exception occurred: " << e.what();
+    }
     catch (...)
     {
-        ss << " ERROR: exception occurred, dump is non-complete";  // need to properly support different kinds
+        ss << " ERROR: unknown exception occurred, dump is non-complete";
     }
     return ss.str();
 }
 
 CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argument)
 {
-    if (&argument == &noArray())
+    if (argument.empty())
         return "InputOutputArrayOfArrays: noArray()";
     std::ostringstream ss;
     ss << "InputOutputArrayOfArrays:";
@@ -204,16 +221,15 @@ CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argume
             }
         } while (0);
     }
+    catch (const std::exception& e)
+    {
+        ss << " ERROR: exception occurred: " << e.what();
+    }
     catch (...)
     {
-        ss << " ERROR: exception occurred, dump is non-complete";  // need to properly support different kinds
+        ss << " ERROR: unknown exception occurred, dump is non-complete";
     }
     return ss.str();
-}
-
-static inline std::ostream& operator<<(std::ostream& os, const cv::Rect& rect)
-{
-    return os << "[x=" << rect.x << ", y=" << rect.y << ", w=" << rect.width << ", h=" << rect.height << ']';
 }
 
 template <class T, class Formatter>
@@ -222,10 +238,11 @@ static inline String dumpVector(const std::vector<T>& vec, Formatter format)
     std::ostringstream oss("[", std::ios::ate);
     if (!vec.empty())
     {
-        oss << format << vec[0];
+        format(oss) << vec[0];
         for (std::size_t i = 1; i < vec.size(); ++i)
         {
-            oss << ", " << format << vec[i];
+            oss << ", ";
+            format(oss) << vec[i];
         }
     }
     oss << "]";


### PR DESCRIPTION
- Applied format for vector element formatting to ensure consistent and clear output representation.  
- Moved `operator<<` to the `cv` namespace to align with OpenCV's coding standards and improve maintainability.  
- Enhanced error handling by including detailed exception messages using `e.what()` for better debugging.  

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
