### PR TITLE
core: add ARM64 NEON support for cvRound in fast_math.hpp

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -201,6 +201,10 @@ cvRound( double value )
 {
 #if defined CV_INLINE_ROUND_DBL
     CV_INLINE_ROUND_DBL(value);
+#elif defined _MSC_VER && defined _M_ARM64
+    float64x1_t v = vdup_n_f64(value);
+    int64x1_t r = vcvtn_s64_f64(v);
+    return static_cast<int>(vget_lane_s64(r, 0));
 #elif ((defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __SSE2__)) && !defined(__CUDACC__)
     __m128d t = _mm_set_sd( value );
     return _mm_cvtsd_si32(t);
@@ -323,6 +327,10 @@ CV_INLINE int cvRound(float value)
 {
 #if defined CV_INLINE_ROUND_FLT
     CV_INLINE_ROUND_FLT(value);
+#elif defined _MSC_VER && defined _M_ARM64
+    float32x2_t v = vdup_n_f32(value);
+    int32x2_t r = vcvtn_s32_f32(v);
+    return vget_lane_s32(r, 0);
 #elif ((defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __SSE2__)) && !defined(__CUDACC__)
     __m128 t = _mm_set_ss( value );
     return _mm_cvtss_si32(t);


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

- This PR adds ARM64 NEON intrinsics-based implementation for the cvRound function in fast_math.hpp for ARM64 targets (_MSC_VER && _M_ARM64).

- Both float and double overloads now use NEON intrinsics (vcntn_s32_f32, vcvtn_s64_f64, etc.) for efficient and accurate rounding.

- The implementation is consistent with platform-specific handling already present for SSE2 (x64) and does not affect non-ARM64 builds.

**Performance Improvements :** 

- The optimization significantly improves the performance of cvRound on Windows ARM64 targets. 
- The table below shows timing comparisons before and after the optimization: 

<img width="731" height="206" alt="image" src="https://github.com/user-attachments/assets/799682ae-2ae2-4874-a322-80a69b77557b" />


