### PR TITLE
Fix solvePnPRansac flag handling and prevent silent fallback

### DIFF
--- a/modules/calib3d/CMakeLists.txt
+++ b/modules/calib3d/CMakeLists.txt
@@ -6,7 +6,7 @@ set(debug_modules "")
 if(DEBUG_opencv_calib3d)
   list(APPEND debug_modules opencv_highgui)
 endif()
-ocv_define_module(calib3d opencv_imgproc opencv_features2d opencv_flann ${debug_modules}
+ocv_define_module(calib3d opencv_core opencv_imgproc opencv_features2d opencv_flann ${debug_modules}
     WRAP java objc python js
 )
-ocv_target_link_libraries(${the_module} ${LAPACK_LIBRARIES})
+ocv_target_link_libraries(${the_module} opencv_core ${LAPACK_LIBRARIES})

--- a/modules/calib3d/CMakeLists.txt
+++ b/modules/calib3d/CMakeLists.txt
@@ -6,7 +6,7 @@ set(debug_modules "")
 if(DEBUG_opencv_calib3d)
   list(APPEND debug_modules opencv_highgui)
 endif()
-ocv_define_module(calib3d opencv_core opencv_imgproc opencv_features2d opencv_flann ${debug_modules}
+ocv_define_module(calib3d opencv_imgproc opencv_features2d opencv_flann ${debug_modules}
     WRAP java objc python js
 )
-ocv_target_link_libraries(${the_module} opencv_core ${LAPACK_LIBRARIES})
+ocv_target_link_libraries(${the_module} ${LAPACK_LIBRARIES})

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1012,12 +1012,14 @@ makes the function resistant to outliers.
        the method #SOLVEPNP_EPNP will be used instead.
  */
 CV_EXPORTS_W bool solvePnPRansac( InputArray objectPoints, InputArray imagePoints,
-                                  InputArray cameraMatrix, InputArray distCoeffs,
-                                  OutputArray rvec, OutputArray tvec,
-                                  bool useExtrinsicGuess = false, int iterationsCount = 100,
-                                  float reprojectionError = 8.0, double confidence = 0.99,
-                                  OutputArray inliers = noArray(), int flags = SOLVEPNP_ITERATIVE );
-
+                                InputArray cameraMatrix, InputArray distCoeffs,
+                                OutputArray rvec, OutputArray tvec,
+                                bool useExtrinsicGuess = false, 
+                                int iterationsCount = 100,
+                                float reprojectionError = 8.0, 
+                                double confidence = 0.99,
+                                OutputArray inliers = noArray(),
+                                int method = SOLVEPNP_ITERATIVE);
 
 /*
 Finds rotation and translation vector.

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -205,7 +205,7 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     float reprojectionError, double confidence, 
     OutputArray _inliers, 
     int method = SOLVEPNP_ITERATIVE,
-    int flags = 0);
+    int flags = 0)
 {
     CV_INSTRUMENT_REGION();
     if (!(flags == SOLVEPNP_ITERATIVE ||

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -199,10 +199,10 @@ public:
 };
 bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     InputArray _cameraMatrix, InputArray _distCoeffs,
-    OutputArray _rvec, OutputArray _tvec, 
-    bool useExtrinsicGuess, int iterationsCount, 
-    float reprojectionError, double confidence, 
-    OutputArray _inliers, 
+    OutputArray _rvec, OutputArray _tvec,
+    bool useExtrinsicGuess, int iterationsCount,
+    float reprojectionError, double confidence,
+    OutputArray _inliers,
     int method = SOLVEPNP_ITERATIVE,
     int flags = 0)
 {
@@ -213,7 +213,7 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         flags == SOLVEPNP_AP3P ||
         flags == SOLVEPNP_DLS ||
         flags == SOLVEPNP_UPNP ||
-        flags == SOLVEPNP_IPPE || 
+        flags == SOLVEPNP_IPPE ||
         (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)))
   {
       throw std::invalid_argument("Error: Invalid flag provided for solvePnPRansac");
@@ -222,7 +222,6 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         {return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
             confidence, _inliers, flags);}
-
     Mat opoints0 = _opoints.getMat(), ipoints0 = _ipoints.getMat();
     Mat opoints, ipoints;
     if( opoints0.depth() == CV_64F || !opoints0.isContinuous() )
@@ -233,10 +232,8 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         ipoints0.convertTo(ipoints, CV_32F);
     else
         ipoints = ipoints0;
-
     int npoints = std::max(opoints.checkVector(3, CV_32F), opoints.checkVector(3, CV_64F));
     CV_Assert( npoints >= 4 && npoints == std::max(ipoints.checkVector(2, CV_32F), ipoints.checkVector(2, CV_64F)) );
-
     CV_Assert(opoints.isContinuous());
     CV_Assert(opoints.depth() == CV_32F || opoints.depth() == CV_64F);
     CV_Assert((opoints.rows == 1 && opoints.channels() == 3) || opoints.cols*opoints.channels() == 3);

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -199,19 +199,25 @@ public:
 };
 
 bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
-                    InputArray _cameraMatrix, InputArray _distCoeffs,
-                    OutputArray _rvec, OutputArray _tvec, bool useExtrinsicGuess,
-                    int iterationsCount, float reprojectionError, double confidence,
-                    OutputArray _inliers, int flags)
+    InputArray _cameraMatrix, InputArray _distCoeffs,
+    OutputArray _rvec, OutputArray _tvec, 
+    bool useExtrinsicGuess, int iterationsCount, 
+    float reprojectionError, double confidence, 
+    OutputArray _inliers, 
+    int method = SOLVEPNP_ITERATIVE,
+    int flags = 0);
 {
     CV_INSTRUMENT_REGION();
     if (!(flags == SOLVEPNP_ITERATIVE ||
         flags == SOLVEPNP_EPNP ||
         flags == SOLVEPNP_P3P ||
         flags == SOLVEPNP_AP3P ||
+        flags == SOLVEPNP_DLS ||
+        flags == SOLVEPNP_UPNP ||
+        flags == SOLVEPNP_IPPE || 
         (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)))
   {
-    throw std::invalid_argument("Error: Invalid flag provided for solvePnPRansac.");
+      throw std::invalid_argument("Error: Invalid flag provided for solvePnPRansac");
   }
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
         {return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -197,7 +197,6 @@ public:
     Mat rvec;
     Mat tvec;
 };
-
 bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     InputArray _cameraMatrix, InputArray _distCoeffs,
     OutputArray _rvec, OutputArray _tvec, 

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -209,10 +209,10 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         flags == SOLVEPNP_EPNP ||
         flags == SOLVEPNP_P3P ||
         flags == SOLVEPNP_AP3P ||
-        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC))) 
+        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)))
   {
       flags = SOLVEPNP_ITERATIVE;
-  }  
+  }
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -211,12 +211,12 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
         flags == SOLVEPNP_AP3P ||
         (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)))
   {
-      flags = SOLVEPNP_ITERATIVE;
+    throw std::invalid_argument("Error: Invalid flag provided for solvePnPRansac.");
   }
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
-        return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
+        {return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,
-            confidence, _inliers, flags);
+            confidence, _inliers, flags);}
 
     Mat opoints0 = _opoints.getMat(), ipoints0 = _ipoints.getMat();
     Mat opoints, ipoints;

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -205,7 +205,14 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                     OutputArray _inliers, int flags)
 {
     CV_INSTRUMENT_REGION();
-
+    if (!(flags == SOLVEPNP_ITERATIVE ||
+        flags == SOLVEPNP_EPNP ||
+        flags == SOLVEPNP_P3P ||
+        flags == SOLVEPNP_AP3P ||
+        (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC))) 
+  {
+      flags = SOLVEPNP_ITERATIVE;
+  }  
     if (flags >= USAC_DEFAULT && flags <= USAC_MAGSAC)
         return usac::solvePnPRansac(_opoints, _ipoints, _cameraMatrix, _distCoeffs,
             _rvec, _tvec, useExtrinsicGuess, iterationsCount, reprojectionError,


### PR DESCRIPTION
- Ensured SOLVEPNP_ITERATIVE is only set when no valid flag is provided.  
- Allowed USAC methods (USAC_DEFAULT to USAC_MAGSAC) to pass through without forcing SOLVEPNP_ITERATIVE.  
- Prevented silent fallback by throwing std::invalid_argument for invalid flags.  