### PR TITLE
fix related the issue 22551

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -126,9 +126,10 @@ const uint32_t id_acTL = 0x4C546361; // Animation control chunk
 const uint32_t id_fcTL = 0x4C546366; // Frame control chunk
 const uint32_t id_IDAT = 0x54414449; // first frame and/or default image
 const uint32_t id_fdAT = 0x54416466; // Frame data chunk
-const uint32_t id_PLTE = 0x45544C50;
-const uint32_t id_bKGD = 0x44474B62;
-const uint32_t id_tRNS = 0x534E5274;
+const uint32_t id_PLTE = 0x45544C50; // The PLTE chunk contains a color palette for indexed-color images
+const uint32_t id_bKGD = 0x44474B62; // The bKGD chunk specifies a default background color for the image
+const uint32_t id_tRNS = 0x534E5274; // The tRNS chunk provides transparency information
+const uint32_t id_tEXt = 0x74584574; // The tEXt chunk stores metadata as text in key-value pairs
 const uint32_t id_IEND = 0x444E4549; // end/footer chunk
 
 APNGFrame::APNGFrame()
@@ -725,7 +726,7 @@ uint32_t PngDecoder::read_chunk(Chunk& chunk)
         // http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.bKGD
         if (size != 8 + 1 + 4 && size != 8 + 2 + 4 && size != 8 + 6 + 4)
             return 0;
-    } else if (id != id_fdAT && id != id_IDAT && id != id_IEND && id != id_PLTE && id != id_tRNS) {
+    } else if (id != id_fdAT && id != id_IDAT && id != id_IEND && id != id_PLTE && id != id_tEXt && id != id_tRNS) {
         if (size > PNG_USER_CHUNK_MALLOC_MAX)
         {
             CV_LOG_WARNING(NULL, "user chunk data is too large");


### PR DESCRIPTION
related  #22551
tEXt: chunk data size is being controlled by LibPNG
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
