### PR TITLE
Fix remaining bugs in PNG reader

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -339,6 +339,10 @@ bool  PngDecoder::readHeader()
             png_bytep trans;
             png_color_16p trans_values;
 
+            // Free chunk in case png_read_info uses longjmp.
+            chunk.p.clear();
+            chunk.p.shrink_to_fit();
+
             png_read_info( png_ptr, info_ptr );
             png_get_IHDR(png_ptr, info_ptr, &wdth, &hght,
                 &bit_depth, &color_type, 0, 0, 0);
@@ -703,6 +707,7 @@ uint32_t PngDecoder::read_chunk(Chunk& chunk)
         if (size > PNG_USER_CHUNK_MALLOC_MAX)
         {
             CV_LOG_WARNING(NULL, "chunk data is too large");
+            return 0;
         }
         chunk.p.resize(size);
         memcpy(chunk.p.data(), len, 4);


### PR DESCRIPTION
- read information at the very beginning (if reading chunk fails, reading the info might not be possible after)
- do not try to allocate when the chunk is > PNG_USER_CHUNK_MALLOC_MAX

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
