### PR TITLE
Try to fix GrabCut assertion

### DIFF
--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -217,7 +217,7 @@ void GMM::calcInverseCovAndDeterm(int ci, const double singularFix)
         }
         covDeterms[ci] = dtrm;
 
-        CV_Assert(std::abs(dtrm) >= std::numeric_limits<double>::epsilon() && !std::isnan(dtrm));
+        CV_Assert(!std::isnan(dtrm) && std::abs(dtrm) >= std::numeric_limits<double>::epsilon());
         double inv_dtrm = 1.0 / dtrm;
         inverseCovs[ci][0][0] =  (c[4]*c[8] - c[5]*c[7]) * inv_dtrm;
         inverseCovs[ci][1][0] = -(c[3]*c[8] - c[5]*c[6]) * inv_dtrm;

--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -217,7 +217,7 @@ void GMM::calcInverseCovAndDeterm(int ci, const double singularFix)
         }
         covDeterms[ci] = dtrm;
 
-        CV_Assert( dtrm > std::numeric_limits<double>::epsilon() );
+        CV_Assert(std::abs(dtrm) >= std::numeric_limits<double>::epsilon() && !std::isnan(dtrm));
         double inv_dtrm = 1.0 / dtrm;
         inverseCovs[ci][0][0] =  (c[4]*c[8] - c[5]*c[7]) * inv_dtrm;
         inverseCovs[ci][1][0] = -(c[3]*c[8] - c[5]*c[6]) * inv_dtrm;

--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -216,8 +216,8 @@ void GMM::calcInverseCovAndDeterm(int ci, const double singularFix)
             dtrm = c[0] * (c[4] * c[8] - c[5] * c[7]) - c[1] * (c[3] * c[8] - c[5] * c[6]) + c[2] * (c[3] * c[7] - c[4] * c[6]);
         }
         covDeterms[ci] = dtrm;
-
-        CV_Assert(!std::isnan(dtrm) && std::abs(dtrm) >= std::numeric_limits<double>::epsilon());
+        dtrm = std::isnan(dtrm) ? std::numeric_limits<double>::epsilon() : std::max(dtrm, std::numeric_limits<double>::epsilon());
+        CV_Assert(std::abs(dtrm) >= std::numeric_limits<double>::epsilon());
         double inv_dtrm = 1.0 / dtrm;
         inverseCovs[ci][0][0] =  (c[4]*c[8] - c[5]*c[7]) * inv_dtrm;
         inverseCovs[ci][1][0] = -(c[3]*c[8] - c[5]*c[6]) * inv_dtrm;


### PR DESCRIPTION
This PR fixes an assertion failure in the GrabCut algorithm caused by a zero or NaN determinant value during matrix inversion. It adds a check to handle these cases and prevent crashes.