### PR TITLE
Fix Typos in Comments and Error Messages Across Multiple Files

### DIFF
--- a/samples/directx/d3d11_interop.cpp
+++ b/samples/directx/d3d11_interop.cpp
@@ -373,7 +373,7 @@ public:
             r = m_pD3D11SwapChain->Present(0, 0);
             if (FAILED(r))
             {
-                throw std::runtime_error("switch betweem fronat and back buffers failed!");
+                throw std::runtime_error("switch between fronat and back buffers failed!");
             }
         } // try
 

--- a/samples/dnn/yolo_detector.cpp
+++ b/samples/dnn/yolo_detector.cpp
@@ -125,7 +125,7 @@ void yoloPostProcessing(
 
     if (model_name == "yolonas")
     {
-        // outs contains 2 elemets of shape [1, 8400, nc] and [1, 8400, 4]. Concat them to get [1, 8400, nc+4]
+        // outs contains 2 elements of shape [1, 8400, nc] and [1, 8400, 4]. Concat them to get [1, 8400, nc+4]
         Mat concat_out;
         // squeeze the first dimension
         outs[0] = outs[0].reshape(1, outs[0].size[1]);

--- a/samples/winrt/ImageManipulations/MediaExtensions/OcvTransform/OcvTransform.cpp
+++ b/samples/winrt/ImageManipulations/MediaExtensions/OcvTransform/OcvTransform.cpp
@@ -1047,7 +1047,7 @@ done:
 
 // Create a partial media type from our list.
 //
-// dwTypeIndex: Index into the list of peferred media types.
+// dwTypeIndex: Index into the list of preferred media types.
 // ppmt:        Receives a pointer to the media type.
 
 HRESULT OcvImageManipulations::OnGetPartialType(DWORD dwTypeIndex, IMFMediaType **ppmt)


### PR DESCRIPTION


Description:  
This pull request corrects several typographical errors in comments and error messages in the following files:
- `samples/directx/d3d11_interop.cpp`: Fixed typo in the error message ("betweem" → "between").
- `samples/dnn/yolo_detector.cpp`: Fixed typo in a comment ("elemets" → "elements").
- `samples/winrt/ImageManipulations/MediaExtensions/OcvTransform.cpp`: Fixed typo in a comment ("peferred" → "preferred").

These changes improve code readability and maintain consistency in documentation and error reporting. No functional code was modified.
