### PR TITLE
Enable Java wrapper generation for Vec4i

### DIFF
--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -615,16 +615,16 @@
             "jn_args": [
                 [
                     "double",
-                    "[0]"
+                    ".val[0]"
                 ],
                 [
                     "double",
-                    "[1]"
+                    ".val[1]"
                 ]
             ],
             "jn_type": "double[]",
             "jni_type": "jdoubleArray",
-            "jni_var": "Vec2d %(n)s(%(n)s0, %(n)s1)",
+            "jni_var": "Vec2d %(n)s(%(n)s_val0, %(n)s_val1)",
             "suffix": "DD"
         },
         "Vec3d": {
@@ -632,20 +632,20 @@
             "jn_args": [
                 [
                     "double",
-                    "[0]"
+                    ".val[0]"
                 ],
                 [
                     "double",
-                    "[1]"
+                    ".val[1]"
                 ],
                 [
                     "double",
-                    "[2]"
+                    ".val[2]"
                 ]
             ],
             "jn_type": "double[]",
             "jni_type": "jdoubleArray",
-            "jni_var": "Vec3d %(n)s(%(n)s0, %(n)s1, %(n)s2)",
+            "jni_var": "Vec3d %(n)s(%(n)s_val0, %(n)s_val1, %(n)s_val2)",
             "suffix": "DDD"
         },
         "Vec4i": {
@@ -653,24 +653,24 @@
             "jn_args": [
                 [
                     "int",
-                    "[0]"
+                    ".val[0]"
                 ],
                 [
                     "int",
-                    "[1]"
+                    ".val[1]"
                 ],
                 [
                     "int",
-                    "[2]"
+                    ".val[2]"
                 ],
                 [
                     "int",
-                    "[3]"
+                    ".val[3]"
                 ]
             ],
             "jn_type": "int[]",
             "jni_type": "jintArray",
-            "jni_var": "Vec4i %(n)s(%(n)s0, %(n)s1, %(n)s2, %(n)s3)",
+            "jni_var": "Vec4i %(n)s(%(n)s_val0, %(n)s_val1, %(n)s_val2, %(n)s_val3)",
             "suffix": "IIII"
         },
         "c_string": {


### PR DESCRIPTION
Fixes an issue where Java wrapper generation skips methods using Vec4i.
Related PR in opencv_contrib: https://github.com/opencv/opencv_contrib/pull/3988

The root cause was the absence of Vec4i in gen_java.json, which led to important methods such as aruco.drawCharucoDiamond() and ximgproc.HoughPoint2Line() being omitted from the Java bindings.

This PR includes the following changes:

- Added Vec4i definition to gen_java.json
- Updated gen_java.py to handle jintArray-based types properly
- ~~Also adjusted jn_args and jni_var for Vec2d and Vec3d to ensure correct JNI behavior~~

The modified Java wrapper generator successfully builds and includes the expected methods using Vec4i.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
