### PR TITLE
fix wrong python type hints for imread

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -52,6 +52,20 @@ def apply_manual_api_refinement(root: NamespaceNode) -> None:
     ])
 
 
+def make_optional_none_return(root_node: NamespaceNode,
+                              function_symbol_name: SymbolName) -> None:
+    """
+    Make return type Optional[MatLike],
+    for the functions that may return None.
+    """
+    function = find_function_node(root_node, function_symbol_name)
+    for overload in function.overloads:
+        if overload.return_type is not None:
+            if not isinstance(overload.return_type.type_node, OptionalTypeNode):
+                overload.return_type.type_node = OptionalTypeNode(
+                    overload.return_type.type_node
+                )
+
 def export_matrix_type_constants(root: NamespaceNode) -> None:
     MAX_PREDEFINED_CHANNELS = 4
 
@@ -326,6 +340,8 @@ NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "resize"): make_optional_arg("dsize"),
     SymbolName(("cv", ), (), "calcHist"): make_optional_arg("mask"),
     SymbolName(("cv", ), (), "floodFill"): make_optional_arg("mask"),
+    SymbolName(("cv", ), (), "imread"): make_optional_none_return,
+    SymbolName(("cv", ), (), "imdecode"): make_optional_none_return,
 }
 
 ERROR_CLASS_PROPERTIES = (


### PR DESCRIPTION
Fixes :  #26811

Updated api_refinement.py to refine the return type of cv2.imread and cv2.imdecode.

- Previously, these functions were typed to always return a valid image.
- Now, they are correctly annotated as MatLike | None, ensuring static type checkers like mypy detect cases where the function might return None.

<details>
<summary>Fix details </summary>

### **Before Fix**  
```python
import tempfile
import cv2

with tempfile.TemporaryFile() as temp_file:
    temp_file.write(b"Corrupted binary data. Not a image")
    temp_file.seek(0)
    image = cv2.imread(str(temp_file.name))
    print(image.shape)

```
```bash
mypy test.py
# output : Success: no issues found in 1 source file
```

### **After Fix**  
Now, `mypy` correctly flags `None` access:
```bash
test.py:8: error: Item "None" of "ndarray[Any, dtype[...]] | None" has no attribute "shape"  [union-attr]
Found 1 error in 1 file (checked 1 source file)
```

</details>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
