### PR TITLE
fix: mark Feature2D.detectAndCompute mask as optional in Python type stubs

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -340,6 +340,7 @@ NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "resize"): make_optional_arg("dsize"),
     SymbolName(("cv", ), (), "calcHist"): make_optional_arg("mask"),
     SymbolName(("cv", ), (), "floodFill"): make_optional_arg("mask"),
+    SymbolName(("cv", ), ("Feature2D", ), "detectAndCompute"): make_optional_arg("mask"),
     SymbolName(("cv", ), (), "imread"): make_optional_none_return,
     SymbolName(("cv", ), (), "imdecode"): make_optional_none_return,
 }


### PR DESCRIPTION
Fixes #27543.

Before patch
```python
@_typing.overload
def detectAndCompute(
    self,
    image: cv2.typing.MatLike,
    mask: cv2.typing.MatLike,
    descriptors: cv2.typing.MatLike | None = ...,
    useProvidedKeypoints: bool = ...,
) -> tuple[_typing.Sequence[KeyPoint], cv2.typing.MatLike]: ...
@_typing.overload
def detectAndCompute(
    self,
    image: UMat,
    mask: UMat,
    descriptors: UMat | None = ...,
    useProvidedKeypoints: bool = ...,
) -> tuple[_typing.Sequence[KeyPoint], UMat]: ...
```

After patch
```python
@_typing.overload
def detectAndCompute(
    self,
    image: cv2.typing.MatLike,
    mask: cv2.typing.MatLike | None,
    descriptors: cv2.typing.MatLike | None = ...,
    useProvidedKeypoints: bool = ...,
) -> tuple[_typing.Sequence[KeyPoint], cv2.typing.MatLike]: ...
@_typing.overload
def detectAndCompute(
    self,
    image: UMat,
    mask: UMat | None,
    descriptors: UMat | None = ...,
    useProvidedKeypoints: bool = ...,
) -> tuple[_typing.Sequence[KeyPoint], UMat]: ...
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
