### PR TITLE
Relax remap relative test to handle the case when HAL implements not all remap options

### DIFF
--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -500,10 +500,10 @@ PARAM_TEST_CASE(RemapRelative, MatDepth, Channels, Interpolation, BorderType, bo
         data64FC1.reshape(nChannels, size.height).convertTo(src, srcType);
 
         cv::Mat mapRelativeX32F(size, CV_32FC1);
-        mapRelativeX32F.setTo(cv::Scalar::all(-0.33));
+        mapRelativeX32F.setTo(cv::Scalar::all(-0.25));
 
         cv::Mat mapRelativeY32F(size, CV_32FC1);
-        mapRelativeY32F.setTo(cv::Scalar::all(-0.33));
+        mapRelativeY32F.setTo(cv::Scalar::all(-0.25));
 
         cv::Mat mapAbsoluteX32F = mapRelativeX32F.clone();
         mapAbsoluteX32F.forEach<float>([&](float& pixel, const int* position) {

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1332,10 +1332,10 @@ TEST_P(Imgproc_RemapRelative, validity)
     data64FC1.reshape(nChannels, size.height).convertTo(src, srcType);
 
     cv::Mat mapRelativeX32F(size, CV_32FC1);
-    mapRelativeX32F.setTo(cv::Scalar::all(-0.33));
+    mapRelativeX32F.setTo(cv::Scalar::all(-0.25));
 
     cv::Mat mapRelativeY32F(size, CV_32FC1);
-    mapRelativeY32F.setTo(cv::Scalar::all(-0.33));
+    mapRelativeY32F.setTo(cv::Scalar::all(-0.25));
 
     cv::Mat mapAbsoluteX32F = mapRelativeX32F.clone();
     mapAbsoluteX32F.forEach<float>([&](float& pixel, const int* position) {
@@ -1371,7 +1371,7 @@ TEST_P(Imgproc_RemapRelative, validity)
         cv::remap(src, dstRelative, mapRelativeX32F, mapRelativeY32F, interpolation | WARP_RELATIVE_MAP, borderType);
     }
 
-    EXPECT_EQ(cvtest::norm(dstAbsolute, dstRelative, NORM_INF), 0);
+    EXPECT_LE(cvtest::norm(dstAbsolute, dstRelative, NORM_INF), 1);
 };
 
 INSTANTIATE_TEST_CASE_P(ImgProc, Imgproc_RemapRelative, testing::Combine(


### PR DESCRIPTION
KleidiCV does not implement relative remap, but does the classic remap. The test checks OpenCV remap relative against standard remap in KleidiCV and fails on rounding details. The patch tunes relative shifts to get better rounding.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
