### PR TITLE
Disabled cv namespace usage inside KleidiCV.

### DIFF
--- a/hal/kleidicv/CMakeLists.txt
+++ b/hal/kleidicv/CMakeLists.txt
@@ -2,6 +2,7 @@ project(kleidicv_hal)
 
 if(HAVE_KLEIDICV)
   option(KLEIDICV_ENABLE_SME2 "" OFF) # not compatible with some CLang versions in NDK
+  option(KLEIDICV_USE_CV_NAMESPACE_IN_OPENCV_HAL "" OFF)
   include("${KLEIDICV_SOURCE_PATH}/adapters/opencv/CMakeLists.txt")
   # HACK to suppress adapters/opencv/kleidicv_hal.cpp:343:12: warning: unused function 'from_opencv' [-Wunused-function]
   target_compile_options( kleidicv_hal PRIVATE


### PR DESCRIPTION
Related patch to KleidiCV itself: https://gitlab.arm.com/kleidi/kleidicv/-/merge_requests/475

Current version of KleidiCV adds all HAL functions to cv namespace to fix short function names resolution during macro substitution. The root cause was covered in https://github.com/opencv/opencv/pull/26878.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
