### PR TITLE
Cocoa/highgui: fix leak in cvGetWindowRect_COCOA

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -662,14 +662,16 @@ CvRect cvGetWindowRect_COCOA( const char* name )
     {
         CV_ERROR( CV_StsNullPtr, "NULL window" );
     } else {
-        NSRect rect = [window frame];
+        @autoreleasepool {
+            NSRect rect = [window frame];
 #if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_6
-        NSPoint pt = [window convertRectToScreen:rect].origin;
+            NSPoint pt = [window convertRectToScreen:rect].origin;
 #else
-        NSPoint pt = [window convertBaseToScreen:rect.origin];
+            NSPoint pt = [window convertBaseToScreen:rect.origin];
 #endif
-        NSSize sz = [[[window contentView] image] size];
-        result = cvRect(pt.x, pt.y, sz.width, sz.height);
+            NSSize sz = [[[window contentView] image] size];
+            result = cvRect(pt.x, pt.y, sz.width, sz.height);
+        }
     }
 
     __END__;


### PR DESCRIPTION
https://github.com/opencv/opencv/issues/26574 reported a memory leak occurring when calling `getWindowImageRect` on macOS. After investigation, it was found that the leak was caused by the `cvGetWindowRect_COCOA`, which created several NSObject instances without setting up a local autorelease pool. 

https://github.com/opencv/opencv/blob/1d4110884b3145f77281ec8402d5dc43da7b8634/modules/highgui/src/window_cocoa.mm#L665-L671

The patch has been compiled and tested on macOS 15.1.1, confirming that the bug is resolved.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
