### PR TITLE
Enhance ldm_inpainting script with model loading and user instructions

### DIFF
--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -457,3 +457,18 @@ lama:
   height: 512
   rgb: false
   sample: "inpainting"
+
+ldm_inpainting:
+  encoder_load_info:
+    encoder_url: "https://dl.opencv.org/models/ldm_inpainting/InpaintEncoder.onnx"
+    encoder_sha1: "eb663262304473d81d6ae627d7117892dac56b5e"
+  encoder_model: "InpaintEncoder.onnx"
+  decoder_load_info:
+    decoder_url: "https://dl.opencv.org/models/ldm_inpainting/InpaintDecoder.onnx"
+    decoder_sha1: "af258c100e3a3b0970493b6375c8775beaffc9d1"
+  decoder_model: "InpaintDecoder.onnx"
+  diffusor_load_info:
+    diffusor_url: "https://dl.opencv.org/models/ldm_inpainting/LatentDiffusion.onnx"
+    diffusor_sha1: "2c6f8a505d9a93195510c854d8f023fab27ce70e"
+  diffusor_model: "LatentDiffusion.onnx"
+  sample: "ldm_inpainting"


### PR DESCRIPTION
This PR adds and fixes following points in the `ldm_inpainting` sample

**DONE:** 
- Added functionality to load models from a YAML configuration file, allowing for automatic downloading if models are not found locally.
- Updated the script usage instructions to reflect the correct command format.
- Improved user interaction by adding instructions to the image window for inpainting controls.
- Introduced a new models.yml configuration section for inpainting models weights downloading, including placeholders for model SHA1 checksums.
- Fixed input types and names of the onnx graph generation. 

**TODO:** 
- [ ] ADD links to onnx graphs and sha1 hashes to `models.yaml` file
- [ ] Fix sample for different `step` paremeter
- [ ] Use generic model search procedure, a.k.a. findModel


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
