### PR TITLE
Fix #25696: Solved the problem in Subdiv2D, empty delaunay triangulation

### DIFF
--- a/modules/imgproc/src/subdivision2d.cpp
+++ b/modules/imgproc/src/subdivision2d.cpp
@@ -493,7 +493,7 @@ void Subdiv2D::initDelaunay( Rect rect )
 {
     CV_INSTRUMENT_REGION();
 
-    float big_coord = 3.f * MAX( rect.width, rect.height );
+    float big_coord = 6.f * MAX( rect.width, rect.height );
     float rx = (float)rect.x;
     float ry = (float)rect.y;
 


### PR DESCRIPTION
Detailed description
Expected behaviour:
Given 4 points, where no three points are collinear, the Delaunay Triangulation Algorithm should return 2 triangles.

Actual:
The algorithm returns zero triangles in this particular case.

Fix:
The radius of the circumcircle tends to infinity when the points are closer to form collinear points, so the problem occurs because the super-triangles are not large enough,
which then results in certain edges are not swapped. The proposed solution just increases the super triangle, duplicating the value of constant for example.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
