### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/samples/cpp/kmeans.cpp
+++ b/samples/cpp/kmeans.cpp
@@ -10,7 +10,7 @@ using namespace std;
 // {
 //     cout << "\nThis program demonstrates kmeans clustering.\n"
 //             "It generates an image with random points, then assigns a random number of cluster\n"
-//             "centers and uses kmeans to move those cluster centers to their representitive location\n"
+//             "centers and uses kmeans to move those cluster centers to their representative location\n"
 //             "Call\n"
 //             "./kmeans\n" << endl;
 // }

--- a/samples/cpp/tutorial_code/gpu/gpu-thrust-interop/main.cu
+++ b/samples/cpp/tutorial_code/gpu/gpu-thrust-interop/main.cu
@@ -55,7 +55,7 @@ int main(void)
     thrust::sequence(idxBegin, idxEnd);
     // Fill the key channel with random numbers between 0 and 10.  A counting iterator is used here to give an integer value for each location as an input to prg::operator()
     thrust::transform(thrust::make_counting_iterator(0), thrust::make_counting_iterator(d_data.cols), keyBegin, prg(0, 10));
-    // Sort the key channel and index channel such that the keys and indecies stay together
+    // Sort the key channel and index channel such that the keys and indices stay together
     thrust::sort_by_key(keyBegin, keyEnd, idxBegin);
 
     cv::Mat h_idx(d_data);


### PR DESCRIPTION


Description:
This pull request corrects minor typos in comments and documentation within the codebase:
- Replaces "representitive" with "representative" in kmeans.cpp.
- Replaces "indices" with the correct spelling in a comment in main.cu.


