### PR TITLE
[WIP] [GSOC] KV Caching for LLM inference

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -245,7 +245,8 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_ARG_INPUT=2, //!< input of the whole model. Before Net::forward() or in Net::forward() all inputs must be set
         DNN_ARG_OUTPUT=3, //!< output of the model.
         DNN_ARG_TEMP=4,   //!< intermediate result, a result of some operation and input to some other operation(s).
-        DNN_ARG_PATTERN=5 //!< not used for now
+        DNN_ARG_PATTERN=5, //!< not used for now
+        DNN_ARG_CACHED=6
     };
 
     CV_EXPORTS std::string argKindToString(ArgKind kind);
@@ -1234,6 +1235,11 @@ CV__DNN_INLINE_NS_BEGIN
     CV_EXPORTS
     Net readNetFromModelOptimizer(const uchar* bufferModelConfigPtr, size_t bufferModelConfigSize,
                                            const uchar* bufferWeightsPtr, size_t bufferWeightsSize);
+
+
+
+
+    CV_EXPORTS_W Net readNetFromGGUF(CV_WRAP_FILE_PATH const String &ggufFile);
 
 
     /** @brief Reads a network model <a href="https://onnx.ai/">ONNX</a>.


### PR DESCRIPTION
OpenCV currently reprocesses the entire input for each token in decoder models. This is inefficient for autoregressive generation. KV Caching will speed thing up.
For this pupose, a new `Arg` type is proposed. The `PagedCacheManager`, manages the allocation of cache in pages.
For integrating the cache into the current workflow, we can inject the cached Tensors represented by `Args` of type `DNN_ARG_CACHED` into the set of `tempMats`,  in the forward call `layer->forward(inpMats, outMats, tempMats);` where needed as a first step. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
_____________________
Reference: https://github.com/opencv/opencv/issues/27176