### PR TITLE
Fixed build issue with some old GCC versions

### DIFF
--- a/modules/imgproc/src/contours_blockstorage.hpp
+++ b/modules/imgproc/src/contours_blockstorage.hpp
@@ -26,14 +26,14 @@ class BlockStorage {
                 dynamicBlocks.push_back(new block_type);
         }
         BlockStorage(const BlockStorage&) = delete;
-        BlockStorage(BlockStorage&&) noexcept = default;
+        BlockStorage(BlockStorage&&) = default;
         ~BlockStorage() {
             for(const auto & block : dynamicBlocks) {
                 delete block;
             }
         }
         BlockStorage& operator=(const BlockStorage&) = delete;
-        BlockStorage& operator=(BlockStorage&&) noexcept = default;
+        BlockStorage& operator=(BlockStorage&&) = default;
 
         void clear(void) {
             const size_t minDynamicBlocks = !staticBlocksCount ? 1 : 0;

--- a/modules/imgproc/src/contours_common.hpp
+++ b/modules/imgproc/src/contours_common.hpp
@@ -190,7 +190,7 @@ public:
     ContourDataStorage(ContourDataStorage&&) noexcept = default;
     ~ContourDataStorage() = default;
     ContourDataStorage& operator=(const ContourDataStorage&) = delete;
-    ContourDataStorage& operator=(ContourDataStorage&&) noexcept = default;
+    ContourDataStorage& operator=(ContourDataStorage&&) = default;
 public:
     typename storage_t::RangeIterator getRangeIterator(void) const {return storage->getRangeIterator(first, last);}
 public:
@@ -243,7 +243,7 @@ public:
     Contour(const Contour&) = delete;
     Contour(Contour&& other) noexcept = default;
     Contour& operator=(const Contour&) = delete;
-    Contour& operator=(Contour&& other) noexcept = default;
+    Contour& operator=(Contour&& other) = default;
     ~Contour() = default;
     void updateBoundingRect() {}
     bool isEmpty() const


### PR DESCRIPTION
Fixes build for GCC 4.8.5 at least. Looks like the method default signature differs cross GCC versions or newer version has softer checker.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
