### PR TITLE
Allow empty output value even without DRYRUN flag

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3074,7 +3074,8 @@ or Triangle algorithm and uses it instead of the specified thresh.
 and the Triangle's method is implemented only for CV_8UC1 images.
 
 @param src input array (multiple-channel, CV_8U, CV_16S, CV_16U, CV_32F or CV_64F).
-@param dst output array of the same size  and type and the same number of channels as src.
+@param dst Optional output array of the same size  and type and the same number of channels as src.
+The dst is not filled if array is not provided or #THRESH_DRYRUN flag is set.
 @param thresh threshold value.
 @param maxval maximum value to use with the #THRESH_BINARY and #THRESH_BINARY_INV thresholding
 types.

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -1545,7 +1545,7 @@ static bool ocl_threshold( InputArray _src, OutputArray _dst, InputArray _mask, 
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type),
         kercn = ocl::predictOptimalVectorWidth(_src, _dst), ktype = CV_MAKE_TYPE(depth, kercn);
     bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0;
-    const bool isDisabled = ((thresh_type & THRESH_DRYRUN) != 0);
+    const bool isDisabled = ((thresh_type & THRESH_DRYRUN) != 0) || !_dst.needed();
     thresh_type &= ~THRESH_DRYRUN;
 
     if ( isDisabled ||
@@ -1614,7 +1614,7 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
     CV_OCL_RUN_(_src.dims() <= 2 && _dst.isUMat(),
                 ocl_threshold(_src, _dst, cv::noArray(), thresh, maxval, type), thresh)
 
-    const bool isDisabled = ((type & THRESH_DRYRUN) != 0);
+    const bool isDisabled = ((type & THRESH_DRYRUN) != 0) || !_dst.needed();
     type &= ~THRESH_DRYRUN;
 
     Mat src = _src.getMat();

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -513,9 +513,14 @@ TEST(Imgproc_Threshold, threshold_dryrun)
     {
         for(int threshFlag : threshFlags)
         {
-            const int _threshType = threshType | threshFlag | THRESH_DRYRUN;
-            cv::threshold(input, input, 2.0, 0.0, _threshType);
-            EXPECT_MAT_NEAR(input, input_original, 0);
+            const int _threshType = threshType | threshFlag;
+            double gt = cv::threshold(input, input, 2.0, 0.0, _threshType);
+            double dry = cv::threshold(input, input, 2.0, 0.0, _threshType | THRESH_DRYRUN);
+            if (_threshType != 0)
+                EXPECT_MAT_NEAR(input, input_original, 0);
+            EXPECT_NEAR(gt, dry, 1e-6);
+            double no_out = cv::threshold(input, cv::noArray(), 2.0, 0.0, _threshType);
+            EXPECT_NEAR(gt, no_out, 1e-6);
         }
     }
 }


### PR DESCRIPTION
Continues https://github.com/opencv/opencv/pull/26836

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
