### PR TITLE
Include opencv2/videoio.hpp

### DIFF
--- a/modules/videoio/misc/java/src/cpp/videoio_converters.hpp
+++ b/modules/videoio/misc/java/src/cpp/videoio_converters.hpp
@@ -4,7 +4,7 @@
 #include <jni.h>
 #include "opencv_java.hpp"
 #include "opencv2/core.hpp"
-#include "opencv2/videoio/videoio.hpp"
+#include "opencv2/videoio.hpp"
 
 class JavaStreamReader : public cv::IStreamReader
 {


### PR DESCRIPTION
In my configuration with bazel, when building the Java bindings, it is not like building C++ and including videio/videoio.hpp triggers:
error this is a compatibility header which should not be used inside the OpenCV library

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
