### PR TITLE
Fix hard dependency of dnn for  mcc module. 

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/mcc_checker_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/mcc_checker_detector.hpp
@@ -29,7 +29,9 @@
 #ifndef OPENCV_OBJDETECT_MCC_CHECKER_DETECTOR_HPP
 #define OPENCV_OBJDETECT_MCC_CHECKER_DETECTOR_HPP
 #include <opencv2/core.hpp>
+#ifdef HAVE_OPENCV_DNN
 #include <opencv2/dnn.hpp>
+#endif
 #include <opencv2/imgproc.hpp>
 
 //---------------------------------------------------------------
@@ -241,7 +243,9 @@ public:
     *
     */
     CV_WRAP static Ptr<CCheckerDetector> create();
-     /** @brief Set the net which will be used to find the approximate
+
+#ifdef HAVE_OPENCV_DNN
+    /** @brief Set the net which will be used to find the approximate
     *         bounding boxes for the color charts. And returns the implementation of the CCheckerDetector.
     *
     * It is not necessary to use this, but this usually results in
@@ -251,6 +255,7 @@ public:
     *            the function will return false.
     */
     CV_WRAP static Ptr<CCheckerDetector> create(const dnn::Net &net);
+#endif
 
     /** @brief Draws the checker to the given image.
         * @param img image in color space BGR
@@ -280,6 +285,7 @@ public:
 
     CV_WRAP virtual void setColorChartType(ColorChart chartType) = 0;
 
+#ifdef HAVE_OPENCV_DNN
     /** @brief Enables or disables the use of the neural network for detection.
         * @param useDnn Boolean flag to indicate whether to use neural network (true) or not (false).
     */
@@ -287,6 +293,7 @@ public:
     CV_WRAP virtual void setUseDnnModel(bool useDnn) = 0;
 
     CV_WRAP virtual bool getUseDnnModel() const = 0;
+#endif
 
     CV_WRAP virtual const DetectorParametersMCC& getDetectionParams() const = 0;
 

--- a/modules/objdetect/misc/python/pyopencv_cchecker.hpp
+++ b/modules/objdetect/misc/python/pyopencv_cchecker.hpp
@@ -1,4 +1,0 @@
-#include "opencv2/objdetect/mcc_checker_detector.hpp"
-
-typedef std::vector<cv::Ptr<mcc::CChecker>> vector_Ptr_CChecker;
-typedef dnn::Net dnn_Net;

--- a/modules/objdetect/misc/python/pyopencv_objdetect.hpp
+++ b/modules/objdetect/misc/python/pyopencv_objdetect.hpp
@@ -3,5 +3,9 @@
 #include "opencv2/objdetect.hpp"
 
 typedef QRCodeEncoder::Params QRCodeEncoder_Params;
+typedef std::vector<cv::Ptr<mcc::CChecker>> vector_Ptr_CChecker;
+#ifdef HAVE_OPENCV_DNN
+typedef dnn::Net dnn_Net;
+#endif
 
 #endif

--- a/modules/objdetect/src/mcc/checker_detector.hpp
+++ b/modules/objdetect/src/mcc/checker_detector.hpp
@@ -45,9 +45,11 @@ class CCheckerDetectorImpl : public CCheckerDetector
 
 public:
     CCheckerDetectorImpl();
+#ifdef HAVE_OPENCV_DNN
     CCheckerDetectorImpl(const dnn::Net& _net){
         net = _net;
     }
+#endif
     virtual ~CCheckerDetectorImpl();
 
     bool process(InputArray image, const std::vector<Rect> &regionsOfInterest,
@@ -72,9 +74,11 @@ public:
 
     virtual void setColorChartType(ColorChart chartType) CV_OVERRIDE;
 
+#ifdef HAVE_OPENCV_DNN
     virtual void setUseDnnModel(bool useDnn) CV_OVERRIDE;
 
     virtual bool getUseDnnModel() const CV_OVERRIDE;
+#endif
 
     virtual const DetectorParametersMCC& getDetectionParams() const CV_OVERRIDE;
 
@@ -164,10 +168,14 @@ protected: // methods pipeline
 
 protected:
     std::vector<Ptr<CChecker>> m_checkers;
+#ifdef HAVE_OPENCV_DNN
     dnn::Net net;
+    bool m_useDnn = true;
+#else
+    bool m_useDnn = false;
+#endif
     DetectorParametersMCC m_params = DetectorParametersMCC();
     ColorChart m_chartType;
-    bool m_useDnn = true;
 
 private: // methods aux
     void get_subbox_chart_physical(

--- a/modules/objdetect/src/mcc/precomp.hpp
+++ b/modules/objdetect/src/mcc/precomp.hpp
@@ -34,7 +34,9 @@
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/3d.hpp>
+#ifdef HAVE_OPENCV_DNN
 #include <opencv2/dnn.hpp>
+#endif
 
 #include <vector>
 #include <string>

--- a/samples/cpp/macbeth_chart_detection.cpp
+++ b/samples/cpp/macbeth_chart_detection.cpp
@@ -1,32 +1,48 @@
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/objdetect.hpp>
+#ifdef HAVE_OPENCV_DNN
 #include <opencv2/dnn.hpp>
-#include <iostream>
 #include "../dnn/common.hpp"
+#endif
+#include <iostream>
 
 using namespace std;
 using namespace cv;
+#ifdef HAVE_OPENCV_DNN
 using namespace cv::dnn;
+#endif
 using namespace mcc;
 
 const string about =
     "This sample demonstrates mcc checker detection with DNN based model and thresholding (default) techniques.\n\n"
     "To run default:\n"
     "\t ./example_cpp_macbeth_chart_detection --input=path/to/your/input/image/or/video (don't give --input flag if want to use device camera)\n"
+#ifdef HAVE_OPENCV_DNN
     "With DNN model:\n"
     "\t ./example_cpp_macbeth_chart_detection mcc --input=path/to/your/input/image/or/video\n\n"
-    "Model path can also be specified using --model argument. And config path can be specified using --config. Download it using python download_models.py mcc from dnn samples directory\n\n";
+    "Model path can also be specified using --model argument. And config path can be specified using --config. Download it using python download_models.py mcc from dnn samples directory\n\n"
+#else
+    "Note: DNN-based detection is not available in this build.\n\n"
+#endif
+    ;
 
 const string param_keys =
     "{ help h          |                   | Print help message. }"
+#ifdef HAVE_OPENCV_DNN
     "{ @alias          |                   | An alias name of model to extract preprocessing parameters from models.yml file. }"
     "{ zoo             | ../dnn/models.yml | An optional path to file with preprocessing parameters }"
+#endif
     "{ input i         |                   | Path to input image or video file. Skip this argument to capture frames from a camera.}"
     "{ type            |         0         | chartType: 0-Standard, 1-DigitalSG, 2-Vinyl, default:0 }"
     "{ num_charts      |         1         | Maximum number of charts in the image }"
+#ifdef HAVE_OPENCV_DNN
     "{ model           |                   | Path to the model file for using dnn model. }";
+#else
+    ;
+#endif
 
+#ifdef HAVE_OPENCV_DNN
 const string backend_keys = format(
     "{ backend          | default | Choose one of computation backends: "
                             "default: automatically (by default), "
@@ -45,8 +61,15 @@ const string target_keys = format(
                             "vulkan: Vulkan, "
                             "cuda: CUDA, "
                             "cuda_fp16: CUDA fp16 (half-float preprocess) }");
+#endif
 
-string keys = param_keys + backend_keys + target_keys;
+// Initialize keys before use
+string keys = param_keys;
+static void initKeys() {
+#ifdef HAVE_OPENCV_DNN
+    keys += backend_keys + target_keys;
+#endif
+}
 
 static bool processFrame(const Mat& frame, Ptr<CCheckerDetector> detector, Mat& src, Mat& tgt, int nc){
     Mat imageCopy = frame.clone();
@@ -67,6 +90,7 @@ static bool processFrame(const Mat& frame, Ptr<CCheckerDetector> detector, Mat& 
 
 int main(int argc, char *argv[])
 {
+    initKeys();
     CommandLineParser parser(argc, argv, keys);
     parser.about(about);
 
@@ -76,6 +100,8 @@ int main(int argc, char *argv[])
         parser.printMessage();
         return -1;
     }
+
+#ifdef HAVE_OPENCV_DNN
     string modelName = parser.get<String>("@alias");
     string zooFile = parser.get<String>("zoo");
     const char* path = getenv("OPENCV_SAMPLES_DATA_PATH");
@@ -88,22 +114,26 @@ int main(int argc, char *argv[])
 
     keys += genPreprocArguments(modelName, zooFile);
     parser = CommandLineParser(argc, argv, keys);
+#endif
 
     int t = parser.get<int>("type");
 
     CV_Assert(0 <= t && t <= 2);
     ColorChart chartType = ColorChart(t);
 
+#ifdef HAVE_OPENCV_DNN
     const string sha1 = parser.get<String>("sha1");
     const string model_path = findModel(parser.get<string>("model"), sha1);
     const string config_sha1 = parser.get<String>("config_sha1");
     const string pbtxt_path = findModel(parser.get<string>("config"), config_sha1);
     const string backend = parser.get<String>("backend");
     const string target = parser.get<String>("target");
+#endif
 
     int nc = parser.get<int>("num_charts");
 
     Ptr<CCheckerDetector> detector;
+#ifdef HAVE_OPENCV_DNN
     if (model_path != "" && pbtxt_path != ""){
         EngineType engine = ENGINE_AUTO;
         if (backend != "default" || target != "cpu"){
@@ -119,6 +149,9 @@ int main(int argc, char *argv[])
     else{
         detector = CCheckerDetector::create();
     }
+#else
+    detector = CCheckerDetector::create();
+#endif
     detector->setColorChartType(chartType);
 
     bool isVideo = true;


### PR DESCRIPTION
Currently building objdetect module without dnn fails due to mcc module. This PR makes the dependency optional, by checking if DNN is available in mcc module. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
