### PR TITLE
Fix test_exif compilation when none of JPEG, PNG, AVIF is enabled

### DIFF
--- a/modules/imgcodecs/test/test_exif.cpp
+++ b/modules/imgcodecs/test/test_exif.cpp
@@ -2,6 +2,9 @@
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html
 
+#include <string>
+#include <vector>
+
 #include "test_precomp.hpp"
 
 namespace opencv_test { namespace {
@@ -110,7 +113,7 @@ TEST_P(Exif, exif_orientation)
     }
 }
 
-const string exif_files[] =
+const std::vector<std::string> exif_files
 {
 #ifdef HAVE_JPEG
     "readwrite/testExifOrientation_1.jpg",


### PR DESCRIPTION
When none of JPEG, PNG, AVIF is enabled, `exif_files` is a zero-length array, which is prohibited by C++ reference.

Reference: https://en.cppreference.com/w/cpp/language/array

CMake config: `cmake -GNinja -B opencv-build-4.x -S . -DWITH_PNG=OFF -DWITH_JPEG=OFF -DWITH_AVIF=OFF -DCMAKE_BUILD_TYPE=Debug`

build log
```
FAILED: modules/imgcodecs/CMakeFiles/opencv_test_imgcodecs.dir/test/test_exif.cpp.o
/usr/bin/ccache /usr/bin/c++ -DHAVE_IMGCODEC_HDR -DHAVE_IMGCODEC_PFM -DHAVE_IMGCODEC_PXM -DHAVE_IMGCODEC_SUNRASTER -DHAVE_WEBP -D_USE_MATH_DEFINES -D__OPENCV_BUILD=1 -D__OPENCV_TESTS=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/fanta/source/opencv/3rdparty/libwebp/src -I/home/fanta/source/opencv/opencv-build-4.x/3rdparty/ippicv/ippicv_lnx/icv/include -I/home/fanta/source/opencv/opencv-build-4.x/3rdparty/ippicv/ippicv_lnx/iw/include -I/home/fanta/source/opencv/opencv-build-4.x -I/home/fanta/source/opencv/modules/ts/include -I/home/fanta/source/opencv/modules/imgcodecs/include -I/home/fanta/source/opencv/modules/videoio/include -I/home/fanta/source/opencv/modules/core/include -I/home/fanta/source/opencv/modules/imgproc/include -I/home/fanta/source/opencv/modules/highgui/include -isystem /usr/include/openjpeg-2.5 -isystem /home/fanta/source/opencv/3rdparty/openexr/Half -isystem /home/fanta/source/opencv/3rdparty/openexr/Iex -isystem /home/fanta/source/opencv/3rdparty/openexr/IlmThread -isystem /home/fanta/source/opencv/3rdparty/openexr/Imath -isystem /home/fanta/source/opencv/3rdparty/openexr/IlmImf -isystem /home/fanta/source/opencv/opencv-build-4.x/3rdparty/openexr -fsigned-char -W -Wall -Wreturn-type -Wnon-virtual-dtor -Waddress -Wsequence-point -Wformat -Wformat-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wuninitialized -Wsuggest-override -Wno-delete-non-virtual-dtor -Wno-comment -Wimplicit-fallthrough=3 -Wno-strict-overflow -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -ffunction-sections -fdata-sections  -msse3 -fvisibility=hidden -fvisibility-inlines-hidden -Wno-deprecated-declarations -g  -O0 -DDEBUG -D_DEBUG -std=c++11 -fPIE -MD -MT modules/imgcodecs/CMakeFiles/opencv_test_imgcodecs.dir/test/test_exif.cpp.o -MF modules/imgcodecs/CMakeFiles/opencv_test_imgcodecs.dir/test/test_exif.cpp.o.d -o modules/imgcodecs/CMakeFiles/opencv_test_imgcodecs.dir/test/test_exif.cpp.o -c /home/fanta/source/opencv/modules/imgcodecs/test/test_exif.cpp
In file included from /home/fanta/source/opencv/modules/ts/include/opencv2/ts.hpp:128,
                 from /home/fanta/source/opencv/modules/imgcodecs/test/test_precomp.hpp:7,
                 from /home/fanta/source/opencv/modules/imgcodecs/test/test_exif.cpp:5:
/home/fanta/source/opencv/modules/imgcodecs/test/test_exif.cpp: In function ‘testing::internal::ParamGenerator<std::__cxx11::basic_string<char> > opencv_test::{anonymous}::gtest_ImgcodecsExif_EvalGenerator_()’:
/home/fanta/source/opencv/modules/imgcodecs/test/test_exif.cpp:148:22: error: no matching function for call to ‘ValuesIn(const std::string [0])’
  148 |     testing::ValuesIn(exif_files));
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:19024:66: note: in definition of macro ‘INSTANTIATE_TEST_CASE_P’
19024 |       gtest_##prefix##test_case_name##_EvalGenerator_() { return generator; } \
      |                                                                  ^~~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17913:1: note: candidate: ‘template<class ForwardIterator> testing::internal::ParamGenerator<typename testing::internal::IteratorTraits<Iterator>::value_type> testing::ValuesIn(ForwardIterator, ForwardIterator)’
17913 | ValuesIn(ForwardIterator begin, ForwardIterator end) {
      | ^~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17913:1: note:   candidate expects 2 arguments, 1 provided
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17921:29: note: candidate: ‘template<class T, long unsigned int N> testing::internal::ParamGenerator<T> testing::ValuesIn(const T (&)[N])’
17921 | internal::ParamGenerator<T> ValuesIn(const T (&array)[N]) {
      |                             ^~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17921:29: note:   template argument deduction/substitution failed:
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17926:58: note: candidate: ‘template<class Container> testing::internal::ParamGenerator<typename Container::value_type> testing::ValuesIn(const Container&)’
17926 | internal::ParamGenerator<typename Container::value_type> ValuesIn(
      |                                                          ^~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17926:58: note:   template argument deduction/substitution failed:
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h: In substitution of ‘template<class Container> testing::internal::ParamGenerator<typename Container::value_type> testing::ValuesIn(const Container&) [with Container = std::__cxx11::basic_string<char> [0]]’:
/home/fanta/source/opencv/modules/imgcodecs/test/test_exif.cpp:147:1:   required from here
  148 |     testing::ValuesIn(exif_files));
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/home/fanta/source/opencv/modules/ts/include/opencv2/ts/ts_gtest.h:17926:58: error: ‘std::__cxx11::basic_string<char> [0]’ is not a class, struct, or union type
17926 | internal::ParamGenerator<typename Container::value_type> ValuesIn(
      |                                                          ^~~~~~~~
[534/541] Building CXX object modules/imgcodecs/CMakeFiles/opencv_test_imgcodecs.dir/test/test_tiff.cpp.o
ninja: build stopped: subcommand failed.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
