### PR TITLE
Warning fix on Windows.

### DIFF
--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -126,7 +126,7 @@ public:
 class SIMDBayerInterpolator_8u
 {
 public:
-    static int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
+    int bayer2Gray(const uchar* bayer, int bayer_step, uchar* dst,
                    int width, int bcoeff, int gcoeff, int rcoeff)
     {
 #if CV_SIMD


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/26868
Warning:
```
C:\build\precommit_windows64\4.x\opencv\modules\imgproc\src\demosaicing.cpp(683): warning C4101: 'vecOp': unreferenced local variable [C:\build\precommit_windows64\build\modules\imgproc\opencv_imgproc.vcxproj]
  C:\build\precommit_windows64\4.x\opencv\modules\imgproc\src\demosaicing.cpp(682): note: while compiling class template member function 'void cv::Bayer2Gray_Invoker<T,SIMDInterpolator>::operator ()(const cv::Range &) const'
          with
          [
              T=uchar,
              SIMDInterpolator=cv::SIMDBayerInterpolator_8u
          ]
  C:\build\precommit_windows64\4.x\opencv\modules\imgproc\src\demosaicing.cpp(793): note: see reference to class template instantiation 'cv::Bayer2Gray_Invoker<T,SIMDInterpolator>' being compiled
          with
          [
              T=uchar,
              SIMDInterpolator=cv::SIMDBayerInterpolator_8u
          ]
  C:\build\precommit_windows64\4.x\opencv\modules\imgproc\src\demosaicing.cpp(1779): note: see reference to function template instantiation 'void cv::Bayer2Gray_<uchar,cv::SIMDBayerInterpolator_8u>(const cv::Mat &,cv::Mat &,int)' being compiled
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
