### PR TITLE
Added fallback to SOLVEPNP_ITERATIVE in solvePnPRansac

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -206,10 +206,16 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 {
     CV_INSTRUMENT_REGION();
 
-    if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
+    if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC){
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
-            confidence, _inliers, flags);
+            confidence, _inliers, flags);}
+    else
+    {
+        return solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
+            _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
+            confidence, _inliers, SOLVEPNP_ITERATIVE);  
+    }
 
     Mat opoints0 = _opoints.getMat(), ipoints0 = _ipoints.getMat();
     Mat opoints, ipoints;

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -205,7 +205,6 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                     OutputArray _inliers, int flags)
 {
     CV_INSTRUMENT_REGION();
-
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC){
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
@@ -216,7 +215,6 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
             confidence, _inliers, SOLVEPNP_ITERATIVE);  
     }
-
     Mat opoints0 = _opoints.getMat(), ipoints0 = _ipoints.getMat();
     Mat opoints, ipoints;
     if( opoints0.depth() == CV_64F || !opoints0.isContinuous() )


### PR DESCRIPTION
- Ensures solvePnPRansac falls back to SOLVEPNP_ITERATIVE when USAC methods are not selected.
- Prevents undefined behavior in cases where no valid flags are provided.
- Improves robustness of PnP solving methods.
