### PR TITLE
Rotary positional embeddings

### DIFF
--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -115,7 +115,7 @@ static void precompRotationTable(float *data,
         // scalar tail
         for (; i < d_half; i+=1)
         {
-            float theta = pos * std::exp(-2.f * i/d * logBase);
+            float theta = pos * std::exp(-2.f * i * inv_d * logBase);
             data_ptr[2*i    ] = std::sin(theta);
             data_ptr[2*i + 1] = std::cos(theta);
         }

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -98,7 +98,7 @@ static void precompRotationTable(float *data,
         const v_float32 v_neg2    = vx_setall_f32(-2.0f);
 
         for (; i + w <= d_half; i+=w) {
-            int idx_buf[CV_SIMD_WIDTH];
+            int idx_buf[VTraits<v_float32>::max_nlanes];
             for (int k = 0; k < int(w); ++k)
                 idx_buf[k] = int(i + k);
             // [i, i+1, …, i+w-1]

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -323,8 +323,8 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
                             static_cast<int>(qkv_head_sizes[1]) / 2
                         );
                         const auto *rope_table_data = rope_table.ptr<const float>();
-                        rotationKernel( dst + dst_offset, 
-                            rope_table_data, rope_table_data + seq_len * rope_head_size, 
+                        rotationKernel( dst + dst_offset,
+                            rope_table_data, rope_table_data + seq_len * rope_head_size,
                             seq_len,  qkv_head_sizes[qkv_index]
                         );
                     }

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -98,7 +98,7 @@ static void precompRotationTable(float *data,
         const v_float32 v_neg2    = v_setall_f32(-2.0f);
 
         for (; i + w <= d_half; i+=w) {
-            int idx_buf[w];
+            int idx_buf[CV_SIMD_WIDTH];
             for (int k = 0; k < int(w); ++k)
                 idx_buf[k] = int(i + k);
             // [i, i+1, …, i+w-1]

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -286,7 +286,7 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
 
             // If rotary is false, evaluates to internals[2], which is the output_buffer
             // but this is not dramatic, because in case rotary is false, the table is not used
-            const auto &rope_table = internals.back(); 
+            const auto &rope_table = internals.back();
 
             opt.multi_thread = false;
             auto fn = [&](const Range &r) {
@@ -427,5 +427,6 @@ class AttentionLayerImpl CV_FINAL : public AttentionLayer {
 Ptr<AttentionLayer> AttentionLayer::create(const LayerParams &params) {
     return makePtr<AttentionLayerImpl>(params);
 }
+
 
 }} // cv::dnn

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -40,7 +40,7 @@ static void rotationKernel(float* data,
         const float* sin_ptr = sin_table + pos * half_dim;
         const float* cos_ptr = cos_table + pos * half_dim;
 
-#ifdef CV_SIMD
+#if (CV_SIMD || CV_SIMD_SCALABLE)
         const size_t w = VTraits<v_float32>::vlanes();  // dynamic lanes for RVV
         size_t d = 0;
         for (; d + w <= half_dim; d += w)

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -93,9 +93,9 @@ static void precompRotationTable(float *data,
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         const size_t w = VTraits<v_float32>::vlanes();
-        const v_float32 v_logBase = v_setall_f32(logBase);
-        const v_float32 v_inv_d   = v_setall_f32(inv_d);
-        const v_float32 v_neg2    = v_setall_f32(-2.0f);
+        const v_float32 v_logBase = vx_setall_f32(logBase);
+        const v_float32 v_inv_d   = vx_setall_f32(inv_d);
+        const v_float32 v_neg2    = vx_setall_f32(-2.0f);
 
         for (; i + w <= d_half; i+=w) {
             int idx_buf[CV_SIMD_WIDTH];

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -39,7 +39,7 @@ static void rotationKernel(
     {
         for (int t = range.start; t < range.end; ++t)
         {
-            float* out_ptr    = data + size_t(t) * d;
+            float* out_ptr = data + size_t(t) * d;
             const float* table_ptr = rotation_table + size_t(t) * d;
             size_t i = 0;
 
@@ -104,7 +104,7 @@ static void precompRotationTable(float *data,
             // [i, i+1, …, i+w-1]
             v_float32 v_idx = v_cvt_f32(vx_load(idx_buf));
             // [10_000^(-i/d), 10_000^(-(i+1)/d), …, 10_000^(-(i+w-1)/d)]
-            v_float32 v_theta   = v_exp(v_mul(v_mul(v_neg2, v_mul(v_idx, v_inv_d)), v_logBase));
+            v_float32 v_theta = v_exp(v_mul(v_mul(v_neg2, v_mul(v_idx, v_inv_d)), v_logBase));
             v_theta = v_mul(v_setall_f32(float(pos)), v_theta);
             v_float32 sin_v, cos_v;
             v_sincos(v_theta, sin_v, cos_v);

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -40,9 +40,10 @@ static void rotationKernel(float* data,
         const float* sin_ptr = sin_table + pos * half_dim;
         const float* cos_ptr = cos_table + pos * half_dim;
 
+        size_t d = 0;
+
 #if (CV_SIMD || CV_SIMD_SCALABLE)
         const size_t w = VTraits<v_float32>::vlanes();  // dynamic lanes for RVV
-        size_t d = 0;
         for (; d + w <= half_dim; d += w)
         {
             // load sin/cos into scalable vectors
@@ -62,6 +63,7 @@ static void rotationKernel(float* data,
             // store back
             v_store_interleave(out_ptr + 2*d, out_even, out_odd);
         }
+#endif
         // scalar tail
         for (; d < half_dim; ++d)
         {
@@ -72,18 +74,6 @@ static void rotationKernel(float* data,
             out_ptr[2*d]   = xe * c - xo * s;
             out_ptr[2*d+1] = xo * c + xe * s;
         }
-#else
-        // fallback: pure scalar
-        for (size_t d = 0; d < half_dim; ++d)
-        {
-            float s  = sin_ptr[d];
-            float c  = cos_ptr[d];
-            float xe = out_ptr[2*d];
-            float xo = out_ptr[2*d+1];
-            out_ptr[2*d]   = xe * c - xo * s;
-            out_ptr[2*d+1] = xo * c + xe * s;
-        }
-#endif
     }
 }
 

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -95,7 +95,7 @@ static void precompRotationTables(float *data,
     // RoPE is a positional encoding method used in transformer models.
     // It uses sine and cosine functions to encode the position of tokens in a sequence
     // initially introduced for NLP in https://arxiv.org/pdf/2104.09864
-    
+
     // assume data is of shape [2,seq_ken,head_size]
 
     float* sin_table = data;

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -46,8 +46,8 @@ static void rotationKernel(float* data,
         for (; d + w <= half_dim; d += w)
         {
             // load sin/cos into scalable vectors
-            v_float32 sin_v = v_load(sin_ptr + d);
-            v_float32 cos_v = v_load(cos_ptr + d);
+            v_float32 sin_v = vx_load(sin_ptr + d);
+            v_float32 cos_v = vx_load(cos_ptr + d);
 
             // deinterleave
             v_float32 x_even, x_odd;

--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -105,7 +105,7 @@ static void precompRotationTable(float *data,
             v_float32 v_idx = v_cvt_f32(vx_load(idx_buf));
             // [10_000^(-i/d), 10_000^(-(i+1)/d), …, 10_000^(-(i+w-1)/d)]
             v_float32 v_theta = v_exp(v_mul(v_mul(v_neg2, v_mul(v_idx, v_inv_d)), v_logBase));
-            v_theta = v_mul(v_setall_f32(float(pos)), v_theta);
+            v_theta = v_mul(vx_setall_f32(float(pos)), v_theta);
             v_float32 sin_v, cos_v;
             v_sincos(v_theta, sin_v, cos_v);
             // store back with interleave

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -754,7 +754,7 @@ TEST(Layer_MHARoPe_Test_Accuracy_with_, Pytorch)
     mhaParams.blobs[1] = QKV_bias;
     mhaParams.set("num_heads", 4);
     mhaParams.set(
-        "qkv_hidden_sizes", 
+        "qkv_hidden_sizes",
         DictValue::arrayInt(&qkv_hidden_sizes[0], qkv_hidden_sizes.size())
     );
     mhaParams.set("do_rotary", true);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -743,6 +743,32 @@ TEST_F(Layer_RNN_Test, get_set_test)
     EXPECT_EQ(shape(outputs[1]), shape(nT, nS, nH));
 }
 
+TEST(Layer_MHARoPe_Test_Accuracy_with_, Pytorch)
+{
+    Mat QKV = blobFromNPY(_tf("mha_rope.QKV.npy"));
+    Mat QKV_bias = blobFromNPY(_tf("mha_rope.QKV_bias.npy"));
+    std::vector<int> qkv_hidden_sizes = { 256, 256, 256 };
+    LayerParams mhaParams;
+    mhaParams.blobs.resize(2);
+    mhaParams.blobs[0] = QKV;
+    mhaParams.blobs[1] = QKV_bias;
+    mhaParams.set("num_heads", 4);
+    mhaParams.set(
+        "qkv_hidden_sizes", 
+        DictValue::arrayInt(&qkv_hidden_sizes[0], qkv_hidden_sizes.size())
+    );
+    mhaParams.set("do_rotary", true);
+
+    Ptr<AttentionLayer> layer = AttentionLayer::create(mhaParams);
+    Mat inp = blobFromNPY(_tf("mha_rope.input.npy"));
+    std::vector<Mat> inputs(1, inp), outputs;
+    runLayer(layer, inputs, outputs);
+    Mat h_t_reference = blobFromNPY(_tf("mha_rope.output.npy"));
+    normAssert(h_t_reference, outputs[0]);
+}
+
+
+
 TEST_P(Test_Caffe_layers, Accum)
 {
 #ifdef OPENCV_DNN_EXTERNAL_PROTOBUF


### PR DESCRIPTION
Rotary positional embeddings let an attention block encode the relative position between tokens. Widely adopted in LLMs such as LLaMA—and equally applicable to Vision Transformers—the ONNX Runtime com.microsoft.Attention operator already exposes this via its `do_rotary` flag (see docs), and this PR adds support for that flag in OpenCV.

_Operator spec: https://github.com/microsoft/onnxruntime/blob/v1.16.1/docs/ContribOperators.md#com.microsoft.Attention_

Materials:
- RoFormer paper https://arxiv.org/abs/2104.09864
- RoPe for Vision Transformer https://github.com/naver-ai/rope-vit
- llama implementation https://github.com/meta-llama/llama/blob/main/llama/model.py#L80


Merge with https://github.com/opencv/opencv_extra/pull/1250

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
