### PR TITLE
added 16-bit support to fastNlMeansDenoising and updated tests

### DIFF
--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -249,16 +249,15 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
     int hn = (int)h.size();
     double granularity = (double)std::max(1., (double)dst.total()/(1 << 16));
 
-    switch (srcImgs[0].type())
-    {
-        case CV_8U:
+    switch (CV_MAT_CN(srcImgs[0].type())) {
+        case 1:
             parallel_for_(cv::Range(0, srcImgs[0].rows),
-                          FastNlMeansMultiDenoisingInvoker<uchar, IT, UIT, D, int>(
+                          FastNlMeansMultiDenoisingInvoker<ST, IT, UIT, D, int>(
                               srcImgs, imgToDenoiseIndex, temporalWindowSize,
                               dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
             break;
-        case CV_8UC2:
+        case 2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
@@ -272,7 +271,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC3:
+        case 3:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
@@ -286,7 +285,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        case CV_8UC4:
+        case 4:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
                               FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
@@ -300,9 +299,9 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
-        default:
+       default:
             CV_Error(Error::StsBadArg,
-                "Unsupported image format! Only CV_8U, CV_8UC2, CV_8UC3 and CV_8UC4 are supported");
+                     "Unsupported number of channels! Only 1, 2, 3, and 4 are supported");
     }
 }
 

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -206,7 +206,7 @@ protected:
         std::vector<float> h_vec = {config.h};
 
         ASSERT_NO_THROW({
-            cv::fastNlMeansDenoisingMulti(inputImages, result, inputImages.size() / 2, inputImages.size(), h_vec, config.templateWindowSize, config.searchWindowSize, cv::NORM_L1);
+            cv::fastNlMeansDenoisingMulti(inputImages, result, static_cast<int>(inputImages.size() / 2), static_cast<int>(inputImages.size()), h_vec, config.templateWindowSize, config.searchWindowSize, cv::NORM_L1);
         }) << "fastNlMeansDenoisingMulti threw an unexpected exception in " << testCaseName;
 
         ASSERT_FALSE(result.empty()) << "Denoising result is empty in " << testCaseName;

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -164,5 +164,80 @@ TEST(Photo_Denoising, speed)
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000./getTickFrequency());
 }
+// Related issue :
+// - https://github.com/opencv/opencv/issues/26582
+class Photo_DenoisingGrayscaleMulti16Bit : public ::testing::Test {
+protected:
+    struct TestConfig {
+        int width = 127;
+        int height = 129;
+        int imgs_count = 3;
+        float h = 15.0f;
+        int templateWindowSize = 7;
+        int searchWindowSize = 21;
+    };
+
+    static double computePSNR(const cv::Mat& I1, const cv::Mat& I2) {
+        CV_Assert(I1.type() == I2.type() && I1.size() == I2.size());
+        cv::Mat s1;
+        cv::absdiff(I1, I2, s1);
+        s1.convertTo(s1, CV_32F);
+        s1 = s1.mul(s1);
+        cv::Scalar s = cv::sum(s1);
+        double mse = s[0] / static_cast<double>(I1.total());
+
+        if (mse == 0) return INFINITY;
+
+        double max_pixel = 65535.0;
+        return 10.0 * log10((max_pixel * max_pixel) / mse);
+    }
+
+    static std::vector<cv::Mat> generateTestImages(const TestConfig& config, int minVal, int maxVal) {
+        std::vector<cv::Mat> images(config.imgs_count);
+        for (int i = 0; i < config.imgs_count; i++) {
+            images[i] = cv::Mat(config.height, config.width, CV_16UC1);
+            cv::randu(images[i], cv::Scalar::all(minVal), cv::Scalar::all(maxVal));
+        }
+        return images;
+    }
+
+    void runDenoisingTest(const std::vector<cv::Mat>& inputImages, const TestConfig& config, const std::string& testCaseName, int expectedMinVal, int expectedMaxVal, double psnrThreshold = -1) {
+        cv::Mat result;
+        std::vector<float> h_vec = {config.h};
+
+        ASSERT_NO_THROW({
+            cv::fastNlMeansDenoisingMulti(inputImages, result, inputImages.size() / 2, inputImages.size(), h_vec, config.templateWindowSize, config.searchWindowSize, cv::NORM_L1);
+        }) << "fastNlMeansDenoisingMulti threw an unexpected exception in " << testCaseName;
+
+        ASSERT_FALSE(result.empty()) << "Denoising result is empty in " << testCaseName;
+        ASSERT_EQ(result.type(), CV_16UC1) << "Incorrect result type in " << testCaseName;
+        ASSERT_EQ(result.size(), inputImages[0].size()) << "Incorrect result size in " << testCaseName;
+
+        double minVal, maxVal;
+        cv::minMaxLoc(result, &minVal, &maxVal);
+        EXPECT_GE(minVal, expectedMinVal) << "Minimum value out of range in " << testCaseName;
+        EXPECT_LE(maxVal, expectedMaxVal) << "Maximum value out of range in " << testCaseName;
+
+        if (psnrThreshold > 0) {
+            cv::Mat groundTruth = cv::Mat::ones(config.height, config.width, CV_16UC1) * 10000;
+            double psnr = computePSNR(result, groundTruth);
+            EXPECT_GT(psnr, psnrThreshold) << "PSNR is too low in " << testCaseName;
+        }
+    }
+};
+
+TEST_F(Photo_DenoisingGrayscaleMulti16Bit, ComprehensiveDenoisingTest)
+{
+    TestConfig config;
+
+    auto randomImages = generateTestImages(config, 9500, 10500);
+    runDenoisingTest(randomImages, config, "RandomValuesDenoising", 0, 65535, 30.0);
+
+    auto maxImages = std::vector<cv::Mat>(config.imgs_count, cv::Mat::ones(config.height, config.width, CV_16UC1) * 65535);
+    runDenoisingTest(maxImages, config, "MaxValueDenoising", 65535, 65535);
+
+    auto zeroImages = std::vector<cv::Mat>(config.imgs_count, cv::Mat::zeros(config.height, config.width, CV_16UC1));
+    runDenoisingTest(zeroImages, config, "ZeroValueDenoising", 0, 0);
+}
 
 }} // namespace

--- a/modules/photo/test/test_precomp.hpp
+++ b/modules/photo/test/test_precomp.hpp
@@ -5,6 +5,7 @@
 #define __OPENCV_TEST_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
+#include "opencv2/ts/ocl_test.hpp"
 #include "opencv2/photo.hpp"
 
 #endif


### PR DESCRIPTION
Fixes : #26582
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
