### PR TITLE
Move the CV_Assert above the << operation to not trigger the fuzzer

### DIFF
--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -319,9 +319,9 @@ bool GifDecoder::lzwDecode() {
     lzwMinCodeSize = m_strm.getByte();
     const int lzwMaxSize = (1 << 12); // 4096 is the maximum size of the LZW table (12 bits)
     int lzwCodeSize = lzwMinCodeSize + 1;
+    CV_Assert(lzwCodeSize > 2 && lzwCodeSize <= 12);
     int clearCode = 1 << lzwMinCodeSize;
     int exitCode = clearCode + 1;
-    CV_Assert(lzwCodeSize > 2 && lzwCodeSize <= 12);
     std::vector<lzwNodeD> lzwExtraTable(lzwMaxSize + 1);
     int colorTableSize = clearCode;
     int lzwTableSize = exitCode;


### PR DESCRIPTION
This is according to https://www.w3.org/Graphics/GIF/spec-gif89a.txt

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
