### PR TITLE
Fix heap buffer overflow in cv::PngDecoder::read_from_io

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -655,7 +655,7 @@ size_t PngDecoder::read_from_io(void* _Buffer, size_t _ElementSize, size_t _Elem
     if (m_f)
         return fread(_Buffer, _ElementSize, _ElementCount, m_f);
 
-    if (m_buf_pos > m_buf.cols * m_buf.rows * m_buf.elemSize())
+    if (m_buf_pos + _ElementSize > m_buf.cols * m_buf.rows * m_buf.elemSize())
         CV_Error(Error::StsInternal, "PNG input buffer is incomplete");
 
     memcpy( _Buffer, m_buf.ptr() + m_buf_pos, _ElementSize );


### PR DESCRIPTION
If the condition is not fixed, the memcpy below can do an out of boundary read

Bug: oss-fuzz:386688710

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
