### PR TITLE
fix: cast coordinates to int32 for compatibility with line function

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
+++ b/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
@@ -36,7 +36,8 @@ Now let's create a function, draw which takes the corners in the chessboard (obt
 **cv.findChessboardCorners()**) and **axis points** to draw a 3D axis.
 @code{.py}
 def draw(img, corners, imgpts):
-    corner = tuple(corners[0].ravel())
+    corner = tuple(corners[0].ravel().astype("int32"))
+    imgpts = imgpts.astype("int32")
     img = cv.line(img, corner, tuple(imgpts[0].ravel()), (255,0,0), 5)
     img = cv.line(img, corner, tuple(imgpts[1].ravel()), (0,255,0), 5)
     img = cv.line(img, corner, tuple(imgpts[2].ravel()), (0,0,255), 5)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work: [https://github.com/opencv/opencv/issues/26692](https://github.com/opencv/opencv/issues/26692)
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name. (Not applicable)
- [ ] The feature is well documented and sample code can be built with the project CMake. (Not applicable)
