### PR TITLE
Update optical_flow.cpp

### DIFF
--- a/samples/cpp/tutorial_code/video/optical_flow/optical_flow.cpp
+++ b/samples/cpp/tutorial_code/video/optical_flow/optical_flow.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         int r = rng.uniform(0, 256);
         int g = rng.uniform(0, 256);
         int b = rng.uniform(0, 256);
-        colors.push_back(Scalar(r,g,b));
+        colors.emplace_back(r,g,b);
     }
 
     Mat old_frame, old_gray;


### PR DESCRIPTION
ref: push_back is changed to emplace_back in order to avoid unnecessary conversions [Scalar(r, g, b))] .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
