### PR TITLE
imgproc: fix performance regressions of c3 kernels of warp functions

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -706,6 +706,14 @@ OPENCV_HAL_IMPL_RVV_LUT_VEC(v_float32, float)
 OPENCV_HAL_IMPL_RVV_LUT_VEC(v_int32, int)
 OPENCV_HAL_IMPL_RVV_LUT_VEC(v_uint32, unsigned)
 
+inline v_uint32 v_lut_expand(const ushort* tab, const v_int32& vidx)
+{
+    const size_t vl = VTraits<v_int32>::vlanes();
+    v_uint32 byte_idx = __riscv_vmul(__riscv_vreinterpret_u32m2(vidx), sizeof(ushort), vl);
+    vuint16m1_t values = __riscv_vloxei32(tab, byte_idx, vl);
+    return __riscv_vwcvtu_x(values, vl);
+}
+
 #if CV_SIMD_SCALABLE_64F
 inline v_float64 v_lut(const double* tab, const v_int32& vidx) \
 { \

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -714,6 +714,13 @@ inline v_uint32 v_lut_expand(const ushort* tab, const v_int32& vidx)
     return __riscv_vwcvtu_x(values, vl);
 }
 
+inline v_uint32 v_lut_expand(const uchar* tab, const v_int32& byte_idx)
+{
+    const size_t vl = VTraits<v_int32>::vlanes();
+    vuint8mf2_t values = __riscv_vloxei32(tab, __riscv_vreinterpret_u32m2(byte_idx), vl);
+    return __riscv_vwcvtu_x(__riscv_vwcvtu_x(values, vl), vl);
+}
+
 #if CV_SIMD_SCALABLE_64F
 inline v_float64 v_lut(const double* tab, const v_int32& vidx) \
 { \

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -563,6 +563,42 @@ template <> inline void v_store<8>(ushort* ptr, const v_uint16& a)
     ptr[4] = buf[4]; ptr[5] = buf[5]; ptr[6] = buf[6]; ptr[7] = buf[7];
 }
 
+template <int N = VTraits<v_uint32>::max_nlanes>
+inline void v_store(unsigned* ptr, const v_uint32& a)
+{
+    unsigned buf[VTraits<v_uint32>::max_nlanes];
+    v_store(buf, a);
+    for (int i = 0; i < N; i++) {
+        ptr[i] = buf[i];
+    }
+}
+
+template <> inline void v_store<4>(unsigned* ptr, const v_uint32& a)
+{
+    unsigned buf[VTraits<v_uint32>::max_nlanes];
+    v_store(buf, a);
+    ptr[0] = buf[0]; ptr[1] = buf[1];
+    ptr[2] = buf[2]; ptr[3] = buf[3];
+}
+
+template <int N = VTraits<v_int32>::max_nlanes>
+inline void v_store(int* ptr, const v_int32& a)
+{
+    int buf[VTraits<v_int32>::max_nlanes];
+    v_store(buf, a);
+    for (int i = 0; i < N; i++) {
+        ptr[i] = buf[i];
+    }
+}
+
+template <> inline void v_store<4>(int* ptr, const v_int32& a)
+{
+    int buf[VTraits<v_int32>::max_nlanes];
+    v_store(buf, a);
+    ptr[0] = buf[0]; ptr[1] = buf[1];
+    ptr[2] = buf[2]; ptr[3] = buf[3];
+}
+
 template <int N = VTraits<v_float32>::max_nlanes>
 inline void v_store(float* ptr, const v_float32& a)
 {
@@ -1681,6 +1717,42 @@ OPENCV_HAL_IMPL_RVV_EXPAND(ushort, v_uint32, vuint32m4_t, v_uint16, 16, u32, u16
 OPENCV_HAL_IMPL_RVV_EXPAND(short, v_int32, vint32m4_t, v_int16, 16, i32, i16, __riscv_vwcvt_x)
 OPENCV_HAL_IMPL_RVV_EXPAND(uint, v_uint64, vuint64m4_t, v_uint32, 32, u64, u32, __riscv_vwcvtu_x)
 OPENCV_HAL_IMPL_RVV_EXPAND(int, v_int64, vint64m4_t, v_int32, 32, i64, i32, __riscv_vwcvt_x)
+
+template <int N = VTraits<v_uint32>::max_nlanes>
+inline v_uint32 v_load(const unsigned* ptr)
+{
+    unsigned buf[VTraits<v_uint32>::max_nlanes];
+    v_store(buf, v_setzero_u32());
+    for (int i = 0; i < N; i++) {
+        buf[i] = ptr[i];
+    }
+    return v_load(buf);
+}
+template <> inline v_uint32 v_load<4>(const unsigned* ptr)
+{
+    unsigned buf[VTraits<v_uint32>::max_nlanes];
+    v_store(buf, v_setzero_u32());
+    buf[0] = ptr[0]; buf[1] = ptr[1]; buf[2] = ptr[2]; buf[3] = ptr[3];
+    return v_load(buf);
+}
+
+template <int N = VTraits<v_int32>::max_nlanes>
+inline v_int32 v_load(const int* ptr)
+{
+    int buf[VTraits<v_int32>::max_nlanes];
+    v_store(buf, v_setzero_s32());
+    for (int i = 0; i < N; i++) {
+        buf[i] = ptr[i];
+    }
+    return v_load(buf);
+}
+template <> inline v_int32 v_load<4>(const int* ptr)
+{
+    int buf[VTraits<v_int32>::max_nlanes];
+    v_store(buf, v_setzero_s32());
+    buf[0] = ptr[0]; buf[1] = ptr[1]; buf[2] = ptr[2]; buf[3] = ptr[3];
+    return v_load(buf);
+}
 
 template <int N = VTraits<v_float32>::max_nlanes>
 inline v_float32 v_load(const float* ptr)

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1317,7 +1317,180 @@
     CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(12, 13) \
     CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(14, 15) \
     CV_WARP_SIMD256_##INTER##_STORE_##DEPTH##C3_I()
-
+// SIMD_SCALABLE (SIMDX), c3, nearest
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_8UC3_I(ofs) \
+    const uint8_t *srcptr##ofs = src + addr[ofs]; \
+    v_uint32 i##ofs##_pix0 = v_load_expand_q<4>(srcptr##ofs);
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_16UC3_I(ofs) \
+    const uint16_t *srcptr##ofs = src + addr[ofs]; \
+    v_uint32 i##ofs##_pix0 = v_load_expand<4>(srcptr##ofs);
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_32FC3_I(ofs) \
+    const float *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_load<4>(srcptr##ofs);
+#define CV_WARP_SIMDX_NEAREST_STORE_8UC3_I() \
+    uint32_t tmp_buf[max_vlanes_16*4]; \
+    v_store<4>(tmp_buf,       i0_pix0); \
+    v_store<4>(tmp_buf + 3,   i1_pix0); \
+    v_store<4>(tmp_buf + 3*2, i2_pix0); \
+    v_store<4>(tmp_buf + 3*3, i3_pix0); \
+    v_store<4>(tmp_buf + 3*4, i4_pix0); \
+    v_store<4>(tmp_buf + 3*5, i5_pix0); \
+    v_store<4>(tmp_buf + 3*6, i6_pix0); \
+    v_store<4>(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack(v_load<4>(tmp_buf),             v_load<4>(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack(v_load<4>(tmp_buf+vlanes_32*2), v_load<4>(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack(v_load<4>(tmp_buf+vlanes_32*4), v_load<4>(tmp_buf+vlanes_32*5)); \
+    v_pack_store<8>(dstptr + 3*x,             pix0); \
+    v_pack_store<8>(dstptr + 3*x+vlanes_16,   pix1); \
+    v_pack_store<8>(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMDX_NEAREST_STORE_16UC3_I() \
+    uint32_t tmp_buf[max_vlanes_16*4]; \
+    v_store<4>(tmp_buf,       i0_pix0); \
+    v_store<4>(tmp_buf + 3,   i1_pix0); \
+    v_store<4>(tmp_buf + 3*2, i2_pix0); \
+    v_store<4>(tmp_buf + 3*3, i3_pix0); \
+    v_store<4>(tmp_buf + 3*4, i4_pix0); \
+    v_store<4>(tmp_buf + 3*5, i5_pix0); \
+    v_store<4>(tmp_buf + 3*6, i6_pix0); \
+    v_store<4>(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack(v_load<4>(tmp_buf),             v_load<4>(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack(v_load<4>(tmp_buf+vlanes_32*2), v_load<4>(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack(v_load<4>(tmp_buf+vlanes_32*4), v_load<4>(tmp_buf+vlanes_32*5)); \
+    v_store<8>(dstptr + 3*x,             pix0); \
+    v_store<8>(dstptr + 3*x+vlanes_16,   pix1); \
+    v_store<8>(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMDX_NEAREST_STORE_32FC3_I() \
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        v_store<4>(tmp_buf,       i0_fpix0); \
+        v_store<4>(tmp_buf + 3,   i1_fpix0); \
+        v_store<4>(tmp_buf + 3*2, i2_fpix0); \
+        v_store<4>(tmp_buf + 3*3, i3_fpix0); \
+        v_store<4>(dstptr + 3*x,             v_load<4>(tmp_buf)); \
+        v_store<4>(dstptr + 3*x+vlanes_32,   v_load<4>(tmp_buf + vlanes_32)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*2, v_load<4>(tmp_buf + vlanes_32*2)); \
+        v_store<4>(tmp_buf,       i4_fpix0); \
+        v_store<4>(tmp_buf + 3,   i5_fpix0); \
+        v_store<4>(tmp_buf + 3*2, i6_fpix0); \
+        v_store<4>(tmp_buf + 3*3, i7_fpix0); \
+        v_store<4>(dstptr + 3*x+vlanes_32*3, v_load<4>(tmp_buf)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*4, v_load<4>(tmp_buf + vlanes_32)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*5, v_load<4>(tmp_buf + vlanes_32*2)); \
+    } else { \
+        v_store<4>(dstptr + 3*(x),   i0_fpix0); \
+        v_store<4>(dstptr + 3*(x+1), i1_fpix0); \
+        v_store<4>(dstptr + 3*(x+2), i2_fpix0); \
+        v_store<4>(dstptr + 3*(x+3), i3_fpix0); \
+        v_store<4>(dstptr + 3*(x+4), i4_fpix0); \
+        v_store<4>(dstptr + 3*(x+5), i5_fpix0); \
+        v_store<4>(dstptr + 3*(x+6), i6_fpix0); \
+        v_store<4>(dstptr + 3*(x+7), i7_fpix0); \
+    }
+// SIMD_SCALABLE (SIMDX), c3, bilinear
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
+    const uint8_t *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs))), \
+              i##ofs##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs+3))), \
+              i##ofs##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs+srcstep))), \
+              i##ofs##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix1, i##ofs##_fpix0), i##ofs##_fpix0); \
+    i##ofs##_fpix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix3, i##ofs##_fpix2), i##ofs##_fpix2); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_fpix2, i##ofs##_fpix0), i##ofs##_fpix0); \
+    auto i##ofs##_pix0 = v_round(i##ofs##_fpix0);
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
+    const uint16_t *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs))), \
+              i##ofs##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs+3))), \
+              i##ofs##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs+srcstep))), \
+              i##ofs##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix1, i##ofs##_fpix0), i##ofs##_fpix0); \
+    i##ofs##_fpix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix3, i##ofs##_fpix2), i##ofs##_fpix2); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_fpix2, i##ofs##_fpix0), i##ofs##_fpix0); \
+    auto i##ofs##_pix0 = v_round(i##ofs##_fpix0);
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
+    const float *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_load<4>(srcptr##ofs), \
+              i##ofs##_fpix1 = v_load<4>(srcptr##ofs+3), \
+              i##ofs##_fpix2 = v_load<4>(srcptr##ofs+srcstep), \
+              i##ofs##_fpix3 = v_load<4>(srcptr##ofs+srcstep+3); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix1, i##ofs##_fpix0), i##ofs##_fpix0); \
+    i##ofs##_fpix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix3, i##ofs##_fpix2), i##ofs##_fpix2); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_fpix2, i##ofs##_fpix0), i##ofs##_fpix0);
+#define CV_WARP_SIMDX_LINEAR_STORE_8UC3_I() \
+    int32_t tmp_buf[max_vlanes_16*4]; \
+    v_store<4>(tmp_buf,       i0_pix0); \
+    v_store<4>(tmp_buf + 3,   i1_pix0); \
+    v_store<4>(tmp_buf + 3*2, i2_pix0); \
+    v_store<4>(tmp_buf + 3*3, i3_pix0); \
+    v_store<4>(tmp_buf + 3*4, i4_pix0); \
+    v_store<4>(tmp_buf + 3*5, i5_pix0); \
+    v_store<4>(tmp_buf + 3*6, i6_pix0); \
+    v_store<4>(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack_u(v_load<4>(tmp_buf),             v_load<4>(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack_u(v_load<4>(tmp_buf+vlanes_32*2), v_load<4>(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack_u(v_load<4>(tmp_buf+vlanes_32*4), v_load<4>(tmp_buf+vlanes_32*5)); \
+    v_pack_store<8>(dstptr + 3*x,             pix0); \
+    v_pack_store<8>(dstptr + 3*x+vlanes_16,   pix1); \
+    v_pack_store<8>(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMDX_LINEAR_STORE_16UC3_I() \
+    int32_t tmp_buf[max_vlanes_16*4]; \
+    v_store<4>(tmp_buf,       i0_pix0); \
+    v_store<4>(tmp_buf + 3,   i1_pix0); \
+    v_store<4>(tmp_buf + 3*2, i2_pix0); \
+    v_store<4>(tmp_buf + 3*3, i3_pix0); \
+    v_store<4>(tmp_buf + 3*4, i4_pix0); \
+    v_store<4>(tmp_buf + 3*5, i5_pix0); \
+    v_store<4>(tmp_buf + 3*6, i6_pix0); \
+    v_store<4>(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack_u(v_load<4>(tmp_buf),             v_load<4>(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack_u(v_load<4>(tmp_buf+vlanes_32*2), v_load<4>(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack_u(v_load<4>(tmp_buf+vlanes_32*4), v_load<4>(tmp_buf+vlanes_32*5)); \
+    v_store<8>(dstptr + 3*x,             pix0); \
+    v_store<8>(dstptr + 3*x+vlanes_16,   pix1); \
+    v_store<8>(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMDX_LINEAR_STORE_32FC3_I() \
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        v_store<4>(tmp_buf,       i0_fpix0); \
+        v_store<4>(tmp_buf + 3,   i1_fpix0); \
+        v_store<4>(tmp_buf + 3*2, i2_fpix0); \
+        v_store<4>(tmp_buf + 3*3, i3_fpix0); \
+        v_store<4>(dstptr + 3*x,             v_load<4>(tmp_buf)); \
+        v_store<4>(dstptr + 3*x+vlanes_32,   v_load<4>(tmp_buf + vlanes_32)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*2, v_load<4>(tmp_buf + vlanes_32*2)); \
+        v_store<4>(tmp_buf,       i4_fpix0); \
+        v_store<4>(tmp_buf + 3,   i5_fpix0); \
+        v_store<4>(tmp_buf + 3*2, i6_fpix0); \
+        v_store<4>(tmp_buf + 3*3, i7_fpix0); \
+        v_store<4>(dstptr + 3*x+vlanes_32*3, v_load<4>(tmp_buf)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*4, v_load<4>(tmp_buf + vlanes_32)); \
+        v_store<4>(dstptr + 3*x+vlanes_32*5, v_load<4>(tmp_buf + vlanes_32*2)); \
+    } else { \
+        v_store<4>(dstptr + 3*(x),   i0_fpix0); \
+        v_store<4>(dstptr + 3*(x+1), i1_fpix0); \
+        v_store<4>(dstptr + 3*(x+2), i2_fpix0); \
+        v_store<4>(dstptr + 3*(x+3), i3_fpix0); \
+        v_store<4>(dstptr + 3*(x+4), i4_fpix0); \
+        v_store<4>(dstptr + 3*(x+5), i5_fpix0); \
+        v_store<4>(dstptr + 3*(x+6), i6_fpix0); \
+        v_store<4>(dstptr + 3*(x+7), i7_fpix0); \
+    }
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(1) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(3) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(4) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(5) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(6) \
+    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(7) \
+    CV_WARP_SIMDX_##INTER##_STORE_##DEPTH##C3_I() \
 
 #define CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD, INTER, DEPTH, CN) \
     CV_WARP_##SIMD##_SHUFFLE_INTER_STORE_##CN(INTER, DEPTH)

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -593,13 +593,7 @@
     CV_WARP_LINEAR_VECTOR_INTER_STORE_F16U8_##CN()
 
 // Special case for C4 shuffle, interpolation and store
-// SIMD128, nearest
-#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC4_I(ofs)
-#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC4_I(ofs)
-#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC4_I(ofs)
+// SIMD128, c4, nearest
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC4_I(ofs) \
     const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
     v_uint32 i##ofs##_pix0 = vx_load_expand_q(srcptr##ofs);
@@ -609,17 +603,6 @@
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC4_I(ofs) \
     const float *srcptr##ofs = src + addr[i+ofs]; \
     v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs);
-#define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
-    v_pack_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-    v_pack_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
-#define CV_WARP_SIMD128_NEAREST_STORE_16UC3_I() \
-    vx_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-    vx_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
-#define CV_WARP_SIMD128_NEAREST_STORE_32FC3_I() \
-    vx_store(dstptr + 3*(x+i),   i0_pix0); \
-    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
-    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
-    vx_store(dstptr + 3*(x+i+3), i3_pix0);
 #define CV_WARP_SIMD128_NEAREST_STORE_8UC4_I() \
     v_pack_store(dstptr + 4*(x+i), v_pack(i0_pix0, i1_pix0)); \
     v_pack_store(dstptr + 4*(x+i+2), v_pack(i2_pix0, i3_pix0));
@@ -631,40 +614,7 @@
     vx_store(dstptr + 4*(x+i+1), i1_pix0); \
     vx_store(dstptr + 4*(x+i+2), i2_pix0); \
     vx_store(dstptr + 4*(x+i+3), i3_pix0);
-// SIMD128, bilinear
-#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
-    const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
-    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs))); \
-    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+3))); \
-    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep))); \
-    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep+3))); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
-    const uint16_t *srcptr##ofs = src + addr[i+ofs]; \
-    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
-    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
-    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
-    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
-    const float *srcptr##ofs = src + addr[i+ofs]; \
-    v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs); \
-    v_float32 i##ofs##_pix1 = vx_load(srcptr##ofs+3); \
-    v_float32 i##ofs##_pix2 = vx_load(srcptr##ofs+srcstep); \
-    v_float32 i##ofs##_pix3 = vx_load(srcptr##ofs+srcstep+3); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+// SIMD128, c4, bilinear
 #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC4_I(ofs) \
     const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
     v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs))); \
@@ -698,21 +648,6 @@
     i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
     i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
     i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-#define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
-    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
-    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
-    v_pack_store(dstptr + 3*(x+i),   i01_pix); \
-    v_pack_store(dstptr + 3*(x+i+2), i23_pix);
-#define CV_WARP_SIMD128_LINEAR_STORE_16UC3_I() \
-    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
-    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
-    vx_store(dstptr + 3*(x+i),   i01_pix); \
-    vx_store(dstptr + 3*(x+i+2), i23_pix);
-#define CV_WARP_SIMD128_LINEAR_STORE_32FC3_I() \
-    vx_store(dstptr + 3*(x+i),   i0_pix0); \
-    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
-    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
-    vx_store(dstptr + 3*(x+i+3), i3_pix0);
 #define CV_WARP_SIMD128_LINEAR_STORE_8UC4_I() \
     v_uint16 i01_pix = v_pack_u(v_round(i0_pix0), v_round(i1_pix0)); \
     v_uint16 i23_pix = v_pack_u(v_round(i2_pix0), v_round(i3_pix0)); \
@@ -728,15 +663,15 @@
     vx_store(dstptr + 4*(x+i+1), i1_pix0); \
     vx_store(dstptr + 4*(x+i+2), i2_pix0); \
     vx_store(dstptr + 4*(x+i+3), i3_pix0);
-#define CV_WARP_SIMD128_SHUFFLE_INTER_STORE(INTER, DEPTH, CN) \
+#define CV_WARP_SIMD128_SHUFFLE_INTER_STORE_C4(INTER, DEPTH) \
     for (int i = 0; i < uf; i+=vlanes_32) { \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##CN##_I(0) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##CN##_I(1) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##CN##_I(2) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##CN##_I(3) \
-        CV_WARP_SIMD128_##INTER##_STORE_##DEPTH##CN##_I() \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C4_I(0) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C4_I(1) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C4_I(2) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C4_I(3) \
+        CV_WARP_SIMD128_##INTER##_STORE_##DEPTH##C4_I() \
     }
-// SIMD256, nearest
+// SIMD256, c4, nearest
 #define CV_WARP_SIMD256_NEAREST_SHUFFLE_INTER_8UC4_I(ofs0, ofs1) \
     const uint8_t *srcptr##ofs0 = src + addr[i+ofs0]; \
     const uint8_t *srcptr##ofs1 = src + addr[i+ofs1]; \
@@ -754,17 +689,17 @@
     const float *srcptr##ofs1 = src + addr[i+ofs1]; \
     v_float32 i##ofs0##ofs1##_fpix00 = vx_load_halves(srcptr##ofs0, srcptr##ofs1);
 #define CV_WARP_SIMD256_NEAREST_STORE_8UC4_I() \
-    v_pack_store(dstptr + 4*(x+i), v_pack(i01_pix00, i23_pix00)); \
+    v_pack_store(dstptr + 4*(x+i),   v_pack(i01_pix00, i23_pix00)); \
     v_pack_store(dstptr + 4*(x+i+4), v_pack(i45_pix00, i67_pix00));
 #define CV_WARP_SIMD256_NEAREST_STORE_16UC4_I() \
-    vx_store(dstptr + 4*(x+i), v_pack(i01_pix00, i23_pix00)); \
+    vx_store(dstptr + 4*(x+i),   v_pack(i01_pix00, i23_pix00)); \
     vx_store(dstptr + 4*(x+i+4), v_pack(i45_pix00, i67_pix00));
 #define CV_WARP_SIMD256_NEAREST_STORE_32FC4_I() \
     vx_store(dstptr + 4*(x+i),    i01_fpix00); \
-    vx_store(dstptr + 4*(x+i)+8,  i23_fpix00); \
-    vx_store(dstptr + 4*(x+i)+16, i45_fpix00); \
-    vx_store(dstptr + 4*(x+i)+24, i67_fpix00);
-// SIMD256, bilinear
+    vx_store(dstptr + 4*(x+i+2),  i23_fpix00); \
+    vx_store(dstptr + 4*(x+i+4),  i45_fpix00); \
+    vx_store(dstptr + 4*(x+i+6),  i67_fpix00);
+// SIMD256, c4, bilinear
 #define CV_WARP_SIMD256_LINEAR_SHUFFLE_INTER_8UC4_I(ofs0, ofs1) \
     const uint8_t *srcptr##ofs0 = src + addr[i+ofs0]; \
     const uint8_t *srcptr##ofs1 = src + addr[i+ofs1]; \
@@ -850,7 +785,7 @@
         CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C4_I(6, 7) \
         CV_WARP_SIMD256_##INTER##_STORE_##DEPTH##C4_I() \
     }
-// SIMD_SCALABLE (SIMDX), nearest
+// SIMD_SCALABLE (SIMDX), c4, nearest
 #define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_8UC4_I(ofs) \
     const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
     v_uint32 i##ofs##_pix0 = v_load_expand_q<4>(srcptr##ofs);
@@ -871,7 +806,7 @@
     v_store<4>(dstptr + 4*(x+i)+4,  i1_fpix0); \
     v_store<4>(dstptr + 4*(x+i)+8,  i2_fpix0); \
     v_store<4>(dstptr + 4*(x+i)+12, i3_fpix0);
-// SIMD_SCALABLE (SIMDX), bilinear
+// SIMD_SCALABLE (SIMDX), c4, bilinear
 #define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_8UC4_I(ofs) \
     const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
     v_float32 i##ofs##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs))), \
@@ -927,5 +862,335 @@
         CV_WARP_SIMDX_##INTER##_STORE_##DEPTH##C4_I(); \
     }
 
+// Special case for C3 shuffle, interpolation and store
+// SIMD128, c3, nearest
+#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC3_I(ofs) \
+    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC4_I(ofs)
+#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC3_I(ofs) \
+    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC4_I(ofs)
+#define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC3_I(ofs) \
+    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC4_I(ofs)
+#define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
+    v_pack_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
+    v_pack_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+#define CV_WARP_SIMD128_NEAREST_STORE_16UC3_I() \
+    vx_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
+    vx_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+#define CV_WARP_SIMD128_NEAREST_STORE_32FC3_I() \
+    vx_store(dstptr + 3*(x+i),   i0_pix0); \
+    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
+    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
+    vx_store(dstptr + 3*(x+i+3), i3_pix0);
+// SIMD128, c3, bilinear
+#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
+    const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
+    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs))); \
+    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+3))); \
+    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep))); \
+    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
+    const uint16_t *srcptr##ofs = src + addr[i+ofs]; \
+    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
+    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
+    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
+    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+#define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
+    const float *srcptr##ofs = src + addr[i+ofs]; \
+    v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs); \
+    v_float32 i##ofs##_pix1 = vx_load(srcptr##ofs+3); \
+    v_float32 i##ofs##_pix2 = vx_load(srcptr##ofs+srcstep); \
+    v_float32 i##ofs##_pix3 = vx_load(srcptr##ofs+srcstep+3); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+#define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
+    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
+    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
+    v_pack_store(dstptr + 3*(x+i),   i01_pix); \
+    v_pack_store(dstptr + 3*(x+i+2), i23_pix);
+#define CV_WARP_SIMD128_LINEAR_STORE_16UC3_I() \
+    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
+    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
+    vx_store(dstptr + 3*(x+i),   i01_pix); \
+    vx_store(dstptr + 3*(x+i+2), i23_pix);
+#define CV_WARP_SIMD128_LINEAR_STORE_32FC3_I() \
+    vx_store(dstptr + 3*(x+i),   i0_pix0); \
+    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
+    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
+    vx_store(dstptr + 3*(x+i+3), i3_pix0);
+#define CV_WARP_SIMD128_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+    for (int i = 0; i < uf; i+=vlanes_32) { \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(1) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2) \
+        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(3) \
+        CV_WARP_SIMD128_##INTER##_STORE_##DEPTH##C3_I() \
+    }
+// SIMD256, c3, nearest
+#define CV_WARP_SIMD256_NEAREST_SHUFFLE_INTER_8UC3_I(ofs0, ofs1) \
+    const uint8_t *srcptr##ofs0 = src + addr[ofs0]; \
+    const uint8_t *srcptr##ofs1 = src + addr[ofs1]; \
+    v_uint32 i##ofs0##_pix0x = v256_load_expand_q(srcptr##ofs0); \
+    v_uint32 i##ofs1##_pix0x = v256_load_expand_q(srcptr##ofs1); \
+    i##ofs0##_pix0x = v_rotate_left<1>(i##ofs0##_pix0x); \
+    v_uint32 i##ofs0##ofs1##_pix00 = v_combine_low(i##ofs0##_pix0x, i##ofs1##_pix0x); \
+    i##ofs0##ofs1##_pix00 = v_rotate_right<1>(i##ofs0##ofs1##_pix00);
+#define CV_WARP_SIMD256_NEAREST_SHUFFLE_INTER_16UC3_I(ofs0, ofs1) \
+    const uint16_t *srcptr##ofs0 = src + addr[ofs0]; \
+    const uint16_t *srcptr##ofs1 = src + addr[ofs1]; \
+    v_uint32 i##ofs0##_pix0x = v256_load_expand(srcptr##ofs0); \
+    v_uint32 i##ofs1##_pix0x = v256_load_expand(srcptr##ofs1); \
+    i##ofs0##_pix0x = v_rotate_left<1>(i##ofs0##_pix0x); \
+    v_uint32 i##ofs0##ofs1##_pix00 = v_combine_low(i##ofs0##_pix0x, i##ofs1##_pix0x); \
+    i##ofs0##ofs1##_pix00 = v_rotate_right<1>(i##ofs0##ofs1##_pix00);
+#define CV_WARP_SIMD256_NEAREST_SHUFFLE_INTER_32FC3_I(ofs0, ofs1) \
+    const float *srcptr##ofs0 = src + addr[ofs0]; \
+    const float *srcptr##ofs1 = src + addr[ofs1]; \
+    v_float32 i##ofs0##ofs1##_pix00 = vx_load_halves(srcptr##ofs0, srcptr##ofs1); \
+    v_float32 i##ofs0##ofs1##_pix00_rl1 = v_rotate_left<1>(i##ofs0##ofs1##_pix00); \
+    i##ofs0##ofs1##_pix00 = v256_combine_diagonal(i##ofs0##ofs1##_pix00_rl1, i##ofs0##ofs1##_pix00); \
+    i##ofs0##ofs1##_pix00 = v_rotate_right<1>(i##ofs0##ofs1##_pix00);
+#define CV_WARP_SIMD256_NEAREST_STORE_8UC3_I() \
+        uint32_t tmp_buf[max_vlanes_16*4]; \
+        vx_store(tmp_buf,        i01_pix00); \
+        vx_store(tmp_buf + 3*2,  i23_pix00); \
+        vx_store(tmp_buf + 3*4,  i45_pix00); \
+        vx_store(tmp_buf + 3*6,  i67_pix00); \
+        vx_store(tmp_buf + 3*8,  i89_pix00); \
+        vx_store(tmp_buf + 3*10, i1011_pix00); \
+        vx_store(tmp_buf + 3*12, i1213_pix00); \
+        vx_store(tmp_buf + 3*14, i1415_pix00); \
+        v_uint16 pix0 = v_pack(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+        v_uint16 pix1 = v_pack(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+        v_uint16 pix2 = v_pack(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+        v_pack_store(dstptr + 3*x,             pix0); \
+        v_pack_store(dstptr + 3*x+vlanes_16,   pix1); \
+        v_pack_store(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMD256_NEAREST_STORE_16UC3_I() \
+        uint32_t tmp_buf[max_vlanes_16*4]; \
+        vx_store(tmp_buf,        i01_pix00); \
+        vx_store(tmp_buf + 3*2,  i23_pix00); \
+        vx_store(tmp_buf + 3*4,  i45_pix00); \
+        vx_store(tmp_buf + 3*6,  i67_pix00); \
+        vx_store(tmp_buf + 3*8,  i89_pix00); \
+        vx_store(tmp_buf + 3*10, i1011_pix00); \
+        vx_store(tmp_buf + 3*12, i1213_pix00); \
+        vx_store(tmp_buf + 3*14, i1415_pix00); \
+        v_uint16 pix0 = v_pack(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+        v_uint16 pix1 = v_pack(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+        v_uint16 pix2 = v_pack(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+        vx_store(dstptr + 3*x,             pix0); \
+        vx_store(dstptr + 3*x+vlanes_16,   pix1); \
+        vx_store(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMD256_NEAREST_STORE_32FC3_I() \
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        vx_store(tmp_buf,      i01_pix00); \
+        vx_store(tmp_buf + 6,  i23_pix00); \
+        vx_store(tmp_buf + 12, i45_pix00); \
+        vx_store(tmp_buf + 18, i67_pix00); \
+        vx_store(dstptr + 3*x,             vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32,   vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*2, vx_load(tmp_buf + vlanes_32*2)); \
+        vx_store(tmp_buf,      i89_pix00); \
+        vx_store(tmp_buf + 6,  i1011_pix00); \
+        vx_store(tmp_buf + 12, i1213_pix00); \
+        vx_store(tmp_buf + 18, i1415_pix00); \
+        vx_store(dstptr + 3*x+vlanes_32*3, vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32*4, vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*5, vx_load(tmp_buf + vlanes_32*2)); \
+    } else { \
+        vx_store(dstptr + 3*(x),   i01_pix00); \
+        vx_store(dstptr + 3*(x+2), i23_pix00); \
+        vx_store(dstptr + 3*(x+4), i45_pix00); \
+        vx_store(dstptr + 3*(x+6), i67_pix00); \
+        vx_store(dstptr + 3*(x+vlanes_32),   i89_pix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+2), i1011_pix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+4), i1213_pix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+6), i1415_pix00); \
+    }
+// SIMD256, c3, bilinear
+#define CV_WARP_SIMD256_LINEAR_SHUFFLE_INTER_8UC3_I(ofs0, ofs1) \
+    const uint8_t *srcptr##ofs0 = src + addr[ofs0]; \
+    const uint8_t *srcptr##ofs1 = src + addr[ofs1]; \
+    v_int32 i##ofs0##_pix01 = v_reinterpret_as_s32(v256_load_expand_q(srcptr##ofs0)), \
+            i##ofs0##_pix23 = v_reinterpret_as_s32(v256_load_expand_q(srcptr##ofs0+srcstep)); \
+    v_int32 i##ofs1##_pix01 = v_reinterpret_as_s32(v256_load_expand_q(srcptr##ofs1)), \
+            i##ofs1##_pix23 = v_reinterpret_as_s32(v256_load_expand_q(srcptr##ofs1+srcstep)); \
+    v_int32 i##ofs0##_pix01_rl1 = v_rotate_left<1>(i##ofs0##_pix01); \
+    v_int32 i##ofs0##_pix23_rl1 = v_rotate_left<1>(i##ofs0##_pix23); \
+    v_int32 i##ofs1##_pix01_rl1 = v_rotate_left<1>(i##ofs1##_pix01); \
+    v_int32 i##ofs1##_pix23_rl1 = v_rotate_left<1>(i##ofs1##_pix23); \
+    i##ofs0##_pix01 = v256_combine_diagonal(i##ofs0##_pix01, i##ofs0##_pix01_rl1); \
+    i##ofs0##_pix23 = v256_combine_diagonal(i##ofs0##_pix23, i##ofs0##_pix23_rl1); \
+    i##ofs1##_pix01 = v256_combine_diagonal(i##ofs1##_pix01, i##ofs1##_pix01_rl1); \
+    i##ofs1##_pix23 = v256_combine_diagonal(i##ofs1##_pix23, i##ofs1##_pix23_rl1); \
+    v_float32 i##ofs0##_fpix01 = v_cvt_f32(i##ofs0##_pix01), i##ofs0##_fpix23 = v_cvt_f32(i##ofs0##_pix23); \
+    v_float32 i##ofs1##_fpix01 = v_cvt_f32(i##ofs1##_pix01), i##ofs1##_fpix23 = v_cvt_f32(i##ofs1##_pix23); \
+    v_float32 i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11, \
+              i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33; \
+    v_recombine(i##ofs0##_fpix01, i##ofs1##_fpix01, i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11); \
+    v_recombine(i##ofs0##_fpix23, i##ofs1##_fpix23, i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33); \
+    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
+              i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
+              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]), \
+              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
+    v_float32 i##ofs0##ofs1##_alpha = v_combine_low(i##ofs0##_alpha, i##ofs1##_alpha), \
+              i##ofs0##ofs1##_beta  = v_combine_low(i##ofs0##_beta,  i##ofs1##_beta); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix11, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix22 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix33, i##ofs0##ofs1##_fpix22), i##ofs0##ofs1##_fpix22); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_beta,  v_sub(i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    v_float32 i##ofs0##ofs1##_fpix00_rl1 = v_rotate_left<1>(i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v256_combine_diagonal(i##ofs0##ofs1##_fpix00_rl1, i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v_rotate_right<1>(i##ofs0##ofs1##_fpix00); \
+    auto i##ofs0##ofs1##_pix00 = v_round(i##ofs0##ofs1##_fpix00);
+#define CV_WARP_SIMD256_LINEAR_SHUFFLE_INTER_16UC3_I(ofs0, ofs1) \
+    const uint16_t *srcptr##ofs0 = src + addr[ofs0]; \
+    const uint16_t *srcptr##ofs1 = src + addr[ofs1]; \
+    v_int32 i##ofs0##_pix01 = v_reinterpret_as_s32(v256_load_expand(srcptr##ofs0)), \
+            i##ofs0##_pix23 = v_reinterpret_as_s32(v256_load_expand(srcptr##ofs0+srcstep)); \
+    v_int32 i##ofs1##_pix01 = v_reinterpret_as_s32(v256_load_expand(srcptr##ofs1)), \
+            i##ofs1##_pix23 = v_reinterpret_as_s32(v256_load_expand(srcptr##ofs1+srcstep)); \
+    v_int32 i##ofs0##_pix01_rl1 = v_rotate_left<1>(i##ofs0##_pix01); \
+    v_int32 i##ofs0##_pix23_rl1 = v_rotate_left<1>(i##ofs0##_pix23); \
+    v_int32 i##ofs1##_pix01_rl1 = v_rotate_left<1>(i##ofs1##_pix01); \
+    v_int32 i##ofs1##_pix23_rl1 = v_rotate_left<1>(i##ofs1##_pix23); \
+    i##ofs0##_pix01 = v256_combine_diagonal(i##ofs0##_pix01, i##ofs0##_pix01_rl1); \
+    i##ofs0##_pix23 = v256_combine_diagonal(i##ofs0##_pix23, i##ofs0##_pix23_rl1); \
+    i##ofs1##_pix01 = v256_combine_diagonal(i##ofs1##_pix01, i##ofs1##_pix01_rl1); \
+    i##ofs1##_pix23 = v256_combine_diagonal(i##ofs1##_pix23, i##ofs1##_pix23_rl1); \
+    v_float32 i##ofs0##_fpix01 = v_cvt_f32(i##ofs0##_pix01), i##ofs0##_fpix23 = v_cvt_f32(i##ofs0##_pix23); \
+    v_float32 i##ofs1##_fpix01 = v_cvt_f32(i##ofs1##_pix01), i##ofs1##_fpix23 = v_cvt_f32(i##ofs1##_pix23); \
+    v_float32 i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11, \
+            i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33; \
+    v_recombine(i##ofs0##_fpix01, i##ofs1##_fpix01, i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11); \
+    v_recombine(i##ofs0##_fpix23, i##ofs1##_fpix23, i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33); \
+    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
+              i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
+              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]), \
+              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
+    v_float32 i##ofs0##ofs1##_alpha = v_combine_low(i##ofs0##_alpha, i##ofs1##_alpha), \
+              i##ofs0##ofs1##_beta  = v_combine_low(i##ofs0##_beta,  i##ofs1##_beta); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix11, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix22 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix33, i##ofs0##ofs1##_fpix22), i##ofs0##ofs1##_fpix22); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_beta,  v_sub(i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    v_float32 i##ofs0##ofs1##_fpix00_rl1 = v_rotate_left<1>(i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v256_combine_diagonal(i##ofs0##ofs1##_fpix00_rl1, i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v_rotate_right<1>(i##ofs0##ofs1##_fpix00); \
+    auto i##ofs0##ofs1##_pix00 = v_round(i##ofs0##ofs1##_fpix00);
+#define CV_WARP_SIMD256_LINEAR_SHUFFLE_INTER_32FC3_I(ofs0, ofs1) \
+    const float *srcptr##ofs0 = src + addr[ofs0]; \
+    const float *srcptr##ofs1 = src + addr[ofs1]; \
+    v_float32 i##ofs0##_fpix01 = v256_load(srcptr##ofs0); \
+    v_float32 i##ofs0##_fpix23 = v256_load(srcptr##ofs0+srcstep); \
+    v_float32 i##ofs1##_fpix01 = v256_load(srcptr##ofs1); \
+    v_float32 i##ofs1##_fpix23 = v256_load(srcptr##ofs1+srcstep); \
+    v_float32 i##ofs0##_fpix01_rl1 = v_rotate_left<1>(i##ofs0##_fpix01); \
+    v_float32 i##ofs0##_fpix23_rl1 = v_rotate_left<1>(i##ofs0##_fpix23); \
+    v_float32 i##ofs1##_fpix01_rl1 = v_rotate_left<1>(i##ofs1##_fpix01); \
+    v_float32 i##ofs1##_fpix23_rl1 = v_rotate_left<1>(i##ofs1##_fpix23); \
+    i##ofs0##_fpix01 = v256_combine_diagonal(i##ofs0##_fpix01, i##ofs0##_fpix01_rl1); \
+    i##ofs0##_fpix23 = v256_combine_diagonal(i##ofs0##_fpix23, i##ofs0##_fpix23_rl1); \
+    i##ofs1##_fpix01 = v256_combine_diagonal(i##ofs1##_fpix01, i##ofs1##_fpix01_rl1); \
+    i##ofs1##_fpix23 = v256_combine_diagonal(i##ofs1##_fpix23, i##ofs1##_fpix23_rl1); \
+    v_float32 i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11; \
+    v_float32 i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33; \
+    v_recombine(i##ofs0##_fpix01, i##ofs1##_fpix01, i##ofs0##ofs1##_fpix00, i##ofs0##ofs1##_fpix11); \
+    v_recombine(i##ofs0##_fpix23, i##ofs1##_fpix23, i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix33); \
+    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
+              i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
+              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]), \
+              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
+    v_float32 i##ofs0##ofs1##_alpha = v_combine_low(i##ofs0##_alpha, i##ofs1##_alpha), \
+              i##ofs0##ofs1##_beta  = v_combine_low(i##ofs0##_beta,  i##ofs1##_beta); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix11, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix22 = v_fma(i##ofs0##ofs1##_alpha, v_sub(i##ofs0##ofs1##_fpix33, i##ofs0##ofs1##_fpix22), i##ofs0##ofs1##_fpix22); \
+    i##ofs0##ofs1##_fpix00 = v_fma(i##ofs0##ofs1##_beta,  v_sub(i##ofs0##ofs1##_fpix22, i##ofs0##ofs1##_fpix00), i##ofs0##ofs1##_fpix00); \
+    v_float32 i##ofs0##ofs1##_fpix00_rl1 = v_rotate_left<1>(i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v256_combine_diagonal(i##ofs0##ofs1##_fpix00_rl1, i##ofs0##ofs1##_fpix00); \
+    i##ofs0##ofs1##_fpix00 = v_rotate_right<1>(i##ofs0##ofs1##_fpix00);
+#define CV_WARP_SIMD256_LINEAR_STORE_8UC3_I() \
+        int32_t tmp_buf[max_vlanes_16*4]; \
+        vx_store(tmp_buf,        i01_pix00); \
+        vx_store(tmp_buf + 3*2,  i23_pix00); \
+        vx_store(tmp_buf + 3*4,  i45_pix00); \
+        vx_store(tmp_buf + 3*6,  i67_pix00); \
+        vx_store(tmp_buf + 3*8,  i89_pix00); \
+        vx_store(tmp_buf + 3*10, i1011_pix00); \
+        vx_store(tmp_buf + 3*12, i1213_pix00); \
+        vx_store(tmp_buf + 3*14, i1415_pix00); \
+        v_uint16 pix0 = v_pack_u(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+        v_uint16 pix1 = v_pack_u(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+        v_uint16 pix2 = v_pack_u(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+        v_pack_store(dstptr + 3*x,             pix0); \
+        v_pack_store(dstptr + 3*x+vlanes_16,   pix1); \
+        v_pack_store(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMD256_LINEAR_STORE_16UC3_I() \
+        int32_t tmp_buf[max_vlanes_16*4]; \
+        vx_store(tmp_buf,        i01_pix00); \
+        vx_store(tmp_buf + 3*2,  i23_pix00); \
+        vx_store(tmp_buf + 3*4,  i45_pix00); \
+        vx_store(tmp_buf + 3*6,  i67_pix00); \
+        vx_store(tmp_buf + 3*8,  i89_pix00); \
+        vx_store(tmp_buf + 3*10, i1011_pix00); \
+        vx_store(tmp_buf + 3*12, i1213_pix00); \
+        vx_store(tmp_buf + 3*14, i1415_pix00); \
+        v_uint16 pix0 = v_pack_u(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+        v_uint16 pix1 = v_pack_u(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+        v_uint16 pix2 = v_pack_u(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+        vx_store(dstptr + 3*x,             pix0); \
+        vx_store(dstptr + 3*x+vlanes_16,   pix1); \
+        vx_store(dstptr + 3*x+vlanes_16*2, pix2);
+#define CV_WARP_SIMD256_LINEAR_STORE_32FC3_I() \
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        vx_store(tmp_buf,      i01_fpix00); \
+        vx_store(tmp_buf + 6,  i23_fpix00); \
+        vx_store(tmp_buf + 12, i45_fpix00); \
+        vx_store(tmp_buf + 18, i67_fpix00); \
+        vx_store(dstptr + 3*x,             vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32,   vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*2, vx_load(tmp_buf + vlanes_32*2)); \
+        vx_store(tmp_buf,      i89_fpix00); \
+        vx_store(tmp_buf + 6,  i1011_fpix00); \
+        vx_store(tmp_buf + 12, i1213_fpix00); \
+        vx_store(tmp_buf + 18, i1415_fpix00); \
+        vx_store(dstptr + 3*x+vlanes_32*3, vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32*4, vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*5, vx_load(tmp_buf + vlanes_32*2)); \
+    } else { \
+        vx_store(dstptr + 3*(x),   i01_fpix00); \
+        vx_store(dstptr + 3*(x+2), i23_fpix00); \
+        vx_store(dstptr + 3*(x+4), i45_fpix00); \
+        vx_store(dstptr + 3*(x+6), i67_fpix00); \
+        vx_store(dstptr + 3*(x+vlanes_32),   i89_fpix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+2), i1011_fpix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+4), i1213_fpix00); \
+        vx_store(dstptr + 3*(x+vlanes_32+6), i1415_fpix00); \
+    }
+#define CV_WARP_SIMD256_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0, 1) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2, 3) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(4, 5) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(6, 7) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(8, 9) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(10, 11) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(12, 13) \
+    CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(14, 15) \
+    CV_WARP_SIMD256_##INTER##_STORE_##DEPTH##C3_I()
+
+
 #define CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD, INTER, DEPTH, CN) \
-    CV_WARP_##SIMD##_SHUFFLE_INTER_STORE(INTER, DEPTH, CN)
+    CV_WARP_##SIMD##_SHUFFLE_INTER_STORE_##CN(INTER, DEPTH)

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1289,218 +1289,101 @@
     CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(12, 13) \
     CV_WARP_SIMD256_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(14, 15) \
     CV_WARP_SIMD256_##INTER##_STORE_##DEPTH##C3_I()
+
+#define CV_WARP_SIMDX_NEAREST_BUFFER_DEF_8UC3() \
+    uint32_t tmp_buf[max_vlanes_16 * 4];
+#define CV_WARP_SIMDX_NEAREST_BUFFER_DEF_16UC3() \
+    uint32_t tmp_buf[max_vlanes_16 * 4];
+#define CV_WARP_SIMDX_NEAREST_BUFFER_DEF_32FC3() \
+    float tmp_buf[max_vlanes_32 * 2 * 4];
+#define CV_WARP_SIMDX_LINEAR_BUFFER_DEF_8UC3() \
+    int32_t tmp_buf[max_vlanes_16 * 4];
+#define CV_WARP_SIMDX_LINEAR_BUFFER_DEF_16UC3() \
+    int32_t tmp_buf[max_vlanes_16 * 4];
+#define CV_WARP_SIMDX_LINEAR_BUFFER_DEF_32FC3() \
+    float tmp_buf[max_vlanes_32 * 2 * 4];
 // SIMD_SCALABLE (SIMDX), c3, nearest
-#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_8UC3_I(ofs0, ofs1) \
-    const uint8_t *srcptr##ofs0 = src + addr[ofs0]; \
-    v_uint32 i##ofs0##_pix0 = v_load_expand_q<4>(srcptr##ofs0); \
-    const uint8_t *srcptr##ofs1 = src + addr[ofs1]; \
-    v_uint32 i##ofs1##_pix0 = v_load_expand_q<4>(srcptr##ofs1);
-#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_16UC3_I(ofs0, ofs1) \
-    const uint16_t *srcptr##ofs0 = src + addr[ofs0]; \
-    v_uint32 i##ofs0##_pix0 = v_load_expand<4>(srcptr##ofs0); \
-    const uint16_t *srcptr##ofs1 = src + addr[ofs1]; \
-    v_uint32 i##ofs1##_pix0 = v_load_expand<4>(srcptr##ofs1);
-#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_32FC3_I(ofs0, ofs1) \
-    const float *srcptr##ofs0 = src + addr[ofs0]; \
-    v_float32 i##ofs0##_fpix0 = v_load<4>(srcptr##ofs0); \
-    const float *srcptr##ofs1 = src + addr[ofs1]; \
-    v_float32 i##ofs1##_fpix0 = v_load<4>(srcptr##ofs1);
-#define CV_WARP_SIMDX_NEAREST_STORE_8UC3_I() \
-    uint32_t tmp_buf[max_vlanes_16*4]; \
-    v_store<4>(tmp_buf,       i0_pix0); \
-    v_store<4>(tmp_buf + 3,   i1_pix0); \
-    v_store<4>(tmp_buf + 3*2, i2_pix0); \
-    v_store<4>(tmp_buf + 3*3, i3_pix0); \
-    v_store<4>(tmp_buf + 3*4, i4_pix0); \
-    v_store<4>(tmp_buf + 3*5, i5_pix0); \
-    v_store<4>(tmp_buf + 3*6, i6_pix0); \
-    v_store<4>(tmp_buf + 3*7, i7_pix0); \
-    v_store<4>(tmp_buf + 3*8, i8_pix0); \
-    v_store<4>(tmp_buf + 3*9, i9_pix0); \
-    v_store<4>(tmp_buf + 3*10, i10_pix0); \
-    v_store<4>(tmp_buf + 3*11, i11_pix0); \
-    v_store<4>(tmp_buf + 3*12, i12_pix0); \
-    v_store<4>(tmp_buf + 3*13, i13_pix0); \
-    v_store<4>(tmp_buf + 3*14, i14_pix0); \
-    v_store<4>(tmp_buf + 3*15, i15_pix0); \
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_8UC3_I() \
+    const uint8_t *srcptrk = src + addr[k]; \
+    v_uint32 ik_pix0 = v_load_expand_q<4>(srcptrk); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_16UC3_I() \
+    const uint16_t *srcptrk = src + addr[k]; \
+    v_uint32 ik_pix0 = v_load_expand<4>(srcptrk); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_NEAREST_SHUFFLE_INTER_32FC3_I() \
+    const float *srcptrk = src + addr[k]; \
+    v_float32 ik_pix0 = v_load<4>(srcptrk); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_NEAREST_STORE_8UC3() \
     for (int k = 0; k < uf*3; k++) { \
         dstptr[3*x+k] = saturate_cast<uchar>(tmp_buf[k]); \
     }
-#define CV_WARP_SIMDX_NEAREST_STORE_16UC3_I() \
-    uint32_t tmp_buf[max_vlanes_16*4]; \
-    v_store<4>(tmp_buf,       i0_pix0); \
-    v_store<4>(tmp_buf + 3,   i1_pix0); \
-    v_store<4>(tmp_buf + 3*2, i2_pix0); \
-    v_store<4>(tmp_buf + 3*3, i3_pix0); \
-    v_store<4>(tmp_buf + 3*4, i4_pix0); \
-    v_store<4>(tmp_buf + 3*5, i5_pix0); \
-    v_store<4>(tmp_buf + 3*6, i6_pix0); \
-    v_store<4>(tmp_buf + 3*7, i7_pix0); \
-    v_store<4>(tmp_buf + 3*8, i8_pix0); \
-    v_store<4>(tmp_buf + 3*9, i9_pix0); \
-    v_store<4>(tmp_buf + 3*10, i10_pix0); \
-    v_store<4>(tmp_buf + 3*11, i11_pix0); \
-    v_store<4>(tmp_buf + 3*12, i12_pix0); \
-    v_store<4>(tmp_buf + 3*13, i13_pix0); \
-    v_store<4>(tmp_buf + 3*14, i14_pix0); \
-    v_store<4>(tmp_buf + 3*15, i15_pix0); \
+#define CV_WARP_SIMDX_NEAREST_STORE_16UC3() \
     for (int k = 0; k < uf*3; k++) { \
         dstptr[3*x+k] = saturate_cast<ushort>(tmp_buf[k]); \
     }
-#define CV_WARP_SIMDX_NEAREST_STORE_32FC3_I() \
-    v_store<3>(dstptr + 3*(x),   i0_fpix0); \
-    v_store<3>(dstptr + 3*(x+1), i1_fpix0); \
-    v_store<3>(dstptr + 3*(x+2), i2_fpix0); \
-    v_store<3>(dstptr + 3*(x+3), i3_fpix0); \
-    v_store<3>(dstptr + 3*(x+4), i4_fpix0); \
-    v_store<3>(dstptr + 3*(x+5), i5_fpix0); \
-    v_store<3>(dstptr + 3*(x+6), i6_fpix0); \
-    v_store<3>(dstptr + 3*(x+7), i7_fpix0); \
-    v_store<3>(dstptr + 3*(x+8), i8_fpix0); \
-    v_store<3>(dstptr + 3*(x+9), i9_fpix0); \
-    v_store<3>(dstptr + 3*(x+10), i10_fpix0); \
-    v_store<3>(dstptr + 3*(x+11), i11_fpix0); \
-    v_store<3>(dstptr + 3*(x+12), i12_fpix0); \
-    v_store<3>(dstptr + 3*(x+13), i13_fpix0); \
-    v_store<3>(dstptr + 3*(x+14), i14_fpix0); \
-    v_store<3>(dstptr + 3*(x+15), i15_fpix0);
+#define CV_WARP_SIMDX_NEAREST_STORE_32FC3() \
+    for (int k = 0; k < uf*3; k++) { \
+        dstptr[3*x+k] = saturate_cast<float>(tmp_buf[k]); \
+    }
 // SIMD_SCALABLE (SIMDX), c3, bilinear
-#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_8UC3_I(ofs0, ofs1) \
-    const uint8_t *srcptr##ofs0 = src + addr[ofs0]; \
-    v_float32 i##ofs0##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs0))), \
-              i##ofs0##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs0+3))), \
-              i##ofs0##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs0+srcstep))), \
-              i##ofs0##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs0+srcstep+3))); \
-    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
-              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix1, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    i##ofs0##_fpix2 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix3, i##ofs0##_fpix2), i##ofs0##_fpix2); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_beta,  v_sub(i##ofs0##_fpix2, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    auto i##ofs0##_pix0 = v_round(i##ofs0##_fpix0); \
-    const uint8_t *srcptr##ofs1 = src + addr[ofs1]; \
-    v_float32 i##ofs1##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs1))), \
-              i##ofs1##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs1+3))), \
-              i##ofs1##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs1+srcstep))), \
-              i##ofs1##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptr##ofs1+srcstep+3))); \
-    v_float32 i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
-              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix1, i##ofs1##_fpix0), i##ofs1##_fpix0); \
-    i##ofs1##_fpix2 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix3, i##ofs1##_fpix2), i##ofs1##_fpix2); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_beta,  v_sub(i##ofs1##_fpix2, i##ofs1##_fpix0), i##ofs1##_fpix0); \
-    auto i##ofs1##_pix0 = v_round(i##ofs1##_fpix0);
-#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_16UC3_I(ofs0, ofs1) \
-    const uint16_t *srcptr##ofs0 = src + addr[ofs0]; \
-    v_float32 i##ofs0##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs0))), \
-              i##ofs0##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs0+3))), \
-              i##ofs0##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs0+srcstep))), \
-              i##ofs0##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs0+srcstep+3))); \
-    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
-              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix1, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    i##ofs0##_fpix2 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix3, i##ofs0##_fpix2), i##ofs0##_fpix2); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_beta,  v_sub(i##ofs0##_fpix2, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    auto i##ofs0##_pix0 = v_round(i##ofs0##_fpix0); \
-    const uint16_t *srcptr##ofs1 = src + addr[ofs1]; \
-    v_float32 i##ofs1##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs1))), \
-              i##ofs1##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs1+3))), \
-              i##ofs1##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs1+srcstep))), \
-              i##ofs1##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptr##ofs1+srcstep+3))); \
-    v_float32 i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
-              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix1, i##ofs1##_fpix0), i##ofs1##_fpix0); \
-    i##ofs1##_fpix2 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix3, i##ofs1##_fpix2), i##ofs1##_fpix2); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_beta,  v_sub(i##ofs1##_fpix2, i##ofs1##_fpix0), i##ofs1##_fpix0); \
-    auto i##ofs1##_pix0 = v_round(i##ofs1##_fpix0);
-#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_32FC3_I(ofs0, ofs1) \
-    const float *srcptr##ofs0 = src + addr[ofs0]; \
-    v_float32 i##ofs0##_fpix0 = v_load<4>(srcptr##ofs0), \
-              i##ofs0##_fpix1 = v_load<4>(srcptr##ofs0+3), \
-              i##ofs0##_fpix2 = v_load<4>(srcptr##ofs0+srcstep), \
-              i##ofs0##_fpix3 = v_load<4>(srcptr##ofs0+srcstep+3); \
-    v_float32 i##ofs0##_alpha = vx_setall_f32(valpha[ofs0]), \
-              i##ofs0##_beta  = vx_setall_f32(vbeta[ofs0]); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix1, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    i##ofs0##_fpix2 = v_fma(i##ofs0##_alpha, v_sub(i##ofs0##_fpix3, i##ofs0##_fpix2), i##ofs0##_fpix2); \
-    i##ofs0##_fpix0 = v_fma(i##ofs0##_beta,  v_sub(i##ofs0##_fpix2, i##ofs0##_fpix0), i##ofs0##_fpix0); \
-    const float *srcptr##ofs1 = src + addr[ofs1]; \
-    v_float32 i##ofs1##_fpix0 = v_load<4>(srcptr##ofs1), \
-              i##ofs1##_fpix1 = v_load<4>(srcptr##ofs1+3), \
-              i##ofs1##_fpix2 = v_load<4>(srcptr##ofs1+srcstep), \
-              i##ofs1##_fpix3 = v_load<4>(srcptr##ofs1+srcstep+3); \
-    v_float32 i##ofs1##_alpha = vx_setall_f32(valpha[ofs1]), \
-              i##ofs1##_beta  = vx_setall_f32(vbeta[ofs1]); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix1, i##ofs1##_fpix0), i##ofs1##_fpix0); \
-    i##ofs1##_fpix2 = v_fma(i##ofs1##_alpha, v_sub(i##ofs1##_fpix3, i##ofs1##_fpix2), i##ofs1##_fpix2); \
-    i##ofs1##_fpix0 = v_fma(i##ofs1##_beta,  v_sub(i##ofs1##_fpix2, i##ofs1##_fpix0), i##ofs1##_fpix0);
-#define CV_WARP_SIMDX_LINEAR_STORE_8UC3_I() \
-    int32_t tmp_buf[max_vlanes_16*4]; \
-    v_store<4>(tmp_buf,       i0_pix0); \
-    v_store<4>(tmp_buf + 3,   i1_pix0); \
-    v_store<4>(tmp_buf + 3*2, i2_pix0); \
-    v_store<4>(tmp_buf + 3*3, i3_pix0); \
-    v_store<4>(tmp_buf + 3*4, i4_pix0); \
-    v_store<4>(tmp_buf + 3*5, i5_pix0); \
-    v_store<4>(tmp_buf + 3*6, i6_pix0); \
-    v_store<4>(tmp_buf + 3*7, i7_pix0); \
-    v_store<4>(tmp_buf + 3*8, i8_pix0); \
-    v_store<4>(tmp_buf + 3*9, i9_pix0); \
-    v_store<4>(tmp_buf + 3*10, i10_pix0); \
-    v_store<4>(tmp_buf + 3*11, i11_pix0); \
-    v_store<4>(tmp_buf + 3*12, i12_pix0); \
-    v_store<4>(tmp_buf + 3*13, i13_pix0); \
-    v_store<4>(tmp_buf + 3*14, i14_pix0); \
-    v_store<4>(tmp_buf + 3*15, i15_pix0); \
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_8UC3_I() \
+    const uint8_t *srcptrk = src + addr[k]; \
+    v_float32 ik_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk))); \
+    v_float32 ik_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + 3))); \
+    v_float32 ik_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep))); \
+    v_float32 ik_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep + 3))); \
+    v_float32 ik_alpha = vx_setall_f32(valpha[k]); \
+    v_float32 ik_beta = vx_setall_f32(vbeta[k]); \
+    ik_fpix0 = v_fma(ik_alpha, v_sub(ik_fpix1, ik_fpix0), ik_fpix0); \
+    ik_fpix2 = v_fma(ik_alpha, v_sub(ik_fpix3, ik_fpix2), ik_fpix2); \
+    ik_fpix0 = v_fma(ik_beta,  v_sub(ik_fpix2, ik_fpix0), ik_fpix0); \
+    auto ik_pix0 = v_round(ik_fpix0); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_16UC3_I() \
+    const uint16_t *srcptrk = src + addr[k]; \
+    v_float32 ik_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptrk))), \
+              ik_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptrk+3))), \
+              ik_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptrk+srcstep))), \
+              ik_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand<4>(srcptrk+srcstep+3))); \
+    v_float32 ik_alpha = vx_setall_f32(valpha[k]), \
+              ik_beta  = vx_setall_f32(vbeta[k]); \
+    ik_fpix0 = v_fma(ik_alpha, v_sub(ik_fpix1, ik_fpix0), ik_fpix0); \
+    ik_fpix2 = v_fma(ik_alpha, v_sub(ik_fpix3, ik_fpix2), ik_fpix2); \
+    ik_fpix0 = v_fma(ik_beta,  v_sub(ik_fpix2, ik_fpix0), ik_fpix0); \
+    auto ik_pix0 = v_round(ik_fpix0); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_LINEAR_SHUFFLE_INTER_32FC3_I() \
+    const float *srcptrk = src + addr[k]; \
+    v_float32 ik_pix0 = v_load<4>(srcptrk); \
+    v_float32 ik_pix1 = v_load<4>(srcptrk+3); \
+    v_float32 ik_pix2 = v_load<4>(srcptrk+srcstep); \
+    v_float32 ik_pix3 = v_load<4>(srcptrk+srcstep+3); \
+    v_float32 ik_alpha = vx_setall_f32(valpha[k]); \
+    v_float32 ik_beta  = vx_setall_f32(vbeta[k]); \
+    ik_pix0 = v_fma(ik_alpha, v_sub(ik_pix1, ik_pix0), ik_pix0); \
+    ik_pix2 = v_fma(ik_alpha, v_sub(ik_pix3, ik_pix2), ik_pix2); \
+    ik_pix0 = v_fma(ik_beta,  v_sub(ik_pix2, ik_pix0), ik_pix0); \
+    v_store<4>(tmp_buf + 3 * k, ik_pix0);
+#define CV_WARP_SIMDX_LINEAR_STORE_8UC3() \
     for (int k = 0; k < uf*3; k++) { \
         dstptr[3*x+k] = saturate_cast<uchar>(tmp_buf[k]); \
     }
-#define CV_WARP_SIMDX_LINEAR_STORE_16UC3_I() \
-    int32_t tmp_buf[max_vlanes_16*4]; \
-    v_store<4>(tmp_buf,       i0_pix0); \
-    v_store<4>(tmp_buf + 3,   i1_pix0); \
-    v_store<4>(tmp_buf + 3*2, i2_pix0); \
-    v_store<4>(tmp_buf + 3*3, i3_pix0); \
-    v_store<4>(tmp_buf + 3*4, i4_pix0); \
-    v_store<4>(tmp_buf + 3*5, i5_pix0); \
-    v_store<4>(tmp_buf + 3*6, i6_pix0); \
-    v_store<4>(tmp_buf + 3*7, i7_pix0); \
-    v_store<4>(tmp_buf + 3*8, i8_pix0); \
-    v_store<4>(tmp_buf + 3*9, i9_pix0); \
-    v_store<4>(tmp_buf + 3*10, i10_pix0); \
-    v_store<4>(tmp_buf + 3*11, i11_pix0); \
-    v_store<4>(tmp_buf + 3*12, i12_pix0); \
-    v_store<4>(tmp_buf + 3*13, i13_pix0); \
-    v_store<4>(tmp_buf + 3*14, i14_pix0); \
-    v_store<4>(tmp_buf + 3*15, i15_pix0); \
+#define CV_WARP_SIMDX_LINEAR_STORE_16UC3() \
     for (int k = 0; k < uf*3; k++) { \
         dstptr[3*x+k] = saturate_cast<ushort>(tmp_buf[k]); \
     }
-#define CV_WARP_SIMDX_LINEAR_STORE_32FC3_I() \
-    v_store<3>(dstptr + 3*(x),   i0_fpix0); \
-    v_store<3>(dstptr + 3*(x+1), i1_fpix0); \
-    v_store<3>(dstptr + 3*(x+2), i2_fpix0); \
-    v_store<3>(dstptr + 3*(x+3), i3_fpix0); \
-    v_store<3>(dstptr + 3*(x+4), i4_fpix0); \
-    v_store<3>(dstptr + 3*(x+5), i5_fpix0); \
-    v_store<3>(dstptr + 3*(x+6), i6_fpix0); \
-    v_store<3>(dstptr + 3*(x+7), i7_fpix0); \
-    v_store<3>(dstptr + 3*(x+8), i8_fpix0); \
-    v_store<3>(dstptr + 3*(x+9), i9_fpix0); \
-    v_store<3>(dstptr + 3*(x+10), i10_fpix0); \
-    v_store<3>(dstptr + 3*(x+11), i11_fpix0); \
-    v_store<3>(dstptr + 3*(x+12), i12_fpix0); \
-    v_store<3>(dstptr + 3*(x+13), i13_fpix0); \
-    v_store<3>(dstptr + 3*(x+14), i14_fpix0); \
-    v_store<3>(dstptr + 3*(x+15), i15_fpix0);
+#define CV_WARP_SIMDX_LINEAR_STORE_32FC3() \
+    for (int k = 0; k < uf*3; k++) { \
+        dstptr[3*x+k] = saturate_cast<float>(tmp_buf[k]); \
+    }
 #define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0, 1) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2, 3) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(4, 5) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(6, 7) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(8, 9) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(10, 11) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(12, 13) \
-    CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(14, 15) \
-    CV_WARP_SIMDX_##INTER##_STORE_##DEPTH##C3_I() \
+    CV_WARP_SIMDX_##INTER##_BUFFER_DEF_##DEPTH##C3() \
+    for (int k = 0; k < uf; k++) { \
+        CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I() \
+    } \
+    CV_WARP_SIMDX_##INTER##_STORE_##DEPTH##C3()
 
 #define CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD, INTER, DEPTH, CN) \
     CV_WARP_##SIMD##_SHUFFLE_INTER_STORE_##CN(INTER, DEPTH)

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -873,16 +873,6 @@
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC3_I(ofs) \
     const float *srcptr##ofs = src + addr[ofs]; \
   v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs);
-// #define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
-//     v_pack_store(dstptr + 3*(x), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-//     v_pack_store(dstptr + 3*(x+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0))); \
-//     v_pack_store(dstptr + 3*(x+4), v_rotate_right<1>(v_pack(v_rotate_left<1>(i4_pix0), i5_pix0))); \
-//     v_pack_store(dstptr + 3*(x+6), v_rotate_right<1>(v_pack(v_rotate_left<1>(i6_pix0), i7_pix0)));
-// #define CV_WARP_SIMD128_NEAREST_STORE_16UC3_I() \
-//     vx_store(dstptr + 3*(x), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-//     vx_store(dstptr + 3*(x+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0))); \
-//     vx_store(dstptr + 3*(x+4), v_rotate_right<1>(v_pack(v_rotate_left<1>(i4_pix0), i5_pix0))); \
-//     vx_store(dstptr + 3*(x+6), v_rotate_right<1>(v_pack(v_rotate_left<1>(i6_pix0), i7_pix0)));
 #define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
     uint32_t tmp_buf[max_vlanes_16*4]; \
     vx_store(tmp_buf,       i0_pix0); \
@@ -978,24 +968,6 @@
     i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
     i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
     i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-// #define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
-//     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i0_pix0), i1_pix0)); \
-//     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i2_pix0), i3_pix0)); \
-//     v_uint16 i45_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i4_pix0), i5_pix0)); \
-//     v_uint16 i67_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i6_pix0), i7_pix0)); \
-//     v_pack_store(dstptr + 3*(x),   i01_pix); \
-//     v_pack_store(dstptr + 3*(x+2), i23_pix); \
-//     v_pack_store(dstptr + 3*(x+4), i45_pix); \
-//     v_pack_store(dstptr + 3*(x+6), i67_pix);
-// #define CV_WARP_SIMD128_LINEAR_STORE_16UC3_I() \
-//     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
-//     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
-//     v_uint16 i45_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i4_pix0)), v_round(i5_pix0))); \
-//     v_uint16 i67_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i6_pix0)), v_round(i7_pix0))); \
-//     vx_store(dstptr + 3*(x),   i01_pix); \
-//     vx_store(dstptr + 3*(x+2), i23_pix); \
-//     vx_store(dstptr + 3*(x+4), i45_pix); \
-//     vx_store(dstptr + 3*(x+6), i67_pix);
 #define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
     int32_t tmp_buf[max_vlanes_16*4]; \
     vx_store(tmp_buf,       i0_pix0); \

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -865,79 +865,206 @@
 // Special case for C3 shuffle, interpolation and store
 // SIMD128, c3, nearest
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_8UC4_I(ofs)
+    const uint8_t *srcptr##ofs = src + addr[ofs]; \
+    v_uint32 i##ofs##_pix0 = vx_load_expand_q(srcptr##ofs);
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_16UC4_I(ofs)
+    const uint16_t *srcptr##ofs = src + addr[ofs]; \
+    v_uint32 i##ofs##_pix0 = vx_load_expand(srcptr##ofs);
 #define CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC3_I(ofs) \
-    CV_WARP_SIMD128_NEAREST_SHUFFLE_INTER_32FC4_I(ofs)
+    const float *srcptr##ofs = src + addr[ofs]; \
+  v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs);
+// #define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
+//     v_pack_store(dstptr + 3*(x), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
+//     v_pack_store(dstptr + 3*(x+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0))); \
+//     v_pack_store(dstptr + 3*(x+4), v_rotate_right<1>(v_pack(v_rotate_left<1>(i4_pix0), i5_pix0))); \
+//     v_pack_store(dstptr + 3*(x+6), v_rotate_right<1>(v_pack(v_rotate_left<1>(i6_pix0), i7_pix0)));
+// #define CV_WARP_SIMD128_NEAREST_STORE_16UC3_I() \
+//     vx_store(dstptr + 3*(x), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
+//     vx_store(dstptr + 3*(x+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0))); \
+//     vx_store(dstptr + 3*(x+4), v_rotate_right<1>(v_pack(v_rotate_left<1>(i4_pix0), i5_pix0))); \
+//     vx_store(dstptr + 3*(x+6), v_rotate_right<1>(v_pack(v_rotate_left<1>(i6_pix0), i7_pix0)));
 #define CV_WARP_SIMD128_NEAREST_STORE_8UC3_I() \
-    v_pack_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-    v_pack_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+    uint32_t tmp_buf[max_vlanes_16*4]; \
+    vx_store(tmp_buf,       i0_pix0); \
+    vx_store(tmp_buf + 3,   i1_pix0); \
+    vx_store(tmp_buf + 3*2, i2_pix0); \
+    vx_store(tmp_buf + 3*3, i3_pix0); \
+    vx_store(tmp_buf + 3*4, i4_pix0); \
+    vx_store(tmp_buf + 3*5, i5_pix0); \
+    vx_store(tmp_buf + 3*6, i6_pix0); \
+    vx_store(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+    v_pack_store(dstptr + 3*x,             pix0); \
+    v_pack_store(dstptr + 3*x+vlanes_16,   pix1); \
+    v_pack_store(dstptr + 3*x+vlanes_16*2, pix2);
 #define CV_WARP_SIMD128_NEAREST_STORE_16UC3_I() \
-    vx_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0))); \
-    vx_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+    uint32_t tmp_buf[max_vlanes_16*4]; \
+    vx_store(tmp_buf,       i0_pix0); \
+    vx_store(tmp_buf + 3,   i1_pix0); \
+    vx_store(tmp_buf + 3*2, i2_pix0); \
+    vx_store(tmp_buf + 3*3, i3_pix0); \
+    vx_store(tmp_buf + 3*4, i4_pix0); \
+    vx_store(tmp_buf + 3*5, i5_pix0); \
+    vx_store(tmp_buf + 3*6, i6_pix0); \
+    vx_store(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+    vx_store(dstptr + 3*x,             pix0); \
+    vx_store(dstptr + 3*x+vlanes_16,   pix1); \
+    vx_store(dstptr + 3*x+vlanes_16*2, pix2);
 #define CV_WARP_SIMD128_NEAREST_STORE_32FC3_I() \
-    vx_store(dstptr + 3*(x+i),   i0_pix0); \
-    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
-    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
-    vx_store(dstptr + 3*(x+i+3), i3_pix0);
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        vx_store(tmp_buf,       i0_pix0); \
+        vx_store(tmp_buf + 3,   i1_pix0); \
+        vx_store(tmp_buf + 3*2, i2_pix0); \
+        vx_store(tmp_buf + 3*3, i3_pix0); \
+        vx_store(dstptr + 3*x,             vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32,   vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*2, vx_load(tmp_buf + vlanes_32*2)); \
+        vx_store(tmp_buf,       i4_pix0); \
+        vx_store(tmp_buf + 3,   i5_pix0); \
+        vx_store(tmp_buf + 3*2, i6_pix0); \
+        vx_store(tmp_buf + 3*3, i7_pix0); \
+        vx_store(dstptr + 3*x+vlanes_32*3, vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32*4, vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*5, vx_load(tmp_buf + vlanes_32*2)); \
+    } else { \
+        vx_store(dstptr + 3*(x),   i0_pix0); \
+        vx_store(dstptr + 3*(x+1), i1_pix0); \
+        vx_store(dstptr + 3*(x+2), i2_pix0); \
+        vx_store(dstptr + 3*(x+3), i3_pix0); \
+        vx_store(dstptr + 3*(x+4), i4_pix0); \
+        vx_store(dstptr + 3*(x+5), i5_pix0); \
+        vx_store(dstptr + 3*(x+6), i6_pix0); \
+        vx_store(dstptr + 3*(x+7), i7_pix0); \
+    }
 // SIMD128, c3, bilinear
 #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
-    const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
-    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs))); \
-    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+3))); \
-    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep))); \
-    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep+3))); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+    const uint8_t *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs))); \
+    v_float32 i##ofs##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+3))); \
+    v_float32 i##ofs##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep))); \
+    v_float32 i##ofs##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]);  \
+    i##ofs##_fpix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix1, i##ofs##_fpix0), i##ofs##_fpix0); \
+    i##ofs##_fpix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix3, i##ofs##_fpix2), i##ofs##_fpix2); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_fpix2, i##ofs##_fpix0), i##ofs##_fpix0); \
+    auto i##ofs##_pix0 = v_round(i##ofs##_fpix0);
 #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
-    const uint16_t *srcptr##ofs = src + addr[i+ofs]; \
-    v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
-    v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
-    v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
-    v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-    i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-    i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-    i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+    const uint16_t *srcptr##ofs = src + addr[ofs]; \
+    v_float32 i##ofs##_fpix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
+    v_float32 i##ofs##_fpix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
+    v_float32 i##ofs##_fpix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
+    v_float32 i##ofs##_fpix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]);  \
+    i##ofs##_fpix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix1, i##ofs##_fpix0), i##ofs##_fpix0); \
+    i##ofs##_fpix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_fpix3, i##ofs##_fpix2), i##ofs##_fpix2); \
+    i##ofs##_fpix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_fpix2, i##ofs##_fpix0), i##ofs##_fpix0); \
+    auto i##ofs##_pix0 = v_round(i##ofs##_fpix0);
 #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
-    const float *srcptr##ofs = src + addr[i+ofs]; \
+    const float *srcptr##ofs = src + addr[ofs]; \
     v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs); \
     v_float32 i##ofs##_pix1 = vx_load(srcptr##ofs+3); \
     v_float32 i##ofs##_pix2 = vx_load(srcptr##ofs+srcstep); \
     v_float32 i##ofs##_pix3 = vx_load(srcptr##ofs+srcstep+3); \
-    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]), \
-              i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+    v_float32 i##ofs##_alpha = vx_setall_f32(valpha[ofs]), \
+              i##ofs##_beta  = vx_setall_f32(vbeta[ofs]);  \
     i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
     i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
     i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+// #define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
+//     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i0_pix0), i1_pix0)); \
+//     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i2_pix0), i3_pix0)); \
+//     v_uint16 i45_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i4_pix0), i5_pix0)); \
+//     v_uint16 i67_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(i6_pix0), i7_pix0)); \
+//     v_pack_store(dstptr + 3*(x),   i01_pix); \
+//     v_pack_store(dstptr + 3*(x+2), i23_pix); \
+//     v_pack_store(dstptr + 3*(x+4), i45_pix); \
+//     v_pack_store(dstptr + 3*(x+6), i67_pix);
+// #define CV_WARP_SIMD128_LINEAR_STORE_16UC3_I() \
+//     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
+//     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
+//     v_uint16 i45_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i4_pix0)), v_round(i5_pix0))); \
+//     v_uint16 i67_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i6_pix0)), v_round(i7_pix0))); \
+//     vx_store(dstptr + 3*(x),   i01_pix); \
+//     vx_store(dstptr + 3*(x+2), i23_pix); \
+//     vx_store(dstptr + 3*(x+4), i45_pix); \
+//     vx_store(dstptr + 3*(x+6), i67_pix);
 #define CV_WARP_SIMD128_LINEAR_STORE_8UC3_I() \
-    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
-    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
-    v_pack_store(dstptr + 3*(x+i),   i01_pix); \
-    v_pack_store(dstptr + 3*(x+i+2), i23_pix);
+    int32_t tmp_buf[max_vlanes_16*4]; \
+    vx_store(tmp_buf,       i0_pix0); \
+    vx_store(tmp_buf + 3,   i1_pix0); \
+    vx_store(tmp_buf + 3*2, i2_pix0); \
+    vx_store(tmp_buf + 3*3, i3_pix0); \
+    vx_store(tmp_buf + 3*4, i4_pix0); \
+    vx_store(tmp_buf + 3*5, i5_pix0); \
+    vx_store(tmp_buf + 3*6, i6_pix0); \
+    vx_store(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack_u(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack_u(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack_u(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+    v_pack_store(dstptr + 3*x,             pix0); \
+    v_pack_store(dstptr + 3*x+vlanes_16,   pix1); \
+    v_pack_store(dstptr + 3*x+vlanes_16*2, pix2);
 #define CV_WARP_SIMD128_LINEAR_STORE_16UC3_I() \
-    v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0))); \
-    v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0))); \
-    vx_store(dstptr + 3*(x+i),   i01_pix); \
-    vx_store(dstptr + 3*(x+i+2), i23_pix);
+    int32_t tmp_buf[max_vlanes_16*4]; \
+    vx_store(tmp_buf,       i0_pix0); \
+    vx_store(tmp_buf + 3,   i1_pix0); \
+    vx_store(tmp_buf + 3*2, i2_pix0); \
+    vx_store(tmp_buf + 3*3, i3_pix0); \
+    vx_store(tmp_buf + 3*4, i4_pix0); \
+    vx_store(tmp_buf + 3*5, i5_pix0); \
+    vx_store(tmp_buf + 3*6, i6_pix0); \
+    vx_store(tmp_buf + 3*7, i7_pix0); \
+    v_uint16 pix0 = v_pack_u(vx_load(tmp_buf),             vx_load(tmp_buf+vlanes_32)); \
+    v_uint16 pix1 = v_pack_u(vx_load(tmp_buf+vlanes_32*2), vx_load(tmp_buf+vlanes_32*3)); \
+    v_uint16 pix2 = v_pack_u(vx_load(tmp_buf+vlanes_32*4), vx_load(tmp_buf+vlanes_32*5)); \
+    vx_store(dstptr + 3*x,             pix0); \
+    vx_store(dstptr + 3*x+vlanes_16,   pix1); \
+    vx_store(dstptr + 3*x+vlanes_16*2, pix2);
 #define CV_WARP_SIMD128_LINEAR_STORE_32FC3_I() \
-    vx_store(dstptr + 3*(x+i),   i0_pix0); \
-    vx_store(dstptr + 3*(x+i+1), i1_pix0); \
-    vx_store(dstptr + 3*(x+i+2), i2_pix0); \
-    vx_store(dstptr + 3*(x+i+3), i3_pix0);
-#define CV_WARP_SIMD128_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
-    for (int i = 0; i < uf; i+=vlanes_32) { \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(1) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2) \
-        CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(3) \
-        CV_WARP_SIMD128_##INTER##_STORE_##DEPTH##C3_I() \
+    if (rightmost) { \
+        float tmp_buf[max_vlanes_32*4]; \
+        vx_store(tmp_buf,       i0_pix0); \
+        vx_store(tmp_buf + 3,   i1_pix0); \
+        vx_store(tmp_buf + 3*2, i2_pix0); \
+        vx_store(tmp_buf + 3*3, i3_pix0); \
+        vx_store(dstptr + 3*x,             vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32,   vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*2, vx_load(tmp_buf + vlanes_32*2)); \
+        vx_store(tmp_buf,       i4_pix0); \
+        vx_store(tmp_buf + 3,   i5_pix0); \
+        vx_store(tmp_buf + 3*2, i6_pix0); \
+        vx_store(tmp_buf + 3*3, i7_pix0); \
+        vx_store(dstptr + 3*x+vlanes_32*3, vx_load(tmp_buf)); \
+        vx_store(dstptr + 3*x+vlanes_32*4, vx_load(tmp_buf + vlanes_32)); \
+        vx_store(dstptr + 3*x+vlanes_32*5, vx_load(tmp_buf + vlanes_32*2)); \
+    } else { \
+        vx_store(dstptr + 3*(x),   i0_pix0); \
+        vx_store(dstptr + 3*(x+1), i1_pix0); \
+        vx_store(dstptr + 3*(x+2), i2_pix0); \
+        vx_store(dstptr + 3*(x+3), i3_pix0); \
+        vx_store(dstptr + 3*(x+4), i4_pix0); \
+        vx_store(dstptr + 3*(x+5), i5_pix0); \
+        vx_store(dstptr + 3*(x+6), i6_pix0); \
+        vx_store(dstptr + 3*(x+7), i7_pix0); \
     }
+#define CV_WARP_SIMD128_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(0) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(1) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(2) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(3) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(4) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(5) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(6) \
+    CV_WARP_SIMD128_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I(7) \
+    CV_WARP_SIMD128_##INTER##_STORE_##DEPTH##C3_I() \
 // SIMD256, c3, nearest
 #define CV_WARP_SIMD256_NEAREST_SHUFFLE_INTER_8UC3_I(ofs0, ofs1) \
     const uint8_t *srcptr##ofs0 = src + addr[ofs0]; \

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1378,12 +1378,134 @@
     for (int k = 0; k < uf*3; k++) { \
         dstptr[3*x+k] = saturate_cast<float>(tmp_buf[k]); \
     }
-#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_GENERIC(INTER, DEPTH) \
     CV_WARP_SIMDX_##INTER##_BUFFER_DEF_##DEPTH##C3() \
     for (int k = 0; k < uf; k++) { \
         CV_WARP_SIMDX_##INTER##_SHUFFLE_INTER_##DEPTH##C3_I() \
     } \
     CV_WARP_SIMDX_##INTER##_STORE_##DEPTH##C3()
 
+#define CV_WARP_SIMDX_LINEAR_GATHER_32FC3_CHANNEL(HALF, CHANNEL, OFFSET) \
+    v_float32 i##HALF##_##CHANNEL##00 = v_lut(src, v_add(i##HALF##_addr00, OFFSET)), \
+              i##HALF##_##CHANNEL##01 = v_lut(src, v_add(i##HALF##_addr01, OFFSET)), \
+              i##HALF##_##CHANNEL##10 = v_lut(src, v_add(i##HALF##_addr10, OFFSET)), \
+              i##HALF##_##CHANNEL##11 = v_lut(src, v_add(i##HALF##_addr11, OFFSET)); \
+    i##HALF##_##CHANNEL##00 = v_fma(i##HALF##_alpha, \
+                                    v_sub(i##HALF##_##CHANNEL##01, i##HALF##_##CHANNEL##00), \
+                                    i##HALF##_##CHANNEL##00); \
+    i##HALF##_##CHANNEL##10 = v_fma(i##HALF##_alpha, \
+                                    v_sub(i##HALF##_##CHANNEL##11, i##HALF##_##CHANNEL##10), \
+                                    i##HALF##_##CHANNEL##10); \
+    v_float32 i##HALF##_##CHANNEL = v_fma(i##HALF##_beta, \
+                                          v_sub(i##HALF##_##CHANNEL##10, i##HALF##_##CHANNEL##00), \
+                                          i##HALF##_##CHANNEL##00);
+
+#define CV_WARP_SIMDX_LINEAR_GATHER_32FC3_I(HALF, DST_OFFSET) \
+    v_int32 i##HALF##_addr00 = addr_##HALF, \
+            i##HALF##_addr01 = v_add(i##HALF##_addr00, three), \
+            i##HALF##_addr10 = v_add(i##HALF##_addr00, v_srcstep), \
+            i##HALF##_addr11 = v_add(i##HALF##_addr10, three), \
+            i##HALF##_zero = vx_setzero_s32(), \
+            i##HALF##_two = v_add(one, one); \
+    v_float32 i##HALF##_alpha = src_x##HALF, \
+              i##HALF##_beta = src_y##HALF; \
+    CV_WARP_SIMDX_LINEAR_GATHER_32FC3_CHANNEL(HALF, r, i##HALF##_zero) \
+    CV_WARP_SIMDX_LINEAR_GATHER_32FC3_CHANNEL(HALF, g, one) \
+    CV_WARP_SIMDX_LINEAR_GATHER_32FC3_CHANNEL(HALF, b, i##HALF##_two) \
+    v_store_interleave(dstptr + 3*(x + DST_OFFSET), i##HALF##_r, i##HALF##_g, i##HALF##_b);
+
+#define CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(CHANNEL, OFFSET) \
+    v_uint16 CHANNEL##00_u16 = v_lut(src + OFFSET, addr), \
+             CHANNEL##01_u16 = v_lut(src + OFFSET, simdx_addr01), \
+             CHANNEL##10_u16 = v_lut(src + OFFSET, simdx_addr10), \
+             CHANNEL##11_u16 = v_lut(src + OFFSET, simdx_addr11); \
+    v_uint32 CHANNEL##00_u32_0, CHANNEL##00_u32_1, \
+             CHANNEL##01_u32_0, CHANNEL##01_u32_1, \
+             CHANNEL##10_u32_0, CHANNEL##10_u32_1, \
+             CHANNEL##11_u32_0, CHANNEL##11_u32_1; \
+    v_expand(CHANNEL##00_u16, CHANNEL##00_u32_0, CHANNEL##00_u32_1); \
+    v_expand(CHANNEL##01_u16, CHANNEL##01_u32_0, CHANNEL##01_u32_1); \
+    v_expand(CHANNEL##10_u16, CHANNEL##10_u32_0, CHANNEL##10_u32_1); \
+    v_expand(CHANNEL##11_u16, CHANNEL##11_u32_0, CHANNEL##11_u32_1); \
+    v_float32 CHANNEL##00_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_0)), \
+              CHANNEL##01_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_0)), \
+              CHANNEL##10_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_0)), \
+              CHANNEL##11_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_0)); \
+    CHANNEL##00_f32_0 = v_fma(src_x0, v_sub(CHANNEL##01_f32_0, CHANNEL##00_f32_0), CHANNEL##00_f32_0); \
+    CHANNEL##10_f32_0 = v_fma(src_x0, v_sub(CHANNEL##11_f32_0, CHANNEL##10_f32_0), CHANNEL##10_f32_0); \
+    v_int32 CHANNEL##_0 = v_round(v_fma(src_y0, v_sub(CHANNEL##10_f32_0, CHANNEL##00_f32_0), CHANNEL##00_f32_0)); \
+    v_float32 CHANNEL##00_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_1)), \
+              CHANNEL##01_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_1)), \
+              CHANNEL##10_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_1)), \
+              CHANNEL##11_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_1)); \
+    CHANNEL##00_f32_1 = v_fma(src_x1, v_sub(CHANNEL##01_f32_1, CHANNEL##00_f32_1), CHANNEL##00_f32_1); \
+    CHANNEL##10_f32_1 = v_fma(src_x1, v_sub(CHANNEL##11_f32_1, CHANNEL##10_f32_1), CHANNEL##10_f32_1); \
+    v_int32 CHANNEL##_1 = v_round(v_fma(src_y1, v_sub(CHANNEL##10_f32_1, CHANNEL##00_f32_1), CHANNEL##00_f32_1)); \
+    v_uint16 simdx_##CHANNEL = v_pack_u(CHANNEL##_0, CHANNEL##_1);
+
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_8U() \
+    uint8_t pixbuf[max_uf*4*3]; \
+    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U); \
+    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U); \
+    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3); \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3); \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_16U() \
+    (void)max_vlanes_16; \
+    int32_t simdx_addr01[max_uf], simdx_addr10[max_uf], simdx_addr11[max_uf]; \
+    for (int i = 0; i < uf; i++) { \
+        simdx_addr01[i] = addr[i] + 3; \
+        simdx_addr10[i] = addr[i] + int(srcstep); \
+        simdx_addr11[i] = simdx_addr10[i] + 3; \
+    } \
+    CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(r, 0) \
+    CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(g, 1) \
+    CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(b, 2) \
+    v_store_interleave(dstptr + 3*x, simdx_r, simdx_g, simdx_b);
+
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_NEAREST_8U() \
+    CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_GENERIC(NEAREST, 8U)
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_NEAREST_16U() \
+    CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_GENERIC(NEAREST, 16U)
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_NEAREST_32F() \
+    CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_GENERIC(NEAREST, 32F)
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_32F() \
+    CV_WARP_SIMDX_LINEAR_GATHER_32FC3_I(0, 0) \
+    CV_WARP_SIMDX_LINEAR_GATHER_32FC3_I(1, vlanes_32)
+#define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3(INTER, DEPTH) \
+    CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_##INTER##_##DEPTH()
+
 #define CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD, INTER, DEPTH, CN) \
     CV_WARP_##SIMD##_SHUFFLE_INTER_STORE_##CN(INTER, DEPTH)
+
+#define CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX() \
+    uint8_t pixbuf[max_uf*4*3]; \
+    if (v_reduce_min(inner_mask) != 0) { \
+        CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U); \
+    } else { \
+        CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U); \
+    } \
+    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U); \
+    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3); \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3); \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+
+#define CV_WARP_VECTOR_LINEAR_32FC3_PROCESS_SIMDX() \
+    if (v_reduce_min(inner_mask) != 0) { \
+        CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3); \
+    } else { \
+        CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F); \
+        CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F); \
+        CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3); \
+        CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3); \
+    }
+#define CV_WARP_VECTOR_LINEAR_32FC3_PROCESS_FIXED() \
+    if (v_reduce_min(inner_mask) != 0) { \
+        CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F); \
+    } else { \
+        CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F); \
+    } \
+    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F); \
+    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3); \
+    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1432,6 +1432,34 @@
     CV_WARP_SIMDX_LINEAR_GATHER_16UC3_HALF(CHANNEL, OFFSET, 1) \
     v_uint16 simdx_##CHANNEL = v_pack_u(CHANNEL##_0, CHANNEL##_1);
 
+#define CV_WARP_SIMDX_LINEAR_GATHER_8UC3_HALF(CHANNEL, OFFSET, HALF) \
+    v_uint32 CHANNEL##00_u32_##HALF = v_lut_expand(src + OFFSET, addr_##HALF), \
+             CHANNEL##01_u32_##HALF = v_lut_expand(src + OFFSET + 3, addr_##HALF), \
+             CHANNEL##10_u32_##HALF = v_lut_expand(src + OFFSET + srcstep, addr_##HALF), \
+             CHANNEL##11_u32_##HALF = v_lut_expand(src + OFFSET + srcstep + 3, addr_##HALF); \
+    v_float32 CHANNEL##00_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_##HALF)), \
+              CHANNEL##01_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_##HALF)), \
+              CHANNEL##10_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_##HALF)), \
+              CHANNEL##11_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_##HALF)); \
+    CHANNEL##00_f32_##HALF = v_fma(src_x##HALF, v_sub(CHANNEL##01_f32_##HALF, CHANNEL##00_f32_##HALF), CHANNEL##00_f32_##HALF); \
+    CHANNEL##10_f32_##HALF = v_fma(src_x##HALF, v_sub(CHANNEL##11_f32_##HALF, CHANNEL##10_f32_##HALF), CHANNEL##10_f32_##HALF); \
+    v_int32 CHANNEL##_##HALF = v_round(v_fma(src_y##HALF, v_sub(CHANNEL##10_f32_##HALF, CHANNEL##00_f32_##HALF), CHANNEL##00_f32_##HALF));
+
+#define CV_WARP_SIMDX_LINEAR_GATHER_8UC3_CHANNEL(CHANNEL, OFFSET) \
+    CV_WARP_SIMDX_LINEAR_GATHER_8UC3_HALF(CHANNEL, OFFSET, 0) \
+    CV_WARP_SIMDX_LINEAR_GATHER_8UC3_HALF(CHANNEL, OFFSET, 1) \
+    v_uint16 simdx_##CHANNEL = v_pack_u(CHANNEL##_0, CHANNEL##_1);
+
+#define CV_WARP_SIMDX_LINEAR_GATHER_8UC3() \
+    CV_WARP_SIMDX_LINEAR_GATHER_8UC3_CHANNEL(r, 0) \
+    CV_WARP_SIMDX_LINEAR_GATHER_8UC3_CHANNEL(g, 1) \
+    CV_WARP_SIMDX_LINEAR_GATHER_8UC3_CHANNEL(b, 2) \
+    uint16_t tbuf[max_vlanes_16*3]; \
+    v_store_interleave(tbuf, simdx_r, simdx_g, simdx_b); \
+    v_pack_store(dstptr + x*3, vx_load(tbuf)); \
+    v_pack_store(dstptr + x*3 + vlanes_16, vx_load(tbuf + vlanes_16)); \
+    v_pack_store(dstptr + x*3 + vlanes_16*2, vx_load(tbuf + vlanes_16*2));
+
 #define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_8U() \
     uint8_t pixbuf[max_uf*4*3]; \
     CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U); \
@@ -1461,6 +1489,18 @@
 
 #define CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD, INTER, DEPTH, CN) \
     CV_WARP_##SIMD##_SHUFFLE_INTER_STORE_##CN(INTER, DEPTH)
+
+#define CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX_GATHER() \
+    if (v_reduce_min(inner_mask) != 0) { \
+        CV_WARP_SIMDX_LINEAR_GATHER_8UC3() \
+    } else { \
+        uint8_t pixbuf[max_uf*4*3]; \
+        CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U); \
+        CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U); \
+        CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3); \
+        CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3); \
+        CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3); \
+    } \
 
 #define CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX() \
     uint8_t pixbuf[max_uf*4*3]; \

--- a/modules/imgproc/src/warp_common.vector.hpp
+++ b/modules/imgproc/src/warp_common.vector.hpp
@@ -1414,33 +1414,22 @@
     CV_WARP_SIMDX_LINEAR_GATHER_32FC3_CHANNEL(HALF, b, i##HALF##_two) \
     v_store_interleave(dstptr + 3*(x + DST_OFFSET), i##HALF##_r, i##HALF##_g, i##HALF##_b);
 
+#define CV_WARP_SIMDX_LINEAR_GATHER_16UC3_HALF(CHANNEL, OFFSET, HALF) \
+    v_uint32 CHANNEL##00_u32_##HALF = v_lut_expand(src + OFFSET, addr_##HALF), \
+             CHANNEL##01_u32_##HALF = v_lut_expand(src + OFFSET + 3, addr_##HALF), \
+             CHANNEL##10_u32_##HALF = v_lut_expand(src + OFFSET + srcstep, addr_##HALF), \
+             CHANNEL##11_u32_##HALF = v_lut_expand(src + OFFSET + srcstep + 3, addr_##HALF); \
+    v_float32 CHANNEL##00_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_##HALF)), \
+              CHANNEL##01_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_##HALF)), \
+              CHANNEL##10_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_##HALF)), \
+              CHANNEL##11_f32_##HALF = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_##HALF)); \
+    CHANNEL##00_f32_##HALF = v_fma(src_x##HALF, v_sub(CHANNEL##01_f32_##HALF, CHANNEL##00_f32_##HALF), CHANNEL##00_f32_##HALF); \
+    CHANNEL##10_f32_##HALF = v_fma(src_x##HALF, v_sub(CHANNEL##11_f32_##HALF, CHANNEL##10_f32_##HALF), CHANNEL##10_f32_##HALF); \
+    v_int32 CHANNEL##_##HALF = v_round(v_fma(src_y##HALF, v_sub(CHANNEL##10_f32_##HALF, CHANNEL##00_f32_##HALF), CHANNEL##00_f32_##HALF));
+
 #define CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(CHANNEL, OFFSET) \
-    v_uint16 CHANNEL##00_u16 = v_lut(src + OFFSET, addr), \
-             CHANNEL##01_u16 = v_lut(src + OFFSET, simdx_addr01), \
-             CHANNEL##10_u16 = v_lut(src + OFFSET, simdx_addr10), \
-             CHANNEL##11_u16 = v_lut(src + OFFSET, simdx_addr11); \
-    v_uint32 CHANNEL##00_u32_0, CHANNEL##00_u32_1, \
-             CHANNEL##01_u32_0, CHANNEL##01_u32_1, \
-             CHANNEL##10_u32_0, CHANNEL##10_u32_1, \
-             CHANNEL##11_u32_0, CHANNEL##11_u32_1; \
-    v_expand(CHANNEL##00_u16, CHANNEL##00_u32_0, CHANNEL##00_u32_1); \
-    v_expand(CHANNEL##01_u16, CHANNEL##01_u32_0, CHANNEL##01_u32_1); \
-    v_expand(CHANNEL##10_u16, CHANNEL##10_u32_0, CHANNEL##10_u32_1); \
-    v_expand(CHANNEL##11_u16, CHANNEL##11_u32_0, CHANNEL##11_u32_1); \
-    v_float32 CHANNEL##00_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_0)), \
-              CHANNEL##01_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_0)), \
-              CHANNEL##10_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_0)), \
-              CHANNEL##11_f32_0 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_0)); \
-    CHANNEL##00_f32_0 = v_fma(src_x0, v_sub(CHANNEL##01_f32_0, CHANNEL##00_f32_0), CHANNEL##00_f32_0); \
-    CHANNEL##10_f32_0 = v_fma(src_x0, v_sub(CHANNEL##11_f32_0, CHANNEL##10_f32_0), CHANNEL##10_f32_0); \
-    v_int32 CHANNEL##_0 = v_round(v_fma(src_y0, v_sub(CHANNEL##10_f32_0, CHANNEL##00_f32_0), CHANNEL##00_f32_0)); \
-    v_float32 CHANNEL##00_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##00_u32_1)), \
-              CHANNEL##01_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##01_u32_1)), \
-              CHANNEL##10_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##10_u32_1)), \
-              CHANNEL##11_f32_1 = v_cvt_f32(v_reinterpret_as_s32(CHANNEL##11_u32_1)); \
-    CHANNEL##00_f32_1 = v_fma(src_x1, v_sub(CHANNEL##01_f32_1, CHANNEL##00_f32_1), CHANNEL##00_f32_1); \
-    CHANNEL##10_f32_1 = v_fma(src_x1, v_sub(CHANNEL##11_f32_1, CHANNEL##10_f32_1), CHANNEL##10_f32_1); \
-    v_int32 CHANNEL##_1 = v_round(v_fma(src_y1, v_sub(CHANNEL##10_f32_1, CHANNEL##00_f32_1), CHANNEL##00_f32_1)); \
+    CV_WARP_SIMDX_LINEAR_GATHER_16UC3_HALF(CHANNEL, OFFSET, 0) \
+    CV_WARP_SIMDX_LINEAR_GATHER_16UC3_HALF(CHANNEL, OFFSET, 1) \
     v_uint16 simdx_##CHANNEL = v_pack_u(CHANNEL##_0, CHANNEL##_1);
 
 #define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_8U() \
@@ -1453,12 +1442,6 @@
 
 #define CV_WARP_SIMDX_SHUFFLE_INTER_STORE_C3_LINEAR_16U() \
     (void)max_vlanes_16; \
-    int32_t simdx_addr01[max_uf], simdx_addr10[max_uf], simdx_addr11[max_uf]; \
-    for (int i = 0; i < uf; i++) { \
-        simdx_addr01[i] = addr[i] + 3; \
-        simdx_addr10[i] = addr[i] + int(srcstep); \
-        simdx_addr11[i] = simdx_addr10[i] + 3; \
-    } \
     CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(r, 0) \
     CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(g, 1) \
     CV_WARP_SIMDX_LINEAR_GATHER_16UC3_CHANNEL(b, 2) \

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -473,8 +473,10 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -759,8 +761,10 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1086,6 +1090,7 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -1337,8 +1342,10 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1379,7 +1386,7 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
     #elif CV_SIMD128
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
     #elif CV_SIMD_SCALABLE
@@ -1620,8 +1627,10 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1946,6 +1955,7 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -2217,8 +2227,10 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2551,8 +2563,10 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2930,6 +2944,7 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -3538,8 +3553,10 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -3886,6 +3903,7 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -4798,8 +4816,10 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -5148,6 +5168,7 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -6131,8 +6152,10 @@ void remapLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
+        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+        int vlanes_16 = VTraits<v_uint16>::vlanes();
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -6534,6 +6557,7 @@ void remapLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_ro
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+                bool rightmost = x + uf >= dstcols;
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -7,6 +7,14 @@
 #include "warp_common.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
+#if CV_SIMD_SCALABLE
+#define CV_WARP_VECTOR_LINEAR_32FC3_PROCESS \
+    CV_WARP_VECTOR_LINEAR_32FC3_PROCESS_SIMDX
+#else
+#define CV_WARP_VECTOR_LINEAR_32FC3_PROCESS \
+    CV_WARP_VECTOR_LINEAR_32FC3_PROCESS_FIXED
+#endif
+
 #define CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1() \
     v_float32 dst_x0 = vx_load(start_indices.data()); \
     v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32))); \
@@ -3221,6 +3229,9 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if CV_SIMD_SCALABLE
+                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX();
+    #else
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                 uint8x8_t p00r, p01r, p10r, p11r,
                           p00g, p01g, p10g, p11g,
@@ -3261,6 +3272,7 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                 CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
     #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
@@ -4513,6 +4525,9 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if CV_SIMD_SCALABLE
+                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX();
+    #else
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                 uint8x8_t p00r, p01r, p10r, p11r,
                           p00g, p01g, p10g, p11g,
@@ -4553,6 +4568,7 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
                 CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
     #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
@@ -5159,14 +5175,7 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
-                if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F);
-                } else {
-                    CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
-                }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
+                CV_WARP_VECTOR_LINEAR_32FC3_PROCESS();
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -5816,6 +5825,9 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if CV_SIMD_SCALABLE
+                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX();
+    #else
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                 uint8x8_t p00r, p01r, p10r, p11r,
                           p00g, p01g, p10g, p11g,
@@ -5856,6 +5868,7 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
                 CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                 CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
     #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -492,7 +492,6 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -515,12 +514,33 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
+                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
+                    // for (int i = 0; i < uf; i+= vlanes_32) {
+                    //     const uint8_t *srcptr0 = src + addr[i+0];
+                    //     v_uint32 i0_pix0 = vx_load_expand_q(srcptr0);
+                    //     const uint8_t *srcptr1 = src + addr[i+1];
+                    //     v_uint32 i1_pix0 = vx_load_expand_q(srcptr1);
+                    //     const uint8_t *srcptr2 = src + addr[i+2];
+                    //     v_uint32 i2_pix0 = vx_load_expand_q(srcptr2);
+                    //     const uint8_t *srcptr3 = src + addr[i+3];
+                    //     v_uint32 i3_pix0 = vx_load_expand_q(srcptr3);
+
+                    //     v_pack_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0)));
+                    //     v_pack_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+                    // }
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
+    #endif
                 } else {
+                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -608,11 +628,11 @@ void warpAffineNearestInvoker_8UC4(const uint8_t *src_data, size_t src_step, int
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4];
@@ -772,7 +792,6 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -795,12 +814,33 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
+                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
+                    // for (int i = 0; i < uf; i+= vlanes_32) {
+                    //     const uint16_t *srcptr0 = src + addr[i+0];
+                    //     v_uint32 i0_pix0 = vx_load_expand(srcptr0);
+                    //     const uint16_t *srcptr1 = src + addr[i+1];
+                    //     v_uint32 i1_pix0 = vx_load_expand(srcptr1);
+                    //     const uint16_t *srcptr2 = src + addr[i+2];
+                    //     v_uint32 i2_pix0 = vx_load_expand(srcptr2);
+                    //     const uint16_t *srcptr3 = src + addr[i+3];
+                    //     v_uint32 i3_pix0 = vx_load_expand(srcptr3);
+
+                    //     vx_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0)));
+                    //     vx_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
+                    // }
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDx, NEAREST, 16U, C3);
+    #endif
                 } else {
+                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -889,11 +929,11 @@ void warpAffineNearestInvoker_16UC4(const uint16_t *src_data, size_t src_step, i
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4];
@@ -1051,7 +1091,6 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1077,12 +1116,35 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
+                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
+                    // for (int i = 0; i < uf; i+= vlanes_32) {
+                    //     const float *srcptr0 = src + addr[i+0];
+                    //     v_float32 i0_pix0 = vx_load(srcptr0);
+                    //     const float *srcptr1 = src + addr[i+1];
+                    //     v_float32 i1_pix0 = vx_load(srcptr1);
+                    //     const float *srcptr2 = src + addr[i+2];
+                    //     v_float32 i2_pix0 = vx_load(srcptr2);
+                    //     const float *srcptr3 = src + addr[i+3];
+                    //     v_float32 i3_pix0 = vx_load(srcptr3);
+
+                    //     vx_store(dstptr + 3*(x+i), i0_pix0);
+                    //     vx_store(dstptr + 3*(x+i+1), i1_pix0);
+                    //     vx_store(dstptr + 3*(x+i+2), i2_pix0);
+                    //     vx_store(dstptr + 3*(x+i+3), i3_pix0);
+                    // }
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
+    #endif
                 } else {
+                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1175,11 +1237,11 @@ void warpAffineNearestInvoker_32FC4(const float *src_data, size_t src_step, int 
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4];
@@ -1338,7 +1400,6 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1361,12 +1422,20 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
+    #elif CV_SIMD128
+                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
+    #endif
                 } else {
+                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1461,11 +1530,11 @@ void warpPerspectiveNearestInvoker_8UC4(const uint8_t *src_data, size_t src_step
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4];
@@ -1622,7 +1691,6 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1645,12 +1713,19 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
+    #endif
                 } else {
+                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1738,11 +1813,11 @@ void warpPerspectiveNearestInvoker_16UC4(const uint16_t *src_data, size_t src_st
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4];
@@ -1900,7 +1975,6 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1926,12 +2000,19 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
+    #endif
                 } else {
+                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2023,11 +2104,11 @@ void warpPerspectiveNearestInvoker_32FC4(const float *src_data, size_t src_step,
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4];
@@ -2207,7 +2288,6 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2232,12 +2312,19 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
+    #endif
                 } else {
+                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2342,11 +2429,11 @@ void remapNearestInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4];
@@ -2535,7 +2622,6 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2560,12 +2646,19 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
+    #endif
                 } else {
+                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2670,11 +2763,11 @@ void remapNearestInvoker_16UC4(const uint16_t *src_data, size_t src_step, int sr
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4];
@@ -2864,7 +2957,6 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2892,12 +2984,19 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
+    #endif
                 } else {
+                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -3006,11 +3105,11 @@ void remapNearestInvoker_32FC4(const float *src_data, size_t src_step, int src_r
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, NEAREST, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4];
@@ -3201,7 +3300,6 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -3212,11 +3310,6 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
-                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
-                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
-    #endif
 #endif
 
         for (int y = r.start; y < r.end; y++) {
@@ -3228,31 +3321,55 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                uint8x8_t p00r, p01r, p10r, p11r,
-                          p00g, p01g, p10g, p11g,
-                          p00b, p01b, p10b, p11b;
-    #endif
                 if (v_reduce_min(inner_mask) != 0) {
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
-    #else
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
+                    // float valpha[max_uf], vbeta[max_uf];
+                    // vx_store(valpha, src_x0);
+                    // vx_store(valpha+vlanes_32, src_x1);
+                    // vx_store(vbeta, src_y0);
+                    // vx_store(vbeta+vlanes_32, src_y1);
+                    // for (int i = 0; i < uf; i+=vlanes_32) {
+                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
+                    //         const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
+                    //         v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs))); \
+                    //         v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+3))); \
+                    //         v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+srcstep))); \
+                    //         v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+srcstep+3))); \
+                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
+                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(1);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(2);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(3);
+                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I
+
+                    //     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0)));
+                    //     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0)));
+                    //     v_pack_store(dstptr + 3*(x+i),   i01_pix);
+                    //     v_pack_store(dstptr + 3*(x+i+2), i23_pix);
+                    // }
                 } else {
+                    uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
-    #endif
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
                 }
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
-    #else
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
-    #endif
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -3353,11 +3470,11 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4*4];
@@ -3523,7 +3640,6 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -3546,14 +3662,54 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 16U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C3);
+    #endif
+                    // float valpha[max_uf], vbeta[max_uf];
+                    // vx_store(valpha, src_x0);
+                    // vx_store(valpha+vlanes_32, src_x1);
+                    // vx_store(vbeta, src_y0);
+                    // vx_store(vbeta+vlanes_32, src_y1);
+                    // for (int i = 0; i < uf; i+=vlanes_32) {
+                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
+                    //         const uint16_t *srcptr##ofs = src + addr[i+ofs]; \
+                    //         v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
+                    //         v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
+                    //         v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
+                    //         v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
+                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
+                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(1);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(2);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(3);
+                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I
+
+                    //     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0)));
+                    //     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0)));
+                    //     vx_store(dstptr + 3*(x+i),   i01_pix);
+                    //     vx_store(dstptr + 3*(x+i+2), i23_pix);
+                    // }
                 } else {
+                    uint16_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -3649,11 +3805,11 @@ void warpAffineLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, in
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4*4];
@@ -3818,7 +3974,6 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*4*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -3844,13 +3999,53 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F);
+    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3);
+    #endif
+                    // float valpha[max_uf], vbeta[max_uf];
+                    // vx_store(valpha, src_x0);
+                    // vx_store(valpha+vlanes_32, src_x1);
+                    // vx_store(vbeta, src_y0);
+                    // vx_store(vbeta+vlanes_32, src_y1);
+                    // for (int i = 0; i < uf; i+=vlanes_32) {
+                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
+                    //         const float *srcptr##ofs = src + addr[i+ofs]; \
+                    //         v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs); \
+                    //         v_float32 i##ofs##_pix1 = vx_load(srcptr##ofs+3); \
+                    //         v_float32 i##ofs##_pix2 = vx_load(srcptr##ofs+srcstep); \
+                    //         v_float32 i##ofs##_pix3 = vx_load(srcptr##ofs+srcstep+3); \
+                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
+                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
+                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
+                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(0);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(1);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(2);
+                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(3);
+                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I
+
+                    //     vx_store(dstptr + 3*(x+i),   i0_pix0);
+                    //     vx_store(dstptr + 3*(x+i+1), i1_pix0);
+                    //     vx_store(dstptr + 3*(x+i+2), i2_pix0);
+                    //     vx_store(dstptr + 3*(x+i+3), i3_pix0);
+                    // }
                 } else {
+                    float pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -3949,16 +4144,15 @@ void warpAffineLinearInvoker_32FC4(const float *src_data, size_t src_step, int s
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4*4];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C4, 32F);
-                    // CV_WARP_LINEAR_VECTOR_INTER_LOAD_F32(C4);
                     CV_WARP_VECTOR_INTER_LOAD(LINEAR, C4, 32F, 32F);
                     CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C4);
                     CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C4);
@@ -4452,7 +4646,6 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -4463,11 +4656,6 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
-                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
-                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
-    #endif
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
         for (int y = r.start; y < r.end; y++) {
@@ -4479,31 +4667,27 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                uint8x8_t p00r, p01r, p10r, p11r,
-                          p00g, p01g, p10g, p11g,
-                          p00b, p01b, p10b, p11b;
-    #endif
                 if (v_reduce_min(inner_mask) != 0) {
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
-    #else
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
                 } else {
+                    uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
-    #endif
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
                 }
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
-    #else
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
-    #endif
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -4601,11 +4785,11 @@ void warpPerspectiveLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step,
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4*4];
@@ -4772,7 +4956,6 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -4795,14 +4978,27 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 16U);
+                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 16U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C3);
+    #endif
                 } else {
+                    uint16_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -4812,9 +5008,7 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
                 float sy = (x*M[3] + y*M[4] + M[5]) / w;
 
                 CV_WARP_SCALAR_SHUFFLE(LINEAR, C3, 16U);
-
                 CV_WARP_SCALAR_LINEAR_INTER_CALC_F32(C3);
-
                 CV_WARP_SCALAR_STORE(LINEAR, C3, 16U);
             }
         }
@@ -4900,11 +5094,11 @@ void warpPerspectiveLinearInvoker_16UC4(const uint16_t *src_data, size_t src_ste
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4*4];
@@ -5071,7 +5265,6 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*4*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -5097,13 +5290,25 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3);
+    #endif
                 } else {
+                    float pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -5113,9 +5318,7 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
                 float sy = (x*M[3] + y*M[4] + M[5]) / w;
 
                 CV_WARP_SCALAR_SHUFFLE(LINEAR, C3, 32F);
-
                 CV_WARP_SCALAR_LINEAR_INTER_CALC_F32(C3);
-
                 CV_WARP_SCALAR_STORE(LINEAR, C3, 32F);
             }
         }
@@ -5205,11 +5408,11 @@ void warpPerspectiveLinearInvoker_32FC4(const float *src_data, size_t src_step, 
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4*4];
@@ -5726,7 +5929,6 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint8_t pixbuf[max_uf*4*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -5737,11 +5939,6 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
-                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
-                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
-    #endif
 #endif
 
         for (int y = r.start; y < r.end; y++) {
@@ -5755,31 +5952,27 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                uint8x8_t p00r, p01r, p10r, p11r,
-                          p00g, p01g, p10g, p11g,
-                          p00b, p01b, p10b, p11b;
-    #endif
                 if (v_reduce_min(inner_mask) != 0) {
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
-    #else
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 8U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
                 } else {
+                    uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
-    #endif
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
                 }
-    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
-                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
-    #else
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
-    #endif
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -5894,11 +6087,11 @@ void remapLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_r
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 8U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 8U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C4);
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4*4];
@@ -6097,7 +6290,6 @@ void remapLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        uint16_t pixbuf[max_uf*4*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -6122,14 +6314,26 @@ void remapLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 16U);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C3);
+    #endif
                 } else {
+                    uint16_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 16U);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
+                    CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 16U, 16U);
-                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U16(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -6242,11 +6446,11 @@ void remapLinearInvoker_16UC4(const uint16_t *src_data, size_t src_step, int src
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 16U, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 16U, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 16U);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C4);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*4*4];
@@ -6445,7 +6649,6 @@ void remapLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_ro
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
-        float pixbuf[max_uf*4*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -6473,13 +6676,25 @@ void remapLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_ro
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F);
+                    float valpha[max_uf], vbeta[max_uf];
+                    vx_store(valpha, src_x0);
+                    vx_store(valpha+vlanes_32, src_x1);
+                    vx_store(vbeta, src_y0);
+                    vx_store(vbeta+vlanes_32, src_y1);
+    #if CV_SIMD256
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C3);
+    #elif CV_SIMD128
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C3);
+    #elif CV_SIMD_SCALABLE
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3);
+    #endif
                 } else {
+                    float pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
+                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
+                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
                 }
-                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
-                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -6596,11 +6811,11 @@ void remapLinearInvoker_32FC4(const float *src_data, size_t src_step, int src_ro
                     vx_store(vbeta, src_y0);
                     vx_store(vbeta+vlanes_32, src_y1);
     #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD256, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C4);
     #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMD128, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C4);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE_C4(SIMDX, LINEAR, 32F);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C4);
     #endif
                 } else {
                     float pixbuf[max_uf*4*4];

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -1090,7 +1090,6 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -1955,7 +1954,6 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -2944,7 +2942,6 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -3319,7 +3316,8 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
         }
     };
 
-    parallel_for_(Range(0, dst_rows), worker);
+    // parallel_for_(Range(0, dst_rows), worker);
+    worker(Range(0, dst_rows));
 }
 
 void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
@@ -3903,7 +3901,6 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -5168,7 +5165,6 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -6557,7 +6553,6 @@ void remapLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_ro
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-                bool rightmost = x + uf >= dstcols;
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -8784,3 +8779,4 @@ ImgWarpFunc getBicubicWarpFunc_(int type)
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 } // cv
+ 

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -3314,25 +3314,6 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C3);
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
-                    // int32_t tmp_buf[max_vlanes_16 * 4];
-                    // for (int k = 0; k < uf; k++) {
-                    //     const uint8_t *srcptrk = src + addr[k];
-                    //     v_float32 ik_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk)));
-                    //     v_float32 ik_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + 3)));
-                    //     v_float32 ik_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep)));
-                    //     v_float32 ik_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep + 3)));
-                    //     v_float32 ik_alpha = vx_setall_f32(valpha[k]);
-                    //     v_float32 ik_beta = vx_setall_f32(vbeta[k]);
-
-                    //     ik_fpix0 = v_fma(ik_alpha, v_sub(ik_fpix1, ik_fpix0), ik_fpix0);
-                    //     ik_fpix2 = v_fma(ik_alpha, v_sub(ik_fpix3, ik_fpix2), ik_fpix2);
-                    //     ik_fpix0 = v_fma(ik_beta,  v_sub(ik_fpix2, ik_fpix0), ik_fpix0);
-                    //     auto ik_pix0 = v_round(ik_fpix0);
-                    //     v_store<4>(tmp_buf + 3 * k, ik_pix0);
-                    // }
-                    // for (int k = 0; k < uf * 3; k++) {
-                    //     dstptr[3 * x + k] = saturate_cast<uchar>(tmp_buf[k]);
-                    // };
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4*3];

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -3230,7 +3230,7 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
     #if CV_SIMD_SCALABLE
-                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX();
+                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX_GATHER();
     #else
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                 uint8x8_t p00r, p01r, p10r, p11r,
@@ -5826,7 +5826,7 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
     #if CV_SIMD_SCALABLE
-                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX();
+                CV_WARP_VECTOR_LINEAR_8UC3_PROCESS_SIMDX_GATHER();
     #else
     #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
                 uint8x8_t p00r, p01r, p10r, p11r,

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -518,20 +518,6 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
     #elif CV_SIMD128
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
-                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
-                    // for (int i = 0; i < uf; i+= vlanes_32) {
-                    //     const uint8_t *srcptr0 = src + addr[i+0];
-                    //     v_uint32 i0_pix0 = vx_load_expand_q(srcptr0);
-                    //     const uint8_t *srcptr1 = src + addr[i+1];
-                    //     v_uint32 i1_pix0 = vx_load_expand_q(srcptr1);
-                    //     const uint8_t *srcptr2 = src + addr[i+2];
-                    //     v_uint32 i2_pix0 = vx_load_expand_q(srcptr2);
-                    //     const uint8_t *srcptr3 = src + addr[i+3];
-                    //     v_uint32 i3_pix0 = vx_load_expand_q(srcptr3);
-
-                    //     v_pack_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0)));
-                    //     v_pack_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
-                    // }
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
     #endif
@@ -818,20 +804,6 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
     #elif CV_SIMD128
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
-                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
-                    // for (int i = 0; i < uf; i+= vlanes_32) {
-                    //     const uint16_t *srcptr0 = src + addr[i+0];
-                    //     v_uint32 i0_pix0 = vx_load_expand(srcptr0);
-                    //     const uint16_t *srcptr1 = src + addr[i+1];
-                    //     v_uint32 i1_pix0 = vx_load_expand(srcptr1);
-                    //     const uint16_t *srcptr2 = src + addr[i+2];
-                    //     v_uint32 i2_pix0 = vx_load_expand(srcptr2);
-                    //     const uint16_t *srcptr3 = src + addr[i+3];
-                    //     v_uint32 i3_pix0 = vx_load_expand(srcptr3);
-
-                    //     vx_store(dstptr + 3*(x+i), v_rotate_right<1>(v_pack(v_rotate_left<1>(i0_pix0), i1_pix0)));
-                    //     vx_store(dstptr + 3*(x+i+2), v_rotate_right<1>(v_pack(v_rotate_left<1>(i2_pix0), i3_pix0)));
-                    // }
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDx, NEAREST, 16U, C3);
     #endif
@@ -1120,22 +1092,6 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
     #elif CV_SIMD128
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
-                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
-                    // for (int i = 0; i < uf; i+= vlanes_32) {
-                    //     const float *srcptr0 = src + addr[i+0];
-                    //     v_float32 i0_pix0 = vx_load(srcptr0);
-                    //     const float *srcptr1 = src + addr[i+1];
-                    //     v_float32 i1_pix0 = vx_load(srcptr1);
-                    //     const float *srcptr2 = src + addr[i+2];
-                    //     v_float32 i2_pix0 = vx_load(srcptr2);
-                    //     const float *srcptr3 = src + addr[i+3];
-                    //     v_float32 i3_pix0 = vx_load(srcptr3);
-
-                    //     vx_store(dstptr + 3*(x+i), i0_pix0);
-                    //     vx_store(dstptr + 3*(x+i+1), i1_pix0);
-                    //     vx_store(dstptr + 3*(x+i+2), i2_pix0);
-                    //     vx_store(dstptr + 3*(x+i+3), i3_pix0);
-                    // }
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
     #endif
@@ -1425,7 +1381,6 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
     #if CV_SIMD256
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
     #elif CV_SIMD128
-                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
@@ -1517,14 +1472,7 @@ void warpPerspectiveNearestInvoker_8UC4(const uint8_t *src_data, size_t src_step
             int x = 0;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            // CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
-            v_float32 dst_x0 = vx_load(start_indices.data());
-            v_float32 dst_x1 = v_add(dst_x0, vx_setall_f32(float(vlanes_32)));
-            v_float32 M0 = vx_setall_f32(M[0]), M3 = vx_setall_f32(M[3]);
-            v_float32 M_x = vx_setall_f32(static_cast<float>(y * M[1] + M[2])),
-                    M_y = vx_setall_f32(static_cast<float>(y * M[4] + M[5]));
-            v_float32 M6 = vx_setall_f32(M[6]);
-            v_float32 M_w = vx_setall_f32(static_cast<float>(y * M[7] + M[8]));
+            CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C4);
@@ -3334,34 +3282,6 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
-                    // float valpha[max_uf], vbeta[max_uf];
-                    // vx_store(valpha, src_x0);
-                    // vx_store(valpha+vlanes_32, src_x1);
-                    // vx_store(vbeta, src_y0);
-                    // vx_store(vbeta+vlanes_32, src_y1);
-                    // for (int i = 0; i < uf; i+=vlanes_32) {
-                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(ofs) \
-                    //         const uint8_t *srcptr##ofs = src + addr[i+ofs]; \
-                    //         v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs))); \
-                    //         v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+3))); \
-                    //         v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+srcstep))); \
-                    //         v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand_q(srcptr##ofs+srcstep+3))); \
-                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
-                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(1);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(2);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I(3);
-                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_8UC3_I
-
-                    //     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0)));
-                    //     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0)));
-                    //     v_pack_store(dstptr + 3*(x+i),   i01_pix);
-                    //     v_pack_store(dstptr + 3*(x+i+2), i23_pix);
-                    // }
                 } else {
                     uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
@@ -3457,12 +3377,9 @@ void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int 
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
-
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C4);
-
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
@@ -3674,34 +3591,6 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 16U, C3);
     #endif
-                    // float valpha[max_uf], vbeta[max_uf];
-                    // vx_store(valpha, src_x0);
-                    // vx_store(valpha+vlanes_32, src_x1);
-                    // vx_store(vbeta, src_y0);
-                    // vx_store(vbeta+vlanes_32, src_y1);
-                    // for (int i = 0; i < uf; i+=vlanes_32) {
-                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(ofs) \
-                    //         const uint16_t *srcptr##ofs = src + addr[i+ofs]; \
-                    //         v_float32 i##ofs##_pix0 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs))); \
-                    //         v_float32 i##ofs##_pix1 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+3))); \
-                    //         v_float32 i##ofs##_pix2 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep))); \
-                    //         v_float32 i##ofs##_pix3 = v_cvt_f32(v_reinterpret_as_s32(vx_load_expand(srcptr##ofs+srcstep+3))); \
-                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
-                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(1);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(2);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I(3);
-                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_16UC3_I
-
-                    //     v_uint16 i01_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i0_pix0)), v_round(i1_pix0)));
-                    //     v_uint16 i23_pix = v_rotate_right<1>(v_pack_u(v_rotate_left<1>(v_round(i2_pix0)), v_round(i3_pix0)));
-                    //     vx_store(dstptr + 3*(x+i),   i01_pix);
-                    //     vx_store(dstptr + 3*(x+i+2), i23_pix);
-                    // }
                 } else {
                     uint16_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 16U);
@@ -3999,7 +3888,7 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    float valpha[max_uf], vbeta[max_uf];
+                    float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
                     vx_store(valpha+vlanes_32, src_x1);
                     vx_store(vbeta, src_y0);
@@ -4011,34 +3900,6 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3);
     #endif
-                    // float valpha[max_uf], vbeta[max_uf];
-                    // vx_store(valpha, src_x0);
-                    // vx_store(valpha+vlanes_32, src_x1);
-                    // vx_store(vbeta, src_y0);
-                    // vx_store(vbeta+vlanes_32, src_y1);
-                    // for (int i = 0; i < uf; i+=vlanes_32) {
-                    //     #define CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(ofs) \
-                    //         const float *srcptr##ofs = src + addr[i+ofs]; \
-                    //         v_float32 i##ofs##_pix0 = vx_load(srcptr##ofs); \
-                    //         v_float32 i##ofs##_pix1 = vx_load(srcptr##ofs+3); \
-                    //         v_float32 i##ofs##_pix2 = vx_load(srcptr##ofs+srcstep); \
-                    //         v_float32 i##ofs##_pix3 = vx_load(srcptr##ofs+srcstep+3); \
-                    //         v_float32 i##ofs##_alpha = vx_setall_f32(valpha[i+ofs]); \
-                    //         v_float32 i##ofs##_beta  = vx_setall_f32(vbeta[i+ofs]);  \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix1, i##ofs##_pix0), i##ofs##_pix0); \
-                    //         i##ofs##_pix2 = v_fma(i##ofs##_alpha, v_sub(i##ofs##_pix3, i##ofs##_pix2), i##ofs##_pix2); \
-                    //         i##ofs##_pix0 = v_fma(i##ofs##_beta,  v_sub(i##ofs##_pix2, i##ofs##_pix0), i##ofs##_pix0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(0);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(1);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(2);
-                    //         CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I(3);
-                    //     #undef CV_WARP_SIMD128_LINEAR_SHUFFLE_INTER_32FC3_I
-
-                    //     vx_store(dstptr + 3*(x+i),   i0_pix0);
-                    //     vx_store(dstptr + 3*(x+i+1), i1_pix0);
-                    //     vx_store(dstptr + 3*(x+i+2), i2_pix0);
-                    //     vx_store(dstptr + 3*(x+i+3), i3_pix0);
-                    // }
                 } else {
                     float pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
@@ -4978,7 +4839,6 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    // CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 16U);
                     float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
                     vx_store(valpha+vlanes_32, src_x1);

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -1090,6 +1090,9 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -1954,6 +1957,9 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -2942,6 +2948,9 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
     #if CV_SIMD256
@@ -3316,8 +3325,7 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
         }
     };
 
-    // parallel_for_(Range(0, dst_rows), worker);
-    worker(Range(0, dst_rows));
+    parallel_for_(Range(0, dst_rows), worker);
 }
 
 void warpAffineLinearInvoker_8UC4(const uint8_t *src_data, size_t src_step, int src_rows, int src_cols,
@@ -3901,6 +3909,9 @@ void warpAffineLinearInvoker_32FC3(const float *src_data, size_t src_step, int s
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -5165,6 +5176,9 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -6553,6 +6567,9 @@ void remapLinearInvoker_32FC3(const float *src_data, size_t src_step, int src_ro
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
+    #if CV_SIMD256 || CV_SIMD128
+                bool rightmost = x + uf >= dstcols;
+    #endif
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
                     float valpha[max_uf], vbeta[max_uf];
@@ -8779,4 +8796,3 @@ ImgWarpFunc getBicubicWarpFunc_(int type)
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 } // cv
- 

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -809,7 +809,7 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
     #elif CV_SIMD128
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
     #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDx, NEAREST, 16U, C3);
+                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
     #endif
                 } else {
                     uint16_t pixbuf[max_uf*3];

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -473,12 +473,8 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -496,6 +492,7 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -518,19 +515,12 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
                 } else {
-                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -763,12 +753,8 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -786,6 +772,7 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -808,19 +795,12 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
                 } else {
-                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1071,6 +1051,7 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1094,24 +1075,14 @@ void warpAffineNearestInvoker_32FC3(const float *src_data, size_t src_step, int 
             CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-    #if CV_SIMD256 || CV_SIMD128
-                bool rightmost = x + uf >= dstcols;
-    #endif
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
                 } else {
-                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1348,12 +1319,8 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1371,6 +1338,7 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1393,19 +1361,12 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
                 } else {
-                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1635,12 +1596,8 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1658,6 +1615,7 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1680,19 +1638,12 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
                 } else {
-                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -1942,6 +1893,7 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -1965,24 +1917,14 @@ void warpPerspectiveNearestInvoker_32FC3(const float *src_data, size_t src_step,
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-    #if CV_SIMD256 || CV_SIMD128
-                bool rightmost = x + uf >= dstcols;
-    #endif
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
                 } else {
-                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2239,12 +2181,8 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2262,6 +2200,7 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint8_t pixbuf[max_uf*3];
 
         uint8_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2286,19 +2225,12 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 8U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 8U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 8U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 8U);
                 } else {
-                    uint8_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 8U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 8U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 8U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2577,12 +2509,8 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
                             srcrows <= 1 ? BORDER_REPLICATE : border_type;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
-    #if CV_SIMD
-        int vlanes_16 = VTraits<v_uint16>::vlanes();
-    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2600,6 +2528,7 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        uint16_t pixbuf[max_uf*3];
 
         uint16_t bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2624,19 +2553,12 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 16U, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 16U, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 16U, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 16U);
                 } else {
-                    uint16_t pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 16U);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 16U, 16U);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 16U, 16U);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -2935,6 +2857,7 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        float pixbuf[max_uf*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -2960,24 +2883,14 @@ void remapNearestInvoker_32FC3(const float *src_data, size_t src_step, int src_r
             CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-    #if CV_SIMD256 || CV_SIMD128
-                bool rightmost = x + uf >= dstcols;
-    #endif
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(NEAREST, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, NEAREST, 32F, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, NEAREST, 32F, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, NEAREST, 32F, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(NEAREST, C3, 32F);
                 } else {
-                    float pixbuf[max_uf*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(NEAREST, C3, 32F);
-                    CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
-                    CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(NEAREST, C3, 32F, 32F);
+                CV_WARP_VECTOR_INTER_STORE(NEAREST, C3, 32F, 32F);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -3291,6 +3204,12 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8_t pixbuf[max_uf*4*3];
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+    #endif
 #endif
 
         for (int y = r.start; y < r.end; y++) {
@@ -3302,7 +3221,15 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPAFFINE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b;
+    #endif
                 if (v_reduce_min(inner_mask) != 0) {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
+    #else
                     float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
                     vx_store(valpha+vlanes_32, src_x1);
@@ -3315,14 +3242,26 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
+    #endif
                 } else {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
+    #else
                     uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
                     CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
                     CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
                 }
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -4557,6 +4496,12 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8_t pixbuf[max_uf*4*3];
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+    #endif
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
         for (int y = r.start; y < r.end; y++) {
@@ -4568,7 +4513,15 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b;
+    #endif
                 if (v_reduce_min(inner_mask) != 0) {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
+    #else
                     float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
                     vx_store(valpha+vlanes_32, src_x1);
@@ -4581,14 +4534,26 @@ void warpPerspectiveLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step,
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
+    #endif
                 } else {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
+    #else
                     uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
                     CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
                     CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
                 }
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -5169,6 +5134,7 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
         int32_t addr[max_uf],
                 src_ix[max_uf],
                 src_iy[max_uf];
+        float pixbuf[max_uf*4*3];
 
         float bvalbuf[max_uf*3];
         for (int i = 0; i < uf; i++) {
@@ -5192,30 +5158,15 @@ void warpPerspectiveLinearInvoker_32FC3(const float *src_data, size_t src_step, 
             CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD1();
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
-    #if CV_SIMD256 || CV_SIMD128
-                bool rightmost = x + uf >= dstcols;
-    #endif
                 CV_WARPPERSPECTIVE_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
                 if (v_reduce_min(inner_mask) != 0) {
-                    float valpha[max_uf], vbeta[max_uf];
-                    vx_store(valpha, src_x0);
-                    vx_store(valpha+vlanes_32, src_x1);
-                    vx_store(vbeta, src_y0);
-                    vx_store(vbeta+vlanes_32, src_y1);
-    #if CV_SIMD256
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD256, LINEAR, 32F, C3);
-    #elif CV_SIMD128
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 32F, C3);
-    #elif CV_SIMD_SCALABLE
-                    CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 32F, C3);
-    #endif
+                    CV_WARP_VECTOR_SHUFFLE_ALLWITHIN(LINEAR, C3, 32F);
                 } else {
-                    float pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 32F);
-                    CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
-                    CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
-                    CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
                 }
+                CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 32F, 32F);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32F32(C3);
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 
@@ -5846,6 +5797,12 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
         v_uint8 bval_v0 = vx_load_low(&bvalbuf[0]);
         v_uint8 bval_v1 = vx_load_low(&bvalbuf[uf]);
         v_uint8 bval_v2 = vx_load_low(&bvalbuf[uf*2]);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+        uint8_t pixbuf[max_uf*4*3];
+        uint8x8_t reds = {0, 8, 16, 24, 3, 11, 19, 27},
+                  greens = {1, 9, 17, 25, 4, 12, 20, 28},
+                  blues = {2, 10, 18, 26, 5, 13, 21, 29};
+    #endif
 #endif
 
         for (int y = r.start; y < r.end; y++) {
@@ -5859,7 +5816,15 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
             for (; x <= dstcols - uf; x += uf) {
                 // [TODO] apply halide trick
                 CV_REMAP_VECTOR_COMPUTE_MAPPED_COORD2(LINEAR, C3);
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                uint8x8_t p00r, p01r, p10r, p11r,
+                          p00g, p01g, p10g, p11g,
+                          p00b, p01b, p10b, p11b;
+    #endif
                 if (v_reduce_min(inner_mask) != 0) {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_ALLWITHIN_NEON_U8(C3);
+    #else
                     float valpha[max_uf], vbeta[max_uf];
                     vx_store(valpha, src_x0);
                     vx_store(valpha+vlanes_32, src_x1);
@@ -5872,14 +5837,26 @@ void remapLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_r
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
     #endif
+    #endif
                 } else {
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                    CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
+                    CV_WARP_VECTOR_LINEAR_SHUFFLE_NOTALLWITHIN_NEON_U8(C3);
+    #else
                     uint8_t pixbuf[max_uf*4*3];
                     CV_WARP_VECTOR_SHUFFLE_NOTALLWITHIN(LINEAR, C3, 8U);
                     CV_WARP_VECTOR_INTER_LOAD(LINEAR, C3, 8U, 16U);
                     CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
                     CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
                 }
+    #if defined(CV_NEON_AARCH64) && CV_NEON_AARCH64
+                CV_WARP_LINEAR_VECTOR_INTER_LOAD_U8U16_NEON(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CONVERT_U16F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_CALC_F32(C3);
+                CV_WARP_LINEAR_VECTOR_INTER_STORE_F32U8(C3);
+    #endif
             }
 #endif // (CV_SIMD || CV_SIMD_SCALABLE)
 

--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -476,7 +476,9 @@ void warpAffineNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -764,7 +766,9 @@ void warpAffineNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, i
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1347,7 +1351,9 @@ void warpPerspectiveNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -1632,7 +1638,9 @@ void warpPerspectiveNearestInvoker_16UC3(const uint16_t *src_data, size_t src_st
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2234,7 +2242,9 @@ void remapNearestInvoker_8UC3(const uint8_t *src_data, size_t src_step, int src_
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -2570,7 +2580,9 @@ void remapNearestInvoker_16UC3(const uint16_t *src_data, size_t src_step, int sr
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -3302,6 +3314,25 @@ void warpAffineLinearInvoker_8UC3(const uint8_t *src_data, size_t src_step, int 
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMD128, LINEAR, 8U, C3);
     #elif CV_SIMD_SCALABLE
                     CV_WARP_VECTOR_SHUFFLE_INTER_STORE(SIMDX, LINEAR, 8U, C3);
+                    // int32_t tmp_buf[max_vlanes_16 * 4];
+                    // for (int k = 0; k < uf; k++) {
+                    //     const uint8_t *srcptrk = src + addr[k];
+                    //     v_float32 ik_fpix0 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk)));
+                    //     v_float32 ik_fpix1 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + 3)));
+                    //     v_float32 ik_fpix2 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep)));
+                    //     v_float32 ik_fpix3 = v_cvt_f32(v_reinterpret_as_s32(v_load_expand_q<4>(srcptrk + srcstep + 3)));
+                    //     v_float32 ik_alpha = vx_setall_f32(valpha[k]);
+                    //     v_float32 ik_beta = vx_setall_f32(vbeta[k]);
+
+                    //     ik_fpix0 = v_fma(ik_alpha, v_sub(ik_fpix1, ik_fpix0), ik_fpix0);
+                    //     ik_fpix2 = v_fma(ik_alpha, v_sub(ik_fpix3, ik_fpix2), ik_fpix2);
+                    //     ik_fpix0 = v_fma(ik_beta,  v_sub(ik_fpix2, ik_fpix0), ik_fpix0);
+                    //     auto ik_pix0 = v_round(ik_fpix0);
+                    //     v_store<4>(tmp_buf + 3 * k, ik_pix0);
+                    // }
+                    // for (int k = 0; k < uf * 3; k++) {
+                    //     dstptr[3 * x + k] = saturate_cast<uchar>(tmp_buf[k]);
+                    // };
     #endif
                 } else {
                     uint8_t pixbuf[max_uf*4*3];
@@ -3562,7 +3593,9 @@ void warpAffineLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, in
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -4827,7 +4860,9 @@ void warpPerspectiveLinearInvoker_16UC3(const uint16_t *src_data, size_t src_ste
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;
@@ -6165,7 +6200,9 @@ void remapLinearInvoker_16UC3(const uint16_t *src_data, size_t src_step, int src
         constexpr int max_vlanes_16{VTraits<v_uint16>::max_nlanes};
         constexpr int max_vlanes_32{VTraits<v_float32>::max_nlanes};
         constexpr int max_uf{max_vlanes_32*2};
+    #if CV_SIMD
         int vlanes_16 = VTraits<v_uint16>::vlanes();
+    #endif
         int vlanes_32 = VTraits<v_float32>::vlanes();
         // unrolling_factor = lane_size / 16 = vlanes_32 * 32 / 16 = vlanes_32 * 2
         int uf = vlanes_32 * 2;


### PR DESCRIPTION
Checklist:
- [x] SIMD128
- [x] SIMD256
- [x] SIMD_SCALABLE
- [x] Measure performance

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
