### PR TITLE
User-defined logger callback, C-style.

### DIFF
--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -43,6 +43,25 @@ CV_EXPORTS void writeLogMessage(LogLevel logLevel, const char* message);
 /** Write log message */
 CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message);
 
+typedef void (*WriteLogMessageFuncType)(LogLevel, const char*);
+typedef void (*WriteLogMessageExFuncType)(LogLevel, const char*, const char*, int, const char*, const char*);
+
+/**
+ * @brief Replaces the OpenCV writeLogMessage function with a user-defined function.
+ * @note Once replaced, logs will not go through the OpenCV writeLogMessage function.
+ * @note To restore, call this function with a nullptr.
+ */
+CV_EXPORTS void replaceWriteLogMessage(WriteLogMessageFuncType f);
+
+/**
+ * @brief Replaces the OpenCV writeLogMessageEx function with a user-defined function.
+ * @note Once replaced, logs will not go through any of the OpenCV logging functions
+ *       such as writeLogMessage or writeLogMessageEx, until their respective restore
+ *       methods are called.
+ * @note To restore, call this function with a nullptr.
+ */
+CV_EXPORTS void replaceWriteLogMessageEx(WriteLogMessageExFuncType f);
+
 } // namespace
 
 struct LogTagAuto

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -43,11 +43,24 @@ CV_EXPORTS void writeLogMessage(LogLevel logLevel, const char* message);
 /** Write log message */
 CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message);
 
+/**
+ * @brief Function pointer type for writeLogMessage. Used by replaceWriteLogMessage.
+ */
 typedef void (*WriteLogMessageFuncType)(LogLevel, const char*);
+
+/**
+ * @brief Function pointer type for writeLogMessageEx. Used by replaceWriteLogMessageEx.
+ */
 typedef void (*WriteLogMessageExFuncType)(LogLevel, const char*, const char*, int, const char*, const char*);
 
 /**
  * @brief Replaces the OpenCV writeLogMessage function with a user-defined function.
+ * @note The user-defined function must have the same signature as writeLogMessage.
+ * @note The user-defined function must accept arguments that can be potentially null.
+ * @note The user-defined function must be thread-safe, as OpenCV logging may be called
+ *       from multiple threads.
+ * @note The user-defined function must not perform any action that can trigger
+ *       deadlocks or infinite loop. Many OpenCV functions are not re-entrant.
  * @note Once replaced, logs will not go through the OpenCV writeLogMessage function.
  * @note To restore, call this function with a nullptr.
  */
@@ -55,6 +68,12 @@ CV_EXPORTS void replaceWriteLogMessage(WriteLogMessageFuncType f);
 
 /**
  * @brief Replaces the OpenCV writeLogMessageEx function with a user-defined function.
+ * @note The user-defined function must have the same signature as writeLogMessage.
+ * @note The user-defined function must accept arguments that can be potentially null.
+ * @note The user-defined function must be thread-safe, as OpenCV logging may be called
+ *       from multiple threads.
+ * @note The user-defined function must not perform any action that can trigger
+ *       deadlocks or infinite loop. Many OpenCV functions are not re-entrant.
  * @note Once replaced, logs will not go through any of the OpenCV logging functions
  *       such as writeLogMessage or writeLogMessageEx, until their respective restore
  *       methods are called.

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -198,7 +198,7 @@ static int getShowTimestampMode()
 void writeLogMessage(LogLevel logLevel, const char* message)
 {
     WriteLogMessageFuncType userFunc = stc_userWriteLogMessageFunc.load();
-    if (userFunc && userFunc != &writeLogMessage)
+    if (userFunc && userFunc != writeLogMessage)
     {
         (*userFunc)(logLevel, message);
         return;
@@ -269,7 +269,7 @@ static const char* stripSourceFilePathPrefix(const char* file)
 void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message)
 {
     WriteLogMessageExFuncType userFunc = stc_userWriteLogMessageExFunc.load();
-    if (userFunc && userFunc != &writeLogMessageEx)
+    if (userFunc && userFunc != writeLogMessageEx)
     {
         (*userFunc)(logLevel, tag, file, line, func, message);
         return;
@@ -299,7 +299,7 @@ void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int
 
 void replaceWriteLogMessage(WriteLogMessageFuncType f)
 {
-    if (f == &writeLogMessage)
+    if (f == writeLogMessage)
     {
         f = nullptr;
     }
@@ -308,7 +308,7 @@ void replaceWriteLogMessage(WriteLogMessageFuncType f)
 
 void replaceWriteLogMessageEx(WriteLogMessageExFuncType f)
 {
-    if (f == &writeLogMessageEx)
+    if (f == writeLogMessageEx)
     {
         f = nullptr;
     }

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <iostream>
 #include <fstream>
+#include <atomic>
 
 #ifdef __ANDROID__
 # include <android/log.h>
@@ -181,6 +182,12 @@ LogLevel getLogLevel()
 
 namespace internal {
 
+namespace //unnamed
+{
+    std::atomic<WriteLogMessageFuncType> stc_userWriteLogMessageFunc{};
+    std::atomic<WriteLogMessageExFuncType> stc_userWriteLogMessageExFunc{};
+} //unnamed
+
 static int getShowTimestampMode()
 {
     static bool param_timestamp_enable = utils::getConfigurationParameterBool("OPENCV_LOG_TIMESTAMP", true);
@@ -190,6 +197,13 @@ static int getShowTimestampMode()
 
 void writeLogMessage(LogLevel logLevel, const char* message)
 {
+    WriteLogMessageFuncType userFunc = stc_userWriteLogMessageFunc.load();
+    if (userFunc && userFunc != &writeLogMessage)
+    {
+        (*userFunc)(logLevel, message);
+        return;
+    }
+
     const int threadID = cv::utils::getThreadID();
 
     std::string message_id;
@@ -230,7 +244,9 @@ void writeLogMessage(LogLevel logLevel, const char* message)
     std::ostream* out = (logLevel <= LOG_LEVEL_WARNING) ? &std::cerr : &std::cout;
     (*out) << ss.str();
     if (logLevel <= LOG_LEVEL_WARNING)
+    {
         (*out) << std::flush;
+    }
 }
 
 static const char* stripSourceFilePathPrefix(const char* file)
@@ -252,6 +268,13 @@ static const char* stripSourceFilePathPrefix(const char* file)
 
 void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message)
 {
+    WriteLogMessageExFuncType userFunc = stc_userWriteLogMessageExFunc.load();
+    if (userFunc && userFunc != &writeLogMessageEx)
+    {
+        (*userFunc)(logLevel, tag, file, line, func, message);
+        return;
+    }
+
     std::ostringstream strm;
     if (tag)
     {
@@ -272,6 +295,24 @@ void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int
     }
     strm << message;
     writeLogMessage(logLevel, strm.str().c_str());
+}
+
+void replaceWriteLogMessage(WriteLogMessageFuncType f)
+{
+    if (f == &writeLogMessage)
+    {
+        f = nullptr;
+    }
+    stc_userWriteLogMessageFunc.store(f);
+}
+
+void replaceWriteLogMessageEx(WriteLogMessageExFuncType f)
+{
+    if (f == &writeLogMessageEx)
+    {
+        f = nullptr;
+    }
+    stc_userWriteLogMessageExFunc.store(f);
 }
 
 } // namespace

--- a/modules/core/test/test_logger_replace.cpp
+++ b/modules/core/test/test_logger_replace.cpp
@@ -1,0 +1,115 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include <atomic>
+#include <opencv2/core/utils/logger.hpp>
+
+namespace opencv_test {
+namespace {
+
+using namespace cv::utils::logging;
+using namespace cv::utils::logging::internal;
+
+TEST(Core_Logger_Replace, WriteLogMessageRestoreCallWithNullOk)
+{
+    replaceWriteLogMessage(nullptr);
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    SUCCEED();
+}
+
+TEST(Core_Logger_Replace, WriteLogMessageExRestoreCallWithNullOk)
+{
+    replaceWriteLogMessageEx(nullptr);
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 1000, "func", "msg");
+    SUCCEED();
+}
+
+std::atomic<uint32_t>& getCallFlagger()
+{
+    static std::atomic<uint32_t> callFlagger(0);
+    return callFlagger;
+}
+
+std::atomic<uint32_t>& getCallCounter()
+{
+    static std::atomic<uint32_t> callCounter(0);
+    return callCounter;
+}
+
+void myWriteLogMessage(LogLevel, const char*)
+{
+    getCallFlagger().fetch_or(1024u);
+    getCallCounter().fetch_add(1u);
+}
+
+void myWriteLogMessageEx(LogLevel, const char*, const char*, int, const char*, const char*)
+{
+    getCallFlagger().fetch_or(2048u);
+    getCallCounter().fetch_add(1u);
+}
+
+TEST(Core_Logger_Replace, WriteLogMessageReplaceRestore)
+{
+    uint32_t step_0 = getCallCounter().load();
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    uint32_t step_1 = getCallCounter().load();
+    EXPECT_EQ(step_0, step_1);
+    replaceWriteLogMessage(nullptr);
+    uint32_t step_2 = getCallCounter().load();
+    EXPECT_EQ(step_1, step_2);
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    uint32_t step_3 = getCallCounter().load();
+    EXPECT_EQ(step_2, step_3);
+    replaceWriteLogMessage(myWriteLogMessage);
+    uint32_t step_4 = getCallCounter().load();
+    EXPECT_EQ(step_3, step_4);
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    uint32_t step_5 = getCallCounter().load();
+    EXPECT_EQ(step_4 + 1, step_5);
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    uint32_t step_6 = getCallCounter().load();
+    EXPECT_EQ(step_5 + 1, step_6);
+    replaceWriteLogMessage(nullptr);
+    uint32_t step_7 = getCallCounter().load();
+    EXPECT_EQ(step_6, step_7);
+    writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, "msg");
+    uint32_t step_8 = getCallCounter().load();
+    EXPECT_EQ(step_7, step_8);
+    uint32_t flags = getCallFlagger().load();
+    EXPECT_NE(flags & 1024u, 0u);
+}
+
+TEST(Core_Logger_Replace, WriteLogMessageExReplaceRestore)
+{
+    uint32_t step_0 = getCallCounter().load();
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 0, "func", "msg");
+    uint32_t step_1 = getCallCounter().load();
+    EXPECT_EQ(step_0, step_1);
+    replaceWriteLogMessageEx(nullptr);
+    uint32_t step_2 = getCallCounter().load();
+    EXPECT_EQ(step_1, step_2);
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 0, "func", "msg");
+    uint32_t step_3 = getCallCounter().load();
+    EXPECT_EQ(step_2, step_3);
+    replaceWriteLogMessageEx(myWriteLogMessageEx);
+    uint32_t step_4 = getCallCounter().load();
+    EXPECT_EQ(step_3, step_4);
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 0, "func", "msg");
+    uint32_t step_5 = getCallCounter().load();
+    EXPECT_EQ(step_4 + 1, step_5);
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 0, "func", "msg");
+    uint32_t step_6 = getCallCounter().load();
+    EXPECT_EQ(step_5 + 1, step_6);
+    replaceWriteLogMessageEx(nullptr);
+    uint32_t step_7 = getCallCounter().load();
+    EXPECT_EQ(step_6, step_7);
+    writeLogMessageEx(cv::utils::logging::LOG_LEVEL_DEBUG, "tag", "file", 0, "func", "msg");
+    uint32_t step_8 = getCallCounter().load();
+    EXPECT_EQ(step_7, step_8);
+    uint32_t flags = getCallFlagger().load();
+    EXPECT_NE(flags & 2048u, 0u);
+}
+
+}} // namespace


### PR DESCRIPTION
This is a competing PR, an alternative to #27140 

Both functions accept C-style pointer to static functions. Both functions allow restoring the OpenCV built-in implementation by passing in a nullptr.
- replaceWriteLogMessage
- replaceWriteLogMessageEx

This implementation is not compatible with C++ log handler objects.

This implementation has minimal thread safety, in the sense that the function pointer are stored and read atomically. But otherwise, the user-defined static functions must accept calls at all times, even after having been deregistered, because some log calls may have started before deregistering.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
