### PR TITLE
Impl RISC-V HAL for norm_hamming

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -24,6 +24,7 @@
 #include "hal_rvv_1p0/mean.hpp" // core
 #include "hal_rvv_1p0/norm.hpp" // core
 #include "hal_rvv_1p0/norm_diff.hpp" // core
+#include "hal_rvv_1p0/norm_hamming.hpp" // core
 #include "hal_rvv_1p0/convert_scale.hpp" // core
 #include "hal_rvv_1p0/minmax.hpp" // core
 #include "hal_rvv_1p0/atan.hpp" // core

--- a/3rdparty/hal_rvv/hal_rvv_1p0/norm_hamming.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/norm_hamming.hpp
@@ -1,0 +1,182 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#pragma once
+
+#include <riscv_vector.h>
+#include <opencv2/core/base.hpp>
+
+namespace cv { namespace cv_hal_rvv {
+
+#undef cv_hal_normHamming8u
+#define cv_hal_normHamming8u cv::cv_hal_rvv::normHamming8u
+#undef cv_hal_normHammingDiff8u
+#define cv_hal_normHammingDiff8u cv::cv_hal_rvv::normHammingDiff8u
+
+template <typename CellType>
+inline void normHammingCnt_m8(vuint8m8_t v, vbool1_t mask, size_t len_bool, size_t& result)
+{
+    auto v_bool0 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 0));
+    auto v_bool1 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 1));
+    auto v_bool2 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 2));
+    auto v_bool3 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 3));
+    auto v_bool4 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 4));
+    auto v_bool5 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 5));
+    auto v_bool6 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 6));
+    auto v_bool7 = __riscv_vreinterpret_b1(__riscv_vget_u8m1(v, 7));
+    result += CellType::popcount(v_bool0, mask, len_bool);
+    result += CellType::popcount(v_bool1, mask, len_bool);
+    result += CellType::popcount(v_bool2, mask, len_bool);
+    result += CellType::popcount(v_bool3, mask, len_bool);
+    result += CellType::popcount(v_bool4, mask, len_bool);
+    result += CellType::popcount(v_bool5, mask, len_bool);
+    result += CellType::popcount(v_bool6, mask, len_bool);
+    result += CellType::popcount(v_bool7, mask, len_bool);
+}
+
+template <typename CellType>
+inline void normHammingCnt_m1(vuint8m1_t v, vbool1_t mask, size_t len_bool, size_t& result)
+{
+    auto v_bool = __riscv_vreinterpret_b1(v);
+    result += CellType::popcount(v_bool, mask, len_bool);
+}
+
+struct NormHammingCell1
+{
+    static inline vbool1_t generateMask([[maybe_unused]] size_t len)
+    {
+        return vbool1_t();
+    }
+
+    template <typename T>
+    static inline void preprocess([[maybe_unused]] T& v, [[maybe_unused]] size_t len)
+    {
+    }
+
+    template <typename T>
+    static inline size_t popcount(T v, [[maybe_unused]] vbool1_t mask, size_t len_bool)
+    {
+        return __riscv_vcpop(v, len_bool);
+    }
+};
+
+struct NormHammingCell2
+{
+    static inline vbool1_t generateMask(size_t len)
+    {
+        return __riscv_vreinterpret_b1(__riscv_vmv_v_x_u8m1(0x55, len));
+    }
+
+    template <typename T>
+    static inline void preprocess(T& v, size_t len)
+    {
+        v = __riscv_vor(v, __riscv_vsrl(v, 1, len), len);
+    }
+
+    template <typename T>
+    static inline size_t popcount(T v, vbool1_t mask, size_t len_bool)
+    {
+        return __riscv_vcpop(mask, v, len_bool);
+    }
+};
+
+struct NormHammingCell4
+{
+    static inline vbool1_t generateMask(size_t len)
+    {
+        return __riscv_vreinterpret_b1(__riscv_vmv_v_x_u8m1(0x11, len));
+    }
+
+    template <typename T>
+    static inline void preprocess(T& v, size_t len)
+    {
+        v = __riscv_vor(v, __riscv_vsrl(v, 2, len), len);
+        v = __riscv_vor(v, __riscv_vsrl(v, 1, len), len);
+    }
+
+    template <typename T>
+    static inline size_t popcount(T v, vbool1_t mask, size_t len_bool)
+    {
+        return __riscv_vcpop(mask, v, len_bool);
+    }
+};
+
+template <typename CellType>
+inline void normHamming8uLoop(const uchar* a, size_t n, size_t& result)
+{
+    size_t len = __riscv_vsetvlmax_e8m8();
+    size_t len_bool = len * 8;
+    vbool1_t mask = CellType::generateMask(len);
+
+    for (; n >= len; n -= len, a += len)
+    {
+        auto v = __riscv_vle8_v_u8m8(a, len);
+        CellType::preprocess(v, len);
+        normHammingCnt_m8<CellType>(v, mask, len_bool, result);
+    }
+    for (; n > 0; n -= len, a += len)
+    {
+        len = __riscv_vsetvl_e8m1(n);
+        auto v = __riscv_vle8_v_u8m1(a, len);
+        CellType::preprocess(v, len);
+        normHammingCnt_m1<CellType>(v, mask, len * 8, result);
+    }
+}
+
+template <typename CellType>
+inline void normHammingDiff8uLoop(const uchar* a, const uchar* b, size_t n, size_t& result)
+{
+    size_t len = __riscv_vsetvlmax_e8m8();
+    size_t len_bool = len * 8;
+    vbool1_t mask = CellType::generateMask(len);
+
+    for (; n >= len; n -= len, a += len, b += len)
+    {
+        auto v_a = __riscv_vle8_v_u8m8(a, len);
+        auto v_b = __riscv_vle8_v_u8m8(b, len);
+        auto v = __riscv_vxor(v_a, v_b, len);
+        CellType::preprocess(v, len);
+        normHammingCnt_m8<CellType>(v, mask, len_bool, result);
+    }
+    for (; n > 0; n -= len, a += len, b += len)
+    {
+        len = __riscv_vsetvl_e8m1(n);
+        auto v_a = __riscv_vle8_v_u8m1(a, len);
+        auto v_b = __riscv_vle8_v_u8m1(b, len);
+        auto v = __riscv_vxor(v_a, v_b, len);
+        CellType::preprocess(v, len);
+        normHammingCnt_m1<CellType>(v, mask, len * 8, result);
+    }
+}
+
+inline int normHamming8u(const uchar* a, int n, int cellSize, int* result)
+{
+    size_t _result = 0;
+
+    switch (cellSize)
+    {
+        case 1: normHamming8uLoop<NormHammingCell1>(a, n, _result); break;
+        case 2: normHamming8uLoop<NormHammingCell2>(a, n, _result); break;
+        case 4: normHamming8uLoop<NormHammingCell4>(a, n, _result); break;
+        default: return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+    *result = static_cast<int>(_result);
+    return CV_HAL_ERROR_OK;
+}
+
+inline int normHammingDiff8u(const uchar* a, const uchar* b, int n, int cellSize, int* result)
+{
+    size_t _result = 0;
+
+    switch (cellSize)
+    {
+        case 1: normHammingDiff8uLoop<NormHammingCell1>(a, b, n, _result); break;
+        case 2: normHammingDiff8uLoop<NormHammingCell2>(a, b, n, _result); break;
+        case 4: normHammingDiff8uLoop<NormHammingCell4>(a, b, n, _result); break;
+        default: return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+    *result = static_cast<int>(_result);
+    return CV_HAL_ERROR_OK;
+}
+
+}}  // namespace cv::cv_hal_rvv

--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -586,7 +586,7 @@ double norm( InputArray _src, int normType, InputArray _mask )
 
                 if( normType == NORM_HAMMING )
                 {
-                    return hal::normHamming(data, (int)len);
+                    return hal::normHamming(data, (int)len, 1);
                 }
 
                 if( normType == NORM_HAMMING2 )


### PR DESCRIPTION
Implement through the existing `cv_hal_normHamming8u` and `cv_hal_normHammingDiff8u` interfaces.

Modified `modules/core/src/norm.cpp:680` to ensure HAL calls are not bypassed.

Tested on
- MUSE-PI
- Compiler: gcc 14.2 (riscv-collab/riscv-gnu-toolchain Nightly: December 16, 2024)

```bash
$ opencv_test_core --gtest_filter="Core_Norm/ElemWiseTest*"
$ opencv_perf_core --gtest_filter="PerfHamming*" --perf_min_samples=300 --perf_force_samples=300
```

Compare with scalar:  
```bash
Geometric mean (ms)

                    Name of Test                     scalar  hal      hal    
                                                                       vs    
                                                                     scalar  
                                                                   (x-factor)
norm2::PerfHamming::(NORM_HAMMING2, 8UC1, 640x480)   0.962  0.128     7.52   
norm2::PerfHamming::(NORM_HAMMING2, 8UC1, 1920x1080) 6.506  0.803     8.10   
norm2::PerfHamming::(NORM_HAMMING, 8UC1, 640x480)    0.964  0.137     7.05   
norm2::PerfHamming::(NORM_HAMMING, 8UC1, 1920x1080)  6.426  0.660     9.74   
norm::PerfHamming::(NORM_HAMMING2, 8UC1, 640x480)    0.606  0.067     9.04   
norm::PerfHamming::(NORM_HAMMING2, 8UC1, 1920x1080)  4.122  0.427     9.65   
norm::PerfHamming::(NORM_HAMMING, 8UC1, 640x480)     0.610  0.049    12.55   
norm::PerfHamming::(NORM_HAMMING, 8UC1, 1920x1080)   4.135  0.333    12.43   
```

Compare with ui:
```bash
Geometric mean (ms)

                    Name of Test                       ui    hal      hal    
                                                                       vs    
                                                                       ui    
                                                                   (x-factor)
norm2::PerfHamming::(NORM_HAMMING2, 8UC1, 640x480)   0.734  0.128     5.74   
norm2::PerfHamming::(NORM_HAMMING2, 8UC1, 1920x1080) 4.915  0.803     6.12   
norm2::PerfHamming::(NORM_HAMMING, 8UC1, 640x480)    0.716  0.137     5.24   
norm2::PerfHamming::(NORM_HAMMING, 8UC1, 1920x1080)  4.771  0.660     7.23   
norm::PerfHamming::(NORM_HAMMING2, 8UC1, 640x480)    0.690  0.067    10.29   
norm::PerfHamming::(NORM_HAMMING2, 8UC1, 1920x1080)  4.670  0.427    10.93   
norm::PerfHamming::(NORM_HAMMING, 8UC1, 640x480)     0.652  0.049    13.40   
norm::PerfHamming::(NORM_HAMMING, 8UC1, 1920x1080)   4.433  0.333    13.33  
```

While working on this, I noticed that the optimization logic in `cv::norm` could be improved:

1. The recently introduced `cv_hal_norm` is too restrictive. I think optimization also can be performed after unfolding using map iteration.
2. `cv_hal_norm` overlaps with `cv_hal_normHamming8u`, and due to its strictness, I implemented the optimization through the latter.
3. `cv::hal::normHamming` has four overloads—two in `norm.cpp` and two in `stat.dispatch.cpp`. The latter should only be used by the former, as `CALL_HAL_RET` is present only in the two in `norm.cpp`. Since they have similar parameters, to avoid confusion, I suggest renaming the two in `stat.dispatch.cpp`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
