### PR TITLE
Fixed JavaDoc generation for StereoBM.

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -3347,7 +3347,6 @@ public:
 
 
 /**
- * @class StereoBM
  * @brief Class for computing stereo correspondence using the block matching algorithm, introduced and contributed to OpenCV by K. Konolige.
  * @details This class implements a block matching algorithm for stereo correspondence, which is used to compute disparity maps from stereo image pairs. It provides methods to fine-tune parameters such as pre-filtering, texture thresholds, uniqueness ratios, and regions of interest (ROIs) to optimize performance and accuracy.
  */


### PR DESCRIPTION
Fixes error:
```
2025-03-25T07:01:03.2173607Z Executing: ['javadoc', '-windowtitle', 'OpenCV 4.12.0-dev Java documentation', '-doctitle', 'OpenCV Java documentation (4.12.0-dev)', '-nodeprecated', '-public', '-sourcepath', '/home/ci/build/OpenCV-android-sdk/sdk/java/src', '-encoding', 'UTF-8', '-charset', 'UTF-8', '-docencoding', 'UTF-8', '--allow-script-in-comments', '-header', "\n            <script>\n              var url = window.location.href;\n              var pos = url.lastIndexOf('/javadoc/');\n              url = pos >= 0 ? (url.substring(0, pos) + '/javadoc/mymath.js') : (window.location.origin + '/mymath.js');\n              var script = document.createElement('script');\n              script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML,' + url;\n              document.getElementsByTagName('head')[0].appendChild(script);\n            </script>\n", '-bottom', 'Generated on 2025-03-25 07:01:03 / OpenCV 4.12.0-dev', '-d', '/home/ci/build/OpenCV-android-sdk/sdk/java/javadoc', '-classpath', '/opt/android-sdk/platforms/android-34/android.jar', '-subpackages', 'org.opencv']
2025-03-25T07:01:03.2193658Z Executing: javadoc -windowtitle OpenCV 4.12.0-dev Java documentation -doctitle OpenCV Java documentation (4.12.0-dev) -nodeprecated -public -sourcepath /home/ci/build/OpenCV-android-sdk/sdk/java/src -encoding UTF-8 -charset UTF-8 -docencoding UTF-8 --allow-script-in-comments -header 
2025-03-25T07:01:03.2201638Z             <script>
2025-03-25T07:01:03.2203018Z               var url = window.location.href;
2025-03-25T07:01:03.2204148Z               var pos = url.lastIndexOf('/javadoc/');
2025-03-25T07:01:03.2205846Z               url = pos >= 0 ? (url.substring(0, pos) + '/javadoc/mymath.js') : (window.location.origin + '/mymath.js');
2025-03-25T07:01:03.2207582Z               var script = document.createElement('script');
2025-03-25T07:01:03.2209678Z               script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML,' + url;
2025-03-25T07:01:03.2211971Z               document.getElementsByTagName('head')[0].appendChild(script);
2025-03-25T07:01:03.2213215Z             </script>
2025-03-25T07:01:03.2215994Z  -bottom Generated on 2025-03-25 07:01:03 / OpenCV 4.12.0-dev -d /home/ci/build/OpenCV-android-sdk/sdk/java/javadoc -classpath /opt/android-sdk/platforms/android-34/android.jar -subpackages org.opencv
2025-03-25T07:01:03.6329524Z Loading source files for package org.opencv...
2025-03-25T07:01:04.4215855Z Constructing Javadoc information...
2025-03-25T07:01:05.2350809Z Building index for all the packages and classes...
2025-03-25T07:01:05.2550782Z Standard Doclet version 17.0.13+11-Ubuntu-2ubuntu120.04
2025-03-25T07:01:05.2554749Z Building tree for all the packages and classes...
2025-03-25T07:01:05.3486830Z /home/ci/build/OpenCV-android-sdk/sdk/java/src/org/opencv/calib3d/StereoBM.java:12: error: unknown tag: class
2025-03-25T07:01:05.3488194Z  * @class StereoBM
2025-03-25T07:01:05.3488500Z    ^
```

Introduced in https://github.com/opencv/opencv/pull/27130


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
