### PR TITLE
replace tostring() with tobytes()

### DIFF
--- a/modules/ml/misc/python/test/test_goodfeatures.py
+++ b/modules/ml/misc/python/test/test_goodfeatures.py
@@ -17,7 +17,7 @@ class TestGoodFeaturesToTrack_test(NewOpenCVTests):
 
         results = dict([(t, cv.goodFeaturesToTrack(arr, numPoints, t, 2, useHarrisDetector=True)) for t in threshes])
         # Check that GoodFeaturesToTrack has not modified input image
-        self.assertTrue(arr.tostring() == original.tostring())
+        self.assertTrue(arr.tobytes() == original.tobytes())
         # Check for repeatability
         for i in range(1):
             results2 = dict([(t, cv.goodFeaturesToTrack(arr, numPoints, t, 2, useHarrisDetector=True)) for t in threshes])

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -58,7 +58,7 @@ class NewOpenCVTests(unittest.TestCase):
 
     def hashimg(self, im):
         """ Compute a hash for an image, useful for image comparisons """
-        return hashlib.md5(im.tostring()).hexdigest()
+        return hashlib.md5(im.tobytes()).hexdigest()
 
     if sys.version_info[:2] == (2, 6):
         def assertLess(self, a, b, msg=None):


### PR DESCRIPTION
Fixes : 

```
test_goodFeaturesToTrack (test_goodfeatures.TestGoodFeaturesToTrack_test) ... /Users/opencv-cn/GHA-0CV-
2/_work/opencv/opencv/opencv/modules/ml/misc/python/test/test_goodfeatures.py:20: DeprecationWarning: tostring() is deprecated.
Use
tobytes() instead.
self.assertTrue(arr.tostring() == original.tostring())

```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
