### PR TITLE
enhance fastNlMeansDenoisingMulti to Support 16-bit Images

### DIFF
--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -16,10 +16,10 @@
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   * Redistribution's of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
 //
-//   * Redistributions in binary form must reproduce the above copyright notice,
+//   * Redistribution's in binary form must reproduce the above copyright notice,
 //     this list of conditions and the following disclaimer in the documentation
 //     and/or other materials provided with the distribution.
 //
@@ -249,23 +249,16 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
     int hn = (int)h.size();
     double granularity = (double)std::max(1., (double)dst.total()/(1 << 16));
 
-    switch (srcImgs[0].type())
-    {
-        case CV_8U:
+
+    switch (CV_MAT_CN(srcImgs[0].type())) {
+        case 1:
             parallel_for_(cv::Range(0, srcImgs[0].rows),
-                          FastNlMeansMultiDenoisingInvoker<uchar, IT, UIT, D, int>(
+                          FastNlMeansMultiDenoisingInvoker<ST, IT, UIT, D, int>(
                               srcImgs, imgToDenoiseIndex, temporalWindowSize,
                               dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
             break;
-        case CV_16U:
-            parallel_for_(cv::Range(0, srcImgs[0].rows),
-                          FastNlMeansMultiDenoisingInvoker<ushort, IT, UIT, D, int64>(
-                              srcImgs, imgToDenoiseIndex, temporalWindowSize,
-                              dst, templateWindowSize, searchWindowSize, &h[0]),
-                          granularity);
-            break;
-        case CV_8UC2:
+        case 2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
@@ -279,7 +272,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC3:
+        case 3:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
@@ -293,7 +286,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC4:
+        case 4:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
@@ -307,9 +300,9 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        default:
+       default:
             CV_Error(Error::StsBadArg,
-                "Unsupported image format! Only CV_8U, CV_8UC2, CV_8UC3 and CV_8UC4 are supported");
+                     "Unsupported number of channels! Only 1, 2, 3, and 4 are supported");
     }
 }
 
@@ -354,16 +347,9 @@ void cv::fastNlMeansDenoisingMulti( InputArrayOfArrays _srcImgs, OutputArray _ds
                                                             h,
                                                             templateWindowSize, searchWindowSize);
                     break;
-                case CV_16U:
-                    fastNlMeansDenoisingMulti_<ushort, int64, uint64,
-                                               DistSquared>(srcImgs, dst,
-                                                            imgToDenoiseIndex, temporalWindowSize,
-                                                            h,
-                                                            templateWindowSize, searchWindowSize);
-                    break;
                 default:
                     CV_Error(Error::StsBadArg,
-                             "Unsupported depth! Only CV_8U and CV_16U are supported for NORM_L2");
+                             "Unsupported depth! Only CV_8U is supported for NORM_L2");
             }
             break;
         case NORM_L1:

--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -242,12 +242,12 @@ static void fastNlMeansDenoisingMultiCheckPreconditions(
 
 template<typename ST, typename IT, typename UIT, typename D>
 static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& dst,
-                                       int imgToDenoiseIndex, int temporalWindowSize,
+                                        int imgToDenoiseIndex, int temporalWindowSize,
                                         const std::vector<float>& h,
-                                       int templateWindowSize, int searchWindowSize)
+                                        int templateWindowSize, int searchWindowSize)
 {
-    int hn = static_cast<int>(h.size());
-    double granularity = std::max(1.0, static_cast<double>(dst.total()) / (1 << 16));
+    int hn = (int)h.size();
+    double granularity = (double)std::max(1., (double)dst.total()/(1 << 16));
 
     int depth = CV_MAT_DEPTH(srcImgs[0].type());
     int channels = CV_MAT_CN(srcImgs[0].type());

--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -16,10 +16,10 @@
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
 //
-//   * Redistribution's of source code must retain the above copyright notice,
+//   * Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
 //
-//   * Redistribution's in binary form must reproduce the above copyright notice,
+//   * Redistributions in binary form must reproduce the above copyright notice,
 //     this list of conditions and the following disclaimer in the documentation
 //     and/or other materials provided with the distribution.
 //
@@ -258,6 +258,13 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                               dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
             break;
+        case CV_16U:
+            parallel_for_(cv::Range(0, srcImgs[0].rows),
+                          FastNlMeansMultiDenoisingInvoker<ushort, IT, UIT, D, int64>(
+                              srcImgs, imgToDenoiseIndex, temporalWindowSize,
+                              dst, templateWindowSize, searchWindowSize, &h[0]),
+                          granularity);
+            break;
         case CV_8UC2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
@@ -347,9 +354,16 @@ void cv::fastNlMeansDenoisingMulti( InputArrayOfArrays _srcImgs, OutputArray _ds
                                                             h,
                                                             templateWindowSize, searchWindowSize);
                     break;
+                case CV_16U:
+                    fastNlMeansDenoisingMulti_<ushort, int64, uint64,
+                                               DistSquared>(srcImgs, dst,
+                                                            imgToDenoiseIndex, temporalWindowSize,
+                                                            h,
+                                                            templateWindowSize, searchWindowSize);
+                    break;
                 default:
                     CV_Error(Error::StsBadArg,
-                             "Unsupported depth! Only CV_8U is supported for NORM_L2");
+                             "Unsupported depth! Only CV_8U and CV_16U are supported for NORM_L2");
             }
             break;
         case NORM_L1:

--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -249,8 +249,8 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
     int hn = (int)h.size();
     double granularity = (double)std::max(1., (double)dst.total()/(1 << 16));
 
-    int depth = CV_MAT_DEPTH(srcImgs[0].type());
-    int channels = CV_MAT_CN(srcImgs[0].type());
+    int depth = srcImgs[0].depth();
+    int channels = srcImgs[0].channels();
 
     switch (depth)
     {

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -185,14 +185,14 @@ TEST(Photo_DenoisingGrayscaleMulti16Bit, ComprehensiveRegression)
         return psnr;
     };
 
-    const int imgs_count = 5;
-    const int width = 512;
-    const int height = 512;
+    const int imgs_count = 3;
+    const int width = 127;
+    const int height = 129;
     std::vector<Mat> original(imgs_count);
 
     for (int i = 0; i < imgs_count; i++)
     {
-        original[i] = Mat::ones(height, width, CV_16UC1) * 10000;
+        original[i] = Mat(height, width, CV_16UC1);
         randu(original[i], Scalar::all(9500), Scalar::all(10500));
     }
 

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -52,24 +52,6 @@ namespace opencv_test { namespace {
 #  define DUMP(image, path)
 #endif
 
-double computePSNR(const Mat& I1, const Mat& I2) {
-    CV_Assert(I1.type() == I2.type() && I1.size() == I2.size());
-
-    Mat s1;
-    absdiff(I1, I2, s1);
-    s1.convertTo(s1, CV_32F);
-    s1 = s1.mul(s1);
-
-    Scalar s = sum(s1);
-
-    double mse = s[0] / static_cast<double>(I1.total());
-    if (mse == 0) {
-        return INFINITY;
-    }
-    double max_pixel = 65535.0;
-    double psnr = 10.0 * log10((max_pixel * max_pixel) / mse);
-    return psnr;
-}
 
 TEST(Photo_DenoisingGrayscale, regression)
 {
@@ -184,6 +166,25 @@ TEST(Photo_Denoising, speed)
 }
 TEST(Photo_DenoisingGrayscaleMulti16Bit, ComprehensiveRegression)
 {
+    auto computePSNR = [](const Mat& I1, const Mat& I2) -> double {
+        CV_Assert(I1.type() == I2.type() && I1.size() == I2.size());
+
+        Mat s1;
+        absdiff(I1, I2, s1);
+        s1.convertTo(s1, CV_32F);
+        s1 = s1.mul(s1);
+
+        Scalar s = sum(s1);
+
+        double mse = s[0] / static_cast<double>(I1.total());
+        if (mse == 0) {
+            return INFINITY;
+        }
+        double max_pixel = 65535.0;
+        double psnr = 10.0 * log10((max_pixel * max_pixel) / mse);
+        return psnr;
+    };
+
     const int imgs_count = 5;
     const int width = 512;
     const int height = 512;


### PR DESCRIPTION
Fixes : #26582


### Changes Made:

- Updated the fastNlMeansDenoisingMulti_ function to switch based on both image depth and channel count.
- Corrected template parameters to ensure proper processing of 16-bit (CV_16U) images alongside existing 8-bit (CV_8U) 
#### test case updates
- Enhanced the test case to include comprehensive scenarios for 16-bit images.
- Added PSNR validation to quantitatively assess denoising effectiveness.
- Included edge case tests with all pixels at maximum (65535) and zero (0) values to ensure robustness.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
