### PR TITLE
core: support parsing null in json parser in FileStorage

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2398,12 +2398,7 @@ std::string FileNode::string() const
 {
     const uchar* p = ptr();
     if( !p || (*p & TYPE_MASK) != STRING )
-    {
-        if ( (*p & TYPE_MASK) == NONE )
-            return std::string("None");
-        else
-            return std::string();
-    }
+        return std::string();
     p += (*p & NAMED) ? 5 : 1;
     size_t sz = (size_t)(unsigned)readInt(p);
     return std::string((const char*)(p + 4), sz - 1);

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2398,7 +2398,12 @@ std::string FileNode::string() const
 {
     const uchar* p = ptr();
     if( !p || (*p & TYPE_MASK) != STRING )
-        return std::string();
+    {
+        if ( (*p & TYPE_MASK) == NONE )
+            return std::string("None");
+        else
+            return std::string();
+    }
     p += (*p & NAMED) ? 5 : 1;
     size_t sz = (size_t)(unsigned)readInt(p);
     return std::string((const char*)(p + 4), sz - 1);

--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -623,9 +623,7 @@ public:
             }
 
             if( len == 4 && memcmp( beg, "null", 4 ) == 0 )
-            {
-                CV_PARSE_ERROR_CPP( "Value 'null' is not supported by this parser" );
-            }
+                ;
             else if( (len == 4 && memcmp( beg, "true", 4 ) == 0) ||
                      (len == 5 && memcmp( beg, "false", 5 ) == 0) )
             {

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1563,8 +1563,8 @@ TEST(Core_InputOutput, FileStorage_json_null_object)
     ASSERT_EQ(fs["truncation"].name(), "truncation");
     ASSERT_EQ(fs["version"].name(), "version");
 
-    ASSERT_EQ(fs["padding"].string(), "None");
-    ASSERT_EQ(fs["truncation"].string(), "None");
+    ASSERT_EQ(fs["padding"].string(), "");
+    ASSERT_EQ(fs["truncation"].string(), "");
     ASSERT_EQ(fs["version"].string(), "1.0");
     fs.release();
 }

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1545,6 +1545,30 @@ TEST(Core_InputOutput, FileStorage_format_yml_gz)
     EXPECT_EQ(FileStorage::FORMAT_YAML, fs.getFormat());
 }
 
+TEST(Core_InputOutput, FileStorage_json_null_object)
+{
+    std::string test =
+        "{ "
+            "\"padding\": null,"
+            "\"truncation\": null,"
+            "\"version\": \"1.0\""
+        "}";
+    FileStorage fs(test, FileStorage::READ | FileStorage::MEMORY);
+
+    ASSERT_TRUE(fs["padding"].isNone());
+    ASSERT_TRUE(fs["truncation"].isNone());
+    ASSERT_TRUE(fs["version"].isString());
+
+    ASSERT_EQ(fs["padding"].name(), "padding");
+    ASSERT_EQ(fs["truncation"].name(), "truncation");
+    ASSERT_EQ(fs["version"].name(), "version");
+
+    ASSERT_EQ(fs["padding"].string(), "None");
+    ASSERT_EQ(fs["truncation"].string(), "None");
+    ASSERT_EQ(fs["version"].string(), "1.0");
+    fs.release();
+}
+
 TEST(Core_InputOutput, FileStorage_json_named_nodes)
 {
     std::string test =


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/27578

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
