### PR TITLE
Migrate remaning OpenVX integrations to OpenVX HAL (core)

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -191,7 +191,7 @@ int ovx_hal_mul(const T *a, size_t astep, const T *b, size_t bstep, T *c, size_t
 #ifdef _WIN32
     const float MAGIC_SCALE = 0x0.01010102p0;
 #else
-    const float MAGIC_SCALE = 0x1.010102p-8;
+    const float MAGIC_SCALE = 0.003922; // 0x1.010102p-8;
 #endif
     try
     {

--- a/3rdparty/openvx/hal/openvx_hal.hpp
+++ b/3rdparty/openvx/hal/openvx_hal.hpp
@@ -56,7 +56,7 @@ int ovx_hal_cvtOnePlaneYUVtoBGR(const uchar * a, size_t astep, uchar * b, size_t
 int ovx_hal_integral(int depth, int sdepth, int, const uchar * a, size_t astep, uchar * b, size_t bstep, uchar * c, size_t, uchar * d, size_t, int w, int h, int cn);
 int ovx_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height,
                        int src_type, double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
-
+int ovx_hal_lut(const uchar *src_data, size_t src_step, size_t src_type, const uchar* lut_data, size_t lut_channel_size, size_t lut_channels, uchar *dst_data, size_t dst_step, int width, int height);
 
 //==================================================================================================
 // functions redefinition
@@ -146,5 +146,7 @@ int ovx_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int he
 #define cv_hal_integral ovx_hal_integral
 #undef cv_hal_meanStdDev
 #define cv_hal_meanStdDev ovx_hal_meanStdDev
+#undef cv_hal_lut
+#define cv_hal_lut ovx_hal_lut
 
 #endif

--- a/3rdparty/openvx/hal/openvx_hal.hpp
+++ b/3rdparty/openvx/hal/openvx_hal.hpp
@@ -54,6 +54,9 @@ int ovx_hal_cvtThreePlaneYUVtoBGR(const uchar * a, size_t astep, uchar * b, size
 int ovx_hal_cvtBGRtoThreePlaneYUV(const uchar * a, size_t astep, uchar * b, size_t bstep, int w, int h, int acn, bool swapBlue, int uIdx);
 int ovx_hal_cvtOnePlaneYUVtoBGR(const uchar * a, size_t astep, uchar * b, size_t bstep, int w, int h, int bcn, bool swapBlue, int uIdx, int ycn);
 int ovx_hal_integral(int depth, int sdepth, int, const uchar * a, size_t astep, uchar * b, size_t bstep, uchar * c, size_t, uchar * d, size_t, int w, int h, int cn);
+int ovx_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height,
+                       int src_type, double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
+
 
 //==================================================================================================
 // functions redefinition
@@ -141,5 +144,7 @@ int ovx_hal_integral(int depth, int sdepth, int, const uchar * a, size_t astep, 
 #define cv_hal_cvtOnePlaneYUVtoBGR ovx_hal_cvtOnePlaneYUVtoBGR
 #undef cv_hal_integral
 #define cv_hal_integral ovx_hal_integral
+#undef cv_hal_meanStdDev
+#define cv_hal_meanStdDev ovx_hal_meanStdDev
 
 #endif

--- a/3rdparty/openvx/hal/openvx_hal.hpp
+++ b/3rdparty/openvx/hal/openvx_hal.hpp
@@ -57,6 +57,8 @@ int ovx_hal_integral(int depth, int sdepth, int, const uchar * a, size_t astep, 
 int ovx_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height,
                        int src_type, double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
 int ovx_hal_lut(const uchar *src_data, size_t src_step, size_t src_type, const uchar* lut_data, size_t lut_channel_size, size_t lut_channels, uchar *dst_data, size_t dst_step, int width, int height);
+int ovx_hal_minMaxIdxMaskStep(const uchar* src_data, size_t src_step, int width, int height, int depth,
+                              double* minVal, double* maxVal, int* minIdx, int* maxIdx, uchar* mask, size_t mask_step);
 
 //==================================================================================================
 // functions redefinition
@@ -148,5 +150,7 @@ int ovx_hal_lut(const uchar *src_data, size_t src_step, size_t src_type, const u
 #define cv_hal_meanStdDev ovx_hal_meanStdDev
 #undef cv_hal_lut
 #define cv_hal_lut ovx_hal_lut
+#undef cv_hal_minMaxIdxMaskStep
+#define cv_hal_minMaxIdxMaskStep ovx_hal_minMaxIdxMaskStep
 
 #endif

--- a/3rdparty/openvx/include/ivx.hpp
+++ b/3rdparty/openvx/include/ivx.hpp
@@ -22,7 +22,13 @@ Details: TBD
 #include <VX/vx.h>
 #include <VX/vxu.h>
 
-#ifndef VX_VERSION_1_1
+// For OpenVX 1.2 & 1.3
+#if (VX_VERSION > VX_VERSION_1_1)
+# include <VX/vx_compatibility.h>
+#endif
+
+
+#if (VX_VERSION == VX_VERSION_1_0)
 // 1.1 to 1.0 backward compatibility defines
 
 static const vx_enum VX_INTERPOLATION_BILINEAR = VX_INTERPOLATION_TYPE_BILINEAR;
@@ -31,12 +37,6 @@ static const vx_enum VX_INTERPOLATION_NEAREST_NEIGHBOR = VX_INTERPOLATION_TYPE_N
 
 static const vx_enum VX_BORDER_CONSTANT = VX_BORDER_MODE_CONSTANT;
 static const vx_enum VX_BORDER_REPLICATE = VX_BORDER_MODE_REPLICATE;
-
-#else
-
-    #ifdef IVX_RENAMED_REFS
-        static const vx_enum VX_REF_ATTRIBUTE_TYPE = VX_REFERENCE_TYPE;
-    #endif
 
 #endif
 
@@ -218,7 +218,7 @@ template<> struct TypeToEnum<vx_int64>    { static const vx_enum value = VX_TYPE
 template<> struct TypeToEnum<vx_uint64>   { static const vx_enum value = VX_TYPE_UINT64; };
 template<> struct TypeToEnum<vx_float32>  { static const vx_enum value = VX_TYPE_FLOAT32, imgType = VX_DF_IMAGE('F', '0', '3', '2'); };
 template<> struct TypeToEnum<vx_float64>  { static const vx_enum value = VX_TYPE_FLOAT64; };
-template<> struct TypeToEnum<vx_bool>     { static const vx_enum value = VX_TYPE_BOOL; };
+//template<> struct TypeToEnum<vx_bool>     { static const vx_enum value = VX_TYPE_BOOL; };
 template<> struct TypeToEnum<vx_keypoint_t> {static const vx_enum value = VX_TYPE_KEYPOINT; };
 // the commented types are aliases (of integral tyes) and have conflicts with the types above
 //template<> struct TypeToEnum<vx_enum>     { static const vx_enum val = VX_TYPE_ENUM; };

--- a/modules/core/src/mean.dispatch.cpp
+++ b/modules/core/src/mean.dispatch.cpp
@@ -5,7 +5,6 @@
 
 #include "precomp.hpp"
 #include "opencl_kernels_core.hpp"
-#include "opencv2/core/openvx/ovx_defs.hpp"
 #include "stat.hpp"
 
 #ifndef OPENCV_IPP_MEAN
@@ -312,70 +311,6 @@ static bool ocl_meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv
 }
 #endif
 
-#ifdef HAVE_OPENVX
-    static bool openvx_meanStdDev(Mat& src, OutputArray _mean, OutputArray _sdv, Mat& mask)
-    {
-        size_t total_size = src.total();
-        int rows = src.size[0], cols = rows ? (int)(total_size / rows) : 0;
-        if (src.type() != CV_8UC1|| !mask.empty() ||
-               (src.dims != 2 && !(src.isContinuous() && cols > 0 && (size_t)rows*cols == total_size))
-           )
-        return false;
-
-        try
-        {
-            ivx::Context ctx = ovx::getOpenVXContext();
-#ifndef VX_VERSION_1_1
-            if (ctx.vendorID() == VX_ID_KHRONOS)
-                return false; // Do not use OpenVX meanStdDev estimation for sample 1.0.1 implementation due to lack of accuracy
-#endif
-
-            ivx::Image
-                ia = ivx::Image::createFromHandle(ctx, VX_DF_IMAGE_U8,
-                    ivx::Image::createAddressing(cols, rows, 1, (vx_int32)(src.step[0])), src.ptr());
-
-            vx_float32 mean_temp, stddev_temp;
-            ivx::IVX_CHECK_STATUS(vxuMeanStdDev(ctx, ia, &mean_temp, &stddev_temp));
-
-            if (_mean.needed())
-            {
-                if (!_mean.fixedSize())
-                    _mean.create(1, 1, CV_64F, -1, true);
-                Mat mean = _mean.getMat();
-                CV_Assert(mean.type() == CV_64F && mean.isContinuous() &&
-                    (mean.cols == 1 || mean.rows == 1) && mean.total() >= 1);
-                double *pmean = mean.ptr<double>();
-                pmean[0] = mean_temp;
-                for (int c = 1; c < (int)mean.total(); c++)
-                    pmean[c] = 0;
-            }
-
-            if (_sdv.needed())
-            {
-                if (!_sdv.fixedSize())
-                    _sdv.create(1, 1, CV_64F, -1, true);
-                Mat stddev = _sdv.getMat();
-                CV_Assert(stddev.type() == CV_64F && stddev.isContinuous() &&
-                    (stddev.cols == 1 || stddev.rows == 1) && stddev.total() >= 1);
-                double *pstddev = stddev.ptr<double>();
-                pstddev[0] = stddev_temp;
-                for (int c = 1; c < (int)stddev.total(); c++)
-                    pstddev[c] = 0;
-            }
-        }
-        catch (const ivx::RuntimeError & e)
-        {
-            VX_DbgThrow(e.what());
-        }
-        catch (const ivx::WrapperError & e)
-        {
-            VX_DbgThrow(e.what());
-        }
-
-        return true;
-    }
-#endif
-
 #ifdef HAVE_IPP
 static bool ipp_meanStdDev(Mat& src, OutputArray _mean, OutputArray _sdv, Mat& mask)
 {
@@ -526,9 +461,6 @@ void meanStdDev(InputArray _src, OutputArray _mean, OutputArray _sdv, InputArray
     Mat src = _src.getMat(), mask = _mask.getMat();
 
     CV_Assert(mask.empty() || src.size == mask.size);
-
-    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MEAN_STDDEV>(src.cols, src.rows),
-               openvx_meanStdDev(src, _mean, _sdv, mask))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 700, ipp_meanStdDev(src, _mean, _sdv, mask));
 


### PR DESCRIPTION
Tested with OpenVX 1.2 & 1.3 sample implementation.

Steps to build and test:
```
git clone git@github.com:KhronosGroup/OpenVX-sample-impl.git
cd OpenVX-sample-impl
python3 Build.py --os=Linux --conf=Release
cd ..
mkdir build
cmake -DWITH_OPENVX=ON -DOPENVX_ROOT=/mnt/Projects/Projects/OpenVX-sample-impl/install/Linux/x64/Release/ ../opencv
make -j8
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
