### PR TITLE
Added define disabling ippiNorm_Inf_16u_C1MR

### DIFF
--- a/hal/ipp/include/ipp_hal_core.hpp
+++ b/hal/ipp/include/ipp_hal_core.hpp
@@ -27,6 +27,12 @@ int ipp_hal_minMaxIdxMaskStep(const uchar* src_data, size_t src_step, int width,
 # define IPP_DISABLE_NORM_8U             0
 #endif
 
+#if (IPP_VERSION_X100 >= 202200 && IPP_VERSION_X100 < 202220)
+# define IPP_DISABLE_NORM_INF_16U_C1MR   1 // segmentation fault in accuracy test
+# else
+# define IPP_DISABLE_NORM_INF_16U_C1MR   0
+#endif
+
 int ipp_hal_norm(const uchar* src, size_t src_step, const uchar* mask, size_t mask_step,
                  int width, int height, int type, int norm_type, double* result);
 

--- a/hal/ipp/src/norm_ipp.cpp
+++ b/hal/ipp/src/norm_ipp.cpp
@@ -143,7 +143,9 @@ int ipp_hal_normDiff(const uchar* src1, size_t src1_step, const uchar* src2, siz
             ippiMaskNormDiffFuncC1 ippiNormRel_C1MR =
             norm_type == cv::NORM_INF ?
             (type == CV_8UC1 ? (ippiMaskNormDiffFuncC1)ippiNormRel_Inf_8u_C1MR :
+            #if (!IPP_DISABLE_NORM_INF_16U_C1MR)
             type == CV_16UC1 ? (ippiMaskNormDiffFuncC1)ippiNormRel_Inf_16u_C1MR :
+            #endif
             type == CV_32FC1 ? (ippiMaskNormDiffFuncC1)ippiNormRel_Inf_32f_C1MR :
             0) :
             norm_type == cv::NORM_L1 ?
@@ -232,7 +234,9 @@ int ipp_hal_normDiff(const uchar* src1, size_t src1_step, const uchar* src2, siz
         ippiMaskNormDiffFuncC1 ippiNormDiff_C1MR =
         norm_type == cv::NORM_INF ?
         (type == CV_8UC1 ? (ippiMaskNormDiffFuncC1)ippiNormDiff_Inf_8u_C1MR :
+        #if (!IPP_DISABLE_NORM_INF_16U_C1MR)
         type == CV_16UC1 ? (ippiMaskNormDiffFuncC1)ippiNormDiff_Inf_16u_C1MR :
+        #endif
         type == CV_32FC1 ? (ippiMaskNormDiffFuncC1)ippiNormDiff_Inf_32f_C1MR :
         0) :
         norm_type == cv::NORM_L1 ?

--- a/hal/ipp/src/norm_ipp.cpp
+++ b/hal/ipp/src/norm_ipp.cpp
@@ -20,7 +20,9 @@ int ipp_hal_norm(const uchar* src, size_t src_step, const uchar* mask, size_t ma
         ippiMaskNormFuncC1 ippiNorm_C1MR =
         norm_type == cv::NORM_INF ?
         (type == CV_8UC1 ? (ippiMaskNormFuncC1)ippiNorm_Inf_8u_C1MR :
+        #if (!IPP_DISABLE_NORM_INF_16U_C1MR)
         type == CV_16UC1 ? (ippiMaskNormFuncC1)ippiNorm_Inf_16u_C1MR :
+        #endif
         type == CV_32FC1 ? (ippiMaskNormFuncC1)ippiNorm_Inf_32f_C1MR :
         0) :
         norm_type == cv::NORM_L1 ?


### PR DESCRIPTION
Workaround for #27380. Fix will be available in the next ICV package update based on IPP 2022.2.0.