### PR TITLE
Fix float-conversion warnings in FLANN by using float literals

### DIFF
--- a/modules/flann/include/opencv2/flann/autotuned_index.h
+++ b/modules/flann/include/opencv2/flann/autotuned_index.h
@@ -54,7 +54,7 @@ NNIndex<Distance>* create_index_by_type(const Matrix<typename Distance::ElementT
 
 struct AutotunedIndexParams : public IndexParams
 {
-    AutotunedIndexParams(float target_precision = 0.8, float build_weight = 0.01, float memory_weight = 0, float sample_fraction = 0.1)
+    AutotunedIndexParams(float target_precision = 0.8f, float build_weight = 0.01f, float memory_weight = 0.f, float sample_fraction = 0.1f)
     {
         (*this)["algorithm"] = FLANN_INDEX_AUTOTUNED;
         // precision desired (used for autotuning, -1 otherwise)

--- a/modules/flann/include/opencv2/flann/composite_index.h
+++ b/modules/flann/include/opencv2/flann/composite_index.h
@@ -46,7 +46,7 @@ namespace cvflann
 struct CompositeIndexParams : public IndexParams
 {
     CompositeIndexParams(int trees = 4, int branching = 32, int iterations = 11,
-                         flann_centers_init_t centers_init = FLANN_CENTERS_RANDOM, float cb_index = 0.2 )
+                         flann_centers_init_t centers_init = FLANN_CENTERS_RANDOM, float cb_index = 0.2f )
     {
         (*this)["algorithm"] = FLANN_INDEX_KMEANS;
         // number of randomized trees to use (for kdtree)

--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -62,7 +62,7 @@ struct KMeansIndexParams : public IndexParams
 {
     KMeansIndexParams(int branching = 32, int iterations = 11,
                       flann_centers_init_t centers_init = FLANN_CENTERS_RANDOM,
-                      float cb_index = 0.2, int trees = 1 )
+                      float cb_index = 0.2f, int trees = 1 )
     {
         (*this)["algorithm"] = FLANN_INDEX_KMEANS;
         // branching factor


### PR DESCRIPTION
### Summary

This pull request fixes several `-Wfloat-conversion` warnings in the FLANN module of OpenCV. These were caused by using double literals (e.g., `0.2`) in contexts where `float` was expected.

### Changes

- Changed `0.2` → `0.2f`, `0.8` → `0.8f`, etc. in:
  - `kmeans_index.h`
  - `composite_index.h`
  - `autotuned_index.h`

### Motivation

This improves clarity and avoids compiler warnings when building with `-Wfloat-conversion` enabled. The changes are minimal, safe, and help clean up the build output especially in strict compilation environments.

### Build & Test

- Build successful with GCC 9.4.0 and `-Wfloat-conversion` enabled.
- Tested with `opencv_test_core`.
```bash
[----------] Global test environment tear-down
[ SKIPSTAT ] 118 tests skipped
[ SKIPSTAT ] TAG='mem_6gb' skip 1 tests
[ SKIPSTAT ] TAG='verylong' skip 1 tests
[ SKIPSTAT ] TAG='skip_bigdata' skip 1 tests
[ SKIPSTAT ] TAG='skip_other' skip 115 tests
[==========] 12273 tests from 292 test cases ran. (157803 ms total)
[  PASSED  ] 12273 tests.
```

Please let me know if further changes or test coverage are needed.