### PR TITLE
Add cv::THRESH_DISABLE flag

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -329,7 +329,8 @@ enum ThresholdTypes {
     THRESH_TOZERO_INV = 4, //!< \f[\texttt{dst} (x,y) =  \fork{0}{if \(\texttt{src}(x,y) > \texttt{thresh}\)}{\texttt{src}(x,y)}{otherwise}\f]
     THRESH_MASK       = 7,
     THRESH_OTSU       = 8, //!< flag, use Otsu algorithm to choose the optimal threshold value
-    THRESH_TRIANGLE   = 16 //!< flag, use Triangle algorithm to choose the optimal threshold value
+    THRESH_TRIANGLE   = 16, //!< flag, use Triangle algorithm to choose the optimal threshold value
+    THRESH_DISABLE    = 128 //!< flag, compute threshold only (useful for OTSU/TRIANGLE) but does not actually run thresholding
 };
 
 //! adaptive threshold algorithm

--- a/modules/imgproc/include/opencv2/imgproc/types_c.h
+++ b/modules/imgproc/include/opencv2/imgproc/types_c.h
@@ -610,9 +610,11 @@ enum
     CV_THRESH_MASK        =7,
     CV_THRESH_OTSU        =8, /**< use Otsu algorithm to choose the optimal threshold value;
                                  combine the flag with one of the above CV_THRESH_* values */
-    CV_THRESH_TRIANGLE    =16  /**< use Triangle algorithm to choose the optimal threshold value;
+    CV_THRESH_TRIANGLE    =16,  /**< use Triangle algorithm to choose the optimal threshold value;
                                  combine the flag with one of the above CV_THRESH_* values, but not
                                  with CV_THRESH_OTSU */
+    CV_THRESH_DISABLE     =128 /**< compute threshold only (useful for OTSU/TRIANGLE) but does not
+                                  actually run thresholding */
 };
 
 /** Adaptive threshold methods */

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -1404,10 +1404,13 @@ static bool ocl_threshold( InputArray _src, OutputArray _dst, double & thresh, d
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type),
         kercn = ocl::predictOptimalVectorWidth(_src, _dst), ktype = CV_MAKE_TYPE(depth, kercn);
     bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0;
+    const bool isDisabled = ((thresh_type & THRESH_DISABLE) != 0);
+    thresh_type &= ~THRESH_DISABLE;
 
-    if ( !(thresh_type == THRESH_BINARY || thresh_type == THRESH_BINARY_INV || thresh_type == THRESH_TRUNC ||
-           thresh_type == THRESH_TOZERO || thresh_type == THRESH_TOZERO_INV) ||
-         (!doubleSupport && depth == CV_64F))
+    if ( isDisabled ||
+        !(thresh_type == THRESH_BINARY || thresh_type == THRESH_BINARY_INV || thresh_type == THRESH_TRUNC ||
+         thresh_type == THRESH_TOZERO || thresh_type == THRESH_TOZERO_INV) ||
+        (!doubleSupport && depth == CV_64F))
         return false;
 
     const char * const thresholdMap[] = { "THRESH_BINARY", "THRESH_BINARY_INV", "THRESH_TRUNC",
@@ -1544,10 +1547,14 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
     CV_OCL_RUN_(_src.dims() <= 2 && _dst.isUMat(),
                 ocl_threshold(_src, _dst, thresh, maxval, type), thresh)
 
+    const bool isDisabled = ((type & THRESH_DISABLE) != 0);
+    type &= ~THRESH_DISABLE;
+
     Mat src = _src.getMat();
 
-    _dst.create( src.size(), src.type() );
-    Mat dst = _dst.getMat();
+    if (!isDisabled)
+        _dst.create( src.size(), src.type() );
+    Mat dst = isDisabled ? cv::Mat() : _dst.getMat();
 
     int automatic_thresh = (type & ~cv::THRESH_MASK);
     type &= THRESH_MASK;
@@ -1574,6 +1581,9 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
     {
         int ithresh = cvFloor(thresh);
         thresh = ithresh;
+        if (isDisabled)
+            return thresh;
+
         int imaxval = cvRound(maxval);
         if( type == THRESH_TRUNC )
             imaxval = ithresh;
@@ -1605,6 +1615,9 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
     {
         int ithresh = cvFloor(thresh);
         thresh = ithresh;
+        if (isDisabled)
+            return thresh;
+
         int imaxval = cvRound(maxval);
         if( type == THRESH_TRUNC )
             imaxval = ithresh;
@@ -1632,6 +1645,9 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
     {
         int ithresh = cvFloor(thresh);
         thresh = ithresh;
+        if (isDisabled)
+            return thresh;
+
         int imaxval = cvRound(maxval);
         if (type == THRESH_TRUNC)
             imaxval = ithresh;
@@ -1662,6 +1678,9 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
         ;
     else
         CV_Error( cv::Error::StsUnsupportedFormat, "" );
+
+    if (isDisabled)
+        return thresh;
 
     parallel_for_(Range(0, dst.rows),
                   ThresholdRunner(src, dst, thresh, maxval, type),

--- a/modules/imgproc/test/ocl/test_imgproc.cpp
+++ b/modules/imgproc/test/ocl/test_imgproc.cpp
@@ -386,6 +386,40 @@ OCL_TEST_P(Threshold, Mat)
     }
 }
 
+struct Threshold_Disabled :
+        public ImgprocTestBase
+{
+    int thresholdType;
+
+    virtual void SetUp()
+    {
+        type = GET_PARAM(0);
+        thresholdType = GET_PARAM(2);
+        useRoi = GET_PARAM(3);
+    }
+};
+
+OCL_TEST_P(Threshold_Disabled, Mat)
+{
+    for (int j = 0; j < test_loop_times; j++)
+    {
+        random_roi();
+
+        double maxVal = randomDouble(20.0, 127.0);
+        double thresh = randomDouble(0.0, maxVal);
+
+        const int _thresholdType = thresholdType | THRESH_DISABLE;
+
+        src_roi.copyTo(dst_roi);
+        usrc_roi.copyTo(udst_roi);
+
+        OCL_OFF(cv::threshold(src_roi, dst_roi, thresh, maxVal, _thresholdType));
+        OCL_ON(cv::threshold(usrc_roi, udst_roi, thresh, maxVal, _thresholdType));
+
+        OCL_EXPECT_MATS_NEAR(dst, 0);
+    }
+}
+
 /////////////////////////////////////////// CLAHE //////////////////////////////////////////////////
 
 PARAM_TEST_CASE(CLAHETest, Size, double, bool)
@@ -474,6 +508,16 @@ OCL_INSTANTIATE_TEST_CASE_P(Imgproc, Integral, Combine(
                             Bool()));
 
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, Threshold, Combine(
+                            Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
+                                   CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4,
+                                   CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4),
+                            Values(0),
+                            Values(ThreshOp(THRESH_BINARY),
+                                   ThreshOp(THRESH_BINARY_INV), ThreshOp(THRESH_TRUNC),
+                                   ThreshOp(THRESH_TOZERO), ThreshOp(THRESH_TOZERO_INV)),
+                            Bool()));
+
+OCL_INSTANTIATE_TEST_CASE_P(Imgproc, Threshold_Disabled, Combine(
                             Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
                                    CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4,
                                    CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4),

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -502,6 +502,25 @@ BIGDATA_TEST(Imgproc_Threshold, huge)
     ASSERT_EQ((uint64)nz, n / 2);
 }
 
+TEST(Imgproc_Threshold, threshold_disabling)
+{
+    Size sz(16, 16);
+    Mat input_original(sz, CV_8U, Scalar::all(2));
+    Mat input = input_original.clone();
+    std::vector<int> threshTypes = {THRESH_BINARY, THRESH_BINARY_INV, THRESH_TRUNC, THRESH_TOZERO, THRESH_TOZERO_INV};
+    std::vector<int> threshFlags = {THRESH_OTSU, THRESH_TRIANGLE};
+    for(int threshType : threshTypes)
+    {
+        for(int threshFlag : threshFlags)
+        {
+            const int _threshType = threshType | threshFlag | THRESH_DISABLE;
+            cv::threshold(input, input, 2.0, 0.0, _threshType);
+            EXPECT_MAT_NEAR(input, input_original, 0);
+        }
+    }
+}
+
+
 TEST(Imgproc_Threshold, regression_THRESH_TOZERO_IPP_16085)
 {
     Size sz(16, 16);


### PR DESCRIPTION
A first proposal for #26777

Adds a cv::THRESH_DISABLE flag to let cv::threshold() compute the threshold (useful for OTSU/TRIANGLE), but without actually running the thresholding. This flags is a proposal instead of a new function cv::computeThreshold()

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
