### PR TITLE
Change article for fitEllipseDirect function

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -424,20 +424,11 @@
   publisher = {BMVA Press},
   url = {https://www.researchgate.net/profile/Robert_Fisher5/publication/2237785_A_Buyer's_Guide_to_Conic_Fitting/links/0fcfd50f59aeded518000000/A-Buyers-Guide-to-Conic-Fitting.pdf}
 }
-@article{fitzgibbon1999,
-  abstract = {This work presents a new efficient method for fitting ellipses to scattered data. Previous algorithms either fitted general conics or were computationally expensive. By minimizing the algebraic distance subject to the constraint 4ac-b<sup>2</sup>=1, the new method incorporates the ellipticity constraint into the normalization factor. The proposed method combines several advantages: It is ellipse-specific, so that even bad data will always return an ellipse. It can be solved naturally by a generalized eigensystem. It is extremely robust, efficient, and easy to implement},
-  author = {Fitzgibbon, Andrew and Pilu, Maurizio and Fisher, Robert B.},
-  doi = {10.1109/34.765658},
-  isbn = {0162-8828},
-  issn = {01628828},
-  journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
-  number = {5},
-  pages = {476--480},
-  pmid = {708},
-  title = {Direct least square fitting of ellipses},
-  volume = {21},
-  year = {1999},
-  url = {https://pdfs.semanticscholar.org/090d/25f94cb021bdd3400a2f547f989a6a5e07ec.pdf}
+@inproceedings{oy1998NumericallySD,
+  title = {Numerically Stable Direct Least Squares Fitting of Ellipses},
+  author = {Radim Hal oy and Jan Flusser},
+  year = {1998},
+  url = {https://www.semanticscholar.org/paper/Numerically-Stable-Direct-Least-Squares-Fitting-of-oy-Flusser/9a8607575ba9c6016e9f3db5e52f5ed4d14d5dfd}
 }
 @article{Gallego2014ACF,
   title = {A Compact Formula for the Derivative of a 3-D Rotation in Exponential Coordinates},

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4342,7 +4342,7 @@ CV_EXPORTS_W RotatedRect fitEllipseAMS( InputArray points );
 
  The function calculates the ellipse that fits a set of 2D points.
  It returns the rotated rectangle in which the ellipse is inscribed.
- The Direct least square (Direct) method by @cite Fitzgibbon1999 is used.
+ The Direct least square (Direct) method by @cite oy1998NumericallySD is used.
 
  For an ellipse, this basis set is \f$ \chi= \left(x^2, x y, y^2, x, y, 1\right) \f$,
  which is a set of six free coefficients \f$ A^T=\left\{A_{\text{xx}},A_{\text{xy}},A_{\text{yy}},A_x,A_y,A_0\right\} \f$.

--- a/samples/cpp/fitellipse.cpp
+++ b/samples/cpp/fitellipse.cpp
@@ -5,7 +5,7 @@
  *  contours and approximate it by ellipses using three methods.
  *  1: OpenCV's original method fitEllipse which implements Fitzgibbon 1995 method.
  *  2: The Approximate Mean Square (AMS) method fitEllipseAMS  proposed by Taubin 1991
- *  3: The Direct least square (Direct) method fitEllipseDirect proposed by Fitzgibbon1999.
+ *  3: The Direct least square (Direct) method fitEllipseDirect proposed by oy1998NumericallySD.
  *
  *  Trackbar specify threshold parameter.
  *


### PR DESCRIPTION
### Pull Request Readiness Checklist

I believe that implementation of fitEllipseDirect function does not correspond to fitzgibbon1999 but to its improvement oy1998NumericallySD

Several arguments in favor of this:
* fitzgibbon1999 suggests to calculate eigenvalues and eigenvectors for 6x6 matrix, but oy1998NumericallySD - for 3x3 matrix M. In implementation we calculate eigenvalues and eigenvectors for 3x3 matrix M
https://github.com/opencv/opencv/blob/d77dbbe7a0c791deaf7f9c612cbfaa36a5e55b0c/modules/imgproc/src/shapedescr.cpp#L782-L800
* fitzgibbon1999 suggests to take eigenvector for positive eigenvalue, but oy1998NumericallySD - for positive `cond = 4 * evec(1, :) .* evec(3, :) - evec(2, :) .ˆ 2`. In implementation we calculate this `cond` and take eigenvector accordingly
https://github.com/opencv/opencv/blob/d77dbbe7a0c791deaf7f9c612cbfaa36a5e55b0c/modules/imgproc/src/shapedescr.cpp#L802-L816

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
