### PR TITLE
Revert "CI: enable AVX2 build"

### DIFF
--- a/.github/workflows/PR-4.x.yaml
+++ b/.github/workflows/PR-4.x.yaml
@@ -24,9 +24,6 @@ jobs:
   Ubuntu2404-x64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U24.yaml@main
 
-  Ubuntu2404-x64-AVX2:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U24-AVX2.yaml@main
-
   Ubuntu2004-x64-CUDA:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'category: dnn') }} || ${{ contains(github.event.pull_request.labels.*.name, 'category: dnn (onnx)') }}"
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@main


### PR DESCRIPTION
Reverts opencv/opencv#26604

GHA is limited to 20 pipeline reference, that PR added 21'st. We need to develop another approach to pipeline usage.