### PR TITLE
Add warp polar

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -284,7 +284,10 @@ enum InterpolationFlags{
 enum WarpPolarMode
 {
     WARP_POLAR_LINEAR = 0, ///< Remaps an image to/from polar space.
-    WARP_POLAR_LOG = 256   ///< Remaps an image to/from semilog-polar space.
+    WARP_POLAR_LOG = 256,   ///< Remaps an image to/from semilog-polar space.
+    WARP_POLAR_EXP = 128,  ///< Remaps an image to/from semiexp-polar space.
+    WARP_POLAR_SQRT = 64,   ///< Remaps an image to/from semisqrt-polar space.
+    WARP_POLAR_SQUARE = 32   ///< Remaps an image to/from semisquare-polar space. 
 };
 
 enum InterpolationMasks {

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -287,7 +287,7 @@ enum WarpPolarMode
     WARP_POLAR_LOG = 256,  ///< Remaps an image to/from semilog-polar space.
     WARP_POLAR_EXP = 128,  ///< Remaps an image to/from semiexp-polar space.
     WARP_POLAR_SQRT = 64,  ///< Remaps an image to/from semisqrt-polar space.
-    WARP_POLAR_SQUARE = 32 ///< Remaps an image to/from semisquare-polar space. 
+    WARP_POLAR_SQUARE = 32 ///< Remaps an image to/from semisquare-polar space.
 };
 
 enum InterpolationMasks {

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -284,10 +284,10 @@ enum InterpolationFlags{
 enum WarpPolarMode
 {
     WARP_POLAR_LINEAR = 0, ///< Remaps an image to/from polar space.
-    WARP_POLAR_LOG = 256,   ///< Remaps an image to/from semilog-polar space.
+    WARP_POLAR_LOG = 256,  ///< Remaps an image to/from semilog-polar space.
     WARP_POLAR_EXP = 128,  ///< Remaps an image to/from semiexp-polar space.
-    WARP_POLAR_SQRT = 64,   ///< Remaps an image to/from semisqrt-polar space.
-    WARP_POLAR_SQUARE = 32   ///< Remaps an image to/from semisquare-polar space. 
+    WARP_POLAR_SQRT = 64,  ///< Remaps an image to/from semisqrt-polar space.
+    WARP_POLAR_SQUARE = 32 ///< Remaps an image to/from semisquare-polar space. 
 };
 
 enum InterpolationMasks {

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -3735,9 +3735,9 @@ Enhancements and updates by Shuaikai Shi, 2024:
 - Added the following macro definitions:
   - WARP_POLAR_EXP: Enables exponential sampling along the radial direction.
   - WARP_POLAR_SQRT: Supports radial square root sampling (similar to WARP_POLAR_LOG).
-  - WARP_POLAR_SQUARE: Performs radial square sampling, compensating for shrinking 
+  - WARP_POLAR_SQUARE: Performs radial square sampling, compensating for shrinking
     sectors to preserve edge details.
-These updates extend the functionality of polar transformations, 
+These updates extend the functionality of polar transformations,
 making them more robust and versatile for diverse image processing tasks.
 ****************************************************************************************/
 void cv::warpPolar(InputArray _src, OutputArray _dst, Size dsize,
@@ -3785,13 +3785,13 @@ void cv::warpPolar(InputArray _src, OutputArray _dst, Size dsize,
                 bufRhos[rho] = (float)(std::log(rho * Kmag+1.0)/std::log( Kmag*dsize.width+1)*maxRadius);
         }
         else if (semiSqrt)
-        {   
+        {
             double Kmag = std::sqrt(maxRadius)/ dsize.width;
             for (rho = 0; rho < dsize.width; rho++)
                 bufRhos[rho] = (float)(std::pow(rho * Kmag,2));
         }
         else if (semiSquare)
-        {   
+        {
             double Kmag =std::pow(maxRadius,2) / dsize.width;
             for (rho = 0; rho < dsize.width; rho++)
                 bufRhos[rho] = (float)(std::sqrt(rho * Kmag));
@@ -3870,19 +3870,19 @@ void cv::warpPolar(InputArray _src, OutputArray _dst, Size dsize,
                 log(bufp, bufp);
             }
             if (semiExp)
-            { 
+            {
                 bufp=bufp/maxRadius;
                 bufp=bufp*std::log( Kmag*dsize.width+1);
                 exp(bufp,bufp);
                 bufp -= 1.f;
             }
             if (semiSqrt)
-            {   
+            {
                 sqrt(bufp, bufp);
             }
             if (semiSquare)
-            {   
-                cv::pow(bufp,2,bufp); 
+            {
+                cv::pow(bufp,2,bufp);
             }
             for (x = 0; x < dsize.width; x++)
             {

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1714,7 +1714,36 @@ TEST(Imgproc_warpPolar, identity)
         double psnr = cv::PSNR(in(roi), src(roi));
         EXPECT_LE(25, psnr) << "iteration=" << ki;
     }
+    // test expPolar
+    src = in.clone();
+    for (int ki = 1; ki <= 5; ki++)
+    {
+        warpPolar(src, dst, src.size(),center, radius, flags + WARP_POLAR_EXP + cv::WARP_INVERSE_MAP );
+        warpPolar(dst, src, src.size(),center, radius, flags + WARP_POLAR_EXP);
 
+        double psnr = cv::PSNR(in(roi), src(roi));
+        EXPECT_LE(25, psnr) << "iteration=" << ki;
+    }
+    // test sqrtPolar
+    src = in.clone();
+    for (int ki = 1; ki <= 5; ki++)
+    {
+        warpPolar(src, dst, src.size(),center, radius, flags + WARP_POLAR_SQRT + cv::WARP_INVERSE_MAP );
+        warpPolar(dst, src, src.size(),center, radius, flags + WARP_POLAR_SQRT);
+
+        double psnr = cv::PSNR(in(roi), src(roi));
+        EXPECT_LE(25, psnr) << "iteration=" << ki;
+    }
+    // test squarePolar
+    src = in.clone();
+    for (int ki = 1; ki <= 5; ki++)
+    {
+        warpPolar(src, dst, src.size(),center, radius, flags + WARP_POLAR_SQUARE + cv::WARP_INVERSE_MAP );
+        warpPolar(dst, src, src.size(),center, radius, flags + WARP_POLAR_SQUARE);
+
+        double psnr = cv::PSNR(in(roi), src(roi));
+        EXPECT_LE(25, psnr) << "iteration=" << ki;
+    }
 #if 0
     Mat all(N*2+2,N*2+2, src.type(), Scalar(0,0,255));
     in.copyTo(all(Rect(0,0,N,N)));


### PR DESCRIPTION
Enhancements and updates warpPolar function:

Introduced new radial non-uniform sampling methods.
- Resolved edge information loss and omissions in cart2pol transformations, improving accuracy for image boundaries.
- Added the following macro definitions:
    - WARP_POLAR_EXP: Enables exponential sampling along the radial direction.
    - WARP_POLAR_SQRT: Similar to logPolar, supports square root sampling for smoother
scaling.
    - WARP_POLAR_SQUARE: Performs radial square sampling, compensating for shrinking
sectors to preserve edge details.

These updates significantly extend the functionality of polar transformations,
making them more robust and versatile for diverse image processing tasks.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake