### PR TITLE
js: remove deprecated DEMANGLE_SUPPORT option

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -34,6 +34,47 @@ if(NOT EMSCRIPTEN_INCLUDE_DIR OR NOT PYTHON_DEFAULT_AVAILABLE)
   ocv_module_disable(js)
 endif()
 
+# Get Emscripten version from emscripten/version.h
+unset(EMSCRIPTEN_VERSION)
+unset(EMSCRIPTEN_VERSION_CONTENTS)
+unset(EMSCRIPTEN_VERSION_MAJOR)
+unset(EMSCRIPTEN_VERSION_MINOR)
+unset(EMSCRIPTEN_VERSION_TINY)
+
+set(EMSCRIPTEN_VERSION_PATH "${EMSCRIPTEN_INCLUDE_DIR}/emscripten/version.h")
+if(NOT EXISTS "${EMSCRIPTEN_VERSION_PATH}")
+  message(STATUS "${EMSCRIPTEN_INCLUDE_DIR}/emscripten/version.h is missing")
+else()
+  file(STRINGS "${EMSCRIPTEN_VERSION_PATH}" EMSCRIPTEN_VERSION_CONTENTS REGEX "^#define[ \t]+__EMSCRIPTEN_[a-z]+__[ \t][0-9]+")
+  if(NOT EMSCRIPTEN_VERSION_CONTENTS)
+    message(STATUS "${EMSCRIPTEN_INCLUDE_DIR}/emscripten/version.h is exists, but is not readable")
+  else()
+    if(EMSCRIPTEN_VERSION_CONTENTS MATCHES "__EMSCRIPTEN_major__[ \t]+([0-9]+)")
+      set(EMSCRIPTEN_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    endif()
+    if(EMSCRIPTEN_VERSION_CONTENTS MATCHES "__EMSCRIPTEN_minor__[ \t]+([0-9]+)")
+      set(EMSCRIPTEN_VERSION_MINOR "${CMAKE_MATCH_1}")
+    endif()
+    if(EMSCRIPTEN_VERSION_CONTENTS MATCHES "__EMSCRIPTEN_tiny__[ \t]+([0-9]+)")
+      set(EMSCRIPTEN_VERSION_TINY "${CMAKE_MATCH_1}")
+    endif()
+
+    # When version(major/minor/tiny) is 0, "if(version)" is failed.
+    # "if(version GREATER_EQUAL 0)" can compare version as numeric.
+    if( (EMSCRIPTEN_VERSION_MAJOR GREATER_EQUAL "0") AND
+        (EMSCRIPTEN_VERSION_MINOR GREATER_EQUAL "0") AND
+        (EMSCRIPTEN_VERSION_TINY  GREATER_EQUAL "0")
+    )
+      set(EMSCRIPTEN_VERSION "${EMSCRIPTEN_VERSION_MAJOR}.${EMSCRIPTEN_VERSION_MINOR}.${EMSCRIPTEN_VERSION_TINY}")
+      message(STATUS "js: Emscripten version = ${EMSCRIPTEN_VERSION}")
+    else()
+      message(STATUS "js: Emscripten version is not able to parsed")
+      message(AUTHOR_WARNING "EMSCRIPTEN_VERSION_CONTENTS = ${EMSCRIPTEN_VERSION_CONTENTS}")
+    endif()
+  endif()
+endif()
+
+
 ocv_add_module(js BINDINGS PRIVATE_REQUIRED opencv_js_bindings_generator)
 
 ocv_module_include_directories(${EMSCRIPTEN_INCLUDE_DIR})
@@ -71,7 +112,12 @@ endif()
 
 set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s TOTAL_MEMORY=128MB -s WASM_MEM_MAX=1GB -s ALLOW_MEMORY_GROWTH=1")
 set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s MODULARIZE=1")
-set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s EXPORT_NAME=\"'cv'\" -s DEMANGLE_SUPPORT=1")
+set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s EXPORT_NAME=\"'cv'\"")
+# See https://github.com/opencv/opencv/issues/27513
+# DEMANGLE_SUPPRT is deprecated at Emscripten 3.1.54 and later.
+if(NOT EMSCRIPTEN_VERSION OR EMSCRIPTEN_VERSION VERSION_LESS "3.1.54")
+    set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s DEMANGLE_SUPPORT=1")
+endif()
 set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s FORCE_FILESYSTEM=1 --use-preload-plugins --bind --post-js ${JS_HELPER} ${COMPILE_FLAGS}")
 set_target_properties(${the_module} PROPERTIES LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS}")
 


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/27513

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
