### PR TITLE
Fix normalization parameters in YOLO example to support multi-channel mean and scale factors

### DIFF
--- a/samples/dnn/yolo_detector.cpp
+++ b/samples/dnn/yolo_detector.cpp
@@ -44,8 +44,8 @@ std::string keys =
     "{ nc          | 80 | Number of classes. Default is 80 (coming from COCO dataset). }"
     "{ thr         | .5 | Confidence threshold. }"
     "{ nms         | .4 | Non-maximum suppression threshold. }"
-    "{ mean        | 0.0 | Normalization constant. }"
-    "{ scale       | 1.0 | Preprocess input image by multiplying on a scale factor. }"
+    "{ mean        | 0.0 0.0 0.0 | Normalization constant. }"
+    "{ scale       | 1.0 1.0 1.0 | Preprocess input image by multiplying on a scale factor. }"
     "{ width       | 640 | Preprocess input image by resizing to a specific width. }"
     "{ height      | 640 | Preprocess input image by resizing to a specific height. }"
     "{ rgb         | 1 | Indicate that model works with RGB input images instead BGR ones. }"
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
     bool swapRB = parser.get<bool>("rgb");
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
-    Scalar scale = parser.get<float>("scale");
+    Scalar scale = parser.get<Scalar>("scale");
     Scalar mean = parser.get<Scalar>("mean");
     ImagePaddingMode paddingMode = static_cast<ImagePaddingMode>(parser.get<int>("paddingmode"));
     //![preprocess_params]


### PR DESCRIPTION
This branch and commit address an issue in the YOLO example (samples/dnn/yolo_detector.cpp) where the mean and scale parameters only affected the first channel (Blue) due to single-value input. The modification updates these parameters to accept multi-channel values, ensuring consistent preprocessing across all image channels.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
