### PR TITLE
fix default cap_prop_orientation_auto behaviour

### DIFF
--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -247,7 +247,7 @@ public:
 class VideoCaptureBase : public IVideoCapture
 {
 public:
-    VideoCaptureBase() : autorotate(false) {}
+    VideoCaptureBase() : autorotate(true) {}
     double getProperty(int propId) const CV_OVERRIDE
     {
         switch(propId)

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -42,8 +42,8 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_meta_auto)
     ASSERT_EQ(480, frame.rows);
 }
 
-// related issue: https://github.com/opencv/opencv/issues/15499
-TEST_P(VideoCaptureAPITests, mp4_orientation_no_rotation)
+// related issues: https://github.com/opencv/opencv/issues/15499 & 26795
+TEST_P(VideoCaptureAPITests, mp4_orientation_test)
 {
     cv::VideoCaptureAPIs api = GetParam();
     if (!videoio_registry::hasBackend(api))
@@ -53,13 +53,29 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_no_rotation)
 
     VideoCapture cap;
     EXPECT_NO_THROW(cap.open(video_file, api));
-    cap.set(CAP_PROP_ORIENTATION_AUTO, 0);
     ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
+
+    // test with default auto-orientation
+    ASSERT_TRUE(cap.get(CAP_PROP_ORIENTATION_AUTO));
+    Size default_size;
+    EXPECT_NO_THROW(default_size = Size((int)cap.get(CAP_PROP_FRAME_WIDTH),
+                                        (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
+    EXPECT_EQ(270, default_size.width);
+    EXPECT_EQ(480, default_size.height);
+
+    Mat default_frame;
+    cap >> default_frame;
+    ASSERT_FALSE(default_frame.empty());
+    EXPECT_EQ(270, default_frame.cols);
+    EXPECT_EQ(480, default_frame.rows);
+
+    // test with auto-orientation disabled
+    cap.set(CAP_PROP_ORIENTATION_AUTO, 0);
     ASSERT_FALSE(cap.get(CAP_PROP_ORIENTATION_AUTO));
 
     Size actual;
     EXPECT_NO_THROW(actual = Size((int)cap.get(CAP_PROP_FRAME_WIDTH),
-                                    (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
+                                       (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
     EXPECT_EQ(480, actual.width);
     EXPECT_EQ(270, actual.height);
 
@@ -69,36 +85,6 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_no_rotation)
 
     ASSERT_EQ(480, frame.cols);
     ASSERT_EQ(270, frame.rows);
-}
-TEST_P(VideoCaptureAPITests, mp4_orientation_auto_by_default)
-{
-    cv::VideoCaptureAPIs api = GetParam();
-    if (!videoio_registry::hasBackend(api))
-        throw SkipTestException("backend " + std::to_string(static_cast<int>(api)) + " was not found");
-    std::string video_file = std::string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
-
-    VideoCapture cap;
-    EXPECT_NO_THROW(cap.open(video_file, api));
-    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file
-                                << " with backend " << api << std::endl;
-
-    double autoRotate = cap.get(cv::CAP_PROP_ORIENTATION_AUTO);
-    EXPECT_EQ(1.0, autoRotate)
-        << "Expected CAP_PROP_ORIENTATION_AUTO to be on (1.0) by default.";
-
-    EXPECT_EQ(90, cap.get(cv::CAP_PROP_ORIENTATION_META));
-    cv::Size size;
-    EXPECT_NO_THROW(size = cv::Size(
-        static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH)),
-        static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT))
-    ));
-    EXPECT_EQ(270, size.width);
-    EXPECT_EQ(480, size.height);
-    cv::Mat frame;
-    cap >> frame;
-    ASSERT_FALSE(frame.empty()) << "Failed to retrieve a frame!";
-    EXPECT_EQ(270, frame.cols);
-    EXPECT_EQ(480, frame.rows);
 }
 
 INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::Values(CAP_FFMPEG, CAP_AVFOUNDATION));

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -8,6 +8,10 @@ using namespace std;
 
 namespace opencv_test { namespace {
 
+// PR: https://github.com/opencv/opencv/pull/26800
+// TODO: Enable the tests back on Windows after FFmpeg plugin rebuild
+#ifndef _WIN32
+
 struct VideoCaptureAPITests: TestWithParam<cv::VideoCaptureAPIs>
 {
     void SetUp()
@@ -77,5 +81,7 @@ static cv::VideoCaptureAPIs supported_backends[] = {
 };
 
 INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::ValuesIn(supported_backends));
+
+#endif // WIN32
 
 }} // namespace

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -33,10 +33,8 @@ struct VideoCaptureAPITests: TestWithParam<cv::VideoCaptureAPIs>
         EXPECT_EQ(width, (int)cap.get(CAP_PROP_FRAME_WIDTH));
         EXPECT_EQ(height, (int)cap.get(CAP_PROP_FRAME_HEIGHT));
 
-        printf("before read frame!\n");
         Mat frame;
         cap >> frame;
-        printf("after read frame!\n");
 
         ASSERT_EQ(width, frame.cols);
         ASSERT_EQ(height, frame.rows);
@@ -52,7 +50,6 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_default_auto)
 {
     EXPECT_TRUE(cap.get(CAP_PROP_ORIENTATION_AUTO));
     orientationCheck(90., 270, 480);
-    printf("Check done!\n");
 }
 
 TEST_P(VideoCaptureAPITests, mp4_orientation_forced)
@@ -63,7 +60,9 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_forced)
 
 TEST_P(VideoCaptureAPITests, mp4_orientation_switch)
 {
+    SCOPED_TRACE("Initial orientation with autorotation");
     orientationCheck(90., 270, 480);
+    SCOPED_TRACE("Disabled autorotation");
     EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, false));
     EXPECT_FALSE(cap.get(CAP_PROP_ORIENTATION_AUTO));
     orientationCheck(90., 480, 270);

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -10,8 +10,55 @@ namespace opencv_test { namespace {
 
 typedef TestWithParam<cv::VideoCaptureAPIs> VideoCaptureAPITests;
 
-// related issue: https://github.com/opencv/opencv/issues/15499
-TEST_P(VideoCaptureAPITests, mp4_orientation_meta_auto)
+static void videoOrientationCheck(cv::VideoCapture& cap, double angle, int width, int height)
+{
+    EXPECT_EQ(angle, cap.get(CAP_PROP_ORIENTATION_META));
+    EXPECT_EQ(width, (int)cap.get(CAP_PROP_FRAME_WIDTH));
+    EXPECT_EQ(height, (int)cap.get(CAP_PROP_FRAME_HEIGHT));
+
+    Mat frame;
+    cap >> frame;
+
+    ASSERT_EQ(width, frame.cols);
+    ASSERT_EQ(height, frame.rows);
+}
+
+// Related issues:
+// - https://github.com/opencv/opencv/issues/26795
+// - https://github.com/opencv/opencv/issues/15499
+TEST_P(VideoCaptureAPITests, mp4_orientation_default_auto)
+{
+    cv::VideoCaptureAPIs api = GetParam();
+    if (!videoio_registry::hasBackend(api))
+        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
+
+    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
+
+    VideoCapture cap;
+    EXPECT_NO_THROW(cap.open(video_file, api));
+    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
+    EXPECT_TRUE(cap.get(CAP_PROP_ORIENTATION_AUTO));
+
+    videoOrientationCheck(cap, 90., 270, 480);
+}
+
+TEST_P(VideoCaptureAPITests, mp4_orientation_forced)
+{
+    cv::VideoCaptureAPIs api = GetParam();
+    if (!videoio_registry::hasBackend(api))
+        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
+
+    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
+
+    VideoCapture cap;
+    EXPECT_NO_THROW(cap.open(video_file, api));
+    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
+    EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, false));
+
+    videoOrientationCheck(cap, 90., 480, 270);
+}
+
+TEST_P(VideoCaptureAPITests, mp4_orientation_switch)
 {
     cv::VideoCaptureAPIs api = GetParam();
     if (!videoio_registry::hasBackend(api))
@@ -23,69 +70,13 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_meta_auto)
     EXPECT_NO_THROW(cap.open(video_file, api));
     ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
 
-    // related issue: https://github.com/opencv/opencv/issues/22088
-    EXPECT_EQ(90, cap.get(CAP_PROP_ORIENTATION_META));
+    videoOrientationCheck(cap, 90., 270, 480);
 
-    EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, true));
-
-    Size actual;
-    EXPECT_NO_THROW(actual = Size((int)cap.get(CAP_PROP_FRAME_WIDTH),
-                                    (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
-    EXPECT_EQ(270, actual.width);
-    EXPECT_EQ(480, actual.height);
-
-    Mat frame;
-
-    cap >> frame;
-
-    ASSERT_EQ(270, frame.cols);
-    ASSERT_EQ(480, frame.rows);
+    EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, false));
+    EXPECT_FALSE(cap.get(CAP_PROP_ORIENTATION_AUTO));
+    videoOrientationCheck(cap, 90., 480, 270);
 }
 
-// related issues: https://github.com/opencv/opencv/issues/15499 & 26795
-TEST_P(VideoCaptureAPITests, mp4_orientation_test)
-{
-    cv::VideoCaptureAPIs api = GetParam();
-    if (!videoio_registry::hasBackend(api))
-        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
-
-    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
-
-    VideoCapture cap;
-    EXPECT_NO_THROW(cap.open(video_file, api));
-    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
-
-    // test with default auto-orientation
-    ASSERT_TRUE(cap.get(CAP_PROP_ORIENTATION_AUTO));
-    Size default_size;
-    EXPECT_NO_THROW(default_size = Size((int)cap.get(CAP_PROP_FRAME_WIDTH),
-                                        (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
-    EXPECT_EQ(270, default_size.width);
-    EXPECT_EQ(480, default_size.height);
-
-    Mat default_frame;
-    cap >> default_frame;
-    ASSERT_FALSE(default_frame.empty());
-    EXPECT_EQ(270, default_frame.cols);
-    EXPECT_EQ(480, default_frame.rows);
-
-    // test with auto-orientation disabled
-    cap.set(CAP_PROP_ORIENTATION_AUTO, 0);
-    ASSERT_FALSE(cap.get(CAP_PROP_ORIENTATION_AUTO));
-
-    Size actual;
-    EXPECT_NO_THROW(actual = Size((int)cap.get(CAP_PROP_FRAME_WIDTH),
-                                       (int)cap.get(CAP_PROP_FRAME_HEIGHT)));
-    EXPECT_EQ(480, actual.width);
-    EXPECT_EQ(270, actual.height);
-
-    Mat frame;
-
-    cap >> frame;
-
-    ASSERT_EQ(480, frame.cols);
-    ASSERT_EQ(270, frame.rows);
-}
 
 INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::Values(CAP_FFMPEG, CAP_AVFOUNDATION));
 

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -78,6 +78,12 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_switch)
 }
 
 
-INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::Values(CAP_FFMPEG, CAP_AVFOUNDATION));
+INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests,
+                            testing::Values(
+#if defined(__APPLE__)
+                                            CAP_AVFOUNDATION,
+#endif
+                                            CAP_FFMPEG
+                                            ));
 
 }} // namespace

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -8,82 +8,75 @@ using namespace std;
 
 namespace opencv_test { namespace {
 
-typedef TestWithParam<cv::VideoCaptureAPIs> VideoCaptureAPITests;
-
-static void videoOrientationCheck(cv::VideoCapture& cap, double angle, int width, int height)
+struct VideoCaptureAPITests: TestWithParam<cv::VideoCaptureAPIs>
 {
-    EXPECT_EQ(angle, cap.get(CAP_PROP_ORIENTATION_META));
-    EXPECT_EQ(width, (int)cap.get(CAP_PROP_FRAME_WIDTH));
-    EXPECT_EQ(height, (int)cap.get(CAP_PROP_FRAME_HEIGHT));
+    void SetUp()
+    {
+        cv::VideoCaptureAPIs api = GetParam();
+        if (!videoio_registry::hasBackend(api))
+            throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
 
-    Mat frame;
-    cap >> frame;
+        string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
 
-    ASSERT_EQ(width, frame.cols);
-    ASSERT_EQ(height, frame.rows);
-}
+        EXPECT_NO_THROW(cap.open(video_file, api));
+        ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
+    }
+
+    void tearDown()
+    {
+        cap.release();
+    }
+
+    void orientationCheck(double angle, int width, int height)
+    {
+        EXPECT_EQ(angle, cap.get(CAP_PROP_ORIENTATION_META));
+        EXPECT_EQ(width, (int)cap.get(CAP_PROP_FRAME_WIDTH));
+        EXPECT_EQ(height, (int)cap.get(CAP_PROP_FRAME_HEIGHT));
+
+        printf("before read frame!\n");
+        Mat frame;
+        cap >> frame;
+        printf("after read frame!\n");
+
+        ASSERT_EQ(width, frame.cols);
+        ASSERT_EQ(height, frame.rows);
+    }
+
+    VideoCapture cap;
+};
 
 // Related issues:
 // - https://github.com/opencv/opencv/issues/26795
 // - https://github.com/opencv/opencv/issues/15499
 TEST_P(VideoCaptureAPITests, mp4_orientation_default_auto)
 {
-    cv::VideoCaptureAPIs api = GetParam();
-    if (!videoio_registry::hasBackend(api))
-        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
-
-    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
-
-    VideoCapture cap;
-    EXPECT_NO_THROW(cap.open(video_file, api));
-    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
     EXPECT_TRUE(cap.get(CAP_PROP_ORIENTATION_AUTO));
-
-    videoOrientationCheck(cap, 90., 270, 480);
+    orientationCheck(90., 270, 480);
+    printf("Check done!\n");
 }
 
 TEST_P(VideoCaptureAPITests, mp4_orientation_forced)
 {
-    cv::VideoCaptureAPIs api = GetParam();
-    if (!videoio_registry::hasBackend(api))
-        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
-
-    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
-
-    VideoCapture cap;
-    EXPECT_NO_THROW(cap.open(video_file, api));
-    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
     EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, false));
-
-    videoOrientationCheck(cap, 90., 480, 270);
+    orientationCheck(90., 480, 270);
 }
 
 TEST_P(VideoCaptureAPITests, mp4_orientation_switch)
 {
-    cv::VideoCaptureAPIs api = GetParam();
-    if (!videoio_registry::hasBackend(api))
-        throw SkipTestException("backend " + std::to_string(int(api)) + " was not found");
-
-    string video_file = string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
-
-    VideoCapture cap;
-    EXPECT_NO_THROW(cap.open(video_file, api));
-    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file << " with backend " << api << std::endl;
-
-    videoOrientationCheck(cap, 90., 270, 480);
-
+    orientationCheck(90., 270, 480);
     EXPECT_TRUE(cap.set(CAP_PROP_ORIENTATION_AUTO, false));
     EXPECT_FALSE(cap.get(CAP_PROP_ORIENTATION_AUTO));
-    videoOrientationCheck(cap, 90., 480, 270);
+    orientationCheck(90., 480, 270);
 }
 
 
-INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests,
-                            testing::Values(
-#if defined(__APPLE__)
-                                            CAP_AVFOUNDATION,
+static cv::VideoCaptureAPIs supported_backends[] = {
+#ifdef HAVE_AVFOUNDATION
+    CAP_AVFOUNDATION,
 #endif
-                                            CAP_FFMPEG
-                                            ));
+    CAP_FFMPEG
+};
+
+INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::ValuesIn(supported_backends));
 
 }} // namespace

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -70,6 +70,36 @@ TEST_P(VideoCaptureAPITests, mp4_orientation_no_rotation)
     ASSERT_EQ(480, frame.cols);
     ASSERT_EQ(270, frame.rows);
 }
+TEST_P(VideoCaptureAPITests, mp4_orientation_auto_by_default)
+{
+    cv::VideoCaptureAPIs api = GetParam();
+    if (!videoio_registry::hasBackend(api))
+        throw SkipTestException("backend " + std::to_string(static_cast<int>(api)) + " was not found");
+    std::string video_file = std::string(cvtest::TS::ptr()->get_data_path()) + "video/rotated_metadata.mp4";
+
+    VideoCapture cap;
+    EXPECT_NO_THROW(cap.open(video_file, api));
+    ASSERT_TRUE(cap.isOpened()) << "Can't open the video: " << video_file
+                                << " with backend " << api << std::endl;
+
+    double autoRotate = cap.get(cv::CAP_PROP_ORIENTATION_AUTO);
+    EXPECT_EQ(1.0, autoRotate)
+        << "Expected CAP_PROP_ORIENTATION_AUTO to be on (1.0) by default.";
+
+    EXPECT_EQ(90, cap.get(cv::CAP_PROP_ORIENTATION_META));
+    cv::Size size;
+    EXPECT_NO_THROW(size = cv::Size(
+        static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH)),
+        static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT))
+    ));
+    EXPECT_EQ(270, size.width);
+    EXPECT_EQ(480, size.height);
+    cv::Mat frame;
+    cap >> frame;
+    ASSERT_FALSE(frame.empty()) << "Failed to retrieve a frame!";
+    EXPECT_EQ(270, frame.cols);
+    EXPECT_EQ(480, frame.rows);
+}
 
 INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::Values(CAP_FFMPEG, CAP_AVFOUNDATION));
 


### PR DESCRIPTION
Fixes : #26795
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
