### PR TITLE
build: fix OpenBLAS detection on Linux

### DIFF
--- a/cmake/OpenCVFindOpenBLAS.cmake
+++ b/cmake/OpenCVFindOpenBLAS.cmake
@@ -1,107 +1,42 @@
-#COPYRIGHT
-#
-#All contributions by the University of California:
-#Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-#All rights reserved.
-#
-#All other contributions:
-#Copyright (c) 2014, 2015, the respective contributors
-#All rights reserved.
-#
-#Caffe uses a shared copyright model: each contributor holds copyright over
-#their contributions to Caffe. The project versioning records all such
-#contribution and copyright details. If a contributor wants to further mark
-#their specific copyright on a particular contribution, they should indicate
-#their copyright solely in the commit message of the change when it is
-#committed.
-#
-#LICENSE
-#
-#Redistribution and use in source and binary forms, with or without
-#modification, are permitted provided that the following conditions are met:
-#
-#1. Redistributions of source code must retain the above copyright notice, this
-#   list of conditions and the following disclaimer.
-#2. Redistributions in binary form must reproduce the above copyright notice,
-#   this list of conditions and the following disclaimer in the documentation
-#   and/or other materials provided with the distribution.
-#
-#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-#ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-#WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-#DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-#ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-#(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-#LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-#ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-#(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-#SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-#CONTRIBUTION AGREEMENT
-#
-#By contributing to the BVLC/caffe repository through pull-request, comment,
-#or otherwise, the contributor releases their content to the
-#license and copyright terms herein.
+# Search for OpenBLAS library
 
-SET(Open_BLAS_INCLUDE_SEARCH_PATHS
-  $ENV{OpenBLAS_HOME}
-  $ENV{OpenBLAS_HOME}/include
-  $ENV{OpenBLAS_HOME}/include/openblas
-  /opt/OpenBLAS/include
-  /usr/local/include/openblas
-  /usr/include/openblas
-  /usr/local/include/openblas-base
-  /usr/include/openblas-base
-  /usr/local/include
-  /usr/include
-)
+if(NOT OpenBLAS_FOUND AND NOT SKIP_OPENBLAS_PACKAGE)
+  find_package(OpenBLAS QUIET)
+  if(OpenBLAS_FOUND)
+    message(STATUS "Found OpenBLAS package")
+  endif()
+endif()
 
-SET(Open_BLAS_LIB_SEARCH_PATHS
-        $ENV{OpenBLAS}
-        $ENV{OpenBLAS}/lib
-        $ENV{OpenBLAS_HOME}
-        $ENV{OpenBLAS_HOME}/lib
-        /opt/OpenBLAS/lib
-        /usr/local/lib64
-        /usr/local/lib
-        /lib/openblas-base
-        /lib64/
-        /lib/
-        /usr/lib/openblas-base
-        /usr/lib64
-        /usr/lib
- )
+if(NOT OpenBLAS_FOUND)
+  find_library(OpenBLAS_LIBRARIES NAMES openblas PATHS ENV "OpenBLAS" ENV "OpenBLAS_HOME" PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
+  find_path(OpenBLAS_INCLUDE_DIRS NAMES cblas.h PATHS ENV "OpenBLAS" ENV "OpenBLAS_HOME" PATH_SUFFIXES "include" NO_DEFAULT_PATH)
+  find_path(OpenBLAS_LAPACKE_DIR NAMES lapacke.h PATHS "${OpenBLAS_INCLUDE_DIRS}" ENV "OpenBLAS" ENV "OpenBLAS_HOME" PATH_SUFFIXES "include" NO_DEFAULT_PATH)
+  if(OpenBLAS_LIBRARIES AND OpenBLAS_INCLUDE_DIRS)
+    message(STATUS "Found OpenBLAS using environment hint")
+    set(OpenBLAS_FOUND ON)
+  else()
+    ocv_clear_vars(OpenBLAS_LIBRARIES OpenBLAS_INCLUDE_DIRS)
+  endif()
+endif()
 
-FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS} NO_DEFAULT_PATH)
-FIND_LIBRARY(OpenBLAS_LIB NAMES openblas libopenblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS}  NO_DEFAULT_PATH)
+if(NOT OpenBLAS_FOUND)
+  find_library(OpenBLAS_LIBRARIES NAMES openblas)
+  find_path(OpenBLAS_INCLUDE_DIRS NAMES cblas.h)
+  find_path(OpenBLAS_LAPACKE_DIR NAMES lapacke.h PATHS "${OpenBLAS_INCLUDE_DIRS}")
+  if(OpenBLAS_LIBRARIES AND OpenBLAS_INCLUDE_DIRS)
+    message(STATUS "Found OpenBLAS in the system")
+    set(OpenBLAS_FOUND ON)
+  else()
+    ocv_clear_vars(OpenBLAS_LIBRARIES OpenBLAS_INCLUDE_DIRS)
+  endif()
+endif()
 
-SET(OpenBLAS_FOUND ON)
+if(OpenBLAS_FOUND)
+  if(OpenBLAS_LAPACKE_DIR)
+    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_INCLUDE_DIRS};${OpenBLAS_LAPACKE_DIR}")
+  endif()
+  message(STATUS "OpenBLAS_LIBRARIES=${OpenBLAS_LIBRARIES}")
+  message(STATUS "OpenBLAS_INCLUDE_DIRS=${OpenBLAS_INCLUDE_DIRS}")
+endif()
 
-#    Check include files
-IF(NOT OpenBLAS_INCLUDE_DIR)
-    SET(OpenBLAS_FOUND OFF)
-    MESSAGE(STATUS "Could not find OpenBLAS include. Turning OpenBLAS_FOUND off")
-ENDIF()
-
-#    Check libraries
-IF(NOT OpenBLAS_LIB)
-    SET(OpenBLAS_FOUND OFF)
-    MESSAGE(STATUS "Could not find OpenBLAS lib. Turning OpenBLAS_FOUND off")
-ENDIF()
-
-IF (OpenBLAS_FOUND)
-  IF (NOT OpenBLAS_FIND_QUIETLY)
-    MESSAGE(STATUS "Found OpenBLAS libraries: ${OpenBLAS_LIB}")
-    MESSAGE(STATUS "Found OpenBLAS include: ${OpenBLAS_INCLUDE_DIR}")
-  ENDIF (NOT OpenBLAS_FIND_QUIETLY)
-ELSE (OpenBLAS_FOUND)
-  IF (OpenBLAS_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find OpenBLAS")
-  ENDIF (OpenBLAS_FIND_REQUIRED)
-ENDIF (OpenBLAS_FOUND)
-
-MARK_AS_ADVANCED(
-    OpenBLAS_INCLUDE_DIR
-    OpenBLAS_LIB
-    OpenBLAS
-)
+mark_as_advanced(OpenBLAS_LIBRARIES OpenBLAS_INCLUDE_DIRS OpenBLAS_LAPACKE_DIR)


### PR DESCRIPTION
Main change is rewritten `OpenCVFindOpenBLAS.cmake`:
- search cmake package first
- search using environment variables second
- search in system locations last
- additionally search for lapacke.h and append its path to the result header location

Other changes:
- use arguments syntax for `ocv_lapack_check`
- debug output

Test framework (Linux): https://github.com/mshabunin/opencv-blas-check

Should be merged with https://github.com/opencv/ci-gha-workflow/pull/237