### PR TITLE
Added extra test tag for Qualcomm DSP (disabled by default)

### DIFF
--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -87,6 +87,7 @@
 
 // Other tests categories
 #define CV_TEST_TAG_OPENCL "opencl"              // Tests with OpenCL
+#define CV_TEST_TAG_DSP "dsp"                    // Tests with Qualcomm DSP
 
 
 

--- a/modules/ts/src/ts_tags.cpp
+++ b/modules/ts/src/ts_tags.cpp
@@ -55,6 +55,7 @@ static std::vector<std::string>& getTestTagsSkipList()
 #if defined(_DEBUG)
         testSkipWithTags.push_back(CV_TEST_TAG_DEBUG_VERYLONG);
 #endif
+        testSkipWithTags.push_back(CV_TEST_TAG_DSP);
         initialized = true;
     }
     return testSkipWithTags;


### PR DESCRIPTION
Merge with https://github.com/opencv/opencv_contrib/pull/3947

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
