### PR TITLE
RISC-V: increase DotProduct test threshold a bit

### DIFF
--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -504,7 +504,7 @@ double Core_DotProductTest::get_success_error_level( int test_case_idx, int i, i
 #ifdef __riscv
     const int depth = test_mat[i][j].depth();
     if (depth == CV_64F)
-        return 1.7e-5;
+        return 2.5e-5;
 #endif
     return Core_MatrixTest::get_success_error_level( test_case_idx, i, j );
 }


### PR DESCRIPTION
See also #26666

To avoid test failures on LicheePi 4A (RVV 0.7.1):

```
[ RUN      ] Core_DotProduct.accuracy
/home/ci/opencv/modules/ts/src/ts.cpp:612: Failure
Failed

	failure reason: Bad accuracy
	test case #264
	seed: 00000000000c5b64
-----------------------------------
	LOG:
output: Too big difference (=2.48997e-05 > 1.7e-05) at element 0
input array 0 type=32fC2, size=(42, 453)
input array 1 type=32fC2, size=(42, 453)
ref output array 0 type=64fC1, size=(1, 4)
test_case_idx = 264

-----------------------------------
	CONSOLE: ................................
-----------------------------------

[  FAILED  ] Core_DotProduct.accuracy (99 ms)
```