### PR TITLE
Make sure to not access outside normDiffTab

### DIFF
--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -571,7 +571,7 @@ double norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask 
               ((normType == NORM_HAMMING || normType == NORM_HAMMING2) && src1.type() == CV_8U) );
 
     NormDiffFunc func = getNormDiffFunc(normType >> 1, depth == CV_16F ? CV_32F : depth);
-    CV_Assert( func != 0 );
+    CV_Assert( (normType >> 1) >= 3 || func != 0 );
 
     if( src1.isContinuous() && src2.isContinuous() && mask.empty() )
     {

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -1350,6 +1350,7 @@ NormDiffFunc getNormDiffFunc(int normType, int depth)
             (NormDiffFunc)normDiffL2_64f, 0
         }
     };
+    if (normType >= 3 || normType < 0) return nullptr;
 
     return normDiffTab[normType][depth];
 }


### PR DESCRIPTION
If the norm is outside the array (e.g. Hamming), memory is read outside of the array, which does not matter because the invalid pointer is not used oustide of the function (e.g. the Hamming path is taken) but it triggers the sanitizer.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
