### PR TITLE
RISC-V: Fix #27003.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -2130,7 +2130,17 @@ inline v_int64 v_dotprod_expand_fast(const v_int16& a, const v_int16& b, const v
 // 32 >> 64f
 #if CV_SIMD_SCALABLE_64F
 inline v_float64 v_dotprod_expand_fast(const v_int32& a, const v_int32& b)
-{ return v_cvt_f64(v_dotprod_fast(a, b)); }
+{
+    vfloat64m1_t zero = __riscv_vfmv_v_f_f64m1(0, VTraits<vuint64m1_t>::vlanes());
+    auto prod_i64 = __riscv_vwmul(a, b, VTraits<v_int32>::vlanes());
+    // Convert to f64 before reduction to avoid overflow: #27003
+    auto prod_f64 = __riscv_vfcvt_f(prod_i64, VTraits<v_int32>::vlanes());
+    return __riscv_vset( // Needs v_float64 (vfloat64m2_t) here.
+        v_setall_f64(0.0f), // zero_f64m2
+        0,
+        __riscv_vfredusum_tu(zero, prod_f64, zero, VTraits<v_int32>::vlanes())
+    );
+}
 inline v_float64 v_dotprod_expand_fast(const v_int32& a, const v_int32& b, const v_float64& c)
 { return v_add(v_dotprod_expand_fast(a, b) , c); }
 #endif


### PR DESCRIPTION
Fix #27003 by converting to f64 before reduction to avoid overflow.

tested on QEMU (VLEN=128 to 1024) and SpaceMIT K1

` ./bin/opencv_perf_core --gtest_filter="MatType_Length_dot.dot/2*"`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
