### PR TITLE
Added fontScale behavior description to putText() documentation

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4848,6 +4848,11 @@ The function cv::putText renders the specified text string in the image. Symbols
 using the specified font are replaced by question marks. See #getTextSize for a text rendering code
 example.
 
+The `fontScale` parameter is a scale factor that is multiplied by the base font size:
+- When scale > 1, the text is magnified.
+- When 0 < scale < 1, the text is minimized.
+- When scale < 0, the text is mirrored or reversed.
+
 @param img Image.
 @param text Text string to be drawn.
 @param org Bottom-left corner of the text string in the image.


### PR DESCRIPTION
- Updated the documentation of the putText function to clarify the behavior of the fontScale parameter.
- Explained how fontScale affects text rendering: magnifying (>1), minimizing (<1), and mirroring (<0).

Fixes #26730 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
