### PR TITLE
hal/riscv-rvv: make use of function tab in copyToMasked and CV_ELEM_SIZE1 in place of elem_size_tab

### DIFF
--- a/hal/riscv-rvv/src/core/dotprod.cpp
+++ b/hal/riscv-rvv/src/core/dotprod.cpp
@@ -190,16 +190,9 @@ int dotprod(const uchar *a_data, size_t a_step, const uchar *b_data, size_t b_st
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }
 
-    static const size_t elem_size_tab[CV_DEPTH_MAX] = {
-        sizeof(uchar),   sizeof(schar),
-        sizeof(ushort),  sizeof(short),
-        sizeof(int),     sizeof(float),
-        sizeof(int64_t), 0,
-    };
-    CV_Assert(elem_size_tab[depth]);
-
-    bool a_continuous = (a_step == width * elem_size_tab[depth] * cn);
-    bool b_continuous = (b_step == width * elem_size_tab[depth] * cn);
+    int elem_size1 = CV_ELEM_SIZE1(type);
+    bool a_continuous = (a_step == width * elem_size1 * cn);
+    bool b_continuous = (b_step == width * elem_size1 * cn);
     size_t nplanes = 1;
     size_t len = width * height;
     if (!a_continuous || !b_continuous) {

--- a/hal/riscv-rvv/src/core/norm.cpp
+++ b/hal/riscv-rvv/src/core/norm.cpp
@@ -999,15 +999,8 @@ int norm(const uchar* src, size_t src_step, const uchar* mask, size_t mask_step,
         },
     };
 
-    static const size_t elem_size_tab[CV_DEPTH_MAX] = {
-        sizeof(uchar),   sizeof(schar),
-        sizeof(ushort),  sizeof(short),
-        sizeof(int),     sizeof(float),
-        sizeof(int64_t), 0,
-    };
-    CV_Assert(elem_size_tab[depth]);
-
-    bool src_continuous = (src_step == width * elem_size_tab[depth] * cn || (src_step != width * elem_size_tab[depth] * cn && height == 1));
+    int elem_size1 = CV_ELEM_SIZE1(type);
+    bool src_continuous = (src_step == width * elem_size1 * cn || (src_step != width * elem_size1 * cn && height == 1));
     bool mask_continuous = (mask_step == static_cast<size_t>(width));
     size_t nplanes = 1;
     size_t size = width * height;
@@ -1030,7 +1023,7 @@ int norm(const uchar* src, size_t src_step, const uchar* mask, size_t mask_step,
     res.d = 0;
     if ((norm_type == NORM_L1 && depth <= CV_16S) ||
         ((norm_type == NORM_L2 || norm_type == NORM_L2SQR) && depth <= CV_8S)) {
-        const size_t esz = elem_size_tab[depth] * cn;
+        const size_t esz = elem_size1 * cn;
         const int total = (int)size;
         const int intSumBlockSize = (norm_type == NORM_L1 && depth <= CV_8S ? (1 << 23) : (1 << 15))/cn;
         const int blockSize = std::min(total, intSumBlockSize);

--- a/hal/riscv-rvv/src/core/norm_diff.cpp
+++ b/hal/riscv-rvv/src/core/norm_diff.cpp
@@ -1111,16 +1111,9 @@ int normDiff(const uchar* src1, size_t src1_step, const uchar* src2, size_t src2
         },
     };
 
-    static const size_t elem_size_tab[CV_DEPTH_MAX] = {
-        sizeof(uchar),   sizeof(schar),
-        sizeof(ushort),  sizeof(short),
-        sizeof(int),     sizeof(float),
-        sizeof(int64_t), 0,
-    };
-    CV_Assert(elem_size_tab[depth]);
-
-    bool src_continuous = (src1_step == width * elem_size_tab[depth] * cn || (src1_step != width * elem_size_tab[depth] * cn && height == 1));
-    src_continuous &= (src2_step == width * elem_size_tab[depth] * cn || (src2_step != width * elem_size_tab[depth] * cn && height == 1));
+    int elem_size1 = CV_ELEM_SIZE1(type);
+    bool src_continuous = (src1_step == width * elem_size1 * cn || (src1_step != width * elem_size1 * cn && height == 1));
+    src_continuous &= (src2_step == width * elem_size1 * cn || (src2_step != width * elem_size1 * cn && height == 1));
     bool mask_continuous = (mask_step == static_cast<size_t>(width));
     size_t nplanes = 1;
     size_t size = width * height;
@@ -1143,7 +1136,7 @@ int normDiff(const uchar* src1, size_t src1_step, const uchar* src2, size_t src2
     res.d = 0;
     if ((norm_type == NORM_L1 && depth <= CV_16S) ||
         ((norm_type == NORM_L2 || norm_type == NORM_L2SQR) && depth <= CV_8S)) {
-        const size_t esz = elem_size_tab[depth] * cn;
+        const size_t esz = elem_size1 * cn;
         const int total = (int)size;
         const int intSumBlockSize = (norm_type == NORM_L1 && depth <= CV_8S ? (1 << 23) : (1 << 15))/cn;
         const int blockSize = std::min(total, intSumBlockSize);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
