### PR TITLE
Fix VideoCapture fails to read single image with digits in name

### DIFF
--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -113,16 +113,9 @@ void CvCapture_Images::close()
 
 bool CvCapture_Images::grabFrame()
 {
-    cv::String filename;
-    if (length == 1)
-        if (currentframe < length)
-            filename = filename_pattern;
-        else
-        {
-            return false;
-        }
-    else
-        filename = cv::format(filename_pattern.c_str(), (int)(firstframe + currentframe));
+    if (length == 1 && currentframe >= length)
+        return false;
+    const cv::String filename = cv::format(filename_pattern.c_str(), (int)(firstframe + currentframe));
     CV_Assert(!filename.empty());
 
     if (grabbedInOpen)

--- a/modules/videoio/test/test_images.cpp
+++ b/modules/videoio/test/test_images.cpp
@@ -288,14 +288,16 @@ TEST(videoio_images, extract_pattern)
 TEST(videoio_images, bug_26457)
 {
     ImageCollection col;
-    col.generate(1);
+    col.generate(1u);
+    ASSERT_EQ(col.getCount(), 1u);
+
     VideoCapture cap(col.getFirstFilename(), CAP_IMAGES);
     ASSERT_TRUE(cap.isOpened());
+
     Mat img;
     const bool read_res = cap.read(img);
     EXPECT_TRUE(read_res);
     EXPECT_MAT_N_DIFF(img, col.getFirstFrame(), 0);
-    EXPECT_EQ(col.getCount(), 1);
 }
 
 // TODO: should writer overwrite files?

--- a/modules/videoio/test/test_images.cpp
+++ b/modules/videoio/test/test_images.cpp
@@ -285,6 +285,19 @@ TEST(videoio_images, extract_pattern)
     EXPECT_THROW(cv::icvExtractPattern("1.png", NULL), cv::Exception);
 }
 
+TEST(videoio_images, bug_26457)
+{
+    ImageCollection col;
+    col.generate(1);
+    VideoCapture cap(col.getFirstFilename(), CAP_IMAGES);
+    ASSERT_TRUE(cap.isOpened());
+    Mat img;
+    const bool read_res = cap.read(img);
+    EXPECT_TRUE(read_res);
+    EXPECT_MAT_N_DIFF(img, col.getFirstFrame(), 0);
+    EXPECT_EQ(col.getCount(), 1);
+}
+
 // TODO: should writer overwrite files?
 // TODO: is clamping good for seeking?
 // TODO: missing files? E.g. 3, 4, 6, 7, 8 (should it finish OR jump over OR return empty frame?)


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #26457 

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
