### PR TITLE
Disable IPP for x86 32bit Android as it's incompatible with modern NDK.

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -138,7 +138,7 @@ class ABI:
     def __str__(self):
         return "%s (%s)" % (self.name, self.toolchain)
     def haveIPP(self):
-        return self.name == "x86" or self.name == "x86_64"
+        return self.name == "x86_64"
     def haveKleidiCV(self):
         return self.name == "arm64-v8a"
 

--- a/platforms/android/default.config.py
+++ b/platforms/android/default.config.py
@@ -2,5 +2,5 @@ ABIs = [
     ABI("2", "armeabi-v7a", None, 21, cmake_vars=dict(ANDROID_ABI='armeabi-v7a with NEON')),
     ABI("3", "arm64-v8a",   None, 21, cmake_vars=dict(ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES='ON')),
     ABI("5", "x86_64",      None, 21, cmake_vars=dict(ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES='ON')),
-    ABI("4", "x86",         None, 21),
+    ABI("4", "x86",         None, 21, cmake_vars=dict(WITH_IPP='OFF')),
 ]


### PR DESCRIPTION
Workaround for https://github.com/opencv/opencv/issues/26072
The IPP conflict blocks NDK update and fixes for issues [#27310](https://github.com/opencv/opencv/issues/27310), [#27024](https://github.com/opencv/opencv/issues/27024).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
