### PR TITLE
[RVV HAL] Add copyright and replace '#pragma once'.

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv.hpp
+++ b/3rdparty/hal_rvv/hal_rvv.hpp
@@ -20,6 +20,7 @@
 #endif
 
 #if defined(__riscv_v) && __riscv_v == 1000000
+#include "hal_rvv_1p0/types.hpp"
 #include "hal_rvv_1p0/merge.hpp" // core
 #include "hal_rvv_1p0/mean.hpp" // core
 #include "hal_rvv_1p0/dxt.hpp" // core

--- a/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
@@ -123,6 +123,6 @@ inline int fast_atan_64(const double* y, const double* x, double* dst, size_t n,
     return CV_HAL_ERROR_OK;
 }
 
-} // namespace cv::cv_hal_rvv
+}} // namespace cv::cv_hal_rvv
 
 #endif //OPENCV_HAL_RVV_ATAN_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/atan.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_ATAN_HPP_INCLUDED
+#define OPENCV_HAL_RVV_ATAN_HPP_INCLUDED
 
 #undef cv_hal_fastAtan32f
 #define cv_hal_fastAtan32f cv::cv_hal_rvv::fast_atan_32
@@ -119,4 +123,6 @@ inline int fast_atan_64(const double* y, const double* x, double* dst, size_t n,
     return CV_HAL_ERROR_OK;
 }
 
-}}  // namespace cv::cv_hal_rvv
+} // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_ATAN_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/cholesky.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/cholesky.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_CHOLESKY_HPP_INCLUDED
 #define OPENCV_HAL_RVV_CHOLESKY_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/color.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/color.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_COLOR_HPP_INCLUDED
 #define OPENCV_HAL_RVV_COLOR_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/convert_scale.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/convert_scale.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_CONVERT_SCALE_HPP_INCLUDED
 #define OPENCV_HAL_RVV_CONVERT_SCALE_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/dxt.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/dxt.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_DXT_HPP_INCLUDED
 #define OPENCV_HAL_RVV_DXT_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/exp.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/exp.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_EXP_HPP_INCLUDED
+#define OPENCV_HAL_RVV_EXP_HPP_INCLUDED
 
 #include <riscv_vector.h>
 
@@ -200,3 +204,5 @@ inline int exp64f(const double* src, double* dst, int _len)
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_EXP_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/filter.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/filter.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_FILTER_HPP_INCLUDED
 #define OPENCV_HAL_RVV_FILTER_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/flip.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/flip.hpp
@@ -1,7 +1,12 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_FLIP_HPP_INCLUDED
+#define OPENCV_HAL_RVV_FLIP_HPP_INCLUDED
+
 
 #include <riscv_vector.h>
 #include <opencv2/core/base.hpp>
@@ -223,3 +228,5 @@ inline int flip(int src_type,
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_FLIP_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/log.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/log.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_LOG_HPP_INCLUDED
+#define OPENCV_HAL_RVV_LOG_HPP_INCLUDED
 
 #include <riscv_vector.h>
 
@@ -379,3 +383,5 @@ inline int log64f(const double* src, double* dst, int _len)
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_LOG_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/lu.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/lu.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_LU_HPP_INCLUDED
 #define OPENCV_HAL_RVV_LU_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/lut.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/lut.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_LUT_HPP_INCLUDED
+#define OPENCV_HAL_RVV_LUT_HPP_INCLUDED
 
 #include <riscv_vector.h>
 #include <opencv2/core/base.hpp>
@@ -188,3 +192,5 @@ inline int lut(const uchar* src_data,
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_LUT_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/mean.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/mean.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_MEANSTDDEV_HPP_INCLUDED
 #define OPENCV_HAL_RVV_MEANSTDDEV_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/merge.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/merge.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_MERGE_HPP_INCLUDED
 #define OPENCV_HAL_RVV_MERGE_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/minmax.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/minmax.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_MINMAX_HPP_INCLUDED
 #define OPENCV_HAL_RVV_MINMAX_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/norm.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/norm.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_NORM_HPP_INCLUDED
 #define OPENCV_HAL_RVV_NORM_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/norm_diff.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/norm_diff.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_NORM_DIFF_HPP_INCLUDED
 #define OPENCV_HAL_RVV_NORM_DIFF_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/norm_hamming.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/norm_hamming.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_NORM_HAMMING_HPP_INCLUDED
+#define OPENCV_HAL_RVV_NORM_HAMMING_HPP_INCLUDED
 
 #include <riscv_vector.h>
 #include <opencv2/core/base.hpp>
@@ -180,3 +184,5 @@ inline int normHammingDiff8u(const uchar* a, const uchar* b, int n, int cellSize
 }
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_NORM_HAMMING_HPP_INCLUDED

--- a/3rdparty/hal_rvv/hal_rvv_1p0/pyramids.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/pyramids.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_PYRAMIDS_HPP_INCLUDED
 #define OPENCV_HAL_RVV_PYRAMIDS_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/qr.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/qr.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_QR_HPP_INCLUDED
 #define OPENCV_HAL_RVV_QR_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/sqrt.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/sqrt.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_SQRT_HPP_INCLUDED
 #define OPENCV_HAL_RVV_SQRT_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/svd.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/svd.hpp
@@ -1,6 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
 #ifndef OPENCV_HAL_RVV_SVD_HPP_INCLUDED
 #define OPENCV_HAL_RVV_SVD_HPP_INCLUDED
 

--- a/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/types.hpp
@@ -1,7 +1,11 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level
 // directory of this distribution and at http://opencv.org/license.html.
-#pragma once
+
+// Copyright (C) 2025, Institute of Software, Chinese Academy of Sciences.
+
+#ifndef OPENCV_HAL_RVV_TYPES_HPP_INCLUDED
+#define OPENCV_HAL_RVV_TYPES_HPP_INCLUDED
 
 #include <riscv_vector.h>
 #include <type_traits>
@@ -483,3 +487,5 @@ HAL_RVV_CVT( uint8_t,  int8_t,  u8,  i8, LMUL_f8, mf8)
 #undef HAL_RVV_CVT
 
 }}  // namespace cv::cv_hal_rvv
+
+#endif //OPENCV_HAL_RVV_TYPES_HPP_INCLUDED


### PR DESCRIPTION
Add copyright and in RVV HAL, since other companies or teams may join the development and add their copyright.

And the '#pragma once' are replaced.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
