### PR TITLE
Optimization for cv::hal::warpAffine for 8U

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -29,6 +29,7 @@
 #include "hal_rvv_1p0/atan.hpp" // core
 #include "hal_rvv_1p0/split.hpp" // core
 #include "hal_rvv_1p0/flip.hpp" // core
+#include "hal_rvv_1p0/warpAffine.hpp" // imgproc
 #endif
 
 #endif

--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -30,6 +30,7 @@
 #include "hal_rvv_1p0/split.hpp" // core
 #include "hal_rvv_1p0/flip.hpp" // core
 #include "hal_rvv_1p0/warpAffine.hpp" // imgproc
+#include "hal_rvv_1p0/flip.hpp" // core
 #endif
 
 #endif

--- a/3rdparty/hal_rvv/hal_rvv_1p0/warpAffine.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/warpAffine.hpp
@@ -1,0 +1,87 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef OPENCV_HAL_RVV_WARPAFFINE_HPP_INCLUDED
+#define OPENCV_HAL_RVV_WARPAFFINE_HPP_INCLUDED
+
+#include <riscv_vector.h>
+namespace cv { namespace cv_hal_rvv {
+#define INTER_BITS 5
+#define INTER_TAB_SIZE (1 << INTER_BITS)
+
+#undef cv_hal_warpAffine
+#define cv_hal_warpAffine cv::cv_hal_rvv::warpAffine
+#undef cv_hal_warpAffineBlocklineNN
+#define cv_hal_warpAffineBlocklineNN cv::cv_hal_rvv::warpAffineBlocklineNN
+#undef cv_hal_warpAffineBlockline
+#define cv_hal_warpAffineBlockline cv::cv_hal_rvv::warpAffineBlockline
+
+static int warpAffine(int src_type,
+                const uchar * src_data, size_t src_step, int src_width, int src_height,
+                uchar * dst_data, size_t dst_step, int dst_width, int dst_height,
+                const double M[6], int interpolation, int borderType, const double borderValue[4]) {
+    return CV_HAL_ERROR_NOT_IMPLEMENTED;
+}   
+
+static int warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, int bw) {
+    constexpr int AB_BITS = MAX(10, static_cast<int>(INTER_BITS));
+    int vl, x1 = 0;
+    for (; x1 < bw; x1 += vl) {
+        // set vl
+        vl = __riscv_vsetvl_e32m8(bw - x1);
+        // load i32 for adelta
+        auto v_adelta = __riscv_vle32_v_i32m8(adelta + x1, vl);
+        auto v_bdelta = __riscv_vle32_v_i32m8(bdelta + x1, vl);
+        // add i32
+        v_adelta = __riscv_vadd_vx_i32m8(v_adelta, X0, vl);
+        v_bdelta = __riscv_vadd_vx_i32m8(v_bdelta, Y0, vl);
+        // shr i32
+        v_adelta = __riscv_vsra_vx_i32m8(v_adelta, AB_BITS, vl);
+        v_bdelta = __riscv_vsra_vx_i32m8(v_bdelta, AB_BITS, vl);
+        // compact to i16
+        auto v_adelta_i16 = __riscv_vnclip_wx_i16m4(v_adelta, 0, 0, vl);
+        auto v_bdelta_i16 = __riscv_vnclip_wx_i16m4(v_bdelta, 0, 0, vl);
+        // store ans i16 
+        __riscv_vsse16_v_i16m4(xy + x1*2, sizeof(short)*2, v_adelta_i16, vl);
+        __riscv_vsse16_v_i16m4(xy + x1*2 + 1, sizeof(short)*2, v_bdelta_i16, vl);
+    }
+    return CV_HAL_ERROR_OK;
+}
+
+static int warpAffineBlockline(int *adelta, int *bdelta, short* xy, short* alpha, int X0, int Y0, int bw) {
+    const int AB_BITS = MAX(10, (int)INTER_BITS);
+    int vl, x1 = 0;
+    for (; x1 < bw; x1 += vl) {
+        // set vl
+        vl = __riscv_vsetvl_e32m8(bw - x1);
+        // load i32 for adelta
+        auto v_adelta = __riscv_vle32_v_i32m8(adelta + x1, vl);
+        auto v_bdelta = __riscv_vle32_v_i32m8(bdelta + x1, vl);
+        // add i32
+        v_adelta = __riscv_vadd_vx_i32m8(v_adelta, X0, vl);
+        v_bdelta = __riscv_vadd_vx_i32m8(v_bdelta, Y0, vl);
+        // shr i32
+        v_adelta = __riscv_vsra_vx_i32m8(v_adelta, AB_BITS - INTER_BITS, vl);
+        v_bdelta = __riscv_vsra_vx_i32m8(v_bdelta, AB_BITS - INTER_BITS, vl);
+        // compact to i16
+        auto v_adelta_i16 = __riscv_vnclip_wx_i16m4(__riscv_vsra_vx_i32m8(v_adelta, INTER_BITS, vl), 0, 0, vl);
+        auto v_bdelta_i16 = __riscv_vnclip_wx_i16m4(__riscv_vsra_vx_i32m8(v_bdelta, INTER_BITS, vl), 0, 0, vl);
+        // store ans i16 
+        __riscv_vsse16_v_i16m4(xy + x1*2, sizeof(short)*2, v_adelta_i16, vl);
+        __riscv_vsse16_v_i16m4(xy + x1*2 + 1, sizeof(short)*2, v_bdelta_i16, vl);
+        
+        // alpha
+        int mask = INTER_TAB_SIZE - 1;
+        v_adelta = __riscv_vand_vx_i32m8(v_adelta, mask, vl);
+        v_bdelta = __riscv_vand_vx_i32m8(v_bdelta, mask, vl);
+        v_bdelta = __riscv_vsll_vx_i32m8(v_bdelta, INTER_BITS, vl);
+        auto v_alpha = __riscv_vor_vv_i32m8(v_adelta, v_bdelta, vl);
+        auto v_alpha_i16 = __riscv_vnclip_wx_i16m4(v_alpha, 0, 0, vl);
+        __riscv_vsse16_v_i16m4(alpha + x1, sizeof(short), v_alpha_i16, vl);
+    }
+    return CV_HAL_ERROR_OK;
+}
+} // cv_hal_rvv::
+} // cv::
+
+#endif

--- a/3rdparty/hal_rvv/hal_rvv_1p0/warpAffine.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/warpAffine.hpp
@@ -9,19 +9,10 @@ namespace cv { namespace cv_hal_rvv {
 #define INTER_BITS 5
 #define INTER_TAB_SIZE (1 << INTER_BITS)
 
-#undef cv_hal_warpAffine
-#define cv_hal_warpAffine cv::cv_hal_rvv::warpAffine
 #undef cv_hal_warpAffineBlocklineNN
 #define cv_hal_warpAffineBlocklineNN cv::cv_hal_rvv::warpAffineBlocklineNN
 #undef cv_hal_warpAffineBlockline
 #define cv_hal_warpAffineBlockline cv::cv_hal_rvv::warpAffineBlockline
-
-static int warpAffine(int src_type,
-                const uchar * src_data, size_t src_step, int src_width, int src_height,
-                uchar * dst_data, size_t dst_step, int dst_width, int dst_height,
-                const double M[6], int interpolation, int borderType, const double borderValue[4]) {
-    return CV_HAL_ERROR_NOT_IMPLEMENTED;
-}   
 
 static int warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, int bw) {
     constexpr int AB_BITS = MAX(10, static_cast<int>(INTER_BITS));


### PR DESCRIPTION
### Pull Request Readiness Checklist

* Lichee Pi 3A (SpacemiT K1) RISC-V
* Compiler: riscv64-unknown-linux-gnu-g++ (g04696df09) 14.2.0

baseline (Origin):  On opencv branch 4.x, just delete the line "#include "hal_rvv_1p0/warpAffine.hpp" // imgproc" in file hal_rvv.hpp. And cmake command like this: " cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=../platforms/linux/riscv64-gcc.toolchain.cmake -DBUILD_EXAMPLES=OFF -DWITH_OPENCL=OFF  -DTOOLCHAIN_COMPILER_LOCATION_HINT=/opt/riscv/bin -DENABLE_RVV=ON -DWITH_HAL_RVV=ON -DBUILD_SHARED_LIBS=OFF -DOPENCV_EXTRA_CXX_FLAGS="-static -static-libgcc -static-libstdc++" -DOPENCV_EXTRA_C_FLAGS="-static -static-libgcc -static-libstdc++" -DCMAKE_BUILD_TYPE=Debug "

```
Geometric mean (ms)
                             Name of Test                                  Origin result    result  
                                                                                                 vs    
                                                                                             newOrigin 
                                                                                             (x-factor)
WarpAffine::TestWarpAffine::(8UC1, 640x480, INTER_LINEAR, BORDER_CONSTANT) 15.561 12.044 1.29
WarpAffine::TestWarpAffine::(8UC1, 640x480, INTER_LINEAR, BORDER_REPLICATE) 15.240 11.975 1.27
WarpAffine::TestWarpAffine::(8UC1, 640x480, INTER_NEAREST, BORDER_CONSTANT) 8.905 3.359 2.65
WarpAffine::TestWarpAffine::(8UC1, 640x480, INTER_NEAREST, BORDER_REPLICATE) 7.491 3.392 2.21
WarpAffine::TestWarpAffine::(8UC1, 1280x720, INTER_LINEAR, BORDER_CONSTANT) 43.256 22.508 1.92
WarpAffine::TestWarpAffine::(8UC1, 1280x720, INTER_LINEAR, BORDER_REPLICATE) 44.054 30.321 1.45
WarpAffine::TestWarpAffine::(8UC1, 1280x720, INTER_NEAREST, BORDER_CONSTANT) 16.535 7.270 2.27
WarpAffine::TestWarpAffine::(8UC1, 1280x720, INTER_NEAREST, BORDER_REPLICATE) 32.019 9.538 3.36
WarpAffine::TestWarpAffine::(8UC1, 1920x1080, INTER_LINEAR, BORDER_CONSTANT) 79.254 37.014 2.14
WarpAffine::TestWarpAffine::(8UC1, 1920x1080, INTER_LINEAR, BORDER_REPLICATE) 111.197 66.404 1.67
WarpAffine::TestWarpAffine::(8UC1, 1920x1080, INTER_NEAREST, BORDER_CONSTANT) 50.795 14.014 3.62
WarpAffine::TestWarpAffine::(8UC1, 1920x1080, INTER_NEAREST, BORDER_REPLICATE) 52.617 21.866 2.41
WarpAffine::TestWarpAffine::(8UC4, 640x480, INTER_LINEAR, BORDER_CONSTANT) 28.872 24.988 1.16
WarpAffine::TestWarpAffine::(8UC4, 640x480, INTER_LINEAR, BORDER_REPLICATE) 28.617 24.967 1.15
WarpAffine::TestWarpAffine::(8UC4, 640x480, INTER_NEAREST, BORDER_CONSTANT) 10.216 4.985 2.05
WarpAffine::TestWarpAffine::(8UC4, 640x480, INTER_NEAREST, BORDER_REPLICATE) 10.045 4.924 2.04
WarpAffine::TestWarpAffine::(8UC4, 1280x720, INTER_LINEAR, BORDER_CONSTANT) 61.101 44.064 1.39
WarpAffine::TestWarpAffine::(8UC4, 1280x720, INTER_LINEAR, BORDER_REPLICATE) 95.034 61.076 1.56
WarpAffine::TestWarpAffine::(8UC4, 1280x720, INTER_NEAREST, BORDER_CONSTANT) 26.003 12.212 2.13
WarpAffine::TestWarpAffine::(8UC4, 1280x720, INTER_NEAREST, BORDER_REPLICATE) 40.456 14.834 2.73
WarpAffine::TestWarpAffine::(8UC4, 1920x1080, INTER_LINEAR, BORDER_CONSTANT) 115.925 66.798 1.74
WarpAffine::TestWarpAffine::(8UC4, 1920x1080, INTER_LINEAR, BORDER_REPLICATE) 208.263 132.257 1.57
WarpAffine::TestWarpAffine::(8UC4, 1920x1080, INTER_NEAREST, BORDER_CONSTANT) 54.290 26.864 2.02
WarpAffine::TestWarpAffine::(8UC4, 1920x1080, INTER_NEAREST, BORDER_REPLICATE) 84.030 35.656 2.36
```
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
