### PR TITLE
system.cpp: add missing #include <exception>

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -43,6 +43,7 @@
 
 #include "precomp.hpp"
 #include <atomic>
+#include <exception>
 #include <iostream>
 #include <ostream>
 
@@ -125,7 +126,6 @@ void* allocSingletonNewBuffer(size_t size) { return malloc(size); }
 #endif
 
 #ifdef CV_ERROR_SET_TERMINATE_HANDLER
-#include <exception>      // std::set_terminate
 #include <cstdlib>        // std::abort
 #endif
 


### PR DESCRIPTION
PR #25899 added an `std::terminate()` call without a corresponding include for `<exception>`:
https://github.com/opencv/opencv/blob/31b0eeea0b44b370fd0712312df4214d4ae1b158/modules/core/src/system.cpp#L1318-L1322

This can cause a compilation error if the header is not coincidentally included elsewhere, as encountered here: https://github.com/conan-io/conan-center-index/issues/27787

```
modules/core/src/system.cpp:1321:10: error: no member named 'terminate' in namespace 'std'
 1321 |     std::terminate();
      |     ~~~~~^
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
