### PR TITLE
Imgcodecs minor improvements for better code readibility

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.hpp
+++ b/modules/imgcodecs/src/grfmt_png.hpp
@@ -137,7 +137,13 @@ private:
     CV_NODISCARD_STD bool processing_start(void* frame_ptr, const Mat& img);
     CV_NODISCARD_STD bool processing_finish();
     void compose_frame(std::vector<png_bytep>& rows_dst, const std::vector<png_bytep>& rows_src, unsigned char bop, uint32_t x, uint32_t y, uint32_t w, uint32_t h, Mat& img);
-    CV_NODISCARD_STD bool read_from_io(void* buffer, size_t num_bytes);
+    /**
+     * @brief Reads data from an I/O source into the provided buffer.
+     * @param buffer Pointer to the buffer where the data will be stored.
+     * @param num_bytes Number of bytes to read into the buffer.
+     * @return true if the operation is successful, false otherwise.
+     */
+    CV_NODISCARD_STD bool readFromStreamOrBuffer(void* buffer, size_t num_bytes);
     uint32_t  read_chunk(Chunk& chunk);
     CV_NODISCARD_STD bool InitPngPtr();
     void ClearPngPtr();
@@ -185,7 +191,24 @@ public:
 protected:
     static void writeDataToBuf(void* png_ptr, unsigned char* src, size_t size);
     static void flushBuf(void* png_ptr);
-    size_t write_to_io(void const* _Buffer, size_t  _ElementSize, size_t _ElementCount, FILE* _Stream);
+    /**
+    * @brief Writes data to an output destination, either a file stream or an in-memory buffer.
+    *
+    * This function handles two output scenarios:
+    * 1. If a file stream is provided, the data is written to the stream using `fwrite`.
+    * 2. If `stream` is null, the data is written to an in-memory buffer (`m_buf`), which is resized as needed.
+    *
+    * @param buffer Pointer to the data to be written.
+    * @param num_bytes The number of bytes to be written.
+    * @param stream Pointer to the file stream for writing. If null, the data is written to the in-memory buffer.
+    * @return The number of bytes successfully written.
+    *         - For file-based writes, this is the number of bytes written to the stream.
+    *         - For buffer-based writes, this is the total number of bytes added to the buffer.
+    *
+    * @throws std::runtime_error If the in-memory buffer (`m_buf`) exceeds its maximum capacity.
+    * @note If `num_bytes` is 0 or `buffer` is null, the function returns 0.
+    */
+    size_t writeToStreamOrBuffer(void const* buffer, size_t  num_bytes, FILE* stream);
 
 private:
     void writeChunk(FILE* f, const char* name, unsigned char* data, uint32_t length);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

The PR addresses the following improvements:

1.Improving member functions:
   - Renaming `read_from_io `and `write_to_io `to more descriptive names for better clarity.
   - Enhancing documentation for these functions to make their purpose, inputs, outputs, and edge-case handling explicit.

2.**RFC** Refactoring functions into the base class with the following considerations (**subject to undone**):
   - This change allows decoders currently with `m_buf_supported = false` to potentially use these functions in the future to support buffer reading.
   - Introducing the `m_f` variable in the base class, which potentially enables efficient handling of file streams by reducing redundant file-opening operations. For example, the source file can be assigned to `m_f `once when the decoder is selected, avoiding the need to reopen the file in `readHeader()`.