### PR TITLE
Fix expression result error [-Werror,-Wunused-value] when compiling with clang

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -706,9 +706,9 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #  else
 #    if defined __ATOMIC_ACQ_REL && !defined __clang__
        // version for gcc >= 4.7
-#      define CV_XADD(addr, delta) (int)__atomic_fetch_add((unsigned*)(addr), (unsigned)(delta), __ATOMIC_ACQ_REL)
+#      define CV_XADD(addr, delta) __atomic_fetch_add((unsigned*)(addr), (unsigned)(delta), __ATOMIC_ACQ_REL)
 #    else
-#      define CV_XADD(addr, delta) (int)__sync_fetch_and_add((unsigned*)(addr), (unsigned)(delta))
+#      define CV_XADD(addr, delta) __sync_fetch_and_add((unsigned*)(addr), (unsigned)(delta))
 #    endif
 #  endif
 #elif defined _MSC_VER && !defined RC_INVOKED


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Fix unused expression warnings in cvstd.hpp
Resolve the `-Wunused-value` warnings in `opencv2/core/cvstd.hpp` by addressing unused expression results. This affects the following lines:
- `(int)(__sync_fetch_and_add((unsigned *)(((int *)(cstr_)) - 1), (unsigned)1));`
- `if (str.cstr_) { (int)(__sync_fetch_and_add((unsigned *)(((int *)(str.cstr_)) - 1), (unsigned)1)); }`
- `(int)(__sync_fetch_and_add((unsigned *)(&(refCount)), (unsigned)1));`
These changes ensure that the code compiles without warnings when `-Werror` is enabled.