### PR TITLE
Fix _DEBUG/NDEBUG handling across modules 

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -55,7 +55,7 @@
 
 namespace cv
 {
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+#if !defined(NDEBUG) || defined(CV_STATIC_ANALYSIS)
 static bool isPlanarObjectPoints(InputArray _objectPoints, double threshold)
 {
     CV_CheckType(_objectPoints.type(), _objectPoints.type() == CV_32FC3 || _objectPoints.type() == CV_64FC3,
@@ -932,7 +932,7 @@ int solvePnPGeneric( InputArray _opoints, InputArray _ipoints,
     {
         CV_Assert(npoints == 4);
 
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+#if !defined(NDEBUG) || defined(CV_STATIC_ANALYSIS)
         double Xs[4][3];
         if (opoints.depth() == CV_32F)
         {

--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -450,7 +450,7 @@ It does not throw exception, but terminates the application.
 
 //! @endcond
 
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+#if !defined(NDEBUG) || defined(CV_STATIC_ANALYSIS)
 #  define CV_DbgAssert(expr) CV_Assert(expr)
 #else
 /** replaced with CV_Assert(expr) in Debug configuration */

--- a/modules/gapi/include/opencv2/gapi/own/assert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/assert.hpp
@@ -19,7 +19,7 @@
 #include <opencv2/core/base.hpp>
 #define GAPI_Assert CV_Assert
 
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+#if !defined(NDEBUG) || defined(CV_STATIC_ANALYSIS)
 #  define GAPI_DbgAssert CV_DbgAssert
 #else
 #  define GAPI_DbgAssert(expr) GAPI_DbgAssertNoOp(expr)

--- a/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
+++ b/modules/gapi/src/streaming/onevpl/cfg_param_device_selector.cpp
@@ -105,7 +105,7 @@ CfgParamDeviceSelector::CfgParamDeviceSelector(const CfgParams& cfg_params) :
             //Create device
             UINT creationFlags = 0;//D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+#if !defined(NDEBUG) || defined(CV_STATIC_ANALYSIS)
             // If the project is in a debug build, enable debugging via SDK Layers with this flag.
             creationFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -1485,9 +1485,6 @@ double CV_ColorRGBTest::get_success_error_level( int /*test_case_idx*/, int /*i*
 void CV_ColorRGBTest::convert_forward( const Mat& src, Mat& dst )
 {
     int depth = src.depth(), cn = src.channels();
-/*#if defined _DEBUG || defined DEBUG
-    int dst_cn = CV_MAT_CN(dst->type);
-#endif*/
     int i, j, cols = src.cols;
     int g_rshift = dst_bits == 16 ? 2 : 3;
     int r_lshift = dst_bits == 16 ? 11 : 10;
@@ -1571,9 +1568,6 @@ void CV_ColorRGBTest::convert_forward( const Mat& src, Mat& dst )
 void CV_ColorRGBTest::convert_backward( const Mat& /*src*/, const Mat& src, Mat& dst )
 {
     int depth = src.depth(), cn = dst.channels();
-/*#if defined _DEBUG || defined DEBUG
-    int src_cn = CV_MAT_CN(src->type);
-#endif*/
     int i, j, cols = src.cols;
     int g_lshift = dst_bits == 16 ? 2 : 3;
     int r_rshift = dst_bits == 16 ? 11 : 10;


### PR DESCRIPTION
Fixes : #26151

NDEBUG macro is standard and associated with assert(): https://en.cppreference.com/w/c/error/assert

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
