### PR TITLE
Fix closing of windows when using the Qt backend

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -859,7 +859,7 @@ void GuiReceiver::isLastWindow()
         delete guiMainThread;//delete global_control_panel too
         guiMainThread = NULL;
 
-        if (!doesExternalQAppExist)
+        if (doesExternalQAppExist)
         {
             qApp->quit();
         }
@@ -1739,13 +1739,6 @@ CvWindow::CvWindow(QString name, int arg2)
 }
 
 
-CvWindow::~CvWindow()
-{
-    if (guiMainThread)
-        guiMainThread->isLastWindow();
-}
-
-
 void CvWindow::setMouseCallBack(CvMouseCallback callback, void* param)
 {
     myView->setMouseCallBack(callback, param);
@@ -2256,6 +2249,15 @@ void CvWindow::keyPressEvent(QKeyEvent *evnt)
     }
 
     QWidget::keyPressEvent(evnt);
+}
+
+
+void CvWindow::closeEvent(QCloseEvent* evnt)
+{
+    QWidget::closeEvent(evnt);
+
+    if (guiMainThread)
+        guiMainThread->isLastWindow();
 }
 
 

--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -298,7 +298,6 @@ class CvWindow : public CvWinModel
     Q_OBJECT
 public:
     CvWindow(QString arg2, int flag = CV_WINDOW_NORMAL);
-    ~CvWindow();
 
     void setMouseCallBack(CvMouseCallback m, void* param);
 
@@ -349,6 +348,7 @@ public:
 
 protected:
     virtual void keyPressEvent(QKeyEvent* event) CV_OVERRIDE;
+    virtual void closeEvent(QCloseEvent* event) CV_OVERRIDE;
 
 private:
 


### PR DESCRIPTION
Notify the main GUI thread upon receiving a close event instead of when
the windows is destroyed. Additionally there was a logic error in in
GuiReceiver::isLastWindow() that is corrected.

Fixes #6479 and #20822

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
