### PR TITLE
Fix Syntax warning in ts summary.py

### DIFF
--- a/modules/ts/misc/summary.py
+++ b/modules/ts/misc/summary.py
@@ -37,8 +37,8 @@ import testlog_parser, sys, os, xml, glob, re
 from table_formatter import *
 from optparse import OptionParser
 
-numeric_re = re.compile("(\d+)")
-cvtype_re = re.compile("(8U|8S|16U|16S|32S|32F|64F)C(\d{1,3})")
+numeric_re = re.compile(r"(\d+)")
+cvtype_re = re.compile(r"(8U|8S|16U|16S|32S|32F|64F)C(\d{1,3})")
 cvtypes = { '8U': 0, '8S': 1, '16U': 2, '16S': 3, '32S': 4, '32F': 5, '64F': 6 }
 
 convert = lambda text: int(text) if text.isdigit() else text


### PR DESCRIPTION
```
C:\Users\voidr\Documents\develop\source\opencv\modules\ts\misc\summary.py:41: SyntaxWarning: invalid escape sequence '\d'
  numeric_re = re.compile("(\d+)")
C:\Users\voidr\Documents\develop\source\opencv\modules\ts\misc\summary.py:42: SyntaxWarning: invalid escape sequence '\d'
  cvtype_re = re.compile("(8U|8S|16U|16S|32S|32F|64F)C(\d{1,3})")
```

Related: https://github.com/opencv/opencv/pull/26579

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
