### PR TITLE
Add Raspberry Pi 4 and 5 V4L2 Stateless HEVC Hardware Acceleration with FFmpeg

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -268,6 +268,7 @@ enum VideoAccelerationType
     VIDEO_ACCELERATION_D3D11    =  2,  //!< DirectX 11
     VIDEO_ACCELERATION_VAAPI    =  3,  //!< VAAPI
     VIDEO_ACCELERATION_MFX      =  4,  //!< libmfx (Intel MediaSDK/oneVPL)
+    VIDEO_ACCELERATION_DRM       =  5,  //!< Raspberry Pi V4
 };
 
 //! @} Hardware acceleration support

--- a/modules/videoio/src/cap_ffmpeg_hw.hpp
+++ b/modules/videoio/src/cap_ffmpeg_hw.hpp
@@ -163,6 +163,7 @@ std::string getEncoderConfiguration(VideoAccelerationType va_type, AVDictionary 
     case VIDEO_ACCELERATION_D3D11: return "";
     case VIDEO_ACCELERATION_VAAPI: return "vaapi.iHD";
     case VIDEO_ACCELERATION_MFX: return "qsv.iHD";
+    case VIDEO_ACCELERATION_DRM: return "";
     // Raspberry Pi 5 has no encoders, so we don't support it
     }
     return "unknown";

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -417,6 +417,7 @@ std::ostream& operator<<(std::ostream& out, const VideoAccelerationType& va_type
     case VIDEO_ACCELERATION_D3D11: out << "D3D11"; return out;
     case VIDEO_ACCELERATION_VAAPI: out << "VAAPI"; return out;
     case VIDEO_ACCELERATION_MFX: out << "MFX"; return out;
+    case VIDEO_ACCELERATION_DRM: out << "DRM"; return out;
     }
     out << cv::format("UNKNOWN(0x%ux)", static_cast<unsigned int>(va_type));
     return out;

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -35,6 +35,7 @@ std::ostream& operator<<(std::ostream& out, const VideoAccelerationType& va_type
             {VIDEO_ACCELERATION_D3D11, "D3D11"},
             {VIDEO_ACCELERATION_VAAPI, "VAAPI"},
             {VIDEO_ACCELERATION_MFX,   "MFX"},
+            {VIDEO_ACCELERATION_DRM,   "DRM"},
     };
     for (const auto& va : va_types) {
         if (va_type == va.va_type) {

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -871,6 +871,7 @@ static const VideoAccelerationType hw_types[] = {
         VIDEO_ACCELERATION_D3D11,
 #else
         VIDEO_ACCELERATION_VAAPI,
+        VIDEO_ACCELERATION_DRM,
 #endif
 };
 

--- a/samples/tapi/video_acceleration.cpp
+++ b/samples/tapi/video_acceleration.cpp
@@ -42,6 +42,7 @@ struct {
     { VIDEO_ACCELERATION_D3D11, "d3d11" },
     { VIDEO_ACCELERATION_VAAPI, "vaapi" },
     { VIDEO_ACCELERATION_MFX, "mfx" },
+    { VIDEO_ACCELERATION_DRM, "drm" },
 };
 
 class FPSCounter {


### PR DESCRIPTION
This PR enables V4L2 stateless HEVC hardware acceleration for Raspberry Pi 5 within OpenCV's videoio module. It leverages FFmpeg's drm acceleration ([FFmpeg API changes](https://github.com/FFmpeg/FFmpeg/blob/ee1f79b0fa4c82da9c19328b049b593c71611402/doc/APIchanges#L1529)), significantly improving HEVC decoding performance on RPi5 for robotics and embedded vision applications.

I have a working proof-of-concept with local benchmarks showing clear gains.

Checklist Status:

Ready: License, branch (4.x), FFmpeg reference, and (linked) related issue (#27452).
Seeking Guidance: Need help with formal C++ performance/accuracy tests, opencv_extra integration, and full documentation/examples.
As a Python developer, I welcome C++ best practice feedback and assistance with testing setup.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
