### PR TITLE
Fix comment for fitEllipse Java case accurracy test

### DIFF
--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -94,7 +94,7 @@ TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
     pts.push_back(Point2f(-1, -1)*scale+shift);
     pts.push_back(Point2f(1, -1)*scale+shift);
 
-    // check that we get almost vertical ellipse centered around (1, 3)
+    // check that we get almost circle centered around (0, 0)
     RotatedRect e = fitEllipse(pts);
     EXPECT_NEAR(e.center.x, 0, 0.01);
     EXPECT_NEAR(e.center.y, 0, 0.01);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
