### PR TITLE
Fix bug with int64 support for FileStorage

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2468,7 +2468,7 @@ size_t FileNode::rawSize() const
         p += 4;
     size_t sz0 = (size_t)(p - p0);
     if( tp == INT )
-        return sz0 + 4;
+        return sz0 + 8;
     if( tp == REAL )
         return sz0 + 8;
     if( tp == NONE )
@@ -2502,13 +2502,7 @@ void FileNode::setValue( int type, const void* value, int len )
         sz += 4;
 
     if( type == INT )
-    {
-        int64_t ival = *(const int64_t*)value;
-        if (ival > INT_MAX || ival < INT_MIN)
-            sz += 8;
-        else
-            sz += 4;
-    }
+        sz += 8;
     else if( type == REAL )
         sz += 8;
     else if( type == STRING )
@@ -2529,10 +2523,7 @@ void FileNode::setValue( int type, const void* value, int len )
     if( type == INT )
     {
         int64_t ival = *(const int64_t*)value;
-        if (sz > 8)
-            writeInt(p, ival);
-        else
-            writeInt(p, static_cast<int>(ival));
+        writeInt(p, ival);
     }
     else if( type == REAL )
     {
@@ -2683,7 +2674,7 @@ FileNodeIterator& FileNodeIterator::readRaw( const String& fmt, void* _data0, si
                 offset = alignSize( offset, elem_size );
                 uchar* data = data0 + offset;
 
-                for( int i = 0; i < count; i++ )
+                for( int i = 0; i < count; i++, ++(*this) )
                 {
                     FileNode node = *(*this);
                     if( node.isInt() )
@@ -2807,11 +2798,6 @@ FileNodeIterator& FileNodeIterator::readRaw( const String& fmt, void* _data0, si
                     }
                     else
                         CV_Error( Error::StsError, "readRawData can only be used to read plain sequences of numbers" );
-                    ++(*this);
-                    if (elem_type == CV_64S)
-                    {
-                        ofs += 4;
-                    }
                 }
                 offset = (int)(data - data0);
             }

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2022,6 +2022,64 @@ TEST(Core_InputOutput, FileStorage_invalid_attribute_value_regression_25946)
     ASSERT_EQ(0, std::remove(fileName.c_str()));
 }
 
+// see https://github.com/opencv/opencv/issues/26829
+TEST(Core_InputOutput, FileStorage_int64_26829)
+{
+    String content =
+        "%YAML:1.0\n"
+        "String1: string1\n"
+        "IntMin: -2147483648\n"
+        "String2: string2\n"
+        "Int64Min: -9223372036854775808\n"
+        "String3: string3\n"
+        "IntMax: 2147483647\n"
+        "String4: string4\n"
+        "Int64Max: 9223372036854775807\n"
+        "String5: string5\n";
+
+    FileStorage fs(content, FileStorage::READ | FileStorage::MEMORY);
+
+    {
+        std::string str;
+
+        fs["String1"] >> str;
+        EXPECT_EQ(str, "string1");
+
+        fs["String2"] >> str;
+        EXPECT_EQ(str, "string2");
+
+        fs["String3"] >> str;
+        EXPECT_EQ(str, "string3");
+
+        fs["String4"] >> str;
+        EXPECT_EQ(str, "string4");
+
+        fs["String5"] >> str;
+        EXPECT_EQ(str, "string5");
+    }
+
+    {
+        int value;
+
+        fs["IntMin"] >> value;
+        EXPECT_EQ(value, INT_MIN);
+
+        fs["IntMax"] >> value;
+        EXPECT_EQ(value, INT_MAX);
+    }
+
+
+    {
+        int64_t value;
+
+        fs["Int64Min"] >> value;
+        EXPECT_EQ(value, INT64_MIN);
+
+        fs["Int64Max"] >> value;
+        EXPECT_EQ(value, INT64_MAX);
+    }
+}
+
 template <typename T>
 T fsWriteRead(const T& expectedValue, const char* ext)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

Port #26846 to `5.x` branch

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
