### PR TITLE
implementation closer to TIFF-spec, less boilerplate-code

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.hpp
+++ b/modules/imgcodecs/src/grfmt_tiff.hpp
@@ -107,7 +107,6 @@ public:
 
 protected:
     cv::Ptr<void> m_tif;
-    int normalizeChannelsNumber(int channels) const;
     bool m_hdr;
     size_t m_buf_pos;
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ X] The PR is proposed to the proper branch
- [X ] There is a reference to the original bug report and related work: none existing
- [ X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name: covered by existing tests
- [X ] The feature is well documented and sample code can be built with the project CMake

From the TIFF-Spec:
```
SamplesPerPixel
...
SamplesPerPixel is usually 1 for bilevel, grayscale, and palette-color images.
SamplesPerPixel is usually 3 for RGB images.
Default = 1. See also BitsPerSample
```
So the default is 1 unless RGB (not 3 as before).

```
BitsPerSample
...
Default = 1. See also SamplesPerPixel.
```
The original code does this with more lines of code. I wondered, why it was different to the retrieval of SamplesPerPixel.