### PR TITLE
loongson/build: added v_gt and v_lt with lsx and lasx to fix build

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lasx.hpp
@@ -1010,7 +1010,11 @@ OPENCV_HAL_IMPL_LASX_CMP_OP_INT(v_uint32x8,  v_int32x8,  w, wu)
     inline _Tpvec v_eq(const _Tpvec& a, const _Tpvec& b)          \
     { return _Tpvec(__lasx_xvseq_##suffix(a.val, b.val)); }       \
     inline _Tpvec v_ne(const _Tpvec& a, const _Tpvec& b)          \
-    { return v_not(v_eq(a, b)); }
+    { return v_not(v_eq(a, b)); }                                 \
+    inline _Tpvec v_gt(const _Tpvec& a, const _Tpvec& b)          \
+    { return _Tpvec(__lasx_xvslt_##suffix(b.val, a.val)); }       \
+    inline _Tpvec v_lt(const _Tpvec& a, const _Tpvec& b)          \
+    { return _Tpvec(__lasx_xvslt_##suffix(a.val, b.val)); }
 
 OPENCV_HAL_IMPL_LASX_CMP_OP_64BIT(v_uint64x4, d)
 OPENCV_HAL_IMPL_LASX_CMP_OP_64BIT(v_int64x4, d)

--- a/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_lsx.hpp
@@ -783,7 +783,11 @@ OPENCV_HAL_IMPL_LSX_CMP_OP_INT(v_uint32x4,  v_int32x4,  w, wu)
     inline _Tpvec v_eq(const _Tpvec& a, const _Tpvec& b)          \
     { return _Tpvec(__lsx_vseq_##suffix(a.val, b.val)); }         \
     inline _Tpvec v_ne(const _Tpvec& a, const _Tpvec& b)          \
-    { return v_not(v_eq(a, b)); }
+    { return v_not(v_eq(a, b)); }                                 \
+    inline _Tpvec v_gt(const _Tpvec& a, const _Tpvec& b)          \
+    { return _Tpvec(__lsx_vslt_##suffix(b.val, a.val)); }         \
+    inline _Tpvec v_lt(const _Tpvec& a, const _Tpvec& b)          \
+    { return _Tpvec(__lsx_vslt_##suffix(a.val, b.val)); }
 
 OPENCV_HAL_IMPL_LSX_CMP_OP_64BIT(v_uint64x2, d)
 OPENCV_HAL_IMPL_LSX_CMP_OP_64BIT(v_int64x2, d)


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/26758

BTW: There is compiler segmentaion fault with `features` about annoy with GCC-8 (8.3.0-6.lnd.vec.31) on the Loongnix 20 OS (CPU: Loongson-3C5000LL). Tested with `-DBUILD_opencv_features=OFF` and the build was successful.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
