### PR TITLE
replace deprecated np.fromstring() by np.frombuffer()

### DIFF
--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -49,7 +49,7 @@ class NewOpenCVTests(unittest.TestCase):
             filepath = self.find_file(filename)
             with open(filepath, 'rb') as f:
                 filedata = f.read()
-            self.image_cache[filename] = cv.imdecode(np.fromstring(filedata, dtype=np.uint8), iscolor)
+            self.image_cache[filename] = cv.imdecode(np.frombuffer(filedata, dtype=np.uint8), iscolor)
         return self.image_cache[filename]
 
     def setUp(self):


### PR DESCRIPTION
Source : https://numpy.org/devdocs/reference/generated/numpy.fromstring.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
