### PR TITLE
build: fix more warnings from recent gcc versions after #27337

### DIFF
--- a/3rdparty/libtiff/tif_hash_set.c
+++ b/3rdparty/libtiff/tif_hash_set.c
@@ -146,7 +146,7 @@ TIFFHashSet *TIFFHashSetNew(TIFFHashSetHashFunc fnHashFunc,
     set->fnEqualFunc = fnEqualFunc ? fnEqualFunc : TIFFHashSetEqualPointer;
     set->fnFreeEltFunc = fnFreeEltFunc;
     set->nSize = 0;
-    set->tabList = (TIFFList **)(calloc(sizeof(TIFFList *), 53));
+    set->tabList = (TIFFList **)(calloc(53, sizeof(TIFFList *)));
     if (set->tabList == NULL)
     {
         free(set);
@@ -367,7 +367,7 @@ static bool TIFFHashSetRehash(TIFFHashSet *set)
 {
     int nNewAllocatedSize = anPrimes[set->nIndiceAllocatedSize];
     TIFFList **newTabList =
-        (TIFFList **)(calloc(sizeof(TIFFList *), nNewAllocatedSize));
+        (TIFFList **)(calloc(nNewAllocatedSize, sizeof(TIFFList *)));
     if (newTabList == NULL)
         return false;
 #ifdef HASH_DEBUG

--- a/hal/riscv-rvv/src/core/copy_mask.cpp
+++ b/hal/riscv-rvv/src/core/copy_mask.cpp
@@ -116,7 +116,8 @@ int copyToMasked(const uchar *src_data, size_t src_step, uchar *dst_data, size_t
         0, 0, 0, 0,
         copyToMasked_e64c4
     };
-    CopyToMaskedFunc func = tab[CV_ELEM_SIZE(type)];
+    size_t elem_size = CV_ELEM_SIZE(type);
+    CopyToMaskedFunc func = elem_size <= 32 ? tab[elem_size] : nullptr;
     if (func == nullptr) {
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }

--- a/hal/riscv-rvv/src/core/flip.cpp
+++ b/hal/riscv-rvv/src/core/flip.cpp
@@ -306,7 +306,7 @@ inline int flip_inplace(int esz, uchar* data, size_t step, int width, int height
         0, 0, 0, 0,
         0
     };
-    FlipInplaceFunc func = flip_inplace_func_tab[esz];
+    FlipInplaceFunc func = esz <= 32 ? flip_inplace_func_tab[esz] : nullptr;
     if (!func) {
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }
@@ -348,7 +348,7 @@ int flip(int src_type, const uchar* src_data, size_t src_step, int src_width, in
         0, 0, 0, 0,
         0
     };
-    FlipFunc func = flip_func_tab[esz];
+    FlipFunc func = esz <= 32 ? flip_func_tab[esz] : nullptr;
     if (func) {
         func(src_data, src_step, dst_data, dst_step, src_width, src_height, flip_mode);
         return CV_HAL_ERROR_OK;

--- a/hal/riscv-rvv/src/core/transpose.cpp
+++ b/hal/riscv-rvv/src/core/transpose.cpp
@@ -201,7 +201,7 @@ int transpose2d(const uchar* src_data, size_t src_step, uchar* dst_data, size_t 
         0, 0, 0, 0,
         0
     };
-    Transpose2dFunc func = tab[element_size];
+    Transpose2dFunc func = element_size <= 32 ? tab[element_size] : nullptr;
     if (!func) {
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -24,10 +24,12 @@ void test_hal_intrin_float16();
 
 //==================================================================================================
 
-#if defined (__GNUC__) && defined(__has_warning)
+#if defined (__clang__) && defined(__has_warning)
     #if __has_warning("-Wmaybe-uninitialized")
         #define CV_DISABLE_GCC_MAYBE_UNINITIALIZED_WARNINGS
     #endif
+#elif defined (__GNUC__) // in case of gcc, it does not have macro __has_warning
+    #define CV_DISABLE_GCC_MAYBE_UNINITIALIZED_WARNINGS
 #endif
 
 #if defined (CV_DISABLE_GCC_MAYBE_UNINITIALIZED_WARNINGS)

--- a/modules/imgproc/src/accum.simd.hpp
+++ b/modules/imgproc/src/accum.simd.hpp
@@ -2825,7 +2825,7 @@ void accW_simd_(const ushort* src, float* dst, const uchar* mask, int len, int c
                 v_expand(v_src1, v_src10, v_src11);
                 v_expand(v_src2, v_src20, v_src21);
 
-                v_float32 v_dst00, v_dst01, v_dst02, v_dst10, v_dst11, v_dst20, v_dst21;
+                v_float32 v_dst00, v_dst01, v_dst10, v_dst11, v_dst20, v_dst21;
                 v_load_deinterleave(dst + x * cn             , v_dst00, v_dst10, v_dst20);
                 v_load_deinterleave(dst + (x +     step) * cn, v_dst01, v_dst11, v_dst21);
 


### PR DESCRIPTION
More fixings after https://github.com/opencv/opencv/pull/27337

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
