### PR TITLE
Add simple image blur example using cv::blur

### DIFF
--- a/samples/cpp/image_blur.cpp
+++ b/samples/cpp/image_blur.cpp
@@ -1,0 +1,20 @@
+#include <opencv2/opencv.hpp>
+#include <iostream>
+
+int main()
+{
+    cv::Mat img = cv::Mat::zeros(300, 500, CV_8UC3); 
+    cv::putText(img, "OpenCV Blur Test", cv::Point(30, 100), cv::FONT_HERSHEY_SIMPLEX, 1.5, cv::Scalar(255, 255, 255), 2);
+
+    cv::circle(img, cv::Point(150, 200), 40, cv::Scalar(0, 255, 0), -1);
+    cv::circle(img, cv::Point(250, 200), 40, cv::Scalar(0, 0, 255), -1);
+    cv::circle(img, cv::Point(350, 200), 40, cv::Scalar(255, 0, 0), -1);
+
+    cv::Mat blurred;
+    cv::blur(img, blurred, cv::Size(5, 5));
+
+    cv::imshow("Original", img);
+    cv::imshow("Blurred", blurred);
+    cv::waitKey(0);
+    return 0;
+}


### PR DESCRIPTION
This pull request adds a simple example that demonstrates how to apply a blur effect using OpenCV's `cv::blur()` function.

The program generates a black image and overlays some white text and three colored circles (green, red, and blue). Then, it applies a uniform blur with a 5x5 kernel and shows both the original and blurred images using `cv::imshow`.

This is useful for beginners to understand how image manipulation and display work in OpenCV. It also serves as a base for extending the example with interactive elements like trackbars.
---
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
