### PR TITLE
fix: update cv_hal_meanstddev api to use sizet for width and height

### DIFF
--- a/3rdparty/fastcv/include/fastcv_hal_core.hpp
+++ b/3rdparty/fastcv/include/fastcv_hal_core.hpp
@@ -105,8 +105,8 @@ int fastcv_hal_transpose2d(
 int fastcv_hal_meanStdDev(
     const uchar     * src_data,
     size_t            src_step,
-    int               width,
-    int               height,
+    size_t            width,
+    size_t            height,
     int               src_type,
     double          * mean_val,
     double          * stddev_val,

--- a/3rdparty/fastcv/src/fastcv_hal_core.cpp
+++ b/3rdparty/fastcv/src/fastcv_hal_core.cpp
@@ -190,8 +190,8 @@ int fastcv_hal_transpose2d(
 int fastcv_hal_meanStdDev(
     const uchar*      src_data,
     size_t            src_step,
-    int               width,
-    int               height,
+    size_t            width,
+    size_t            height,
     int               src_type,
     double*           mean_val,
     double*           stddev_val,
@@ -217,7 +217,7 @@ int fastcv_hal_meanStdDev(
 
     float32_t mean, variance;
 
-    fcvStatus status = fcvImageIntensityStats_v2(src_data, src_step, 0, 0, width, height,
+    fcvStatus status = fcvImageIntensityStats_v2(src_data, src_step, 0, 0, (int)width, (int)height,
                                    &mean, &variance, FASTCV_BIASED_VARIANCE_ESTIMATOR);
 
     if(mean_val != nullptr)

--- a/3rdparty/hal_rvv/hal_rvv_1p0/mean.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/mean.hpp
@@ -11,14 +11,14 @@ namespace cv { namespace cv_hal_rvv {
 #undef cv_hal_meanStdDev
 #define cv_hal_meanStdDev cv::cv_hal_rvv::meanStdDev
 
-inline int meanStdDev_8UC1(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_8UC1(const uchar* src_data, size_t src_step, size_t width, size_t height,
                             double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
-inline int meanStdDev_8UC4(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_8UC4(const uchar* src_data, size_t src_step, size_t width, size_t height,
                             double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
-inline int meanStdDev_32FC1(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_32FC1(const uchar* src_data, size_t src_step, size_t width, size_t height,
                             double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
 
-inline int meanStdDev(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev(const uchar* src_data, size_t src_step, size_t width, size_t height,
                              int src_type, double* mean_val, double* stddev_val, uchar* mask, size_t mask_step) {
     switch (src_type)
     {
@@ -33,7 +33,7 @@ inline int meanStdDev(const uchar* src_data, size_t src_step, int width, int hei
     }
 }
 
-inline int meanStdDev_8UC1(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_8UC1(const uchar* src_data, size_t src_step, size_t width, size_t height,
                              double* mean_val, double* stddev_val, uchar* mask, size_t mask_step) {
     int nz = 0;
     int vlmax = __riscv_vsetvlmax_e64m8();
@@ -93,7 +93,7 @@ inline int meanStdDev_8UC1(const uchar* src_data, size_t src_step, int width, in
     return CV_HAL_ERROR_OK;
 }
 
-inline int meanStdDev_8UC4(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_8UC4(const uchar* src_data, size_t src_step, size_t width, size_t height,
                              double* mean_val, double* stddev_val, uchar* mask, size_t mask_step) {
     int nz = 0;
     int vlmax = __riscv_vsetvlmax_e64m8();
@@ -163,7 +163,7 @@ inline int meanStdDev_8UC4(const uchar* src_data, size_t src_step, int width, in
     return CV_HAL_ERROR_OK;
 }
 
-inline int meanStdDev_32FC1(const uchar* src_data, size_t src_step, int width, int height,
+inline int meanStdDev_32FC1(const uchar* src_data, size_t src_step, size_t width, size_t height,
                              double* mean_val, double* stddev_val, uchar* mask, size_t mask_step) {
     int nz = 0;
     int vlmax = __riscv_vsetvlmax_e64m4();

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -946,7 +946,7 @@ inline int hal_ni_minMaxIdxMaskStep(const uchar* src_data, size_t src_step, int 
    @param mask_step Mask array step.
    @sa meanStdDev
 */
-inline int hal_ni_meanStdDev(const uchar* src_data, size_t src_step, int width, int height,
+inline int hal_ni_meanStdDev(const uchar* src_data, size_t src_step, size_t width, size_t height,
                              int src_type, double* mean_val, double* stddev_val, uchar* mask, size_t mask_step)
 { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 

--- a/modules/core/src/mean.dispatch.cpp
+++ b/modules/core/src/mean.dispatch.cpp
@@ -568,16 +568,17 @@ void meanStdDev(InputArray _src, OutputArray _mean, OutputArray _sdv, InputArray
 
     if (src.isContinuous() && mask.isContinuous())
     {
-        CALL_HAL(meanStdDev, cv_hal_meanStdDev, src.data, 0, (int)src.total(), 1, src.type(),
+        CALL_HAL(meanStdDev, cv_hal_meanStdDev, src.data, 0, src.total(), static_cast<size_t>(1),
+                 src.type(),
                  _mean.needed() ? mean_mat.ptr<double>() : nullptr,
                  _sdv.needed() ? stddev_mat.ptr<double>() : nullptr,
-                 mask.data, 0);
+                 mask.data, static_cast<size_t>(0));
     }
     else
     {
         if (src.dims <= 2)
         {
-            CALL_HAL(meanStdDev, cv_hal_meanStdDev, src.data, src.step, src.cols, src.rows, src.type(),
+            CALL_HAL(meanStdDev, cv_hal_meanStdDev, src.data, src.step, static_cast<size_t>(src.cols), static_cast<size_t>(src.rows), src.type(),
                      _mean.needed() ? mean_mat.ptr<double>() : nullptr,
                      _sdv.needed() ? stddev_mat.ptr<double>() : nullptr,
                      mask.data, mask.step);


### PR DESCRIPTION
Related to the issue #26861 

This patch updates the cv_hal_meanStdDev interface to use size_t for the width and height parameters, thus preventing potential integer overflow when processing large images.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
