### PR TITLE
core: legacy intrin operators - fixed version warning condition

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_legacy_ops.h
+++ b/modules/core/include/opencv2/core/hal/intrin_legacy_ops.h
@@ -17,8 +17,8 @@
 #warning "Operators might conflict with built-in functions on RISC-V platform"
 #endif
 
-#if defined(CV_VERSION) && CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR < 11
-#warning "Older versions of OpenCV (<4.11) already have Universal Intrinscs operators"
+#if defined(CV_VERSION) && CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR < 9
+#warning "Older versions of OpenCV (<4.9) already have Universal Intrinscs operators"
 #endif
 
 


### PR DESCRIPTION
Fix for #27327 ([comment](https://github.com/opencv/opencv/pull/27327#discussion_r2094518977))