### PR TITLE
Use universal intrinsics in bayer2gray

### DIFF
--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -123,12 +123,12 @@ public:
     }
 };
 
-#if CV_SIMD128
+#if CV_SIMD || CV_SIMD_SCALABLE
 class SIMDBayerInterpolator_8u
 {
 public:
-    int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
-                   int width, int bcoeff, int gcoeff, int rcoeff) const
+    static int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
+                   int width, int bcoeff, int gcoeff, int rcoeff)
     {
 #if CV_NEON
         uint16x8_t masklo = vdupq_n_u16(255);
@@ -177,96 +177,97 @@ public:
             vst1_u8(dst + 8, p.val[1]);
         }
 #else
-        v_uint16x8 v255 = v_setall_u16(255);
-        v_int16x8 v_descale = v_setall_s16(static_cast<short>(1 << 14));
-        v_int16x8 dummy;
-        v_int16x8 cxrb;
-        v_int16x8 cxg2;
-        v_zip(v_setall_s16(static_cast<short>(rcoeff)),
-              v_setall_s16(static_cast<short>(bcoeff)),
+        v_uint16 v255 = vx_setall_u16(255);
+        v_int16 v_descale = vx_setall_s16(static_cast<short>(1 << 14));
+        v_int16 dummy;
+        v_int16 cxrb;
+        v_int16 cxg2;
+        v_zip(vx_setall_s16(static_cast<short>(rcoeff)),
+              vx_setall_s16(static_cast<short>(bcoeff)),
               cxrb,
               dummy);
-        v_zip(v_setall_s16(static_cast<short>(gcoeff)),
-              v_setall_s16(static_cast<short>(2)),
+        v_zip(vx_setall_s16(static_cast<short>(gcoeff)),
+              vx_setall_s16(static_cast<short>(2)),
               cxg2,
               dummy);
 
         const uchar* bayer_end = bayer + width;
 
-        for (; bayer < bayer_end - 14; bayer += 14, dst += 14)
+        const int step = VTraits<v_uint8>::vlanes() - 2;
+        for (; bayer < bayer_end - step; bayer += step, dst += step)
         {
-            v_uint16x8 first_line = v_reinterpret_as_u16(v_load(bayer));
-            v_uint16x8 second_line = v_reinterpret_as_u16(v_load(bayer + bayer_step));
-            v_uint16x8 third_line = v_reinterpret_as_u16(v_load(bayer + bayer_step * 2));
+            v_uint16 first_line = v_reinterpret_as_u16(vx_load(bayer));
+            v_uint16 second_line = v_reinterpret_as_u16(vx_load(bayer + bayer_step));
+            v_uint16 third_line = v_reinterpret_as_u16(vx_load(bayer + bayer_step * 2));
 
             // bayer[0]
-            v_uint16x8 first_line0 = v_and(first_line, v255);
+            v_uint16 first_line0 = v_and(first_line, v255);
             // bayer[bayer_step*2]
-            v_uint16x8 third_line0 = v_and(third_line, v255);
+            v_uint16 third_line0 = v_and(third_line, v255);
             // bayer[0] + bayer[bayer_step*2]
-            v_uint16x8 first_third_line0 = v_add(first_line0, third_line0);
+            v_uint16 first_third_line0 = v_add(first_line0, third_line0);
             // bayer[2] + bayer[bayer_step*2+2]
-            v_uint16x8 first_third_line2 = v_rotate_right<1>(first_third_line0);
+            v_uint16 first_third_line2 = v_rotate_right<1>(first_third_line0);
             // bayer[0] + bayer[2] + bayer[bayer_step*2] + bayer[bayer_step*2+2]
-            v_int16x8 r0 = v_reinterpret_as_s16(v_add(first_third_line0, first_third_line2));
+            v_int16 r0 = v_reinterpret_as_s16(v_add(first_third_line0, first_third_line2));
             // (bayer[2] + bayer[bayer_step*2+2]) * 2
-            v_int16x8 r1 = v_reinterpret_as_s16(v_shl<1>(first_third_line2));
+            v_int16 r1 = v_reinterpret_as_s16(v_shl<1>(first_third_line2));
 
             // bayer[bayer_step+1]
-            v_uint16x8 second_line1 = v_shr<8>(second_line);
+            v_uint16 second_line1 = v_shr<8>(second_line);
             // bayer[bayer_step+1] * 4
-            v_int16x8 b0 = v_reinterpret_as_s16(v_shl<2>(second_line1));
+            v_int16 b0 = v_reinterpret_as_s16(v_shl<2>(second_line1));
             // bayer[bayer_step+3]
-            v_uint16x8 second_line3 = v_rotate_right<1>(second_line1);
+            v_uint16 second_line3 = v_rotate_right<1>(second_line1);
             // bayer[bayer_step+1] + bayer[bayer_step+3]
-            v_uint16x8 second_line13 = v_add(second_line1, second_line3);
+            v_uint16 second_line13 = v_add(second_line1, second_line3);
             // (bayer[bayer_step+1] + bayer[bayer_step+3]) * 2
-            v_int16x8 b1 = v_reinterpret_as_s16(v_shl(second_line13, 1));
+            v_int16 b1 = v_reinterpret_as_s16(v_shl(second_line13, 1));
 
             // bayer[1]
-            v_uint16x8 first_line1 = v_shr<8>(first_line);
+            v_uint16 first_line1 = v_shr<8>(first_line);
             // bayer[bayer_step]
-            v_uint16x8 second_line0 = v_and(second_line, v255);
+            v_uint16 second_line0 = v_and(second_line, v255);
             // bayer[bayer_step+2]
-            v_uint16x8 second_line2 = v_rotate_right<1>(second_line0);
+            v_uint16 second_line2 = v_rotate_right<1>(second_line0);
             // bayer[bayer_step] + bayer[bayer_step+2]
-            v_uint16x8 second_line02 = v_add(second_line0, second_line2);
+            v_uint16 second_line02 = v_add(second_line0, second_line2);
             // bayer[bayer_step*2+1]
-            v_uint16x8 third_line1 = v_shr<8>(third_line);
+            v_uint16 third_line1 = v_shr<8>(third_line);
             // bayer[1] + bayer[bayer_step*2+1]
-            v_uint16x8 first_third_line1 = v_add(first_line1, third_line1);
+            v_uint16 first_third_line1 = v_add(first_line1, third_line1);
             // bayer[1] + bayer[bayer_step] + bayer[bayer_step+2] + bayer[bayer_step*2+1]
-            v_int16x8 g0 = v_reinterpret_as_s16(v_add(first_third_line1, second_line02));
+            v_int16 g0 = v_reinterpret_as_s16(v_add(first_third_line1, second_line02));
             // bayer[bayer_step+2] * 4
-            v_int16x8 g1 = v_reinterpret_as_s16(v_shl<2>(second_line2));
+            v_int16 g1 = v_reinterpret_as_s16(v_shl<2>(second_line2));
 
-            v_int16x8 rb0;
-            v_int16x8 rb1;
-            v_int16x8 rb2;
-            v_int16x8 rb3;
+            v_int16 rb0;
+            v_int16 rb1;
+            v_int16 rb2;
+            v_int16 rb3;
             v_zip(r0, b0, rb0, rb1);
             v_zip(r1, b1, rb2, rb3);
 
-            v_int16x8 gd0;
-            v_int16x8 gd1;
-            v_int16x8 gd2;
-            v_int16x8 gd3;
+            v_int16 gd0;
+            v_int16 gd1;
+            v_int16 gd2;
+            v_int16 gd3;
             v_zip(g0, v_descale, gd0, gd1);
             v_zip(g1, v_descale, gd2, gd3);
 
-            v_int32x4 gray_even0 = v_shr<16>(v_add(v_dotprod(rb0, cxrb), v_dotprod(gd0, cxg2)));
-            v_int32x4 gray_even1 = v_shr<16>(v_add(v_dotprod(rb1, cxrb), v_dotprod(gd1, cxg2)));
-            v_int32x4 gray_odd0 = v_shr<16>(v_add(v_dotprod(rb2, cxrb), v_dotprod(gd2, cxg2)));
-            v_int32x4 gray_odd1 = v_shr<16>(v_add(v_dotprod(rb3, cxrb), v_dotprod(gd3, cxg2)));
+            v_int32 gray_even0 = v_shr<16>(v_add(v_dotprod(rb0, cxrb), v_dotprod(gd0, cxg2)));
+            v_int32 gray_even1 = v_shr<16>(v_add(v_dotprod(rb1, cxrb), v_dotprod(gd1, cxg2)));
+            v_int32 gray_odd0 = v_shr<16>(v_add(v_dotprod(rb2, cxrb), v_dotprod(gd2, cxg2)));
+            v_int32 gray_odd1 = v_shr<16>(v_add(v_dotprod(rb3, cxrb), v_dotprod(gd3, cxg2)));
 
-            v_int16x8 gray_even = v_pack(gray_even0, gray_even1);
-            v_int16x8 gray_odd = v_pack(gray_odd0, gray_odd1);
+            v_int16 gray_even = v_pack(gray_even0, gray_even1);
+            v_int16 gray_odd = v_pack(gray_odd0, gray_odd1);
 
-            v_int16x8 gray_d0;
-            v_int16x8 gray_d1;
+            v_int16 gray_d0;
+            v_int16 gray_d1;
             v_zip(gray_even, gray_odd, gray_d0, gray_d1);
 
-            v_uint8x16 gray = v_pack(v_reinterpret_as_u16(gray_d0), v_reinterpret_as_u16(gray_d1));
+            v_uint8 gray = v_pack(v_reinterpret_as_u16(gray_d0), v_reinterpret_as_u16(gray_d1));
 
             v_store(dst, gray);
         }

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -129,7 +129,7 @@ public:
     static int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
                    int width, int bcoeff, int gcoeff, int rcoeff)
     {
-#if CV_SIMD || CV_SIMD_SCALABLE
+#if CV_SIMD
 #if CV_NEON
         uint16x8_t masklo = vdupq_n_u16(255);
         const uchar* bayer_end = bayer + width;

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -412,6 +412,7 @@ public:
 
         return (int)(bayer - (bayer_end - width));
 #else
+        CV_UNUSED(bayer); CV_UNUSED(bayer_step); CV_UNUSED(dst); CV_UNUSED(width); CV_UNUSED(blue);
         return 0;
 #endif
     }
@@ -547,6 +548,8 @@ public:
 
         return (int)(bayer - (bayer_end - width));
 #else
+        CV_UNUSED(bayer); CV_UNUSED(bayer_step); CV_UNUSED(dst);
+        CV_UNUSED(width); CV_UNUSED(blue); CV_UNUSED(alpha);
         return 0;
 #endif
     }
@@ -657,6 +660,7 @@ public:
 
         return int(bayer - (bayer_end - width));
 #else
+        CV_UNUSED(bayer); CV_UNUSED(bayer_step); CV_UNUSED(dst); CV_UNUSED(width); CV_UNUSED(blue);
         return 0;
 #endif
     }

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -551,6 +551,7 @@ public:
 
     int bayer2RGB_EA(const uchar* bayer, int bayer_step, uchar* dst, int width, int blue) const
     {
+#if CV_SIMD128
         const uchar* bayer_end = bayer + width;
         v_uint16x8 masklow = v_setall_u16(0x00ff);
         v_uint16x8 delta1 = v_setall_u16(1), delta2 = v_setall_u16(2);
@@ -566,7 +567,6 @@ public:
              B G B G | B G B G | B G B G | B G B G
              */
 
-#if CV_SIMD128
             v_uint16x8 r0 = v_reinterpret_as_u16(v_load(bayer));
             v_uint16x8 r1 = v_reinterpret_as_u16(v_load(bayer+bayer_step));
             v_uint16x8 r2 = v_reinterpret_as_u16(v_load(bayer+bayer_step*2));

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -275,6 +275,8 @@ public:
 
         return static_cast<int>(bayer - (bayer_end - width));
 #else
+        CV_UNUSED(bayer); CV_UNUSED(bayer_step); CV_UNUSED(dst);
+        CV_UNUSED(width); CV_UNUSED(bcoeff); CV_UNUSED(gcoeff); CV_UNUSED(rcoeff);
         return 0;
 #endif
     }

--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -123,13 +123,13 @@ public:
     }
 };
 
-#if CV_SIMD || CV_SIMD_SCALABLE
 class SIMDBayerInterpolator_8u
 {
 public:
     static int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
                    int width, int bcoeff, int gcoeff, int rcoeff)
     {
+#if CV_SIMD || CV_SIMD_SCALABLE
 #if CV_NEON
         uint16x8_t masklo = vdupq_n_u16(255);
         const uchar* bayer_end = bayer + width;
@@ -274,6 +274,9 @@ public:
 #endif
 
         return static_cast<int>(bayer - (bayer_end - width));
+#else
+        return 0;
+#endif
     }
 
     int bayer2RGB(const uchar* bayer, int bayer_step, uchar* dst, int width, int blue) const
@@ -283,7 +286,7 @@ public:
          G R G R | G R G R | G R G R | G R G R
          B G B G | B G B G | B G B G | B G B G
          */
-
+#if CV_SIMD128
 #if CV_NEON
         uint16x8_t masklo = vdupq_n_u16(255);
         uint8x16x3_t pix;
@@ -406,6 +409,9 @@ public:
 #endif
 
         return (int)(bayer - (bayer_end - width));
+#else
+        return 0;
+#endif
     }
 
     int bayer2RGBA(const uchar* bayer, int bayer_step, uchar* dst, int width, int blue, const uchar alpha) const
@@ -416,6 +422,7 @@ public:
          B G B G | B G B G | B G B G | B G B G
          */
 
+#if CV_SIMD128
 #if CV_NEON
         uint16x8_t masklo = vdupq_n_u16(255);
         uint8x16x4_t pix;
@@ -537,6 +544,9 @@ public:
 #endif
 
         return (int)(bayer - (bayer_end - width));
+#else
+        return 0;
+#endif
     }
 
     int bayer2RGB_EA(const uchar* bayer, int bayer_step, uchar* dst, int width, int blue) const
@@ -556,6 +566,7 @@ public:
              B G B G | B G B G | B G B G | B G B G
              */
 
+#if CV_SIMD128
             v_uint16x8 r0 = v_reinterpret_as_u16(v_load(bayer));
             v_uint16x8 r1 = v_reinterpret_as_u16(v_load(bayer+bayer_step));
             v_uint16x8 r2 = v_reinterpret_as_u16(v_load(bayer+bayer_step*2));
@@ -643,12 +654,11 @@ public:
         }
 
         return int(bayer - (bayer_end - width));
+#else
+        return 0;
+#endif
     }
 };
-#else
-typedef SIMDBayerStubInterpolator_<uchar> SIMDBayerInterpolator_8u;
-#endif
-
 
 template<typename T, class SIMDInterpolator>
 class Bayer2Gray_Invoker :


### PR DESCRIPTION
I tested this patch on my 14900K desktop with `-DCPU_BASELINE=AVX2`, performance doesn't go down.
```
Geometric mean (ms)

                             Name of Test                               old-avx2  avx2      avx2
                                                                                             vs
                                                                                          old-avx2
                                                                                         (x-factor)
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerBG2BGR)      4.325    4.139     1.04
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerBG2BGRA)     4.419    4.393     1.01
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerBG2BGR_VNG) 101.168  101.138    1.00
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerBG2GRAY)     0.950    0.913     1.04
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGB2BGR)      4.085    4.045     1.01
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGB2BGRA)     4.354    4.406     0.99
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGB2BGR_VNG) 102.400  101.853    1.01
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGB2GRAY)     1.083    1.011     1.07
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGR2BGR)      4.346    4.076     1.07
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGR2BGRA)     4.297    4.387     0.98
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGR2BGR_VNG) 102.164  101.412    1.01
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerGR2GRAY)     0.904    0.949     0.95
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerRG2BGR)      4.101    4.131     0.99
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerRG2BGRA)     4.403    4.416     1.00
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerRG2BGR_VNG) 101.669  103.508    0.98
cvtColorBayer8u::Size_CvtMode_Bayer::(7680x4320, COLOR_BayerRG2GRAY)     0.978    0.861     1.14
```

I also try to use universal intrinsics on aarch64, however, time becomes twice as previous hand-written intrinsics. I'll find out that later.

For this patch, it should optimize the performance on machine with `CV_SIMD_SCALABLE`.

To make this patch simple, I only modify bayer2gray and leave bayer2bgr, bayer2bgra and bayer2bgr_ea as is.

Related: https://github.com/opencv/opencv/issues/25724 https://github.com/opencv/opencv/pull/26012

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
