### PR TITLE
Fix tests for ellipse fitting

### DIFF
--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -64,7 +64,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_1, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -102,7 +102,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_2, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -151,7 +151,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_3, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -219,7 +219,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_4, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -289,7 +289,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_5, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -357,7 +357,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_6, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -425,7 +425,7 @@ TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -64,7 +64,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_1, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -102,7 +102,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_2, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -151,7 +151,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_3, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -219,7 +219,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_4, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -289,7 +289,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_5, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -357,7 +357,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_6, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}
@@ -425,7 +425,7 @@ TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
     for (size_t i=0; i <=3; i++) {
         Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
         float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; i <=3; i++) {
+        for (size_t j=1; j <=3; j++) {
             diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
             float dd = diff.x * diff.x + diff.y * diff.y;
             if(dd<d){d=dd;}


### PR DESCRIPTION
### Pull Request Readiness Checklist

Before comparison of ellipses was incomplete - only one point of test ellipse with index `j = 1` was involved in inner loop (instead of all for complete comparison)

Related to #26694 

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
