### PR TITLE
Add examples for each `cv::BorderTypes` enum types in the documentation

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -263,8 +263,72 @@ enum DftFlags {
     DCT_ROWS           = DFT_ROWS
 };
 
-//! Various border types, image boundaries are denoted with `|`
-//! @see borderInterpolate, copyMakeBorder
+/*! Various border types, image boundaries are denoted with the `|` character in the table below, when describing each method.
+
+The following examples show the result of the @ref copyMakeBorder call according to different methods.
+Input image is `6x4` (width x height) size and the @ref copyMakeBorder function is used with a border size of 2 pixels
+in each direction, giving a resulting image of `10x8` resolution.
+
+@code
+Input image:
+[[ 0  1  2  3  4  5]
+ [ 6  7  8  9 10 11]
+ [12 13 14 15 16 17]
+ [18 19 20 21 22 23]]
+
+Border type: BORDER_CONSTANT (a constant value of 255 is used)
+[[255 255 255 255 255 255 255 255 255 255]
+ [255 255 255 255 255 255 255 255 255 255]
+ [255 255   0   1   2   3   4   5 255 255]
+ [255 255   6   7   8   9  10  11 255 255]
+ [255 255  12  13  14  15  16  17 255 255]
+ [255 255  18  19  20  21  22  23 255 255]
+ [255 255 255 255 255 255 255 255 255 255]
+ [255 255 255 255 255 255 255 255 255 255]]
+
+Border type: BORDER_REPLICATE
+[[ 0  0  0  1  2  3  4  5  5  5]
+ [ 0  0  0  1  2  3  4  5  5  5]
+ [ 0  0  0  1  2  3  4  5  5  5]
+ [ 6  6  6  7  8  9 10 11 11 11]
+ [12 12 12 13 14 15 16 17 17 17]
+ [18 18 18 19 20 21 22 23 23 23]
+ [18 18 18 19 20 21 22 23 23 23]
+ [18 18 18 19 20 21 22 23 23 23]]
+
+Border type: BORDER_REFLECT
+[[ 7  6  6  7  8  9 10 11 11 10]
+ [ 1  0  0  1  2  3  4  5  5  4]
+ [ 1  0  0  1  2  3  4  5  5  4]
+ [ 7  6  6  7  8  9 10 11 11 10]
+ [13 12 12 13 14 15 16 17 17 16]
+ [19 18 18 19 20 21 22 23 23 22]
+ [19 18 18 19 20 21 22 23 23 22]
+ [13 12 12 13 14 15 16 17 17 16]]
+
+Border type: BORDER_WRAP
+[[16 17 12 13 14 15 16 17 12 13]
+ [22 23 18 19 20 21 22 23 18 19]
+ [ 4  5  0  1  2  3  4  5  0  1]
+ [10 11  6  7  8  9 10 11  6  7]
+ [16 17 12 13 14 15 16 17 12 13]
+ [22 23 18 19 20 21 22 23 18 19]
+ [ 4  5  0  1  2  3  4  5  0  1]
+ [10 11  6  7  8  9 10 11  6  7]]
+
+Border type: BORDER_REFLECT_101
+[[14 13 12 13 14 15 16 17 16 15]
+ [ 8  7  6  7  8  9 10 11 10  9]
+ [ 2  1  0  1  2  3  4  5  4  3]
+ [ 8  7  6  7  8  9 10 11 10  9]
+ [14 13 12 13 14 15 16 17 16 15]
+ [20 19 18 19 20 21 22 23 22 21]
+ [14 13 12 13 14 15 16 17 16 15]
+ [ 8  7  6  7  8  9 10 11 10  9]]
+@endcode
+
+@see borderInterpolate, copyMakeBorder
+ */
 enum BorderTypes {
     BORDER_CONSTANT    = 0, //!< `iiiiii|abcdefgh|iiiiiii`  with some specified `i`
     BORDER_REPLICATE   = 1, //!< `aaaaaa|abcdefgh|hhhhhhh`


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

---

I have added the results of calling `copyMakeBorder()` for each `cv::BorderTypes` on a simple example in the documentation for better understanding.

- before:

![image](https://github.com/user-attachments/assets/dec2475e-4099-4277-8c87-7dbea821d4cb)

---

- after:

![image](https://github.com/user-attachments/assets/656ce5b4-60ba-45b2-9ffd-b11aef32e80f)

