### PR TITLE
videoio: print test params instead of indexes

### DIFF
--- a/.github/workflows/PR-4.x.yaml
+++ b/.github/workflows/PR-4.x.yaml
@@ -8,49 +8,49 @@ on:
 jobs:
 
   Linux:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@fix-videoio-filters
     with:
-      workflow_branch: main
+      workflow_branch: fix-videoio-filters
 
   Ubuntu2004-ARM64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64.yaml@fix-videoio-filters
 
   Ubuntu2004-ARM64-Debug:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml@fix-videoio-filters
 
   Ubuntu2004-x64-OpenVINO:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml@fix-videoio-filters
 
   Ubuntu2004-x64-CUDA:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'category: dnn') }} || ${{ contains(github.event.pull_request.labels.*.name, 'category: dnn (onnx)') }}"
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@fix-videoio-filters
 
   Windows10-x64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10.yaml@fix-videoio-filters
 
   Windows10-x64-Vulkan:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml@fix-videoio-filters
 
   macOS-ARM64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml@fix-videoio-filters
 
   macOS-x64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml@fix-videoio-filters
 
   macOS-ARM64-Vulkan:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml@fix-videoio-filters
 
   iOS:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-iOS.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-iOS.yaml@fix-videoio-filters
 
   Android-SDK:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-4.x-Android-SDK.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-4.x-Android-SDK.yaml@fix-videoio-filters
 
   TIM-VX:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-timvx-backend-tests-4.x.yml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-timvx-backend-tests-4.x.yml@fix-videoio-filters
 
   docs:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-docs.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-docs.yaml@fix-videoio-filters
 
   Linux-RISC-V-Clang:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-RISCV.yaml@main
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-RISCV.yaml@fix-videoio-filters

--- a/.github/workflows/PR-4.x.yaml
+++ b/.github/workflows/PR-4.x.yaml
@@ -8,49 +8,49 @@ on:
 jobs:
 
   Linux:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@main
     with:
-      workflow_branch: fix-videoio-filters
+      workflow_branch: main
 
   Ubuntu2004-ARM64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64.yaml@main
 
   Ubuntu2004-ARM64-Debug:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml@main
 
   Ubuntu2004-x64-OpenVINO:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml@main
 
   Ubuntu2004-x64-CUDA:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'category: dnn') }} || ${{ contains(github.event.pull_request.labels.*.name, 'category: dnn (onnx)') }}"
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@main
 
   Windows10-x64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10.yaml@main
 
   Windows10-x64-Vulkan:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml@main
 
   macOS-ARM64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml@main
 
   macOS-x64:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml@main
 
   macOS-ARM64-Vulkan:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml@main
 
   iOS:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-iOS.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-iOS.yaml@main
 
   Android-SDK:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-4.x-Android-SDK.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-4.x-Android-SDK.yaml@main
 
   TIM-VX:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-timvx-backend-tests-4.x.yml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-timvx-backend-tests-4.x.yml@main
 
   docs:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-docs.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-docs.yaml@main
 
   Linux-RISC-V-Clang:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-RISCV.yaml@fix-videoio-filters
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-RISCV.yaml@main

--- a/modules/videoio/test/test_audio.cpp
+++ b/modules/videoio/test/test_audio.cpp
@@ -135,7 +135,16 @@ TEST_P(Audio, audio)
     doTest();
 }
 
-INSTANTIATE_TEST_CASE_P(/**/, Audio, testing::ValuesIn(audioParams));
+inline static std::string Audio_name_printer(const testing::TestParamInfo<Audio::ParamType>& info)
+{
+    std::ostringstream out;
+    out << getExtensionSafe(get<0>(info.param)) << "_"
+        << get<1>(info.param) << "CN" << "_"
+        << getBackendNameSafe(get<4>(info.param));
+    return out.str();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Audio, testing::ValuesIn(audioParams), Audio_name_printer);
 
 class MediaTestFixture : public AudioBaseTest, public testing::TestWithParam <paramCombination>
 {
@@ -283,7 +292,16 @@ const paramCombination mediaParams[] =
 #endif  // _WIN32
 };
 
-INSTANTIATE_TEST_CASE_P(/**/, Media, testing::ValuesIn(mediaParams));
+inline static std::string Media_name_printer(const testing::TestParamInfo<Media::ParamType>& info)
+{
+    std::ostringstream out;
+    out << getExtensionSafe(get<0>(info.param)) << "_"
+        << get<1>(info.param) << "CN" << "_"
+        << getBackendNameSafe(get<10>(info.param));
+    return out.str();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Media, testing::ValuesIn(mediaParams), Media_name_printer);
 
 TEST(AudioOpenCheck, bad_arg_invalid_audio_stream)
 {

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -78,7 +78,16 @@ const FourCC_Ext_Size entries[] =
     make_tuple("FFV1", "mkv", bigSize)
 };
 
-INSTANTIATE_TEST_CASE_P(videoio, videoio_ffmpeg, testing::ValuesIn(entries));
+inline static std::string videoio_ffmpeg_name_printer(const testing::TestParamInfo<videoio_ffmpeg::ParamType>& info)
+{
+    std::ostringstream os;
+    const string & fourcc = get<0>(info.param);
+    const Size sz = get<2>(info.param);
+    os << (fourcc.size() == 0 ? "NONE" : fourcc) << "_" << get<1>(info.param) << "_" << sz.height << "p";
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, videoio_ffmpeg, testing::ValuesIn(entries), videoio_ffmpeg_name_printer);
 
 //==========================================================================
 
@@ -143,9 +152,19 @@ const videoio_read_params_t videoio_read_params[] =
     //videoio_read_params_t("video/big_buck_bunny.wmv", 125, true),
 };
 
+inline static std::string videoio_read_name_printer(const testing::TestParamInfo<videoio_read::ParamType>& info)
+{
+    std::ostringstream out;
+    out << getExtensionSafe(get<0>(get<0>(info.param))) << "_"
+        << get<1>(info.param) << "_"
+        << (get<2>(info.param) ? "RAW" : "ENC");
+    return out.str();
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, videoio_read, testing::Combine(testing::ValuesIn(videoio_read_params),
                                                              testing::Values(0, 1, 2, 50),
-                                                             testing::Values(true, false)));
+                                                             testing::Values(true, false)),
+                        videoio_read_name_printer);
 
 //==========================================================================
 
@@ -720,7 +739,15 @@ const ffmpeg_get_fourcc_param_t ffmpeg_get_fourcc_param[] =
     ffmpeg_get_fourcc_param_t("video/sample_322x242_15frames.yuv420p.libx264.mp4", "h264")
 };
 
-INSTANTIATE_TEST_CASE_P(videoio, ffmpeg_get_fourcc, testing::ValuesIn(ffmpeg_get_fourcc_param));
+inline static std::string ffmpeg_get_fourcc_name_printer(const testing::TestParamInfo<ffmpeg_get_fourcc::ParamType>& info)
+{
+    std::ostringstream os;
+    const string & fourcc = get<1>(info.param);
+    os << info.index << "_" << (fourcc.size() == 0 ? "NONE" : fourcc);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, ffmpeg_get_fourcc, testing::ValuesIn(ffmpeg_get_fourcc_param), ffmpeg_get_fourcc_name_printer);
 
 static void ffmpeg_check_read_raw(VideoCapture& cap)
 {
@@ -914,6 +941,16 @@ const FourCC_Ext_Color_Support sixteen_bit_modes[] =
 
 };
 
-INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_16bit, testing::ValuesIn(sixteen_bit_modes));
+inline static std::string videoio_ffmpeg_16bit_name_printer(const testing::TestParamInfo<videoio_ffmpeg_16bit::ParamType>& info)
+{
+    std::ostringstream os;
+    os << get<0>(info.param) << "_"
+        << get<1>(info.param) << "_"
+        << (get<2>(info.param) ? "COLOR" : "GRAY") << "_"
+        << (get<3>(info.param) ? "SUP" : "NOT");
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_16bit, testing::ValuesIn(sixteen_bit_modes), videoio_ffmpeg_16bit_name_printer);
 
 }} // namespace

--- a/modules/videoio/test/test_gstreamer.cpp
+++ b/modules/videoio/test/test_gstreamer.cpp
@@ -218,7 +218,14 @@ static const string bunny_params[] = {
     string("mjpg.avi")
 };
 
-INSTANTIATE_TEST_CASE_P(videoio, gstreamer_bunny, testing::ValuesIn(bunny_params));
+inline static std::string gstreamer_bunny_name_printer(const testing::TestParamInfo<gstreamer_bunny::ParamType>& info)
+{
+    std::ostringstream out;
+    out << extToStringSafe(info.param);
+    return out.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, gstreamer_bunny, testing::ValuesIn(bunny_params), gstreamer_bunny_name_printer);
 
 
 }} // namespace

--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -160,8 +160,9 @@ inline static std::string videoio_mfx_name_printer(const testing::TestParamInfo<
 {
     std::ostringstream out;
     const Size sz = get<0>(info.param);
-    const std::string ext = get<2>(info.param);
-    out << sz.width << "x" << sz.height << "x" << get<1>(info.param) << "x" << ext.substr(1, ext.size() - 1);
+    out << sz.height << "p" << "_"
+        << get<1>(info.param) << "FPS" << "_"
+        << extToStringSafe(get<2>(info.param));
     return out.str();
 }
 

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -80,7 +80,14 @@ static cv::VideoCaptureAPIs supported_backends[] = {
     CAP_FFMPEG
 };
 
-INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::ValuesIn(supported_backends));
+inline static std::string VideoCaptureAPITests_name_printer(const testing::TestParamInfo<VideoCaptureAPITests::ParamType>& info)
+{
+    std::ostringstream out;
+    out << getBackendNameSafe(info.param);
+    return out.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::ValuesIn(supported_backends), VideoCaptureAPITests_name_printer);
 
 #endif // WIN32
 

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -63,7 +63,8 @@ inline std::string fourccToStringSafe(int fourcc)
 {
     std::string res = fourccToString(fourcc);
     // TODO: return hex values for invalid characters
-    std::transform(res.begin(), res.end(), res.begin(), [](char c) -> char { return (c >= '0' && c <= 'z') ? c : (c == ' ' ? '_' : 'x'); });
+    std::transform(res.begin(), res.end(), res.begin(),
+        [](char c) -> char { return (c >= '0' && c <= 'z') ? c : (c == ' ' ? '_' : 'x'); });
     return res;
 }
 
@@ -71,6 +72,37 @@ inline int fourccFromString(const std::string &fourcc)
 {
     if (fourcc.size() != 4) return 0;
     return cv::VideoWriter::fourcc(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
+}
+
+inline std::string extToStringSafe(const std::string & ext)
+{
+    std::string res;
+    const bool start_with_dot = (ext.size() > 0) && (ext[0] == '.');
+    std::transform(start_with_dot ? ext.begin() + 1 : ext.begin(), ext.end(), std::back_inserter(res),
+        [](char c) -> char { return (c >= '0' && c <= 'z') ? c : ((c == ' ' || c == '.') ? '_' : 'x'); });
+    return res;
+}
+
+inline std::string getExtensionSafe(const std::string & fname)
+{
+    std::string fext(std::find(fname.begin(), fname.end(), '.'), fname.end());
+    if (fext.size() == 0)
+        return std::string("NOEXT");
+    else
+        return extToStringSafe(fext);
+}
+
+inline std::string getBackendNameSafe(const cv::VideoCaptureAPIs & api)
+{
+    const std::string res = cv::videoio_registry::getBackendName(api);
+    if (res.substr(0, 7) == "Unknown")
+    {
+        std::ostringstream os; os << "BACKEND_" << (size_t)api; return os.str();
+    }
+    else
+    {
+        return res;
+    }
 }
 
 inline void generateFrame(int i, int FRAME_COUNT, cv::Mat & frame)

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -383,10 +383,20 @@ TEST_P(videoio_bunny, frame_count) { doFrameCountTest(); }
 
 TEST_P(videoio_bunny, frame_timestamp) { doTimestampTest(); }
 
+inline static std::string videoio_bunny_name_printer(const testing::TestParamInfo<videoio_bunny::ParamType>& info)
+{
+    std::ostringstream os;
+    os << extToStringSafe(get<0>(info.param)) << "_"
+        << getBackendNameSafe(get<1>(info.param));
+    return os.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, videoio_bunny,
                           testing::Combine(
                               testing::ValuesIn(bunny_params),
-                              testing::ValuesIn(backend_params)));
+                              testing::ValuesIn(backend_params)),
+                          videoio_bunny_name_printer);
+
 
 
 inline static std::ostream &operator<<(std::ostream &out, const Ext_Fourcc_PSNR &p)
@@ -446,10 +456,23 @@ Size all_sizes[] = {
 
 TEST_P(videoio_synthetic, write_read_position) { doTest(); }
 
+inline static std::string videoio_synthetic_name_printer(const testing::TestParamInfo<videoio_synthetic::ParamType>& info)
+{
+    std::ostringstream os;
+    const Size sz = get<0>(info.param);
+    const Ext_Fourcc_PSNR & param = get<1>(info.param);
+    os << sz.height << "p" << "_"
+        << param.ext << "_"
+        << param.fourcc << "_"
+        << getBackendNameSafe(param.api);
+    return os.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, videoio_synthetic,
                         testing::Combine(
                             testing::ValuesIn(all_sizes),
-                            testing::ValuesIn(synthetic_params)));
+                            testing::ValuesIn(synthetic_params)),
+                        videoio_synthetic_name_printer);
 
 struct Ext_Fourcc_API
 {
@@ -531,7 +554,19 @@ static vector<Ext_Fourcc_API> generate_Ext_Fourcc_API()
     return result;
 }
 
-INSTANTIATE_TEST_CASE_P(videoio, Videoio_Writer, testing::ValuesIn(generate_Ext_Fourcc_API()));
+inline static std::string Videoio_Writer_name_printer(const testing::TestParamInfo<Videoio_Writer::ParamType>& info)
+{
+    std::ostringstream os;
+    std::string ext(info.param.ext);
+    if (info.param.api == CAP_GSTREAMER && info.param.fourcc[0] == '\0') // gstreamer pipeline instead of extension
+        os << getExtensionSafe(info.param.ext) << "_" << "NONE";
+    else
+        os << info.param.ext << "_" << info.param.fourcc;
+    os << "_" << getBackendNameSafe(info.param.api);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, Videoio_Writer, testing::ValuesIn(generate_Ext_Fourcc_API()), Videoio_Writer_name_printer);
 
 
 TEST(Videoio, exceptions)
@@ -610,7 +645,7 @@ static vector<Ext_Fourcc_API> generate_Ext_Fourcc_API_nocrash()
     return result;
 }
 
-INSTANTIATE_TEST_CASE_P(videoio, Videoio_Writer_bad_fourcc, testing::ValuesIn(generate_Ext_Fourcc_API_nocrash()));
+INSTANTIATE_TEST_CASE_P(videoio, Videoio_Writer_bad_fourcc, testing::ValuesIn(generate_Ext_Fourcc_API_nocrash()), Videoio_Writer_name_printer);
 
 typedef testing::TestWithParam<VideoCaptureAPIs> safe_capture;
 
@@ -643,7 +678,15 @@ TEST_P(safe_capture, frames_independency)
 }
 
 static VideoCaptureAPIs safe_apis[] = {CAP_FFMPEG, CAP_GSTREAMER, CAP_MSMF,CAP_AVFOUNDATION};
-INSTANTIATE_TEST_CASE_P(videoio, safe_capture, testing::ValuesIn(safe_apis));
+
+inline static std::string safe_capture_name_printer(const testing::TestParamInfo<safe_capture::ParamType>& info)
+{
+    std::ostringstream os;
+    os << getBackendNameSafe(info.param);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, safe_capture, testing::ValuesIn(safe_apis), safe_capture_name_printer);
 
 //==================================================================================================
 // TEST_P(videocapture_acceleration, ...)
@@ -836,12 +879,22 @@ static bool hw_use_umat[] = {
         true
 };
 
+inline static std::string videocapture_acceleration_name_printer(const testing::TestParamInfo<videocapture_acceleration::ParamType>& info)
+{
+    std::ostringstream os;
+    os << getExtensionSafe(get<0>(info.param).filename) << "_"
+        << getBackendNameSafe(get<1>(info.param)) << "_"
+        << get<2>(info.param) << "_"
+        << (get<3>(info.param) ? "UMAT" : "MAT");
+    return os.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, videocapture_acceleration, testing::Combine(
     testing::ValuesIn(hw_filename),
     testing::ValuesIn(hw_backends),
     testing::ValuesIn(hw_types),
     testing::ValuesIn(hw_use_umat)
-));
+), videocapture_acceleration_name_printer);
 
 ////////////////////////////////////////// TEST_P(video_acceleration, write_read)
 
@@ -1019,11 +1072,23 @@ static Ext_Fourcc_PSNR hw_codecs[] = {
 #endif
 };
 
+inline static std::string videowriter_acceleration_name_printer(const testing::TestParamInfo<videowriter_acceleration::ParamType>& info)
+{
+    std::ostringstream os;
+    const Ext_Fourcc_PSNR & param = get<0>(info.param);
+    os << extToStringSafe(param.ext) << "_"
+        << param.fourcc << "_"
+        << getBackendNameSafe(param.api) << "_"
+        << get<1>(info.param) << "_"
+        << (get<2>(info.param) ? "UMAT" : "MAT");
+    return os.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, videowriter_acceleration, testing::Combine(
         testing::ValuesIn(hw_codecs),
         testing::ValuesIn(hw_types),
         testing::ValuesIn(hw_use_umat)
-));
+), videowriter_acceleration_name_printer);
 
 class BufferStream : public cv::IStreamReader
 {
@@ -1094,10 +1159,20 @@ TEST_P(stream_capture, read)
     for(int i = 0; i < numFrames; i++)
         EXPECT_EQ(0, cv::norm(frames[i], hardCopies[i], NORM_INF)) << i;
 }
+
+inline static std::string stream_capture_name_printer(const testing::TestParamInfo<stream_capture::ParamType>& info)
+{
+    std::ostringstream os;
+    os << extToStringSafe(get<0>(info.param)) << "_"
+        << getBackendNameSafe(get<1>(info.param));
+    return os.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, stream_capture,
                           testing::Combine(
                               testing::ValuesIn(bunny_params),
-                              testing::ValuesIn(backend_params)));
+                              testing::ValuesIn(backend_params)),
+                          stream_capture_name_printer);
 
 // This test for stream input for container format (See test_ffmpeg/videoio_container.read test)
 typedef testing::TestWithParam<std::string> stream_capture_ffmpeg;
@@ -1152,6 +1227,14 @@ TEST_P(stream_capture_ffmpeg, raw)
         EXPECT_EQ(0, cv::norm(frame, frameRef, NORM_INF)) << i;
     }
 }
-INSTANTIATE_TEST_CASE_P(videoio, stream_capture_ffmpeg, testing::Values("h264", "h265", "mjpg.avi"));
+
+inline static std::string stream_capture_ffmpeg_name_printer(const testing::TestParamInfo<stream_capture_ffmpeg::ParamType>& info)
+{
+    std::ostringstream os;
+    os << extToStringSafe(info.param);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, stream_capture_ffmpeg, testing::Values("h264", "h265", "mjpg.avi"), stream_capture_ffmpeg_name_printer);
 
 } // namespace


### PR DESCRIPTION
_videoio_ test names changed - use string instead of index.
E.g. `videoio_read.threads/0` is now `videoio_read.threads/h264_0_RAW`.
It allows to filter tests independently of the platform.

**Notes:**
- not all tests has been updated - only simpler ones and those which have varying parameters depending on platform