### PR TITLE
ChAruco detector: stop-gap measure for poor detection rate on tough perspective

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
@@ -16,6 +16,7 @@ struct CV_EXPORTS_W_SIMPLE CharucoParameters {
     CV_WRAP CharucoParameters() {
         minMarkers = 2;
         tryRefineMarkers = false;
+        checkMarkers = true;
     }
     /// cameraMatrix optional 3x3 floating-point camera matrix
     CV_PROP_RW Mat cameraMatrix;
@@ -28,6 +29,9 @@ struct CV_EXPORTS_W_SIMPLE CharucoParameters {
 
     /// try to use refine board, default false
     CV_PROP_RW bool tryRefineMarkers;
+
+    // run check to verify that markers belong to the same board, default true
+    CV_PROP_RW bool checkMarkers;
 };
 
 class CV_EXPORTS_W CharucoDetector : public Algorithm {

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -335,7 +335,7 @@ struct CharucoDetector::CharucoDetectorImpl {
         InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : tmpMarkerCorners;
         InputOutputArray _markerIds = markerIds.needed() ? markerIds : tmpMarkerIds;
         detectBoard(image, charucoCorners, charucoIds, _markerCorners, _markerIds);
-        if (checkBoard(_markerCorners, _markerIds, charucoCorners, charucoIds) == false) {
+        if (charucoParameters.checkMarkers && checkBoard(_markerCorners, _markerIds, charucoCorners, charucoIds) == false) {
             CV_LOG_DEBUG(NULL, "ChArUco board is built incorrectly");
             charucoCorners.release();
             charucoIds.release();


### PR DESCRIPTION
Maybe just a discussion starter and potential quick-fix for charuco detector regression since OpenCV 4.7.

Related to #25850 and few other related Charuco tickets.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
