### PR TITLE
Remove MSVS 2013 related

### DIFF
--- a/cmake/checks/cpu_avx.cpp
+++ b/cmake/checks/cpu_avx.cpp
@@ -1,4 +1,4 @@
-#if !defined __AVX__ // MSVC supports this flag since MSVS 2013
+#if !defined __AVX__
 #error "__AVX__ define is missing"
 #endif
 #include <immintrin.h>

--- a/cmake/checks/cpu_avx2.cpp
+++ b/cmake/checks/cpu_avx2.cpp
@@ -1,4 +1,4 @@
-#if !defined __AVX2__ // MSVC supports this flag since MSVS 2013
+#if !defined __AVX2__
 #error "__AVX2__ define is missing"
 #endif
 #include <immintrin.h>

--- a/modules/core/include/opencv2/core/cvstd_wrapper.hpp
+++ b/modules/core/include/opencv2/core/cvstd_wrapper.hpp
@@ -49,12 +49,7 @@ private:
     typedef decltype(has_parenthesis_operator_check<C>(0)) type;
 
 public:
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
     static CV_CONSTEXPR bool value = type::value;
-#else
-    // support MSVS 2013
-    static const int value = type::value;
-#endif
 };
 } // namespace sfinae
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -3292,13 +3292,7 @@ public:
                            int _borderType, const Scalar &_borderValue) :
         ParallelLoopBody(), src(_src), dst(_dst), M(_M), interpolation(_interpolation),
         borderType(_borderType), borderValue(_borderValue)
-    {
-#if defined(_MSC_VER) && _MSC_VER == 1800 /* MSVS 2013 */ && CV_AVX
-        // details: https://github.com/opencv/opencv/issues/11026
-        borderValue.val[2] = _borderValue.val[2];
-        borderValue.val[3] = _borderValue.val[3];
-#endif
-    }
+    {}
 
     virtual void operator() (const Range& range) const CV_OVERRIDE
     {

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -142,12 +142,7 @@ public:
      * When setting a resolution for stitching, this values is a placeholder
      * for preserving the original resolution.
      */
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
     static constexpr double ORIG_RESOL = -1.0;
-#else
-    // support MSVS 2013
-    static const double ORIG_RESOL; // Initialized in stitcher.cpp
-#endif
 
     enum Status
     {

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -44,12 +44,6 @@
 
 namespace cv {
 
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
-// Stitcher::ORIG_RESOL is initialized in stitching.hpp.
-#else
-const double Stitcher::ORIG_RESOL = -1.0;
-#endif
-
 Ptr<Stitcher> Stitcher::create(Mode mode)
 {
     Ptr<Stitcher> stitcher = makePtr<Stitcher>();


### PR DESCRIPTION
OpenCV 5.x requires MSVC >= 2017 15.7 and MSVS 2013 is EOF currently.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
