### PR TITLE
feat: G-API: Custom stream sources in Python (#27276)

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -66,6 +66,7 @@ file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/streaming/onevpl/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/plaidml/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/util/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/pysrc/*.hpp"
     )
 
 set(gapi_srcs
@@ -241,6 +242,9 @@ set(gapi_srcs
     src/streaming/gstreamer/gstreamer_buffer_utils.cpp
     src/streaming/gstreamer/gstreamer_media_adapter.cpp
     src/streaming/gstreamer/gstreamerenv.cpp
+
+    # Python Custom Stream source
+    src/pysrc/python_stream_source.cpp
 
     # Utils (ITT tracing)
     src/utils/itt.cpp

--- a/modules/gapi/include/opencv2/gapi/pysrc/python_stream_source.hpp
+++ b/modules/gapi/include/opencv2/gapi/pysrc/python_stream_source.hpp
@@ -1,0 +1,65 @@
+#ifndef OPENCV_GAPI_PYSRC_PYTHONSTREAMSOURCE_HPP
+#define OPENCV_GAPI_PYSRC_PYTHONSTREAMSOURCE_HPP
+#include <opencv2/gapi/streaming/source.hpp>
+#include <opencv2/core.hpp>
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+/**
+ * @brief Creates a G-API IStreamSource that delegates to a Python-defined source.
+ *
+ * This factory function wraps a Python object (for example, an instance of a class
+ * implementing a `pull()` and a `descr_of()` method) into a `cv::gapi::wip::IStreamSource`,
+ * enabling it to be used within a G-API computation graph. The OpenCV Python bindings
+ * automatically convert the PyObject into a `cv::Ptr<IStreamSource>`.
+ *
+ * @param src
+ * A `cv::Ptr<IStreamSource>` that internally holds the original Python object.
+ *
+ * @return
+ * A `cv::Ptr<IStreamSource>` that wraps the provided Python object. On each frame pull,
+ * G-API will:
+ *   - Acquire the Python GIL
+ *   - Call the Python object’s `pull()` method
+ *   - Convert the resulting NumPy array to a `cv::Mat`
+ *   - Pass the `cv::Mat` into the G-API pipeline
+ *
+ * @note
+ * In Python, you can use the returned `make_py_src` as follows:
+ *
+ * @code{.py}
+ * class MyClass:
+ *     def __init__(self):
+ *         # Initialize your source
+ *     def pull(self):
+ *         # Return the next frame as a numpy.ndarray or None for end-of-stream
+ *     def descr_of(self):
+ *         # Return a numpy.ndarray that describes the format of the frames
+ *
+ * # Create a G-API source from a Python class
+ * py_src = cv.gapi.wip.make_py_src(MyClass())
+ *
+ * # Define a simple graph: input → copy → output
+ * g_in = cv.GMat()
+ * g_out = cv.gapi.copy(g_in)
+ * graph = cv.GComputation(g_in, g_out)
+ *
+ * # Compile the pipeline for streaming and assign the source
+ * pipeline = graph.compileStreaming()
+ * pipeline.setSource([py_src])
+ * pipeline.start()
+ * @endcode
+ */
+
+CV_EXPORTS_W cv::Ptr<cv::gapi::wip::IStreamSource>
+make_py_src(const cv::Ptr<cv::gapi::wip::IStreamSource>& src);
+
+
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+
+#endif // OPENCV_GAPI_PYSRC_PYTHONSTREAMSOURCE_HPP

--- a/modules/gapi/src/pysrc/python_stream_source.cpp
+++ b/modules/gapi/src/pysrc/python_stream_source.cpp
@@ -1,0 +1,17 @@
+#include <opencv2/gapi/pysrc/python_stream_source.hpp>
+#include <opencv2/gapi/streaming/source.hpp>
+#include <opencv2/core/utils/logger.hpp>
+#include <opencv2/core.hpp>
+
+namespace cv {
+namespace gapi {
+namespace wip {
+
+cv::Ptr<cv::gapi::wip::IStreamSource> make_py_src(const cv::Ptr<cv::gapi::wip::IStreamSource>& src)
+{
+    return src;
+}
+
+} // namespace wip
+} // namespace gapi
+} // namespace cv


### PR DESCRIPTION
Implemented:

- A C++ proxy class PythonCustomStreamSource that implements the IStreamSource interface. This class acts as a bridge between G-API’s internal streaming engine and user-defined Python objects. Internally, it stores a reference to a Python object (PyObject*) and is responsible for: calling the Python object’s pull() method to retrieve the next frame, calling the descr_of() method to obtain the frame format description, acquiring and releasing the Python GIL as needed, converting the returned numpy.ndarray into cv::Mat, and handling any exceptions or conversion errors with proper diagnostics.

- A Python-facing factory function, cv.gapi.wip.make_py_src(), which takes a Python object as an argument and wraps it into a cv::Ptr<IStreamSource>. Internally, this function constructs a PythonCustomStreamSource instance and passes the Python object to it. This design allows Python users to define any class that implements two methods: pull() and descr_of(). No subclassing or special decorators are required on the Python side. The user simply needs to implement the expected interface.

This design enables any Python class with `pull()` and `descr_of()` to act as a custom stream source, no decorators or inheritance needed.

GSoC 2023 idea 15: [https://github.com/opencv/opencv/wiki/GSoC_2023#idea-g-api-implement-custom-stream-sources-in-python](url)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [X] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
