### PR TITLE
Fix valgrind warnings in tests

### DIFF
--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -344,7 +344,11 @@ protected:
             }
         }
 
-        solvePnPRansac(points, projectedPoints, intrinsics, distCoeffs, rvec, tvec, false, pointsCount, 0.5f, 0.99, inliers, method);
+        bool isEstimateSuccess = solvePnPRansac(points, projectedPoints, intrinsics, distCoeffs, rvec, tvec, false, pointsCount, 0.5f, 0.99, inliers, method);
+        if (!isEstimateSuccess)
+        {
+            return false;
+        }
 
         bool isTestSuccess = inliers.size() + numOutliers >= points.size();
 

--- a/modules/imgproc/test/test_cornersubpix.cpp
+++ b/modules/imgproc/test/test_cornersubpix.cpp
@@ -69,6 +69,8 @@ TEST(Imgproc_CornerSubPix, out_of_image_corners)
 TEST(Imgproc_CornerSubPix, corners_on_the_edge)
 {
     cv::Mat image(500, 500, CV_8UC1);
+    RNG& rng = TS::ptr()->get_rng();
+    cvtest::randUni(rng, image, 0, 255);
     cv::Size win(1, 1);
     cv::Size zeroZone(-1, -1);
     cv::TermCriteria criteria;


### PR DESCRIPTION
### Pull Request Readiness Checklist

https://pullrequest.opencv.org/buildbot/builders/4_x_valgrind-lin64-debug/builds/100131/steps/test_calib3d/logs/valgrind%20summary
https://pullrequest.opencv.org/buildbot/builders/4_x_valgrind-lin64-debug/builds/100131/steps/test_imgproc/logs/valgrind%20summary

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
