### PR TITLE
minor changes : Replace ndarray.ptp() with np.ptp() for NumPy 2.0 Compatibility

### DIFF
--- a/samples/python/mosse.py
+++ b/samples/python/mosse.py
@@ -107,7 +107,7 @@ class MOSSE:
         h, w = f.shape
         f = np.roll(f, -h//2, 0)
         f = np.roll(f, -w//2, 1)
-        kernel = np.uint8( (f-f.min()) / f.ptp()*255 )
+        kernel = np.uint8( (f-f.min()) / np.ptp(f)*255 )
         resp = self.last_resp
         resp = np.uint8(np.clip(resp/resp.max(), 0, 1)*255)
         vis = np.hstack([self.last_img, kernel, resp])

--- a/samples/python/turing.py
+++ b/samples/python/turing.py
@@ -62,7 +62,7 @@ def main():
             vs.append(v)
         mi = np.argmin(vs, 0)
         a += np.choose(mi, ms) * 0.025
-        a = (a-a.min()) / a.ptp()
+        a = (a-a.min()) / np.ptp(a)
 
         if out:
             out.write(a)


### PR DESCRIPTION
Fixes : #27131

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
