### PR TITLE
java: Set Automatic-Module-Name manifest attribute in the built JAR file

### DIFF
--- a/modules/java/jar/MANIFEST.MF.in
+++ b/modules/java/jar/MANIFEST.MF.in
@@ -3,3 +3,4 @@ Specification-Version: @OPENCV_VERSION@
 Implementation-Title: OpenCV
 Implementation-Version: @OPENCV_VCSVERSION@
 Implementation-Date: @OPENCV_TIMESTAMP@
+Automatic-Module-Name: org.opencv

--- a/modules/java/jar/build.xml.in
+++ b/modules/java/jar/build.xml.in
@@ -24,6 +24,7 @@
         <attribute name="Implementation-Title" value="OpenCV"/>
         <attribute name="Implementation-Version" value="@OPENCV_VCSVERSION@"/>
         <attribute name="Implementation-Date" value="${timestamp}"/>
+        <attribute name="Automatic-Module-Name" value="org.opencv"/>
       </manifest>
     </jar>
   </target>


### PR DESCRIPTION
This is a useful attribute for modularized Java libraries and applications to be able to use OpenCV.

A full module-info.java file for true compatibility with the Java module system would require compiling with Java 9+ and either use a multi-release JAR (which can be tricky to maintain) or compile the entire library with Java 9+ (which would break Android consumers on older SDK versions). In the interest of causing the least disruption, only an automatic module name is set so that modular Java consumers can use OpenCV but not break anybody else.

Current workarounds for modular applications and libraries that use OpenCV require patching the JAR file during builds to manually set module information, which is fragile and can't be shared by downstream users (they would have to do the same kind of manual patching).

Reference reading on the Java module system, and automatic module names in particular:
- https://dev.java/learn/modules/intro/
- https://dev.java/learn/modules/automatic-module/

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- ~~[ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable~~ (n/a)
      Patch to opencv_extra has the same branch name.
- ~~[ ] The feature is well documented and sample code can be built with the project CMake~~
  - n/a? It builds, and I have verified that the built JAR file includes the new manifest file entry
