### PR TITLE
Qrcode multidetect fix

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -3435,134 +3435,6 @@ bool QRDetectMulti::compareSquare::operator()(const Vec3i& a, const Vec3i& b) co
 
 int QRDetectMulti::findNumberLocalizationPoints(vector<Point2f>& tmp_localization_points)
 {
-    size_t number_possible_purpose = 1;
-    if (purpose == SHRINKING)
-        number_possible_purpose = 2;
-    Mat tmp_shrinking = bin_barcode;
-    int tmp_num_points = 0;
-    int num_points = -1;
-    for (eps_horizontal = 0.1; eps_horizontal < 0.4; eps_horizontal += 0.1)
-    {
-        tmp_num_points = 0;
-        num_points = -1;
-        if (purpose == SHRINKING)
-            number_possible_purpose = 2;
-        else
-            number_possible_purpose = 1;
-        for (size_t k = 0; k < number_possible_purpose; k++)
-        {
-            if (k == 1)
-                bin_barcode = bin_barcode_fullsize;
-            vector<Vec3d> list_lines_x = searchHorizontalLines();
-            if (list_lines_x.empty())
-            {
-                if (k == 0)
-                {
-                    k = 1;
-                    bin_barcode = bin_barcode_fullsize;
-                    list_lines_x = searchHorizontalLines();
-                    if (list_lines_x.empty())
-                        break;
-                }
-                else
-                    break;
-            }
-            vector<Point2f> list_lines_y = extractVerticalLines(list_lines_x, eps_horizontal);
-            if (list_lines_y.size() < 3)
-            {
-                if (k == 0)
-                {
-                    k = 1;
-                    bin_barcode = bin_barcode_fullsize;
-                    list_lines_x = searchHorizontalLines();
-                    if (list_lines_x.empty())
-                        break;
-                    list_lines_y = extractVerticalLines(list_lines_x, eps_horizontal);
-                    if (list_lines_y.size() < 3)
-                        break;
-                }
-                else
-                    break;
-            }
-            vector<int> index_list_lines_y;
-            for (size_t i = 0; i < list_lines_y.size(); i++)
-                index_list_lines_y.push_back(-1);
-            num_points = 0;
-            for (size_t i = 0; i < list_lines_y.size() - 1; i++)
-            {
-                for (size_t j = i; j < list_lines_y.size(); j++ )
-                {
-
-                    double points_distance = norm(list_lines_y[i] - list_lines_y[j]);
-                    if (points_distance <= 10)
-                    {
-                        if ((index_list_lines_y[i] == -1) && (index_list_lines_y[j] == -1))
-                        {
-                            index_list_lines_y[i] = num_points;
-                            index_list_lines_y[j] = num_points;
-                            num_points++;
-                        }
-                        else if (index_list_lines_y[i] != -1)
-                            index_list_lines_y[j] = index_list_lines_y[i];
-                        else if (index_list_lines_y[j] != -1)
-                            index_list_lines_y[i] = index_list_lines_y[j];
-                    }
-                }
-            }
-            for (size_t i = 0; i < index_list_lines_y.size(); i++)
-            {
-                if (index_list_lines_y[i] == -1)
-                {
-                    index_list_lines_y[i] = num_points;
-                    num_points++;
-                }
-            }
-            if ((tmp_num_points < num_points) && (k == 1))
-            {
-                purpose = UNCHANGED;
-                tmp_num_points = num_points;
-                bin_barcode = bin_barcode_fullsize;
-                coeff_expansion = 1.0;
-            }
-            if ((tmp_num_points < num_points) && (k == 0))
-            {
-                tmp_num_points = num_points;
-            }
-        }
-
-        if ((tmp_num_points < 3) && (tmp_num_points >= 1))
-        {
-            const double min_side = std::min(bin_barcode_fullsize.size().width, bin_barcode_fullsize.size().height);
-            if (min_side > 512)
-            {
-                bin_barcode = tmp_shrinking;
-                purpose = SHRINKING;
-                coeff_expansion = min_side / 512.0;
-            }
-            if (min_side < 512)
-            {
-                bin_barcode = tmp_shrinking;
-                purpose = ZOOMING;
-                coeff_expansion = 512 / min_side;
-            }
-        }
-        else
-            break;
-    }
-    if (purpose == SHRINKING)
-        bin_barcode = tmp_shrinking;
-    num_points = tmp_num_points;
-    vector<Vec3d> list_lines_x = searchHorizontalLines();
-    if (list_lines_x.empty())
-        return num_points;
-    vector<Point2f> list_lines_y = extractVerticalLines(list_lines_x, eps_horizontal);
-    if (list_lines_y.size() < 3)
-        return num_points;
-    if (num_points < 3)
-        return num_points;
-
-     /* --- calculate centers of each cluster --- */
-
     struct Cluster {
         Point2f center = Point2f(0, 0);
         int numPoints = 0;
@@ -3571,57 +3443,110 @@ int QRDetectMulti::findNumberLocalizationPoints(vector<Point2f>& tmp_localizatio
             center = ((center * numPoints) + point) / (1+numPoints);
             ++numPoints;
         }
-    };
-    std::vector<Cluster> clusters;
+        static vector<Cluster> findClustersInPoints(const vector<Point2f>& points) {
+            vector<Cluster> clusters;
+            for(const auto& point : points) {
+                bool isWithinCluster = false;
+                for(auto& cluster : clusters) {
+                    if(cluster.distance(point) < 10.0) {
+                        cluster.addPoint(point);
+                        isWithinCluster = true;
+                        break;
+                    }
+                }
+                if(!isWithinCluster) {
+                    Cluster newCluster;
+                    newCluster.addPoint(point);
+                    clusters.push_back(newCluster);
+                }
+            }
 
-    for(const auto& point : list_lines_y) {
-        bool isWithinCluster = false;
-        for(auto& cluster : clusters) {
-            if(cluster.distance(point) < 10.0) {
-                cluster.addPoint(point);
-                isWithinCluster = true;
-                break;
+            return clusters;
+        }
+    };
+
+    size_t NumPositionIndicatorsInQRCode = 3;
+    Mat scaledBinBarcodeCache = bin_barcode;
+    bool useFullsized = false;
+    size_t numPoints = 0;
+    vector<Cluster> clusters;
+
+    // Loop through each horizontal epsilon
+    for (eps_horizontal = 0.1; eps_horizontal < 0.4; eps_horizontal += 0.1) {
+        // Attempt first on scaled image
+        {
+            vector<Vec3d> intermediatePotentialPoints = searchHorizontalLines();
+            if(!intermediatePotentialPoints.empty()) {
+                vector<Point2f> potentialPoints = \
+                    extractVerticalLines(intermediatePotentialPoints, eps_horizontal);
+                if(potentialPoints.size() >= NumPositionIndicatorsInQRCode) {
+                    clusters = Cluster::findClustersInPoints(potentialPoints);
+                    numPoints = clusters.size();
+                }
             }
         }
-        if(!isWithinCluster) {
-            Cluster newCluster;
-            newCluster.addPoint(point);
-            clusters.push_back(newCluster);
+
+        // If the image was originally shrunk, attempt to find points on the fullsized image.
+        if(purpose == SHRINKING)
+        {
+            bin_barcode = bin_barcode_fullsize;
+            vector<Vec3d> intermediatePotentialPoints = searchHorizontalLines();
+            if(!intermediatePotentialPoints.empty()) {
+                vector<Point2f> potentialPoints = \
+                    extractVerticalLines(intermediatePotentialPoints, eps_horizontal);
+                if(potentialPoints.size() >= NumPositionIndicatorsInQRCode) {
+                    vector<Cluster> clustersOnFullSize = \
+                        Cluster::findClustersInPoints(potentialPoints);
+                    if(numPoints < clustersOnFullSize.size()) {
+                        useFullsized = true;
+                        numPoints = clustersOnFullSize.size();
+                        clusters = clustersOnFullSize;
+                    }
+                }
+            }
+        }
+
+        // Found enough points in the image.
+        if(NumPositionIndicatorsInQRCode < numPoints) {
+            if(useFullsized) {
+                purpose = UNCHANGED;
+                coeff_expansion = 1.0;
+            } else {
+                bin_barcode = scaledBinBarcodeCache;
+            }
+            break;
+        }
+        else {
+            // Reset state
+            bin_barcode = scaledBinBarcodeCache;
+            useFullsized = false;
+            numPoints = 0;
+            clusters.clear();
         }
     }
 
+    if(numPoints < NumPositionIndicatorsInQRCode)
+        return numPoints;
+
+    // Save clusters.
     tmp_localization_points.clear();
     for(const auto& cluster : clusters)
         tmp_localization_points.push_back(cluster.center);
-
-    num_points = static_cast<int>(clusters.size());
-
-    /* ----------------------------------------- */
-
+    
+    // Use unscaled images, while protecting any pre-existing references.
     bin_barcode_temp = bin_barcode.clone();
-    if (purpose == SHRINKING)
-    {
-        const int width  = cvRound(bin_barcode.size().width  * coeff_expansion);
-        const int height = cvRound(bin_barcode.size().height * coeff_expansion);
-        Size new_size(width, height);
+    if (purpose == SHRINKING || purpose == ZOOMING) {
+        int width = cvRound(bin_barcode.cols * (purpose == SHRINKING ? coeff_expansion : 1/coeff_expansion));
+        int height = cvRound(bin_barcode.rows * (purpose == SHRINKING ? coeff_expansion : 1/coeff_expansion));
+        Size unscaledSize(width, height);
         Mat intermediate;
-        resize(bin_barcode, intermediate, new_size, 0, 0, INTER_LINEAR_EXACT);
+        resize(bin_barcode, intermediate, unscaledSize, 0, 0, INTER_LINEAR_EXACT);
         bin_barcode = intermediate.clone();
-    }
-    else if (purpose == ZOOMING)
-    {
-        const int width  = cvRound(bin_barcode.size().width  / coeff_expansion);
-        const int height = cvRound(bin_barcode.size().height / coeff_expansion);
-        Size new_size(width, height);
-        Mat intermediate;
-        resize(bin_barcode, intermediate, new_size, 0, 0, INTER_LINEAR_EXACT);
-        bin_barcode = intermediate.clone();
-    }
-    else
-    {
+    } else {
         bin_barcode = bin_barcode_fullsize.clone();
     }
-    return num_points;
+
+    return numPoints;
 }
 
 void QRDetectMulti::findQRCodeContours(vector<Point2f>& tmp_localization_points,

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -411,6 +411,32 @@ TEST_P(Objdetect_QRCode_detectMulti, detect_regression_16961)
     EXPECT_EQ(corners.size(), expect_corners_size);
 }
 
+typedef testing::TestWithParam<std::string> Objdetect_QRCode_detectMulti;
+TEST_P(Objdetect_QRCode_detectMulti, detect_none_26642)
+{
+    const std::string method = GetParam();
+    const std::string name_current_image = "issue_26642.jpg";
+    const std::string root = "qrcode/";
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat src = imread(image_path);
+    ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
+    GraphicalCodeDetector detector = QRCodeDetector();
+    if (method == "aruco_based") {
+        detector = QRCodeDetectorAruco();
+    }
+    std::vector<Point> corners;
+
+    auto start = std::chrono::system_clock::now();
+    bool retval = detector.detectMulti(src, corners);
+    auto end = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsedTime = end - start;
+
+    EXPECT_LT(elapsedTime.count(), 15.0);
+    EXPECT_EQ((int)corners.size(), 0);
+    ASSERT_FALSE(retval);
+}
+
+
 INSTANTIATE_TEST_CASE_P(/**/, Objdetect_QRCode_detectMulti, testing::Values("contours_based", "aruco_based"));
 typedef testing::TestWithParam<std::string> Objdetect_QRCode_detectAndDecodeMulti;
 TEST_P(Objdetect_QRCode_detectAndDecodeMulti, check_output_parameters_type_19363)


### PR DESCRIPTION
### Why is there a PR on a previously closed issue?
This PR would address issue #26642. It was previously closed, however, the problem was only partially solved. The prior PR to close this issue fixed a memory leak. However, `detectMulti()` is still taking nearly $10$ minutes to complete if it doesn't cause a memory allocation error beforehand. Me and @marcreichman-pfi continued discussing this issue in the previous PR #26650 (thanks for the help).

- Here's the PR for submitting the image to the opencv_extra repo: https://github.com/opencv/opencv_extra/pull/1228.

### What does this PR accomplish?
1. Ensures that `detectMulti()` always returns results quickly no matter the input, fixing the issue of taking several minutes on images without any QR codes to be detected. 
2. A new unit test to ensure the detector can handle images without any QR codes.
3. Verified performance using pre-existing unit tests as well as a custom benchmark using $1000$ images containing QR codes. 

### What changes were made?
- In `findQRCodeContours()` an upper limit for the number of attempts for a kmeans algorithm was set to 10. The original approach ran kmeans as many times as there were points resulting in a cubic runtime where diminished results were likely occuring after so many runs.
- Refactored `findNumberLocalizationPoints()`. The original approach was very cryptic and hard to bug fix with. So I tried to stick as close to the original code as possible while introducing more intuitive structure, control flow and names.
- Limit the max number of points in `findNumberLocalizationPoints()`, this was the true fix to the issue. Downstream functions have very poor runtime and space complexities. In `checkSets()` for instance, nearly $n^3$ points are allocated (if you have a 2000 points-as was the case in the image-you have an attempted allocation of 8 billion data points) which often caused allocation errors.
- Unit test using one of the images in the issue was made to ensure it can run in less than 15 seconds and not find any QR codes in the image. (Image submitted in separate PR to opencv_extra).

### Performance
All unit tests for QR codes on the `objdetect` module passed. On pre-existing unit tests (excluding the new addition), the updated approach never ran slower than the prior method, so speed won't be hampered. 

A [dataset](https://universe.roboflow.com/qrdetection-eohio/qrcodedetection-sovr6) from roboflow was used to test the accuracy of the original algorithm as well as the new algorithm on $1000$ images containing QR codes. The dataset provides bounding box data for each QR code. If the IoU (intersection over union) between a detected qr code's bounding box and the ground truth bound box was more than $0.8$ then they were considered a match. I used three metrics for accuracy.
1. **Match**, QR code is in image and QR code was detected.
2. **Miss**, QR code is in image and QR code was not detected.
3. **Wrong**, QR code is not in image and QR code was detected.

| Method | Matches | Undetected | False Detections |
| --- | --- | --- | --- |
| Original | 426 | 895 | 48 |
| New | 465 | 856 | 78 |
| ArUco | 645 | 676 | 163 |

With the $1000$ images there were $1321$ annotations. A byproduct of my approach seems to have prevented less tags being missed, as well as slight increase in false detections.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
