### PR TITLE
[HAL RVV] unify and impl polar_to_cart | add perf test

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -32,6 +32,7 @@
 #include "hal_rvv_1p0/split.hpp" // core
 #include "hal_rvv_1p0/magnitude.hpp" // core
 #include "hal_rvv_1p0/cart_to_polar.hpp" // core
+#include "hal_rvv_1p0/polar_to_cart.hpp" // core
 #include "hal_rvv_1p0/flip.hpp" // core
 #include "hal_rvv_1p0/lut.hpp" // core
 #include "hal_rvv_1p0/exp.hpp" // core

--- a/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
@@ -1,79 +1,50 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-#pragma once
+#ifndef OPENCV_HAL_RVV_POLAR_TO_CART_HPP_INCLUDED
+#define OPENCV_HAL_RVV_POLAR_TO_CART_HPP_INCLUDED
 
 #include <riscv_vector.h>
 #include "hal_rvv_1p0/sincos.hpp"
+#include "hal_rvv_1p0/types.hpp"
 
 namespace cv { namespace cv_hal_rvv {
 
 #undef cv_hal_polarToCart32f
-#define cv_hal_polarToCart32f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::PolarToCart32f>
+#define cv_hal_polarToCart32f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::RVV_F32M4>
 #undef cv_hal_polarToCart64f
-#define cv_hal_polarToCart64f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::PolarToCart64f>
-
-struct PolarToCart32f
-{
-    using ElemType = float;
-    static inline size_t setvl(size_t len) { return __riscv_vsetvl_e32m4(len); }
-    static inline vfloat32m4_t vload(const float* ptr, size_t vl) { return __riscv_vle32_v_f32m4(ptr, vl); }
-    static inline void vstore(float* ptr, vfloat32m4_t v, size_t vl) { __riscv_vse32(ptr, v, vl); }
-};
-
-struct PolarToCart64f
-{
-    using ElemType = double;
-    static inline size_t setvl(size_t len) { return __riscv_vsetvl_e64m8(len); }
-    static inline vfloat32m4_t vload(const double* ptr, size_t vl) { return __riscv_vfncvt_f(__riscv_vle64_v_f64m8(ptr, vl), vl); }
-    static inline void vstore(double* ptr, vfloat32m4_t v, size_t vl) { __riscv_vse64(ptr, __riscv_vfwcvt_f(v, vl), vl); }
-};
-
-template <typename RVV_T, typename Vlen, typename Elem = typename RVV_T::ElemType>
-inline void polarToCartLoop(const Elem* mag,
-                            const Elem* angle,
-                            Elem* x,
-                            Elem* y,
-                            int len,
-                            bool angleInDegrees)
-{
-    const auto sincos_scale = angleInDegrees ? detail::sincos_deg_scale : detail::sincos_rad_scale;
-    const auto sincos_table = detail::SinCosLoadTab<Vlen>();
-
-    size_t vl;
-    for (; len > 0; len -= (int)vl, angle += vl, x += vl, y += vl)
-    {
-        vl = RVV_T::setvl(len);
-        vfloat32m4_t vangle = RVV_T::vload(angle, vl);
-        vfloat32m4_t vsin, vcos;
-        detail::SinCos32f<Vlen>(vangle, sincos_scale, sincos_table, vl, vsin, vcos);
-        if (mag)
-        {
-            vfloat32m4_t vmag = RVV_T::vload(mag, vl);
-            vsin = __riscv_vfmul(vsin, vmag, vl);
-            vcos = __riscv_vfmul(vcos, vmag, vl);
-            mag += vl;
-        }
-        RVV_T::vstore(x, vcos, vl);
-        RVV_T::vstore(y, vsin, vl);
-    }
-}
+#define cv_hal_polarToCart64f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::RVV_F64M8>
 
 template <typename RVV_T, typename Elem = typename RVV_T::ElemType>
 inline int
     polarToCart(const Elem* mag, const Elem* angle, Elem* x, Elem* y, int len, bool angleInDegrees)
 {
-    size_t vlen = __riscv_vlenb() * 8;
-    if (vlen >= 512)
-        polarToCartLoop<RVV_T, detail::SinCosVlen512>(mag, angle, x, y, len, angleInDegrees);
-    else if (vlen >= 256)
-        polarToCartLoop<RVV_T, detail::SinCosVlen256>(mag, angle, x, y, len, angleInDegrees);
-    else if (vlen >= 128)
-        polarToCartLoop<RVV_T, detail::SinCosVlen128>(mag, angle, x, y, len, angleInDegrees);
-    else
-        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    using T = RVV_F32M4;
+    const auto sincos_scale = angleInDegrees ? detail::sincos_deg_scale : detail::sincos_rad_scale;
+
+    size_t vl = T::setvlmax();
+    auto cos_p2 = T::vmv(detail::sincos_cos_p2, vl);
+    auto cos_p0 = T::vmv(detail::sincos_cos_p0, vl);
+    for (; len > 0; len -= (int)vl, angle += vl, x += vl, y += vl)
+    {
+        vl = RVV_T::setvl(len);
+        auto vangle = T::cast(RVV_T::vload(angle, vl), vl);
+        T::VecType vsin, vcos;
+        detail::SinCos32f<T>(vangle, vsin, vcos, sincos_scale, cos_p2, cos_p0, vl);
+        if (mag)
+        {
+            auto vmag = T::cast(RVV_T::vload(mag, vl), vl);
+            vsin = __riscv_vfmul(vsin, vmag, vl);
+            vcos = __riscv_vfmul(vcos, vmag, vl);
+            mag += vl;
+        }
+        RVV_T::vstore(x, RVV_T::cast(vcos, vl), vl);
+        RVV_T::vstore(y, RVV_T::cast(vsin, vl), vl);
+    }
 
     return CV_HAL_ERROR_OK;
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif  // OPENCV_HAL_RVV_POLAR_TO_CART_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_POLAR_TO_CART_HPP_INCLUDED
 #define OPENCV_HAL_RVV_POLAR_TO_CART_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
@@ -1,0 +1,79 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#pragma once
+
+#include <riscv_vector.h>
+#include "hal_rvv_1p0/sincos.hpp"
+
+namespace cv { namespace cv_hal_rvv {
+
+#undef cv_hal_polarToCart32f
+#define cv_hal_polarToCart32f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::PolarToCart32f>
+#undef cv_hal_polarToCart64f
+#define cv_hal_polarToCart64f cv::cv_hal_rvv::polarToCart<cv::cv_hal_rvv::PolarToCart64f>
+
+struct PolarToCart32f
+{
+    using ElemType = float;
+    static inline size_t setvl(size_t len) { return __riscv_vsetvl_e32m4(len); }
+    static inline vfloat32m4_t vload(const float* ptr, size_t vl) { return __riscv_vle32_v_f32m4(ptr, vl); }
+    static inline void vstore(float* ptr, vfloat32m4_t v, size_t vl) { __riscv_vse32(ptr, v, vl); }
+};
+
+struct PolarToCart64f
+{
+    using ElemType = double;
+    static inline size_t setvl(size_t len) { return __riscv_vsetvl_e64m8(len); }
+    static inline vfloat32m4_t vload(const double* ptr, size_t vl) { return __riscv_vfncvt_f(__riscv_vle64_v_f64m8(ptr, vl), vl); }
+    static inline void vstore(double* ptr, vfloat32m4_t v, size_t vl) { __riscv_vse64(ptr, __riscv_vfwcvt_f(v, vl), vl); }
+};
+
+template <typename RVV_T, typename Vlen, typename Elem = typename RVV_T::ElemType>
+inline void polarToCartLoop(const Elem* mag,
+                            const Elem* angle,
+                            Elem* x,
+                            Elem* y,
+                            int len,
+                            bool angleInDegrees)
+{
+    const auto sincos_scale = angleInDegrees ? detail::sincos_deg_scale : detail::sincos_rad_scale;
+    const auto sincos_table = detail::SinCosLoadTab<Vlen>();
+
+    size_t vl;
+    for (; len > 0; len -= (int)vl, angle += vl, x += vl, y += vl)
+    {
+        vl = RVV_T::setvl(len);
+        vfloat32m4_t vangle = RVV_T::vload(angle, vl);
+        vfloat32m4_t vsin, vcos;
+        detail::SinCos32f<Vlen>(vangle, sincos_scale, sincos_table, vl, vsin, vcos);
+        if (mag)
+        {
+            vfloat32m4_t vmag = RVV_T::vload(mag, vl);
+            vsin = __riscv_vfmul(vsin, vmag, vl);
+            vcos = __riscv_vfmul(vcos, vmag, vl);
+            mag += vl;
+        }
+        RVV_T::vstore(x, vcos, vl);
+        RVV_T::vstore(y, vsin, vl);
+    }
+}
+
+template <typename RVV_T, typename Elem = typename RVV_T::ElemType>
+inline int
+    polarToCart(const Elem* mag, const Elem* angle, Elem* x, Elem* y, int len, bool angleInDegrees)
+{
+    size_t vlen = __riscv_vlenb() * 8;
+    if (vlen >= 512)
+        polarToCartLoop<RVV_T, detail::SinCosVlen512>(mag, angle, x, y, len, angleInDegrees);
+    else if (vlen >= 256)
+        polarToCartLoop<RVV_T, detail::SinCosVlen256>(mag, angle, x, y, len, angleInDegrees);
+    else if (vlen >= 128)
+        polarToCartLoop<RVV_T, detail::SinCosVlen128>(mag, angle, x, y, len, angleInDegrees);
+    else
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+
+    return CV_HAL_ERROR_OK;
+}
+
+}}  // namespace cv::cv_hal_rvv

--- a/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/polar_to_cart.hpp
@@ -22,9 +22,9 @@ inline int
     using T = RVV_F32M4;
     const auto sincos_scale = angleInDegrees ? detail::sincos_deg_scale : detail::sincos_rad_scale;
 
-    size_t vl = T::setvlmax();
-    auto cos_p2 = T::vmv(detail::sincos_cos_p2, vl);
-    auto cos_p0 = T::vmv(detail::sincos_cos_p0, vl);
+    size_t vl;
+    auto cos_p2 = T::vmv(detail::sincos_cos_p2, T::setvlmax());
+    auto cos_p0 = T::vmv(detail::sincos_cos_p0, T::setvlmax());
     for (; len > 0; len -= (int)vl, angle += vl, x += vl, y += vl)
     {
         vl = RVV_T::setvl(len);

--- a/3rdparty/hal_rvv/hal_rvv_1p0/pyramids.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/pyramids.hpp
@@ -22,8 +22,8 @@ template<> struct rvv<uchar>
     using WT = RVV_SameLen<int, T>;
     using MT = RVV_SameLen<uint, T>;
 
-    static inline WT::VecType vcvt_T_WT(T::VecType a, size_t b) { return WT::cast(MT::cast(a, b), b); }
-    static inline T::VecType vcvt_WT_T(WT::VecType a, int b, size_t c) { return T::cast(MT::cast(__riscv_vsra(__riscv_vadd(a, 1 << (b - 1), c), b, c), c), c); }
+    static inline WT::VecType vcvt_T_WT(T::VecType a, size_t b) { return WT::reinterpret(MT::cast(a, b)); }
+    static inline T::VecType vcvt_WT_T(WT::VecType a, int b, size_t c) { return T::cast(MT::reinterpret(__riscv_vsra(__riscv_vadd(a, 1 << (b - 1), c), b, c)), c); }
     static inline WT::VecType down0(WT::VecType vec_src0, WT::VecType vec_src1, WT::VecType vec_src2, WT::VecType vec_src3, WT::VecType vec_src4, size_t vl) {
         return __riscv_vadd(__riscv_vadd(__riscv_vadd(vec_src0, vec_src4, vl), __riscv_vadd(vec_src2, vec_src2, vl), vl),
                             __riscv_vsll(__riscv_vadd(__riscv_vadd(vec_src1, vec_src2, vl), vec_src3, vl), 2, vl), vl);

--- a/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
@@ -1,0 +1,172 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level
+// directory of this distribution and at http://opencv.org/license.html.
+#pragma once
+
+#include <riscv_vector.h>
+
+namespace cv { namespace cv_hal_rvv { namespace detail {
+
+static constexpr size_t sincos_90 = 16;
+static constexpr size_t sincos_180 = sincos_90 * 2;
+static constexpr size_t sincos_mask = sincos_180 * 2 - 1;
+
+static constexpr float sincos_rad_scale = (float)sincos_180 / CV_PI;
+static constexpr float sincos_deg_scale = (float)sincos_180 / 180.f;
+
+static constexpr float sincos_table[] =
+{
+     0.00000000000000000000,     0.09801714032956060400,
+     0.19509032201612825000,     0.29028467725446233000,
+     0.38268343236508978000,     0.47139673682599764000,
+     0.55557023301960218000,     0.63439328416364549000,
+     0.70710678118654746000,     0.77301045336273699000,
+     0.83146961230254524000,     0.88192126434835494000,
+     0.92387953251128674000,     0.95694033573220894000,
+     0.98078528040323043000,     0.99518472667219682000,
+     1.00000000000000000000,     0.99518472667219693000,
+     0.98078528040323043000,     0.95694033573220894000,
+     0.92387953251128674000,     0.88192126434835505000,
+     0.83146961230254546000,     0.77301045336273710000,
+     0.70710678118654757000,     0.63439328416364549000,
+     0.55557023301960218000,     0.47139673682599786000,
+     0.38268343236508989000,     0.29028467725446239000,
+     0.19509032201612861000,     0.09801714032956082600,
+     0.00000000000000012246,    -0.09801714032956059000,
+    -0.19509032201612836000,    -0.29028467725446211000,
+    -0.38268343236508967000,    -0.47139673682599764000,
+    -0.55557023301960196000,    -0.63439328416364527000,
+    -0.70710678118654746000,    -0.77301045336273666000,
+    -0.83146961230254524000,    -0.88192126434835494000,
+    -0.92387953251128652000,    -0.95694033573220882000,
+    -0.98078528040323032000,    -0.99518472667219693000,
+    -1.00000000000000000000,    -0.99518472667219693000,
+    -0.98078528040323043000,    -0.95694033573220894000,
+    -0.92387953251128663000,    -0.88192126434835505000,
+    -0.83146961230254546000,    -0.77301045336273688000,
+    -0.70710678118654768000,    -0.63439328416364593000,
+    -0.55557023301960218000,    -0.47139673682599792000,
+    -0.38268343236509039000,    -0.29028467725446250000,
+    -0.19509032201612872000,    -0.09801714032956050600,
+};
+
+static constexpr float sincos_sin_p1 = 0.098174770424681;
+static constexpr float sincos_sin_p3 = -0.000157706078493;
+static constexpr float sincos_cos_p0 = 1.000000000000000;
+static constexpr float sincos_cos_p2 = -0.004819142773969;
+
+struct SinCosVlen128
+{
+    static constexpr size_t table_size = 128 * 4 / 32;
+
+    static inline void lookup(vint32m4_t idx,
+                              vfloat32m4_t table,
+                              size_t vl,
+                              vfloat32m4_t& sinval,
+                              vfloat32m4_t& cosval)
+    {
+        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
+        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
+
+        auto sin180 = __riscv_vmsgtu(sin_idx, sincos_180, vl);
+        auto cos180 = __riscv_vmsgtu(cos_idx, sincos_180, vl);
+
+        sin_idx = __riscv_vsub_mu(sin180, sin_idx, sin_idx, sincos_180, vl);
+        cos_idx = __riscv_vsub_mu(cos180, cos_idx, cos_idx, sincos_180, vl);
+
+        auto sin90 = __riscv_vmsgtu(sin_idx, sincos_90, vl);
+        auto cos90 = __riscv_vmsgtu(cos_idx, sincos_90, vl);
+
+        sin_idx = __riscv_vrsub_mu(sin90, sin_idx, sin_idx, sincos_180, vl);
+        cos_idx = __riscv_vrsub_mu(cos90, cos_idx, cos_idx, sincos_180, vl);
+
+        sinval = __riscv_vrgather(table, sin_idx, vl);
+        cosval = __riscv_vrgather(table, cos_idx, vl);
+
+        sinval = __riscv_vfmerge(sinval, 1.f, __riscv_vmseq(sin_idx, sincos_90, vl), vl);
+        cosval = __riscv_vfmerge(cosval, 1.f, __riscv_vmseq(cos_idx, sincos_90, vl), vl);
+
+        sinval = __riscv_vfneg_mu(sin180, sinval, sinval, vl);
+        cosval = __riscv_vfneg_mu(cos180, cosval, cosval, vl);
+    }
+};
+
+struct SinCosVlen256
+{
+    static constexpr size_t table_size = 256 * 4 / 32;
+ 
+    static inline void lookup(vint32m4_t idx,
+                              vfloat32m4_t table,
+                              size_t vl,
+                              vfloat32m4_t& sinval,
+                              vfloat32m4_t& cosval)
+    {
+        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
+        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
+
+        auto sin180 = __riscv_vmsgeu(sin_idx, sincos_180, vl);
+        auto cos180 = __riscv_vmsgeu(cos_idx, sincos_180, vl);
+
+        sin_idx = __riscv_vsub_mu(sin180, sin_idx, sin_idx, sincos_180, vl);
+        cos_idx = __riscv_vsub_mu(cos180, cos_idx, cos_idx, sincos_180, vl);
+
+        sinval = __riscv_vrgather(table, sin_idx, vl);
+        cosval = __riscv_vrgather(table, cos_idx, vl);
+
+        sinval = __riscv_vfneg_mu(sin180, sinval, sinval, vl);
+        cosval = __riscv_vfneg_mu(cos180, cosval, cosval, vl);
+    }
+};
+
+struct SinCosVlen512
+{
+    static constexpr size_t table_size = 512 * 4 / 32;
+
+    static inline void lookup(vint32m4_t idx,
+                              vfloat32m4_t table,
+                              size_t vl,
+                              vfloat32m4_t& sinval,
+                              vfloat32m4_t& cosval)
+    {
+        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
+        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
+
+        sinval = __riscv_vrgather(table, sin_idx, vl);
+        cosval = __riscv_vrgather(table, cos_idx, vl);
+    }
+};
+
+template <typename SinCosVlen>
+static inline vfloat32m4_t SinCosLoadTab()
+{
+    return __riscv_vle32_v_f32m4(sincos_table, SinCosVlen::table_size);
+}
+
+template <typename SinCosVlen>
+static inline void SinCos32f(vfloat32m4_t angle,
+                              float scale,
+                              vfloat32m4_t table,
+                              size_t vl,
+                              vfloat32m4_t& sinval,
+                              vfloat32m4_t& cosval)
+{
+    angle = __riscv_vfmul(angle, scale, vl);
+    auto round_angle = __riscv_vfcvt_x_f_v_i32m4(angle, vl);
+    auto delta_angle =
+        __riscv_vfsub(angle, __riscv_vfcvt_f_x_v_f32m4(round_angle, vl), vl);
+
+    vfloat32m4_t sin_a, cos_a;
+    SinCosVlen::lookup(round_angle, table, vl, sin_a, cos_a);
+
+    auto delta_angle2 = __riscv_vfmul(delta_angle, delta_angle, vl);
+
+    auto sin_b = __riscv_vfmul(delta_angle2, sincos_sin_p3, vl);
+    sin_b = __riscv_vfmul(__riscv_vfadd(sin_b, sincos_sin_p1, vl), delta_angle, vl);
+    auto cos_b = __riscv_vfmul(delta_angle2, sincos_cos_p2, vl);
+    cos_b = __riscv_vfadd(cos_b, sincos_cos_p0, vl);
+
+    sinval = __riscv_vfadd(__riscv_vfmul(sin_a, cos_b, vl), __riscv_vfmul(cos_a, sin_b, vl), vl);
+    cosval = __riscv_vfsub(__riscv_vfmul(cos_a, cos_b, vl), __riscv_vfmul(sin_a, sin_b, vl), vl);
+}
+
+}}}  // namespace cv::cv_hal_rvv::detail

--- a/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
@@ -1,172 +1,69 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
-#pragma once
+#ifndef OPENCV_HAL_RVV_SINCOS_HPP_INCLUDED
+#define OPENCV_HAL_RVV_SINCOS_HPP_INCLUDED
 
 #include <riscv_vector.h>
+#include "hal_rvv_1p0/types.hpp"
 
 namespace cv { namespace cv_hal_rvv { namespace detail {
 
-static constexpr size_t sincos_90 = 16;
-static constexpr size_t sincos_180 = sincos_90 * 2;
-static constexpr size_t sincos_mask = sincos_180 * 2 - 1;
+static constexpr size_t sincos_mask = 0x3;
 
-static constexpr float sincos_rad_scale = (float)sincos_180 / CV_PI;
-static constexpr float sincos_deg_scale = (float)sincos_180 / 180.f;
+static constexpr float sincos_rad_scale = 2.f / CV_PI;
+static constexpr float sincos_deg_scale = 2.f / 180.f;
 
-static constexpr float sincos_table[] =
-{
-     0.00000000000000000000,     0.09801714032956060400,
-     0.19509032201612825000,     0.29028467725446233000,
-     0.38268343236508978000,     0.47139673682599764000,
-     0.55557023301960218000,     0.63439328416364549000,
-     0.70710678118654746000,     0.77301045336273699000,
-     0.83146961230254524000,     0.88192126434835494000,
-     0.92387953251128674000,     0.95694033573220894000,
-     0.98078528040323043000,     0.99518472667219682000,
-     1.00000000000000000000,     0.99518472667219693000,
-     0.98078528040323043000,     0.95694033573220894000,
-     0.92387953251128674000,     0.88192126434835505000,
-     0.83146961230254546000,     0.77301045336273710000,
-     0.70710678118654757000,     0.63439328416364549000,
-     0.55557023301960218000,     0.47139673682599786000,
-     0.38268343236508989000,     0.29028467725446239000,
-     0.19509032201612861000,     0.09801714032956082600,
-     0.00000000000000012246,    -0.09801714032956059000,
-    -0.19509032201612836000,    -0.29028467725446211000,
-    -0.38268343236508967000,    -0.47139673682599764000,
-    -0.55557023301960196000,    -0.63439328416364527000,
-    -0.70710678118654746000,    -0.77301045336273666000,
-    -0.83146961230254524000,    -0.88192126434835494000,
-    -0.92387953251128652000,    -0.95694033573220882000,
-    -0.98078528040323032000,    -0.99518472667219693000,
-    -1.00000000000000000000,    -0.99518472667219693000,
-    -0.98078528040323043000,    -0.95694033573220894000,
-    -0.92387953251128663000,    -0.88192126434835505000,
-    -0.83146961230254546000,    -0.77301045336273688000,
-    -0.70710678118654768000,    -0.63439328416364593000,
-    -0.55557023301960218000,    -0.47139673682599792000,
-    -0.38268343236509039000,    -0.29028467725446250000,
-    -0.19509032201612872000,    -0.09801714032956050600,
-};
+// Taylor expansion coefficients for sin(x*pi/2) and cos(x*pi/2)
+static constexpr double sincos_sin_p7 = -0.004681754135319;
+static constexpr double sincos_sin_p5 = 0.079692626246167;
+static constexpr double sincos_sin_p3 = -0.645964097506246;
+static constexpr double sincos_sin_p1 = 1.570796326794897;
 
-static constexpr float sincos_sin_p1 = 0.098174770424681;
-static constexpr float sincos_sin_p3 = -0.000157706078493;
-static constexpr float sincos_cos_p0 = 1.000000000000000;
-static constexpr float sincos_cos_p2 = -0.004819142773969;
+static constexpr double sincos_cos_p8 = 0.000919260274839;
+static constexpr double sincos_cos_p6 = -0.020863480763353;
+static constexpr double sincos_cos_p4 = 0.253669507901048;
+static constexpr double sincos_cos_p2 = -1.233700550136170;
+static constexpr double sincos_cos_p0 = 1.000000000000000;
 
-struct SinCosVlen128
-{
-    static constexpr size_t table_size = 128 * 4 / 32;
-
-    static inline void lookup(vint32m4_t idx,
-                              vfloat32m4_t table,
-                              size_t vl,
-                              vfloat32m4_t& sinval,
-                              vfloat32m4_t& cosval)
-    {
-        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
-        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
-
-        auto sin180 = __riscv_vmsgtu(sin_idx, sincos_180, vl);
-        auto cos180 = __riscv_vmsgtu(cos_idx, sincos_180, vl);
-
-        sin_idx = __riscv_vsub_mu(sin180, sin_idx, sin_idx, sincos_180, vl);
-        cos_idx = __riscv_vsub_mu(cos180, cos_idx, cos_idx, sincos_180, vl);
-
-        auto sin90 = __riscv_vmsgtu(sin_idx, sincos_90, vl);
-        auto cos90 = __riscv_vmsgtu(cos_idx, sincos_90, vl);
-
-        sin_idx = __riscv_vrsub_mu(sin90, sin_idx, sin_idx, sincos_180, vl);
-        cos_idx = __riscv_vrsub_mu(cos90, cos_idx, cos_idx, sincos_180, vl);
-
-        sinval = __riscv_vrgather(table, sin_idx, vl);
-        cosval = __riscv_vrgather(table, cos_idx, vl);
-
-        sinval = __riscv_vfmerge(sinval, 1.f, __riscv_vmseq(sin_idx, sincos_90, vl), vl);
-        cosval = __riscv_vfmerge(cosval, 1.f, __riscv_vmseq(cos_idx, sincos_90, vl), vl);
-
-        sinval = __riscv_vfneg_mu(sin180, sinval, sinval, vl);
-        cosval = __riscv_vfneg_mu(cos180, cosval, cosval, vl);
-    }
-};
-
-struct SinCosVlen256
-{
-    static constexpr size_t table_size = 256 * 4 / 32;
- 
-    static inline void lookup(vint32m4_t idx,
-                              vfloat32m4_t table,
-                              size_t vl,
-                              vfloat32m4_t& sinval,
-                              vfloat32m4_t& cosval)
-    {
-        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
-        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
-
-        auto sin180 = __riscv_vmsgeu(sin_idx, sincos_180, vl);
-        auto cos180 = __riscv_vmsgeu(cos_idx, sincos_180, vl);
-
-        sin_idx = __riscv_vsub_mu(sin180, sin_idx, sin_idx, sincos_180, vl);
-        cos_idx = __riscv_vsub_mu(cos180, cos_idx, cos_idx, sincos_180, vl);
-
-        sinval = __riscv_vrgather(table, sin_idx, vl);
-        cosval = __riscv_vrgather(table, cos_idx, vl);
-
-        sinval = __riscv_vfneg_mu(sin180, sinval, sinval, vl);
-        cosval = __riscv_vfneg_mu(cos180, cosval, cosval, vl);
-    }
-};
-
-struct SinCosVlen512
-{
-    static constexpr size_t table_size = 512 * 4 / 32;
-
-    static inline void lookup(vint32m4_t idx,
-                              vfloat32m4_t table,
-                              size_t vl,
-                              vfloat32m4_t& sinval,
-                              vfloat32m4_t& cosval)
-    {
-        auto sin_idx = __riscv_vand(__riscv_vreinterpret_u32m4(idx), sincos_mask, vl);
-        auto cos_idx = __riscv_vand(__riscv_vadd(sin_idx, sincos_90, vl), sincos_mask, vl);
-
-        sinval = __riscv_vrgather(table, sin_idx, vl);
-        cosval = __riscv_vrgather(table, cos_idx, vl);
-    }
-};
-
-template <typename SinCosVlen>
-static inline vfloat32m4_t SinCosLoadTab()
-{
-    return __riscv_vle32_v_f32m4(sincos_table, SinCosVlen::table_size);
-}
-
-template <typename SinCosVlen>
-static inline void SinCos32f(vfloat32m4_t angle,
-                              float scale,
-                              vfloat32m4_t table,
-                              size_t vl,
-                              vfloat32m4_t& sinval,
-                              vfloat32m4_t& cosval)
+// Taylor expansion and angle sum identity
+// Use 7 LMUL registers (can be reduced to 5 by splitting fmadd to fadd and fmul)
+template <typename RVV_T, typename T = typename RVV_T::VecType>
+static inline void
+    SinCos32f(T angle, T& sinval, T& cosval, float scale, T cos_p2, T cos_p0, size_t vl)
 {
     angle = __riscv_vfmul(angle, scale, vl);
-    auto round_angle = __riscv_vfcvt_x_f_v_i32m4(angle, vl);
-    auto delta_angle =
-        __riscv_vfsub(angle, __riscv_vfcvt_f_x_v_f32m4(round_angle, vl), vl);
-
-    vfloat32m4_t sin_a, cos_a;
-    SinCosVlen::lookup(round_angle, table, vl, sin_a, cos_a);
-
+    auto round_angle = RVV_ToInt<RVV_T>::cast(angle, vl);
+    auto delta_angle = __riscv_vfsub(angle, RVV_T::cast(round_angle, vl), vl);
     auto delta_angle2 = __riscv_vfmul(delta_angle, delta_angle, vl);
 
-    auto sin_b = __riscv_vfmul(delta_angle2, sincos_sin_p3, vl);
-    sin_b = __riscv_vfmul(__riscv_vfadd(sin_b, sincos_sin_p1, vl), delta_angle, vl);
-    auto cos_b = __riscv_vfmul(delta_angle2, sincos_cos_p2, vl);
-    cos_b = __riscv_vfadd(cos_b, sincos_cos_p0, vl);
+    auto sin = __riscv_vfadd(__riscv_vfmul(delta_angle2, sincos_sin_p7, vl), sincos_sin_p5, vl);
+    sin = __riscv_vfadd(__riscv_vfmul(delta_angle2, sin, vl), sincos_sin_p3, vl);
+    sin = __riscv_vfadd(__riscv_vfmul(delta_angle2, sin, vl), sincos_sin_p1, vl);
+    sin = __riscv_vfmul(delta_angle, sin, vl);
 
-    sinval = __riscv_vfadd(__riscv_vfmul(sin_a, cos_b, vl), __riscv_vfmul(cos_a, sin_b, vl), vl);
-    cosval = __riscv_vfsub(__riscv_vfmul(cos_a, cos_b, vl), __riscv_vfmul(sin_a, sin_b, vl), vl);
+    auto cos = __riscv_vfadd(__riscv_vfmul(delta_angle2, sincos_cos_p8, vl), sincos_cos_p6, vl);
+    cos = __riscv_vfadd(__riscv_vfmul(delta_angle2, cos, vl), sincos_cos_p4, vl);
+    cos = __riscv_vfmadd(cos, delta_angle2, cos_p2, vl);
+    cos = __riscv_vfmadd(cos, delta_angle2, cos_p0, vl);
+
+    // idx = 0: sinval =  sin, cosval =  cos
+    // idx = 1: sinval =  cos, cosval = -sin
+    // idx = 2: sinval = -sin, cosval = -cos
+    // idx = 3: sinval = -cos, cosval =  sin
+    auto idx = __riscv_vand(round_angle, sincos_mask, vl);
+    auto idx1 = __riscv_vmseq(idx, 1, vl);
+    auto idx2 = __riscv_vmseq(idx, 2, vl);
+    auto idx3 = __riscv_vmseq(idx, 3, vl);
+
+    auto idx13 = __riscv_vmor(idx1, idx3, vl);
+    sinval = __riscv_vmerge(sin, cos, idx13, vl);
+    cosval = __riscv_vmerge(cos, sin, idx13, vl);
+
+    sinval = __riscv_vfneg_mu(__riscv_vmor(idx2, idx3, vl), sinval, sinval, vl);
+    cosval = __riscv_vfneg_mu(__riscv_vmor(idx1, idx2, vl), cosval, cosval, vl);
 }
 
 }}}  // namespace cv::cv_hal_rvv::detail
+
+#endif  // OPENCV_HAL_RVV_SINCOS_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/sincos.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_SINCOS_HPP_INCLUDED
 #define OPENCV_HAL_RVV_SINCOS_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
@@ -222,6 +222,8 @@ static inline BaseType vredmax(VecType vs2, BaseType vs1, size_t vl) {          
                                                            \
         template <typename FROM>                           \
         inline static VecType cast(FROM v, size_t vl);     \
+        template <typename FROM>                           \
+        inline static VecType reinterpret(FROM v);         \
     };                                                     \
                                                            \
     template <>                                            \
@@ -467,18 +469,52 @@ HAL_RVV_CVT(RVV_F32MF2, RVV_F64M1)
 
 #undef HAL_RVV_CVT
 
-#define HAL_RVV_CVT(A, B, A_TYPE, B_TYPE, LMUL_TYPE, LMUL)                                    \
+#define HAL_RVV_CVT(A, B, A_TYPE, B_TYPE, LMUL_TYPE, LMUL, IS_U)                              \
     template <>                                                                               \
     inline RVV<A, LMUL_TYPE>::VecType RVV<A, LMUL_TYPE>::cast(                                \
-        RVV<B, LMUL_TYPE>::VecType v, [[maybe_unused]] size_t vl                              \
+        RVV<B, LMUL_TYPE>::VecType v, size_t vl                                               \
     ) {                                                                                       \
-        return __riscv_vreinterpret_##A_TYPE##LMUL(v);                                        \
+        return __riscv_vfcvt_f_x##IS_U##_v_##A_TYPE##LMUL(v, vl);                             \
     }                                                                                         \
     template <>                                                                               \
     inline RVV<B, LMUL_TYPE>::VecType RVV<B, LMUL_TYPE>::cast(                                \
-        RVV<A, LMUL_TYPE>::VecType v, [[maybe_unused]] size_t vl                              \
+        RVV<A, LMUL_TYPE>::VecType v, size_t vl                                               \
     ) {                                                                                       \
-        return __riscv_vreinterpret_##B_TYPE##LMUL(v);                                        \
+        return __riscv_vfcvt_x##IS_U##_f_v_##B_TYPE##LMUL(v, vl);                             \
+    }
+
+HAL_RVV_CVT( float,  int32_t, f32, i32,  LMUL_1,  m1, )
+HAL_RVV_CVT( float,  int32_t, f32, i32,  LMUL_2,  m2, )
+HAL_RVV_CVT( float,  int32_t, f32, i32,  LMUL_4,  m4, )
+HAL_RVV_CVT( float,  int32_t, f32, i32,  LMUL_8,  m8, )
+HAL_RVV_CVT( float,  int32_t, f32, i32, LMUL_f2, mf2, )
+
+HAL_RVV_CVT( float, uint32_t, f32, u32,  LMUL_1,  m1, u)
+HAL_RVV_CVT( float, uint32_t, f32, u32,  LMUL_2,  m2, u)
+HAL_RVV_CVT( float, uint32_t, f32, u32,  LMUL_4,  m4, u)
+HAL_RVV_CVT( float, uint32_t, f32, u32,  LMUL_8,  m8, u)
+HAL_RVV_CVT( float, uint32_t, f32, u32, LMUL_f2, mf2, u)
+
+HAL_RVV_CVT(double,  int64_t, f64, i64,  LMUL_1,  m1, )
+HAL_RVV_CVT(double,  int64_t, f64, i64,  LMUL_2,  m2, )
+HAL_RVV_CVT(double,  int64_t, f64, i64,  LMUL_4,  m4, )
+HAL_RVV_CVT(double,  int64_t, f64, i64,  LMUL_8,  m8, )
+
+HAL_RVV_CVT(double, uint64_t, f64, u64,  LMUL_1,  m1, u)
+HAL_RVV_CVT(double, uint64_t, f64, u64,  LMUL_2,  m2, u)
+HAL_RVV_CVT(double, uint64_t, f64, u64,  LMUL_4,  m4, u)
+HAL_RVV_CVT(double, uint64_t, f64, u64,  LMUL_8,  m8, u)
+
+#undef HAL_RVV_CVT
+
+#define HAL_RVV_CVT(A, B, A_TYPE, B_TYPE, LMUL_TYPE, LMUL)                                           \
+    template <>                                                                                      \
+    inline RVV<A, LMUL_TYPE>::VecType RVV<A, LMUL_TYPE>::reinterpret(RVV<B, LMUL_TYPE>::VecType v) { \
+        return __riscv_vreinterpret_##A_TYPE##LMUL(v);                                               \
+    }                                                                                                \
+    template <>                                                                                      \
+    inline RVV<B, LMUL_TYPE>::VecType RVV<B, LMUL_TYPE>::reinterpret(RVV<A, LMUL_TYPE>::VecType v) { \
+        return __riscv_vreinterpret_##B_TYPE##LMUL(v);                                               \
     }
 
 #define HAL_RVV_CVT2(A, B, A_TYPE, B_TYPE)        \

--- a/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
@@ -92,6 +92,22 @@ template <typename Dst_T, typename RVV_T>
 using RVV_SameLen =
     RVV<Dst_T, RVV_LMUL(RVV_T::lmul / sizeof(typename RVV_T::ElemType) * sizeof(Dst_T))>;
 
+template <size_t DstSize> struct RVV_ToIntHelper;
+template <size_t DstSize> struct RVV_ToUintHelper;
+template <size_t DstSize> struct RVV_ToFloatHelper;
+
+template <typename RVV_T>
+using RVV_ToInt =
+    RVV<typename RVV_ToIntHelper<sizeof(typename RVV_T::ElemType)>::type, RVV_T::lmul>;
+
+template <typename RVV_T>
+using RVV_ToUint =
+    RVV<typename RVV_ToUintHelper<sizeof(typename RVV_T::ElemType)>::type, RVV_T::lmul>;
+
+template <typename RVV_T>
+using RVV_ToFloat =
+    RVV<typename RVV_ToFloatHelper<sizeof(typename RVV_T::ElemType)>::type, RVV_T::lmul>;
+
 template <typename RVV_T>
 using RVV_BaseType = RVV<typename RVV_T::ElemType, LMUL_1>;
 
@@ -199,7 +215,7 @@ static inline BaseType vredmax(VecType vs2, BaseType vs1, size_t vl) {          
         using BoolType = HAL_RVV_BOOL_TYPE(__VA_ARGS__);   \
         using BaseType = v##VEC_TYPE##m1_t;                \
                                                            \
-        static constexpr size_t lmul = LMUL_TYPE;          \
+        static constexpr RVV_LMUL lmul = LMUL_TYPE;        \
                                                            \
         HAL_RVV_SIZE_RELATED(EEW, TYPE, LMUL, __VA_ARGS__) \
         HAL_RVV_SIZE_UNRELATED(__VA_ARGS__)                \
@@ -299,6 +315,20 @@ HAL_RVV_DEFINE_ONE( float, float32, LMUL_f2, 32, f32, mf2, HAL_RVV_FLOAT_PARAM)
 #undef HAL_RVV_SIZE_RELATED
 
 // -------------------------------Define cast--------------------------------
+
+template <> struct RVV_ToIntHelper<1> {using type = int8_t;};
+template <> struct RVV_ToIntHelper<2> {using type = int16_t;};
+template <> struct RVV_ToIntHelper<4> {using type = int32_t;};
+template <> struct RVV_ToIntHelper<8> {using type = int64_t;};
+
+template <> struct RVV_ToUintHelper<1> {using type = uint8_t;};
+template <> struct RVV_ToUintHelper<2> {using type = uint16_t;};
+template <> struct RVV_ToUintHelper<4> {using type = uint32_t;};
+template <> struct RVV_ToUintHelper<8> {using type = uint64_t;};
+
+template <> struct RVV_ToFloatHelper<2> {using type = _Float16;};
+template <> struct RVV_ToFloatHelper<4> {using type = float;};
+template <> struct RVV_ToFloatHelper<8> {using type = double;};
 
 #define HAL_RVV_CVT(ONE, TWO)                                                                   \
     template <>                                                                                 \

--- a/modules/core/perf/perf_math.cpp
+++ b/modules/core/perf/perf_math.cpp
@@ -79,6 +79,28 @@ PERF_TEST_P(CartToPolarFixture, CartToPolar,
     SANITY_CHECK_NOTHING();
 }
 
+///////////// Polar to Cart /////////////
+
+typedef Size_MatType PolarToCartFixture;
+
+PERF_TEST_P(PolarToCartFixture, PolarToCart,
+    testing::Combine(testing::Values(TYPICAL_MAT_SIZES), testing::Values(CV_32F, CV_64F)))
+{
+    cv::Size size = std::get<0>(GetParam());
+    int type = std::get<1>(GetParam());
+
+    cv::Mat magnitude(size, type);
+    cv::Mat angle(size, type);
+    cv::Mat x(size, type);
+    cv::Mat y(size, type);
+
+    declare.in(magnitude, angle, WARMUP_RNG).out(x, y);
+
+    TEST_CYCLE() cv::polarToCart(magnitude, angle, x, y);
+
+    SANITY_CHECK_NOTHING();
+}
+
 // generates random vectors, performs Gram-Schmidt orthogonalization on them
 Mat randomOrtho(int rows, int ftype, RNG& rng)
 {

--- a/modules/core/src/mathfuncs_core.dispatch.cpp
+++ b/modules/core/src/mathfuncs_core.dispatch.cpp
@@ -29,6 +29,26 @@ void cartToPolar64f(const double* x, const double* y, double* mag, double* angle
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+void polarToCart32f(const float* mag, const float* angle, float* x, float* y, int len, bool angleInDegrees)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(polarToCart32f, cv_hal_polarToCart32f, mag, angle, x, y, len, angleInDegrees);
+
+    CV_CPU_DISPATCH(polarToCart32f, (mag, angle, x, y, len, angleInDegrees),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
+
+void polarToCart64f(const double* mag, const double* angle, double* x, double* y, int len, bool angleInDegrees)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(polarToCart64f, cv_hal_polarToCart64f, mag, angle, x, y, len, angleInDegrees);
+
+    CV_CPU_DISPATCH(polarToCart64f, (mag, angle, x, y, len, angleInDegrees),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
+
 void fastAtan32f(const float *Y, const float *X, float *angle, int len, bool angleInDegrees )
 {
     CV_INSTRUMENT_REGION();


### PR DESCRIPTION
### Summary

1. Implement through the existing `cv_hal_polarToCart32f` and `cv_hal_polarToCart64f` interfaces.
2. Add `polarToCart` performance tests
3. Make `cv::polarToCart` use CALL_HAL in the same way as `cv::cartToPolar`
4. To achieve the 3rd point, the original implementation was moved, and some modifications were made.

Tested through:
```sh
opencv_test_core --gtest_filter="*PolarToCart*:*Core_CartPolar_reverse*" 
opencv_perf_core --gtest_filter="*PolarToCart*" --perf_min_samples=300 --perf_force_samples=300
```

### HAL performance test

***UPDATE***: Current implementation is no more depending on vlen.

**NOTE**: Due to the 4th point in the summary above, the `scalar` and `ui` test is based on the modified code of this PR. The impact of this patch on `scalar` and `ui` is evaluated in the next section, `Effect of Point 4`.

Vlen 256 (Muse Pi):
```
                   Name of Test                     scalar    ui     rvv       ui        rvv    
                                                                               vs         vs    
                                                                             scalar     scalar  
                                                                           (x-factor) (x-factor)
PolarToCart::PolarToCartFixture::(127x61, 32FC1)     0.315  0.110  0.034     2.85       9.34   
PolarToCart::PolarToCartFixture::(127x61, 64FC1)     0.423  0.163  0.045     2.59       9.34   
PolarToCart::PolarToCartFixture::(640x480, 32FC1)   13.695  4.325  1.278     3.17      10.71   
PolarToCart::PolarToCartFixture::(640x480, 64FC1)   17.719  7.118  2.105     2.49       8.42   
PolarToCart::PolarToCartFixture::(1280x720, 32FC1)  40.678  13.114 3.977     3.10      10.23   
PolarToCart::PolarToCartFixture::(1280x720, 64FC1)  53.124  21.298 6.519     2.49       8.15   
PolarToCart::PolarToCartFixture::(1920x1080, 32FC1) 95.158  29.465 8.894     3.23      10.70   
PolarToCart::PolarToCartFixture::(1920x1080, 64FC1) 119.262 47.743 14.129    2.50       8.44   
```

### Effect of Point 4

To make `cv::polarToCart` behave the same as `cv::cartToPolar`, the implementation detail of the former has been moved to the latter's location (from `mathfuncs.cpp` to `mathfuncs_core.simd.hpp`).

#### Reason for Changes:

This function works as follows:  
$y = \text{mag} \times \sin(\text{angle})$ and $x = \text{mag} \times \cos(\text{angle})$. The original implementation first calculates the values of $\sin$ and $\cos$, storing the results in the output buffers $x$ and $y$, and then multiplies the result by $\text{mag}$. 

However, when the function is used as an in-place operation (one of the output buffers is also an input buffer), the original implementation allocates an extra buffer to store the $\sin$ and $\cos$ values in case the $\text{mag}$ value gets overwritten. This extra buffer allocation prevents `cv::polarToCart` from functioning in the same way as `cv::cartToPolar`.

Therefore, the multiplication is now performed immediately without storing intermediate values. Since the original implementation also had AVX2 optimizations, I have applied the same optimizations to the AVX2 version of this implementation.

***UPDATE***: UI use v_sincos from #25892 now. The original implementation has AVX2 optimizations but is slower much than current UI so it's removed, and AVX2 perf test is below. Scalar implementation isn't changed because it's faster than using UI's method.

#### Test Result

`scalar` and `ui` test is done on Muse PI, and AVX2 test is done on Intel(R) Xeon(R) Gold 6140 CPU @ 2.30GHz.

`scalar` test:
```
                   Name of Test                      orig     pr        pr    
                                                                        vs    
                                                                       orig   
                                                                    (x-factor)
PolarToCart::PolarToCartFixture::(127x61, 32FC1)     0.333   0.294     1.13   
PolarToCart::PolarToCartFixture::(127x61, 64FC1)     0.385   0.403     0.96   
PolarToCart::PolarToCartFixture::(640x480, 32FC1)   14.749  12.343     1.19   
PolarToCart::PolarToCartFixture::(640x480, 64FC1)   19.419  16.743     1.16   
PolarToCart::PolarToCartFixture::(1280x720, 32FC1)  44.155  37.822     1.17   
PolarToCart::PolarToCartFixture::(1280x720, 64FC1)  62.108  50.358     1.23   
PolarToCart::PolarToCartFixture::(1920x1080, 32FC1) 99.011  85.769     1.15   
PolarToCart::PolarToCartFixture::(1920x1080, 64FC1) 127.740 112.874    1.13   
```

`ui` test:
```
                   Name of Test                      orig     pr        pr    
                                                                        vs    
                                                                       orig   
                                                                    (x-factor)
PolarToCart::PolarToCartFixture::(127x61, 32FC1)     0.306  0.110     2.77   
PolarToCart::PolarToCartFixture::(127x61, 64FC1)     0.455  0.163     2.79   
PolarToCart::PolarToCartFixture::(640x480, 32FC1)   13.381  4.325     3.09   
PolarToCart::PolarToCartFixture::(640x480, 64FC1)   21.851  7.118     3.07   
PolarToCart::PolarToCartFixture::(1280x720, 32FC1)  39.975  13.114    3.05   
PolarToCart::PolarToCartFixture::(1280x720, 64FC1)  67.006  21.298    3.15   
PolarToCart::PolarToCartFixture::(1920x1080, 32FC1) 90.362  29.465    3.07   
PolarToCart::PolarToCartFixture::(1920x1080, 64FC1) 129.637 47.743    2.72   
```

AVX2 test:
```
                   Name of Test                     orig   pr       pr    
                                                                    vs    
                                                                   orig   
                                                                (x-factor)
PolarToCart::PolarToCartFixture::(127x61, 32FC1)    0.019 0.009    2.11   
PolarToCart::PolarToCartFixture::(127x61, 64FC1)    0.022 0.013    1.74   
PolarToCart::PolarToCartFixture::(640x480, 32FC1)   0.788 0.355    2.22   
PolarToCart::PolarToCartFixture::(640x480, 64FC1)   1.102 0.618    1.78   
PolarToCart::PolarToCartFixture::(1280x720, 32FC1)  2.383 1.042    2.29   
PolarToCart::PolarToCartFixture::(1280x720, 64FC1)  3.758 2.316    1.62   
PolarToCart::PolarToCartFixture::(1920x1080, 32FC1) 5.577 2.559    2.18   
PolarToCart::PolarToCartFixture::(1920x1080, 64FC1) 9.710 6.424    1.51   
```

A slight performance loss occurs because the check for whether $mag$ is nullptr is performed with every calculation, instead of being done once per batch. This is to reuse current `SinCos_32f` function.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
