### PR TITLE
Fix heap buffer overflow and use after free in imgcodecs

### DIFF
--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -392,6 +392,7 @@ bool GifDecoder::lzwDecode() {
             if (code < colorTableSize) {
                 imgCodeStream[idx++] = (uchar)code;
             } else {
+                if (idx + lzwExtraTable[code].length > width * height) return false;
                 for (int i = 0; i < lzwExtraTable[code].length - 1; i++) {
                     imgCodeStream[idx++] = lzwExtraTable[code].prefix[i];
                 }

--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -392,7 +392,8 @@ bool GifDecoder::lzwDecode() {
             if (code < colorTableSize) {
                 imgCodeStream[idx++] = (uchar)code;
             } else {
-                if (idx + lzwExtraTable[code].length > width * height) return false;
+                CV_LOG_WARNING(NULL, "Too long LZW length in GIF.");
+                CV_Assert(idx + lzwExtraTable[code].length <= width * height);
                 for (int i = 0; i < lzwExtraTable[code].length - 1; i++) {
                     imgCodeStream[idx++] = lzwExtraTable[code].prefix[i];
                 }

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -401,7 +401,7 @@ bool  PngDecoder::readData( Mat& img )
         Mat mat_cur = Mat::zeros(img.rows, img.cols, m_type);
         uint32_t id = 0;
         uint32_t j = 0;
-        uint32_t imagesize = m_width * m_height * mat_cur.elemSize();
+        uint32_t imagesize = m_width * m_height * (uint32_t)mat_cur.elemSize();
         m_is_IDAT_loaded = false;
 
         if (m_frame_no == 0)
@@ -451,18 +451,26 @@ bool  PngDecoder::readData( Mat& img )
                         delay_den = 100;
                     m_animation.durations.push_back(cvRound(1000.*delay_num/delay_den));
 
-                    Mat mat_cur_scaled;
-                    if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
-                        mat_cur.convertTo(mat_cur_scaled, CV_8U, 1. / 255);
+                    if (mat_cur.channels() == img.channels())
+                    {
+                        if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
+                            mat_cur.convertTo(img, CV_8U, 1. / 255);
+                        else
+                            mat_cur.copyTo(img);
+                    }
                     else
-                        mat_cur_scaled = mat_cur;
+                    {
+                        Mat mat_cur_scaled;
+                        if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
+                            mat_cur.convertTo(mat_cur_scaled, CV_8U, 1. / 255);
+                        else
+                            mat_cur_scaled = mat_cur;
 
-                    if (mat_cur_scaled.channels() == img.channels())
-                        mat_cur_scaled.copyTo(img);
-                    else if (img.channels() == 1)
-                        cvtColor(mat_cur_scaled, img, COLOR_BGRA2GRAY);
-                    else if (img.channels() == 3)
-                        cvtColor(mat_cur_scaled, img, COLOR_BGRA2BGR);
+                        if (img.channels() == 1)
+                            cvtColor(mat_cur_scaled, img, COLOR_BGRA2GRAY);
+                        else if (img.channels() == 3)
+                            cvtColor(mat_cur_scaled, img, COLOR_BGRA2BGR);
+                    }
 
                     if (dop != 2)
                     {
@@ -520,15 +528,19 @@ bool  PngDecoder::readData( Mat& img )
                         delay_den = 100;
                     m_animation.durations.push_back(cvRound(1000.*delay_num/delay_den));
 
-                    if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
-                        mat_cur.convertTo(mat_cur, CV_8U, 1. / 255);
-
-                    if (mat_cur.channels() == img.channels())
-                        mat_cur.copyTo(img);
-                    else if (img.channels() == 1)
-                        cvtColor(mat_cur, img, COLOR_BGRA2GRAY);
-                    else if (img.channels() == 3)
-                        cvtColor(mat_cur, img, COLOR_BGRA2BGR);
+                    if (mat_cur.depth() == CV_16U && img.depth() == CV_8U && mat_cur.channels() == img.channels())
+                        mat_cur.convertTo(img, CV_8U, 1. / 255);
+                    else
+                    {
+                        if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
+                            mat_cur.convertTo(mat_cur, CV_8U, 1. / 255);
+                        if (mat_cur.channels() == img.channels())
+                            mat_cur.copyTo(img);
+                        else if (img.channels() == 1)
+                            cvtColor(mat_cur, img, COLOR_BGRA2GRAY);
+                        else if (img.channels() == 3)
+                            cvtColor(mat_cur, img, COLOR_BGRA2BGR);
+                    }
                 }
                 else
                     return false;

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -401,7 +401,7 @@ bool  PngDecoder::readData( Mat& img )
         Mat mat_cur = Mat::zeros(img.rows, img.cols, m_type);
         uint32_t id = 0;
         uint32_t j = 0;
-        uint32_t imagesize = m_width * m_height * mat_cur.channels();
+        uint32_t imagesize = m_width * m_height * mat_cur.elemSize();
         m_is_IDAT_loaded = false;
 
         if (m_frame_no == 0)
@@ -451,15 +451,18 @@ bool  PngDecoder::readData( Mat& img )
                         delay_den = 100;
                     m_animation.durations.push_back(cvRound(1000.*delay_num/delay_den));
 
+                    Mat mat_cur_scaled;
                     if (mat_cur.depth() == CV_16U && img.depth() == CV_8U)
-                        mat_cur.convertTo(mat_cur, CV_8U, 1. / 255);
+                        mat_cur.convertTo(mat_cur_scaled, CV_8U, 1. / 255);
+                    else
+                        mat_cur_scaled = mat_cur;
 
-                    if (mat_cur.channels() == img.channels())
-                        mat_cur.copyTo(img);
+                    if (mat_cur_scaled.channels() == img.channels())
+                        mat_cur_scaled.copyTo(img);
                     else if (img.channels() == 1)
-                        cvtColor(mat_cur, img, COLOR_BGRA2GRAY);
+                        cvtColor(mat_cur_scaled, img, COLOR_BGRA2GRAY);
                     else if (img.channels() == 3)
-                        cvtColor(mat_cur, img, COLOR_BGRA2BGR);
+                        cvtColor(mat_cur_scaled, img, COLOR_BGRA2BGR);
 
                     if (dop != 2)
                     {


### PR DESCRIPTION
This fixes
https://g-issues.oss-fuzz.com/issues/405243132
https://g-issues.oss-fuzz.com/issues/405456349

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
