### PR TITLE
Added TopK layer with dynamic K support for new DNN engine

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1382,6 +1382,12 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<TriluLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS TopK2Layer : public Layer
+    {
+    public:
+        static Ptr<TopK2Layer> create(const LayerParams &params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -222,6 +222,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(ScatterND,      ScatterNDLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Tile,           TileLayer);
     CV_DNN_REGISTER_LAYER_CLASS(TopK,           TopKLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(TopK2,          TopK2Layer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Quantize,         QuantizeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Dequantize,       DequantizeLayer);

--- a/modules/dnn/src/layers/topk2_layer.cpp
+++ b/modules/dnn/src/layers/topk2_layer.cpp
@@ -2,12 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#include <algorithm>
-#include <numeric>
-
 #include "../precomp.hpp"
-#include "../net_impl.hpp"
-#include "layers_common.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 namespace cv { namespace dnn {

--- a/modules/dnn/src/layers/topk2_layer.cpp
+++ b/modules/dnn/src/layers/topk2_layer.cpp
@@ -83,6 +83,11 @@ public:
         return backendId == DNN_BACKEND_OPENCV;
     }
 
+    virtual bool dynamicOutputShapes() const CV_OVERRIDE
+    {
+        return dynamicK;
+    }
+
     bool getMemoryShapes(const std::vector<MatShape>& inputs,
                          const int requiredOutputs,
                          std::vector<MatShape>& outputs,
@@ -93,12 +98,10 @@ public:
         int inputDims = static_cast<int>(inShape.size());
         int a = normalize_axis(axis, inputDims);
         CV_Assert(a >= 0 && a < inputDims);
-
-        int outK = dynamicK ? inShape[a] : K;
-        CV_CheckLT(outK, inShape[a] + 1, "TopK2: K is out of range");
+        CV_CheckLT(K, inShape[a] + 1, "TopK2: K is out of range");
 
         MatShape outShape = inShape;
-        outShape[a] = outK;
+        outShape[a] = K;
         outputs.assign(2, outShape);
         internals.clear();
         return false;

--- a/modules/dnn/src/layers/topk2_layer.cpp
+++ b/modules/dnn/src/layers/topk2_layer.cpp
@@ -1,0 +1,252 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <algorithm>
+#include <numeric>
+
+#include "../precomp.hpp"
+#include "../net_impl.hpp"
+#include "layers_common.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
+
+namespace cv { namespace dnn {
+
+namespace {
+
+template<typename T>
+class ComparatorGreater {
+public:
+    ComparatorGreater(const T* data, size_t step)
+        : data_(data), step_(step) {}
+
+    void addOffset(size_t offset) {
+        data_ += offset;
+    }
+
+    void minusOffset(size_t offset) {
+        data_ -= offset;
+    }
+
+    bool operator()(const size_t lhs_idx, const size_t rhs_idx) {
+        T lhs = *(data_ + lhs_idx * step_),
+          rhs = *(data_ + rhs_idx * step_);
+        return (lhs > rhs || (lhs == rhs && lhs_idx < rhs_idx));
+    }
+
+private:
+    const T* data_;
+    size_t step_;
+};
+
+template<typename T>
+class ComparatorLess {
+public:
+    ComparatorLess(const T* data, size_t step)
+        : data_(data), step_(step) {}
+
+    void addOffset(size_t offset) {
+        data_ += offset;
+    }
+
+    void minusOffset(size_t offset) {
+        data_ -= offset;
+    }
+
+    bool operator()(const size_t lhs_idx, const size_t rhs_idx) {
+        T lhs = *(data_ + lhs_idx * step_),
+          rhs = *(data_ + rhs_idx * step_);
+        return (lhs < rhs || (lhs == rhs && lhs_idx < rhs_idx));
+    }
+
+private:
+    const T* data_;
+    size_t step_;
+};
+}
+
+class TopK2LayerImpl CV_FINAL : public TopK2Layer
+{
+public:
+    int axis;
+    bool largest;
+    bool sorted;
+    int K;
+    bool dynamicK;
+
+    TopK2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        axis    = params.get<int>("axis", -1);
+        largest = params.get<int>("largest", 1) == 1;
+        sorted  = params.get<int>("sorted", 1) == 1;
+        CV_CheckTrue(sorted, "TopK2: sorted == false is not supported");
+        if (params.has("k")) {
+            K = params.get<int>("k");
+            CV_CheckGT(K, 0, "TopK2: K needs to be a positive integer");
+            dynamicK = false;
+        } else {
+            dynamicK = true;
+            K = 0;
+        }
+    }
+
+    bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    bool getMemoryShapes(const std::vector<MatShape>& inputs,
+                         const int requiredOutputs,
+                         std::vector<MatShape>& outputs,
+                         std::vector<MatShape>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(!inputs.empty());
+        const MatShape& inShape = inputs[0];
+        int inputDims = static_cast<int>(inShape.size());
+        int a = normalize_axis(axis, inputDims);
+        CV_Assert(a >= 0 && a < inputDims);
+
+        int outK = dynamicK ? inShape[a] : K;
+        CV_CheckLT(outK, inShape[a] + 1, "TopK2: K is out of range");
+
+        MatShape outShape = inShape;
+        outShape[a] = outK;
+        outputs.assign(2, outShape);
+        internals.clear();
+        return false;
+    }
+
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        outputs.resize(2);
+        outputs[0] = inputs.front();
+        outputs[1] = CV_64S;
+    }
+
+private:
+    template<class Comparator, typename T>
+    void FindTopK(const Mat &input, Mat &output_vals, Mat &output_idxs)
+    {
+        const auto inShape = shape(input);
+        size_t outer = std::accumulate(inShape.begin(), inShape.begin() + axis, 1, std::multiplies<int>());
+        size_t inner = std::accumulate(inShape.begin() + axis + 1, inShape.end(), 1, std::multiplies<int>());
+        int dimAxis = inShape[axis];
+
+        auto worker = [&](const Range &r) {
+            const T* inPtr = input.ptr<T>();
+            T* valPtr = output_vals.ptr<T>();
+            int64_t* idxPtr = output_idxs.ptr<int64_t>();
+            Comparator cmp(inPtr, inner);
+            AutoBuffer<size_t> indices(dimAxis);
+            size_t* idxBuf = indices.data();
+            for (size_t b = r.start; b < r.end; ++b) {
+                for (size_t j = 0; j < inner; ++j) {
+                    size_t offset = b * dimAxis * inner + j;
+                    cmp.addOffset(offset);
+                    std::iota(idxBuf, idxBuf + dimAxis, 0);
+                    std::stable_sort(idxBuf, idxBuf + dimAxis, cmp);
+                    // By the time we reach here, 'K' has been resolved. Use it directly.
+                    int currentK = K;
+                    for (int i = 0; i < currentK; ++i) {
+                        size_t src = idxBuf[i];
+                        valPtr[b * currentK * inner + i * inner + j] = inPtr[offset + src * inner];
+                        idxPtr[b * currentK * inner + i * inner + j] = static_cast<int64_t>(src);
+                    }
+                    cmp.minusOffset(offset);
+                }
+            }
+        };
+        parallel_for_(Range(0, static_cast<int>(outer)), worker);
+    }
+
+public:
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        std::vector<Mat> inputs, outputs;
+        inputs_arr.getMatVector(inputs);
+        outputs_arr.getMatVector(outputs);
+
+        const auto &input = inputs.front();
+        auto &output_value = outputs.front();
+        auto &output_index = outputs.back();
+
+        if (dynamicK) {
+            CV_Assert(inputs.size() == 2);
+            int64_t kVal = inputs[1].at<int64_t>(0);
+            CV_CheckGT(kVal, 0, "TopK2: dynamic K must be > 0");
+            CV_CheckLT(kVal, input.size[axis] + 1, "TopK2: dynamic K is out of range");
+            K = static_cast<int>(kVal);
+
+            MatShape outShape = shape(input);
+            outShape[axis] = K;
+
+            auto kind = outputs_arr.kind();
+            if (kind == _InputArray::STD_VECTOR_MAT) {
+                std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+                CV_Assert(outs.size() == 2);
+                outs[0].fit(outShape, input.type());
+                outs[1].fit(outShape, CV_64S);
+                output_value = outs[0];
+                output_index = outs[1];
+            } else if (kind == _InputArray::STD_VECTOR_UMAT) {
+                std::vector<UMat>& uouts = outputs_arr.getUMatVecRef();
+                CV_Assert(uouts.size() == 2);
+                uouts[0].fit(outShape, input.type());
+                uouts[1].fit(outShape, CV_64S);
+                output_value = uouts[0].getMat(ACCESS_WRITE);
+                output_index = uouts[1].getMat(ACCESS_WRITE);
+            } else {
+                // Fallback – recreate directly on provided Mat refs.
+                output_value.create(outShape, input.type());
+                output_index.create(outShape, CV_64S);
+            }
+        }
+
+        if (largest) {
+            switch (input.depth()) {
+                case CV_8U: FindTopK<ComparatorGreater<uint8_t>, uint8_t>(input, output_value, output_index); break;
+                case CV_8S: FindTopK<ComparatorGreater<int8_t>, int8_t>(input, output_value, output_index); break;
+                case CV_16U: FindTopK<ComparatorGreater<uint16_t>, uint16_t>(input, output_value, output_index); break;
+                case CV_16S: FindTopK<ComparatorGreater<int16_t>, int16_t>(input, output_value, output_index); break;
+                case CV_16F: FindTopK<ComparatorGreater<hfloat>, hfloat>(input, output_value, output_index); break;
+                case CV_32U: FindTopK<ComparatorGreater<unsigned>, unsigned>(input, output_value, output_index); break;
+                case CV_32S: FindTopK<ComparatorGreater<int>, int>(input, output_value, output_index); break;
+                case CV_32F: FindTopK<ComparatorGreater<float>, float>(input, output_value, output_index); break;
+                case CV_64U: FindTopK<ComparatorGreater<uint64_t>, uint64_t>(input, output_value, output_index); break;
+                case CV_64S: FindTopK<ComparatorGreater<int64_t>, int64_t>(input, output_value, output_index); break;
+                case CV_64F: FindTopK<ComparatorGreater<double>, double>(input, output_value, output_index); break;
+                default: CV_Error(Error::BadDepth, "Unsupported input data type");
+            }
+        } else {
+            switch (input.depth()) {
+                case CV_8U: FindTopK<ComparatorLess<uint8_t>, uint8_t>(input, output_value, output_index); break;
+                case CV_8S: FindTopK<ComparatorLess<int8_t>, int8_t>(input, output_value, output_index); break;
+                case CV_16U: FindTopK<ComparatorLess<uint16_t>, uint16_t>(input, output_value, output_index); break;
+                case CV_16S: FindTopK<ComparatorLess<int16_t>, int16_t>(input, output_value, output_index); break;
+                case CV_16F: FindTopK<ComparatorLess<hfloat>, hfloat>(input, output_value, output_index); break;
+                case CV_32U: FindTopK<ComparatorLess<unsigned>, unsigned>(input, output_value, output_index); break;
+                case CV_32S: FindTopK<ComparatorLess<int>, int>(input, output_value, output_index); break;
+                case CV_32F: FindTopK<ComparatorLess<float>, float>(input, output_value, output_index); break;
+                case CV_64U: FindTopK<ComparatorLess<uint64_t>, uint64_t>(input, output_value, output_index); break;
+                case CV_64S: FindTopK<ComparatorLess<int64_t>, int64_t>(input, output_value, output_index); break;
+                case CV_64F: FindTopK<ComparatorLess<double>, double>(input, output_value, output_index); break;
+                default: CV_Error(Error::BadDepth, "Unsupported input data type");
+            }
+        }
+    }
+};
+
+Ptr<TopK2Layer> TopK2Layer::create(const LayerParams& params)
+{
+    return makePtr<TopK2LayerImpl>(params);
+}
+
+}} // namespace cv::dnn

--- a/modules/dnn/src/layers/topk2_layer.cpp
+++ b/modules/dnn/src/layers/topk2_layer.cpp
@@ -155,8 +155,8 @@ private:
                             [&](auto const &a, auto const &b) {
                                 return cmp(a.first, b.first);
                             }
-                        );                    }
-
+                        );
+                    }
                     for (int i = 0; i < kVal; ++i) {
                         auto &p = sortbuf[i];
                         valPtr[b * kVal * inner + i * inner + j] = p.second;

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1773,7 +1773,8 @@ void ONNXImporter2::parseTopK2(LayerParams& layerParams, const opencv_onnx::Node
     if (node_proto.input_size() >= 2 && net.isConstArg(node_inputs[1]))
     {
         Mat kMat = net.argTensor(node_inputs[1]);
-        int k = getScalarFromMat<int>(kMat);
+        CV_Assert(kMat.type() == CV_32S || kMat.type() == CV_64S);
+        int k = kMat.type() == CV_32S ? getScalarFromMat<int>(kMat):(int)getScalarFromMat<int64_t>(kMat);
         layerParams.set("k", k);
         addLayer(layerParams, node_proto, 1);
     }

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -224,6 +224,7 @@ protected:
     void parseTranspose            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseUnsqueeze            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseUpsample             (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseTopK2                (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
 
     // Domain: com.microsoft
     // URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
@@ -1766,6 +1767,22 @@ void ONNXImporter2::parseEinsum(LayerParams& layerParams, const opencv_onnx::Nod
     addLayer(layerParams, node_proto);
 }
 
+void ONNXImporter2::parseTopK2(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
+{
+    layerParams.type = "TopK2";
+    if (node_proto.input_size() >= 2 && net.isConstArg(node_inputs[1]))
+    {
+        Mat kMat = net.argTensor(node_inputs[1]);
+        int k = getScalarFromMat<int>(kMat);
+        layerParams.set("k", k);
+        addLayer(layerParams, node_proto, 1);
+    }
+    else //Dynamic K
+    {
+        addLayer(layerParams, node_proto);
+    }
+}
+
 void ONNXImporter2::parseDequantizeLinear(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     addLayer(layerParams, node_proto);
@@ -2428,6 +2445,7 @@ void ONNXImporter2::buildDispatchMap_ONNX_AI(int opset_version)
     dispatch["Where"] = &ONNXImporter2::parseElementWise;
     dispatch["Range"] = &ONNXImporter2::parseRange;
     dispatch["Einsum"] = &ONNXImporter2::parseEinsum;
+    dispatch["TopK"] = &ONNXImporter2::parseTopK2;
 
     std::vector<std::string> simpleLayers {
         "Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh", "Ceil", "Celu", "Cos",

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -2028,9 +2028,9 @@ CASE(test_tile_precomputed)
 CASE(test_top_k)
     SKIP;
 CASE(test_top_k_negative_axis)
-    // no filter
+    SKIP;
 CASE(test_top_k_smallest)
-    // no filter
+    SKIP;
 CASE(test_training_dropout)
     // no filter
 CASE(test_training_dropout_default)

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -2026,7 +2026,7 @@ CASE(test_tile)
 CASE(test_tile_precomputed)
     // no filter
 CASE(test_top_k)
-    // no filter
+    SKIP
 CASE(test_top_k_negative_axis)
     // no filter
 CASE(test_top_k_smallest)

--- a/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter__openvino.inl.hpp
@@ -2026,7 +2026,7 @@ CASE(test_tile)
 CASE(test_tile_precomputed)
     // no filter
 CASE(test_top_k)
-    SKIP
+    SKIP;
 CASE(test_top_k_negative_axis)
     // no filter
 CASE(test_top_k_smallest)

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_classic_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_classic_denylist.inl.hpp
@@ -1,1 +1,2 @@
 "test_if",
+"test_top_k", // Issue:: K being input is not compatible with the current engine

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_classic_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_classic_denylist.inl.hpp
@@ -1,2 +1,4 @@
 "test_if",
 "test_top_k", // Issue:: K being input is not compatible with the current engine
+"test_top_k_negative_axis",  // ---- same as above ---
+"test_top_k_smallest",  // ---- same as above ---

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -394,7 +394,6 @@
 "test_tfidfvectorizer_tf_uniandbigrams_skip5", // Issue:: Parser: Can't create layer "onnx_node_output_0!Y" of type "TfIdfVectorizer" in function 'getLayerInstance'
 "test_tile", // Issue:: Parser: ONNX/Tile: repeats being non-constant is not supported. in function 'parseTile' (layer parameters are dynamic)
 "test_tile_precomputed", //  // ---- same as above ---
-"test_top_k", // Issue:: K being input is not compatible with the current engine
 "test_top_k_negative_axis",  // ---- same as above ---
 "test_top_k_smallest",  // ---- same as above ---
 "test_training_dropout", // Issue::cvtest::norm::wrong data type

--- a/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_parser_denylist.inl.hpp
@@ -394,8 +394,6 @@
 "test_tfidfvectorizer_tf_uniandbigrams_skip5", // Issue:: Parser: Can't create layer "onnx_node_output_0!Y" of type "TfIdfVectorizer" in function 'getLayerInstance'
 "test_tile", // Issue:: Parser: ONNX/Tile: repeats being non-constant is not supported. in function 'parseTile' (layer parameters are dynamic)
 "test_tile_precomputed", //  // ---- same as above ---
-"test_top_k_negative_axis",  // ---- same as above ---
-"test_top_k_smallest",  // ---- same as above ---
 "test_training_dropout", // Issue::cvtest::norm::wrong data type
 "test_training_dropout_default",  // ---- same as above ---
 "test_training_dropout_default_mask",  // ---- same as above ---


### PR DESCRIPTION
This pull request adds TopK layer support to new DNN engine along with dynamic K support.

Initial version inherited from https://github.com/opencv/opencv/pull/26731. Credits to Abduragim.

Closes:
- https://github.com/opencv/opencv/issues/27061
- https://github.com/opencv/opencv/issues/25712

Also closes the topk issue for below issues but having (`Unsupported operations:        NonZero` for new dnn engine) which is unrelated to topk.
- https://github.com/opencv/opencv/issues/23663 
- https://github.com/opencv/opencv/issues/23297

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
