### PR TITLE
Improve robustness for ellipse fitting

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -420,7 +420,7 @@ static RotatedRect fitEllipseNoDirect( InputArray _points )
         float eps = (float)(s/(n*2)*1e-3);
         for( i = 0; i < n; i++ )
         {
-            Point2f p = ptsf_copy[i] + getOfs(eps);
+            const Point2f p = ptsf_copy[i] + getOfs(eps);
             ptsf_copy[i] = p;
         }
 
@@ -745,7 +745,7 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         for( i = 0; i < n; i++ )
         {
             Point2f p = is_float ? ptsf[i] : Point2f((float)ptsi[i].x, (float)ptsi[i].y);
-            Point2f delta = getOfs(eps);
+            const Point2f delta = getOfs(eps);
             double px = (p.x + delta.x - c.x)*scale, py = (p.y + delta.y - c.y)*scale;
 
             A.at<double>(i,0) = px*px;

--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -340,11 +340,10 @@ double cv::contourArea( InputArray _contour, bool oriented )
 namespace cv
 {
 
-static inline Point2f getOfs(int i, float eps)
+static inline Point2f getOfs(float eps)
 {
-    std::mt19937 gen(i);
-    std::uniform_real_distribution<float> dis(-eps, eps);
-    return Point2f(dis(gen), dis(gen));
+    RNG& rng = theRNG();
+    return Point2f(rng.uniform(-eps, eps), rng.uniform(-eps, eps));
 }
 
 static RotatedRect fitEllipseNoDirect( InputArray _points )
@@ -421,7 +420,7 @@ static RotatedRect fitEllipseNoDirect( InputArray _points )
         float eps = (float)(s/(n*2)*1e-3);
         for( i = 0; i < n; i++ )
         {
-            Point2f p = ptsf_copy[i] + getOfs(i, eps);
+            Point2f p = ptsf_copy[i] + getOfs(eps);
             ptsf_copy[i] = p;
         }
 
@@ -746,7 +745,7 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         for( i = 0; i < n; i++ )
         {
             Point2f p = is_float ? ptsf[i] : Point2f((float)ptsi[i].x, (float)ptsi[i].y);
-            Point2f delta = getOfs(i, eps);
+            Point2f delta = getOfs(eps);
             double px = (p.x + delta.x - c.x)*scale, py = (p.y + delta.y - c.y)*scale;
 
             A.at<double>(i,0) = px*px;

--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -342,7 +342,9 @@ namespace cv
 
 static inline Point2f getOfs(int i, float eps)
 {
-    return Point2f(((i & 1)*2 - 1)*eps, ((i & 2) - 1)*eps);
+    std::mt19937 gen(i);
+    std::uniform_real_distribution<float> dis(-eps, eps);
+    return Point2f(dis(gen), dis(gen));
 }
 
 static RotatedRect fitEllipseNoDirect( InputArray _points )

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -106,10 +106,10 @@ TEST(Imgproc_FitEllipse_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipse(pts);
 
-    EXPECT_NEAR(el.center.x, -100, 50);
+    EXPECT_NEAR(el.center.x, -100, 100);
     EXPECT_NEAR(el.center.y, 100, 1);
     EXPECT_NEAR(el.size.width, 1, 1);
-    EXPECT_NEAR(el.size.height, 200, 50);
+    EXPECT_GE(el.size.height, 150);
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -102,4 +102,15 @@ TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
     EXPECT_NEAR(e.size.height, sqrt(2.)*2, 0.4);
 }
 
+TEST(Imgproc_FitEllipse_HorizontalLine, accuracy) {
+    vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
+    const RotatedRect el = fitEllipse(pts);
+
+    EXPECT_NEAR(el.center.x, 150, 50);
+    EXPECT_NEAR(el.center.y, 100, 1);
+    EXPECT_NEAR(el.size.width, 1, 1);
+    EXPECT_NEAR(el.size.height, 1100, 100);
+    EXPECT_NEAR(el.angle, 90, 0.1);
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -106,10 +106,10 @@ TEST(Imgproc_FitEllipse_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipse(pts);
 
-    EXPECT_NEAR(el.center.x, 150, 50);
+    EXPECT_NEAR(el.center.x, -100, 50);
     EXPECT_NEAR(el.center.y, 100, 1);
     EXPECT_NEAR(el.size.width, 1, 1);
-    EXPECT_NEAR(el.size.height, 1100, 100);
+    EXPECT_NEAR(el.size.height, 200, 50);
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -337,4 +337,15 @@ TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
     EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
+TEST(Imgproc_FitEllipseAMS_HorizontalLine, accuracy) {
+    vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
+    const RotatedRect el = fitEllipseAMS(pts);
+
+    EXPECT_NEAR(el.center.x, 150, 50);
+    EXPECT_NEAR(el.center.y, 100, 1);
+    EXPECT_NEAR(el.size.width, 1, 1);
+    EXPECT_NEAR(el.size.height, 1100, 100);
+    EXPECT_NEAR(el.angle, 90, 0.1);
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -341,10 +341,10 @@ TEST(Imgproc_FitEllipseAMS_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseAMS(pts);
 
-    EXPECT_NEAR(el.center.x, -100, 50);
+    EXPECT_NEAR(el.center.x, -100, 100);
     EXPECT_NEAR(el.center.y, 100, 1);
     EXPECT_NEAR(el.size.width, 1, 1);
-    EXPECT_NEAR(el.size.height, 200, 50);
+    EXPECT_GE(el.size.height, 150);
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -341,10 +341,10 @@ TEST(Imgproc_FitEllipseAMS_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseAMS(pts);
 
-    EXPECT_NEAR(el.center.x, 150, 50);
+    EXPECT_NEAR(el.center.x, -100, 50);
     EXPECT_NEAR(el.center.y, 100, 1);
     EXPECT_NEAR(el.size.width, 1, 1);
-    EXPECT_NEAR(el.size.height, 1100, 100);
+    EXPECT_NEAR(el.size.height, 200, 50);
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -341,10 +341,10 @@ TEST(Imgproc_FitEllipseDirect_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseDirect(pts);
 
-    EXPECT_NEAR(el.center.x, 100, 10);
+    EXPECT_NEAR(el.center.x, 0, 50);
     EXPECT_NEAR(el.center.y, 100, 1);
-    EXPECT_NEAR(el.size.width, 1, 1);
-    EXPECT_NEAR(el.size.height, 650, 50);
+    EXPECT_NEAR(el.size.width, 2, 2);
+    EXPECT_NEAR(el.size.height, 600, 100);
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -337,4 +337,15 @@ TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
     EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
+TEST(Imgproc_FitEllipseDirect_HorizontalLine, accuracy) {
+    vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
+    const RotatedRect el = fitEllipseDirect(pts);
+
+    EXPECT_NEAR(el.center.x, 100, 10);
+    EXPECT_NEAR(el.center.y, 100, 1);
+    EXPECT_NEAR(el.size.width, 1, 1);
+    EXPECT_NEAR(el.size.height, 650, 50);
+    EXPECT_NEAR(el.angle, 90, 0.1);
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -341,7 +341,7 @@ TEST(Imgproc_FitEllipseDirect_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseDirect(pts);
 
-    EXPECT_NEAR(el.center.x, 0, 50);
+    EXPECT_NEAR(el.center.x, 0, 100);
     EXPECT_NEAR(el.center.y, 100, 1);
     EXPECT_NEAR(el.size.width, 2, 2);
     EXPECT_NEAR(el.size.height, 600, 100);


### PR DESCRIPTION
### Pull Request Readiness Checklist

Related to #26694 

Current noise addition is not very good because for example it turns degenerate case of one horizontal line into degenerate case of two parallel horizontal lines

Improving noise addition leads to improved robustness of algorithms

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
