### PR TITLE
Fix a missing in the last 5.x merge 4.x

### DIFF
--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -45,7 +45,7 @@ struct NormL2_SIMD {
     inline ST operator() (const T* src, int n) const {
         ST s = 0;
         for (int i = 0; i < n; i++) {
-            ST v = src[i];
+            ST v = (ST)src[i];
             s += v * v;
         }
         return s;

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -578,7 +578,8 @@ normInf_(const T* src, const uchar* mask, ST* _result, int len, int cn)
     ST result = *_result;
     if( !mask )
     {
-        result = std::max(result, normInf<T, ST>(src, len*cn));
+        NormInf_SIMD<T, ST> op;
+        result = std::max(result, op(src, len*cn));
     }
     else
     {
@@ -599,7 +600,8 @@ normL1_(const T* src, const uchar* mask, ST* _result, int len, int cn)
     ST result = *_result;
     if( !mask )
     {
-        result += normL1<T, ST>(src, len*cn);
+        NormL1_SIMD<T, ST> op;
+        result += op(src, len*cn);
     }
     else
     {
@@ -620,7 +622,8 @@ normL2_(const T* src, const uchar* mask, ST* _result, int len, int cn)
     ST result = *_result;
     if( !mask )
     {
-        result += normL2Sqr<T, ST>(src, len*cn);
+        NormL2_SIMD<T, ST> op;
+        result += op(src, len*cn);
     }
     else
     {


### PR DESCRIPTION
It should look like this

https://github.com/opencv/opencv/blob/14396b802947d69d3cc44f0e809977b891ef8f4a/modules/core/src/norm.simd.hpp#L1229-L1230

https://github.com/opencv/opencv/blob/14396b802947d69d3cc44f0e809977b891ef8f4a/modules/core/src/norm.simd.hpp#L1248-L1249

https://github.com/opencv/opencv/blob/14396b802947d69d3cc44f0e809977b891ef8f4a/modules/core/src/norm.simd.hpp#L1267-L1268

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
