### PR TITLE
HAL: aligned behavior of normDiff 32s kernels in hal_rvv in 4.x

### DIFF
--- a/3rdparty/hal_rvv/hal_rvv_1p0/norm_diff.hpp
+++ b/3rdparty/hal_rvv/hal_rvv_1p0/norm_diff.hpp
@@ -130,7 +130,8 @@ struct NormDiffInf_RVV<int, int> {
             vl = __riscv_vsetvl_e32m8(n - i);
             auto v1 = __riscv_vle32_v_i32m8(src1 + i, vl);
             auto v2 = __riscv_vle32_v_i32m8(src2 + i, vl);
-            auto v = custom_intrin::__riscv_vabd(v1, v2, vl);
+            // auto v = custom_intrin::__riscv_vabd(v1, v2, vl); // 5.x
+            auto v = custom_intrin::__riscv_vabs(__riscv_vsub(v1, v2, vl), vl); // 4.x
             s = __riscv_vmaxu_tu(s, s, v, vl);
         }
         return __riscv_vmv_x(__riscv_vredmaxu(s, __riscv_vmv_s_x_u32m1(0, __riscv_vsetvlmax_e32m1()), vlmax));
@@ -247,7 +248,8 @@ struct NormDiffL1_RVV<int, double> {
             vl = __riscv_vsetvl_e32m4(n - i);
             auto v1 = __riscv_vle32_v_i32m4(src1 + i, vl);
             auto v2 = __riscv_vle32_v_i32m4(src2 + i, vl);
-            auto v = custom_intrin::__riscv_vabd(v1, v2, vl);
+            // auto v = custom_intrin::__riscv_vabd(v1, v2, vl); // 5.x
+            auto v = custom_intrin::__riscv_vabs(__riscv_vsub(v1, v2, vl), vl); // 4.x
             s = __riscv_vfadd_tu(s, s, __riscv_vfwcvt_f(v, vl), vl);
         }
         return __riscv_vfmv_f(__riscv_vfredosum(s, __riscv_vfmv_s_f_f64m1(0, __riscv_vsetvlmax_e64m1()), vlmax));
@@ -577,7 +579,8 @@ struct MaskedNormDiffInf_RVV<int, int> {
                 vl = __riscv_vsetvl_e32m8(len - i);
                 auto v1 = __riscv_vlse32_v_i32m8(src1 + cn * i + cn_index, sizeof(int) * cn, vl);
                 auto v2 = __riscv_vlse32_v_i32m8(src2 + cn * i + cn_index, sizeof(int) * cn, vl);
-                auto v = custom_intrin::__riscv_vabd(v1, v2, vl);
+                // auto v = custom_intrin::__riscv_vabd(v1, v2, vl); // 5.x
+                auto v = custom_intrin::__riscv_vabs(__riscv_vsub(v1, v2, vl), vl); // 4.x
                 auto m = __riscv_vle8_v_u8m2(mask + i, vl);
                 auto b = __riscv_vmsne(m, 0, vl);
                 s = __riscv_vmaxu_tumu(b, s, s, v, vl);
@@ -759,7 +762,8 @@ struct MaskedNormDiffL1_RVV<int, double> {
                 vl = __riscv_vsetvl_e32m4(len - i);
                 auto v1 = __riscv_vlse32_v_i32m4(src1 + cn * i + cn_index, sizeof(int) * cn, vl);
                 auto v2 = __riscv_vlse32_v_i32m4(src2 + cn * i + cn_index, sizeof(int) * cn, vl);
-                auto v = custom_intrin::__riscv_vabd(v1, v2, vl);
+                // auto v = custom_intrin::__riscv_vabd(v1, v2, vl); // 5.x
+                auto v = custom_intrin::__riscv_vabs(__riscv_vsub(v1, v2, vl), vl); // 4.x
                 auto m = __riscv_vle8_v_u8m1(mask + i, vl);
                 auto b = __riscv_vmsne(m, 0, vl);
                 s = __riscv_vfadd_tumu(b, s, s, __riscv_vfwcvt_f(b, v, vl), vl);


### PR DESCRIPTION
This patch is intended for 4.x to fix sanity checks in performance testings.

**Do not port to 5.x.**

Reproducer:

1. Build latest 4.x.
2. Run on QEMU or SpaceMIT K1:
  ```
  export OPENCV_TEST_DATA_PATH=/path/to/opencv_extra/test_data
  ./opencv_perf_core --gtest_filter="*norm2*" --perf_force_samples=1
  ```

Issue:

<details>

```
[  FAILED  ] 32 tests, listed below:
[  FAILED  ] Size_MatType_NormType_norm2.norm2/30, where GetParam() = (640x480, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/31, where GetParam() = (640x480, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/33, where GetParam() = (640x480, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/34, where GetParam() = (640x480, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/78, where GetParam() = (1280x720, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/79, where GetParam() = (1280x720, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/81, where GetParam() = (1280x720, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/82, where GetParam() = (1280x720, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/126, where GetParam() = (1920x1080, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/127, where GetParam() = (1920x1080, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/129, where GetParam() = (1920x1080, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/130, where GetParam() = (1920x1080, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/174, where GetParam() = (127x61, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/175, where GetParam() = (127x61, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/177, where GetParam() = (127x61, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2.norm2/178, where GetParam() = (127x61, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/30, where GetParam() = (640x480, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/31, where GetParam() = (640x480, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/33, where GetParam() = (640x480, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/34, where GetParam() = (640x480, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/78, where GetParam() = (1280x720, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/79, where GetParam() = (1280x720, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/81, where GetParam() = (1280x720, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/82, where GetParam() = (1280x720, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/126, where GetParam() = (1920x1080, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/127, where GetParam() = (1920x1080, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/129, where GetParam() = (1920x1080, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/130, where GetParam() = (1920x1080, 32SC1, NORM_L1|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/174, where GetParam() = (127x61, 32SC1, NORM_INF)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/175, where GetParam() = (127x61, 32SC1, NORM_L1)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/177, where GetParam() = (127x61, 32SC1, NORM_INF|NORM_RELATIVE)
[  FAILED  ] Size_MatType_NormType_norm2_mask.norm2_mask/178, where GetParam() = (127x61, 32SC1, NORM_L1|NORM_RELATIVE)
```

</details>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
