### PR TITLE
[WIP] modules/videoio: add libcamera backend for OpenCV Video I/O

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,9 @@ OCV_OPTION(WITH_WAYLAND "Include Wayland support" OFF
 OCV_OPTION(WITH_IPP "Include Intel IPP support" (NOT MINGW AND NOT CV_DISABLE_OPTIMIZATION)
   VISIBLE_IF (X86_64 OR X86) AND NOT WINRT AND NOT IOS AND NOT XROS
   VERIFY HAVE_IPP)
+OCV_OPTION(WITH_LIBCAMERA "Include libcamera support" OFF
+  VISIBLE_IF NOT IOS AND NOT WINRT
+  VERIFY HAVE_LIBCAMERA)
 OCV_OPTION(WITH_VULKAN "Include Vulkan support" OFF
   VISIBLE_IF TRUE
   VERIFY HAVE_VULKAN)
@@ -1583,6 +1586,13 @@ if(WITH_V4L OR HAVE_V4L)
     IF HAVE_VIDEOIO THEN "sys/videoio.h"
     ELSE "NO")
   status("    v4l/v4l2:" HAVE_V4L THEN "YES (${v4l_status})" ELSE NO)
+endif()
+
+if(WITH_LIBCAMERA OR HAVE_LIBCAMERA)
+  ocv_build_features_string(libcamera_status
+    IF HAVE_LIBCAMERA THEN "${LIBCAMERA_VERSION}"
+    ELSE "NO")
+  status("    libcamera:" HAVE_LIBCAMERA THEN "YES (${libcamera_status})" ELSE NO)
 endif()
 
 if(WITH_DSHOW OR HAVE_DSHOW)

--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -139,6 +139,11 @@ if(TARGET ocv.3rdparty.v4l)
   list(APPEND tgts ocv.3rdparty.v4l)
 endif()
 
+if(TARGET ocv.3rdparty.libcamera)
+  list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_libcamera.cpp)
+  list(APPEND tgts ocv.3rdparty.libcamera)
+endif()
+
 if(TARGET ocv.3rdparty.openni2)
   list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_openni2.cpp)
   list(APPEND tgts ocv.3rdparty.openni2)

--- a/modules/videoio/cmake/detect_libcamera.cmake
+++ b/modules/videoio/cmake/detect_libcamera.cmake
@@ -1,0 +1,15 @@
+# --- libcamera ---
+if(NOT HAVE_LIBCAMERA AND PKG_CONFIG_FOUND)
+  ocv_check_modules(LIBCAMERA libcamera)
+
+  if(LIBCAMERA_FOUND)
+    set(HAVE_LIBCAMERA TRUE)
+    set(LIBCAMERA_VERSION ${LIBCAMERA_VERSION})
+    set(LIBCAMERA_LIBRARIES ${LIBCAMERA_LIBRARIES})
+    set(LIBCAMERA_INCLUDE_DIRS ${LIBCAMERA_INCLUDE_DIRS})
+  endif()
+endif()
+
+if(HAVE_LIBCAMERA)
+  ocv_add_external_target(libcamera "${LIBCAMERA_INCLUDE_DIRS}" "${LIBCAMERA_LIBRARIES}" "HAVE_LIBCAMERA")
+endif()

--- a/modules/videoio/cmake/init.cmake
+++ b/modules/videoio/cmake/init.cmake
@@ -11,6 +11,7 @@ endmacro()
 add_backend("ffmpeg" WITH_FFMPEG)
 add_backend("gstreamer" WITH_GSTREAMER)
 add_backend("v4l" WITH_V4L)
+add_backend("libcamera" WITH_LIBCAMERA)
 
 add_backend("aravis" WITH_ARAVIS)
 add_backend("dc1394" WITH_1394)

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -122,7 +122,8 @@ enum VideoCaptureAPIs {
        CAP_XINE         = 2400,         //!< XINE engine (Linux)
        CAP_UEYE         = 2500,         //!< uEye Camera API
        CAP_OBSENSOR     = 2600,         //!< For Orbbec 3D-Sensor device/module (Astra+, Femto, Astra2, Gemini2, Gemini2L, Gemini2XL, Femto Mega) attention: Astra2 cameras currently only support Windows and Linux kernel versions no higher than 4.15, and higher versions of Linux kernel may have exceptions.
-     };
+       CAP_LIBCAMERA    = 2700,         //!< libcamera
+      };
 
 
 /** @brief cv::VideoCapture generic properties identifier.
@@ -402,6 +403,26 @@ enum { CAP_PVAPI_PIXELFORMAT_MONO8    = 1,    //!< Mono8
      };
 
 //! @} PvAPI
+
+//! libcamera: PixelFormat
+enum { FMT_MJPEG = 0,
+  FMT_YUYV  = 1,
+  FMT_NV12 = 2,
+  FMT_NV21 = 3,
+  FMT_RGB888 = 4,
+  FMT_BGR888 = 5,
+  FMT_UYVY = 6,
+  FMT_YUV420 = 7
+};
+
+//! libcamera: StreamRole
+enum { ROLE_VIDEO = 0,
+  ROLE_STILL = 1,
+  ROLE_RAW = 2,
+  ROLE_VIEWFINDER = 3
+};
+
+//! @} libcamera
 
 /** @name XIMEA Camera API
     @{

--- a/modules/videoio/misc/gen_dict.json
+++ b/modules/videoio/misc/gen_dict.json
@@ -6,6 +6,7 @@
         "CV_CAP_MIL",
         "CV_CAP_V4L",
         "CV_CAP_V4L2",
+        "CV_CAP_LIBCAMERA"
         "CV_CAP_FIREWARE",
         "CV_CAP_FIREWIRE",
         "CV_CAP_IEEE1394",

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -339,6 +339,9 @@ Ptr<IVideoCapture> create_DShow_capture(int index, const VideoCaptureParameters&
 Ptr<IVideoCapture> create_V4L_capture_cam(int index);
 Ptr<IVideoCapture> create_V4L_capture_file(const std::string &filename);
 
+Ptr<IVideoCapture> create_libcamera_capture_cam(int index);
+Ptr<IVideoCapture> create_libcamera_capture_file(const std::string &filename);
+
 Ptr<IVideoCapture> create_OpenNI2_capture_cam( int index );
 Ptr<IVideoCapture> create_OpenNI2_capture_file( const std::string &filename );
 

--- a/modules/videoio/src/cap_libcamera.cpp
+++ b/modules/videoio/src/cap_libcamera.cpp
@@ -1,32 +1,13 @@
 /*
- *  cap_libcamera.cpp
- *  For Video I/O
- *  by Advait Dhamorikar advaitdhamorikar[at]gmail[dot]com
- *  and Umang Jain email[at]uajain[dot]com
- *  Copyright 2025. All rights reserved.
+ * cap_libcamera.cpp
+ * For Video I/O
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This file is part of the OpenCV project.
+ * It is subject to the license terms in the LICENSE file found in the top-level directory
+ * of this distribution and at http://opencv.org/license.html.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ * Copyright 2025 Advait Dhamorikar <advaitdhamorikar[at]gmail.com>
+ * Copyright 2025 Umang Jain <email[at]uajain.com>
  */
 
 #include "precomp.hpp"

--- a/modules/videoio/src/cap_libcamera.cpp
+++ b/modules/videoio/src/cap_libcamera.cpp
@@ -1,0 +1,403 @@
+/*
+ *  cap_libcamera.cpp
+ *  For Video I/O
+ *  by Advait Dhamorikar advaitdhamorikar[at]gmail[dot]com
+ *  and Umang Jain email[at]uajain[dot]com
+ *  Copyright 2025. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "precomp.hpp"
+#include "cap_libcamera.hpp"
+
+using namespace cv;
+using namespace libcamera;
+
+namespace cv {
+
+void CvCapture_libcamera_proxy::cam_init()
+{
+   std::cout << "Initializing camera: " << cameraId_ << std::endl;
+   opened_ = true;
+}
+
+void CvCapture_libcamera_proxy::requestComplete(Request *request)
+{
+   if (!request || !camera_)
+       return;
+
+   if (request->status() == Request::RequestCancelled)
+       return;
+
+   std::lock_guard<std::mutex> lock(mutex_);
+   completedRequests_.push(request);
+   requestAvailable_.notify_one();
+}
+
+int CvCapture_libcamera_proxy::mapFrameBuffer(const FrameBuffer *buffer)
+{
+    int error;
+    if (buffer->planes().empty())
+    {
+        std::cerr << "Buffer has no planes " << std::endl;
+        return -EINVAL;
+    }
+    maps_.clear();
+    planes_.clear();
+    planes_.reserve(buffer->planes().size());
+    std::map<int, MappedBufferInfo> mappedBuffers;
+    for (const FrameBuffer::Plane &plane : buffer->planes())
+    {
+        const int fd = plane.fd.get();
+        if (mappedBuffers.find(fd) == mappedBuffers.end())
+        {
+            const size_t length = lseek(fd, 0, SEEK_END);
+            mappedBuffers[fd] = MappedBufferInfo{ nullptr, 0, length };
+        }
+        const size_t length = mappedBuffers[fd].dmabufLength;
+        if (plane.offset > length || plane.offset + plane.length > length)
+        {
+                    std::cerr << "plane is out of buffer: "
+                     << "buffer length=" << length
+                     << ", plane offset=" << plane.offset
+                     << ", plane length=" << plane.length << std::endl;
+            return -ERANGE;
+        }
+        size_t &mapLength = mappedBuffers[fd].mapLength;
+        mapLength = std::max(mapLength,
+                           static_cast<size_t>(plane.offset + plane.length));
+    }
+    for (const FrameBuffer::Plane &plane : buffer->planes())
+    {
+        const int fd = plane.fd.get();
+        auto &info = mappedBuffers[fd];
+        if (!info.address)
+        {
+            void *address = mmap(nullptr, info.mapLength, PROT_READ | PROT_WRITE,
+                                 MAP_SHARED, fd, 0);
+            if (address == MAP_FAILED)
+            {
+                error = -errno;
+                std::cerr <<  "Failed to mmap plane: "
+                         << strerror(-error) << std::endl;
+                return -error;
+            }
+            info.address = static_cast<uint8_t *>(address);
+            maps_.emplace_back(info.address, info.mapLength);
+        }
+
+        planes_.emplace_back(info.address + plane.offset, plane.length);
+    }
+    return 0;
+}
+
+bool CvCapture_libcamera_proxy::icvSetFrameSize(int width, int height)
+{
+    if (width > 0)
+        width_ = width;
+    if (height > 0)
+        height_ = height;
+
+    streamConfig_.size.width = width_;
+    streamConfig_.size.height = height_;
+
+    return true;
+}
+
+int CvCapture_libcamera_proxy::convertToRgb(Request *request, OutputArray &outImage)
+{
+    FrameBuffer *fb = nullptr;
+    const Request::BufferMap &buffers = request->buffers();
+    for (const auto &[stream, buffer] : buffers)
+    {
+        if (stream->configuration().pixelFormat == pixelFormat_)
+        {
+            fb = buffer;
+        }
+    }
+
+    int ret = mapFrameBuffer(fb);
+    const FrameMetadata &metadata = fb->metadata();
+    if (ret < 0 || !fb)
+    {
+        std::cerr << "Failed to mmap buffer." << std::endl;
+        return ret;
+    }
+
+    unsigned char* data = static_cast<unsigned char*>(planes_[0].data());
+    cv::Mat& destination = outImage.getMatRef();
+    switch (pixFmt_)
+    {
+        case FMT_MJPEG:
+        {
+            cv::imdecode(
+                cv::Mat(1, metadata.planes()[0].bytesused, CV_8U, data),
+                IMREAD_COLOR, &destination);
+            break;
+        }
+        case FMT_YUYV:
+        {
+            if (metadata.planes()[0].bytesused <
+                config_->at(0).size.width * config_->at(0).size.height * 2)
+            {
+                std::cerr << "YUYV: Frame too small." << std::endl;
+                return -1;
+            }
+
+            cv::cvtColor(
+                cv::Mat(config_->at(0).size.height,
+                        config_->at(0).size.width,
+                        CV_8UC2, data),
+                destination, cv::COLOR_YUV2BGR_YUYV);
+            break;
+        }
+        case FMT_NV12:
+        {
+            cv::cvtColor(
+                cv::Mat(config_->at(0).size.height * 3 / 2,
+                        config_->at(0).size.width,
+                        CV_8UC1, data),
+                destination, cv::COLOR_YUV2BGR_NV12);
+            break;
+        }
+        case FMT_RGB888:
+        {
+            destination = cv::Mat(config_->at(0).size.height,
+                                config_->at(0).size.width,
+                                CV_8UC3, data).clone();
+            break;
+        }
+        case FMT_BGR888:
+        {
+            cv::cvtColor(
+                cv::Mat(config_->at(0).size.height,
+                        config_->at(0).size.width,
+                        CV_8UC3, data),
+                destination, cv::COLOR_BGR2RGB);
+            break;
+        }
+        case FMT_UYVY:
+        {
+            cv::Mat yuyvFrame(config_->at(0).size.height,
+                            config_->at(0).size.width,
+                            CV_8UC2, data);
+            cv::cvtColor(yuyvFrame, destination, cv::COLOR_YUV2BGR_YUY2);
+            break;
+        }
+        case FMT_YUV420:
+        {
+            cv::cvtColor(
+                cv::Mat(config_->at(0).size.height * 3 / 2,
+                        config_->at(0).size.width,
+                        CV_8UC1, data),
+                destination, cv::COLOR_YUV2BGR_I420);
+            break;
+        }
+        default:
+        {
+            if (metadata.planes()[0].bytesused <
+                config_->at(0).size.width * config_->at(0).size.height * 2)
+            {
+                std::cerr << "YUYV: Frame too small." << std::endl;
+                return -1;
+            }
+            cv::cvtColor(
+                cv::Mat(config_->at(0).size.height,
+                        config_->at(0).size.width,
+                        CV_8UC2, data),
+                destination, cv::COLOR_YUV2BGR_YUYV);
+            break;
+        }
+    }
+
+    return 0;
+}
+
+bool CvCapture_libcamera_proxy::open()
+{
+    std::unique_ptr<Request> request;
+    unsigned int nbuffers = UINT_MAX;
+    int ret = 0;
+    try
+    {
+        allocator_ = std::make_unique<FrameBufferAllocator>(camera_);
+        for (StreamConfiguration &cfg : *config_)
+        {
+            ret = allocator_->allocate(cfg.stream());
+            if (ret < 0)
+            {
+                std::cerr << "Can't allocate buffers" << std::endl;
+                return false;
+            }
+            allocated_ = allocator_->buffers(cfg.stream()).size();
+            nbuffers = std::min(nbuffers, allocated_);
+        }
+
+        for (unsigned int i = 0; i < nbuffers; i++)
+        {
+            request = camera_->createRequest();
+            if (!request)
+            {
+                std::cerr << "Can't create request" << std::endl;
+                return EXIT_FAILURE;
+            }
+            for (StreamConfiguration &cfg : *config_)
+            {
+                Stream *stream = cfg.stream();
+                const std::vector<std::unique_ptr<FrameBuffer>> &buffers =
+                allocator_->buffers(stream);
+                const std::unique_ptr<FrameBuffer> &buffer = buffers[i];
+                ret = request->addBuffer(stream, buffer.get());
+                if (ret < 0)
+                {
+                    std::cerr << "Can't set buffer for request"<< std::endl;
+                    return ret;
+                }
+            }
+            requests_.push_back(std::move(request));
+        }
+        camera_->requestCompleted.connect(this, &CvCapture_libcamera_proxy::requestComplete);
+        camera_->start();
+        for (std::unique_ptr<Request> &req : requests_)
+             camera_->queueRequest(req.get());
+
+        return 1;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+        std::cerr<<"CvCapture_libcamera_proxy::open failed"<<std::endl;
+        opened_ = false;
+    }
+
+    return opened_;
+}
+
+bool CvCapture_libcamera_proxy::grabFrame()
+{
+    if (!opened_ && gc > 0)
+    {
+        ;
+    }
+    else if (opened_ && gc == 0)
+    {
+        // Generate configuration
+        config_ = camera_->generateConfiguration({ strcfg_ });
+        if (!config_ || config_->empty())
+        {
+            std::cerr << "Failed to generate stream configuration." << std::endl;
+            return -1;
+        }
+
+        // Update configuration
+        StreamConfiguration &cfg = config_->at(0);
+        cfg.pixelFormat = pixelFormat_;
+        cfg.size.width = width_;
+        cfg.size.height = height_;
+
+        // Validate config
+        CameraConfiguration::Status status = config_->validate();
+
+        if (status == CameraConfiguration::Invalid)
+        {
+            std::cerr << "Camera configuration is invalid!" << std::endl;
+            return -1;
+        }
+        if (status == CameraConfiguration::Adjusted)
+        {
+            std::cout << "Camera configuration was adjusted by libcamera!" << std::endl;
+        }
+
+        camera_->configure(config_.get());
+        streamConfig_ = cfg;
+
+        gc++;
+        open();
+    }
+
+    return true;
+}
+
+bool CvCapture_libcamera_proxy::retrieveFrame(int, OutputArray &outputFrame)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+    requestAvailable_.wait(lock, [this] { return !completedRequests_.empty(); });
+
+    Request *request = completedRequests_.front();
+    completedRequests_.pop();
+    lock.unlock();
+
+    int ret = convertToRgb(request, outputFrame);
+    if (ret < 0)
+    {
+        std::cerr << "convertToRGB failed\n";
+        return false;
+    }
+
+    request->reuse(Request::ReuseBuffers);
+    camera_->queueRequest(request);
+
+    return !outputFrame.empty();
+}
+
+double CvCapture_libcamera_proxy::getProperty(int property_id) const
+{
+    switch (property_id)
+    {
+        case CAP_PROP_POS_FRAMES: return completedRequests_.front()->sequence();
+        case CAP_PROP_FRAME_WIDTH: return streamConfig_.size.width;
+        case CAP_PROP_FRAME_HEIGHT: return streamConfig_.size.height;
+    }
+    return 0;
+}
+
+bool CvCapture_libcamera_proxy::setProperty(int property_id, double value)
+{
+    switch (property_id)
+    {
+        case CAP_PROP_FRAME_WIDTH:
+            return icvSetFrameSize(cvRound(value), height_);
+        case CAP_PROP_FRAME_HEIGHT:
+            return icvSetFrameSize(width_, cvRound(value));
+        case CAP_PROP_MODE:
+            pixFmt_ = cvRound(value);
+            return getLibcameraPixelFormat(pixFmt_);
+        case CAP_PROP_FORMAT:
+            propFmt_ = cvRound(value);
+            return getCameraConfiguration(propFmt_);
+    }
+    return false;
+}
+
+cv::Ptr<cv::IVideoCapture> create_libcamera_capture_cam(int index)
+{
+    cv::Ptr<CvCapture_libcamera_proxy> capture = cv::makePtr<CvCapture_libcamera_proxy>(index);
+    if (capture)
+    {
+        return capture;
+    }
+    return cv::Ptr<cv::IVideoCapture>();
+}
+}//namespace cv

--- a/modules/videoio/src/cap_libcamera.cpp
+++ b/modules/videoio/src/cap_libcamera.cpp
@@ -292,8 +292,9 @@ bool CvCapture_libcamera_proxy::grabFrame()
         }
 
         // Update configuration
+        CV_LOG_DEBUG(NULL, "Updating configuration.");
         StreamConfiguration &cfg = config_->at(0);
-        cfg.pixelFormat = pixelFormat_;
+        getLibcameraPixelFormat(pixFmt_);
         cfg.size.width = width_;
         cfg.size.height = height_;
 
@@ -363,7 +364,7 @@ bool CvCapture_libcamera_proxy::setProperty(int property_id, double value)
             return icvSetFrameSize(width_, cvRound(value));
         case CAP_PROP_MODE:
             pixFmt_ = cvRound(value);
-            return getLibcameraPixelFormat(pixFmt_);
+            return true;
         case CAP_PROP_FORMAT:
             propFmt_ = cvRound(value);
             return getCameraConfiguration(propFmt_);

--- a/modules/videoio/src/cap_libcamera.hpp
+++ b/modules/videoio/src/cap_libcamera.hpp
@@ -42,7 +42,7 @@ public:
         std::cout << "libcamera cameras(): " << cm_->cameras().size() << std::endl;
         if (index >= cm_->cameras().size())
         {
-            std::cerr << "Invalid camera index " << index << std::endl;
+            CV_LOG_ERROR(NULL, "Invalid camera index");
             return;
         }
 
@@ -51,13 +51,13 @@ public:
 
         if (!camera_)
         {
-            std::cerr << "Camera " << cameraId_ << " not found" << std::endl;
+            CV_LOG_ERROR(NULL, cv::format("Camera %s not found", cameraId_.c_str()));
             return;
         }
 
         if (camera_->acquire())
         {
-            std::cerr << "Failed to acquire camera " << cameraId_ << std::endl;
+            CV_LOG_ERROR(NULL, cv::format("Failed to acquire camera %s", cameraId_.c_str()));
             return;
         }
 
@@ -202,7 +202,7 @@ public:
     };
     StreamConfiguration streamConfig_;
     StreamRole strcfg_ = StreamRole::VideoRecording;
-    PixelFormat pixelFormat_ = libcamera::formats::MJPEG;
+    PixelFormat pixelFormat_ = libcamera::formats::YUYV;
 };
 }
 

--- a/modules/videoio/src/cap_libcamera.hpp
+++ b/modules/videoio/src/cap_libcamera.hpp
@@ -1,0 +1,209 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+// Copyright (C) 2025, Advait Dhamorikar all rights reserved.
+
+#ifdef HAVE_LIBCAMERA
+
+#include <iostream>
+#include <sys/mman.h>
+#include <errno.h>
+#include <memory>
+#include <queue>
+#include <map>
+#include <unistd.h>
+#include <opencv2/core.hpp>
+#include <opencv2/videoio.hpp>
+#include <libcamera/libcamera.h>
+#include <libcamera/framebuffer.h>
+#include <libcamera/base/span.h>
+#include <condition_variable>
+
+using namespace cv;
+using namespace libcamera;
+
+namespace cv {
+
+class CvCapture_libcamera_proxy CV_FINAL : public cv::IVideoCapture
+{
+public:
+    bool isOpened() const CV_OVERRIDE { return opened_; }
+    bool open();
+    bool grabFrame() CV_OVERRIDE;
+    bool retrieveFrame(int, OutputArray) CV_OVERRIDE;
+    virtual double getProperty(int) const CV_OVERRIDE;
+    virtual bool setProperty(int, double) CV_OVERRIDE;
+    virtual int getCaptureDomain() CV_OVERRIDE { return cv::CAP_LIBCAMERA; }
+
+    CvCapture_libcamera_proxy(size_t index = 0)
+    {
+        cm_ = std::make_unique<CameraManager>();
+        cm_->start();
+        std::cout << "libcamera cameras(): " << cm_->cameras().size() << std::endl;
+        if (index >= cm_->cameras().size())
+        {
+            std::cerr << "Invalid camera index " << index << std::endl;
+            return;
+        }
+
+        cameraId_ = cm_->cameras()[index]->id();
+        camera_ = cm_->get(cameraId_);
+
+        if (!camera_)
+        {
+            std::cerr << "Camera " << cameraId_ << " not found" << std::endl;
+            return;
+        }
+
+        if (camera_->acquire())
+        {
+            std::cerr << "Failed to acquire camera " << cameraId_ << std::endl;
+            return;
+        }
+
+        cam_init();
+   }
+
+
+    ~CvCapture_libcamera_proxy()
+    {
+        if (!opened_)
+            return;
+
+        if (camera_)
+        {
+            camera_->stop();
+        }
+
+        for (auto &req : requests_)
+        {
+            if (req && req->status() == libcamera::Request::RequestPending)
+            {
+                camera_->release();
+            }
+        }
+
+
+        allocator_.reset();
+        requests_.clear();
+        planes_.clear();
+        maps_.clear();
+
+        config_.reset();
+        streamConfig_ = {};
+
+        if (camera_)
+        {
+            camera_->release();
+            camera_.reset();
+        }
+
+        if (cm_)
+        {
+            cm_->stop();
+            cm_.reset();
+        }
+
+        cameraId_.clear();
+        opened_ = false;
+        open_ = false;
+        std::cout << "Closing the device" << std::endl;
+    }
+
+    private:
+    bool getLibcameraPixelFormat(int value)
+    {
+        switch (value)
+        {
+            case FMT_MJPEG:
+                pixelFormat_ = libcamera::formats::MJPEG;
+                return true;
+
+            case FMT_YUYV:
+                pixelFormat_ = libcamera::formats::YUYV;
+                return true;
+
+            case FMT_RGB888:
+                pixelFormat_ = libcamera::formats::RGB888;
+                return true;
+
+            case FMT_BGR888:
+                pixelFormat_ = libcamera::formats::BGR888;
+                return true;
+
+            case FMT_NV12:
+                pixelFormat_ = libcamera::formats::NV12;
+                return true;
+
+            case FMT_YUV420:
+                pixelFormat_ = libcamera::formats::YUV420;
+                return true;
+
+            default:
+                pixelFormat_ = libcamera::formats::YUYV;
+                return false;
+        }
+    }
+
+    bool getCameraConfiguration(int value)
+    {
+     switch (value)
+       {
+        case ROLE_RAW:
+            strcfg_ = StreamRole::Raw;
+            return true;
+        case ROLE_STILL:
+            strcfg_ = StreamRole::StillCapture;
+            return true;
+        case ROLE_VIDEO:
+            strcfg_ = StreamRole::VideoRecording;
+            return true;
+        case ROLE_VIEWFINDER:
+            strcfg_ = StreamRole::Viewfinder;
+            return true;
+        default:
+            strcfg_ = StreamRole::VideoRecording;
+            return true;
+        }
+    }
+
+    void requestComplete(Request *request);
+    void cam_init();
+    void cam_init(int index);
+    int mapFrameBuffer(const FrameBuffer *buffer);
+    int convertToRgb(libcamera::Request *req, OutputArray &outImage);
+    bool icvSetFrameSize(int, int);
+
+    std::queue<Request*> completedRequests_;
+    std::unique_ptr<CameraConfiguration> config_;
+    std::unique_ptr<CameraManager> cm_;
+    std::shared_ptr<Camera> camera_;
+    std::string cameraId_;
+    std::vector<libcamera::Span<uint8_t>> planes_;
+    std::vector<libcamera::Span<uint8_t>> maps_;
+    std::vector<std::unique_ptr<Request>> requests_;
+    std::unique_ptr<FrameBufferAllocator> allocator_;
+    std::condition_variable requestAvailable_;
+    std::mutex mutex_;
+
+    int width_ = 480, height_ = 640;
+    int pixFmt_;
+    int propFmt_;
+    int gc = 0;
+    unsigned int allocated_;
+    bool opened_ = false;
+    bool open_ = false;
+
+    struct MappedBufferInfo
+    {
+        uint8_t *address = nullptr;
+        size_t mapLength = 0;
+        size_t dmabufLength = 0;
+    };
+    StreamConfiguration streamConfig_;
+    StreamRole strcfg_ = StreamRole::VideoRecording;
+    PixelFormat pixelFormat_ = libcamera::formats::MJPEG;
+};
+}
+
+#endif

--- a/modules/videoio/src/cap_libcamera.hpp
+++ b/modules/videoio/src/cap_libcamera.hpp
@@ -35,10 +35,15 @@ public:
     virtual bool setProperty(int, double) CV_OVERRIDE;
     virtual int getCaptureDomain() CV_OVERRIDE { return cv::CAP_LIBCAMERA; }
 
+    static std::shared_ptr<CameraManager> cm_;
+
     CvCapture_libcamera_proxy(size_t index = 0)
     {
-        cm_ = std::make_unique<CameraManager>();
-        cm_->start();
+        if (!cm_)
+        {
+            cm_ = std::make_shared<CameraManager>();
+            cm_->start();
+        }
         std::cout << "libcamera cameras(): " << cm_->cameras().size() << std::endl;
         if (index >= cm_->cameras().size())
         {
@@ -204,7 +209,6 @@ public:
 
     std::queue<Request*> completedRequests_;
     std::unique_ptr<CameraConfiguration> config_;
-    std::unique_ptr<CameraManager> cm_;
     std::shared_ptr<Camera> camera_;
     std::string cameraId_;
     std::vector<libcamera::Span<uint8_t>> planes_;
@@ -232,6 +236,9 @@ public:
     StreamRole strcfg_ = StreamRole::VideoRecording;
     PixelFormat pixelFormat_;
 };
+
+std::shared_ptr<CameraManager> CvCapture_libcamera_proxy::cm_ = nullptr;
+
 }
 
 #endif

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -112,6 +112,9 @@ static const struct VideoBackendInfo builtin_backends[] =
     DECLARE_STATIC_BACKEND(CAP_V4L, "V4L_BSD", MODE_CAPTURE_ALL, create_V4L_capture_file, create_V4L_capture_cam, 0)
 #endif
 
+#if defined HAVE_LIBCAMERA
+    DECLARE_STATIC_BACKEND(CAP_LIBCAMERA, "libcamera", MODE_CAPTURE_ALL, create_V4L_capture_file, create_libcamera_capture_cam, 0)
+#endif
 
     // RGB-D universal
 #ifdef HAVE_OPENNI2

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -95,6 +95,7 @@ class Builder:
                "-DWITH_EIGEN=OFF",
                "-DWITH_FFMPEG=OFF",
                "-DWITH_GSTREAMER=OFF",
+               "-DWITH_LIBCAMERA=OFF",
                "-DWITH_GTK=OFF",
                "-DWITH_GTK_2_X=OFF",
                "-DWITH_IPP=OFF",


### PR DESCRIPTION
Adds [libcamera](https://libcamera.org/) backend for OpenCV's Video I/O module. Provides integration with the libcamera stack, enabling native support for modern Linux camera pipelines, especially on embedded platforms like Raspberry Pi.
Implements the functionality to be used by the VideoCapture class for reading and displaying supported streams.

#### What works
- Displaying frames from common formats: **MJPEG, YUYV, NV12**, and more.
- Setting camera properties:
  - `cv::CAP_PROP_FRAME_WIDTH` – Set frame width
  - `cv::CAP_PROP_FRAME_HEIGHT` – Set frame height
  - `cv::CAP_PROP_MODE` – Select PixelFormat  
    *(e.g., `FMT_MJPEG`, `FMT_YUYV`, `FMT_RGB888`, `FMT_BGR888`, `FMT_NV12`, `FMT_YUV420`)*
  - `cv::CAP_PROP_FORMAT` – Select StreamRole  
    *(e.g., `ROLE_RAW`, `ROLE_VIDEO`, `ROLE_STILL`, `ROLE_VIEWFINDER`)*
- Reading some set camera properties (may be unstable):
  - `cv::CAP_PROP_FRAME_WIDTH`
  - `cv::CAP_PROP_FRAME_HEIGHT`

#### Known issues
- Multiple camera support works, but it is laggy for the second camera at the moment (tested with 2 cameras)
- ~~`cv::CAP_PROP_MODE` must be explicitly set,  for USB and CSI cameras, to avoid crashes.~~

Detailed usage instructions can be found [here](https://gist.github.com/advait-0/0d514a9c4328a28a29b52b297d555c43).
Sample testing program can be found [here](https://paste.debian.net/1365183/).

Attempts to close #21653
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
