### PR TITLE
Fix `yoloPostProcessing` to return correct NMS output

### DIFF
--- a/samples/dnn/yolo_detector.cpp
+++ b/samples/dnn/yolo_detector.cpp
@@ -174,7 +174,7 @@ void yoloPostProcessing(
                 boxes.push_back(Rect2d(cx, cy, w, h));
             } else {
                 boxes.push_back(Rect2d(cx - 0.5 * w, cy - 0.5 * h,
-                                        cx + 0.5 * w, cy + 0.5 * h));
+                                        w, h));
             }
             classIds.push_back(maxLoc.x);
             confidences.push_back(static_cast<float>(conf));


### PR DESCRIPTION
The boxes coordinates should be in the `xywh` format rather than `xyxy`. 