### PR TITLE
Fixed bilateral filter's sigma color and sigma space issue

### DIFF
--- a/hal/ndsrvp/src/bilateralFilter.cpp
+++ b/hal/ndsrvp/src/bilateralFilter.cpp
@@ -156,10 +156,12 @@ int bilateralFilter(const uchar* src_data, size_t src_step,
 
     int i, j, maxk, radius;
 
-    if( sigma_color <= 0 )
-        sigma_color = 1;
-    if( sigma_space <= 0 )
-        sigma_space = 1;
+    constexpr double eps = 1e-6;
+    if( sigma_color <= eps || sigma_space <= eps )
+    {
+        src.copyTo(dst);
+        return CV_HAL_ERROR_OK;
+    }
 
     double gauss_color_coeff = -0.5/(sigma_color * sigma_color);
     double gauss_space_coeff = -0.5/(sigma_space * sigma_space);

--- a/modules/imgproc/src/bilateral_filter.dispatch.cpp
+++ b/modules/imgproc/src/bilateral_filter.dispatch.cpp
@@ -75,10 +75,12 @@ static bool ocl_bilateralFilter_8u(InputArray _src, OutputArray _dst, int d,
     if (depth != CV_8U || cn > 4)
         return false;
 
-    if (sigma_color <= 0)
-        sigma_color = 1;
-    if (sigma_space <= 0)
-        sigma_space = 1;
+    constexpr double eps = 1e-6;
+    if( sigma_color <= eps || sigma_space <= eps )
+    {
+        _src.copyTo(_dst);
+        return true;
+    }
 
     double gauss_color_coeff = -0.5 / (sigma_color * sigma_color);
     double gauss_space_coeff = -0.5 / (sigma_space * sigma_space);
@@ -165,10 +167,12 @@ bilateralFilter_8u( const Mat& src, Mat& dst, int d,
 
     CV_Assert( (src.type() == CV_8UC1 || src.type() == CV_8UC3) && src.data != dst.data );
 
-    if( sigma_color <= 0 )
-        sigma_color = 1;
-    if( sigma_space <= 0 )
-        sigma_space = 1;
+    constexpr double eps = 1e-6;
+    if( sigma_color <= eps || sigma_space <= eps )
+    {
+        src.copyTo(dst);
+        return;
+    }
 
     double gauss_color_coeff = -0.5/(sigma_color*sigma_color);
     double gauss_space_coeff = -0.5/(sigma_space*sigma_space);
@@ -232,10 +236,12 @@ bilateralFilter_32f( const Mat& src, Mat& dst, int d,
 
     CV_Assert( (src.type() == CV_32FC1 || src.type() == CV_32FC3) && src.data != dst.data );
 
-    if( sigma_color <= 0 )
-        sigma_color = 1;
-    if( sigma_space <= 0 )
-        sigma_space = 1;
+    constexpr double eps = 1e-6;
+    if( sigma_color <= eps || sigma_space <= eps )
+    {
+        src.copyTo(dst);
+        return;
+    }
 
     double gauss_color_coeff = -0.5/(sigma_color*sigma_color);
     double gauss_space_coeff = -0.5/(sigma_space*sigma_space);
@@ -358,9 +364,16 @@ static bool ipp_bilateralFilter(Mat &src, Mat &dst, int d, double sigmaColor, do
 #ifdef HAVE_IPP_IW
     CV_INSTRUMENT_REGION_IPP();
 
+    constexpr double eps = 1e-6;
+    if( sigmaColor <= eps || sigmaSpace <= eps )
+    {
+        src.copyTo(dst);
+        return true;
+    }
+
     int         radius         = IPP_MAX(((d <= 0)?cvRound(sigmaSpace*1.5):d/2), 1);
-    Ipp32f      valSquareSigma = (Ipp32f)((sigmaColor <= 0)?1:sigmaColor*sigmaColor);
-    Ipp32f      posSquareSigma = (Ipp32f)((sigmaSpace <= 0)?1:sigmaSpace*sigmaSpace);
+    Ipp32f      valSquareSigma = (Ipp32f)(sigmaColor*sigmaColor);
+    Ipp32f      posSquareSigma = (Ipp32f)(sigmaSpace*sigmaSpace);
 
     // Acquire data and begin processing
     try

--- a/modules/imgproc/test/test_bilateral_filter.cpp
+++ b/modules/imgproc/test/test_bilateral_filter.cpp
@@ -110,10 +110,12 @@ namespace opencv_test { namespace {
             src.type() == dst.type() && src.size() == dst.size() &&
             src.data != dst.data );
 
-        if( sigma_color <= 0 )
-            sigma_color = 1;
-        if( sigma_space <= 0 )
-            sigma_space = 1;
+        constexpr double eps = 1e-6;
+        if( sigma_color <= eps || sigma_space <= eps )
+        {
+            src.copyTo(dst);
+            return;
+        }
 
         double gauss_color_coeff = -0.5/(sigma_color*sigma_color);
         double gauss_space_coeff = -0.5/(sigma_space*sigma_space);


### PR DESCRIPTION
The PR resolves the issue: https://github.com/opencv/opencv/issues/22886

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
