### PR TITLE
Reworked HSV color conversion tables initialization for OpenCL branch

### DIFF
--- a/modules/imgproc/src/color_hsv.dispatch.cpp
+++ b/modules/imgproc/src/color_hsv.dispatch.cpp
@@ -257,6 +257,34 @@ bool oclCvtColorBGR2HLS( InputArray _src, OutputArray _dst, int bidx, bool full 
     return h.run();
 }
 
+static UMat init_sdiv_table()
+{
+    std::vector<int> sdiv(256);
+
+    const int hsv_shift = 12;
+    const int v = 255 << hsv_shift;
+
+    sdiv[0] = 0;
+    for(int i = 1; i < 256; i++ )
+        sdiv[i] = saturate_cast<int>(v/(1.*i));
+
+    return UMat(sdiv, true);
+}
+
+static UMat init_hdiv_table(int hrange)
+{
+    std::vector<int> hdiv(256);
+
+    const int hsv_shift = 12;
+    const int v = hrange << hsv_shift;
+
+    hdiv[0] = 0;
+    for (int i = 1; i < 256; i++ )
+        hdiv[i] = saturate_cast<int>(v/(6.*i));
+
+    return UMat(hdiv, true);
+}
+
 bool oclCvtColorBGR2HSV( InputArray _src, OutputArray _dst, int bidx, bool full )
 {
     OclHelper< Set<3, 4>, Set<3>, Set<CV_8U, CV_32F> > h(_src, _dst, 3);
@@ -274,41 +302,22 @@ bool oclCvtColorBGR2HSV( InputArray _src, OutputArray _dst, int bidx, bool full 
 
     if(_src.depth() == CV_8U)
     {
-        static UMat sdiv_data;
-        static UMat hdiv_data180;
-        static UMat hdiv_data256;
-        static int sdiv_table[256];
-        static int hdiv_table180[256];
-        static int hdiv_table256[256];
-        static volatile bool initialized180 = false, initialized256 = false;
-        volatile bool & initialized = hrange == 180 ? initialized180 : initialized256;
+        static UMat sdiv_data = init_sdiv_table();
+        UMat hdiv_data;
 
-        if (!initialized)
+        if (hrange == 180)
         {
-            int * const hdiv_table = hrange == 180 ? hdiv_table180 : hdiv_table256, hsv_shift = 12;
-            UMat & hdiv_data = hrange == 180 ? hdiv_data180 : hdiv_data256;
-
-            sdiv_table[0] = hdiv_table180[0] = hdiv_table256[0] = 0;
-
-            int v = 255 << hsv_shift;
-            if (!initialized180 && !initialized256)
-            {
-                for(int i = 1; i < 256; i++ )
-                    sdiv_table[i] = saturate_cast<int>(v/(1.*i));
-                Mat(1, 256, CV_32SC1, sdiv_table).copyTo(sdiv_data);
-            }
-
-            v = hrange << hsv_shift;
-            for (int i = 1; i < 256; i++ )
-                hdiv_table[i] = saturate_cast<int>(v/(6.*i));
-
-            Mat(1, 256, CV_32SC1, hdiv_table).copyTo(hdiv_data);
-            initialized = true;
+            static UMat hdiv_data180 = init_hdiv_table(180);
+            hdiv_data = hdiv_data180;
+        }
+        else
+        {
+            static UMat hdiv_data256 = init_hdiv_table(256);
+            hdiv_data = hdiv_data256;
         }
 
         h.setArg(ocl::KernelArg::PtrReadOnly(sdiv_data));
-        h.setArg(hrange == 256 ? ocl::KernelArg::PtrReadOnly(hdiv_data256) :
-                                 ocl::KernelArg::PtrReadOnly(hdiv_data180));
+        h.setArg(ocl::KernelArg::PtrReadOnly(hdiv_data));
     }
 
     return h.run();


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/24443
Replaces https://github.com/opencv/opencv/pull/24444

C++11 and upper guaranties that local static variables are initialized once in thread safe way.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
