### PR TITLE
flag validation in solvePnPRansac

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -209,10 +209,10 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         flags == SOLVEPNP_EPNP ||
         flags == SOLVEPNP_P3P ||
         flags == SOLVEPNP_AP3P ||
-        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC))) 
+        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)))
   {
       flags = SOLVEPNP_ITERATIVE;
-  }  
+  }
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -205,7 +205,14 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                     OutputArray _inliers, int flags)
 {
     CV_INSTRUMENT_REGION();
-
+    if (!(flags == SOLVEPNP_ITERATIVE ||
+        flags == SOLVEPNP_EPNP ||
+        flags == SOLVEPNP_P3P ||
+        flags == SOLVEPNP_AP3P ||
+        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC))) 
+  {
+      flags = SOLVEPNP_ITERATIVE;
+  }  
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,


### PR DESCRIPTION
- Checks if flag is valid – Only allows correct methods.
- Sets default only if needed – Uses SOLVEPNP_ITERATIVE only for invalid flags.
- Keeps USAC methods untouched – Passes them directly without forcing changes.