### PR TITLE
core: fixed VSX build with GCC 15

### DIFF
--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -257,8 +257,8 @@ VSX_IMPL_1VRG(vec_udword2, vec_udword2, vpopcntd, vec_popcntu)
 VSX_IMPL_1VRG(vec_udword2, vec_dword2,  vpopcntd, vec_popcntu)
 
 // converts between single and double-precision
-VSX_REDIRECT_1RG(vec_float4,  vec_double2, vec_cvfo, __builtin_vsx_xvcvdpsp)
-VSX_REDIRECT_1RG(vec_double2, vec_float4,  vec_cvfo, __builtin_vsx_xvcvspdp)
+VSX_REDIRECT_1RG(vec_float4,  vec_double2, vec_cvfo, vec_floate)
+VSX_REDIRECT_1RG(vec_double2, vec_float4,  vec_cvfo, vec_doubleo)
 
 // converts word and doubleword to double-precision
 #undef vec_ctd
@@ -398,10 +398,6 @@ VSX_REDIRECT_1RG(vec_uchar16, vec_uchar16, vec_popcntu, vec_popcnt)
 VSX_REDIRECT_1RG(vec_ushort8, vec_ushort8, vec_popcntu, vec_popcnt)
 VSX_REDIRECT_1RG(vec_uint4,   vec_uint4,   vec_popcntu, vec_popcnt)
 VSX_REDIRECT_1RG(vec_udword2, vec_udword2, vec_popcntu, vec_popcnt)
-
-// converts between single and double precision
-VSX_REDIRECT_1RG(vec_float4,  vec_double2, vec_cvfo, __builtin_vsx_xvcvdpsp)
-VSX_REDIRECT_1RG(vec_double2, vec_float4,  vec_cvfo, __builtin_vsx_xvcvspdp)
 
 // converts word and doubleword to double-precision
 #ifdef vec_ctd


### PR DESCRIPTION
Resolves #26770

- This patch only fixes compilation with GCC 15 (tested with cross-toolchain from debian experimental)
- I've found that many tests fail on ubuntu 22.04 with qemu before and after this patch. I can't check them on real HW, but the list of failed tests is the same before and after this patch, so we can assume that we haven't break it more than it was. I've created separate issue for this problem: #26785
- According to [Programming reference](https://openpowerfoundation.org/specifications/vectorintrinsicprogrammingreference/), on LE platform `vec_floate` is equivalent to `xvcvdpsp` and `vec_doubleo` is equivalent to `xvcvspdp`. I assume we do not support BE platforms at all.