### PR TITLE
Add RISC-V HAL implementation for fastAtan32f/fastAtan64f

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -22,6 +22,7 @@
 #if defined(__riscv_v) && __riscv_v == 1000000
 #include "hal_rvv_1p0/merge.hpp" // core
 #include "hal_rvv_1p0/mean.hpp" // core
+#include "hal_rvv_1p0/atan.hpp" // core
 #endif
 
 #endif

--- a/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
@@ -1,0 +1,128 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level
+// directory of this distribution and at http://opencv.org/license.html.
+#pragma once
+
+#undef cv_hal_fastAtan32f
+#define cv_hal_fastAtan32f cv::cv_hal_rvv::fast_atan_32
+
+#undef cv_hal_fastAtan64f
+#define cv_hal_fastAtan64f cv::cv_hal_rvv::fast_atan_64
+
+#include <riscv_vector.h>
+
+#include <cfloat>
+
+namespace cv::cv_hal_rvv {
+
+namespace detail {
+// ref: mathfuncs_core.simd.hpp
+static constexpr float pi = CV_PI;
+static constexpr float atan2_p1 = 0.9997878412794807F * (180 / pi);
+static constexpr float atan2_p3 = -0.3258083974640975F * (180 / pi);
+static constexpr float atan2_p5 = 0.1555786518463281F * (180 / pi);
+static constexpr float atan2_p7 = -0.04432655554792128F * (180 / pi);
+
+__attribute__((always_inline)) inline vfloat32m4_t
+rvv_atan_f32(vfloat32m4_t vy, vfloat32m4_t vx, size_t vl, float p7,
+             vfloat32m4_t vp5, vfloat32m4_t vp3, vfloat32m4_t vp1,
+             float angle_90_deg) {
+    const auto ax = __riscv_vfabs(vx, vl);
+    const auto ay = __riscv_vfabs(vy, vl);
+    const auto c = __riscv_vfdiv(
+        __riscv_vfmin(ax, ay, vl),
+        __riscv_vfadd(__riscv_vfmax(ax, ay, vl), FLT_EPSILON, vl), vl);
+    const auto c2 = __riscv_vfmul(c, c, vl);
+
+    auto a = __riscv_vfmadd(c2, p7, vp5, vl);
+    a = __riscv_vfmadd(a, c2, vp3, vl);
+    a = __riscv_vfmadd(a, c2, vp1, vl);
+    a = __riscv_vfmul(a, c, vl);
+
+    const auto mask = __riscv_vmflt(ax, ay, vl);
+    a = __riscv_vfrsub_mu(mask, a, a, angle_90_deg, vl);
+
+    a = __riscv_vfrsub_mu(__riscv_vmflt(vx, 0.F, vl), a, a, angle_90_deg * 2,
+                          vl);
+    a = __riscv_vfrsub_mu(__riscv_vmflt(vy, 0.F, vl), a, a, angle_90_deg * 4,
+                          vl);
+
+    return a;
+}
+
+} // namespace detail
+
+inline int fast_atan_32(const float *y, const float *x, float *dst, size_t n,
+                        bool angle_in_deg) {
+    const float scale = angle_in_deg ? 1.f : CV_PI / 180.f;
+    const float p1 = detail::atan2_p1 * scale;
+    const float p3 = detail::atan2_p3 * scale;
+    const float p5 = detail::atan2_p5 * scale;
+    const float p7 = detail::atan2_p7 * scale;
+    const float angle_90_deg = 90.F * scale;
+
+    static size_t vlmax = __riscv_vsetvlmax_e32m4();
+    auto vp1 = __riscv_vfmv_v_f_f32m4(p1, vlmax);
+    auto vp3 = __riscv_vfmv_v_f_f32m4(p3, vlmax);
+    auto vp5 = __riscv_vfmv_v_f_f32m4(p5, vlmax);
+
+    for (size_t vl{}; n > 0; n -= vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+
+        auto vy = __riscv_vle32_v_f32m4(y, vl);
+        auto vx = __riscv_vle32_v_f32m4(x, vl);
+
+        auto a =
+            detail::rvv_atan_f32(vy, vx, vl, p7, vp5, vp3, vp1, angle_90_deg);
+
+        __riscv_vse32(dst, a, vl);
+
+        x += vl;
+        y += vl;
+        dst += vl;
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+inline int fast_atan_64(const double *y, const double *x, double *dst, size_t n,
+                        bool angle_in_deg) {
+    // this also uses float32 version, ref: mathfuncs_core.simd.hpp
+
+    const float scale = angle_in_deg ? 1.f : CV_PI / 180.f;
+    const float p1 = detail::atan2_p1 * scale;
+    const float p3 = detail::atan2_p3 * scale;
+    const float p5 = detail::atan2_p5 * scale;
+    const float p7 = detail::atan2_p7 * scale;
+    const float angle_90_deg = 90.F * scale;
+
+    static size_t vlmax = __riscv_vsetvlmax_e32m4();
+    auto vp1 = __riscv_vfmv_v_f_f32m4(p1, vlmax);
+    auto vp3 = __riscv_vfmv_v_f_f32m4(p3, vlmax);
+    auto vp5 = __riscv_vfmv_v_f_f32m4(p5, vlmax);
+
+    for (size_t vl{}; n > 0; n -= vl) {
+        vl = __riscv_vsetvl_e64m8(n);
+
+        auto wy = __riscv_vle64_v_f64m8(y, vl);
+        auto wx = __riscv_vle64_v_f64m8(x, vl);
+
+        auto vy = __riscv_vfncvt_f_f_w_f32m4(wy, vl);
+        auto vx = __riscv_vfncvt_f_f_w_f32m4(wx, vl);
+
+        auto a =
+            detail::rvv_atan_f32(vy, vx, vl, p7, vp5, vp3, vp1, angle_90_deg);
+
+        auto wa = __riscv_vfwcvt_f_f_v_f64m8(a, vl);
+
+        __riscv_vse64(dst, wa, vl);
+
+        x += vl;
+        y += vl;
+        dst += vl;
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+} // namespace cv::cv_hal_rvv


### PR DESCRIPTION
Current universal intrinsic implementation of `fastAtan32f_` in `mathfuncs_core.simd.hpp` does not work for RVV (`CV_SIMD_SCALABLE`) so it falls back to scalar method.

This pull request adds an HAL implementation as a workaround allowing it to benefit form RVV vectorization.

Tested on Spacemit X60 cpu:

gcc version 14.2.1
```
         Name of Test            perf  perf     perf   
                                scalar  rvv     rvv    
                                                 vs    
                                                perf   
                                               scalar  
                                             (x-factor)
phase32f::VectorLength::128     0.007  0.002    3.20   
phase32f::VectorLength::1000    0.046  0.007    6.66   
phase32f::VectorLength::131072  5.995  0.740    8.10   
phase32f::VectorLength::524288  23.857 2.906    8.21   
phase32f::VectorLength::1048576 47.654 5.789    8.23   
phase64f::VectorLength::128     0.008  0.002    3.51   
phase64f::VectorLength::1000    0.056  0.009    6.47   
phase64f::VectorLength::131072  7.427  0.978    7.59   
phase64f::VectorLength::524288  30.726 3.937    7.80   
phase64f::VectorLength::1048576 59.783 7.739    7.72 
```

clang version 19.1.7
```
         Name of Test            perf  perf     perf   
                                clang  clang   clang   
                                scalar  rvv     rvv    
                                                 vs    
                                                perf   
                                               clang   
                                               scalar  
                                             (x-factor)
phase32f::VectorLength::128     0.007  0.002    3.22   
phase32f::VectorLength::1000    0.047  0.007    6.36   
phase32f::VectorLength::131072  6.133  0.803    7.63   
phase32f::VectorLength::524288  24.542 3.249    7.55   
phase32f::VectorLength::1048576 49.033 6.489    7.56   
phase64f::VectorLength::128     0.008  0.002    3.81   
phase64f::VectorLength::1000    0.059  0.009    6.66   
phase64f::VectorLength::131072  7.788  1.008    7.72   
phase64f::VectorLength::524288  31.644 4.132    7.66   
phase64f::VectorLength::1048576 62.591 8.074    7.75 
```

All of which were compiled with `-O2` enabled.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
