### PR TITLE
imgproc: disable SIMD for compareHist(INTERSECT) if f64 is unsupported

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -2132,7 +2132,8 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
                 v_result = v_add(v_result, v_add(v_cvt_f64(v_src), v_cvt_f64_high(v_src)));
             }
             result += v_reduce_sum(v_result);
-#elif CV_SIMD
+#elif CV_SIMD && 0 // Disable vectorization for CV_COMP_INTERSECT if f64 is unsupported due to low precision
+                   // See https://github.com/opencv/opencv/issues/24757
             v_float32 v_result = vx_setzero_f32();
             for (; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes())
             {

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2103,12 +2103,12 @@ TEST(Imgproc_Hist_Compare, intersect_regression_24757)
     cv::Mat src2 = cv::Mat(128,1, CV_32FC1, cv::Scalar(std::numeric_limits<double>::max()));
 
                                              // Ideal result        Wrong result
-    src1.at<float>(32 * 0,0) = +1.0;         // work = +1.0         +1.0
-    src1.at<float>(32 * 1,0) = +55555555.5;  // work = +55555556.5  +55555555.5
-    src1.at<float>(32 * 2,0) = -55555555.5;  // work = +1.0         0.0
-    src1.at<float>(32 * 3,0) = -1.0;         // work = 0.0          -1.0
+    src1.at<float>(32 * 0,0) = +1.0f;        // work = +1.0         +1.0
+    src1.at<float>(32 * 1,0) = +55555555.5f; // work = +55555556.5  +55555555.5
+    src1.at<float>(32 * 2,0) = -55555555.5f; // work = +1.0         0.0
+    src1.at<float>(32 * 3,0) = -1.0f;        // work = 0.0          -1.0
 
-    EXPECT_FLOAT_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0);
+    EXPECT_FLOAT_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0f);
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2108,7 +2108,7 @@ TEST(Imgproc_Hist_Compare, intersect_regression_24757)
     src1.at<float>(32 * 2,0) = -55555555.5f; // work = +1.0         0.0
     src1.at<float>(32 * 3,0) = -1.0f;        // work = 0.0          -1.0
 
-    EXPECT_FLOAT_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0f);
+    EXPECT_DOUBLE_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0);
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2096,5 +2096,20 @@ INSTANTIATE_TEST_CASE_P(Imgproc_Hist, Imgproc_Equalize_Hist, ::testing::Combine(
                         ::testing::Values(cv::Size(123, 321), cv::Size(256, 256), cv::Size(1024, 768)),
                         ::testing::Range(0, 10)));
 
+// See https://github.com/opencv/opencv/issues/24757
+TEST(Imgproc_Hist_Compare, intersect_regression_24757)
+{
+    cv::Mat src1 = cv::Mat::zeros(128,1, CV_32FC1);
+    cv::Mat src2 = cv::Mat(128,1, CV_32FC1, cv::Scalar(std::numeric_limits<double>::max()));
+
+                                             // Ideal result        Wrong result
+    src1.at<float>(32 * 0,0) = +1.0;         // work = +1.0         +1.0
+    src1.at<float>(32 * 1,0) = +55555555.5;  // work = +55555556.5  +55555555.5
+    src1.at<float>(32 * 2,0) = -55555555.5;  // work = +1.0         0.0
+    src1.at<float>(32 * 3,0) = -1.0;         // work = 0.0          -1.0
+
+    EXPECT_FLOAT_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0);
+}
+
 }} // namespace
 /* End Of File */


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/24757

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
