### PR TITLE
Refactor ArucoDetector::ArucoDetectorImpl::filterTooCloseCandidates

### DIFF
--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -687,7 +687,6 @@ struct ArucoDetector::ArucoDetectorImpl {
         vector<vector<size_t> > groupedCandidates;
         vector<bool> isSelectedContours(candidateTree.size(), true);
 
-        size_t countSelectedContours = 0ull;
         for (size_t i = 0ull; i < candidateTree.size(); i++) {
             for (size_t j = i + 1ull; j < candidateTree.size(); j++) {
                 float minDist = getAverageDistance(candidateTree[i].corners, candidateTree[j].corners);
@@ -720,7 +719,12 @@ struct ArucoDetector::ArucoDetectorImpl {
                     }
                 }
             }
-            countSelectedContours += isSelectedContours[i];
+            // group of one candidate
+            if(isSelectedContours[i]) {
+                isSelectedContours[i] = false;
+                groupId[i] = (int)groupedCandidates.size();
+                groupedCandidates.push_back({i});
+            }
         }
 
         for (vector<size_t>& grouped : groupedCandidates) {
@@ -743,8 +747,8 @@ struct ArucoDetector::ArucoDetectorImpl {
             }
         }
 
-        vector<MarkerCandidateTree> selectedCandidates(countSelectedContours + groupedCandidates.size());
-        countSelectedContours = 0ull;
+        vector<MarkerCandidateTree> selectedCandidates(groupedCandidates.size());
+        size_t countSelectedContours = 0ull;
         for (size_t i = 0ull; i < candidateTree.size(); i++) {
             if (isSelectedContours[i]) {
                 selectedCandidates[countSelectedContours] = std::move(candidateTree[i]);


### PR DESCRIPTION
### Pull Request Readiness Checklist

Related to #26968 

Made the `ArucoDetector::ArucoDetectorImpl::filterTooCloseCandidates` method more unified and easier to understand.
Before - contours after the grouping stage can be in two states:
1. contained in `groupedCandidates` and `isSelectedContour = false` (group of several contours)
2. `isSelectedContour = true` (one independent contour).

But we can create a separate group for one independent contour - all contours will be in the same state and further processing code is already adapted for this and will be more unified.

These changes will help me make it easier to make changes in #26968  to fix failed tests.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
