### PR TITLE
Use std::alligned_alloc since c++17

### DIFF
--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -54,8 +54,7 @@
 
 //#define OPENCV_ALLOC_ENABLE_STATISTICS
 
-
-#ifdef HAVE_POSIX_MEMALIGN
+#if defined(HAVE_POSIX_MEMALIGN) || (__cplusplus >= 201703L)
 #include <stdlib.h>
 #elif defined HAVE_MALLOC_H
 #include <malloc.h>
@@ -130,6 +129,15 @@ void* fastMalloc_(size_t size)
 void* fastMalloc(size_t size)
 #endif
 {
+#if __cplusplus >= 201703L
+    if (isAlignedAllocationEnabled())
+    {
+        void* ptr = std::aligned_alloc(size, CV_MALLOC_ALIGN);
+        if(!ptr)
+            return OutOfMemoryError(size);
+        return ptr;
+    }
+#endif
 #ifdef HAVE_POSIX_MEMALIGN
     if (isAlignedAllocationEnabled())
     {
@@ -172,7 +180,7 @@ void fastFree_(void* ptr)
 void fastFree(void* ptr)
 #endif
 {
-#if defined HAVE_POSIX_MEMALIGN || defined HAVE_MEMALIGN
+#if defined HAVE_POSIX_MEMALIGN || defined HAVE_MEMALIGN || (__cplusplus >= 201703L)
     if (isAlignedAllocationEnabled())
     {
         free(ptr);


### PR DESCRIPTION
More conservative replacement for https://github.com/opencv/opencv/pull/24844/

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
