### PR TITLE
Fix bug different marker ordering with findChessboardCornersSBWithMeta and CALIB_CB_LARGER flag

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -3720,10 +3720,11 @@ Chessboard::Board Chessboard::detectImpl(const Mat& gray,std::vector<cv::Mat> &f
                     continue;
                 }
 
+                iter_boards->normalizeOrientation(false);
+
                 if(iter_boards->getSize() == parameters.chessboard_size ||
                         iter_boards->getSize() == chessboard_size2)
                 {
-                    iter_boards->normalizeOrientation(false);
                     if(iter_boards->getSize() != parameters.chessboard_size)
                     {
                         if(iter_boards->isCellBlack(0,0) == iter_boards->isCellBlack(0,int(iter_boards->colCount())-1))

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -849,5 +849,18 @@ TEST(Calib3d_RotatedCirclesPatternDetector, issue_24964)
     EXPECT_LE(error, precise_success_error_level);
 }
 
+TEST(Calib3d_CornerOrdering, issue_26830) {
+    const cv::String dataDir = string(TS::ptr()->get_data_path()) + "cv/cameracalibration/";
+    const cv::Mat image = cv::imread(dataDir + "checkerboard_marker_white.png");
+
+    std::vector<Point2f> cornersMinimumSizeMatchesPatternSize;
+    ASSERT_TRUE(cv::findChessboardCornersSB(image, Size(14, 9), cornersMinimumSizeMatchesPatternSize, CALIB_CB_MARKER | CALIB_CB_LARGER));
+
+    std::vector<Point2f> cornersMinimumSizeSmallerThanPatternSize;
+    ASSERT_TRUE(cv::findChessboardCornersSB(image, Size(4, 4), cornersMinimumSizeSmallerThanPatternSize, CALIB_CB_MARKER | CALIB_CB_LARGER));
+
+    ASSERT_EQ(cornersMinimumSizeMatchesPatternSize, cornersMinimumSizeSmallerThanPatternSize);
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
Fix for proposed issue in https://github.com/opencv/opencv/issues/26830

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
