### PR TITLE
Fix memory leaks for JpegXLDecoder

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpegxl.cpp
+++ b/modules/imgcodecs/src/grfmt_jpegxl.cpp
@@ -32,9 +32,9 @@ JpegXLDecoder::~JpegXLDecoder()
 void JpegXLDecoder::close()
 {
     if (m_decoder)
-        m_decoder.release();
+        m_decoder.reset();
     if (m_f)
-        m_f.release();
+        m_f.reset();
     m_read_buffer = {};
     m_width = m_height = 0;
     m_type = m_convert = -1;


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #26766 

It should additionally fix issue itself (problem with `remove` on `Windows`), but I can't be completely sure - I can't test this on `Windows`

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
