### PR TITLE
fix #26138: Saturation between single and multi-channel matrix operation

### DIFF
--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -1341,8 +1341,13 @@ void MatOp_AddEx::assign(const MatExpr& e, Mat& m, int _type) const
         cv::subtract(e.s, e.a, dst);
     else
     {
-        e.a.convertTo(dst, e.a.type(), e.alpha);
-        cv::add(dst, e.s, dst);
+        int depth = e.a.depth();
+        int precType = (depth == CV_8U || depth == CV_16U) ? CV_16S : CV_32F;
+        cv::Mat prec;
+        e.a.convertTo(prec, precType);
+        prec = prec * e.alpha;
+        cv::add(prec, e.s, prec);
+        prec.convertTo(dst, e.a.type());
     }
 
     if( dst.data != m.data )

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2634,4 +2634,29 @@ TEST(Mat, Recreate1DMatWithSameMeta)
     EXPECT_NO_THROW(m.create(dims, depth));
 }
 
+TEST(Mat, ScalarMultiplicationSaturation) {
+    for (int c = 1; c <= 9; c++) {
+        cv::Mat m1 = cv::Mat::zeros(1,1, CV_8UC1);
+        cv::Mat m3 = cv::Mat::zeros(1,1, CV_8UC3);
+        m1 += cv::Scalar(100);
+        m3 += cv::Scalar(100,100,100);
+        cv::Scalar b1 = cv::Scalar(70);
+        cv::Scalar b3 = cv::Scalar(70,70,70);
+        m1 = c * (m1 - b1);
+        m3 = c * (m3 - b3);
+        int m1_val = m1.at<uchar>(0,0);
+        int m3_val = m3.at<cv::Vec3b>(0,0)[0];
+
+        if (c * (100 - 70) > 255) {
+            EXPECT_EQ(m1_val, 255);
+        } else {
+            EXPECT_EQ(m1_val, c * (100 - 70));
+        }
+        if (c * (100 - 70) > 255) {
+            EXPECT_EQ(m3_val, 255);
+        } else {
+            EXPECT_EQ(m3_val, c * (100 - 70));
+        }
+    }
+  }
 }} // namespace


### PR DESCRIPTION
Description:
The issue was that when doing the operation m = c*(m - b) with m being an 8-Bit 3-channel matrix (CV_8UC3), the result of c*(m-b) should be a matrix with values of 4*(100-70)=120. Instead, it is a matrix of zeros because 4*100 was capped at 255 and after subtracting 4*70 we get -25 which becomes 0 after the final saturation operation. So instead  I am performing calculations in higher precision (CV_16S or CV_32F) to prevent capping out at 255 during the operations and after performing the operation I convert it back to the original type ensuring that capping at 255 happens only once.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
