### PR TITLE
Enable Java bindings for SimpleBlobDetector::blobColor

### DIFF
--- a/modules/features2d/misc/java/gen_dict.json
+++ b/modules/features2d/misc/java/gen_dict.json
@@ -7,6 +7,12 @@
             "jni_var": "Feature2D %(n)s",
             "suffix": "J",
             "j_import": "org.opencv.features2d.Feature2D"
+        },
+        "uchar": {
+            "j_type": "byte",
+            "jn_type": "byte",
+            "jni_type": "jbyte",
+            "suffix": "B"
         }
     }
 }

--- a/modules/features2d/misc/java/test/SIMPLEBLOBFeatureDetectorTest.java
+++ b/modules/features2d/misc/java/test/SIMPLEBLOBFeatureDetectorTest.java
@@ -108,8 +108,7 @@ public class SIMPLEBLOBFeatureDetectorTest extends OpenCVTestCase {
         assertEquals(2, params.get_minRepeatability());
         assertEquals(10.0f, params.get_minDistBetweenBlobs());
         assertEquals(true, params.get_filterByColor());
-        // FIXME: blobColor field has uchar type in C++ and cannot be automatically wrapped to Java as it does not support unsigned types
-        //assertEquals(0, params.get_blobColor());
+        assertEquals(0, params.get_blobColor());
         assertEquals(true, params.get_filterByArea());
         assertEquals(800f, params.get_minArea());
         assertEquals(6000f, params.get_maxArea());


### PR DESCRIPTION
This PR adds a type_dict entry for SimpleBlobDetector::blobColor to gen_dict.json, enabling the blobColor property to be exposed in the Java bindings.

As a result, the Java wrapper will automatically generate get_blobColor() and set_blobColor() methods, allowing access to the blobColor field from Java.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
