### PR TITLE
Fixed out-of-bound access to function table in cv::norm for HORM_HAMING

### DIFF
--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -316,7 +316,7 @@ double norm( InputArray _src, int normType, InputArray _mask )
     }
 
     NormFunc func = getNormFunc(normType >> 1, depth == CV_16F ? CV_32F : depth);
-    CV_Assert( func != 0 );
+    CV_Assert( (normType >> 1) >= 3 || func != 0 );
 
     if( src.isContinuous() && mask.empty() )
     {

--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -1324,6 +1324,8 @@ NormFunc getNormFunc(int normType, int depth)
         }
     };
 
+    if (normType >= 3 || normType < 0) return nullptr;
+
     return normTab[normType][depth];
 }
 


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/27465
Similar to https://github.com/opencv/opencv/pull/27321

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
