### PR TITLE
fix #26276: cv::VideoWriter fails writing colorless images

### DIFF
--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -194,7 +194,16 @@ public:
             }
         }
 
-        icvWriteFrame_FFMPEG_p(ffmpegWriter, (const uchar*)image.getMat().ptr(), (int)image.step(), image.cols(), image.rows(), image.channels(), 0);
+        cv::Mat imageMat = image.getMat();
+        // when isColor=false, image must have 1 channel (grayscale)
+        if (!ffmpegWriter->isColor() && imageMat.channels() != 1)
+        {
+            // convert input image to grayscale
+            cv::cvtColor(imageMat, imageMat, cv::COLOR_BGR2GRAY);
+        }
+
+        if(!icvWriteFrame_FFMPEG_p(ffmpegWriter, imageMat.data, (int)imageMat.step, imageMat.cols, imageMat.rows, imageMat.channels(), 0))
+            CV_LOG_WARNING(NULL, "FFmpeg: Unable to write frame");
     }
     virtual bool open( const cv::String& filename, int fourcc, double fps, cv::Size frameSize, const VideoWriterParameters& params )
     {

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -194,8 +194,8 @@ public:
             }
         }
 
-        if (!icvWriteFrame_FFMPEG_p(ffmpegWriter, (const uchar*)image.getMat().ptr(), (int)image.step(), image.cols(), image.rows(), image.type(), 0))
-            CV_LOG_WARNING(NULL, "FFmpeg: Unable to write frame");
+        if (!icvWriteFrame_FFMPEG_p(ffmpegWriter, (const uchar*)image.getMat().ptr(), (int)image.step(), image.cols(), image.rows(), image.channels(), 0))
+            CV_LOG_WARNING(NULL, "FFmpeg: Failed to write frame");
     }
     virtual bool open( const cv::String& filename, int fourcc, double fps, cv::Size frameSize, const VideoWriterParameters& params )
     {

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -194,15 +194,7 @@ public:
             }
         }
 
-        cv::Mat imageMat = image.getMat();
-        // when isColor=false, image must have 1 channel (grayscale)
-        if (!ffmpegWriter->isColor() && imageMat.channels() != 1)
-        {
-            // convert input image to grayscale
-            cv::cvtColor(imageMat, imageMat, cv::COLOR_BGR2GRAY);
-        }
-
-        if(!icvWriteFrame_FFMPEG_p(ffmpegWriter, imageMat.data, (int)imageMat.step, imageMat.cols, imageMat.rows, imageMat.channels(), 0))
+        if (!icvWriteFrame_FFMPEG_p(ffmpegWriter, (const uchar*)image.getMat().ptr(), (int)image.step(), image.cols(), image.rows(), image.type(), 0))
             CV_LOG_WARNING(NULL, "FFmpeg: Unable to write frame");
     }
     virtual bool open( const cv::String& filename, int fourcc, double fps, cv::Size frameSize, const VideoWriterParameters& params )

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2552,7 +2552,7 @@ bool CvVideoWriter_FFMPEG::writeFrame( const unsigned char* data, int step, int 
                 inputMat.convertTo(convertedMat, CV_16UC1, 256.0);  // CV_8UC1 -> CV_16UC1
             }
             break;
-        
+
         default:
             CV_LOG_WARNING(NULL, "Unknown pixel format: " << av_get_pix_fmt_name(input_pix_fmt));
             CV_Assert(false);

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -2699,7 +2699,7 @@ void CvVideoWriter_GStreamer::write(InputArray image)
     }
     else if (input_pix_fmt == GST_VIDEO_FORMAT_GRAY16_LE) {
         if (image.type() != CV_16UC1) {
-            CV_WARN("write frame skipped - expected CV_16UC3");
+            CV_WARN("write frame skipped - expected CV_16UC1");
             return;
         }
     }

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -990,13 +990,13 @@ TEST_P(videoio_ffmpeg_channel_mismatch, basic)
 
     writer.release();
 
-    VideoCapture cap(filename, CAP_FFMPEG);       
+    VideoCapture cap(filename, CAP_FFMPEG);
 
     if (is_valid) {
-        ASSERT_TRUE(cap.isOpened()) << "Can't open written video " << description;
-        EXPECT_EQ(cap.get(CAP_PROP_FRAME_COUNT), 15) << "Video capture should be able to read all frames for: " << description;
+        ASSERT_TRUE(cap.isOpened()) << "Can't open video for " << description;
+        EXPECT_EQ(cap.get(CAP_PROP_FRAME_COUNT), 15) << "All frames should be written for: " << description;
     } else {
-        ASSERT_FALSE(cap.isOpened()) << "Video capture should not be able to read any frames for: " << description;
+        ASSERT_FALSE(cap.isOpened()) << "Video capture should fail to open for: " << description;
     }
 
     std::remove(filename.c_str());

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -975,7 +975,7 @@ TEST_P(videoio_ffmpeg_type_mismatch, type_mismatch)
 
     ASSERT_TRUE(writer.isOpened()) << "Failed to open video writer for: " << description;
 
-    for (int i = 1; i <= 90; i++)
+    for (int i = 1; i <= 30; i++)
     {
         // There's a mismatch between the given and expected types. Writer
         // should produce a warning communicating it to the user.
@@ -985,17 +985,8 @@ TEST_P(videoio_ffmpeg_type_mismatch, type_mismatch)
     writer.release();
 
     VideoCapture cap(filename, CAP_FFMPEG);
-    if (!cap.isOpened())
-        throw SkipTestException("Failed to open video file, stream not supported or invalid");
-
-    Mat readFrame;
-    int frameCount = 0;
-    while (cap.read(readFrame))
-        frameCount++;
-
-    // Since there's a mismatch, no frames should have been written.
-    EXPECT_EQ(frameCount, 0) << "Although there was a mismatch between given and expected types, " << frameCount << " frames were written for: " << description;
-
+    ASSERT_FALSE(cap.isOpened()) << "Video capture should fail to open for: " << description 
+                                 << " as no frames should have been written due to the existent mismatch";
     std::remove(filename.c_str());
 }
 

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -965,7 +965,7 @@ TEST_P(videoio_ffmpeg_conversion, handle_conversion)
     int input_type = get<0>(GetParam());
     int target_type = get<1>(GetParam());
     bool isColor = get<2>(GetParam());
-    string description = get<3>(GetParam());
+    const string description = get<3>(GetParam());
 
     const double fps = 30.0;
     const int fourcc = VideoWriter::fourcc('m', 'p', '4', 'v');
@@ -990,16 +990,15 @@ TEST_P(videoio_ffmpeg_conversion, handle_conversion)
 
     VideoCapture cap(filename, CAP_FFMPEG);
     if (!cap.isOpened())
-        throw SkipTestException("Failed to open written video");
+        throw SkipTestException("Failed to open video file, stream not supported or invalid");
 
     Mat readFrame;
     int frameCount = 0;
     while (cap.read(readFrame))
         frameCount++;
 
-    // Simply checking if all 90 frames can be read is enough.
-    // If no conversion is done 0 frames will be written.
-    EXPECT_EQ(frameCount, 90) << "Not all frames were read for: " << description;
+    // Checking if all 90 frames can be read is enough, if no conversion is done 0 frames will be written.
+    EXPECT_EQ(frameCount, 90) << "Not all frames were read for: " << description << "(expected 90, got " << frameCount << ")";
 
     std::remove(filename.c_str());
 }

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -973,7 +973,8 @@ TEST_P(videoio_ffmpeg_type_mismatch, type_mismatch)
 
     VideoWriter writer(filename, fourcc, fps, frame.size(), {cv::VIDEOWRITER_PROP_DEPTH, CV_MAT_DEPTH(expected_type), VIDEOWRITER_PROP_IS_COLOR, is_Color});
 
-    ASSERT_TRUE(writer.isOpened()) << "Failed to open video writer for: " << description;
+    if (!writer.isOpened())
+        throw SkipTestException("Failed to open video writer");
 
     for (int i = 1; i <= 30; i++)
     {
@@ -985,7 +986,7 @@ TEST_P(videoio_ffmpeg_type_mismatch, type_mismatch)
     writer.release();
 
     VideoCapture cap(filename, CAP_FFMPEG);
-    ASSERT_FALSE(cap.isOpened()) << "Video capture should fail to open for: " << description 
+    ASSERT_FALSE(cap.isOpened()) << "Video capture should fail to open for: " << description
                                  << " as no frames should have been written due to the existent mismatch";
     std::remove(filename.c_str());
 }

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -960,17 +960,17 @@ TEST_P(videoio_ffmpeg_conversion, handle_conversion)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
         throw SkipTestException("FFmpeg backend was not found");
-    
+
     const string filename = "conversion_video.mp4";
     int input_type = get<0>(GetParam());
     int target_type = get<1>(GetParam());
     bool isColor = get<2>(GetParam());
     string description = get<3>(GetParam());
-    
+
     const double fps = 30.0;
     const int fourcc = VideoWriter::fourcc('m', 'p', '4', 'v');
     const Mat frame(480, 640, input_type, Scalar::all(0));
-     
+
     VideoWriter writer(filename, fourcc, fps, frame.size(), isColor);
     writer.set(VIDEOWRITER_PROP_DEPTH, CV_MAT_DEPTH(target_type));
 
@@ -991,15 +991,15 @@ TEST_P(videoio_ffmpeg_conversion, handle_conversion)
     VideoCapture cap(filename, CAP_FFMPEG);
     if (!cap.isOpened())
         throw SkipTestException("Failed to open written video");
-    
+
     Mat readFrame;
     int frameCount = 0;
     while (cap.read(readFrame))
         frameCount++;
-    
+
     // Simply checking if all 90 frames can be read is enough.
     // If no conversion is done 0 frames will be written.
-    EXPECT_EQ(frameCount, 90) << "Not all frames were read for: " << description; 
+    EXPECT_EQ(frameCount, 90) << "Not all frames were read for: " << description;
 
     std::remove(filename.c_str());
 }
@@ -1009,11 +1009,11 @@ const ConversionTestParams conversion_cases[] =
     // converting to 8UC3
     make_tuple(CV_8UC1, CV_8UC3, true, "CV_8UC1_to_CV_8UC3"),
     make_tuple(CV_16UC1, CV_8UC3, true, "CV_16UC1_to_CV_8UC3"),
-    
+
     // converting to 8UC1
     make_tuple(CV_8UC3, CV_8UC1, false, "CV_8UC3_to_CV_8UC1"),
     make_tuple(CV_16UC1, CV_8UC1, false, "CV_16UC1_to_CV_8UC1"),
-    
+
     // converting to 16UC1
     make_tuple(CV_8UC3, CV_16UC1, false, "CV_8UC3_to_CV_16UC1"),
     make_tuple(CV_8UC1, CV_16UC1, false, "CV_8UC1_to_CV_16UC1"),


### PR DESCRIPTION
When writing grayscale images (`isColor=false`), `cv::VideoWriter` failed as FFmpeg backend requires input frames to be in a grayscale format. Unlike other backends, FFmpeg doesn't perform this conversion internally and expects the input to be pre-converted. To fix this, I inserted a check in the `CvVideoWriter_FFMPEG_proxy::write` to convert input frames to grayscale when the input has more than 1 channel. If this is true, then the input is converted to a gray image using `cv::cvtColor` (with `cv::COLOR_BGR2GRAY`).
Additionally, as suggested in the issue comments, I have correctly propagated the return value of `CvVideoWriter_FFMPEG::writeFrame` back to the `CvVideoWriter_FFMPEG_proxy::write`. This return value wasn't being used, and `writeFrame` was always returning false since the FFmeg's return code `AVERROR(EAGAIN)` was mistakenly being treated as an error. Now it's handled as a signal for additional input (current input was successfully written, and a new frame should be sent. [See FFmpeg documentation for  `avcodec_receive_packet`](https://ffmpeg.org/doxygen/6.1/group__lavc__decoding.html)). A warning is displayed if  `CvVideoWriter_FFMPEG::writeFrame` returns false. Alternatively, this could be propagated back up to the user, making cv::VideoWriter::write a boolean.
Finally, I added a test case to verify if the grayscale conversion is being done correctly. 

Fixes #26276

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
