### PR TITLE
core: vectorize cv::normalize / cv::norm

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -12,6 +12,7 @@ ocv_add_dispatched_file(mean SSE2 AVX2 LASX)
 ocv_add_dispatched_file(merge SSE2 AVX2 LASX)
 ocv_add_dispatched_file(split SSE2 AVX2 LASX)
 ocv_add_dispatched_file(sum SSE2 AVX2 LASX)
+ocv_add_dispatched_file(norm SSE2 SSE4_1 AVX AVX2 NEON_DOTPROD LASX)
 
 # dispatching for accuracy tests
 ocv_add_dispatched_file_force_all(test_intrin128 TEST SSE2 SSE3 SSSE3 SSE4_1 SSE4_2 AVX FP16 AVX2 AVX512_SKX)

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -297,14 +297,22 @@ template<> inline
 int normInf(const int* src, int n) {
     v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
     v_uint32 r2 = vx_setzero_u32(), r3 = vx_setzero_u32();
+    v_uint32 r4 = vx_setzero_u32(), r5 = vx_setzero_u32();
+    v_uint32 r6 = vx_setzero_u32(), r7 = vx_setzero_u32();
     int j = 0;
-    for (; j <= n - 4 * VTraits<v_int32>::vlanes(); j += 4 * VTraits<v_int32>::vlanes()) {
+    for (; j <= n - 8 * VTraits<v_int32>::vlanes(); j += 8 * VTraits<v_int32>::vlanes()) {
         r0 = v_max(r0, v_abs(vx_load(src + j                                 )));
         r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int32>::vlanes())));
         r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_int32>::vlanes())));
         r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int32>::vlanes())));
+        r4 = v_max(r4, v_abs(vx_load(src + j + 4 * VTraits<v_int32>::vlanes())));
+        r5 = v_max(r5, v_abs(vx_load(src + j + 5 * VTraits<v_int32>::vlanes())));
+        r6 = v_max(r6, v_abs(vx_load(src + j + 6 * VTraits<v_int32>::vlanes())));
+        r7 = v_max(r7, v_abs(vx_load(src + j + 7 * VTraits<v_int32>::vlanes())));
     }
     r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+    r4 = v_max(r4, v_max(r5, v_max(r6, r7)));
+    r0 = v_max(r0, r4);
     int s = 0;
     for (; j < n; j++) {
         s = std::max(s, cv_abs(src[j]));
@@ -380,29 +388,29 @@ int normL1(const schar* src, int n) {
     v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
     int j = 0;
     for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
-        v_int8 v0 = vx_load(src + j);
-        v_int16 v00, v01;
+        v_uint8 v0 = v_abs(vx_load(src + j));
+        v_uint16 v00, v01;
         v_expand(v0, v00, v01);
-        v_int32 v000, v001, v010, v011;
+        v_uint32 v000, v001, v010, v011;
         v_expand(v00, v000, v001);
         v_expand(v01, v010, v011);
 
-        r00 = v_add(r00, v_abs(v000));
-        r01 = v_add(r01, v_abs(v001));
-        r10 = v_add(r10, v_abs(v010));
-        r11 = v_add(r11, v_abs(v011));
+        r00 = v_add(r00, v000);
+        r01 = v_add(r01, v001);
+        r10 = v_add(r10, v010);
+        r11 = v_add(r11, v011);
 
-        v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
-        v_int16 v10, v11;
+        v_uint8 v1 = v_abs(vx_load(src + j + VTraits<v_int8>::vlanes()));
+        v_uint16 v10, v11;
         v_expand(v1, v10, v11);
-        v_int32 v100, v101, v110, v111;
+        v_uint32 v100, v101, v110, v111;
         v_expand(v10, v100, v101);
         v_expand(v11, v110, v111);
 
-        r20 = v_add(r20, v_abs(v100));
-        r21 = v_add(r21, v_abs(v101));
-        r30 = v_add(r30, v_abs(v110));
-        r31 = v_add(r31, v_abs(v111));
+        r20 = v_add(r20, v100);
+        r21 = v_add(r21, v101);
+        r30 = v_add(r30, v110);
+        r31 = v_add(r31, v111);
     }
     int s = 0;
     s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
@@ -456,23 +464,23 @@ int normL1(const short* src, int n) {
     v_uint32 d30 = vx_setzero_u32(), d31 = vx_setzero_u32();
     int j = 0;
     for (; j<= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
-        v_int16 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
-        v_int32 v00, v01, v10, v11;
+        v_uint16 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
+        v_uint32 v00, v01, v10, v11;
         v_expand(v0, v00, v01);
         v_expand(v1, v10, v11);
-        d00 = v_add(d00, v_abs(v00));
-        d01 = v_add(d01, v_abs(v01));
-        d10 = v_add(d10, v_abs(v10));
-        d11 = v_add(d11, v_abs(v11));
+        d00 = v_add(d00, v00);
+        d01 = v_add(d01, v01);
+        d10 = v_add(d10, v10);
+        d11 = v_add(d11, v11);
 
-        v_int16 v2 = vx_load(src + j + 2 * VTraits<v_int16>::vlanes()), v3 = vx_load(src + j + 3 * VTraits<v_int16>::vlanes());
-        v_int32 v20, v21, v30, v31;
+        v_uint16 v2 = v_abs(vx_load(src + j + 2 * VTraits<v_int16>::vlanes())), v3 = v_abs(vx_load(src + j + 3 * VTraits<v_int16>::vlanes()));
+        v_uint32 v20, v21, v30, v31;
         v_expand(v2, v20, v21);
         v_expand(v3, v30, v31);
-        d20 = v_add(d20, v_abs(v20));
-        d21 = v_add(d21, v_abs(v21));
-        d30 = v_add(d30, v_abs(v30));
-        d31 = v_add(d31, v_abs(v31));
+        d20 = v_add(d20, v20);
+        d21 = v_add(d21, v21);
+        d30 = v_add(d30, v30);
+        d31 = v_add(d31, v31);
     }
     int s = 0;
     s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
@@ -601,9 +609,9 @@ double normL1(const int* src, int n) {
     v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
     int j = 0;
     for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
-        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes()));
-        r00 = v_add(r00, v_abs(v_cvt_f64(v0))); r01 = v_add(r01, v_abs(v_cvt_f64_high(v0)));
-        r10 = v_add(r10, v_abs(v_cvt_f64(v1))); r11 = v_add(r11, v_abs(v_cvt_f64_high(v1)));
+        v_float32 v0 = v_abs(v_cvt_f32(vx_load(src + j))), v1 = v_abs(v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes())));
+        r00 = v_add(r00, v_cvt_f64(v0)); r01 = v_add(r01, v_cvt_f64_high(v0));
+        r10 = v_add(r10, v_cvt_f64(v1)); r11 = v_add(r11, v_cvt_f64_high(v1));
     }
     double s = 0.f;
     s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -288,7 +288,7 @@ int normInf(const short* src, int n) {
     d0 = v_max(d0, v_max(d1, v_max(d2, d3)));
     int s = 0;
     for (; j < n; j++) {
-        s = std::max(s, (int)src[j]);
+        s = std::max(s, saturate_cast<int>(cv_abs(src[j])));
     }
     return std::max(s, saturate_cast<int>(v_reduce_max(d0)));
 }

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -237,6 +237,25 @@ int normInf(const uchar* src, int n) {
 }
 
 template<> inline
+int normInf(const schar* src, int n) {
+    v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
+    v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
+    int j = 0;
+    for (; j <= n - 4 * VTraits<v_int8>::vlanes(); j += 4 * VTraits<v_int8>::vlanes()) {
+        r0 = v_max(r0, v_abs(vx_load(src + j                                )));
+        r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int8>::vlanes())));
+        r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_int8>::vlanes())));
+        r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int8>::vlanes())));
+    }
+    r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+    int s = 0;
+    for (; j < n; j++) {
+        s = std::max(s, cv_abs(src[j]));
+    }
+    return std::max(s, saturate_cast<int>(v_reduce_max(r0)));
+}
+
+template<> inline
 int normInf(const ushort* src, int n) {
     v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
     v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
@@ -335,6 +354,47 @@ int normL1(const uchar* src, int n) {
 }
 
 template<> inline
+int normL1(const schar* src, int n) {
+    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
+    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
+    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
+    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    int j = 0;
+    for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
+        v_int8 v0 = vx_load(src + j);
+        v_int16 v00, v01;
+        v_expand(v0, v00, v01);
+        v_int32 v000, v001, v010, v011;
+        v_expand(v00, v000, v001);
+        v_expand(v01, v010, v011);
+
+        r00 = v_add(r00, v000);
+        r01 = v_add(r01, v001);
+        r10 = v_add(r10, v010);
+        r11 = v_add(r11, v011);
+
+        v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
+        v_int16 v10, v11;
+        v_expand(v1, v10, v11);
+        v_int32 v100, v101, v110, v111;
+        v_expand(v10, v100, v101);
+        v_expand(v11, v110, v111);
+
+        r20 = v_add(r20, v100);
+        r21 = v_add(r21, v101);
+        r30 = v_add(r30, v110);
+        r31 = v_add(r31, v111);
+    }
+    int s = 0;
+    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    for (; j < n; j++) {
+        s += src[j];
+    }
+    return s;
+}
+
+template<> inline
 int normL1(const ushort* src, int n) {
     v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
     v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
@@ -411,6 +471,48 @@ int normL2Sqr(const uchar* src, int n) {
     return s;
 }
 
+template<> inline
+int normL2Sqr(const schar* src, int n) {
+    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
+    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
+    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
+    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    int j = 0;
+    for (; j <= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
+        v_int8 v0 = vx_load(src + j);
+        v_int16 v00, v01;
+        v_expand(v0, v00, v01);
+        v_int32 v000, v001, v010, v011;
+        v_expand(v00, v000, v001);
+        v_expand(v01, v010, v011);
+
+        r00 = v_add(r00, v_mul(v000, v000));
+        r01 = v_add(r01, v_mul(v001, v001));
+        r10 = v_add(r10, v_mul(v010, v010));
+        r11 = v_add(r11, v_mul(v011, v011));
+
+        v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
+        v_int16 v10, v11;
+        v_expand(v1, v10, v11);
+        v_int32 v100, v101, v110, v111;
+        v_expand(v10, v100, v101);
+        v_expand(v11, v110, v111);
+
+        r20 = v_add(r20, v_mul(v100, v100));
+        r21 = v_add(r21, v_mul(v101, v101));
+        r30 = v_add(r30, v_mul(v110, v110));
+        r31 = v_add(r31, v_mul(v111, v111));
+    }
+    int s = 0;
+    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    for (; j < n; j++) {
+        int v = saturate_cast<int>(src[j]);
+        s += v * v;
+    }
+    return s;
+}
+
 #endif
 
 #if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
@@ -420,8 +522,8 @@ double normL1(const int* src, int n) {
     v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
     v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
     int j = 0;
-    for (; j <= n - 2 * VTraits<v_float32>::vlanes(); j += 2 * VTraits<v_float32>::vlanes()) {
-        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_float32>::vlanes()));
+    for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
+        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes()));
         r00 = v_add(r00, v_abs(v_cvt_f64(v0))); r01 = v_add(r01, v_abs(v_cvt_f64_high(v0)));
         r10 = v_add(r10, v_abs(v_cvt_f64(v1))); r11 = v_add(r11, v_abs(v_cvt_f64_high(v1)));
     }
@@ -483,8 +585,8 @@ double normL2Sqr(const int* src, int n) {
     v_float64 d00 = vx_setzero_f64(), d01 = vx_setzero_f64();
     v_float64 d10 = vx_setzero_f64(), d11 = vx_setzero_f64();
     int j = 0;
-    for (; j <= n - 2 * VTraits<v_float32>::vlanes(); j += 2 * VTraits<v_float32>::vlanes()) {
-        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_float32>::vlanes()));
+    for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
+        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes()));
         v_float64 v00 = v_cvt_f64(v0), v01 = v_cvt_f64_high(v0);
         v_float64 v10 = v_cvt_f64(v1), v11 = v_cvt_f64_high(v1);
         d00 = v_add(d00, v_mul(v00, v00)); d01 = v_add(d01, v_mul(v01, v01));

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -218,11 +218,30 @@ int normL1_(const uchar* a, const uchar* b, int n)
 #if (CV_SIMD || CV_SIMD_SCALABLE)
 
 template<> inline
+int normInf(const uchar* src, int n) {
+    v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
+    v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
+    int j = 0;
+    for (; j <= n - 4 * VTraits<v_uint8>::vlanes(); j += 4 * VTraits<v_uint8>::vlanes()) {
+        r0 = v_max(r0, vx_load(src + j                                 ));
+        r1 = v_max(r1, vx_load(src + j +     VTraits<v_uint8>::vlanes()));
+        r2 = v_max(r2, vx_load(src + j + 2 * VTraits<v_uint8>::vlanes()));
+        r3 = v_max(r3, vx_load(src + j + 3 * VTraits<v_uint8>::vlanes()));
+    }
+    r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+    int s = 0;
+    for (; j < n; j++) {
+        s = std::max(s, (int)src[j]);
+    }
+    return std::max(s, (int)v_reduce_max(r0));
+}
+
+template<> inline
 int normInf(const ushort* src, int n) {
     v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
     v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
     int j = 0;
-    for (; j<= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
+    for (; j <= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
         d0 = v_max(d0, vx_load(src + j                                  ));
         d1 = v_max(d1, vx_load(src + j +     VTraits<v_uint16>::vlanes()));
         d2 = v_max(d2, vx_load(src + j + 2 * VTraits<v_uint16>::vlanes()));
@@ -256,6 +275,47 @@ float normInf(const float* src, int n) {
 }
 
 template<> inline
+int normL1(const uchar* src, int n) {
+    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
+    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
+    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
+    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    int j = 0;
+    for (; j<= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
+        v_uint8 v0 = vx_load(src + j);
+        v_uint16 v00, v01;
+        v_expand(v0, v00, v01);
+        v_uint32 v000, v001, v010, v011;
+        v_expand(v00, v000, v001);
+        v_expand(v01, v010, v011);
+
+        r00 = v_add(r00, v_reinterpret_as_s32(v000));
+        r01 = v_add(r01, v_reinterpret_as_s32(v001));
+        r10 = v_add(r10, v_reinterpret_as_s32(v010));
+        r11 = v_add(r11, v_reinterpret_as_s32(v011));
+
+        v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
+        v_uint16 v10, v11;
+        v_expand(v1, v10, v11);
+        v_uint32 v100, v101, v110, v111;
+        v_expand(v10, v100, v101);
+        v_expand(v11, v110, v111);
+
+        r20 = v_add(r20, v_reinterpret_as_s32(v100));
+        r21 = v_add(r21, v_reinterpret_as_s32(v101));
+        r30 = v_add(r30, v_reinterpret_as_s32(v110));
+        r31 = v_add(r31, v_reinterpret_as_s32(v111));
+    }
+    int s = 0;
+    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    for (; j < n; j++) {
+        s += src[j];
+    }
+    return s;
+}
+
+template<> inline
 int normL1(const ushort* src, int n) {
     v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
     v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
@@ -286,6 +346,48 @@ int normL1(const ushort* src, int n) {
     s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
     for (; j < n; j++) {
         s += src[j];
+    }
+    return s;
+}
+
+template<> inline
+int normL2Sqr(const uchar* src, int n) {
+    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
+    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
+    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
+    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    int j = 0;
+    for (; j <= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
+        v_uint8 v0 = vx_load(src + j);
+        v_uint16 v00, v01;
+        v_expand(v0, v00, v01);
+        v_uint32 v000, v001, v010, v011;
+        v_expand(v00, v000, v001);
+        v_expand(v01, v010, v011);
+
+        r00 = v_add(r00, v_reinterpret_as_s32(v_mul(v000, v000)));
+        r01 = v_add(r01, v_reinterpret_as_s32(v_mul(v001, v001)));
+        r10 = v_add(r10, v_reinterpret_as_s32(v_mul(v010, v010)));
+        r11 = v_add(r11, v_reinterpret_as_s32(v_mul(v011, v011)));
+
+        v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
+        v_uint16 v10, v11;
+        v_expand(v1, v10, v11);
+        v_uint32 v100, v101, v110, v111;
+        v_expand(v10, v100, v101);
+        v_expand(v11, v110, v111);
+
+        r20 = v_add(r20, v_reinterpret_as_s32(v_mul(v100, v100)));
+        r21 = v_add(r21, v_reinterpret_as_s32(v_mul(v101, v101)));
+        r30 = v_add(r30, v_reinterpret_as_s32(v_mul(v110, v110)));
+        r31 = v_add(r31, v_reinterpret_as_s32(v_mul(v111, v111)));
+    }
+    int s = 0;
+    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    for (; j < n; j++) {
+        int v = saturate_cast<int>(src[j]);
+        s += v * v;
     }
     return s;
 }

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -485,39 +485,17 @@ int normL1(const short* src, int n) {
 
 template<> inline
 int normL2Sqr(const uchar* src, int n) {
-    v_uint32 r00 = vx_setzero_u32(), r01 = vx_setzero_u32();
-    v_uint32 r10 = vx_setzero_u32(), r11 = vx_setzero_u32();
-    v_uint32 r20 = vx_setzero_u32(), r21 = vx_setzero_u32();
-    v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
+    v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
     int j = 0;
     for (; j <= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
         v_uint8 v0 = vx_load(src + j);
-        v_uint16 v00, v01;
-        v_expand(v0, v00, v01);
-        v_uint32 v000, v001, v010, v011;
-        v_expand(v00, v000, v001);
-        v_expand(v01, v010, v011);
-
-        r00 = v_add(r00, v_mul(v000, v000));
-        r01 = v_add(r01, v_mul(v001, v001));
-        r10 = v_add(r10, v_mul(v010, v010));
-        r11 = v_add(r11, v_mul(v011, v011));
+        r0 = v_dotprod_expand(v0, v0, r0);
 
         v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
-        v_uint16 v10, v11;
-        v_expand(v1, v10, v11);
-        v_uint32 v100, v101, v110, v111;
-        v_expand(v10, v100, v101);
-        v_expand(v11, v110, v111);
-
-        r20 = v_add(r20, v_mul(v100, v100));
-        r21 = v_add(r21, v_mul(v101, v101));
-        r30 = v_add(r30, v_mul(v110, v110));
-        r31 = v_add(r31, v_mul(v111, v111));
+        r1 = v_dotprod_expand(v1, v1, r1);
     }
     int s = 0;
-    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
-    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    s += v_reduce_sum(v_add(r0, r1));
     for (; j < n; j++) {
         int v = saturate_cast<int>(src[j]);
         s += v * v;
@@ -527,39 +505,16 @@ int normL2Sqr(const uchar* src, int n) {
 
 template<> inline
 int normL2Sqr(const schar* src, int n) {
-    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
-    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
-    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
-    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    v_int32 r0 = vx_setzero_s32(), r1 = vx_setzero_s32();
     int j = 0;
     for (; j <= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
         v_int8 v0 = vx_load(src + j);
-        v_int16 v00, v01;
-        v_expand(v0, v00, v01);
-        v_int32 v000, v001, v010, v011;
-        v_expand(v00, v000, v001);
-        v_expand(v01, v010, v011);
-
-        r00 = v_add(r00, v_mul(v000, v000));
-        r01 = v_add(r01, v_mul(v001, v001));
-        r10 = v_add(r10, v_mul(v010, v010));
-        r11 = v_add(r11, v_mul(v011, v011));
-
+        r0 = v_dotprod_expand(v0, v0, r0);
         v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
-        v_int16 v10, v11;
-        v_expand(v1, v10, v11);
-        v_int32 v100, v101, v110, v111;
-        v_expand(v10, v100, v101);
-        v_expand(v11, v110, v111);
-
-        r20 = v_add(r20, v_mul(v100, v100));
-        r21 = v_add(r21, v_mul(v101, v101));
-        r30 = v_add(r30, v_mul(v110, v110));
-        r31 = v_add(r31, v_mul(v111, v111));
+        r1 = v_dotprod_expand(v1, v1, r1);
     }
     int s = 0;
-    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
-    s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+    s += v_reduce_sum(v_add(r0, r1));
     for (; j < n; j++) {
         int v = saturate_cast<int>(src[j]);
         s += v * v;
@@ -659,24 +614,19 @@ double normL1(const double* src, int n) {
 
 template<> inline
 double normL2Sqr(const ushort* src, int n) {
-    v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
-    v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+    v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
     int j = 0;
-    for (; j <= n - VTraits<v_uint16>::vlanes(); j += VTraits<v_uint16>::vlanes()) {
-        v_uint16 v = vx_load(src + j);
-        v_uint32 v0, v1;
-        v_expand(v, v0, v1);
-        v_int32 s0 = v_reinterpret_as_s32(v0), s1 = v_reinterpret_as_s32(v1);
-        v_float64 f00 = v_cvt_f64(s0), f01 = v_cvt_f64_high(s0);
-        v_float64 f10 = v_cvt_f64(s1), f11 = v_cvt_f64_high(s1);
+    for (; j <= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
+        v_uint16 v0 = vx_load(src + j);
+        v_uint64 u0 = v_dotprod_expand(v0, v0);
+        r0 = v_add(r0, v_cvt_f64(v_reinterpret_as_s64(u0)));
 
-        r00 = v_add(r00, v_mul(f00, f00));
-        r01 = v_add(r01, v_mul(f01, f01));
-        r10 = v_add(r10, v_mul(f10, f10));
-        r11 = v_add(r11, v_mul(f11, f11));
+        v_uint16 v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
+        v_uint64 u1 = v_dotprod_expand(v1, v1);
+        r1 = v_add(r1, v_cvt_f64(v_reinterpret_as_s64(u1)));
     }
     double s = 0;
-    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(r0, r1));
     for (; j < n; j++) {
         double v = saturate_cast<double>(src[j]);
         s += v * v;
@@ -686,23 +636,17 @@ double normL2Sqr(const ushort* src, int n) {
 
 template<> inline
 double normL2Sqr(const short* src, int n) {
-    v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
-    v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+    v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
     int j = 0;
-    for (; j <= n - VTraits<v_int16>::vlanes(); j += VTraits<v_int16>::vlanes()) {
-        v_int16 v = vx_load(src + j);
-        v_int32 v0, v1;
-        v_expand(v, v0, v1);
-        v_float64 f00 = v_cvt_f64(v0), f01 = v_cvt_f64_high(v0);
-        v_float64 f10 = v_cvt_f64(v1), f11 = v_cvt_f64_high(v1);
+    for (; j <= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
+        v_int16 v0 = vx_load(src + j);
+        r0 = v_add(r0, v_cvt_f64(v_dotprod_expand(v0, v0)));
 
-        r00 = v_add(r00, v_mul(f00, f00));
-        r01 = v_add(r01, v_mul(f01, f01));
-        r10 = v_add(r10, v_mul(f10, f10));
-        r11 = v_add(r11, v_mul(f11, f11));
+        v_int16 v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
+        r1 = v_add(r1, v_cvt_f64(v_dotprod_expand(v1, v1)));
     }
     double s = 0;
-    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+    s += v_reduce_sum(v_add(r0, r1));
     for (; j < n; j++) {
         double v = saturate_cast<double>(src[j]);
         s += v * v;
@@ -712,18 +656,17 @@ double normL2Sqr(const short* src, int n) {
 
 template<> inline
 double normL2Sqr(const int* src, int n) {
-    v_float64 d00 = vx_setzero_f64(), d01 = vx_setzero_f64();
-    v_float64 d10 = vx_setzero_f64(), d11 = vx_setzero_f64();
+    v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
     int j = 0;
     for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
-        v_float32 v0 = v_cvt_f32(vx_load(src + j)), v1 = v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes()));
-        v_float64 v00 = v_cvt_f64(v0), v01 = v_cvt_f64_high(v0);
-        v_float64 v10 = v_cvt_f64(v1), v11 = v_cvt_f64_high(v1);
-        d00 = v_add(d00, v_mul(v00, v00)); d01 = v_add(d01, v_mul(v01, v01));
-        d10 = v_add(d10, v_mul(v10, v10)); d11 = v_add(d11, v_mul(v11, v11));
+        v_int32 v0 = vx_load(src + j);
+        r0 = v_add(r0, v_cvt_f64(v_dotprod(v0, v0)));
+
+        v_int32 v1 = vx_load(src + j + VTraits<v_int32>::vlanes());
+        r1 = v_add(r1, v_cvt_f64(v_dotprod(v1, v1)));
     }
     double s = 0.f;
-    s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
+    s += v_reduce_sum(v_add(r0, r1));
     for (; j < n; j++) {
         double v = src[j];
         s += v * v;
@@ -733,18 +676,18 @@ double normL2Sqr(const int* src, int n) {
 
 template<> inline
 double normL2Sqr(const float* src, int n) {
-    v_float64 d00 = vx_setzero_f64(), d01 = vx_setzero_f64();
-    v_float64 d10 = vx_setzero_f64(), d11 = vx_setzero_f64();
+    v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+    v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
     int j = 0;
     for (; j <= n - 2 * VTraits<v_float32>::vlanes(); j += 2 * VTraits<v_float32>::vlanes()) {
         v_float32 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_float32>::vlanes());
         v_float64 v00 = v_cvt_f64(v0), v01 = v_cvt_f64_high(v0);
         v_float64 v10 = v_cvt_f64(v1), v11 = v_cvt_f64_high(v1);
-        d00 = v_add(d00, v_mul(v00, v00)); d01 = v_add(d01, v_mul(v01, v01));
-        d10 = v_add(d10, v_mul(v10, v10)); d11 = v_add(d11, v_mul(v11, v11));
+        r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
+        r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
     }
     double s = 0.f;
-    s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
+    s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
     for (; j < n; j++) {
         double v = src[j];
         s += v * v;
@@ -762,8 +705,8 @@ double normL2Sqr(const double* src, int n) {
         v_float64 v01 = vx_load(src + j +     VTraits<v_float64>::vlanes());
         v_float64 v10 = vx_load(src + j + 2 * VTraits<v_float64>::vlanes());
         v_float64 v11 = vx_load(src + j + 3 * VTraits<v_float64>::vlanes());
-        r00 = v_add(r00, v_mul(v00, v00)); r01 = v_add(r01, v_mul(v01, v01));
-        r10 = v_add(r10, v_mul(v10, v10)); r11 = v_add(r11, v_mul(v11, v11));
+        r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
+        r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
     }
     double s = 0.f;
     s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -297,22 +297,14 @@ template<> inline
 int normInf(const int* src, int n) {
     v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
     v_uint32 r2 = vx_setzero_u32(), r3 = vx_setzero_u32();
-    v_uint32 r4 = vx_setzero_u32(), r5 = vx_setzero_u32();
-    v_uint32 r6 = vx_setzero_u32(), r7 = vx_setzero_u32();
     int j = 0;
-    for (; j <= n - 8 * VTraits<v_int32>::vlanes(); j += 8 * VTraits<v_int32>::vlanes()) {
+    for (; j <= n - 4 * VTraits<v_int32>::vlanes(); j += 4 * VTraits<v_int32>::vlanes()) {
         r0 = v_max(r0, v_abs(vx_load(src + j                                 )));
         r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int32>::vlanes())));
         r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_int32>::vlanes())));
         r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int32>::vlanes())));
-        r4 = v_max(r4, v_abs(vx_load(src + j + 4 * VTraits<v_int32>::vlanes())));
-        r5 = v_max(r5, v_abs(vx_load(src + j + 5 * VTraits<v_int32>::vlanes())));
-        r6 = v_max(r6, v_abs(vx_load(src + j + 6 * VTraits<v_int32>::vlanes())));
-        r7 = v_max(r7, v_abs(vx_load(src + j + 7 * VTraits<v_int32>::vlanes())));
     }
     r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-    r4 = v_max(r4, v_max(r5, v_max(r6, r7)));
-    r0 = v_max(r0, r4);
     int s = 0;
     for (; j < n; j++) {
         s = std::max(s, cv_abs(src[j]));

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -374,10 +374,10 @@ int normL1(const uchar* src, int n) {
 
 template<> inline
 int normL1(const schar* src, int n) {
-    v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
-    v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
-    v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
-    v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+    v_uint32 r00 = vx_setzero_u32(), r01 = vx_setzero_u32();
+    v_uint32 r10 = vx_setzero_u32(), r11 = vx_setzero_u32();
+    v_uint32 r20 = vx_setzero_u32(), r21 = vx_setzero_u32();
+    v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
     int j = 0;
     for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
         v_int8 v0 = vx_load(src + j);
@@ -387,10 +387,10 @@ int normL1(const schar* src, int n) {
         v_expand(v00, v000, v001);
         v_expand(v01, v010, v011);
 
-        r00 = v_add(r00, v000);
-        r01 = v_add(r01, v001);
-        r10 = v_add(r10, v010);
-        r11 = v_add(r11, v011);
+        r00 = v_add(r00, v_abs(v000));
+        r01 = v_add(r01, v_abs(v001));
+        r10 = v_add(r10, v_abs(v010));
+        r11 = v_add(r11, v_abs(v011));
 
         v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
         v_int16 v10, v11;
@@ -399,16 +399,16 @@ int normL1(const schar* src, int n) {
         v_expand(v10, v100, v101);
         v_expand(v11, v110, v111);
 
-        r20 = v_add(r20, v100);
-        r21 = v_add(r21, v101);
-        r30 = v_add(r30, v110);
-        r31 = v_add(r31, v111);
+        r20 = v_add(r20, v_abs(v100));
+        r21 = v_add(r21, v_abs(v101));
+        r30 = v_add(r30, v_abs(v110));
+        r31 = v_add(r31, v_abs(v111));
     }
     int s = 0;
     s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
     s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
     for (; j < n; j++) {
-        s += src[j];
+        s += saturate_cast<int>(cv_abs(src[j]));
     }
     return s;
 }
@@ -450,35 +450,35 @@ int normL1(const ushort* src, int n) {
 
 template<> inline
 int normL1(const short* src, int n) {
-    v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
-    v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
-    v_int32 d20 = vx_setzero_s32(), d21 = vx_setzero_s32();
-    v_int32 d30 = vx_setzero_s32(), d31 = vx_setzero_s32();
+    v_uint32 d00 = vx_setzero_u32(), d01 = vx_setzero_u32();
+    v_uint32 d10 = vx_setzero_u32(), d11 = vx_setzero_u32();
+    v_uint32 d20 = vx_setzero_u32(), d21 = vx_setzero_u32();
+    v_uint32 d30 = vx_setzero_u32(), d31 = vx_setzero_u32();
     int j = 0;
     for (; j<= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
         v_int16 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
         v_int32 v00, v01, v10, v11;
         v_expand(v0, v00, v01);
         v_expand(v1, v10, v11);
-        d00 = v_add(d00, v00);
-        d01 = v_add(d01, v01);
-        d10 = v_add(d10, v10);
-        d11 = v_add(d11, v11);
+        d00 = v_add(d00, v_abs(v00));
+        d01 = v_add(d01, v_abs(v01));
+        d10 = v_add(d10, v_abs(v10));
+        d11 = v_add(d11, v_abs(v11));
 
         v_int16 v2 = vx_load(src + j + 2 * VTraits<v_int16>::vlanes()), v3 = vx_load(src + j + 3 * VTraits<v_int16>::vlanes());
         v_int32 v20, v21, v30, v31;
         v_expand(v2, v20, v21);
         v_expand(v3, v30, v31);
-        d20 = v_add(d20, v20);
-        d21 = v_add(d21, v21);
-        d30 = v_add(d30, v30);
-        d31 = v_add(d31, v31);
+        d20 = v_add(d20, v_abs(v20));
+        d21 = v_add(d21, v_abs(v21));
+        d30 = v_add(d30, v_abs(v30));
+        d31 = v_add(d31, v_abs(v31));
     }
     int s = 0;
     s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
     s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
     for (; j < n; j++) {
-        s += src[j];
+        s += saturate_cast<int>(cv_abs(src[j]));
     }
     return s;
 }

--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -567,11 +567,17 @@ double norm( InputArray _src, int normType, InputArray _mask )
             {
                 const uchar* data = src.ptr<const uchar>();
 
-                if( normType == NORM_L2 || normType == NORM_L2SQR || normType == NORM_L1 || normType == NORM_INF )
+                if( normType == NORM_L2 || normType == NORM_L2SQR || normType == NORM_L1 )
                 {
                     double result = 0;
                     func(data, 0, (uchar*)&result, (int)len, 1);
                     return normType == NORM_L2 ? std::sqrt(result) : result;
+                }
+                if( normType == NORM_INF )
+                {
+                    float result = 0;
+                    func(data, 0, (uchar*)&result, (int)len, 1);
+                    return result;
                 }
             }
             if( depth == CV_8U )

--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -567,29 +567,11 @@ double norm( InputArray _src, int normType, InputArray _mask )
             {
                 const uchar* data = src.ptr<const uchar>();
 
-                if( normType == NORM_L2 )
+                if( normType == NORM_L2 || normType == NORM_L2SQR || normType == NORM_L1 || normType == NORM_INF )
                 {
                     double result = 0;
                     func(data, 0, (uchar*)&result, (int)len, 1);
-                    return std::sqrt(result);
-                }
-                if( normType == NORM_L2SQR )
-                {
-                    double result = 0;
-                    func(data, 0, (uchar*)&result, (int)len, 1);
-                    return result;
-                }
-                if( normType == NORM_L1 )
-                {
-                    double result = 0;
-                    func(data, 0, (uchar*)&result, (int)len, 1);
-                    return result;
-                }
-                if( normType == NORM_INF )
-                {
-                    float result = 0;
-                    func(data, 0, (uchar*)&result, (int)len, 1);
-                    return result;
+                    return normType == NORM_L2 ? std::sqrt(result) : result;
                 }
             }
             if( depth == CV_8U )

--- a/modules/core/src/norm.rvv1p0.hpp
+++ b/modules/core/src/norm.rvv1p0.hpp
@@ -1,0 +1,40 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copytright (C) 2025, SpaceMIT Inc., all rights reserved.
+
+#include "opencv2/core/hal/intrin.hpp"
+
+namespace cv {
+
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+double inline normL1_rvv(const double* src, int n, int& j) {
+    const int vle64m1 = __riscv_vsetvlmax_e64m1();
+    vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    for (; j <= n - vle64m1; j += vle64m1) {
+        vfloat64m1_t v00 = __riscv_vle64_v_f64m1(src + j, vle64m1);
+        v00 = __riscv_vfabs(v00, vle64m1);
+        r00 = __riscv_vfadd(r00, v00, vle64m1);
+    }
+    vfloat64m1_t s00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    s00 = __riscv_vfredusum(r00, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1);
+    return __riscv_vfmv_f(s00);
+}
+
+double inline normL2_rvv(const double* src, int n, int& j) {
+    const int vle64m1 = __riscv_vsetvlmax_e64m1();
+    vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    for (; j <= n - vle64m1; j += vle64m1) {
+        vfloat64m1_t v00 = __riscv_vle64_v_f64m1(src + j, vle64m1);
+        r00 = __riscv_vfmacc(r00, v00, v00, vle64m1);
+    }
+    vfloat64m1_t s00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    s00 = __riscv_vfredusum(r00, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1);
+    return __riscv_vfmv_f(s00);
+}
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+
+} // cv::

--- a/modules/core/src/norm.rvv1p0.hpp
+++ b/modules/core/src/norm.rvv1p0.hpp
@@ -31,28 +31,6 @@ template <typename T, typename ST> inline
 ST normL2_rvv(const T* src, int n, int& j);
 
 template<> inline
-int normL2_rvv(const schar* src, int n, int& j) {
-    const int vle8m1 = __riscv_vsetvlmax_e8m1();
-    const int vle16m1 = __riscv_vsetvlmax_e16m1();
-    const int vle32m1 = __riscv_vsetvlmax_e32m1();
-    const int vle64m1 = __riscv_vsetvlmax_e64m1();
-    vint32m1_t r0 = __riscv_vmv_v_x_i32m1(0, vle32m1), r1 = __riscv_vmv_v_x_i32m1(0, vle32m1);
-    for (; j <= n - 2 * vle8m1; j += 2 * vle8m1) {
-        vint8m1_t v0 = __riscv_vle8_v_i8m1(src + j, vle8m1);
-        vint16m2_t s0 = __riscv_vwmul_vv_i16m2(v0, v0, vle8m1);
-        r0 = __riscv_vwredsum_vs_i16m2_i32m1(s0, r0, vle16m1);
-
-        vint8m1_t v1 = __riscv_vle8_v_i8m1(src + j + vle8m1, vle8m1);
-        vint16m2_t s1 = __riscv_vwmul_vv_i16m2(v1, v1, vle8m1);
-        r1 = __riscv_vwredsum_vs_i16m2_i32m1(s1, r1, vle16m1);
-    }
-    r0 = __riscv_vsadd(r0, r1, vle32m1);
-    vint64m1_t zero = __riscv_vmv_v_x_i64m1(0, vle64m1);
-    vint64m1_t res = __riscv_vwredsum(r0, zero, vle32m1);
-    return (int)__riscv_vmv_x(res);
-}
-
-template<> inline
 double normL2_rvv(const double* src, int n, int& j) {
     const int vle64m1 = __riscv_vsetvlmax_e64m1();
     vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);

--- a/modules/core/src/norm.rvv1p0.hpp
+++ b/modules/core/src/norm.rvv1p0.hpp
@@ -8,66 +8,191 @@
 
 namespace cv {
 
+namespace {
+
+// [TODO] Drop this until rvv has dedicated intrinsics for abs on integers.
+template<typename T, typename ST> inline ST __riscv_vabs(const T&);
+
+template<> inline
+vuint8m1_t __riscv_vabs(const vint8m1_t& v) {
+    const int vle8m1 = __riscv_vsetvlmax_e8m1();
+    vint8m1_t mask = __riscv_vsra_vx_i8m1(v, 7, vle8m1);
+    vint8m1_t v_xor = __riscv_vxor_vv_i8m1(v, mask, vle8m1);
+    return __riscv_vreinterpret_v_i8m1_u8m1(
+        __riscv_vsub_vv_i8m1(v_xor, mask, vle8m1)
+    );
+}
+
+template<> inline
+vuint16m1_t __riscv_vabs(const vint16m1_t& v) {
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    vint16m1_t mask = __riscv_vsra_vx_i16m1(v, 15, vle16m1);
+    vint16m1_t v_xor = __riscv_vxor_vv_i16m1(v, mask, vle16m1);
+    return __riscv_vreinterpret_v_i16m1_u16m1(
+        __riscv_vsub_vv_i16m1(v_xor, mask, vle16m1)
+    );
+}
+
+template<> inline
+vuint32m1_t __riscv_vabs(const vint32m1_t& v) {
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vint32m1_t mask = __riscv_vsra_vx_i32m1(v, 31, vle32m1);
+    vint32m1_t v_xor = __riscv_vxor_vv_i32m1(v, mask, vle32m1);
+    return __riscv_vreinterpret_v_i32m1_u32m1(
+        __riscv_vsub_vv_i32m1(v_xor, mask, vle32m1)
+    );
+}
+}
+
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+template <typename T, typename ST> inline
+ST normInf_rvv(const T* src, int n, int& j);
+
+template<> inline
+int normInf_rvv(const int* src, int n, int& j) {
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vuint32m1_t r0 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint32m1_t r1 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j <= n - 2 * vle32m1; j += 2 * vle32m1) {
+        vuint32m1_t v0 = __riscv_vabs<vint32m1_t, vuint32m1_t>(__riscv_vle32_v_i32m1(src + j, vle32m1));
+        r0 = __riscv_vmaxu(r0, v0, vle32m1);
+
+        vuint32m1_t v1 = __riscv_vabs<vint32m1_t, vuint32m1_t>(__riscv_vle32_v_i32m1(src + j + vle32m1, vle32m1));
+        r1 = __riscv_vmaxu(r1, v1, vle32m1);
+    }
+    r0 = __riscv_vmaxu(r0, r1, vle32m1);
+    return (int)__riscv_vmv_x(__riscv_vredmaxu(r0, __riscv_vmv_v_x_u32m1(0, vle32m1), vle32m1));
+}
 
 template <typename T, typename ST> inline
 ST normL1_rvv(const T* src, int n, int& j);
 
 template<> inline
+int normL1_rvv(const schar* src, int n, int& j) {
+    const int vle8m1 = __riscv_vsetvlmax_e8m1();
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vuint32m1_t r0 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint32m1_t r1 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint16m1_t zero = __riscv_vmv_v_x_u16m1(0, vle16m1);
+    for (; j <= n - 2 * vle8m1; j += 2 * vle8m1) {
+        vuint8m1_t v0 = __riscv_vabs<vint8m1_t, vuint8m1_t>(__riscv_vle8_v_i8m1(src + j, vle8m1));
+        vuint16m1_t u0 = __riscv_vwredsumu_tu(zero, v0, zero, vle8m1);
+        r0 = __riscv_vwredsumu(u0, r0, vle16m1);
+
+        vuint8m1_t v1 = __riscv_vabs<vint8m1_t, vuint8m1_t>(__riscv_vle8_v_i8m1(src + j + vle8m1, vle8m1));
+        vuint16m1_t u1 = __riscv_vwredsumu_tu(zero, v1, zero, vle8m1);
+        r1 = __riscv_vwredsumu(u1, r1, vle16m1);
+    }
+    return (int)__riscv_vmv_x(__riscv_vadd(r0, r1, vle32m1));
+}
+
+template<> inline
 int normL1_rvv(const ushort* src, int n, int& j) {
     const int vle16m1 = __riscv_vsetvlmax_e16m1();
     const int vle32m1 = __riscv_vsetvlmax_e32m1();
-    vuint32m1_t r = __riscv_vmv_v_x_u32m1(0, vle32m1);
-    for (; j <= n - vle16m1; j += vle16m1) {
-        vuint16m1_t v = __riscv_vle16_v_u16m1(src + j, vle16m1);
-        r = __riscv_vwredsumu(v, r, vle16m1);
+    vuint32m1_t r0 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint32m1_t r1 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j <= n - 2 * vle16m1; j += 2 * vle16m1) {
+        vuint16m1_t v0 = __riscv_vle16_v_u16m1(src + j, vle16m1);
+        r0 = __riscv_vwredsumu(v0, r0, vle16m1);
+
+        vuint16m1_t v1 = __riscv_vle16_v_u16m1(src + j + vle16m1, vle16m1);
+        r1 = __riscv_vwredsumu(v1, r1, vle16m1);
     }
-    return (int)__riscv_vmv_x(r);
+    return (int)__riscv_vmv_x(__riscv_vadd(r0, r1, vle32m1));
 }
 
 template<> inline
 int normL1_rvv(const short* src, int n, int& j) {
     const int vle16m1 = __riscv_vsetvlmax_e16m1();
     const int vle32m1 = __riscv_vsetvlmax_e32m1();
-    vuint32m1_t r = __riscv_vmv_v_x_u32m1(0, vle32m1);
-    for (; j<= n - vle16m1; j += vle16m1) {
-        vint16m1_t v = __riscv_vle16_v_i16m1(src + j, vle16m1);
-        vint16m1_t mask = __riscv_vsra_vx_i16m1(v, 15, vle16m1);
-        vint16m1_t v_xor = __riscv_vxor_vv_i16m1(v, mask, vle16m1);
-        vuint16m1_t v_abs = __riscv_vreinterpret_v_i16m1_u16m1(__riscv_vsub_vv_i16m1(v_xor, mask, vle16m1));
-        r = __riscv_vwredsumu(v_abs, r, vle16m1);
+    vuint32m1_t r0 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint32m1_t r1 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j<= n - 2 * vle16m1; j += 2 * vle16m1) {
+        vuint16m1_t v0 = __riscv_vabs<vint16m1_t, vuint16m1_t>(__riscv_vle16_v_i16m1(src + j, vle16m1));
+        r0 = __riscv_vwredsumu(v0, r0, vle16m1);
+
+        vuint16m1_t v1 = __riscv_vabs<vint16m1_t, vuint16m1_t>(__riscv_vle16_v_i16m1(src + j + vle16m1, vle16m1));
+        r1 = __riscv_vwredsumu(v1, r1, vle16m1);
     }
-    return (int)__riscv_vmv_x(r);
+    return (int)__riscv_vmv_x(__riscv_vadd(r0, r1, vle32m1));
 }
 
 template<> inline
 double normL1_rvv(const double* src, int n, int& j) {
     const int vle64m1 = __riscv_vsetvlmax_e64m1();
-    vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
-    for (; j <= n - vle64m1; j += vle64m1) {
-        vfloat64m1_t v00 = __riscv_vle64_v_f64m1(src + j, vle64m1);
-        v00 = __riscv_vfabs(v00, vle64m1);
-        r00 = __riscv_vfadd(r00, v00, vle64m1);
+    vfloat64m1_t r0 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    vfloat64m1_t r1 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    for (; j <= n - 2 * vle64m1; j += 2 * vle64m1) {
+        vfloat64m1_t v0 = __riscv_vle64_v_f64m1(src + j, vle64m1);
+        v0 = __riscv_vfabs(v0, vle64m1);
+        r0 = __riscv_vfadd(r0, v0, vle64m1);
+
+        vfloat64m1_t v1 = __riscv_vle64_v_f64m1(src + j + vle64m1, vle64m1);
+        v1 = __riscv_vfabs(v1, vle64m1);
+        r1 = __riscv_vfadd(r1, v1, vle64m1);
     }
-    vfloat64m1_t s00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
-    s00 = __riscv_vfredusum(r00, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1);
-    return __riscv_vfmv_f(s00);
+    r0 = __riscv_vfadd(r0, r1, vle64m1);
+    return __riscv_vfmv_f(__riscv_vfredusum(r0, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1));
 }
 
 template <typename T, typename ST> inline
 ST normL2_rvv(const T* src, int n, int& j);
 
 template<> inline
+int normL2_rvv(const uchar* src, int n, int& j) {
+    const int vle8m1 = __riscv_vsetvlmax_e8m1();
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vuint32m1_t r0 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    vuint32m1_t r1 = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j <= n - 2 * vle8m1; j += 2 * vle8m1) {
+        vuint8m1_t v0 = __riscv_vle8_v_u8m1(src + j, vle8m1);
+        vuint16m2_t u0 = __riscv_vwmulu(v0, v0, vle8m1);
+        r0 = __riscv_vwredsumu(u0, r0, vle16m1 * 2);
+
+        vuint8m1_t v1 = __riscv_vle8_v_u8m1(src + j + vle8m1, vle8m1);
+        vuint16m2_t u1 = __riscv_vwmulu(v1, v1, vle8m1);
+        r1 = __riscv_vwredsumu(u1, r1, vle16m1 * 2);
+    }
+    return (int)__riscv_vmv_x(__riscv_vadd(r0, r1, vle32m1));
+}
+
+template<> inline
+int normL2_rvv(const schar* src, int n, int& j) {
+    const int vle8m1 = __riscv_vsetvlmax_e8m1();
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vint32m1_t r0 = __riscv_vmv_v_x_i32m1(0, vle32m1);
+    vint32m1_t r1 = __riscv_vmv_v_x_i32m1(0, vle32m1);
+    for (; j <= n - 2 * vle8m1; j += 2 * vle8m1) {
+        vint8m1_t v0 = __riscv_vle8_v_i8m1(src + j, vle8m1);
+        vint16m2_t u0 = __riscv_vwmul(v0, v0, vle8m1);
+        r0 = __riscv_vwredsum(u0, r0, vle16m1 * 2);
+
+        vint8m1_t v1 = __riscv_vle8_v_i8m1(src + j + vle8m1, vle8m1);
+        vint16m2_t u1 = __riscv_vwmul(v1, v1, vle8m1);
+        r1 = __riscv_vwredsum(u1, r1, vle16m1 * 2);
+    }
+    return __riscv_vmv_x(__riscv_vadd(r0, r1, vle32m1));
+}
+
+template<> inline
 double normL2_rvv(const double* src, int n, int& j) {
     const int vle64m1 = __riscv_vsetvlmax_e64m1();
-    vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
-    for (; j <= n - vle64m1; j += vle64m1) {
-        vfloat64m1_t v00 = __riscv_vle64_v_f64m1(src + j, vle64m1);
-        r00 = __riscv_vfmacc(r00, v00, v00, vle64m1);
+    vfloat64m1_t r0 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    vfloat64m1_t r1 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
+    for (; j <= n - 2 * vle64m1; j += 2 * vle64m1) {
+        vfloat64m1_t v0 = __riscv_vle64_v_f64m1(src + j, vle64m1);
+        r0 = __riscv_vfmacc(r0, v0, v0, vle64m1);
+
+        vfloat64m1_t v1 = __riscv_vle64_v_f64m1(src + j + vle64m1, vle64m1);
+        r1 = __riscv_vfmacc(r1, v1, v1, vle64m1);
     }
-    vfloat64m1_t s00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);
-    s00 = __riscv_vfredusum(r00, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1);
-    return __riscv_vfmv_f(s00);
+    r0 = __riscv_vfadd(r0, r1, vle64m1);
+    return __riscv_vfmv_f(__riscv_vfredusum(r0, __riscv_vfmv_v_f_f64m1(0.f, vle64m1), vle64m1));
 }
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END

--- a/modules/core/src/norm.rvv1p0.hpp
+++ b/modules/core/src/norm.rvv1p0.hpp
@@ -14,6 +14,33 @@ template <typename T, typename ST> inline
 ST normL1_rvv(const T* src, int n, int& j);
 
 template<> inline
+int normL1_rvv(const ushort* src, int n, int& j) {
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vuint32m1_t r = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j <= n - vle16m1; j += vle16m1) {
+        vuint16m1_t v = __riscv_vle16_v_u16m1(src + j, vle16m1);
+        r = __riscv_vwredsumu(v, r, vle16m1);
+    }
+    return (int)__riscv_vmv_x(r);
+}
+
+template<> inline
+int normL1_rvv(const short* src, int n, int& j) {
+    const int vle16m1 = __riscv_vsetvlmax_e16m1();
+    const int vle32m1 = __riscv_vsetvlmax_e32m1();
+    vuint32m1_t r = __riscv_vmv_v_x_u32m1(0, vle32m1);
+    for (; j<= n - vle16m1; j += vle16m1) {
+        vint16m1_t v = __riscv_vle16_v_i16m1(src + j, vle16m1);
+        vint16m1_t mask = __riscv_vsra_vx_i16m1(v, 15, vle16m1);
+        vint16m1_t v_xor = __riscv_vxor_vv_i16m1(v, mask, vle16m1);
+        vuint16m1_t v_abs = __riscv_vreinterpret_v_i16m1_u16m1(__riscv_vsub_vv_i16m1(v_xor, mask, vle16m1));
+        r = __riscv_vwredsumu(v_abs, r, vle16m1);
+    }
+    return (int)__riscv_vmv_x(r);
+}
+
+template<> inline
 double normL1_rvv(const double* src, int n, int& j) {
     const int vle64m1 = __riscv_vsetvlmax_e64m1();
     vfloat64m1_t r00 = __riscv_vfmv_v_f_f64m1(0.f, vle64m1);

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -53,9 +53,10 @@ struct NormL2_SIMD {
 template<>
 struct NormInf_SIMD<uchar, int> {
     int operator() (const uchar* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
         v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_uint8>::vlanes(); j += 4 * VTraits<v_uint8>::vlanes()) {
             r0 = v_max(r0, vx_load(src + j                                 ));
             r1 = v_max(r1, vx_load(src + j +     VTraits<v_uint8>::vlanes()));
@@ -63,7 +64,6 @@ struct NormInf_SIMD<uchar, int> {
             r3 = v_max(r3, vx_load(src + j + 3 * VTraits<v_uint8>::vlanes()));
         }
         r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-        int s = 0;
         for (; j < n; j++) {
             s = std::max(s, (int)src[j]);
         }
@@ -74,9 +74,10 @@ struct NormInf_SIMD<uchar, int> {
 template<>
 struct NormInf_SIMD<schar, int> {
     int operator() (const schar* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
         v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_int8>::vlanes(); j += 4 * VTraits<v_int8>::vlanes()) {
             r0 = v_max(r0, v_abs(vx_load(src + j                                )));
             r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int8>::vlanes())));
@@ -84,7 +85,6 @@ struct NormInf_SIMD<schar, int> {
             r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int8>::vlanes())));
         }
         r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-        int s = 0;
         for (; j < n; j++) {
             s = std::max(s, cv_abs(src[j]));
         }
@@ -95,9 +95,10 @@ struct NormInf_SIMD<schar, int> {
 template<>
 struct NormInf_SIMD<ushort, int> {
     int operator() (const ushort* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
         v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
             d0 = v_max(d0, vx_load(src + j                                  ));
             d1 = v_max(d1, vx_load(src + j +     VTraits<v_uint16>::vlanes()));
@@ -105,7 +106,6 @@ struct NormInf_SIMD<ushort, int> {
             d3 = v_max(d3, vx_load(src + j + 3 * VTraits<v_uint16>::vlanes()));
         }
         d0 = v_max(d0, v_max(d1, v_max(d2, d3)));
-        int s = 0;
         for (; j < n; j++) {
             s = std::max(s, (int)src[j]);
         }
@@ -116,9 +116,10 @@ struct NormInf_SIMD<ushort, int> {
 template<>
 struct NormInf_SIMD<short, int> {
     int operator() (const short* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
         v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
             d0 = v_max(d0, v_abs(vx_load(src + j                                  )));
             d1 = v_max(d1, v_abs(vx_load(src + j +     VTraits<v_int16>::vlanes())));
@@ -126,7 +127,6 @@ struct NormInf_SIMD<short, int> {
             d3 = v_max(d3, v_abs(vx_load(src + j + 3 * VTraits<v_int16>::vlanes())));
         }
         d0 = v_max(d0, v_max(d1, v_max(d2, d3)));
-        int s = 0;
         for (; j < n; j++) {
             s = std::max(s, saturate_cast<int>(cv_abs(src[j])));
         }
@@ -137,9 +137,10 @@ struct NormInf_SIMD<short, int> {
 template<>
 struct NormInf_SIMD<int, int> {
     int operator() (const int* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
         v_uint32 r2 = vx_setzero_u32(), r3 = vx_setzero_u32();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_int32>::vlanes(); j += 4 * VTraits<v_int32>::vlanes()) {
             r0 = v_max(r0, v_abs(vx_load(src + j                                 )));
             r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int32>::vlanes())));
@@ -147,7 +148,6 @@ struct NormInf_SIMD<int, int> {
             r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int32>::vlanes())));
         }
         r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-        int s = 0;
         for (; j < n; j++) {
             s = std::max(s, cv_abs(src[j]));
         }
@@ -158,9 +158,10 @@ struct NormInf_SIMD<int, int> {
 template<>
 struct NormInf_SIMD<float, float> {
     float operator() (const float* src, int n) const {
+        int j = 0;
+        float s = 0.f;
         v_float32 r0 = vx_setzero_f32(), r1 = vx_setzero_f32();
         v_float32 r2 = vx_setzero_f32(), r3 = vx_setzero_f32();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_float32>::vlanes(); j += 4 * VTraits<v_float32>::vlanes()) {
             r0 = v_max(r0, v_abs(vx_load(src + j                                   )));
             r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_float32>::vlanes())));
@@ -168,7 +169,6 @@ struct NormInf_SIMD<float, float> {
             r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_float32>::vlanes())));
         }
         r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-        float s = 0.f;
         for (; j < n; j++) {
             s = std::max(s, cv_abs(src[j]));
         }
@@ -179,11 +179,12 @@ struct NormInf_SIMD<float, float> {
 template<>
 struct NormL1_SIMD<uchar, int> {
     int operator() (const uchar* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
         v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
         v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
         v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
-        int j = 0;
         for (; j<= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
             v_uint8 v0 = vx_load(src + j);
             v_uint16 v00, v01;
@@ -209,7 +210,6 @@ struct NormL1_SIMD<uchar, int> {
             r30 = v_add(r30, v_reinterpret_as_s32(v110));
             r31 = v_add(r31, v_reinterpret_as_s32(v111));
         }
-        int s = 0;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
         s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
         for (; j < n; j++) {
@@ -222,11 +222,12 @@ struct NormL1_SIMD<uchar, int> {
 template<>
 struct NormL1_SIMD<schar, int> {
     int operator() (const schar* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint32 r00 = vx_setzero_u32(), r01 = vx_setzero_u32();
         v_uint32 r10 = vx_setzero_u32(), r11 = vx_setzero_u32();
         v_uint32 r20 = vx_setzero_u32(), r21 = vx_setzero_u32();
         v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
-        int j = 0;
         for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
             v_uint8 v0 = v_abs(vx_load(src + j));
             v_uint16 v00, v01;
@@ -252,7 +253,6 @@ struct NormL1_SIMD<schar, int> {
             r30 = v_add(r30, v110);
             r31 = v_add(r31, v111);
         }
-        int s = 0;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
         s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
         for (; j < n; j++) {
@@ -265,11 +265,12 @@ struct NormL1_SIMD<schar, int> {
 template<>
 struct NormL1_SIMD<ushort, int> {
     int operator() (const ushort* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
         v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
         v_int32 d20 = vx_setzero_s32(), d21 = vx_setzero_s32();
         v_int32 d30 = vx_setzero_s32(), d31 = vx_setzero_s32();
-        int j = 0;
         for (; j<= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
             v_uint16 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
             v_uint32 v00, v01, v10, v11;
@@ -289,7 +290,6 @@ struct NormL1_SIMD<ushort, int> {
             d30 = v_add(d30, v_reinterpret_as_s32(v30));
             d31 = v_add(d31, v_reinterpret_as_s32(v31));
         }
-        int s = 0;
         s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
         s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
         for (; j < n; j++) {
@@ -302,11 +302,12 @@ struct NormL1_SIMD<ushort, int> {
 template<>
 struct NormL1_SIMD<short, int> {
     int operator() (const short* src, int n) const {
+        int j = 0;
+        int s = 0;
         v_uint32 d00 = vx_setzero_u32(), d01 = vx_setzero_u32();
         v_uint32 d10 = vx_setzero_u32(), d11 = vx_setzero_u32();
         v_uint32 d20 = vx_setzero_u32(), d21 = vx_setzero_u32();
         v_uint32 d30 = vx_setzero_u32(), d31 = vx_setzero_u32();
-        int j = 0;
         for (; j<= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
             v_uint16 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
             v_uint32 v00, v01, v10, v11;
@@ -326,7 +327,6 @@ struct NormL1_SIMD<short, int> {
             d30 = v_add(d30, v30);
             d31 = v_add(d31, v31);
         }
-        int s = 0;
         s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
         s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
         for (; j < n; j++) {
@@ -339,8 +339,9 @@ struct NormL1_SIMD<short, int> {
 template<>
 struct NormL2_SIMD<uchar, int> {
     int operator() (const uchar* src, int n) const {
-        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
         int j = 0;
+        int s = 0;
+        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
         for (; j <= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
             v_uint8 v0 = vx_load(src + j);
             r0 = v_dotprod_expand(v0, v0, r0);
@@ -348,7 +349,6 @@ struct NormL2_SIMD<uchar, int> {
             v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
             r1 = v_dotprod_expand(v1, v1, r1);
         }
-        int s = 0;
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             int v = saturate_cast<int>(src[j]);
@@ -361,15 +361,15 @@ struct NormL2_SIMD<uchar, int> {
 template<>
 struct NormL2_SIMD<schar, int> {
     int operator() (const schar* src, int n) const {
-        v_int32 r0 = vx_setzero_s32(), r1 = vx_setzero_s32();
         int j = 0;
+        int s = 0;
+        v_int32 r0 = vx_setzero_s32(), r1 = vx_setzero_s32();
         for (; j <= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
             v_int8 v0 = vx_load(src + j);
             r0 = v_dotprod_expand(v0, v0, r0);
             v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
             r1 = v_dotprod_expand(v1, v1, r1);
         }
-        int s = 0;
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             int v = saturate_cast<int>(src[j]);
@@ -386,9 +386,10 @@ struct NormL2_SIMD<schar, int> {
 template<>
 struct NormInf_SIMD<double, double> {
     double operator() (const double* src, int n) const {
+        int j = 0;
+        double s = 0.f;
         v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         v_float64 r2 = vx_setzero_f64(), r3 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
             r0 = v_max(r0, v_abs(vx_load(src + j                                   )));
             r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_float64>::vlanes())));
@@ -396,10 +397,10 @@ struct NormInf_SIMD<double, double> {
             r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_float64>::vlanes())));
         }
         r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
-        double s = 0;
         for (; j < n; j++) {
             s = std::max(s, cv_abs(src[j]));
         }
+        // [TODO]: use v_reduce_max when it supports float64
         double t[VTraits<v_float64>::max_nlanes];
         vx_store(t, r0);
         for (int i = 0; i < VTraits<v_float64>::vlanes(); i++) {
@@ -412,15 +413,15 @@ struct NormInf_SIMD<double, double> {
 template<>
 struct NormL1_SIMD<int, double> {
     double operator() (const int* src, int n) const {
+        int j = 0;
+        double s = 0.f;
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
             v_float32 v0 = v_abs(v_cvt_f32(vx_load(src + j))), v1 = v_abs(v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes())));
             r00 = v_add(r00, v_cvt_f64(v0)); r01 = v_add(r01, v_cvt_f64_high(v0));
             r10 = v_add(r10, v_cvt_f64(v1)); r11 = v_add(r11, v_cvt_f64_high(v1));
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
         for (; j < n; j++) {
             s += cv_abs(src[j]);
@@ -432,11 +433,12 @@ struct NormL1_SIMD<int, double> {
 template<>
 struct NormL1_SIMD<float, double> {
     double operator() (const float* src, int n) const {
+        int j = 0;
+        double s = 0.f;
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
         v_float64 r20 = vx_setzero_f64(), r21 = vx_setzero_f64();
         v_float64 r30 = vx_setzero_f64(), r31 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_float32>::vlanes(); j += 4 * VTraits<v_float32>::vlanes()) {
             v_float32 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_float32>::vlanes()));
             r00 = v_add(r00, v_cvt_f64(v0)); r01 = v_add(r01, v_cvt_f64_high(v0));
@@ -446,7 +448,6 @@ struct NormL1_SIMD<float, double> {
             r20 = v_add(r20, v_cvt_f64(v2)); r21 = v_add(r21, v_cvt_f64_high(v2));
             r30 = v_add(r30, v_cvt_f64(v3)); r31 = v_add(r31, v_cvt_f64_high(v3));
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
         s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
         for (; j < n; j++) {
@@ -459,17 +460,19 @@ struct NormL1_SIMD<float, double> {
 template<>
 struct NormL1_SIMD<double, double> {
     double operator() (const double* src, int n) const {
+        int j = 0;
+        double s = 0.f;
+#ifndef CV_RVV  // It triggers segmentation fault on CI but it works fine on real hardware
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
             r00 = v_add(r00, v_abs(vx_load(src + j                                   )));
             r01 = v_add(r01, v_abs(vx_load(src + j +     VTraits<v_float64>::vlanes())));
             r10 = v_add(r10, v_abs(vx_load(src + j + 2 * VTraits<v_float64>::vlanes())));
             r11 = v_add(r11, v_abs(vx_load(src + j + 3 * VTraits<v_float64>::vlanes())));
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+#endif
         for (; j < n; j++) {
             s += cv_abs(src[j]);
         }
@@ -480,8 +483,9 @@ struct NormL1_SIMD<double, double> {
 template<>
 struct NormL2_SIMD<ushort, double> {
     double operator() (const ushort* src, int n) const {
-        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         int j = 0;
+        double s = 0.f;
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
             v_uint16 v0 = vx_load(src + j);
             v_uint64 u0 = v_dotprod_expand(v0, v0);
@@ -491,7 +495,6 @@ struct NormL2_SIMD<ushort, double> {
             v_uint64 u1 = v_dotprod_expand(v1, v1);
             r1 = v_add(r1, v_cvt_f64(v_reinterpret_as_s64(u1)));
         }
-        double s = 0;
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             double v = saturate_cast<double>(src[j]);
@@ -504,8 +507,9 @@ struct NormL2_SIMD<ushort, double> {
 template<>
 struct NormL2_SIMD<short, double> {
     double operator() (const short* src, int n) const {
-        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         int j = 0;
+        double s = 0.f;
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
             v_int16 v0 = vx_load(src + j);
             r0 = v_add(r0, v_cvt_f64(v_dotprod_expand(v0, v0)));
@@ -513,7 +517,6 @@ struct NormL2_SIMD<short, double> {
             v_int16 v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
             r1 = v_add(r1, v_cvt_f64(v_dotprod_expand(v1, v1)));
         }
-        double s = 0;
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             double v = saturate_cast<double>(src[j]);
@@ -526,8 +529,9 @@ struct NormL2_SIMD<short, double> {
 template<>
 struct NormL2_SIMD<int, double> {
     double operator() (const int* src, int n) const {
-        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         int j = 0;
+        double s = 0.f;
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
             v_int32 v0 = vx_load(src + j);
             r0 = v_add(r0, v_cvt_f64(v_dotprod(v0, v0)));
@@ -535,7 +539,6 @@ struct NormL2_SIMD<int, double> {
             v_int32 v1 = vx_load(src + j + VTraits<v_int32>::vlanes());
             r1 = v_add(r1, v_cvt_f64(v_dotprod(v1, v1)));
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             double v = src[j];
@@ -548,9 +551,10 @@ struct NormL2_SIMD<int, double> {
 template<>
 struct NormL2_SIMD<float, double> {
     double operator() (const float* src, int n) const {
+        int j = 0;
+        double s = 0.f;
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 2 * VTraits<v_float32>::vlanes(); j += 2 * VTraits<v_float32>::vlanes()) {
             v_float32 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_float32>::vlanes());
             v_float64 v00 = v_cvt_f64(v0), v01 = v_cvt_f64_high(v0);
@@ -558,7 +562,6 @@ struct NormL2_SIMD<float, double> {
             r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
             r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
         for (; j < n; j++) {
             double v = src[j];
@@ -571,9 +574,11 @@ struct NormL2_SIMD<float, double> {
 template<>
 struct NormL2_SIMD<double, double> {
     double operator() (const double* src, int n) const {
+        int j = 0;
+        double s = 0.f;
+#ifndef CV_RVV // It triggers segmentation fault on CI but it works fine on real hardware
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
-        int j = 0;
         for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
             v_float64 v00 = vx_load(src + j                                   );
             v_float64 v01 = vx_load(src + j +     VTraits<v_float64>::vlanes());
@@ -582,8 +587,8 @@ struct NormL2_SIMD<double, double> {
             r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
             r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
         }
-        double s = 0.f;
         s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+#endif
         for (; j < n; j++) {
             double v = src[j];
             s += v * v;

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -4,6 +4,10 @@
 
 #include "precomp.hpp"
 
+#if CV_RVV
+#include "norm.rvv1p0.hpp"
+#endif
+
 namespace cv {
 
 using NormFunc = int (*)(const uchar*, const uchar*, uchar*, int, int);
@@ -462,7 +466,9 @@ struct NormL1_SIMD<double, double> {
     double operator() (const double* src, int n) const {
         int j = 0;
         double s = 0.f;
-#ifndef CV_RVV  // It triggers segmentation fault on CI but it works fine on real hardware
+#if CV_RVV // This is introduced to workaround the accuracy issue on ci
+        s = normL1_rvv(src, n, j);
+#else
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
         for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
@@ -576,7 +582,9 @@ struct NormL2_SIMD<double, double> {
     double operator() (const double* src, int n) const {
         int j = 0;
         double s = 0.f;
-#ifndef CV_RVV // It triggers segmentation fault on CI but it works fine on real hardware
+#if CV_RVV // This is introduced to workaround the accuracy issue on ci
+        s = normL2_rvv(src, n, j);
+#else
         v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
         v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
         for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -348,10 +348,10 @@ struct NormL2_SIMD<uchar, int> {
         v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
         for (; j <= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
             v_uint8 v0 = vx_load(src + j);
-            r0 = v_dotprod_expand(v0, v0, r0);
+            r0 = v_dotprod_expand_fast(v0, v0, r0);
 
             v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
-            r1 = v_dotprod_expand(v1, v1, r1);
+            r1 = v_dotprod_expand_fast(v1, v1, r1);
         }
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
@@ -367,18 +367,14 @@ struct NormL2_SIMD<schar, int> {
     int operator() (const schar* src, int n) const {
         int j = 0;
         int s = 0;
-#if CV_RVV
-        s = normL2_rvv<schar, int>(src, n, j);
-#else
         v_int32 r0 = vx_setzero_s32(), r1 = vx_setzero_s32();
         for (; j <= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
             v_int8 v0 = vx_load(src + j);
-            r0 = v_dotprod_expand(v0, v0, r0);
+            r0 = v_dotprod_expand_fast(v0, v0, r0);
             v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
-            r1 = v_dotprod_expand(v1, v1, r1);
+            r1 = v_dotprod_expand_fast(v1, v1, r1);
         }
         s += v_reduce_sum(v_add(r0, r1));
-#endif
         for (; j < n; j++) {
             int v = saturate_cast<int>(src[j]);
             s += v * v;
@@ -498,11 +494,11 @@ struct NormL2_SIMD<ushort, double> {
         v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
             v_uint16 v0 = vx_load(src + j);
-            v_uint64 u0 = v_dotprod_expand(v0, v0);
+            v_uint64 u0 = v_dotprod_expand_fast(v0, v0);
             r0 = v_add(r0, v_cvt_f64(v_reinterpret_as_s64(u0)));
 
             v_uint16 v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
-            v_uint64 u1 = v_dotprod_expand(v1, v1);
+            v_uint64 u1 = v_dotprod_expand_fast(v1, v1);
             r1 = v_add(r1, v_cvt_f64(v_reinterpret_as_s64(u1)));
         }
         s += v_reduce_sum(v_add(r0, r1));
@@ -522,10 +518,10 @@ struct NormL2_SIMD<short, double> {
         v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
             v_int16 v0 = vx_load(src + j);
-            r0 = v_add(r0, v_cvt_f64(v_dotprod_expand(v0, v0)));
+            r0 = v_add(r0, v_cvt_f64(v_dotprod_expand_fast(v0, v0)));
 
             v_int16 v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
-            r1 = v_add(r1, v_cvt_f64(v_dotprod_expand(v1, v1)));
+            r1 = v_add(r1, v_cvt_f64(v_dotprod_expand_fast(v1, v1)));
         }
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
@@ -544,10 +540,10 @@ struct NormL2_SIMD<int, double> {
         v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
             v_int32 v0 = vx_load(src + j);
-            r0 = v_add(r0, v_cvt_f64(v_dotprod(v0, v0)));
+            r0 = v_add(r0, v_cvt_f64(v_dotprod_fast(v0, v0)));
 
             v_int32 v1 = vx_load(src + j + VTraits<v_int32>::vlanes());
-            r1 = v_add(r1, v_cvt_f64(v_dotprod(v1, v1)));
+            r1 = v_add(r1, v_cvt_f64(v_dotprod_fast(v1, v1)));
         }
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -1,0 +1,698 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "precomp.hpp"
+
+namespace cv {
+
+using NormFunc = int (*)(const uchar*, const uchar*, uchar*, int, int);
+
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+NormFunc getNormFunc(int normType, int depth);
+
+#ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+template <typename T, typename ST>
+struct NormInf_SIMD {
+    inline ST operator() (const T* src, int n) const {
+        ST s = 0;
+        for (int i = 0; i < n; i++) {
+            s += std::max(s, (ST)cv_abs(src[i]));
+        }
+        return s;
+    }
+};
+
+template <typename T, typename ST>
+struct NormL1_SIMD {
+    inline ST operator() (const T* src, int n) const {
+        ST s = 0;
+        for (int i = 0; i < n; i++) {
+            s += cv_abs(src[i]);
+        }
+        return s;
+    }
+};
+
+template <typename T, typename ST>
+struct NormL2_SIMD {
+    inline ST operator() (const T* src, int n) const {
+        ST s = 0;
+        for (int i = 0; i < n; i++) {
+            ST v = src[i];
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+
+template<>
+struct NormInf_SIMD<uchar, int> {
+    int operator() (const uchar* src, int n) const {
+        v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
+        v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_uint8>::vlanes(); j += 4 * VTraits<v_uint8>::vlanes()) {
+            r0 = v_max(r0, vx_load(src + j                                 ));
+            r1 = v_max(r1, vx_load(src + j +     VTraits<v_uint8>::vlanes()));
+            r2 = v_max(r2, vx_load(src + j + 2 * VTraits<v_uint8>::vlanes()));
+            r3 = v_max(r3, vx_load(src + j + 3 * VTraits<v_uint8>::vlanes()));
+        }
+        r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+        int s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, (int)src[j]);
+        }
+        return std::max(s, (int)v_reduce_max(r0));
+    }
+};
+
+template<>
+struct NormInf_SIMD<schar, int> {
+    int operator() (const schar* src, int n) const {
+        v_uint8 r0 = vx_setzero_u8(), r1 = vx_setzero_u8();
+        v_uint8 r2 = vx_setzero_u8(), r3 = vx_setzero_u8();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_int8>::vlanes(); j += 4 * VTraits<v_int8>::vlanes()) {
+            r0 = v_max(r0, v_abs(vx_load(src + j                                )));
+            r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int8>::vlanes())));
+            r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_int8>::vlanes())));
+            r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int8>::vlanes())));
+        }
+        r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+        int s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, cv_abs(src[j]));
+        }
+        return std::max(s, saturate_cast<int>(v_reduce_max(r0)));
+    }
+};
+
+template<>
+struct NormInf_SIMD<ushort, int> {
+    int operator() (const ushort* src, int n) const {
+        v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
+        v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
+            d0 = v_max(d0, vx_load(src + j                                  ));
+            d1 = v_max(d1, vx_load(src + j +     VTraits<v_uint16>::vlanes()));
+            d2 = v_max(d2, vx_load(src + j + 2 * VTraits<v_uint16>::vlanes()));
+            d3 = v_max(d3, vx_load(src + j + 3 * VTraits<v_uint16>::vlanes()));
+        }
+        d0 = v_max(d0, v_max(d1, v_max(d2, d3)));
+        int s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, (int)src[j]);
+        }
+        return std::max(s, (int)v_reduce_max(d0));
+    }
+};
+
+template<>
+struct NormInf_SIMD<short, int> {
+    int operator() (const short* src, int n) const {
+        v_uint16 d0 = vx_setzero_u16(), d1 = vx_setzero_u16();
+        v_uint16 d2 = vx_setzero_u16(), d3 = vx_setzero_u16();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
+            d0 = v_max(d0, v_abs(vx_load(src + j                                  )));
+            d1 = v_max(d1, v_abs(vx_load(src + j +     VTraits<v_int16>::vlanes())));
+            d2 = v_max(d2, v_abs(vx_load(src + j + 2 * VTraits<v_int16>::vlanes())));
+            d3 = v_max(d3, v_abs(vx_load(src + j + 3 * VTraits<v_int16>::vlanes())));
+        }
+        d0 = v_max(d0, v_max(d1, v_max(d2, d3)));
+        int s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, saturate_cast<int>(cv_abs(src[j])));
+        }
+        return std::max(s, saturate_cast<int>(v_reduce_max(d0)));
+    }
+};
+
+template<>
+struct NormInf_SIMD<int, int> {
+    int operator() (const int* src, int n) const {
+        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
+        v_uint32 r2 = vx_setzero_u32(), r3 = vx_setzero_u32();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_int32>::vlanes(); j += 4 * VTraits<v_int32>::vlanes()) {
+            r0 = v_max(r0, v_abs(vx_load(src + j                                 )));
+            r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_int32>::vlanes())));
+            r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_int32>::vlanes())));
+            r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_int32>::vlanes())));
+        }
+        r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+        int s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, cv_abs(src[j]));
+        }
+        return std::max(s, saturate_cast<int>(v_reduce_max(r0)));
+    }
+};
+
+template<>
+struct NormInf_SIMD<float, float> {
+    float operator() (const float* src, int n) const {
+        v_float32 r0 = vx_setzero_f32(), r1 = vx_setzero_f32();
+        v_float32 r2 = vx_setzero_f32(), r3 = vx_setzero_f32();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_float32>::vlanes(); j += 4 * VTraits<v_float32>::vlanes()) {
+            r0 = v_max(r0, v_abs(vx_load(src + j                                   )));
+            r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_float32>::vlanes())));
+            r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_float32>::vlanes())));
+            r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_float32>::vlanes())));
+        }
+        r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+        float s = 0.f;
+        for (; j < n; j++) {
+            s = std::max(s, cv_abs(src[j]));
+        }
+        return std::max(s, v_reduce_max(r0));
+    }
+};
+
+template<>
+struct NormL1_SIMD<uchar, int> {
+    int operator() (const uchar* src, int n) const {
+        v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
+        v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
+        v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
+        v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+        int j = 0;
+        for (; j<= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
+            v_uint8 v0 = vx_load(src + j);
+            v_uint16 v00, v01;
+            v_expand(v0, v00, v01);
+            v_uint32 v000, v001, v010, v011;
+            v_expand(v00, v000, v001);
+            v_expand(v01, v010, v011);
+
+            r00 = v_add(r00, v_reinterpret_as_s32(v000));
+            r01 = v_add(r01, v_reinterpret_as_s32(v001));
+            r10 = v_add(r10, v_reinterpret_as_s32(v010));
+            r11 = v_add(r11, v_reinterpret_as_s32(v011));
+
+            v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
+            v_uint16 v10, v11;
+            v_expand(v1, v10, v11);
+            v_uint32 v100, v101, v110, v111;
+            v_expand(v10, v100, v101);
+            v_expand(v11, v110, v111);
+
+            r20 = v_add(r20, v_reinterpret_as_s32(v100));
+            r21 = v_add(r21, v_reinterpret_as_s32(v101));
+            r30 = v_add(r30, v_reinterpret_as_s32(v110));
+            r31 = v_add(r31, v_reinterpret_as_s32(v111));
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+        for (; j < n; j++) {
+            s += src[j];
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<schar, int> {
+    int operator() (const schar* src, int n) const {
+        v_uint32 r00 = vx_setzero_u32(), r01 = vx_setzero_u32();
+        v_uint32 r10 = vx_setzero_u32(), r11 = vx_setzero_u32();
+        v_uint32 r20 = vx_setzero_u32(), r21 = vx_setzero_u32();
+        v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
+        int j = 0;
+        for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
+            v_uint8 v0 = v_abs(vx_load(src + j));
+            v_uint16 v00, v01;
+            v_expand(v0, v00, v01);
+            v_uint32 v000, v001, v010, v011;
+            v_expand(v00, v000, v001);
+            v_expand(v01, v010, v011);
+
+            r00 = v_add(r00, v000);
+            r01 = v_add(r01, v001);
+            r10 = v_add(r10, v010);
+            r11 = v_add(r11, v011);
+
+            v_uint8 v1 = v_abs(vx_load(src + j + VTraits<v_int8>::vlanes()));
+            v_uint16 v10, v11;
+            v_expand(v1, v10, v11);
+            v_uint32 v100, v101, v110, v111;
+            v_expand(v10, v100, v101);
+            v_expand(v11, v110, v111);
+
+            r20 = v_add(r20, v100);
+            r21 = v_add(r21, v101);
+            r30 = v_add(r30, v110);
+            r31 = v_add(r31, v111);
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+        for (; j < n; j++) {
+            s += saturate_cast<int>(cv_abs(src[j]));
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<ushort, int> {
+    int operator() (const ushort* src, int n) const {
+        v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
+        v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
+        v_int32 d20 = vx_setzero_s32(), d21 = vx_setzero_s32();
+        v_int32 d30 = vx_setzero_s32(), d31 = vx_setzero_s32();
+        int j = 0;
+        for (; j<= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
+            v_uint16 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
+            v_uint32 v00, v01, v10, v11;
+            v_expand(v0, v00, v01);
+            v_expand(v1, v10, v11);
+            d00 = v_add(d00, v_reinterpret_as_s32(v00));
+            d01 = v_add(d01, v_reinterpret_as_s32(v01));
+            d10 = v_add(d10, v_reinterpret_as_s32(v10));
+            d11 = v_add(d11, v_reinterpret_as_s32(v11));
+
+            v_uint16 v2 = vx_load(src + j + 2 * VTraits<v_uint16>::vlanes()), v3 = vx_load(src + j + 3 * VTraits<v_uint16>::vlanes());
+            v_uint32 v20, v21, v30, v31;
+            v_expand(v2, v20, v21);
+            v_expand(v3, v30, v31);
+            d20 = v_add(d20, v_reinterpret_as_s32(v20));
+            d21 = v_add(d21, v_reinterpret_as_s32(v21));
+            d30 = v_add(d30, v_reinterpret_as_s32(v30));
+            d31 = v_add(d31, v_reinterpret_as_s32(v31));
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
+        s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
+        for (; j < n; j++) {
+            s += src[j];
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<short, int> {
+    int operator() (const short* src, int n) const {
+        v_uint32 d00 = vx_setzero_u32(), d01 = vx_setzero_u32();
+        v_uint32 d10 = vx_setzero_u32(), d11 = vx_setzero_u32();
+        v_uint32 d20 = vx_setzero_u32(), d21 = vx_setzero_u32();
+        v_uint32 d30 = vx_setzero_u32(), d31 = vx_setzero_u32();
+        int j = 0;
+        for (; j<= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
+            v_uint16 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
+            v_uint32 v00, v01, v10, v11;
+            v_expand(v0, v00, v01);
+            v_expand(v1, v10, v11);
+            d00 = v_add(d00, v00);
+            d01 = v_add(d01, v01);
+            d10 = v_add(d10, v10);
+            d11 = v_add(d11, v11);
+
+            v_uint16 v2 = v_abs(vx_load(src + j + 2 * VTraits<v_int16>::vlanes())), v3 = v_abs(vx_load(src + j + 3 * VTraits<v_int16>::vlanes()));
+            v_uint32 v20, v21, v30, v31;
+            v_expand(v2, v20, v21);
+            v_expand(v3, v30, v31);
+            d20 = v_add(d20, v20);
+            d21 = v_add(d21, v21);
+            d30 = v_add(d30, v30);
+            d31 = v_add(d31, v31);
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
+        s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
+        for (; j < n; j++) {
+            s += saturate_cast<int>(cv_abs(src[j]));
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<uchar, int> {
+    int operator() (const uchar* src, int n) const {
+        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
+            v_uint8 v0 = vx_load(src + j);
+            r0 = v_dotprod_expand(v0, v0, r0);
+
+            v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
+            r1 = v_dotprod_expand(v1, v1, r1);
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(r0, r1));
+        for (; j < n; j++) {
+            int v = saturate_cast<int>(src[j]);
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<schar, int> {
+    int operator() (const schar* src, int n) const {
+        v_int32 r0 = vx_setzero_s32(), r1 = vx_setzero_s32();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
+            v_int8 v0 = vx_load(src + j);
+            r0 = v_dotprod_expand(v0, v0, r0);
+            v_int8 v1 = vx_load(src + j + VTraits<v_int8>::vlanes());
+            r1 = v_dotprod_expand(v1, v1, r1);
+        }
+        int s = 0;
+        s += v_reduce_sum(v_add(r0, r1));
+        for (; j < n; j++) {
+            int v = saturate_cast<int>(src[j]);
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+#endif
+
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+
+template<>
+struct NormInf_SIMD<double, double> {
+    double operator() (const double* src, int n) const {
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
+        v_float64 r2 = vx_setzero_f64(), r3 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
+            r0 = v_max(r0, v_abs(vx_load(src + j                                   )));
+            r1 = v_max(r1, v_abs(vx_load(src + j +     VTraits<v_float64>::vlanes())));
+            r2 = v_max(r2, v_abs(vx_load(src + j + 2 * VTraits<v_float64>::vlanes())));
+            r3 = v_max(r3, v_abs(vx_load(src + j + 3 * VTraits<v_float64>::vlanes())));
+        }
+        r0 = v_max(r0, v_max(r1, v_max(r2, r3)));
+        double s = 0;
+        for (; j < n; j++) {
+            s = std::max(s, cv_abs(src[j]));
+        }
+        double t[VTraits<v_float64>::max_nlanes];
+        vx_store(t, r0);
+        for (int i = 0; i < VTraits<v_float64>::vlanes(); i++) {
+            s = std::max(s, cv_abs(t[i]));
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<int, double> {
+    double operator() (const int* src, int n) const {
+        v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+        v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
+            v_float32 v0 = v_abs(v_cvt_f32(vx_load(src + j))), v1 = v_abs(v_cvt_f32(vx_load(src + j + VTraits<v_int32>::vlanes())));
+            r00 = v_add(r00, v_cvt_f64(v0)); r01 = v_add(r01, v_cvt_f64_high(v0));
+            r10 = v_add(r10, v_cvt_f64(v1)); r11 = v_add(r11, v_cvt_f64_high(v1));
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        for (; j < n; j++) {
+            s += cv_abs(src[j]);
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<float, double> {
+    double operator() (const float* src, int n) const {
+        v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+        v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+        v_float64 r20 = vx_setzero_f64(), r21 = vx_setzero_f64();
+        v_float64 r30 = vx_setzero_f64(), r31 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_float32>::vlanes(); j += 4 * VTraits<v_float32>::vlanes()) {
+            v_float32 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_float32>::vlanes()));
+            r00 = v_add(r00, v_cvt_f64(v0)); r01 = v_add(r01, v_cvt_f64_high(v0));
+            r10 = v_add(r10, v_cvt_f64(v1)); r11 = v_add(r11, v_cvt_f64_high(v1));
+
+            v_float32 v2 = v_abs(vx_load(src + j + 2 * VTraits<v_float32>::vlanes())), v3 = v_abs(vx_load(src + j + 3 * VTraits<v_float32>::vlanes()));
+            r20 = v_add(r20, v_cvt_f64(v2)); r21 = v_add(r21, v_cvt_f64_high(v2));
+            r30 = v_add(r30, v_cvt_f64(v3)); r31 = v_add(r31, v_cvt_f64_high(v3));
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+        for (; j < n; j++) {
+            s += cv_abs(src[j]);
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL1_SIMD<double, double> {
+    double operator() (const double* src, int n) const {
+        v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+        v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
+            r00 = v_add(r00, v_abs(vx_load(src + j                                   )));
+            r01 = v_add(r01, v_abs(vx_load(src + j +     VTraits<v_float64>::vlanes())));
+            r10 = v_add(r10, v_abs(vx_load(src + j + 2 * VTraits<v_float64>::vlanes())));
+            r11 = v_add(r11, v_abs(vx_load(src + j + 3 * VTraits<v_float64>::vlanes())));
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        for (; j < n; j++) {
+            s += cv_abs(src[j]);
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<ushort, double> {
+    double operator() (const ushort* src, int n) const {
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
+            v_uint16 v0 = vx_load(src + j);
+            v_uint64 u0 = v_dotprod_expand(v0, v0);
+            r0 = v_add(r0, v_cvt_f64(v_reinterpret_as_s64(u0)));
+
+            v_uint16 v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
+            v_uint64 u1 = v_dotprod_expand(v1, v1);
+            r1 = v_add(r1, v_cvt_f64(v_reinterpret_as_s64(u1)));
+        }
+        double s = 0;
+        s += v_reduce_sum(v_add(r0, r1));
+        for (; j < n; j++) {
+            double v = saturate_cast<double>(src[j]);
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<short, double> {
+    double operator() (const short* src, int n) const {
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
+            v_int16 v0 = vx_load(src + j);
+            r0 = v_add(r0, v_cvt_f64(v_dotprod_expand(v0, v0)));
+
+            v_int16 v1 = vx_load(src + j + VTraits<v_int16>::vlanes());
+            r1 = v_add(r1, v_cvt_f64(v_dotprod_expand(v1, v1)));
+        }
+        double s = 0;
+        s += v_reduce_sum(v_add(r0, r1));
+        for (; j < n; j++) {
+            double v = saturate_cast<double>(src[j]);
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<int, double> {
+    double operator() (const int* src, int n) const {
+        v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
+            v_int32 v0 = vx_load(src + j);
+            r0 = v_add(r0, v_cvt_f64(v_dotprod(v0, v0)));
+
+            v_int32 v1 = vx_load(src + j + VTraits<v_int32>::vlanes());
+            r1 = v_add(r1, v_cvt_f64(v_dotprod(v1, v1)));
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(r0, r1));
+        for (; j < n; j++) {
+            double v = src[j];
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<float, double> {
+    double operator() (const float* src, int n) const {
+        v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+        v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 2 * VTraits<v_float32>::vlanes(); j += 2 * VTraits<v_float32>::vlanes()) {
+            v_float32 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_float32>::vlanes());
+            v_float64 v00 = v_cvt_f64(v0), v01 = v_cvt_f64_high(v0);
+            v_float64 v10 = v_cvt_f64(v1), v11 = v_cvt_f64_high(v1);
+            r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
+            r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        for (; j < n; j++) {
+            double v = src[j];
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+template<>
+struct NormL2_SIMD<double, double> {
+    double operator() (const double* src, int n) const {
+        v_float64 r00 = vx_setzero_f64(), r01 = vx_setzero_f64();
+        v_float64 r10 = vx_setzero_f64(), r11 = vx_setzero_f64();
+        int j = 0;
+        for (; j <= n - 4 * VTraits<v_float64>::vlanes(); j += 4 * VTraits<v_float64>::vlanes()) {
+            v_float64 v00 = vx_load(src + j                                   );
+            v_float64 v01 = vx_load(src + j +     VTraits<v_float64>::vlanes());
+            v_float64 v10 = vx_load(src + j + 2 * VTraits<v_float64>::vlanes());
+            v_float64 v11 = vx_load(src + j + 3 * VTraits<v_float64>::vlanes());
+            r00 = v_fma(v00, v00, r00); r01 = v_fma(v01, v01, r01);
+            r10 = v_fma(v10, v10, r10); r11 = v_fma(v11, v11, r11);
+        }
+        double s = 0.f;
+        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
+        for (; j < n; j++) {
+            double v = src[j];
+            s += v * v;
+        }
+        return s;
+    }
+};
+
+#endif
+
+template<typename T, typename ST> int
+normInf_(const T* src, const uchar* mask, ST* _result, int len, int cn) {
+    ST result = *_result;
+    if( !mask ) {
+        NormInf_SIMD<T, ST> op;
+        result = std::max(result, op(src, len*cn));
+    } else {
+        for( int i = 0; i < len; i++, src += cn ) {
+            if( mask[i] ) {
+                for( int k = 0; k < cn; k++ ) {
+                    result = std::max(result, ST(cv_abs(src[k])));
+                }
+            }
+        }
+    }
+    *_result = result;
+    return 0;
+}
+
+template<typename T, typename ST> int
+normL1_(const T* src, const uchar* mask, ST* _result, int len, int cn) {
+    ST result = *_result;
+    if( !mask ) {
+        NormL1_SIMD<T, ST> op;
+        result += op(src, len*cn);
+    } else {
+        for( int i = 0; i < len; i++, src += cn ) {
+            if( mask[i] ) {
+                for( int k = 0; k < cn; k++ ) {
+                    result += cv_abs(src[k]);
+                }
+            }
+        }
+    }
+    *_result = result;
+    return 0;
+}
+
+template<typename T, typename ST> int
+normL2_(const T* src, const uchar* mask, ST* _result, int len, int cn) {
+    ST result = *_result;
+    if( !mask ) {
+        NormL2_SIMD<T, ST> op;
+        result += op(src, len*cn);
+    } else {
+        for( int i = 0; i < len; i++, src += cn ) {
+            if( mask[i] ) {
+                for( int k = 0; k < cn; k++ ) {
+                    T v = src[k];
+                    result += (ST)v*v;
+                }
+            }
+        }
+    }
+    *_result = result;
+    return 0;
+}
+
+#define CV_DEF_NORM_FUNC(L, suffix, type, ntype) \
+    static int norm##L##_##suffix(const type* src, const uchar* mask, ntype* r, int len, int cn) \
+{ CV_INSTRUMENT_REGION(); return norm##L##_(src, mask, r, len, cn); } \
+
+#define CV_DEF_NORM_ALL(suffix, type, inftype, l1type, l2type) \
+    CV_DEF_NORM_FUNC(Inf, suffix, type, inftype) \
+    CV_DEF_NORM_FUNC(L1, suffix, type, l1type) \
+    CV_DEF_NORM_FUNC(L2, suffix, type, l2type)
+
+CV_DEF_NORM_ALL(8u, uchar, int, int, int)
+CV_DEF_NORM_ALL(8s, schar, int, int, int)
+CV_DEF_NORM_ALL(16u, ushort, int, int, double)
+CV_DEF_NORM_ALL(16s, short, int, int, double)
+CV_DEF_NORM_ALL(32s, int, int, double, double)
+CV_DEF_NORM_ALL(32f, float, float, double, double)
+CV_DEF_NORM_ALL(64f, double, double, double, double)
+
+NormFunc getNormFunc(int normType, int depth)
+{
+    CV_INSTRUMENT_REGION();
+    static NormFunc normTab[3][8] =
+    {
+        {
+            (NormFunc)GET_OPTIMIZED(normInf_8u), (NormFunc)GET_OPTIMIZED(normInf_8s), (NormFunc)GET_OPTIMIZED(normInf_16u), (NormFunc)GET_OPTIMIZED(normInf_16s),
+            (NormFunc)GET_OPTIMIZED(normInf_32s), (NormFunc)GET_OPTIMIZED(normInf_32f), (NormFunc)normInf_64f, 0
+        },
+        {
+            (NormFunc)GET_OPTIMIZED(normL1_8u), (NormFunc)GET_OPTIMIZED(normL1_8s), (NormFunc)GET_OPTIMIZED(normL1_16u), (NormFunc)GET_OPTIMIZED(normL1_16s),
+            (NormFunc)GET_OPTIMIZED(normL1_32s), (NormFunc)GET_OPTIMIZED(normL1_32f), (NormFunc)normL1_64f, 0
+        },
+        {
+            (NormFunc)GET_OPTIMIZED(normL2_8u), (NormFunc)GET_OPTIMIZED(normL2_8s), (NormFunc)GET_OPTIMIZED(normL2_16u), (NormFunc)GET_OPTIMIZED(normL2_16s),
+            (NormFunc)GET_OPTIMIZED(normL2_32s), (NormFunc)GET_OPTIMIZED(normL2_32f), (NormFunc)normL2_64f, 0
+        }
+    };
+
+    return normTab[normType][depth];
+}
+
+#endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+
+} // cv::

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -185,37 +185,16 @@ struct NormL1_SIMD<uchar, int> {
     int operator() (const uchar* src, int n) const {
         int j = 0;
         int s = 0;
-        v_int32 r00 = vx_setzero_s32(), r01 = vx_setzero_s32();
-        v_int32 r10 = vx_setzero_s32(), r11 = vx_setzero_s32();
-        v_int32 r20 = vx_setzero_s32(), r21 = vx_setzero_s32();
-        v_int32 r30 = vx_setzero_s32(), r31 = vx_setzero_s32();
+        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
+        v_uint8  one = vx_setall_u8(1);
         for (; j<= n - 2 * VTraits<v_uint8>::vlanes(); j += 2 * VTraits<v_uint8>::vlanes()) {
             v_uint8 v0 = vx_load(src + j);
-            v_uint16 v00, v01;
-            v_expand(v0, v00, v01);
-            v_uint32 v000, v001, v010, v011;
-            v_expand(v00, v000, v001);
-            v_expand(v01, v010, v011);
-
-            r00 = v_add(r00, v_reinterpret_as_s32(v000));
-            r01 = v_add(r01, v_reinterpret_as_s32(v001));
-            r10 = v_add(r10, v_reinterpret_as_s32(v010));
-            r11 = v_add(r11, v_reinterpret_as_s32(v011));
+            r0 = v_dotprod_expand_fast(v0, one, r0);
 
             v_uint8 v1 = vx_load(src + j + VTraits<v_uint8>::vlanes());
-            v_uint16 v10, v11;
-            v_expand(v1, v10, v11);
-            v_uint32 v100, v101, v110, v111;
-            v_expand(v10, v100, v101);
-            v_expand(v11, v110, v111);
-
-            r20 = v_add(r20, v_reinterpret_as_s32(v100));
-            r21 = v_add(r21, v_reinterpret_as_s32(v101));
-            r30 = v_add(r30, v_reinterpret_as_s32(v110));
-            r31 = v_add(r31, v_reinterpret_as_s32(v111));
+            r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
-        s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+        s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             s += src[j];
         }
@@ -228,37 +207,16 @@ struct NormL1_SIMD<schar, int> {
     int operator() (const schar* src, int n) const {
         int j = 0;
         int s = 0;
-        v_uint32 r00 = vx_setzero_u32(), r01 = vx_setzero_u32();
-        v_uint32 r10 = vx_setzero_u32(), r11 = vx_setzero_u32();
-        v_uint32 r20 = vx_setzero_u32(), r21 = vx_setzero_u32();
-        v_uint32 r30 = vx_setzero_u32(), r31 = vx_setzero_u32();
+        v_uint32 r0 = vx_setzero_u32(), r1 = vx_setzero_u32();
+        v_uint8  one = vx_setall_u8(1);
         for (; j<= n - 2 * VTraits<v_int8>::vlanes(); j += 2 * VTraits<v_int8>::vlanes()) {
             v_uint8 v0 = v_abs(vx_load(src + j));
-            v_uint16 v00, v01;
-            v_expand(v0, v00, v01);
-            v_uint32 v000, v001, v010, v011;
-            v_expand(v00, v000, v001);
-            v_expand(v01, v010, v011);
-
-            r00 = v_add(r00, v000);
-            r01 = v_add(r01, v001);
-            r10 = v_add(r10, v010);
-            r11 = v_add(r11, v011);
+            r0 = v_dotprod_expand_fast(v0, one, r0);
 
             v_uint8 v1 = v_abs(vx_load(src + j + VTraits<v_int8>::vlanes()));
-            v_uint16 v10, v11;
-            v_expand(v1, v10, v11);
-            v_uint32 v100, v101, v110, v111;
-            v_expand(v10, v100, v101);
-            v_expand(v11, v110, v111);
-
-            r20 = v_add(r20, v100);
-            r21 = v_add(r21, v101);
-            r30 = v_add(r30, v110);
-            r31 = v_add(r31, v111);
+            r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(v_add(v_add(r00, r01), r10), r11));
-        s += v_reduce_sum(v_add(v_add(v_add(r20, r21), r30), r31));
+        s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             s += saturate_cast<int>(cv_abs(src[j]));
         }
@@ -271,31 +229,16 @@ struct NormL1_SIMD<ushort, int> {
     int operator() (const ushort* src, int n) const {
         int j = 0;
         int s = 0;
-        v_int32 d00 = vx_setzero_s32(), d01 = vx_setzero_s32();
-        v_int32 d10 = vx_setzero_s32(), d11 = vx_setzero_s32();
-        v_int32 d20 = vx_setzero_s32(), d21 = vx_setzero_s32();
-        v_int32 d30 = vx_setzero_s32(), d31 = vx_setzero_s32();
-        for (; j<= n - 4 * VTraits<v_uint16>::vlanes(); j += 4 * VTraits<v_uint16>::vlanes()) {
-            v_uint16 v0 = vx_load(src + j), v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
-            v_uint32 v00, v01, v10, v11;
-            v_expand(v0, v00, v01);
-            v_expand(v1, v10, v11);
-            d00 = v_add(d00, v_reinterpret_as_s32(v00));
-            d01 = v_add(d01, v_reinterpret_as_s32(v01));
-            d10 = v_add(d10, v_reinterpret_as_s32(v10));
-            d11 = v_add(d11, v_reinterpret_as_s32(v11));
+        v_uint64 r0 = vx_setzero_u64(), r1 = vx_setzero_u64();
+        v_uint16 one = vx_setall_u16(1);
+        for (; j<= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
+            v_uint16 v0 = vx_load(src + j);
+            r0 = v_dotprod_expand_fast(v0, one, r0);
 
-            v_uint16 v2 = vx_load(src + j + 2 * VTraits<v_uint16>::vlanes()), v3 = vx_load(src + j + 3 * VTraits<v_uint16>::vlanes());
-            v_uint32 v20, v21, v30, v31;
-            v_expand(v2, v20, v21);
-            v_expand(v3, v30, v31);
-            d20 = v_add(d20, v_reinterpret_as_s32(v20));
-            d21 = v_add(d21, v_reinterpret_as_s32(v21));
-            d30 = v_add(d30, v_reinterpret_as_s32(v30));
-            d31 = v_add(d31, v_reinterpret_as_s32(v31));
+            v_uint16 v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
+            r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
-        s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
+        s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             s += src[j];
         }
@@ -308,31 +251,16 @@ struct NormL1_SIMD<short, int> {
     int operator() (const short* src, int n) const {
         int j = 0;
         int s = 0;
-        v_uint32 d00 = vx_setzero_u32(), d01 = vx_setzero_u32();
-        v_uint32 d10 = vx_setzero_u32(), d11 = vx_setzero_u32();
-        v_uint32 d20 = vx_setzero_u32(), d21 = vx_setzero_u32();
-        v_uint32 d30 = vx_setzero_u32(), d31 = vx_setzero_u32();
-        for (; j<= n - 4 * VTraits<v_int16>::vlanes(); j += 4 * VTraits<v_int16>::vlanes()) {
-            v_uint16 v0 = v_abs(vx_load(src + j)), v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
-            v_uint32 v00, v01, v10, v11;
-            v_expand(v0, v00, v01);
-            v_expand(v1, v10, v11);
-            d00 = v_add(d00, v00);
-            d01 = v_add(d01, v01);
-            d10 = v_add(d10, v10);
-            d11 = v_add(d11, v11);
+        v_uint64 r0 = vx_setzero_u64(), r1 = vx_setzero_u64();
+        v_uint16 one = vx_setall_u16(1);
+        for (; j<= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
+            v_uint16 v0 = v_abs(vx_load(src + j));
+            r0 = v_dotprod_expand_fast(v0, one, r0);
 
-            v_uint16 v2 = v_abs(vx_load(src + j + 2 * VTraits<v_int16>::vlanes())), v3 = v_abs(vx_load(src + j + 3 * VTraits<v_int16>::vlanes()));
-            v_uint32 v20, v21, v30, v31;
-            v_expand(v2, v20, v21);
-            v_expand(v3, v30, v31);
-            d20 = v_add(d20, v20);
-            d21 = v_add(d21, v21);
-            d30 = v_add(d30, v30);
-            d31 = v_add(d31, v31);
+            v_uint16 v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
+            r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(v_add(v_add(d00, d01), d10), d11));
-        s += v_reduce_sum(v_add(v_add(v_add(d20, d21), d30), d31));
+        s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {
             s += saturate_cast<int>(cv_abs(src[j]));
         }
@@ -540,10 +468,10 @@ struct NormL2_SIMD<int, double> {
         v_float64 r0 = vx_setzero_f64(), r1 = vx_setzero_f64();
         for (; j <= n - 2 * VTraits<v_int32>::vlanes(); j += 2 * VTraits<v_int32>::vlanes()) {
             v_int32 v0 = vx_load(src + j);
-            r0 = v_add(r0, v_cvt_f64(v_dotprod_fast(v0, v0)));
+            r0 = v_dotprod_expand_fast(v0, v0, r0);
 
             v_int32 v1 = vx_load(src + j + VTraits<v_int32>::vlanes());
-            r1 = v_add(r1, v_cvt_f64(v_dotprod_fast(v1, v1)));
+            r1 = v_dotprod_expand_fast(v1, v1, r1);
         }
         s += v_reduce_sum(v_add(r0, r1));
         for (; j < n; j++) {

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -229,6 +229,9 @@ struct NormL1_SIMD<ushort, int> {
     int operator() (const ushort* src, int n) const {
         int j = 0;
         int s = 0;
+#if CV_RVV
+        s = normL1_rvv<ushort, int>(src, n, j);
+#else
         v_uint64 r0 = vx_setzero_u64(), r1 = vx_setzero_u64();
         v_uint16 one = vx_setall_u16(1);
         for (; j<= n - 2 * VTraits<v_uint16>::vlanes(); j += 2 * VTraits<v_uint16>::vlanes()) {
@@ -238,7 +241,8 @@ struct NormL1_SIMD<ushort, int> {
             v_uint16 v1 = vx_load(src + j + VTraits<v_uint16>::vlanes());
             r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(r0, r1));
+        s += (int)v_reduce_sum(v_add(r0, r1));
+#endif
         for (; j < n; j++) {
             s += src[j];
         }
@@ -251,6 +255,9 @@ struct NormL1_SIMD<short, int> {
     int operator() (const short* src, int n) const {
         int j = 0;
         int s = 0;
+#if CV_RVV
+        s = normL1_rvv<short, int>(src, n, j);
+#else
         v_uint64 r0 = vx_setzero_u64(), r1 = vx_setzero_u64();
         v_uint16 one = vx_setall_u16(1);
         for (; j<= n - 2 * VTraits<v_int16>::vlanes(); j += 2 * VTraits<v_int16>::vlanes()) {
@@ -260,7 +267,8 @@ struct NormL1_SIMD<short, int> {
             v_uint16 v1 = v_abs(vx_load(src + j + VTraits<v_int16>::vlanes()));
             r1 = v_dotprod_expand_fast(v1, one, r1);
         }
-        s += v_reduce_sum(v_add(r0, r1));
+        s += (int)v_reduce_sum(v_add(r0, r1));
+#endif
         for (; j < n; j++) {
             s += saturate_cast<int>(cv_abs(src[j]));
         }


### PR DESCRIPTION
Checklist:
|      | normInf | normL1 | normL2 |
| ---- | ------- | ------ | ------ |
| bool |    -    |   -    |   -    |
| 8u   |    √    |   √    |   √    |
| 8s   |    √    |   √    |   √    |
| 16u  |    √    |   √    |   √    |
| 16s  |    √    |   √    |   √    |
| 16f  |    -    |   -    |   -    |
| 16bf |    -    |   -    |   -    |
| 32u  |    -    |   -    |   -    |
| 32s  |    √    |   √    |   √    |
| 32f  |    √    |   √    |   √    |
| 64u  |    -    |   -    |   -    |
| 64s  |    -    |   -    |   -    |
| 64f  |    √    |   √    |   √    |

*: Vectorization of data type bool, 16f, 16bf, 32u, 64u and 64s needs to be done on 5.x.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
