### PR TITLE
cuda: Fix GpuMat::convertTo issues described in 27373

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -254,10 +254,13 @@ public:
 
     //! converts GpuMat to another datatype with scaling (Blocking call)
     void convertTo(OutputArray dst, int rtype, double alpha, double beta = 0.0) const;
+
     //! bindings overload which converts GpuMat to another datatype with scaling(Blocking call)
-    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha, double beta = 0.0) const {
+#ifdef OPENCV_BINDINGS_PARSER
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha=1.0, double beta = 0.0) const {
         convertTo(static_cast<OutputArray>(dst), rtype, alpha, beta);
     }
+#endif
 
     //! converts GpuMat to another datatype with scaling (Non-Blocking call)
     void convertTo(OutputArray dst, int rtype, double alpha, Stream& stream) const;

--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -240,6 +240,10 @@ public:
 
     //! converts GpuMat to another datatype (Blocking call)
     void convertTo(OutputArray dst, int rtype) const;
+    //! bindings overload which converts GpuMat to another datatype (Blocking call)
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype) const {
+        convertTo(static_cast<OutputArray>(dst), rtype);
+    }
 
     //! converts GpuMat to another datatype (Non-Blocking call)
     void convertTo(OutputArray dst, int rtype, Stream& stream) const;
@@ -251,7 +255,7 @@ public:
     //! converts GpuMat to another datatype with scaling (Blocking call)
     void convertTo(OutputArray dst, int rtype, double alpha, double beta = 0.0) const;
     //! bindings overload which converts GpuMat to another datatype with scaling(Blocking call)
-    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha = 1.0, double beta = 0.0) const {
+    CV_WRAP void convertTo(CV_OUT GpuMat& dst, int rtype, double alpha, double beta = 0.0) const {
         convertTo(static_cast<OutputArray>(dst), rtype, alpha, beta);
     }
 

--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -546,7 +546,7 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, Stream& stream) co
         return;
     }
 
-    CV_DbgAssert( sdepth <= CV_64F && ddepth <= CV_64F );
+    CV_Assert( sdepth <= CV_64F && ddepth <= CV_64F );
 
     GpuMat src = *this;
 
@@ -577,6 +577,8 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, double alpha, doub
 
     const int sdepth = depth();
     const int ddepth = CV_MAT_DEPTH(rtype);
+
+    CV_Assert(sdepth <= CV_64F && ddepth <= CV_64F);
 
     GpuMat src = *this;
 


### PR DESCRIPTION
 Fix https://github.com/opencv/opencv/issues/27373.

1. `GpuMat::convertTo` uses `convertToScale` due to incorrect overload.
2. There are no runtime checks to prevent the use of `CV_16U` data types in Release builds.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
