### PR TITLE
imgcodecs: fix a minor bug in CMake for JPEG-XL

### DIFF
--- a/modules/imgcodecs/CMakeLists.txt
+++ b/modules/imgcodecs/CMakeLists.txt
@@ -23,11 +23,6 @@ if(HAVE_JPEG)
   list(APPEND GRFMT_LIBS ${JPEG_LIBRARIES})
 endif()
 
-if(HAVE_JPEGXL)
-  ocv_include_directories(${OPENJPEG_INCLUDE_DIRS})
-  list(APPEND GRFMT_LIBS ${OPENJPEG_LIBRARIES})
-endif()
-
 if(HAVE_WEBP)
   add_definitions(-DHAVE_WEBP)
   ocv_include_directories(${WEBP_INCLUDE_DIR})


### PR DESCRIPTION
Fixes a likely copy-paste error from #26379.

There's both a

```cmake
if(HAVE_JPEGXL)
  ocv_include_directories(${JPEGXL_INCLUDE_DIRS})
  message(STATUS "JPEGXL_INCLUDE_DIRS: ${JPEGXL_INCLUDE_DIRS}")
  list(APPEND GRFMT_LIBS ${JPEGXL_LIBRARIES})
endif()
```
and
```cmake
if(HAVE_OPENJPEG)
  ocv_include_directories(${OPENJPEG_INCLUDE_DIRS})
  list(APPEND GRFMT_LIBS ${OPENJPEG_LIBRARIES})
endif()
```
in the CMake file, so 
```cmake
if(HAVE_JPEGXL)
  ocv_include_directories(${OPENJPEG_INCLUDE_DIRS})
  list(APPEND GRFMT_LIBS ${OPENJPEG_LIBRARIES})
endif()
```
is probably unintentional and incorrect. JPEG-XL does not depend on OpenJPEG in any way.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
