### PR TITLE
Fix: handle empty filename in icvExtractPattern function

### DIFF
--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -249,7 +249,10 @@ std::string icvExtractPattern(const std::string& filename, unsigned *offset)
 #ifdef _WIN32
         if (pos == std::string::npos)
             pos = filename.rfind('\\');
-#endif
+#endif  
+        if (filename.empty())
+            return "";
+
         if (pos != std::string::npos)
             pos++;
         else
@@ -258,7 +261,7 @@ std::string icvExtractPattern(const std::string& filename, unsigned *offset)
         while (pos < len && !isdigit(filename[pos])) pos++;
 
         if (pos == len)
-            return "";
+            return filename;
 
         std::string::size_type pos0 = pos;
 


### PR DESCRIPTION
To remove the restriction requiring a digit in the filename:

1. **Early Validation**: Check if the filename is empty at the start. Return an empty string if true.  
   ```cpp
   if (filename.empty()) return "";
   ```

2. **No Digits Found**: If no digits exist (`pos == len`), return the original filename instead of an empty string.  
   ```cpp
   return filename;
   ```

3. **Normal Logic**: Process filenames with digits as usual.