### PR TITLE
Add support to set workloadtype dynamically

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -691,6 +691,29 @@ namespace wip { namespace ov {
  */
 struct benchmark_mode { };
 
+struct workload_type {
+    using callback = std::function<void(const unsigned int)>;
+
+    std::shared_ptr<void> addListener(callback cb){
+        int id = nextId++;
+        listeners.emplace_back(id, std::move(cb));
+
+        auto remover = [this, id](void*){ removeListener(id);};
+
+        return std::shared_ptr<void>(nullptr, remover);
+    }
+    void setWorkloadType(const unsigned int type) {
+        for(const auto& [id, cb] : listeners) {
+            cb(type);
+        }
+    }
+ private:
+    std::vector<std::pair<int, callback>> listeners;
+    int nextId = 0;
+    void removeListener(int id) {
+        listeners.erase(std::remove_if(listeners.begin(), listeners.end(), [=](auto& pair){return pair.first == id;}), listeners.end());
+    }
+};
 } // namespace ov
 } // namespace wip
 
@@ -701,6 +724,14 @@ namespace detail
     template<> struct CompileArgTag<cv::gapi::wip::ov::benchmark_mode>
     {
         static const char* tag() { return "gapi.wip.ov.benchmark_mode"; }
+    };
+    template<> struct CompileArgTag<cv::gapi::wip::ov::workload_type>
+    {
+        static const char* tag() { return "gapi.wip.ov.workload_type"; }
+    };
+    template<> struct CompileArgTag<std::reference_wrapper<cv::gapi::wip::ov::workload_type>>
+    {
+        static const char* tag() { return "gapi.wip.ov.workload_type_ref"; }
     };
 }
 

--- a/modules/gapi/src/backends/ov/govbackend.cpp
+++ b/modules/gapi/src/backends/ov/govbackend.cpp
@@ -1542,6 +1542,10 @@ cv::gimpl::ov::GOVExecutable::GOVExecutable(const ade::Graph &g,
                                             const std::vector<ade::NodeHandle> &nodes)
     : m_g(g), m_gm(m_g) {
 
+    if(cv::gapi::getCompileArg<std::reference_wrapper<cv::gapi::wip::ov::workload_type>>(compileArgs).has_value()) {
+        auto workload_type = cv::gapi::getCompileArg<std::reference_wrapper<cv::gapi::wip::ov::workload_type>>(compileArgs).value();
+        listenerRemover = workload_type.get().addListener(std::bind(&GOVExecutable::setWorkLoadType, this, std::placeholders::_1));
+    }
     m_options.inference_only =
         cv::gapi::getCompileArg<cv::gapi::wip::ov::benchmark_mode>(compileArgs).has_value();
     // FIXME: Currently this backend is capable to run a single inference node only.
@@ -1578,6 +1582,10 @@ cv::gimpl::ov::GOVExecutable::GOVExecutable(const ade::Graph &g,
     }
 }
 
+void cv::gimpl::ov::GOVExecutable::setWorkLoadType(const unsigned int type)
+{
+    compiled.compiled_model.set_property({{"WorkLoadType", type}});
+}
 void cv::gimpl::ov::GOVExecutable::run(cv::gimpl::GIslandExecutable::IInput  &in,
                                        cv::gimpl::GIslandExecutable::IOutput &out) {
     std::vector<InObj>  input_objs;

--- a/modules/gapi/src/backends/ov/govbackend.hpp
+++ b/modules/gapi/src/backends/ov/govbackend.hpp
@@ -50,6 +50,8 @@ class GOVExecutable final: public GIslandExecutable
 
     // To manage additional execution options
     Options m_options;
+    std::shared_ptr<void> listenerRemover;
+    void setWorkLoadType(const unsigned type);
 
 public:
     GOVExecutable(const ade::Graph                   &graph,


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
