### PR TITLE
video: break hard dependency on dnn

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -3294,6 +3294,12 @@ protected:
     void writeFormat(FileStorage& fs) const;
 };
 
+class CV_EXPORTS_W_SIMPLE DeepNeuralNet
+{
+public:
+    virtual ~DeepNeuralNet() {}
+};
+
 enum struct Param {
     INT=0, BOOLEAN=1, REAL=2, STRING=3, MAT=4, MAT_VECTOR=5, ALGORITHM=6, FLOAT=7,
     UNSIGNED_INT=8, UINT64=9, UCHAR=11, SCALAR=12

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -471,7 +471,7 @@ CV__DNN_INLINE_NS_BEGIN
      *
      * This class supports reference counting of its instances, i. e. copies point to the same instance.
      */
-    class CV_EXPORTS_W_SIMPLE Net
+    class CV_EXPORTS_W_SIMPLE Net : public cv::DeepNeuralNet
     {
     public:
 

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -46,9 +46,6 @@
 
 #include "opencv2/core.hpp"
 #include "opencv2/imgproc.hpp"
-#ifdef HAVE_OPENCV_DNN
-# include "opencv2/dnn.hpp"
-#endif
 
 namespace cv
 {
@@ -829,12 +826,10 @@ public:
     static CV_WRAP
     Ptr<TrackerGOTURN> create(const TrackerGOTURN::Params& parameters = TrackerGOTURN::Params());
 
-#ifdef HAVE_OPENCV_DNN
     /** @brief Constructor
     @param model pre-loaded GOTURN model
     */
-    static CV_WRAP Ptr<TrackerGOTURN> create(const dnn::Net& model);
-#endif
+    static CV_WRAP Ptr<TrackerGOTURN> create(cv::DeepNeuralNet & model);
 
     //void init(InputArray image, const Rect& boundingBox) CV_OVERRIDE;
     //bool update(InputArray image, CV_OUT Rect& boundingBox) CV_OVERRIDE;
@@ -863,15 +858,13 @@ public:
     static CV_WRAP
     Ptr<TrackerDaSiamRPN> create(const TrackerDaSiamRPN::Params& parameters = TrackerDaSiamRPN::Params());
 
-#ifdef HAVE_OPENCV_DNN
     /** @brief Constructor
      *  @param siam_rpn pre-loaded SiamRPN model
      *  @param kernel_cls1 pre-loaded CLS model
      *  @param kernel_r1 pre-loaded R1 model
      */
     static CV_WRAP
-    Ptr<TrackerDaSiamRPN> create(const dnn::Net& siam_rpn, const dnn::Net& kernel_cls1, const dnn::Net& kernel_r1);
-#endif
+    Ptr<TrackerDaSiamRPN> create(cv::DeepNeuralNet & siam_rpn, cv::DeepNeuralNet & kernel_cls1, cv::DeepNeuralNet & kernel_r1);
 
     /** @brief Return tracking score
     */
@@ -911,14 +904,12 @@ public:
     static CV_WRAP
     Ptr<TrackerNano> create(const TrackerNano::Params& parameters = TrackerNano::Params());
 
-#ifdef HAVE_OPENCV_DNN
     /** @brief Constructor
      *  @param backbone pre-loaded backbone model
      *  @param neckhead pre-loaded neckhead model
      */
     static CV_WRAP
-    Ptr<TrackerNano> create(const dnn::Net& backbone, const dnn::Net& neckhead);
-#endif
+    Ptr<TrackerNano> create(cv::DeepNeuralNet & backbone, cv::DeepNeuralNet & neckhead);
 
     /** @brief Return tracking score
     */
@@ -958,7 +949,6 @@ public:
     static CV_WRAP
     Ptr<TrackerVit> create(const TrackerVit::Params& parameters = TrackerVit::Params());
 
-#ifdef HAVE_OPENCV_DNN
     /** @brief Constructor
      *  @param model pre-loaded DNN model
      *  @param meanvalue mean value for image preprocessing
@@ -966,9 +956,8 @@ public:
      *  @param tracking_score_threshold threshold for tracking score
      */
     static CV_WRAP
-    Ptr<TrackerVit> create(const dnn::Net& model, Scalar meanvalue = Scalar(0.485, 0.456, 0.406),
+    Ptr<TrackerVit> create(cv::DeepNeuralNet & model, Scalar meanvalue = Scalar(0.485, 0.456, 0.406),
                            Scalar stdvalue = Scalar(0.229, 0.224, 0.225), float tracking_score_threshold = 0.20f);
-#endif
 
     /** @brief Return tracking score
     */

--- a/modules/video/misc/java/test/TrackerCreateTest.java
+++ b/modules/video/misc/java/test/TrackerCreateTest.java
@@ -69,11 +69,13 @@ public class TrackerCreateTest extends OpenCVTestCase {
         try {
             String protoFile = new File(testDataPath, "dnn/gsoc2016-goturn/goturn.prototxt").toString();
             String weightsFile = new File(modelsDataPath, "dnn/gsoc2016-goturn/goturn.caffemodel").toString();
-            net = dnnClass.getMethod("readNetFromCaffe", String.class, String.class).invoke(protoFile, weightsFile);
+            net = dnnClass.getMethod("readNetFromCaffe", String.class, String.class).invoke(null, protoFile, weightsFile);
             tracker = TrackerGOTURN.create(DeepNeuralNet.class.cast(net));
         } catch (CvException e) {
+            e.printStackTrace();
             return;
         } catch (Exception e) {
+            e.printStackTrace();
             return;
         }
         assert(tracker != null);
@@ -86,12 +88,14 @@ public class TrackerCreateTest extends OpenCVTestCase {
         try {
             String backboneFile = new File(modelsDataPath, "dnn/onnx/models/nanotrack_backbone_sim_v2.onnx").toString();
             String neckheadFile = new File(modelsDataPath, "dnn/onnx/models/nanotrack_head_sim_v2.onnx").toString();
-            backbone = dnnClass.getMethod("readNet", String.class).invoke(backboneFile);
-            neckhead = dnnClass.getMethod("readNet", String.class).invoke(neckheadFile);
+            backbone = dnnClass.getMethod("readNet", String.class).invoke(null, backboneFile);
+            neckhead = dnnClass.getMethod("readNet", String.class).invoke(null, neckheadFile);
             tracker = TrackerNano.create(DeepNeuralNet.class.cast(backbone), DeepNeuralNet.class.cast(neckhead));
         } catch (CvException e) {
+            e.printStackTrace();
             return;
         } catch (Exception e) {
+            e.printStackTrace();
             return;
         }
         assert(tracker != null);
@@ -101,12 +105,14 @@ public class TrackerCreateTest extends OpenCVTestCase {
         Object net;
         Tracker tracker;
         try {
-            String backboneFile = new File(modelsDataPath, "dnn/onnx/models/vitTracker.onnx").toString();
-            net = dnnClass.getMethod("readNet", String.class).invoke(backboneFile);
+            String backboneFile = new File(testDataPath, "dnn/onnx/models/vitTracker.onnx").toString();
+            net = dnnClass.getMethod("readNet", String.class).invoke(null, backboneFile);
             tracker = TrackerVit.create(DeepNeuralNet.class.cast(net));
         } catch (CvException e) {
+            e.printStackTrace();
             return;
         } catch (Exception e) {
+            e.printStackTrace();
             return;
         }
         assert(tracker != null);

--- a/modules/video/src/precomp.hpp
+++ b/modules/video/src/precomp.hpp
@@ -49,4 +49,12 @@
 #include "opencv2/core/ocl.hpp"
 #include "opencv2/core.hpp"
 
+#ifdef HAVE_OPENCV_DNN
+# define BAD_INST(algorithm) \
+    CV_Error(Error::StsBadArg, "Bad model instance passed to " algorithm);
+#else
+# define NOT_IMPL(algorithm) \
+    CV_Error(cv::Error::StsNotImplemented, algorithm " requires build with opencv_dnn");
+#endif
+
 #endif

--- a/modules/video/src/tracking/tracker_dasiamrpn.cpp
+++ b/modules/video/src/tracking/tracker_dasiamrpn.cpp
@@ -438,16 +438,29 @@ Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(const TrackerDaSiamRPN::Params& p
     return makePtr<TrackerDaSiamRPNImpl>(parameters);
 }
 
-Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(const dnn::Net& siam_rpn, const dnn::Net& kernel_cls1, const dnn::Net& kernel_r1)
+Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(cv::DeepNeuralNet & siam_rpn, cv::DeepNeuralNet & kernel_cls1, cv::DeepNeuralNet & kernel_r1)
 {
-    return makePtr<TrackerDaSiamRPNImpl>(siam_rpn, kernel_cls1, kernel_r1);
+    try
+    {
+        return makePtr<TrackerDaSiamRPNImpl>(dynamic_cast<dnn::Net&>(siam_rpn), dynamic_cast<dnn::Net&>(kernel_cls1), dynamic_cast<dnn::Net&>(kernel_r1));
+    }
+    catch (const std::bad_cast & e)
+    {
+        BAD_INST("DaSiamRPN");
+    }
 }
 
 #else  // OPENCV_HAVE_DNN
-Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(const TrackerDaSiamRPN::Params& parameters)
+
+Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(const TrackerDaSiamRPN::Params &)
 {
-    (void)(parameters);
-    CV_Error(cv::Error::StsNotImplemented, "to use DaSiamRPN, the tracking module needs to be built with opencv_dnn !");
+    NOT_IMPL("DaSiamRPN");
 }
+
+Ptr<TrackerDaSiamRPN> TrackerDaSiamRPN::create(cv::DeepNeuralNet &, cv::DeepNeuralNet &, cv::DeepNeuralNet &)
+{
+    NOT_IMPL("DaSiamRPN");
+}
+
 #endif  // OPENCV_HAVE_DNN
 }

--- a/modules/video/src/tracking/tracker_goturn.cpp
+++ b/modules/video/src/tracking/tracker_goturn.cpp
@@ -132,17 +132,30 @@ Ptr<TrackerGOTURN> TrackerGOTURN::create(const TrackerGOTURN::Params& parameters
     return makePtr<TrackerGOTURNImpl>(parameters);
 }
 
-Ptr<TrackerGOTURN> TrackerGOTURN::create(const dnn::Net& model)
+Ptr<TrackerGOTURN> TrackerGOTURN::create(cv::DeepNeuralNet & model)
 {
-    return makePtr<TrackerGOTURNImpl>(model);
+    try
+    {
+        return makePtr<TrackerGOTURNImpl>(dynamic_cast<dnn::Net&>(model));
+    }
+    catch (const std::bad_cast & e)
+    {
+        BAD_INST("GOTURN");
+    }
 }
 
 #else  // OPENCV_HAVE_DNN
-Ptr<TrackerGOTURN> TrackerGOTURN::create(const TrackerGOTURN::Params& parameters)
+
+Ptr<TrackerGOTURN> TrackerGOTURN::create(const TrackerGOTURN::Params&)
 {
-    (void)(parameters);
-    CV_Error(cv::Error::StsNotImplemented, "to use GOTURN, the tracking module needs to be built with opencv_dnn !");
+    NOT_IMPL("GOTURN");
 }
+
+Ptr<TrackerGOTURN> TrackerGOTURN::create(cv::DeepNeuralNet &)
+{
+    NOT_IMPL("GOTURN");
+}
+
 #endif  // OPENCV_HAVE_DNN
 
 }  // namespace cv

--- a/modules/video/src/tracking/tracker_nano.cpp
+++ b/modules/video/src/tracking/tracker_nano.cpp
@@ -355,16 +355,29 @@ Ptr<TrackerNano> TrackerNano::create(const TrackerNano::Params& parameters)
     return makePtr<TrackerNanoImpl>(parameters);
 }
 
-Ptr<TrackerNano> TrackerNano::create(const dnn::Net& backbone, const dnn::Net& neckhead)
+Ptr<TrackerNano> TrackerNano::create(cv::DeepNeuralNet & backbone, cv::DeepNeuralNet & neckhead)
 {
-    return makePtr<TrackerNanoImpl>(backbone, neckhead);
+    try
+    {
+        return makePtr<TrackerNanoImpl>(dynamic_cast<dnn::Net&>(backbone), dynamic_cast<dnn::Net&>(neckhead));
+    }
+    catch (const std::bad_cast & e)
+    {
+        BAD_INST("Nano");
+    }
 }
 
 #else  // OPENCV_HAVE_DNN
-Ptr<TrackerNano> TrackerNano::create(const TrackerNano::Params& parameters)
+
+Ptr<TrackerNano> TrackerNano::create(const TrackerNano::Params&)
 {
-    CV_UNUSED(parameters);
-    CV_Error(cv::Error::StsNotImplemented, "to use NanoTrack, the tracking module needs to be built with opencv_dnn !");
+    NOT_IMPL("Nano");
 }
+
+Ptr<TrackerNano> TrackerNano::create(cv::DeepNeuralNet &, cv::DeepNeuralNet &)
+{
+    NOT_IMPL("Nano");
+}
+
 #endif  // OPENCV_HAVE_DNN
 }

--- a/modules/video/src/tracking/tracker_vit.cpp
+++ b/modules/video/src/tracking/tracker_vit.cpp
@@ -223,16 +223,29 @@ Ptr<TrackerVit> TrackerVit::create(const TrackerVit::Params& parameters)
     return makePtr<TrackerVitImpl>(parameters);
 }
 
-Ptr<TrackerVit> TrackerVit::create(const dnn::Net& model, Scalar meanvalue, Scalar stdvalue, float tracking_score_threshold)
+Ptr<TrackerVit> TrackerVit::create(cv::DeepNeuralNet & model, Scalar meanvalue, Scalar stdvalue, float tracking_score_threshold)
 {
-    return makePtr<TrackerVitImpl>(model, meanvalue, stdvalue, tracking_score_threshold);
+    try
+    {
+        return makePtr<TrackerVitImpl>(dynamic_cast<dnn::Net&>(model), meanvalue, stdvalue, tracking_score_threshold);
+    }
+    catch (const std::bad_cast & e)
+    {
+        BAD_INST("Vit");
+    }
 }
 
 #else  // OPENCV_HAVE_DNN
-Ptr<TrackerVit> TrackerVit::create(const TrackerVit::Params& parameters)
+
+Ptr<TrackerVit> TrackerVit::create(const TrackerVit::Params&)
 {
-    CV_UNUSED(parameters);
-    CV_Error(Error::StsNotImplemented, "to use vittrack, the tracking module needs to be built with opencv_dnn !");
+    NOT_IMPL("Vit");
 }
+
+Ptr<TrackerVit> TrackerVit::create(cv::DeepNeuralNet &, Scalar, Scalar, float)
+{
+    NOT_IMPL("Vit");
+}
+
 #endif  // OPENCV_HAVE_DNN
 }


### PR DESCRIPTION
Related PR #26875

Trying to break interface dependency on _dnn_ module.
Fixes python/java build without dnn module: `-DBUILD_opencv_dnn=OFF`

**Concerns**: additional usage of exceptions and RTTI