### PR TITLE
added POST_BUILD to `add_custom_command` in python_loader.cmake to avoid warning

### DIFF
--- a/modules/python/python_loader.cmake
+++ b/modules/python/python_loader.cmake
@@ -138,6 +138,7 @@ if(${PYTHON}_VERSION_STRING VERSION_GREATER "3.6" AND PYTHON_DEFAULT_VERSION VER
   # CMake constructions, because failed generation produces a warning instead of
   # halts on hard error.
   add_custom_command(
+    POST_BUILD
     TARGET copy_opencv_typing_stubs
     COMMAND ${PYTHON_DEFAULT_EXECUTABLE} ${PYTHON_SOURCE_DIR}/src2/copy_typings_stubs_on_success.py
             --stubs_dir ${OPENCV_PYTHON_BINDINGS_DIR}/cv2


### PR DESCRIPTION
### **Description**
This pull request resolves a build warning related to `add_custom_command` in `python_loader.cmake` by explicitly specifying `POST_BUILD`.

#### **System Information**
- **Operating System:** macOS
- **CMake Version:** 3.31.3

#### **Resolved Warning**
```
CMake Warning (dev) at modules/python/python_loader.cmake:140 (add_custom_command):
Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
