### PR TITLE
Check for empty vector to avoid throwing an exception in LineSegmentDetectorImpl::drawSegments() 

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -1076,6 +1076,10 @@ void LineSegmentDetectorImpl::drawSegments(InputOutputArray _image, InputArray l
     }
 
     Mat _lines = lines.getMat();
+    if (_lines.empty())
+    {
+        return;
+    }
     const int N = _lines.checkVector(4);
 
     CV_Assert(_lines.depth() == CV_32F || _lines.depth() == CV_32S);

--- a/modules/imgproc/test/test_lsd.cpp
+++ b/modules/imgproc/test/test_lsd.cpp
@@ -402,4 +402,18 @@ TEST_F(Imgproc_LSD_Common, compareSegmentsVec4i)
     ASSERT_EQ(result2, 11);
 }
 
+TEST_F(Imgproc_LSD_Common, drawSegmentsEmpty)
+{
+    Ptr<LineSegmentDetector> detector = createLineSegmentDetector(LSD_REFINE_STD);
+    Mat1b img = Mat1b::zeros(240, 320);
+
+    std::vector<Vec4i> lines_4i;
+    detector->detect(img, lines_4i);
+
+    Mat3b img_color = Mat3b::zeros(240, 320);
+    ASSERT_NO_THROW(
+        detector->drawSegments(img_color, lines_4i);
+    );
+}
+
 }} // namespace


### PR DESCRIPTION
Check for empty vector to avoid throwing an exception in LineSegmentDetectorImpl::drawSegments()  function.
Otherwise it throws:
```
Exception message: OpenCV(4.12.0-pre) <>/opencv/modules/imgproc/src/lsd.cpp:1081: error: (-215:Assertion failed) _lines.depth() == CV_32F || _lines.depth() == CV_32S in function 'drawSegments'
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
