### PR TITLE
Registering user-defined logging callback. OE-11 see #11003

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -74,6 +74,10 @@ performing mathematical computations, and managing memory efficiently within the
     @defgroup core_utils Utility and system functions and macros
     @{
         @defgroup core_logging Logging facilities
+        @{
+            @defgroup core_logging_callback_interface Logging callback interface
+            @defgroup core_logging_callback Logging callback registration
+        @}
         @defgroup core_utils_sse SSE utilities
         @defgroup core_utils_neon NEON utilities
         @defgroup core_utils_vsx VSX utilities

--- a/modules/core/include/opencv2/core/utils/logger.defines.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.defines.hpp
@@ -35,6 +35,16 @@ enum LogLevel {
 #endif
 };
 
+/**
+ * @todo Add Documentation for LoggingCallbackPtrType
+ */
+using LoggingCallbackPtrType = void (*)(LogLevel, const char*);
+
+/**
+ * @todo Add Documentation for LoggingCallbackHandler
+ */
+class LoggingCallbackHandler;
+
 }}} // namespace
 
 //! @}

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -8,6 +8,7 @@
 #include <opencv2/core/utils/logger.hpp>
 #include "utils/logtagmanager.hpp"
 #include "utils/logtagconfigparser.hpp"
+#include "utils/logcallbackmanager.hpp"
 
 #include <sstream>
 #include <iostream>
@@ -41,9 +42,11 @@ public:
 
 public:
     LogTagManager logTagManager;
+    LogCallbackManager callbackManager;
 
     GlobalLoggingInitStruct()
         : logTagManager(m_defaultUnconfiguredGlobalLevel)
+        , callbackManager{}
     {
         (void)getInitializationMutex();  // ensure initialization of global objects
 
@@ -119,6 +122,12 @@ static LogTagManager& getLogTagManager()
     return logTagManagerInstance;
 }
 
+static LogCallbackManager& getLogCallbackManager()
+{
+    static LogCallbackManager& logCallbackManagerInstance = getGlobalLoggingInitStruct().callbackManager;
+    return logCallbackManagerInstance;
+}
+
 static LogLevel& getLogLevelVariable()
 {
     static LogLevel& refGlobalLogLevel = getGlobalLogTag()->level;
@@ -179,6 +188,126 @@ LogLevel getLogLevel()
     return internal::getLogLevelVariable();
 }
 
+void addLoggingCallback(LoggingCallbackPtrType callback)
+{
+    if (!callback)
+    {
+        return;
+    }
+    if (callback == &cv::utils::logging::internal::writeLogMessage)
+    {
+        // Prevent malicious use of causing infinite recursion
+        return;
+    }
+    LogCallbackManager& refCallbackManager = internal::getLogCallbackManager();
+    refCallbackManager.add(callback);
+}
+
+void addLoggingCallbackHandler(cv::Ptr<LoggingCallbackHandler> callback)
+{
+    if (!callback)
+    {
+        return;
+    }
+    LogCallbackManager& refCallbackManager = internal::getLogCallbackManager();
+    refCallbackManager.add(callback);
+}
+
+void removeLoggingCallback(LoggingCallbackPtrType callback)
+{
+    LogCallbackManager& refCallbackManager = internal::getLogCallbackManager();
+    refCallbackManager.remove(callback);
+}
+
+void removeLoggingCallbackHandler(cv::Ptr<LoggingCallbackHandler> callback)
+{
+    LogCallbackManager& refCallbackManager = internal::getLogCallbackManager();
+    refCallbackManager.remove(callback);
+}
+
+void removeAllLoggingCallbacks()
+{
+    LogCallbackManager& refCallbackManager = internal::getLogCallbackManager();
+    refCallbackManager.removeAll();
+}
+
+namespace /*unnamed*/
+{
+
+class LoggingCallbackHandlerFromFunction final
+    : public LoggingCallbackHandler
+{
+public:
+    LoggingCallbackHandlerFromFunction(std::function<void(LogLevel, const char*, const char*, int, const char*, const char*)> callback)
+        : m_callback(callback)
+    {
+    }
+
+    ~LoggingCallbackHandlerFromFunction() final
+    {
+    }
+
+    void operator()(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message) final
+    {
+        if (this->m_callback)
+        {
+            this->m_callback(logLevel, tag, file, line, func, message);
+        }
+    }
+
+private:
+    std::function<void(LogLevel, const char*, const char*, int, const char*, const char*)> m_callback;
+};
+
+class LoggingCallbackHandlerFromStaticFuncPtr final
+    : public LoggingCallbackHandler
+{
+public:
+    LoggingCallbackHandlerFromStaticFuncPtr(void (*callback)(LogLevel, const char*, const char*, int, const char*, const char*) )
+        : m_callback(callback)
+    {
+    }
+
+    ~LoggingCallbackHandlerFromStaticFuncPtr() final
+    {
+    }
+
+    void operator()(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message) final
+    {
+        auto callback = this->m_callback;
+        if (callback)
+        {
+            (*callback)(logLevel, tag, file, line, func, message);
+        }
+    }
+
+private:
+    void (*m_callback)(LogLevel, const char*, const char*, int, const char*, const char*);
+};
+
+} //unnamed
+
+cv::Ptr<LoggingCallbackHandler> LoggingCallbackHandler::createFromFunction(
+    std::function<void(LogLevel, const char*, const char*, int, const char*, const char*)> callback)
+{
+    /**
+     * @warning This allocation may leak - handlers don't get automatically removed from the callback manager at shutdown.
+     * @todo Check valgrand and update suppression.
+     */
+    return cv::makePtr<LoggingCallbackHandlerFromFunction>(callback);
+}
+
+cv::Ptr<LoggingCallbackHandler> LoggingCallbackHandler::createFromStaticFuncPtr(
+    void (*callback)(LogLevel, const char*, const char*, int, const char*, const char*) )
+{
+    /**
+     * @warning This allocation may leak - handlers don't get automatically removed from the callback manager at shutdown.
+     * @todo Check valgrand and update suppression.
+     */
+    return cv::makePtr<LoggingCallbackHandlerFromStaticFuncPtr>(callback);
+}
+
+
 namespace internal {
 
 static int getShowTimestampMode()
@@ -230,7 +359,21 @@ void writeLogMessage(LogLevel logLevel, const char* message)
     std::ostream* out = (logLevel <= LOG_LEVEL_WARNING) ? &std::cerr : &std::cout;
     (*out) << ss.str();
     if (logLevel <= LOG_LEVEL_WARNING)
+    {
         (*out) << std::flush;
+    }
+
+    LogCallbackManager& refCallbackManager = cv::utils::logging::internal::getLogCallbackManager();
+    std::vector<LoggingCallbackPtrType> callbacks;
+    callbacks.reserve(16u); // reserve some space to avoid reallocations; can grow if needed.
+    refCallbackManager.readInto(callbacks);
+    for (const auto& callback : callbacks)
+    {
+        if (callback)
+        {
+            (*callback)(logLevel, ss.str().c_str());
+        }
+    }
 }
 
 static const char* stripSourceFilePathPrefix(const char* file)
@@ -252,6 +395,18 @@ static const char* stripSourceFilePathPrefix(const char* file)
 
 void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message)
 {
+    LogCallbackManager& refCallbackManager = cv::utils::logging::internal::getLogCallbackManager();
+    std::vector<cv::Ptr<LoggingCallbackHandler>> handlers;
+    handlers.reserve(16u); // reserve some space to avoid reallocations; can grow if needed.
+    refCallbackManager.readInto(handlers);
+    for (const auto& handler : handlers)
+    {
+        if (handler)
+        {
+            handler->operator()(logLevel, tag, file, line, func, message);
+        }
+    }
+
     std::ostringstream strm;
     if (tag)
     {

--- a/modules/core/src/utils/logcallbackmanager.cpp
+++ b/modules/core/src/utils/logcallbackmanager.cpp
@@ -1,0 +1,158 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "logcallbackmanager.hpp"
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+LogCallbackManager::LogCallbackManager()
+    : m_mutex()
+    , m_handlers()
+#ifdef ALLOW_DEPRECATED_CODE
+    , m_callbacks()
+#endif
+{
+}
+
+LogCallbackManager::~LogCallbackManager()
+{
+}
+
+size_t LogCallbackManager::count() const
+{
+    const LockType lock(m_mutex);
+    size_t total = 0u;
+    total += m_handlers.size();
+
+#ifdef ALLOW_DEPRECATED_CODE
+    total += m_callbacks.size();
+#endif
+
+    return total;
+}
+
+bool LogCallbackManager::contains(const cv::Ptr<LoggingCallbackHandler>& handler) const
+{
+    const LockType lock(m_mutex);
+    const LoggingCallbackHandler* const handler_ptr = handler.get();
+    return m_handlers.find(handler_ptr) != m_handlers.end();
+}
+
+void LogCallbackManager::add(cv::Ptr<LoggingCallbackHandler> handler)
+{
+    const LoggingCallbackHandler* const handler_ptr = handler.get();
+    if (!handler_ptr)
+    {
+        return;
+    }
+    const LockType lock(m_mutex);
+    auto iter = m_handlers.find(handler_ptr);
+    if (iter != m_handlers.end())
+    {
+        return;
+    }
+    m_handlers.emplace(std::make_pair(handler_ptr, std::move(handler)));
+}
+
+void LogCallbackManager::remove(const cv::Ptr<LoggingCallbackHandler>& handler)
+{
+    const LoggingCallbackHandler* const handler_ptr = handler.get();
+    if (!handler_ptr)
+    {
+        return;
+    }
+    const LockType lock(m_mutex);
+    auto iter = m_handlers.find(handler_ptr);
+    if (iter == m_handlers.end())
+    {
+        return;
+    }
+    m_handlers.erase(iter);
+}
+
+void LogCallbackManager::readInto(std::vector<cv::Ptr<LoggingCallbackHandler>>& handlers) const
+{
+    const LockType lock(m_mutex);
+    size_t count = m_handlers.size();
+    handlers.clear();
+    handlers.reserve(count);
+    for (const auto& handler : m_handlers)
+    {
+        handlers.push_back(handler.second);
+    }
+}
+
+#ifdef ALLOW_DEPRECATED_CODE // deprecated(LoggingCallbackPtrType)
+bool LogCallbackManager::contains(LoggingCallbackPtrType callback) const
+{
+    const LockType lock(m_mutex);
+    return m_callbacks.find(callback) != m_callbacks.end();
+}
+
+void LogCallbackManager::add(LoggingCallbackPtrType callback)
+{
+    if (!callback)
+    {
+        return;
+    }
+    const LockType lock(m_mutex);
+    m_callbacks.insert(callback);
+}
+
+void LogCallbackManager::remove(LoggingCallbackPtrType callback)
+{
+    if (!callback)
+    {
+        return;
+    }
+    const LockType lock(m_mutex);
+    m_callbacks.erase(callback);
+}
+
+void LogCallbackManager::readInto(std::vector<LoggingCallbackPtrType>& callbacks) const
+{
+    const LockType lock(m_mutex);
+    callbacks.assign(m_callbacks.cbegin(), m_callbacks.cend());
+}
+#endif //ALLOW_DEPRECATED_CODE // deprecated(LoggingCallbackPtrType)
+
+
+void LogCallbackManager::removeAll()
+{
+    const LockType lock(m_mutex);
+    m_handlers.clear();
+
+#ifdef ALLOW_DEPRECATED_CODE
+    m_callbacks.clear();
+#endif //ALLOW_DEPRECATED_CODE
+
+}
+
+
+#ifdef ALLOW_CONTROVERSIAL_CODE
+size_t LogCallbackManager::tryReadIntoSz(LoggingCallbackPtrType (&callbacks)[], size_t arr_sz) const
+{
+    const LockType lock(m_mutex);
+    const auto it_end = m_callbacks.cend();
+    auto iter = m_callbacks.cbegin();
+    for (size_t idx = 0u; idx < arr_sz; ++idx)
+    {
+        if (iter == it_end)
+        {
+            callbacks[idx] = nullptr;
+        }
+        else
+        {
+            callbacks[idx] = *iter;
+            ++iter;
+        }
+    }
+    return m_callbacks.size();
+}
+#endif //ALLOW_CONTROVERSIAL_CODE
+
+}}} //namespace

--- a/modules/core/src/utils/logcallbackmanager.hpp
+++ b/modules/core/src/utils/logcallbackmanager.hpp
@@ -1,0 +1,114 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_LOGCALLBACKMANAGER_HPP
+#define OPENCV_CORE_LOGCALLBACKMANAGER_HPP
+
+#if 1 // if not already in precompiled headers
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set> // Only used by deprecated(LoggingCallbackPtrType)
+#include <array>
+#include <memory>
+#endif
+
+#include "opencv2/core/cvstd.hpp"
+#include "opencv2/core/utils/logger.defines.hpp"
+
+#define ALLOW_DEPRECATED_CODE
+// #ifdef ALLOW_DEPRECATED_CODE
+// #  undef ALLOW_DEPRECATED_CODE
+// #endif
+#ifdef ALLOW_CONTROVERSIAL_CODE
+#  undef ALLOW_CONTROVERSIAL_CODE
+#endif
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+class LogCallbackManager
+{
+private:
+    using MutexType = cv::Mutex;
+    using LockType = cv::AutoLock;
+
+public:
+    explicit LogCallbackManager();
+    ~LogCallbackManager();
+
+    /**
+     * @brief Returns the total count of all registered callbacks, including C-style static functions
+     *        and handler objects.
+     */
+    size_t count() const;
+
+    bool contains(const cv::Ptr<LoggingCallbackHandler>& handler) const;
+    void add(cv::Ptr<LoggingCallbackHandler> handler);
+    void remove(const cv::Ptr<LoggingCallbackHandler>& handler);
+    void readInto(std::vector<cv::Ptr<LoggingCallbackHandler>>& handlers) const;
+
+#ifdef ALLOW_DEPRECATED_CODE
+bool contains(LoggingCallbackPtrType callback) const;
+void add(LoggingCallbackPtrType callback);
+void remove(LoggingCallbackPtrType callback);
+void readInto(std::vector<LoggingCallbackPtrType>& callbacks) const;
+#endif //ALLOW_DEPRECATED_CODE
+
+    /**
+     * @brief Remove all registered callbacks, including C-style static functions
+     *        and handler objects.
+     */
+    void removeAll();
+
+#ifdef ALLOW_CONTROVERSIAL_CODE
+    /**
+     * @brief Read as many callbacks as possible into a fixed-size receiving array.
+     * @param callbacks The receiving array. Unused entries will be set to nullptr.
+     * @param arr_sz Capacity of the receiving array.
+     * @return Actual number of callbacks that have been registered. If this number
+     *         is greater than arr_sz, some callbacks have not been copied.
+     */
+    template <size_t arr_sz>
+    size_t tryReadInto(std::array<LoggingCallbackPtrType, arr_sz>& callbacks) const
+    {
+        return this->tryReadIntoSz(callbacks.data(), arr_sz);
+    }
+
+    /**
+     * @brief Read as many callbacks as possible into a fixed-size receiving array.
+     * @param callbacks The receiving array. Unused entries will be set to nullptr.
+     * @param arr_sz Capacity of the receiving array.
+     * @return Actual number of callbacks that have been registered. If this number
+     *         is greater than arr_sz, some callbacks have not been copied.
+     */
+    template <size_t arr_sz>
+    size_t tryReadInto(LoggingCallbackPtrType (&callbacks)[arr_sz]) const
+    {
+        return this->tryReadIntoSz(&callbacks, arr_sz);
+    }
+#endif //ALLOW_CONTROVERSIAL_CODE
+
+private:
+    LogCallbackManager(const LogCallbackManager&) = delete;
+    LogCallbackManager(LogCallbackManager&&) = delete;
+    LogCallbackManager& operator=(const LogCallbackManager&) = delete;
+    LogCallbackManager& operator=(LogCallbackManager&&) = delete;
+
+#ifdef ALLOW_CONTROVERSIAL_CODE
+    size_t tryReadIntoSz(LoggingCallbackPtrType (&callbacks)[], size_t arr_sz) const;
+#endif //ALLOW_CONTROVERSIAL_CODE
+
+private:
+    mutable MutexType m_mutex;
+    std::unordered_map<const LoggingCallbackHandler*, cv::Ptr<LoggingCallbackHandler> > m_handlers;
+
+#ifdef ALLOW_DEPRECATED_CODE
+    std::unordered_set<LoggingCallbackPtrType> m_callbacks;
+#endif //ALLOW_DEPRECATED_CODE
+};
+
+}}} //namespace
+
+#endif //OPENCV_CORE_LOGCALLBACKMANAGER_HPP

--- a/modules/core/test/test_logcallbackmanager.cpp
+++ b/modules/core/test/test_logcallbackmanager.cpp
@@ -1,0 +1,337 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include <opencv2/core/utils/logger.hpp>
+
+#include "../src/utils/logcallbackmanager.hpp"
+
+// Because "LogCallbackManager" isn't exported from "opencv_core", the only way
+// to perform test is to compile the source code into "opencv_test_core".
+// This workaround may cause step debugger breakpoints to work unreliably.
+#if 1
+#include "../src/utils/logcallbackmanager.cpp"
+#endif
+
+#include <atomic>
+
+namespace opencv_test {
+namespace {
+
+using LogLevel = cv::utils::logging::LogLevel;
+using LogCallbackManager = cv::utils::logging::LogCallbackManager;
+using LoggingCallbackHandler = cv::utils::logging::LoggingCallbackHandler;
+
+// A base fixture consisting of the LogCallbackManager.
+class LogCallbackManagerTestFixture
+    : public ::testing::Test
+{
+public:
+    LogCallbackManagerTestFixture()
+        : m_manager(cv::makePtr<LogCallbackManager>())
+    {
+    }
+
+    ~LogCallbackManagerTestFixture()
+    {
+    }
+
+protected:
+    cv::Ptr<LogCallbackManager> m_manager;
+};
+
+class LoggingCallbackHandlerTestSpy
+    : public LoggingCallbackHandler
+{
+public:
+    struct Args
+    {
+        size_t spy_captured_idx;
+        LogLevel logLevel;
+        const char* tag;
+        const char* file;
+        int line;
+        const char* func;
+        const char* message;
+    };
+
+    void operator()(LogLevel logLevel, const char* tag,
+        const char* file, int line, const char* func,
+        const char* message) final
+    {
+        auto& this_captures = this->m_captured_args;
+        size_t spy_captured_idx = this_captures.size();
+        this_captures.emplace_back(Args{
+            spy_captured_idx,
+            logLevel,
+            tag,
+            file,
+            line,
+            func,
+            message
+        });
+    }
+
+    size_t capturedCount() const
+    {
+        return m_captured_args.size();
+    }
+
+    const Args& getCaptured(size_t idx) const
+    {
+        return m_captured_args.at(idx);
+    }
+
+private:
+    std::vector<Args> m_captured_args;
+};
+
+class LogCallbackManagerSmokeTest
+    : public LogCallbackManagerTestFixture
+{
+protected:
+    LogCallbackManagerSmokeTest()
+        : LogCallbackManagerTestFixture()
+        , m_spy(cv::makePtr<LoggingCallbackHandlerTestSpy>())
+        , m_spyTwo(cv::makePtr<LoggingCallbackHandlerTestSpy>())
+    {
+    }
+
+    cv::Ptr<LoggingCallbackHandlerTestSpy> m_spy;
+    cv::Ptr<LoggingCallbackHandlerTestSpy> m_spyTwo;
+};
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartCountIsZero)
+{
+    EXPECT_EQ(m_manager->count(), 0u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartContainsIsFalse)
+{
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartRemoveSpyIsOkay)
+{
+    m_manager->remove(m_spy);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartRemoveSpyCountIsZero)
+{
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 0u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartRemoveAllIsOkay)
+{
+    m_manager->removeAll();
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AtStartRemoveAllCountIsZero)
+{
+    m_manager->removeAll();
+    EXPECT_EQ(m_manager->count(), 0u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AfterAddSpyCountIsOne)
+{
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AfterAddSpyContainsIsTrue)
+{
+    m_manager->add(m_spy);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AfterAddSpyTwiceCountIsOne)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, AfterAddSpyTwiceContainsIsTrue)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spy);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RemoveAnyOneRemovesSame)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spy);
+    m_manager->remove(m_spy);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RepeatRemoveIsOkay)
+{
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RemoveThenAddAgainIsOkay)
+{
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+    m_manager->add(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, OnlyContainsSpecificOne)
+{
+    m_manager->add(m_spy);
+    EXPECT_FALSE(m_manager->contains(m_spyTwo));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, OnlySpecificOneRemoved)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spyTwo);
+    EXPECT_EQ(m_manager->count(), 2u);
+    EXPECT_TRUE(m_manager->contains(m_spy));
+    EXPECT_TRUE(m_manager->contains(m_spyTwo));
+    m_manager->remove(m_spy);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+    EXPECT_TRUE(m_manager->contains(m_spyTwo));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RemoveAllRemovesAll)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spyTwo);
+    m_manager->removeAll();
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(m_spy));
+    EXPECT_FALSE(m_manager->contains(m_spyTwo));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, ReadInto)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spyTwo);
+    std::vector<cv::Ptr<LoggingCallbackHandler>> handlers;
+    m_manager->readInto(handlers);
+    EXPECT_EQ(handlers.size(), 2u);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RemoveOneThenReadInto)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spyTwo);
+    m_manager->remove(m_spy);
+    std::vector<cv::Ptr<LoggingCallbackHandler>> handlers;
+    m_manager->readInto(handlers);
+    EXPECT_EQ(handlers.size(), 1u);
+    EXPECT_EQ(handlers.at(0), m_spyTwo);
+}
+
+TEST_F(LogCallbackManagerSmokeTest, RemoveAllThenReadInto)
+{
+    m_manager->add(m_spy);
+    m_manager->add(m_spyTwo);
+    m_manager->removeAll();
+    std::vector<cv::Ptr<LoggingCallbackHandler>> handlers;
+    m_manager->readInto(handlers);
+    EXPECT_EQ(handlers.size(), 0u);
+}
+
+namespace log_callback_test_statics
+{
+    static std::atomic<int>& getAtomicIntRef()
+    {
+        static std::atomic<int> stc_atomic{};
+        return stc_atomic;
+    }
+
+    static int getAtomicInt()
+    {
+        return getAtomicIntRef().load();
+    }
+
+    static void incrementAtomicInt()
+    {
+        getAtomicIntRef().fetch_add(1);
+    }
+
+    static void log_callback_test_statics(LogLevel, const char*, const char*, int, const char*, const char*)
+    {
+        incrementAtomicInt();
+    }
+
+}//log_callback_test_statics
+
+TEST_F(LogCallbackManagerSmokeTest, StaticFuncWrapperTest)
+{
+    auto handler = LoggingCallbackHandler::createFromStaticFuncPtr(log_callback_test_statics::log_callback_test_statics);
+    m_manager->add(handler);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(handler));
+    m_manager->remove(handler);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(handler));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, StdFunctionWrapperTest)
+{
+    std::function<void(LogLevel, const char*, const char*, int,
+        const char*, const char*)> func = [](LogLevel, const char*,
+            const char*, int, const char*, const char*) {};
+    auto handler = LoggingCallbackHandler::createFromFunction(func);
+    m_manager->add(handler);
+    EXPECT_EQ(m_manager->count(), 1u);
+    EXPECT_TRUE(m_manager->contains(handler));
+    m_manager->remove(handler);
+    EXPECT_EQ(m_manager->count(), 0u);
+    EXPECT_FALSE(m_manager->contains(handler));
+}
+
+TEST_F(LogCallbackManagerSmokeTest, StaticFuncWrapperCallThru)
+{
+    int pre_count = log_callback_test_statics::getAtomicInt();
+    auto handler = LoggingCallbackHandler::createFromStaticFuncPtr(log_callback_test_statics::log_callback_test_statics);
+    handler->operator()(LogLevel::LOG_LEVEL_VERBOSE, "tag", "file", 42, "func", "message");
+    int post_count = log_callback_test_statics::getAtomicInt();
+    EXPECT_TRUE(post_count >= pre_count + 1)
+        << "Expects logging callback wrapper call to increment count. "
+        << "post_count=" << post_count << " pre_count=" << pre_count;
+}
+
+TEST_F(LogCallbackManagerSmokeTest, StdFunctionWrapperCallThru)
+{
+    bool called = false;
+    std::function<void(LogLevel, const char*, const char*, int, const char*,
+        const char*)> func = [&called](LogLevel, const char*, const char*, int, const char*, const char*) {
+        called = true;
+    };
+    auto handler = LoggingCallbackHandler::createFromFunction(func);
+    handler->operator()(LogLevel::LOG_LEVEL_VERBOSE, "tag", "file", 42, "func", "message");
+    EXPECT_TRUE(called);
+}
+
+}} // namespace


### PR DESCRIPTION
### This pullrequest changes

Allow OpenCV user register for logging callback.
Proposal: OE-11 (https://github.com/opencv/opencv/wiki/OE-11.-Logging)
Design discussions: https://github.com/opencv/opencv/issues/11003
PR: https://github.com/opencv/opencv/pull/27140

Summary:
- LoggingCallbackHandler added (abstract base class)
  - Allow users to subclass and implement
- LogCallbackManager (internal singleton)
  - Thread-safety via cv::Mutex
  - add(), remove() are idempotent
- Wrapper methods for creating a handler
  - Static LoggingCallbackHandler functions
    - createFromFunction (wraps std::function)
    - createFromStaticFuncPtr (wraps raw pointer to static function)
- Tests
  - core/test/test_logcallbackmanager.cpp
- Docs
  - Added two Doxygen subgroups under core_logging
    - core_logging_callback_interface
    - core_logging_callback
- Changes to legacy code
  - TODO: okay to remove from PR
  - LoggingCallbackPtrType (C-style raw pointer, which does not accept file/line/func args)
  - addLoggingCallback(LoggingCallbackPtrType)
  - removeLoggingCallback(LoggingCallbackPtrType)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] The commits to this PR is up-to-date and squashed
- [ ] The commits to this PR does not contain any code that is still being debated or disagreed with
    Currently, it does. Surrounded with ```ALLOW_DEPRECATED_CODE``` and ```ALLOW_CONTROVERSIAL_CODE``` 

**Checklist**

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
