### PR TITLE
Call contructor instead of operator overload for CHullCmpPoints

### DIFF
--- a/modules/imgproc/src/convhull.cpp
+++ b/modules/imgproc/src/convhull.cpp
@@ -167,7 +167,7 @@ void convexHull( InputArray _points, OutputArray _hull, bool clockwise, bool ret
     // sort the point set by x-coordinate, find min and max y
     if( !is_float )
     {
-        std::sort(pointer, pointer + total, CHullCmpPoints<int>());
+        std::sort(pointer, pointer + total, CHullCmpPoints<int>{});
         for( i = 1; i < total; i++ )
         {
             int y = pointer[i]->y;
@@ -179,7 +179,7 @@ void convexHull( InputArray _points, OutputArray _hull, bool clockwise, bool ret
     }
     else
     {
-        std::sort(pointerf, pointerf + total, CHullCmpPoints<float>());
+        std::sort(pointerf, pointerf + total, CHullCmpPoints<float>{});
         for( i = 1; i < total; i++ )
         {
             float y = pointerf[i]->y;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See  #26950

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
