### PR TITLE
ffmpeg/4.x: update FFmpeg wrapper 2024.12

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/4.x_20240522
-# Binaries were created for OpenCV: 8393885a39dac1e650bf5d0aaff84c04ad8bcdd3
-ocv_update(FFMPEG_BINARIES_COMMIT "394dca6ceb3085c979415e6385996b6570e94153")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "bdfbd1efb295f3e54c07d2cb7a843bf9")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "bfef029900f788480a363d6dc05c4f0e")
+# Binaries branch name: ffmpeg/4.x_20241226
+# Binaries were created for OpenCV: 09892c9d1706f40342bda0bc404580f63492d9f8
+ocv_update(FFMPEG_BINARIES_COMMIT "d63d7c154c57242bf2283be61166be2bd30ec47e")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "642b94d032a8292b07550126934173f6")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "a8c3560c8f20e1ae465bef81580fa92c")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
 
 function(download_win_ffmpeg script_var)

--- a/modules/imgproc/CMakeLists.txt
+++ b/modules/imgproc/CMakeLists.txt
@@ -12,6 +12,10 @@ ocv_add_dispatched_file(smooth SSE2 SSE4_1 AVX2)
 ocv_add_dispatched_file(sumpixels SSE2 AVX2 AVX512_SKX)
 ocv_define_module(imgproc opencv_core WRAP java objc python js)
 
+if(OPENCV_CORE_EXCLUDE_C_API)
+  ocv_target_compile_definitions(${the_module} PRIVATE "OPENCV_EXCLUDE_C_API=1")
+endif()
+
 if(HAVE_IPP)
   # OPENCV_IPP_ENABLE_ALL is defined in modules/core/CMakeList.txt
   OCV_OPTION(OPENCV_IPP_GAUSSIAN_BLUR "Enable IPP optimizations for GaussianBlur (+8Mb in binary size)" OPENCV_IPP_ENABLE_ALL)

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -387,6 +387,7 @@ void cvtColor( InputArray _src, OutputArray _dst, int code, int dcn, AlgorithmHi
 }
 } //namespace cv
 
+#ifndef OPENCV_EXCLUDE_C_API
 
 CV_IMPL void
 cvCvtColor( const CvArr* srcarr, CvArr* dstarr, int code )
@@ -397,3 +398,5 @@ cvCvtColor( const CvArr* srcarr, CvArr* dstarr, int code )
     cv::cvtColor(src, dst, code, dst.channels());
     CV_Assert( dst.data == dst0.data );
 }
+
+#endif

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -4245,6 +4245,7 @@ void cv::resize( InputArray _src, OutputArray _dst, Size dsize,
     hal::resize(src.type(), src.data, src.step, src.cols, src.rows, dst.data, dst.step, dst.cols, dst.rows, inv_scale_x, inv_scale_y, interpolation);
 }
 
+#ifndef OPENCV_EXCLUDE_C_API
 
 CV_IMPL void
 cvResize( const CvArr* srcarr, CvArr* dstarr, int method )
@@ -4255,4 +4256,5 @@ cvResize( const CvArr* srcarr, CvArr* dstarr, int method )
         (double)dst.rows/src.rows, method );
 }
 
+#endif
 /* End of file. */

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -296,10 +296,6 @@ INSTANTIATE_TEST_CASE_P(/**/, videoio_container_get, testing::ValuesIn(videoio_c
 typedef tuple<string, string, int, int, bool, bool> videoio_encapsulate_params_t;
 typedef testing::TestWithParam< videoio_encapsulate_params_t > videoio_encapsulate;
 
-#if defined(WIN32)  // remove when FFmpeg wrapper includes PR25874
-#define WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE
-#endif
-
 TEST_P(videoio_encapsulate, write)
 {
     const VideoCaptureAPIs api = CAP_FFMPEG;
@@ -331,11 +327,10 @@ TEST_P(videoio_encapsulate, write)
         Mat rawFrame;
         for (int i = 0; i < nFrames; i++) {
             ASSERT_TRUE(capRaw.read(rawFrame));
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
             if (setPts && i == 0) {
-                ASSERT_TRUE(container.set(VIDEOWRITER_PROP_DTS_DELAY, capRaw.get(CAP_PROP_DTS_DELAY)));
+                double dts = capRaw.get(CAP_PROP_DTS_DELAY);
+                ASSERT_TRUE(container.set(VIDEOWRITER_PROP_DTS_DELAY, dts)) << "dts=" << dts;
             }
-#endif
             ASSERT_FALSE(rawFrame.empty());
             if (i == 0 && mpeg4) {
                 Mat tmp = rawFrame.clone();
@@ -346,11 +341,10 @@ TEST_P(videoio_encapsulate, write)
                 memcpy(rawFrame.data, extraData.data, extraData.total());
                 memcpy(rawFrame.data + extraData.total(), tmp.data, tmp.total());
             }
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
             if (setPts) {
-                ASSERT_TRUE(container.set(VIDEOWRITER_PROP_PTS, capRaw.get(CAP_PROP_PTS)));
+                double pts = capRaw.get(CAP_PROP_PTS);
+                ASSERT_TRUE(container.set(VIDEOWRITER_PROP_PTS, pts)) << "pts=" << pts;
             }
-#endif
             container.write(rawFrame);
         }
         container.release();
@@ -381,11 +375,9 @@ TEST_P(videoio_encapsulate, write)
             const bool keyFrameActual = capActualRaw.get(CAP_PROP_LRF_HAS_KEY_FRAME) == 1.;
             const bool keyFrameReference = idrPeriod ? i % idrPeriod == 0 : 1;
             ASSERT_EQ(keyFrameReference, keyFrameActual);
-#if !defined(WIN32_WAIT_FOR_FFMPEG_WRAPPER_UPDATE)
             if (tsWorking) {
                 ASSERT_EQ(round(capReference.get(CAP_PROP_POS_MSEC)), round(capActual.get(CAP_PROP_POS_MSEC)));
             }
-#endif
         }
     }
 


### PR DESCRIPTION
Merge with 3rdparty: https://github.com/opencv/opencv_3rdparty/pull/91

FFmpeg 4.4.5
OpenH264 version 1.8.0
libVPX version 1.15.0
libAOM version 3.11.0

previous update: https://github.com/opencv/opencv/pull/25619

```
allow_multiple_commits=1
force_builders=Win64,Win32
```