### PR TITLE
Optimize undistort points

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -479,9 +479,16 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         {
             Vec2d pu = pw * scale; //undistorted point
 
-            // reproject
-            Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
-            Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+            if (!R.empty() || !P.empty())
+            {
+                // reproject
+                Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
+                Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+            }
+            else
+            {
+                Vec2d fi = pu;
+            }
 
             if( sdepth == CV_32F )
                 dstf[i] = fi;

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -478,16 +478,17 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         if ((converged || !isEps) && !theta_flipped)
         {
             Vec2d pu = pw * scale; //undistorted point
+            Vec2d fi;
 
             if (!R.empty() || !P.empty())
             {
                 // reproject
                 Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
-                Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+                fi = Vec2d(pr[0]/pr[2], pr[1]/pr[2]);     // final
             }
             else
             {
-                Vec2d fi = pu;
+                fi = pu;
             }
 
             if( sdepth == CV_32F )

--- a/modules/calib3d/src/undistort.dispatch.cpp
+++ b/modules/calib3d/src/undistort.dispatch.cpp
@@ -488,11 +488,14 @@ static void cvUndistortPointsInternal( const CvMat* _src, CvMat* _dst, const CvM
             }
         }
 
-        double xx = RR[0][0]*x + RR[0][1]*y + RR[0][2];
-        double yy = RR[1][0]*x + RR[1][1]*y + RR[1][2];
-        double ww = 1./(RR[2][0]*x + RR[2][1]*y + RR[2][2]);
-        x = xx*ww;
-        y = yy*ww;
+        if( matR || matP )
+        {
+            double xx = RR[0][0]*x + RR[0][1]*y + RR[0][2];
+            double yy = RR[1][0]*x + RR[1][1]*y + RR[1][2];
+            double ww = 1./(RR[2][0]*x + RR[2][1]*y + RR[2][2]);
+            x = xx*ww;
+            y = yy*ww;
+        }
 
         if( dtype == CV_32FC2 )
         {


### PR DESCRIPTION
Skips unnecessary rotation with identity matrix if no R or P mats are given.
