### PR TITLE
G-API: Implement cfgEnsureNamedTensors option to OpenVINO Params

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -99,6 +99,8 @@ struct ParamDesc {
     PluginConfigT config;
 
     size_t nireq = 1;
+
+    bool ensure_named_tensors = false;
 };
 
 // NB: Just helper to avoid code duplication.
@@ -202,6 +204,24 @@ public:
     */
     Params<Net>& cfgPluginConfig(const detail::ParamDesc::PluginConfigT &config) {
         m_desc.config = config;
+        return *this;
+    }
+
+    /** @brief Ensures the model has named tensors.
+
+    This function is used to ensure that all tensors in the model have names.
+    It goes through all input and output nodes of the model and sets their names
+    if they are not set. This is neccessary for models with nameless tensors.
+
+    If a tensor does not have a name, it will be assigned a default name
+    based on the node's friendly name. If the node has multiple outputs,
+    the name will be in the form "node_name:N", where N is the output index.
+
+    @param flag If true, will ensure all the tensors are named.
+    @return reference to this parameter structure.
+     */
+    Params<Net>& cfgEnsureNamedTensors(bool flag = true) {
+        m_desc.ensure_named_tensors = flag;
         return *this;
     }
 
@@ -521,6 +541,12 @@ public:
     /** @see ov::Params::cfgPluginConfig. */
     Params& cfgPluginConfig(const detail::ParamDesc::PluginConfigT &config) {
         m_desc.config = config;
+        return *this;
+    }
+
+    /** @see ov::Params::cfgEnsureNamedTensors. */
+    Params& cfgEnsureNamedTensors(bool flag = true) {
+        m_desc.ensure_named_tensors = flag;
         return *this;
     }
 

--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -214,8 +214,8 @@ public:
     if they are not set. This is neccessary for models with nameless tensors.
 
     If a tensor does not have a name, it will be assigned a default name
-    based on the node's friendly name. If the node has multiple outputs,
-    the name will be in the form "node_name:N", where N is the output index.
+    based on the producer node's friendly name. If the producer node has multiple
+    outputs, the name will be in the form "node_name:N", where N is the output index.
 
     @param flag If true, then it guarantees that all tensors will have names.
     @return reference to this parameter structure.

--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -210,14 +210,14 @@ public:
     /** @brief Ensures the model has named tensors.
 
     This function is used to ensure that all tensors in the model have names.
-    It goes through all input and output nodes of the model and sets their names
+    It goes through all input and output nodes of the model and sets the names
     if they are not set. This is neccessary for models with nameless tensors.
 
     If a tensor does not have a name, it will be assigned a default name
     based on the node's friendly name. If the node has multiple outputs,
     the name will be in the form "node_name:N", where N is the output index.
 
-    @param flag If true, will ensure all the tensors are named.
+    @param flag If true, then it guarantees that all tensors will have names.
     @return reference to this parameter structure.
      */
     Params<Net>& cfgEnsureNamedTensors(bool flag = true) {


### PR DESCRIPTION
Added the option cfgEnsureNamedTensors to be applied on OpenVINO models with nameless tensors. If a tensor doesn't have a name, it sets a default one. The default name is created using OpenVINO's standard `make_default_tensor_name` . `make_default_tensor_name`  had to be rewritten because it is only available in OpenVINO's dev_api.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
