### PR TITLE
fixed fallback behavior for unsupported depth in imwrite and imwriteanimation

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -963,20 +963,16 @@ static bool imwriteanimation_(const String& filename, const Animation& animation
         {
             tempAnim.frames.push_back(inFrame);
         }
-        // use 16-bit depth if supported by the encoder
-        else if (inFrame.depth() == CV_16U && encoder->isFormatSupported(CV_16U))
-        {
-            tempAnim.frames.push_back(inFrame);
-        }
         else
         {
             // fallback to 8-bit depth if unsupported
             CV_LOG_ONCE_WARNING(NULL,
-                "imwriteanimation_: Unsupported depth for this encoder, fallback to CV_8U");
+                                "imwriteanimation_: Unsupported depth for this encoder, fallback to CV_8U");
             Mat converted;
             inFrame.convertTo(converted, CV_8U);
             tempAnim.frames.push_back(converted);
         }
+
         tempAnim.durations.push_back(animation.durations[i]);
     }
     encoder->setDestination(filename);


### PR DESCRIPTION
Fixes : #26839

After fix
```
[ WARN:0@0.021] global loadsave.cpp:848 imwrite_ Unsupported depth image for selected encoder is fallbacked to CV_8U.
0.0395393sec
0.0246938sec
[ WARN:0@0.084] global loadsave.cpp:965 imwriteanimation_ imwriteanimation_ Unsupported depth image for selected encoder is fallbacked to CV_8U.
0.411231sec
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
