### PR TITLE
cmake/OpenCVDetectCUDAUtils.cmake: use IN_LIST to avoid regex matching valid capabilities

### DIFF
--- a/cmake/OpenCVDetectCUDAUtils.cmake
+++ b/cmake/OpenCVDetectCUDAUtils.cmake
@@ -310,12 +310,12 @@ macro(ocv_set_cuda_arch_bin_and_ptx nvcc_executable)
 
   # Check if user specified 1.0/2.1 compute capability: we don't support it
   macro(ocv_wipeout_deprecated_cc target_cc)
-    if(" ${CUDA_ARCH_BIN} ${CUDA_ARCH_PTX}" MATCHES " ${target_cc}")
+    if(${target_cc} IN_LIST ARCH_BIN_NO_POINTS OR ${target_cc} IN_LIST ARCH_PTX_NO_POINTS)
       message(SEND_ERROR "CUDA: ${target_cc} compute capability is not supported - exclude it from ARCH/PTX list and re-run CMake")
     endif()
   endmacro()
-  ocv_wipeout_deprecated_cc("1.0")
-  ocv_wipeout_deprecated_cc("2.1")
+  ocv_wipeout_deprecated_cc("10")
+  ocv_wipeout_deprecated_cc("21")
 endmacro()
 
 macro(ocv_set_nvcc_threads_for_vs)


### PR DESCRIPTION
Continuing the work started in #26820, this corrects a bug in checking for deprecated capabilities: CMake's `MATCHES` operator accepts a regex and the value provided was not properly escaped. This results in configuration failing when specifying `CUDA_ARCH_BIN` containing the capability `100` (that's `10.0`), since the `.` in the regex `1.0` will match the middle zero in `100`. Example failure:

```console
opencv> -- CUDA: Using CUDA_ARCH_BIN=100
opencv> CMake Error at cmake/OpenCVDetectCUDAUtils.cmake:314 (message):
opencv>   CUDA: 1.0 compute capability is not supported - exclude it from ARCH/PTX
opencv>   list and re-run CMake
opencv> Call Stack (most recent call first):
opencv>   cmake/OpenCVDetectCUDAUtils.cmake:317 (ocv_wipeout_deprecated_cc)
opencv>   cmake/OpenCVDetectCUDALanguage.cmake:78 (ocv_set_cuda_arch_bin_and_ptx)
opencv>   cmake/OpenCVFindLibsPerf.cmake:44 (include)
opencv>   CMakeLists.txt:800 (include)
```

This PR rewrites the relevant check to use CMake's `IN_LIST` operator, and additionally checks against normalized versions of the capabilities with dots removed.

Although, perhaps those capabilities are old enough now that this check can be removed entirely?

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
