### PR TITLE
Speed up and reduce memory consumption for findContours

### DIFF
--- a/modules/imgproc/src/contours_new.cpp
+++ b/modules/imgproc/src/contours_new.cpp
@@ -368,10 +368,6 @@ CNode& ContourScanner_::makeContour(schar& nbd_, const bool is_hole, const int x
     const Point start_pt(x - (is_hole ? 1 : 0), y);
 
     CNode& res = tree.newElem();
-    if (isChain)
-        res.body.codes.reserve(200);
-    else
-        res.body.pts.reserve(200);
     res.body.isHole = is_hole;
     res.body.isChain = isChain;
     res.body.origin = start_pt + offset;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Related to #26683 

I ran reproducer from issue with one iteration.

Before
```
iteration 0 took 3.1967720985412598 seconds. Total process memory: 5,331,820,544
```

After
```
iteration 0 took 1.3795826435089111 seconds. Total process memory: 500,125,696
```

Speedup more than `2` times and memory consumption reduction more than `10` times

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
