### PR TITLE
Fix matchTemplate with mask crash

### DIFF
--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -850,7 +850,8 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
 
         // CCorr(I', T') = CCorr(I, T'*M) - sum(T'*M)/sum(M)*CCorr(I, M)
         // It does not matter what to use Mat/MatExpr, it should be evaluated to perform assign subtraction
-        Mat temp_res = img_mask_corr.mul(sum(templx_mask).div(mask_sum));
+        Mat temp_res;
+        multiply(img_mask_corr, sum(templx_mask).div(mask_sum), temp_res);
         if (img.channels() == 1)
         {
             result -= temp_res;
@@ -881,8 +882,11 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
             Mat img_mask2_corr(corrSize, img.type());
             crossCorr(img2, mask2, norm_imgx, Point(0,0), 0, 0);
             crossCorr(img, mask2, img_mask2_corr, Point(0,0), 0, 0);
-            temp_res = img_mask_corr.mul(Scalar(1.0, 1.0, 1.0, 1.0).div(mask_sum))
-                           .mul(img_mask_corr.mul(mask2_sum.div(mask_sum)) - 2 * img_mask2_corr);
+            Mat temp_res1;
+            multiply(img_mask_corr, Scalar(1.0, 1.0, 1.0, 1.0).div(mask_sum), temp_res1);
+            Mat temp_res2;
+            multiply(img_mask_corr, mask2_sum.div(mask_sum), temp_res2);
+            temp_res = temp_res1.mul(temp_res2 - 2 * img_mask2_corr);
             if (img.channels() == 1)
             {
                 norm_imgx += temp_res;

--- a/modules/imgproc/test/test_templmatchmask.cpp
+++ b/modules/imgproc/test/test_templmatchmask.cpp
@@ -275,4 +275,16 @@ INSTANTIATE_TEST_CASE_P(MultiChannelMask, Imgproc_MatchTemplateWithMask2,
         Values(cv::TM_SQDIFF, cv::TM_SQDIFF_NORMED, cv::TM_CCORR, cv::TM_CCORR_NORMED,
                cv::TM_CCOEFF, cv::TM_CCOEFF_NORMED)));
 
+TEST(Imgproc_MatchTemplateWithMask, bug_26389) {
+    const Mat image = Mat::ones(Size(10, 10), CV_8UC1);
+    const Mat templ = Mat::ones(Size(10, 7), CV_8UC1);
+    const Mat mask = Mat::ones(Size(10, 7), CV_8UC1);
+
+    for (const int method : {TM_CCOEFF, TM_CCOEFF_NORMED})
+    {
+        Mat result;
+        matchTemplate(image, templ, result, method, mask);
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #26389 

Problem is in using `Mat::mul` method when second argument is `Matx41d` - in the end it calls `arithm_op` but second argument is casted to `Mat` before, but in `arithm_op` there is logic which relies on arguments perfect forwarding and it stops working https://github.com/opencv/opencv/blob/4d26e16af8f45dc8d356770749ae273c8992aa4e/modules/core/src/arithm.cpp#L642-L644

`multiply` function is equivalent to `Mat::mul` method (I hope so) with second argument perfect forwarding, so necessary logic continues to work

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake