### PR TITLE
Simplified cv_absdiff for Consistent Results Across Compilers

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -316,8 +316,8 @@ inline int cv_absdiff(uchar x, uchar y) { return (int)std::abs((int)x - (int)y);
 inline int cv_absdiff(schar x, schar y) { return (int)std::abs((int)x - (int)y); }
 inline int cv_absdiff(ushort x, ushort y) { return (int)std::abs((int)x - (int)y); }
 inline int cv_absdiff(short x, short y) { return (int)std::abs((int)x - (int)y); }
-inline unsigned cv_absdiff(int x, int y) { return (unsigned)(std::max(x, y) - std::min(x, y)); }
-inline unsigned cv_absdiff(unsigned x, unsigned y) { return std::max(x, y) - std::min(x, y); }
+inline unsigned cv_absdiff(int x, int y) { return (unsigned)((x > y) ? (x - y) : (y - x)); }
+inline unsigned cv_absdiff(unsigned x, unsigned y) { return (x > y) ? (x - y) : (y - x); }
 inline uint64 cv_absdiff(uint64 x, uint64 y) { return std::max(x, y) - std::min(x, y); }
 inline float cv_absdiff(hfloat x, hfloat y) { return std::abs((float)x - (float)y); }
 inline float cv_absdiff(bfloat x, bfloat y) { return std::abs((float)x - (float)y); }


### PR DESCRIPTION
Relates to https://github.com/opencv/opencv/issues/27080

- Issue: std::max and std::min were optimized differently across compilers and optimization levels, causing inconsistent results.
- Fix: Replaced std::max and std::min with direct comparison: ((x > y) ? (x - y) : (y - x)).
- Reason: Direct comparison ensures consistent behavior across platforms and compilers.
- Scope: Fix applied to both int and unsigned int versions of cv_absdiff.