### PR TITLE
Optimize camera matrix undistortion

### DIFF
--- a/modules/calib3d/src/calibration_base.cpp
+++ b/modules/calib3d/src/calibration_base.cpp
@@ -1530,15 +1530,20 @@ void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs
     Mat _pts(1, 4*(N-1), CV_64FC2);
     Point2d* pts = _pts.ptr<Point2d>();
 
+    // generate a grid of points across the image to estimate the distortion deformation
+    double stepX = (imgSize.width - 1) / static_cast<double>(N - 1);
+    double stepY = (imgSize.height - 1) / static_cast<double>(N - 1);
     for( y = k = 0; y < N; y++ )
     {
         for( x = 0; x < N; x++ )
         {
             if (x != 0 && x != N - 1 && y != 0 && y != N - 1)
             {
+                // skip all points except those on the image border, because inner grid points
+                // have no influence on the two deformation rectangles that are calculated below
                 continue;
             }
-            pts[k++] = Point2d((double)x*(imgSize.width-1)/(N-1), (double)y*(imgSize.height-1)/(N-1));
+            pts[k++] = Point2d(x * stepX, y * stepY);
         }
     }
 

--- a/modules/calib3d/src/calibration_base.cpp
+++ b/modules/calib3d/src/calibration_base.cpp
@@ -1527,12 +1527,20 @@ void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs
 {
     const int N = 9;
     int x, y, k;
-    Mat _pts(1, N*N, CV_64FC2);
+    Mat _pts(1, 4*(N-1), CV_64FC2);
     Point2d* pts = _pts.ptr<Point2d>();
 
     for( y = k = 0; y < N; y++ )
+    {
         for( x = 0; x < N; x++ )
+        {
+            if (x != 0 && x != N - 1 && y != 0 && y != N - 1)
+            {
+                continue;
+            }
             pts[k++] = Point2d((double)x*(imgSize.width-1)/(N-1), (double)y*(imgSize.height-1)/(N-1));
+        }
+    }
 
     undistortPoints(_pts, _pts, _cameraMatrix, _distCoeffs, R, newCameraMatrix);
 
@@ -1541,8 +1549,14 @@ void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs
     // find the inscribed rectangle.
     // the code will likely not work with extreme rotation matrices (R) (>45%)
     for( y = k = 0; y < N; y++ )
+    {
         for( x = 0; x < N; x++ )
         {
+            if (x != 0 && x != N - 1 && y != 0 && y != N - 1)
+            {
+                continue;
+            }
+
             Point2d p = pts[k++];
             oX0 = MIN(oX0, p.x);
             oX1 = MAX(oX1, p.x);
@@ -1558,6 +1572,7 @@ void cv::getUndistortRectangles(InputArray _cameraMatrix, InputArray _distCoeffs
             if( y == N-1 )
                 iY1 = MIN(iY1, p.y);
         }
+    }
     inner = Rect_<double>(iX0, iY0, iX1-iX0, iY1-iY0);
     outer = Rect_<double>(oX0, oY0, oX1-oX0, oY1-oY0);
 }


### PR DESCRIPTION
Use only image contour for camera matrix undistortion. \
For inner and outer rectangles of the undistorted image only the image border should be necessary when standard distortion models are used. Using inner image points notably slows down the process since more points need to be undistorted (81 vs 32).