### PR TITLE
Fixed Android setCameraIndex issue.

### DIFF
--- a/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
+++ b/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
@@ -96,10 +96,10 @@ public class JavaCamera2View extends CameraBridgeViewBase {
                 Log.e(LOGTAG, "Error: camera isn't detected.");
                 return false;
             }
-            boolean chosed = false;  // remember whether the camera ID is set.
+            boolean chosen = false;  // remember whether the camera ID is set.
             if (mCameraIndex == CameraBridgeViewBase.CAMERA_ID_ANY) {
                 mCameraID = camList[0];
-                chosed = true;
+                chosen = true;
             } else {
                 for (String cameraID : camList) {
                     CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraID);
@@ -109,12 +109,12 @@ public class JavaCamera2View extends CameraBridgeViewBase {
                             characteristics.get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_FRONT)
                     ) {
                         mCameraID = cameraID;
-                        chosed = true;
+                        chosen = true;
                         break;
                     }
                 }
             }
-            if (mCameraID == null || !chosed) { // make JavaCamera2View behaves in the same way as JavaCameraView
+            if (mCameraID == null || !chosen) { // make JavaCamera2View behaves in the same way as JavaCameraView
                 Log.i(LOGTAG, "Selecting camera by index (" + mCameraIndex + ")");
                 if (mCameraIndex < camList.length) {
                     mCameraID = camList[mCameraIndex];

--- a/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
+++ b/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
@@ -96,8 +96,10 @@ public class JavaCamera2View extends CameraBridgeViewBase {
                 Log.e(LOGTAG, "Error: camera isn't detected.");
                 return false;
             }
+            boolean chosed = false;  // remember whether the camera ID is set.
             if (mCameraIndex == CameraBridgeViewBase.CAMERA_ID_ANY) {
                 mCameraID = camList[0];
+                chosed = true;
             } else {
                 for (String cameraID : camList) {
                     CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraID);
@@ -107,11 +109,12 @@ public class JavaCamera2View extends CameraBridgeViewBase {
                             characteristics.get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_FRONT)
                     ) {
                         mCameraID = cameraID;
+                        chosed = true;
                         break;
                     }
                 }
             }
-            if (mCameraID == null) { // make JavaCamera2View behaves in the same way as JavaCameraView
+            if (mCameraID == null || !chosed) { // make JavaCamera2View behaves in the same way as JavaCameraView
                 Log.i(LOGTAG, "Selecting camera by index (" + mCameraIndex + ")");
                 if (mCameraIndex < camList.length) {
                     mCameraID = camList[mCameraIndex];


### PR DESCRIPTION
Fixed camera switching issue on Android devices: When a device has more than two cameras, the setCameraIndex method failed to switch to non-default cameras.

Root cause: The original code only considered two default camera IDs when updating camera IDs, ignoring all others. This fix ensures all camera IDs are properly handled.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
