### PR TITLE
Fix Typo in Function Docstring: "Forword" → "Forward" in person_reid.py

### DIFF
--- a/samples/dnn/person_reid.py
+++ b/samples/dnn/person_reid.py
@@ -86,7 +86,7 @@ def extract_feature(img_dir, model_path, batch_size = 32, resize_h = 384, resize
 
 def run_net(inputs, model_path, backend=cv.dnn.DNN_BACKEND_OPENCV, target=cv.dnn.DNN_TARGET_CPU):
     """
-    Forword propagation for a batch of images.
+    Forward propagation for a batch of images.
     :param inputs: input batch of images
     :param model_path: path to ReID model
     :param backend: name of computation backend


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the docstring of the run_net function within samples/dnn/person_reid.py. The word "Forword" has been changed to the correct spelling "Forward" in the phrase "Forward propagation for a batch of images." 