### PR TITLE
Disable obsolete GHA pipelines for 3.4

### DIFF
--- a/.github/workflows/PR-3.4.yaml
+++ b/.github/workflows/PR-3.4.yaml
@@ -9,9 +9,6 @@ jobs:
   Ubuntu2004-ARM64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-3.4-ARM64.yaml@main
 
-  Ubuntu1404-x64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-3.4-U14.yaml@main
-
   Ubuntu2004-x64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-3.4-U20.yaml@main
 


### PR DESCRIPTION
Related https://github.com/opencv/ci-gha-workflow/pull/209

Ubuntu 14 is not compatible with Node.js 20.x used by GHA.