### PR TITLE
Remove code duplication from tests for ellipse fitting

### DIFF
--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -8,6 +8,25 @@
 
 namespace opencv_test { namespace {
 
+static bool checkEllipse(const RotatedRect& ellipseAMSTest, const RotatedRect& ellipseAMSTrue, const float tol) {
+    Point2f         ellipseAMSTrueVertices[4];
+    Point2f         ellipseAMSTestVertices[4];
+    ellipseAMSTest.points(ellipseAMSTestVertices);
+    ellipseAMSTrue.points(ellipseAMSTrueVertices);
+    float AMSDiff = 0.0f;
+    for (size_t i=0; i <=3; i++) {
+        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
+        float d = diff.x * diff.x + diff.y * diff.y;
+        for (size_t j=1; j <=3; j++) {
+            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
+            float dd = diff.x * diff.x + diff.y * diff.y;
+            if(dd<d){d=dd;}
+        }
+        AMSDiff += std::sqrt(d);
+    }
+    return AMSDiff < tol;
+}
+
 TEST(Imgproc_FitEllipseAMS_Issue_1, accuracy) {
     vector<Point2f>pts;
     pts.push_back(Point2f(173.41854895999165f, 125.84473135880411f));
@@ -51,29 +70,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_1, accuracy) {
     pts.push_back(Point2f(6.719616410428614f, 50.15263031354927f));
     pts.push_back(Point2f(5.122267598477748f, 46.03603214691343f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(94.4037f, 84.743f), Size2f(190.614f, 153.543f), 19.832f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseAMS_Issue_2, accuracy) {
@@ -89,29 +91,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_2, accuracy) {
     pts.push_back(Point2f(91.66999301197541f, 300.57303988670515f));
     pts.push_back(Point2f(28.286233855826133f, 268.0670159317756f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(223.917f, 169.701f), Size2f(456.628f, 277.809f), -12.6378f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 
@@ -138,29 +123,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_3, accuracy) {
     pts.push_back(Point2f(39.683930802331844f, 110.26290871953987f));
     pts.push_back(Point2f(47.85826684019932f, 70.82454140948524f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(266.796f, 260.167f), Size2f(580.374f, 469.465f), 50.3961f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseAMS_Issue_4, accuracy) {
@@ -206,29 +174,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_4, accuracy) {
     pts.push_back(Point2f(54.55733659450332f, 136.54322891729444f));
     pts.push_back(Point2f(78.60990563833005f, 112.76538180538182f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(237.108f, 207.32f), Size2f(517.287f, 357.591f), -36.3653f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 
@@ -276,29 +227,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_5, accuracy) {
     pts.push_back(Point2f(27.855803175234342f, 450.2298664426336f));
     pts.push_back(Point2f(12.832198085636549f, 435.6317753810441f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(265.252f, 451.597f), Size2f(503.386f, 174.674f), 5.31814f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseAMS_Issue_6, accuracy) {
@@ -344,29 +278,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_6, accuracy) {
     pts.push_back(Point2f(30.71132492338431f, 402.85098740402844f));
     pts.push_back(Point2f(10.994737323179852f, 394.6764602972333f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(192.467f, 204.404f), Size2f(551.397f, 165.068f), 136.913f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
@@ -412,29 +329,12 @@ TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
     pts.push_back(Point2f(9.929991244497518f, 203.20662088477752f));
     pts.push_back(Point2f(0.0f, 190.04891498441148f));
 
-    bool AMSGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseAMSTrue = cv::RotatedRect(Point2f(197.292f, 134.64f), Size2f(401.092f, 320.051f), 165.429f);
     RotatedRect     ellipseAMSTest = fitEllipseAMS(pts);
-    Point2f         ellipseAMSTrueVertices[4];
-    Point2f         ellipseAMSTestVertices[4];
-    ellipseAMSTest.points(ellipseAMSTestVertices);
-    ellipseAMSTrue.points(ellipseAMSTrueVertices);
-    float AMSDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseAMSTrueVertices[i] - ellipseAMSTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        AMSDiff += std::sqrt(d);
-    }
-    AMSGoodQ = AMSDiff < tol;
 
-    EXPECT_TRUE(AMSGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -8,6 +8,25 @@
 
 namespace opencv_test { namespace {
 
+static bool checkEllipse(const RotatedRect& ellipseDirectTest, const RotatedRect& ellipseDirectTrue, const float tol) {
+    Point2f         ellipseDirectTrueVertices[4];
+    Point2f         ellipseDirectTestVertices[4];
+    ellipseDirectTest.points(ellipseDirectTestVertices);
+    ellipseDirectTrue.points(ellipseDirectTrueVertices);
+    float directDiff = 0.0f;
+    for (size_t i=0; i <=3; i++) {
+        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
+        float d = diff.x * diff.x + diff.y * diff.y;
+        for (size_t j=1; j <=3; j++) {
+            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
+            float dd = diff.x * diff.x + diff.y * diff.y;
+            if(dd<d){d=dd;}
+        }
+        directDiff += std::sqrt(d);
+    }
+    return directDiff < tol;
+}
+
 TEST(Imgproc_FitEllipseDirect_Issue_1, accuracy) {
     vector<Point2f>pts;
     pts.push_back(Point2f(173.41854895999165f, 125.84473135880411f));
@@ -51,29 +70,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_1, accuracy) {
     pts.push_back(Point2f(6.719616410428614f, 50.15263031354927f));
     pts.push_back(Point2f(5.122267598477748f, 46.03603214691343f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(91.3256f, 90.4668f),Size2f(187.211f, 140.031f), 21.5808f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseDirect_Issue_2, accuracy) {
@@ -89,29 +91,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_2, accuracy) {
     pts.push_back(Point2f(91.66999301197541f, 300.57303988670515f));
     pts.push_back(Point2f(28.286233855826133f, 268.0670159317756f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(228.232f, 174.879f),Size2f(450.68f, 265.556f), 166.181f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 
@@ -138,29 +123,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_3, accuracy) {
     pts.push_back(Point2f(39.683930802331844f, 110.26290871953987f));
     pts.push_back(Point2f(47.85826684019932f, 70.82454140948524f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(255.326f, 272.626f),Size2f(570.999f, 434.23f), 49.0265f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseDirect_Issue_4, accuracy) {
@@ -206,29 +174,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_4, accuracy) {
     pts.push_back(Point2f(54.55733659450332f, 136.54322891729444f));
     pts.push_back(Point2f(78.60990563833005f, 112.76538180538182f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(236.836f, 208.089f),Size2f(515.893f, 357.166f), -35.9996f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 
@@ -276,29 +227,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_5, accuracy) {
     pts.push_back(Point2f(27.855803175234342f, 450.2298664426336f));
     pts.push_back(Point2f(12.832198085636549f, 435.6317753810441f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(264.354f, 457.336f),Size2f(493.728f, 162.9f), 5.36186f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseDirect_Issue_6, accuracy) {
@@ -344,29 +278,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_6, accuracy) {
     pts.push_back(Point2f(30.71132492338431f, 402.85098740402844f));
     pts.push_back(Point2f(10.994737323179852f, 394.6764602972333f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(207.145f, 223.308f),Size2f(499.583f, 117.473f), -42.6851f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
@@ -412,29 +329,12 @@ TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
     pts.push_back(Point2f(9.929991244497518f, 203.20662088477752f));
     pts.push_back(Point2f(0.0f, 190.04891498441148f));
 
-    bool directGoodQ;
     float tol = 0.01f;
 
     RotatedRect     ellipseDirectTrue = cv::RotatedRect(Point2f(199.463f, 150.997f),Size2f(390.341f, 286.01f), -12.9696f);
     RotatedRect     ellipseDirectTest = fitEllipseDirect(pts);
-    Point2f         ellipseDirectTrueVertices[4];
-    Point2f         ellipseDirectTestVertices[4];
-    ellipseDirectTest.points(ellipseDirectTestVertices);
-    ellipseDirectTrue.points(ellipseDirectTrueVertices);
-    float directDiff = 0.0f;
-    for (size_t i=0; i <=3; i++) {
-        Point2f diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[0];
-        float d = diff.x * diff.x + diff.y * diff.y;
-        for (size_t j=1; j <=3; j++) {
-            diff = ellipseDirectTrueVertices[i] - ellipseDirectTestVertices[j];
-            float dd = diff.x * diff.x + diff.y * diff.y;
-            if(dd<d){d=dd;}
-        }
-        directDiff += std::sqrt(d);
-    }
-    directGoodQ = directDiff < tol;
 
-    EXPECT_TRUE(directGoodQ);
+    EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
