### PR TITLE
Fixed ifdef logic operators evaluation with some old python versions.

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -97,7 +97,8 @@ def evaluate_conditional_inclusion_directive(directive, preprocessor_definitions
         ...
     ValueError: Failed to evaluate '#if strangedefinedvar' directive, stripped down to 'strangedefinedvar'
     """
-    OPERATORS = { "!": "not ", "&&": "and", "&": "and", "||": "or", "|": "or" }
+    OPERATORS1 = {"&&": "and", "||": "or"}
+    OPERATORS2 = { "!": "not ", "&": "and", "|": "or" }
 
     input_directive = directive
 
@@ -134,7 +135,10 @@ def evaluate_conditional_inclusion_directive(directive, preprocessor_definitions
         directive
     )
 
-    for src_op, dst_op in OPERATORS.items():
+    for src_op, dst_op in OPERATORS1.items():
+        directive = directive.replace(src_op, dst_op)
+
+    for src_op, dst_op in OPERATORS2.items():
         directive = directive.replace(src_op, dst_op)
 
     try:


### PR DESCRIPTION
Before the patch I got the following with Python 3.5.2 (Ubuntu 16.04):
```
[ 14%] Building CXX object hal/carotene/hal/carotene/CMakeFiles/carotene_objs.dir/src/count_nonzero.cpp.o
WARNING! Typing stubs can be generated only with Python 3.6 or higher. Current version sys.version_info(major=3, minor=5, micro=2, releaselevel='final', serial=0)
WARNING! Typing stubs can be generated only with Python 3.6 or higher. Current version sys.version_info(major=3, minor=5, micro=2, releaselevel='final', serial=0)
Traceback (most recent call last):
  File "/mnt/disk/opencv-next/modules/python/src2/hdr_parser.py", line 150, in evaluate_conditional_inclusion_directive
    preprocessor_definitions)
  File "<string>", line 1
    True andand False
              ^
SyntaxError: invalid syntax

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/disk/opencv-next/modules/python/src2/gen2.py", line 1555, in <module>
    generator.gen(config.headers, args.output_dir, config.preprocessor_definitions)
  File "/mnt/disk/opencv-next/modules/python/src2/gen2.py", line 1356, in gen
    decls = self.parser.parse(hdr)
  File "/mnt/disk/opencv-next/modules/python/src2/hdr_parser.py", line 1040, in parse
    l, self.preprocessor_definitions
  File "/mnt/disk/opencv-next/modules/python/src2/hdr_parser.py", line 156, in evaluate_conditional_inclusion_directive
    ) from e
ValueError: Failed to evaluate '#if defined EIGEN_WORLD_VERSION && defined EIGEN_GEOMETRY_MODULE_H' directive, stripped down to 'True andand False'
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
