### PR TITLE
GIF: Make sure to resize lzwExtraTable before each block

### DIFF
--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -337,6 +337,7 @@ bool GifDecoder::lzwDecode() {
     int leftBits = 0;
     uint32_t src = 0;
     auto blockLen = (uchar)m_strm.getByte();
+    clear();
     while (blockLen) {
         if (leftBits < lzwCodeSize) {
             src |= m_strm.getByte() << leftBits;
@@ -344,7 +345,6 @@ bool GifDecoder::lzwDecode() {
             leftBits += 8;
         }
 
-        clear();
         while (leftBits >= lzwCodeSize) {
             // get the code
             uint16_t code = src & ((1 << lzwCodeSize) - 1);
@@ -358,6 +358,7 @@ bool GifDecoder::lzwDecode() {
             }
             // end of information
             if (!(code ^ exitCode)) {
+                clear();
                 break;
             }
 

--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -322,9 +322,9 @@ bool GifDecoder::lzwDecode() {
     CV_Assert(lzwCodeSize > 2 && lzwCodeSize <= 12);
     const int clearCode = 1 << lzwMinCodeSize;
     const int exitCode = clearCode + 1;
-    std::vector<lzwNodeD> lzwExtraTable;
+    std::vector<lzwNodeD> lzwExtraTable(lzwMaxSize + 1);
     const int colorTableSize = clearCode;
-    int lzwTableSize;
+    int lzwTableSize = exitCode;
     auto clear = [&]() {
         lzwExtraTable.clear();
         lzwExtraTable.resize(lzwMaxSize + 1);
@@ -337,7 +337,6 @@ bool GifDecoder::lzwDecode() {
     int leftBits = 0;
     uint32_t src = 0;
     auto blockLen = (uchar)m_strm.getByte();
-    clear();
     while (blockLen) {
         if (leftBits < lzwCodeSize) {
             src |= m_strm.getByte() << leftBits;


### PR DESCRIPTION
This fixes https://g-issues.oss-fuzz.com/issues/403364362

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
