### PR TITLE
imgcodecs: png: add log if first chunk is not IHDR

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -133,6 +133,7 @@ const uint32_t id_bKGD = 0x624B4744; // The bKGD chunk specifies a default backg
 const uint32_t id_tRNS = 0x74524E53; // The tRNS chunk provides transparency information
 const uint32_t id_tEXt = 0x74455874; // The tEXt chunk stores metadata as text in key-value pairs
 const uint32_t id_IEND = 0x49454E44; // end/footer chunk
+const uint32_t id_CgBI = 0x43674249; // The CgBI chunk(Apple private) is not supported.
 
 APNGFrame::APNGFrame()
 {
@@ -285,9 +286,14 @@ bool  PngDecoder::readHeader()
     if (!readFromStreamOrBuffer(&sig, 8))
         return false;
 
+    // IHDR chunk shall be first. ( https://www.w3.org/TR/png-3/#5ChunkOrdering )
     id = read_chunk(m_chunkIHDR);
     if (id != id_IHDR)
+    {
+        CV_LOG_IF_ERROR(NULL, id == id_CgBI, "CgBI chunk(Apple private) shall not be first instead of IHDR");
+        CV_LOG_IF_ERROR(NULL, id != id_CgBI, "IHDR chunk shall be first, this data may be broken");
         return false;
+    }
 
     m_is_fcTL_loaded = false;
     while (true)

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -133,7 +133,7 @@ const uint32_t id_bKGD = 0x624B4744; // The bKGD chunk specifies a default backg
 const uint32_t id_tRNS = 0x74524E53; // The tRNS chunk provides transparency information
 const uint32_t id_tEXt = 0x74455874; // The tEXt chunk stores metadata as text in key-value pairs
 const uint32_t id_IEND = 0x49454E44; // end/footer chunk
-const uint32_t id_CgBI = 0x43674249; // The CgBI chunk(Apple private) is not supported.
+const uint32_t id_CgBI = 0x43674249; // The CgBI chunk (Apple private) is not supported.
 
 APNGFrame::APNGFrame()
 {
@@ -288,10 +288,14 @@ bool  PngDecoder::readHeader()
 
     // IHDR chunk shall be first. ( https://www.w3.org/TR/png-3/#5ChunkOrdering )
     id = read_chunk(m_chunkIHDR);
+    if (id == id_CgBI)
+    {
+        CV_LOG_ERROR(NULL, "CgBI chunk (Apple private) found as the first chunk. IHDR is expected.");
+        return false;
+    }
     if (id != id_IHDR)
     {
-        CV_LOG_IF_ERROR(NULL, id == id_CgBI, "CgBI chunk(Apple private) shall not be first instead of IHDR");
-        CV_LOG_IF_ERROR(NULL, id != id_CgBI, "IHDR chunk shall be first, this data may be broken");
+        CV_LOG_ERROR(NULL, "IHDR chunk shall be first. This data may be broken or malformed.");
         return false;
     }
 

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -121,26 +121,25 @@ TEST(Imgcodecs_Png, decode_regression27295)
 
     Mat img;
 
-    // If first is IHDR chunk, output shall not be empty.
-    // 8 means PNG sigunature length.
-    // 4 means lenght of chunk.
+    // If IHDR chunk found as the first chunk, output shall not be empty.
+    // 8 means PNG signature length.
+    // 4 means length field(uint32_t).
     EXPECT_EQ(buff[8+4+0], 'I');
     EXPECT_EQ(buff[8+4+1], 'H');
     EXPECT_EQ(buff[8+4+2], 'D');
     EXPECT_EQ(buff[8+4+3], 'R');
-
     EXPECT_NO_THROW(img = imdecode(buff, IMREAD_COLOR));
     EXPECT_FALSE(img.empty());
 
-    // If first is not IHDR chunk, output shall be empty.
-    buff[8+4+0] = 'i';
+    // If Non-IHDR chunk found as the first chunk, output shall be empty.
+    buff[8+4+0] = 'i'; // Not 'I'
     buff[8+4+1] = 'H';
     buff[8+4+2] = 'D';
     buff[8+4+3] = 'R';
     EXPECT_NO_THROW(img = imdecode(buff, IMREAD_COLOR));
     EXPECT_TRUE(img.empty());
 
-    // If first is CgBI chunk(Apple private), output shall be empty with special message.
+    // If CgBI chunk (Apple private) found as the first chunk, output shall be empty with special message.
     buff[8+4+0] = 'C';
     buff[8+4+1] = 'g';
     buff[8+4+2] = 'B';


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/27295

To optimize for the native pixel format of the iPhone's early PowerVR GPUs, Apple implemented a non-standard PNG format.

Details: https://theapplewiki.com/wiki/PNG_CgBI_Format

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
