### PR TITLE
Move IPP Remap to HAL

### DIFF
--- a/hal/ipp/include/ipp_hal_imgproc.hpp
+++ b/hal/ipp/include/ipp_hal_imgproc.hpp
@@ -24,4 +24,13 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
 #define cv_hal_warpPerspective ipp_hal_warpPerspective
 #endif
 
+
+int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+    uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
+    float* mapx, size_t mapx_step, float* mapy, size_t mapy_step,
+    int interpolation, int border_type, const double border_value[4]);
+#undef cv_hal_remap32f
+#define cv_hal_remap32f ipp_hal_remap32f
+
+
 #endif //__IPP_HAL_IMGPROC_HPP__

--- a/hal/ipp/src/precomp_ipp.hpp
+++ b/hal/ipp/src/precomp_ipp.hpp
@@ -11,6 +11,18 @@
 #include "iw++/iw.hpp"
 #endif
 
+static inline IppiSize ippiSize(size_t width, size_t height)
+{
+    IppiSize size = { (int)width, (int)height };
+    return size;
+}
+
+static inline IppiSize ippiSize(const cv::Size & _size)
+{
+    IppiSize size = { _size.width, _size.height };
+    return size;
+}
+
 static inline IppDataType ippiGetDataType(int depth)
 {
     depth = CV_MAT_DEPTH(depth);


### PR DESCRIPTION
IPP implementation of remap was moved from imgproc to HAL
Currently it's disabled as produce test fails. And would be enabled separately.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
