### PR TITLE
Add CV_WRAP to registerOutput for language bindings support

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -606,7 +606,7 @@ CV__DNN_INLINE_NS_BEGIN
          *
          *  @returns index of bound layer (the same as layerId or newly created)
          */
-        int registerOutput(const std::string& outputName, int layerId, int outputPort);
+        CV_WRAP int registerOutput(const std::string& outputName, int layerId, int outputPort);
 
         /** @brief Sets outputs names of the network input pseudo layer.
          *


### PR DESCRIPTION
**Description:**
This pull request adds the CV_WRAP annotation to the cv::dnn::Net::registerOutput method to make it accessible from language bindings such as Python and Java.

**Background**
The methods getUnconnectedOutLayers and getUnconnectedOutLayersNames are deprecated, and registerOutput is the recommended alternative. However, it is currently not available from wrappers, making migration difficult.

**Changes**
Added CV_WRAP to Net::registerOutput in dnn.hpp.

**Notes**
This change does not affect existing functionality and only exposes the method to binding generators.

Please let me know if further adjustments are needed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
