### PR TITLE
Issue 26972: Proper treatment of float values in intersectConvexConvex

### DIFF
--- a/modules/imgproc/src/geometry.cpp
+++ b/modules/imgproc/src/geometry.cpp
@@ -346,8 +346,10 @@ static LineSegmentIntersection intersectLineSegments( Point2f a, Point2f b, Poin
     p.y = (float)(a.y + s*(b.y - a.y));
     q = p;
 
-    return s < 0. || s > 1. || t < 0. || t > 1. ? LS_NO_INTERSECTION :
-           s == 0. || s == 1. || t == 0. || t == 1. ? LS_ENDPOINT_INTERSECTION : LS_SINGLE_INTERSECTION;
+    static const double eps = 1e-5;
+    return s < - eps || s > 1.+ eps || t < - eps || t > 1. + eps ? LS_NO_INTERSECTION :
+           s < eps || s > 1. - eps || t < eps || t > 1. - eps ? LS_ENDPOINT_INTERSECTION :
+           LS_SINGLE_INTERSECTION;
 }
 
 static tInFlag inOut( Point2f p, tInFlag inflag, int aHB, int bHA, Point2f*& result )

--- a/modules/imgproc/src/geometry.cpp
+++ b/modules/imgproc/src/geometry.cpp
@@ -326,52 +326,25 @@ static LineSegmentIntersection parallelInt( Point2f a, Point2f b, Point2f c, Poi
     return code;
 }
 
-// Finds intersection of two directed line segments: (a -> b) and (c -> d).
+// Finds intersection of two line segments: (a, b) and (c, d).
 static LineSegmentIntersection intersectLineSegments( Point2f a, Point2f b, Point2f c,
-                                                      Point2f d, Point2f& p, Point2f& q,
-                                                      int aHB, int a1HB, int aHB1,
-                                                      int a1HB1, int bHA, int b1HA,
-                                                      int bHA1, int b1HA1, bool checkLineStartA)
+                                                      Point2f d, Point2f& p, Point2f& q )
 {
-    double denom = (a.x - b.x) * (double)(d.y - c.y) - (a.y - b.y) * (double)(d.x - c.x);
+    double denom = ((double)a.x - b.x) * ((double)d.y - c.y) - ((double)a.y - b.y) * ((double)d.x - c.x);
 
     // If denom is zero, then segments are parallel: handle separately.
     if( denom == 0. )
         return parallelInt(a, b, c, d, p, q);
 
-    double num = (d.y - a.y) * (double)(a.x - c.x) + (a.x - d.x) * (double)(a.y - c.y);
+    double num = ((double)d.y - a.y) * ((double)a.x - c.x) + ((double)a.x - d.x) * ((double)a.y - c.y);
     double s = num / denom;
 
-    num = (b.y - a.y) * (double)(a.x - c.x) + (c.y - a.y) * (double)(b.x - a.x);
+    num = ((double)b.y - a.y) * ((double)a.x - c.x) + ((double)c.y - a.y) * ((double)b.x - a.x);
     double t = num / denom;
 
-    p.x = (float)(a.x + s*(b.x - a.x));
-    p.y = (float)(a.y + s*(b.y - a.y));
+    p.x = (float)(a.x + s*((double)b.x - a.x));
+    p.y = (float)(a.y + s*((double)b.y - a.y));
     q = p;
-
-    // Double check whether we had an intersection at the vertex, the == 0 check can fail
-    // It should be enough to check retrospectively - verify
-    const auto eps = 1e-4;
-    const bool isCloseToA = -eps < s && s < eps;
-    const bool isCloseToC = -eps < t && t < eps;
-    if (checkLineStartA && isCloseToA)
-    {
-        const bool wasOutside = b1HA1 < 0 && b1HA < 0;
-        const bool isInside = bHA1 > 0 && bHA > 0;
-        if (wasOutside && isInside)
-        {
-            return LS_ENDPOINT_INTERSECTION;
-        }
-    }
-    if (!checkLineStartA /*i.e. check C*/ && isCloseToC)
-    {
-        const bool wasOutside = a1HB1 < 0 && a1HB < 0;
-        const bool isInside = aHB1 > 0 && aHB > 0;
-        if (wasOutside && isInside)
-        {
-            return LS_ENDPOINT_INTERSECTION;
-        }
-    }
 
     return s < 0. || s > 1. || t < 0. || t > 1. ? LS_NO_INTERSECTION :
            s == 0. || s == 1. || t == 0. || t == 1. ? LS_ENDPOINT_INTERSECTION : LS_SINGLE_INTERSECTION;
@@ -421,12 +394,6 @@ static int intersectConvexConvex_( const Point2f* P, int n, const Point2f* Q, in
     Point2f p0;             // The first point.
     *result++ = Point2f(FLT_MAX, FLT_MAX);
 
-    bool isPadvanced = false; // false means Q advanced
-    int aHB1 = 0;
-    int bHA1 = 0;
-    int a1HB1 = 0;
-    int b1HA1 = 0;
-
     do
     {
         // Computations of key variables.
@@ -436,16 +403,12 @@ static int intersectConvexConvex_( const Point2f* P, int n, const Point2f* Q, in
         Point2f A = P[a] - P[a1], B = Q[b] - Q[b1]; // directed edges on P and Q (resp.)
 
         int cross = areaSign( Origin, A, B );    // sign of z-component of A x B
-        int aHB = areaSign( Q[b1], Q[b], P[a] ); // 1 if a in H(b), 0 if on line, else -1
+        int aHB = areaSign( Q[b1], Q[b], P[a] ); // a in H(b).
         int bHA = areaSign( P[a1], P[a], Q[b] ); // b in H(A);
-        int a1HB = areaSign(Q[b1], Q[b], P[a1]); // a-1 in H(b).
-        int b1HA = areaSign(P[a1], P[a], Q[b1]); // b-1 in H(A);
 
         // If A & B intersect, update inflag.
         Point2f p, q;
-        LineSegmentIntersection code =
-            intersectLineSegments( P[a1], P[a], Q[b1], Q[b], p, q, aHB, a1HB,
-                                   aHB1, a1HB1, bHA, b1HA, bHA1, b1HA1, isPadvanced );
+        LineSegmentIntersection code = intersectLineSegments( P[a1], P[a], Q[b1], Q[b], p, q );
         if( code == LS_SINGLE_INTERSECTION || code == LS_ENDPOINT_INTERSECTION )
         {
             if( inflag == Unknown && FirstPoint )
@@ -475,55 +438,25 @@ static int intersectConvexConvex_( const Point2f* P, int n, const Point2f* Q, in
         else if ( cross == 0 && aHB == 0 && bHA == 0 ) {
             // Advance but do not output point.
             if ( inflag == Pin )
-            {
                 b = advance( b, &ba, m, inflag == Qin, Q[b], result );
-                isPadvanced = false;
-                aHB1 = aHB;
-                a1HB1 = a1HB;
-            }
             else
-            {
                 a = advance( a, &aa, n, inflag == Pin, P[a], result );
-                isPadvanced = true;
-                bHA1 = bHA;
-                b1HA1 = b1HA;
-            }
         }
 
         // Generic cases.
         else if( cross >= 0 )
         {
             if( bHA > 0)
-            {
                 a = advance( a, &aa, n, inflag == Pin, P[a], result );
-                isPadvanced = true;
-                bHA1 = bHA;
-                b1HA1 = b1HA;
-            }
             else
-            {
                 b = advance( b, &ba, m, inflag == Qin, Q[b], result );
-                isPadvanced = false;
-                aHB1 = aHB;
-                a1HB1 = a1HB;
-            }
         }
         else
         {
             if( aHB > 0)
-            {
                 b = advance( b, &ba, m, inflag == Qin, Q[b], result );
-                isPadvanced = false;
-                aHB1 = aHB;
-                a1HB1 = a1HB;
-            }
             else
-            {
                 a = advance( a, &aa, n, inflag == Pin, P[a], result );
-                isPadvanced = true;
-                bHA1 = bHA;
-                b1HA1 = b1HA;
-            }
         }
         // Quit when both adv. indices have cycled, or one has cycled twice.
     }

--- a/modules/imgproc/test/test_intersectconvexconvex.cpp
+++ b/modules/imgproc/test/test_intersectconvexconvex.cpp
@@ -292,5 +292,27 @@ TEST(Imgproc_IntersectConvexConvex, not_convex)
     EXPECT_LE(area, 0.f);
 }
 
+// The intersection was not properly detected when one line sneaked its way in through an edge point
+TEST(Imgproc_IntersectConvexConvex, intersection_at_line_transition)
+{
+    std::vector<cv::Point2f> convex1 = {
+        {  -1.7604526f,  -0.00028443217f },
+        {1276.5778f   ,   0.2091252f},
+        {1276.4617f   , 719.27f},
+        {  -1.8754264f, 719.06866f}
+
+    };
+    std::vector<cv::Point2f> convex2 = {
+        {   0.f ,   0.f },
+        {1280.f ,   0.f },
+        {1280.f , 720.f},
+        {   0.f , 720.f }
+    };
+    std::vector<cv::Point> intersection;
+
+    float area = cv::intersectConvexConvex(convex1, convex2, intersection, false);
+    EXPECT_GE(cv::contourArea(convex1), area);
+    EXPECT_GE(cv::contourArea(convex2), area);
+}
 } // namespace
 } // opencv_test


### PR DESCRIPTION
As outlined in https://github.com/opencv/opencv/issues/26972 the function `intersectConvexConvex()` may not work as expected in the corner case, where two polygons intersect at a corner. A concrete example is given that I added as unit test. The unit test would fail without the proposed bug fix. I recommend porting the fix to all versions.

Now concerning the fix: When digging into the implementation I found, that when the line intersections are computed, openCV currently does not apply floating point comparison syntax, but pretends that line end points are exact. Instead I replaced the formulation using the eps that is already used in another component of the function in line.277: `epx=1e-5`. IMO that is solid enough, definitely better than assuming an exact floating point comparison is possible.

As a follow up I would suggest to use a scalable eps, s.t. also cases with high floating point numbers would be less error prone. However that would need to be done in all relevant sub steps, not just the line intersection code. So for me outside the scope of this fix.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

