### PR TITLE
Remove useless -Wno-long-long option

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -191,11 +191,6 @@ if(CV_GCC OR CV_CLANG OR CV_ICX)
   endif()
   add_extra_compiler_option(-fdiagnostics-show-option)
 
-  # The -Wno-long-long is required in 64bit systems when including system headers.
-  if(X86_64)
-    add_extra_compiler_option(-Wno-long-long)
-  endif()
-
   # We need pthread's, unless we have explicitly disabled multi-thread execution.
   if(NOT OPENCV_DISABLE_THREAD_SUPPORT
       AND (


### PR DESCRIPTION
According to GCC doc, -Wlong-long: Warn if long long type is used. This is enabled by either -Wpedantic or -Wtraditional in ISO C90 and C++98 modes. To inhibit the warning messages, use -Wno-long-long.

OpenCV 4.x requires C++11. As result, this option is useless.

Ref: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
