### PR TITLE
CUDA 12.9 support: build NppStreamContext manually

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -155,7 +155,7 @@ namespace cv { namespace cuda
 
                 cudaDeviceProp prop{};
                 cudaSafeCall(cudaGetDeviceProperties(&prop, device));
-                
+
                 nppStreamContext.nCudaDeviceId = device;
                 nppStreamContext.nMultiProcessorCount = prop.multiProcessorCount;
                 nppStreamContext.nMaxThreadsPerMultiProcessor = prop.maxThreadsPerMultiProcessor;


### PR DESCRIPTION
fixes #27289

## 🚀 CUDA 12.9 Compatibility Fix
File: modules/core/include/opencv2/core/private.cuda.hpp
Starting with CUDA 12.9, NVIDIA removed the helper API nppGetStreamContext() from public headers.
As a result, any module (e.g., OpenCV’s CUDA parts) that attempted to build with CUDA 12.9+ would fail at compile time:

![err1](https://github.com/user-attachments/assets/785f30b2-7e64-4e43-b7f6-d0a4ab8c5a49)
## 🔧 What I did
1.  🧯 Add version guard for legacy toolkits
```cpp
#if CUDA_VERSION < 12090
    nppSafeCall(nppGetStreamContext(&nppStreamContext)); 
#else
    // Manual context construction below
```
2.  🛠 Manually construct NppStreamContext for CUDA ≥ 12.9
```cpp
int device = 0;
cudaSafeCall(cudaGetDevice(&device));

cudaDeviceProp prop{};
cudaSafeCall(cudaGetDeviceProperties(&prop, device));

nppStreamContext.nCudaDeviceId = device;
nppStreamContext.nMultiProcessorCount = prop.multiProcessorCount;
nppStreamContext.nMaxThreadsPerMultiProcessor = prop.maxThreadsPerMultiProcessor;
nppStreamContext.nMaxThreadsPerBlock = prop.maxThreadsPerBlock;
nppStreamContext.nSharedMemPerBlock = prop.sharedMemPerBlock;
nppStreamContext.nCudaDevAttrComputeCapabilityMajor = prop.major;
nppStreamContext.nCudaDevAttrComputeCapabilityMinor = prop.minor;
```
## ✅ Tested
cuda-version 12.9
- npp module builds successfully:
![wechat_2025-05-06_233443_510](https://github.com/user-attachments/assets/a69aa74a-a0d1-471f-9b6d-47c04c323c6c)
- project builds successfully:
![wechat_2025-05-06_234157_358](https://github.com/user-attachments/assets/6404924e-76cb-48fb-856f-8b04a60e4b71)

