### PR TITLE
 Updated TopK Handling in ONNX Importer

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3124,18 +3124,33 @@ void ONNXImporter::parseLayerNorm(LayerParams& layerParams, const opencv_onnx::N
 
 void ONNXImporter::parseTopK(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
+    int k = -1;
+    for (const auto& attr : node_proto.attribute())
+    {
+        if (attr.name() == "k")
+        {
+            k = attr.i();
+            break;
+        }
+    }
+
     // K needs to be constant in case of being input (since opset 10)
+    int K = -1; // Define K at a higher scope
     if (node_proto.input_size() == 2) {
         bool K_const = constBlobs.find(node_proto.input(1)) != constBlobs.end();
         CV_CheckTrue(K_const, "OnnxImporter/TopK: K being non-constant is not supported");
 
         Mat input_K = getBlob(node_proto, 1);
-        int K = input_K.at<int>(0);
-        layerParams.set("k", K);
+        K = input_K.at<int>(0);
     }
 
+    CV_CheckTrue(k != -1 || K != -1, "OnnxImporter/TopK: K parameter is required but missing");
+
+    // Use K if available, otherwise fallback to k
+    layerParams.set("k", K != -1 ? K : k);
     addLayer(layerParams, node_proto);
 }
+
 
 void ONNXImporter::parseSimpleLayers(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {


### PR DESCRIPTION
Fixed the issue with the ONNX TopK operator in OpenCV.

The TopK operator needs a value k to work. Before, OpenCV expected k to always be set as a constant value.
If k was provided as an input (instead of a constant), OpenCV would fail with an error saying k was missing.
The fix allows OpenCV to read k from the input if it’s available.
If k is still missing after checking the inputs, OpenCV will now give a clear error message.