### PR TITLE
Try to fix distant points to save time when ThickLine() calls FillConvexPoly()

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1646,6 +1646,18 @@ ThickLine( Mat& img, Point2l p0, Point2l p1, const void* color,
 {
     static const double INV_XY_ONE = 1./static_cast<double>(XY_ONE);
 
+    Rect boundingRect = Rect(Point(0, 0), img.size());
+    if (!boundingRect.contains(p0) || !boundingRect.contains(p1))
+    {
+      const int margin = thickness;
+      const Point2l offset(margin, margin);
+      p0 += offset;
+      p1 += offset;
+      clipLine(Size2l(boundingRect.width+2*margin, boundingRect.height+2*margin), p0, p1);
+      p0 -= offset;
+      p1 -= offset;
+    }
+
     p0.x <<= XY_SHIFT - shift;
     p0.y <<= XY_SHIFT - shift;
     p1.x <<= XY_SHIFT - shift;


### PR DESCRIPTION
Proposal for #27365

cv::clipLine() is useful, but one should take care of a margin to preserve line caps.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
