### PR TITLE
remove undefined/legacy CvArr reference in window_QT.h

### DIFF
--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -459,7 +459,7 @@ public:
     double getRatio() CV_OVERRIDE;
     void setRatio(int flags) CV_OVERRIDE;
 
-    void updateImage(const CvArr* arr) CV_OVERRIDE;
+    void updateImage(cv::InputArray arr) CV_OVERRIDE;
 
     void startDisplayInfo(QString text, int delayms) CV_OVERRIDE;
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
-------------------------------------------------------------------------------------------------------------
issue: https://github.com/opencv/opencv/issues/27187

Some legacy data structures (including CvArr) were removed in the 5.x branch. CvArr is no longer defined, but one reference remains in:
modules/highgui/src/window_QT.h

`void updateImage(const CvArr* arr) CV_OVERRIDE;`

should be changed to:

`void updateImage(cv::InputArray arr) CV_OVERRIDE;`
