### PR TITLE
Extension to PR #26605 ldm inpainting sample

### DIFF
--- a/samples/dnn/common.py
+++ b/samples/dnn/common.py
@@ -62,16 +62,17 @@ def add_argument(zoo, parser, name, help, required=False, default=None, type=Non
 
 def add_preproc_args(zoo, parser, sample, alias=None, prefix=""):
     aliases = []
-    if os.path.isfile(zoo):
+    if os.path.isfile(zoo) and prefix == "":
         fs = cv.FileStorage(zoo, cv.FILE_STORAGE_READ)
         root = fs.root()
         for name in root.keys():
             model = root.getNode(name)
             if model.getNode('sample').string() == sample:
                 aliases.append(name)
+    if len(aliases):
+        parser.add_argument(prefix+'alias', nargs='?', choices=aliases,
+                            help='An alias name of model to extract preprocessing parameters from models.yml file.')
 
-    parser.add_argument(prefix+'alias', nargs='?', choices=aliases,
-                        help='An alias name of model to extract preprocessing parameters from models.yml file.')
     add_argument(zoo, parser, prefix+'model',
                  help='Path to a binary file of model contains trained weights. '
                       'It could be a file with extensions .caffemodel (Caffe), '

--- a/samples/dnn/download_models.py
+++ b/samples/dnn/download_models.py
@@ -14,7 +14,7 @@ import requests
 import shutil
 from pathlib import Path
 from datetime import datetime
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 import xml.etree.ElementTree as ET
 
 __all__ = ["downloadFile"]
@@ -188,9 +188,11 @@ class URLLoader(Loader):
         self.url = url
 
     def download(self, filepath):
-        r = urlopen(self.url, timeout=60)
-        self.printRequest(r)
-        self.save(filepath, r)
+        headers = {'User-Agent': 'Wget/1.20.3'}
+        req = Request(self.url, headers=headers)
+        with urlopen(req, timeout=60) as r:
+            self.printRequest(r)
+            self.save(filepath, r)
         return os.path.getsize(filepath)
 
     def printRequest(self, r):

--- a/samples/dnn/ldm_inpainting.py
+++ b/samples/dnn/ldm_inpainting.py
@@ -117,7 +117,7 @@ def make_batch_blob(image, mask):
 
     blob_image = cv.dnn.blobFromImage(image, scalefactor=args.scale, size=(args.width, args.height), mean=args.mean, swapRB=args.rgb, crop=False)
 
-    blob_mask = cv.dnn.blobFromImage(mask, scalefactor=args.scale, size=(args.width, args.height), mean=args.mean, swapRB=args.rgb, crop=False)
+    blob_mask = cv.dnn.blobFromImage(mask, scalefactor=args.scale, size=(args.width, args.height), mean=args.mean, swapRB=False, crop=False)
 
     blob_mask = (blob_mask >= 0.5).astype(np.float32)
     masked_image = (1 - blob_mask) * blob_image
@@ -583,6 +583,7 @@ def main(args):
 
     result = result.astype(np.uint8)
     result = cv.resize(result, (args.width, height))
+    result = cv.cvtColor(result, cv.COLOR_RGB2BGR)
     cv.imshow("Inpainted Image", result)
     cv.waitKey(0)
     cv.destroyAllWindows()

--- a/samples/dnn/ldm_inpainting.py
+++ b/samples/dnn/ldm_inpainting.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import os
 from common import *
 
-## let use write description of the script and general information how to use it
+## General information on how to use the sample
 
 '''
 This sample proposes experimental inpainting sample using Latent Diffusion Model (LDM) for inpainting.
@@ -15,14 +15,12 @@ Most of the script is based on the code from the official repository of the LDM 
 
 Current limitations of the script:
     - Slow diffusion sampling
-    - Not exact reproduction of the results from the original repository (due to issues related deviation in covolution operation.
+    - Not exact reproduction of the results from the original repository (due to issues related deviation in convolution operation.
     See issue for more details: https://github.com/opencv/opencv/pull/25973)
 
-Steps for running the script:
+LDM inpainting model was converted to ONNX graph using following steps:
 
-1. Firstly generate ONNX graph of the Latent Diffusion Model.
-
-    Generate the using this [repo](https://github.com/Abdurrahheem/latent-diffusion/tree/ash/export2onnx) and follow instructions below
+    Generate the onnx model using this [repo](https://github.com/Abdurrahheem/latent-diffusion/tree/ash/export2onnx) and follow instructions below
 
     - git clone https://github.com/Abdurrahheem/latent-diffusion.git
     - cd latent-diffusion
@@ -31,17 +29,19 @@ Steps for running the script:
     - wget -O models/ldm/inpainting_big/last.ckpt https://heibox.uni-heidelberg.de/f/4d9ac7ea40c64582b7c9/?dl=1
     - python -m scripts.inpaint.py --indir data/inpainting_examples/ --outdir outputs/inpainting_results --export=True
 
-2. Build opencv (preferebly with CUDA support enabled
+2. Build opencv
 3. Run the script
 
     - cd opencv/samples/dnn
-    - python ldm_inpainting -e=<path-to-InpaintEncoder.onnx file> -d=<path-to-InpaintDecoder.onnx file> -df=<path-to-LatenDiffusion.onnx file> -i=<path-to-image>
+    - Download models using `python download_models.py ldm_inpainting`
+    - python ldm_inpainting.py
+    - For more options, use python ldm_inpainting.py -h
 
-Right after the last command you will be promted with image. You can click on left mouse botton and starting selection a region you would like to be inpainted (delited).
-Once you finish marking the region, click on left mouse botton again and press esc botton on your keyboard. The inpainting proccess will start.
+After running the code you will be promted with image. You can click on left mouse button and start selecting a region you would like to be inpainted (deleted).
+Once you finish marking the region, click on left mouse button again and press esc button on your keyboard. The inpainting proccess will start.
 
 Note: If you are running it on CPU it might take a large chank of time.
-Also make sure to have abount 15GB of RAM to make proccess faster (other wise swapping will ckick in and everything will be slower)
+Also make sure to have abount 15GB of RAM to make proccess faster (other wise swapping will kick in and everything will be slower)
 '''
 
 def get_args_parser():
@@ -79,7 +79,7 @@ def get_args_parser():
     add_preproc_args(args.zoo, parser, 'ldm_inpainting', prefix="decoder_", alias="ldm_inpainting")
     add_preproc_args(args.zoo, parser, 'ldm_inpainting', prefix="diffusor_", alias="ldm_inpainting")
     parser = argparse.ArgumentParser(parents=[parser],
-                                        description='Image inpainting using OpenCV.',
+                                        description='Diffusion based image inpainting using OpenCV.',
                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     return parser.parse_args()
 
@@ -106,10 +106,10 @@ def help():
         '''
         Use this script for image inpainting using OpenCV.
 
-        Firstly, download required models i.e. ldm_inpainting using `download_models.py` (if not already done). Set environment variable OPENCV_DOWNLOAD_CACHE_DIR to specify where models should be downloaded. Also, point OPENCV_SAMPLES_DATA_PATH to opencv/samples/data.
+        Firstly, download required models i.e. ldm_inpainting using `download_models.py ldm_inpainting` (if not already done). Set environment variable OPENCV_DOWNLOAD_CACHE_DIR to specify where models should be downloaded. Also, point OPENCV_SAMPLES_DATA_PATH to opencv/samples/data.
 
         To run:
-        Example: python ldm_inpainting.py [--input=<image_name>]
+        Example: python ldm_inpainting.py
         '''
     )
 

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -471,4 +471,9 @@ ldm_inpainting:
     diffusor_url: "https://dl.opencv.org/models/ldm_inpainting/LatentDiffusion.onnx"
     diffusor_sha1: "2c6f8a505d9a93195510c854d8f023fab27ce70e"
   diffusor_model: "LatentDiffusion.onnx"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 512
+  height: 512
+  rgb: true
   sample: "ldm_inpainting"

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -475,5 +475,5 @@ ldm_inpainting:
   scale: 0.00392
   width: 512
   height: 512
-  rgb: false
+  rgb: true
   sample: "ldm_inpainting"

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -457,3 +457,18 @@ lama:
   height: 512
   rgb: false
   sample: "inpainting"
+
+ldm_inpainting:
+  encoder_load_info:
+    encoder_url: "https://dl.opencv.org/models/ldm_inpainting/InpaintEncoder.onnx"
+    encoder_sha1: "eb663262304473d81d6ae627d7117892dac56b5e"
+  encoder_model: "InpaintEncoder.onnx"
+  decoder_load_info:
+    decoder_url: "https://dl.opencv.org/models/ldm_inpainting/InpaintDecoder.onnx"
+    decoder_sha1: "af258c100e3a3b0970493b6375c8775beaffc9d1"
+  decoder_model: "InpaintDecoder.onnx"
+  diffusor_load_info:
+    diffusor_url: "https://dl.opencv.org/models/ldm_inpainting/LatentDiffusion.onnx"
+    diffusor_sha1: "2c6f8a505d9a93195510c854d8f023fab27ce70e"
+  diffusor_model: "LatentDiffusion.onnx"
+  sample: "ldm_inpainting"

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -475,5 +475,5 @@ ldm_inpainting:
   scale: 0.00392
   width: 512
   height: 512
-  rgb: true
+  rgb: false
   sample: "ldm_inpainting"


### PR DESCRIPTION
This PR adds and fixes following points in the ldm_inpainting sample on top of original PR #26605 by @Abdurrahheem 

DONE:

1. Added functionality to load models from a YAML configuration file, allowing for automatic downloading if models are not found locally.
2. Updated the script usage instructions to reflect the correct command format.
3. Improved user interaction by adding instructions to the image window for inpainting controls.
4. Introduced a new models.yml configuration section for inpainting models weights downloading, including placeholders for model SHA1 checksums.
5. Fixed input types and names of the onnx graph generation.
6. Added links to onnx graphs in models.yml
7. Support added for findModels and standarized the sample usage similar to other dnn samples
8. Fixes issue in download_models.py for downloading models from dl.opencv.org
9. Fixes issue in common.py which used to print duplicated positional arguments in case of samples that use multiple models. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
