### PR TITLE
hide internal Impl classes to prevent symbol export

### DIFF
--- a/modules/core/include/opencv2/core/async.hpp
+++ b/modules/core/include/opencv2/core/async.hpp
@@ -89,7 +89,7 @@ public:
 
 
     // PImpl
-    struct Impl; friend struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl; friend struct Impl;
     inline void* _getImpl() const CV_NOEXCEPT { return p; }
 protected:
     Impl* p;

--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -247,7 +247,7 @@ public:
       */
     static Device fromHandle(void* d);
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return (Impl*)p; }
     inline bool empty() const { return !p; }
 protected:
@@ -322,7 +322,7 @@ public:
     void setUserContext(std::type_index typeId, const std::shared_ptr<UserContext>& userContext);
     std::shared_ptr<UserContext> getUserContext(std::type_index typeId);
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return (Impl*)p; }
     inline bool empty() const { return !p; }
 // TODO OpenCV 5.0
@@ -346,7 +346,7 @@ public:
     /** @deprecated */
     static Platform& getDefault();
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return (Impl*)p; }
     inline bool empty() const { return !p; }
 protected:
@@ -411,7 +411,7 @@ public:
     /// @brief Returns OpenCL command queue with enable profiling mode support
     const Queue& getProfilingQueue() const;
 
-    struct Impl; friend struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl; friend struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return p; }
     inline bool empty() const { return !p; }
 protected:
@@ -545,7 +545,7 @@ public:
     size_t localMemSize() const;
 
     void* ptr() const;
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
 
 protected:
     Impl* p;
@@ -579,7 +579,7 @@ public:
      */
     void getBinary(std::vector<char>& binary) const;
 
-    struct Impl; friend struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl; friend struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return (Impl*)p; }
     inline bool empty() const { return !p; }
 protected:
@@ -663,7 +663,7 @@ public:
     //        const unsigned char* binary, const size_t size,
     //        const cv::String& buildOptions = cv::String());
 
-    struct Impl; friend struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl; friend struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return (Impl*)p; }
     inline bool empty() const { return !p; }
 protected:
@@ -696,7 +696,7 @@ public:
     int deviceNumber() const;
     void getDevice(Device& device, int d) const;
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     bool empty() const { return !p; }
 protected:
     Impl* p;
@@ -772,7 +772,7 @@ public:
 
     void* ptr() const;
 protected:
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     Impl* p;
 };
 
@@ -787,7 +787,7 @@ public:
     uint64 durationNS() const; ///< duration in nanoseconds
 
 protected:
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     Impl* const p;
 
 private:
@@ -875,7 +875,7 @@ public:
     /** @overload */
     static OpenCLExecutionContext create(const Context& context, const Device& device);
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     inline bool empty() const { return !p; }
     void release();
 protected:

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -1029,7 +1029,7 @@ protected:
     void getByName(const String& name, bool space_delete, Param type, void* dst) const;
     void getByIndex(int index, bool space_delete, Param type, void* dst) const;
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     Impl* impl;
 };
 

--- a/modules/core/include/opencv2/core/utils/filesystem.private.hpp
+++ b/modules/core/include/opencv2/core/utils/filesystem.private.hpp
@@ -53,7 +53,7 @@ public:
     void lock_shared(); ///< acquire shareable (reader) lock
     void unlock_shared(); ///< release shareable (reader) lock
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
 protected:
     Impl* pImpl;
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -885,7 +885,7 @@ CV__DNN_INLINE_NS_BEGIN
         CV_WRAP int64 getPerfProfile(CV_OUT std::vector<double>& timings);
 
 
-        struct Impl;
+        struct __attribute__((visibility("hidden"))) Impl;
         inline Impl* getImpl() const { return impl.get(); }
         inline Impl& getImplRef() const { CV_DbgAssert(impl); return *impl.get(); }
         friend class accessor::DnnNetAccessor;
@@ -1496,7 +1496,7 @@ CV__DNN_INLINE_NS_BEGIN
          Net& getNetwork_() const;
          inline Net& getNetwork_() { return const_cast<const Model*>(this)->getNetwork_(); }
 
-         struct Impl;
+         struct __attribute__((visibility("hidden"))) Impl;
          inline Impl* getImpl() const { return impl.get(); }
          inline Impl& getImplRef() const { CV_DbgAssert(impl); return *impl.get(); }
      protected:

--- a/modules/imgproc/include/opencv2/imgproc/segmentation.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/segmentation.hpp
@@ -126,7 +126,7 @@ public:
     CV_WRAP void getContour(const Point& targetPt, OutputArray contour, bool backward = false) const;
 
 #ifndef CV_DOXYGEN
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
     inline Impl* getImpl() const { return impl.get(); }
 protected:
     std::shared_ptr<Impl> impl;

--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -93,7 +93,7 @@ public:
     CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     Board();
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
 protected:
     Board(const Ptr<Impl>& impl);
     Ptr<Impl> impl;

--- a/modules/objdetect/include/opencv2/objdetect/graphical_code_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/graphical_code_detector.hpp
@@ -73,7 +73,7 @@ public:
     */
     CV_WRAP bool detectAndDecodeMulti(InputArray img, CV_OUT std::vector<std::string>& decoded_info, OutputArray points = noArray(),
                                       OutputArrayOfArrays straight_code = noArray()) const;
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
 protected:
     Ptr<Impl> p;
 };

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -771,7 +771,7 @@ public:
     bool trylock();
     void unlock();
 
-    struct Impl;
+    struct __attribute__((visibility("hidden"))) Impl;
 protected:
     Impl* impl;
 


### PR DESCRIPTION
Fixes : #26935

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
