### PR TITLE
hal/riscv-rvv: disable integral for now

### DIFF
--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -236,8 +236,10 @@ int integral(int depth, int sdepth, int sqdepth,
              uchar* tilted_data, [[maybe_unused]] size_t tilted_step,
              int width, int height, int cn);
 
-#undef cv_hal_integral
-#define cv_hal_integral cv::rvv_hal::imgproc::integral
+// Diasbled due to accuracy issue.
+// Details see https://github.com/opencv/opencv/issues/27407.
+//#undef cv_hal_integral
+//#define cv_hal_integral cv::rvv_hal::imgproc::integral
 
 #endif // CV_HAL_RVV_1P0_ENABLED
 


### PR DESCRIPTION
Workaround #27407 for now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
