### PR TITLE
Fixed std::vector<Point3f> handling in JS wrappers

### DIFF
--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -466,7 +466,8 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<double>("DoubleVector");
     register_vector<std::string>("StringVector");
     register_vector<cv::Point>("PointVector");
-    register_vector<cv::Point3f>("Point3fVector");
+    register_vector<cv::Point2f>("Point2fVector");
+    register_vector<cv::Point3_<float>>("Point3fVector");
     register_vector<cv::Mat>("MatVector");
     register_vector<cv::Rect>("RectVector");
     register_vector<cv::KeyPoint>("KeyPointVector");
@@ -612,6 +613,7 @@ EMSCRIPTEN_BINDINGS(binding_utils)
 
     EMSCRIPTEN_CV_RECT(int, "Rect")
     EMSCRIPTEN_CV_RECT(float, "Rect2f")
+    EMSCRIPTEN_CV_RECT(double, "Rect2d")
 
     emscripten::value_object<cv::RotatedRect>("RotatedRect")
         .field("center", &cv::RotatedRect::center)

--- a/modules/js/test/test_objdetect.js
+++ b/modules/js/test/test_objdetect.js
@@ -286,6 +286,8 @@ QUnit.test('Charuco detector', function (assert) {
         board.generateImage(new cv.Size(300, 500), board_image);
         assert.ok(!board_image.empty());
 
+        let chess_corners = board.getChessboardCorners();
+
         detector.detectBoard(board_image, corners, ids);
         assert.ok(!corners.empty());
         assert.ok(!ids.empty());
@@ -300,5 +302,6 @@ QUnit.test('Charuco detector', function (assert) {
         detector.delete();
         corners.delete();
         ids.delete();
+        chess_corners.delete();
     }
 });


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/26626

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-1,linux-4,linux-f1
