### PR TITLE
doc: js: unwrap promise-typed cv object

### DIFF
--- a/doc/js_tutorials/js_assets/js_setup_usage.html
+++ b/doc/js_tutorials/js_assets/js_setup_usage.html
@@ -36,7 +36,8 @@ inputElement.addEventListener('change', (e) => {
     imgElement.src = URL.createObjectURL(e.target.files[0]);
 }, false);
 
-imgElement.onload = function() {
+imgElement.onload = async function() {
+    cv = (cv instanceof Promise) ? await cv : cv;
     let mat = cv.imread(imgElement);
     cv.imshow('canvasOutput', mat);
     mat.delete();

--- a/doc/js_tutorials/js_setup/js_setup/js_setup.markdown
+++ b/doc/js_tutorials/js_setup/js_setup/js_setup.markdown
@@ -73,6 +73,10 @@ Building OpenCV.js from Source
 ---------------------------------------
 
 -#  To build `opencv.js`, execute python script `<opencv_src_dir>/platforms/js/build_js.py <build_dir>`.
+    The build script builds WebAssembly version by default(`--build_wasm` switch is kept by back-compatibility reason).
+    By default everything is bundled into one JavaScript file by `base64` encoding the WebAssembly code. For production
+    builds you can add `--disable_single_file` which will reduce total size by writing the WebAssembly code
+    to a dedicated `.wasm` file which the generated JavaScript file will automatically load.
 
     For example, to build in `build_js` directory:
     @code{.bash}
@@ -81,16 +85,6 @@ Building OpenCV.js from Source
 
     @note
     It requires `python` and `cmake` installed in your development environment.
-
--#  The build script builds asm.js version by default. To build WebAssembly version, append `--build_wasm` switch.
-    By default everything is bundled into one JavaScript file by `base64` encoding the WebAssembly code. For production
-    builds you can add `--disable_single_file` which will reduce total size by writing the WebAssembly code
-    to a dedicated `.wasm` file which the generated JavaScript file will automatically load.
-
-    For example, to build wasm version in `build_wasm` directory:
-    @code{.bash}
-    emcmake python ./opencv/platforms/js/build_js.py build_wasm --build_wasm
-    @endcode
 
 -#  [Optional] To build the OpenCV.js loader, append `--build_loader`.
 

--- a/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
+++ b/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
@@ -63,13 +63,16 @@ Example for asynchronous loading
 ### Use OpenCV.js
 
 Once `opencv.js` is ready, you can access OpenCV objects and functions through `cv` object.
+The promise-typed `cv` object should be unwrap with `await` operator.
+See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await .
 
 For example, you can create a cv.Mat from an image by cv.imread.
 
 @note Because image loading is asynchronous, you need to put cv.Mat creation inside the `onload` callback.
 
 @code{.js}
-imgElement.onload = function() {
+imgElement.onload = await function() {
+  cv = (cv instanceof Promise) ? await cv : cv;
   let mat = cv.imread(imgElement);
 }
 @endcode
@@ -116,7 +119,8 @@ inputElement.addEventListener('change', (e) => {
   imgElement.src = URL.createObjectURL(e.target.files[0]);
 }, false);
 
-imgElement.onload = function() {
+imgElement.onload = async function() {
+  cv = (cv instanceof Promise) ? await cv : cv;
   let mat = cv.imread(imgElement);
   cv.imshow('canvasOutput', mat);
   mat.delete();


### PR DESCRIPTION
Close #27129 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
```