### PR TITLE
displayOverlay doesn't disappear after timeout

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -299,13 +299,6 @@ CV_IMPL void cvDisplayOverlay(const char* name, const char* text, int delayms)
         Q_ARG(QString, QString(name)),
         Q_ARG(QString, QString(text)),
         Q_ARG(int, delayms));
-
-    if (delayms > 0)
-    {
-        QTimer::singleShot(delayms, [name]() {
-            cvUpdateWindow(name);  // Force redraw
-        });
-    }
 }
 
 
@@ -2662,10 +2655,7 @@ void DefaultViewPort::startDisplayInfo(QString text, int delayms)
         stopDisplayInfo();
 
     infoText = text;
-    if (delayms > 0)  {
-        timerDisplay->start(delayms);
-        QTimer::singleShot(delayms, this, SLOT(update())); //force referesh
-    }
+    if (delayms > 0) timerDisplay->start(delayms);
     drawInfo = true;
 }
 
@@ -2959,6 +2949,7 @@ void DefaultViewPort::stopDisplayInfo()
 {
     timerDisplay->stop();
     drawInfo = false;
+    viewport()->update();
 }
 
 

--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -299,6 +299,13 @@ CV_IMPL void cvDisplayOverlay(const char* name, const char* text, int delayms)
         Q_ARG(QString, QString(name)),
         Q_ARG(QString, QString(text)),
         Q_ARG(int, delayms));
+
+    if (delayms > 0)
+    {
+        QTimer::singleShot(delayms, [name]() {
+            cvUpdateWindow(name);  // Force redraw
+        });
+    }
 }
 
 
@@ -2655,7 +2662,10 @@ void DefaultViewPort::startDisplayInfo(QString text, int delayms)
         stopDisplayInfo();
 
     infoText = text;
-    if (delayms > 0) timerDisplay->start(delayms);
+    if (delayms > 0)  {
+        timerDisplay->start(delayms);
+        QTimer::singleShot(delayms, this, SLOT(update())); //force referesh
+    }
     drawInfo = true;
 }
 


### PR DESCRIPTION
Fixes #26555

### Expected Behaviour
An overlay should be displayed atop an image and then disappear after `delayms` has timed out, but it doesn't. Also, `displayStatusBar` doesn't appear to set any text on the window.

### Actual Behaviour
The overlay appears but doesn't disappear unless a mouse move event happens on the image.

### Changes
- Fixed the issue with `displayOverlay` not disappearing after the timeout.

### Checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch.
- [x] There is a reference to the original bug report and related work.
- [ ] There is accuracy test, performance test, and test data in the opencv_extra repository, if applicable.
- [ ] The feature is well documented, and sample code can be built with the project CMake.