### PR TITLE
Add missing include in gislandmodel.hpp

### DIFF
--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -10,6 +10,7 @@
 
 #include <unordered_set>
 #include <memory>        // shared_ptr
+#include <exception>     // exception_ptr
 
 #include <ade/graph.hpp>
 #include <ade/typed_graph.hpp>

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -8,9 +8,11 @@
 #ifndef OPENCV_GAPI_GISLANDMODEL_HPP
 #define OPENCV_GAPI_GISLANDMODEL_HPP
 
-#include <unordered_set>
+#include <unordered_set> // unordered_map
 #include <memory>        // shared_ptr
 #include <exception>     // exception_ptr
+#include <string>        // string
+#include <cstddef>       // size_t
 
 #include <ade/graph.hpp>
 #include <ade/typed_graph.hpp>


### PR DESCRIPTION
Add `<exception>`, `<string>`, and `<cstddef>` includes to `gislandmodel.hpp` which are required due to the usage of `std::exception_ptr`, `std::string`, and `size_t` in this header.

Notably one of those causes a build error on recent versions of Xcode: #26780 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [N/A] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [N/A] The feature is well documented and sample code can be built with the project CMake
