### PR TITLE
Cherry-pick OpenJPEG deconding status fix.

### DIFF
--- a/3rdparty/openjpeg/openjp2/jp2.c
+++ b/3rdparty/openjpeg/openjp2/jp2.c
@@ -2873,7 +2873,7 @@ OPJ_BOOL opj_jp2_read_header(opj_stream_private_t *p_stream,
                               p_image,
                               p_manager);
 
-    if (p_image && *p_image) {
+    if (ret && p_image && *p_image) {
         /* Set Image Color Space */
         if (jp2->enumcs == 16) {
             (*p_image)->color_space = OPJ_CLRSPC_SRGB;


### PR DESCRIPTION
Cherry-picked https://github.com/uclouvain/openjpeg/pull/1573

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
