### PR TITLE
Fix integer overflow in in cv::BmpDecoder::readHeader

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -208,7 +208,12 @@ bool  BmpDecoder::readHeader()
     // in 32 bit case alpha channel is used - so require CV_8UC4 type
     m_type = iscolor ? ((m_bpp == 32 && m_rle_code != BMP_RGB) ? CV_8UC4 : CV_8UC3 ) : CV_8UC1;
     m_origin = m_height > 0 ? ORIGIN_BL : ORIGIN_TL;
-    m_height = std::abs(m_height);
+    if ( m_height == std::numeric_limits<int>::min() ) {
+        // abs(std::numeric_limits<int>::min()) is undefined behavior.
+        result = false;
+    } else {
+        m_height = std::abs(m_height);
+    }
 
     if( !result )
     {


### PR DESCRIPTION
Bug: oss-fuzz:371546812

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
