### PR TITLE
Take into account overflow for connected components

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -262,8 +262,8 @@ namespace cv{
     template<typename LabelT>
     inline static
     void checkLabelTypeOverflow(const LabelT numLabels) {
-        constexpr LabelT max_label_type_value = std::numeric_limits<LabelT>::max();
-        if (numLabels == max_label_type_value) {
+        constexpr LabelT maxLabelTypeValue = std::numeric_limits<LabelT>::max();
+        if (numLabels == maxLabelTypeValue) {
             CV_Error(
                 cv::Error::StsError,
                 "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");

--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -261,10 +261,12 @@ namespace cv{
 
     template<typename LabelT>
     inline static
-    void checkLabelTypeOverflow(const LabelT numLabels){
+    void checkLabelTypeOverflow(const LabelT numLabels) {
         constexpr LabelT max_label_type_value = std::numeric_limits<LabelT>::max();
         if (numLabels == max_label_type_value) {
-            CV_Error(cv::Error::StsError, "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");
+            CV_Error(
+                cv::Error::StsError,
+                "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");
         }
     }
 

--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -261,13 +261,12 @@ namespace cv{
 
     template<typename LabelT>
     inline static
-    void checkLabelTypeOverflow(const LabelT numLabels) {
+    void checkLabelTypeOverflowBeforeIncrement(const LabelT numLabels) {
         constexpr LabelT maxLabelTypeValue = std::numeric_limits<LabelT>::max();
-        if (numLabels == maxLabelTypeValue) {
-            CV_Error(
-                cv::Error::StsError,
-                "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");
-        }
+        CV_CheckLT(
+            numLabels,
+            maxLabelTypeValue,
+            "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");
     }
 
     template<typename LabelT>
@@ -279,7 +278,7 @@ namespace cv{
             }
             else{ //for root node
                 P[i] = k;
-                checkLabelTypeOverflow(k);
+                checkLabelTypeOverflowBeforeIncrement(k);
                 k = k + 1;
             }
         }
@@ -365,7 +364,7 @@ namespace cv{
 // Action 2: New label (the block has foreground pixels and is not connected to anything else)
 #define ACTION_2 img_labels_row[c] = label; \
                     P_[label] = label; \
-                    checkLabelTypeOverflow(label); \
+                    checkLabelTypeOverflowBeforeIncrement(label); \
                     label = label + 1;
 //Action 3: Assign label of block P
 #define ACTION_3 img_labels_row[c] = img_labels_row_prev_prev[c - 2];
@@ -1274,7 +1273,7 @@ namespace cv{
                 // Action 2: New label (the block has foreground pixels and is not connected to anything else)
                 #define ACTION_2 img_labels_row[c] = lunique; \
                                  P[lunique] = lunique;        \
-                                 checkLabelTypeOverflow(lunique); \
+                                 checkLabelTypeOverflowBeforeIncrement(lunique); \
                                  lunique = lunique + 1;
                 //Action 3: Assign label of block P
                 #define ACTION_3 img_labels_row[c] = img_labels_row_prev_prev[c - 2];
@@ -1868,7 +1867,7 @@ namespace cv{
 #define ACTION_1 img_labels_row[c] = 0;
 #define ACTION_2 img_labels_row[c] = lunique; \
                                      P[lunique] = lunique;        \
-                                     checkLabelTypeOverflow(lunique); \
+                                     checkLabelTypeOverflowBeforeIncrement(lunique); \
                                      lunique = lunique + 1; // new label
 #define ACTION_3 img_labels_row[c] = img_labels_row_prev[c]; // x <- q
 #define ACTION_4 img_labels_row[c] = img_labels_row[c - 1]; // x <- s
@@ -2067,7 +2066,7 @@ namespace cv{
                                             //new label
                                             imgLabels_row[c] = label;
                                             P_[label] = label;
-                                            checkLabelTypeOverflow(label);
+                                            checkLabelTypeOverflowBeforeIncrement(label);
                                             label = label + 1;
                                         }
                                     }
@@ -2151,7 +2150,7 @@ namespace cv{
                                     //new label
                                     imgLabels_row[c] = label;
                                     P_[label] = label;
-                                    checkLabelTypeOverflow(label);
+                                    checkLabelTypeOverflowBeforeIncrement(label);
                                     label = label + 1;
                                 }
                             }
@@ -2450,7 +2449,7 @@ namespace cv{
                                             //new label
                                             imgLabels_row[c] = lunique;
                                             P[lunique] = lunique;
-                                            checkLabelTypeOverflow(lunique);
+                                            checkLabelTypeOverflowBeforeIncrement(lunique);
                                             lunique = lunique + 1;
                                         }
                                     }
@@ -2501,7 +2500,7 @@ namespace cv{
                                     //new label
                                     imgLabels_row[c] = lunique;
                                     P[lunique] = lunique;
-                                    checkLabelTypeOverflow(lunique);
+                                    checkLabelTypeOverflowBeforeIncrement(lunique);
                                     lunique = lunique + 1;
                                 }
                             }
@@ -3127,7 +3126,7 @@ namespace cv{
                                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                         imgLabels_row[c] = label;
                                                         P_[label] = label;
-                                                        checkLabelTypeOverflow(label);
+                                                        checkLabelTypeOverflowBeforeIncrement(label);
                                                         label = label + 1;
                                                         continue;
                                                     }
@@ -3150,7 +3149,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = label;
                                                     P_[label] = label;
-                                                    checkLabelTypeOverflow(label);
+                                                    checkLabelTypeOverflowBeforeIncrement(label);
                                                     label = label + 1;
                                                     continue;
                                                 }
@@ -3504,7 +3503,7 @@ namespace cv{
                                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                         imgLabels_row[c] = label;
                                                         P_[label] = label;
-                                                        checkLabelTypeOverflow(label);
+                                                        checkLabelTypeOverflowBeforeIncrement(label);
                                                         label = label + 1;
                                                         continue;
                                                     }
@@ -3529,7 +3528,7 @@ namespace cv{
                                             //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                             imgLabels_row[c] = label;
                                             P_[label] = label;
-                                            checkLabelTypeOverflow(label);
+                                            checkLabelTypeOverflowBeforeIncrement(label);
                                             label = label + 1;
                                             continue;
                                         }
@@ -3573,7 +3572,7 @@ namespace cv{
                                                 //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                 imgLabels_row[c] = label;
                                                 P_[label] = label;
-                                                checkLabelTypeOverflow(label);
+                                                checkLabelTypeOverflowBeforeIncrement(label);
                                                 label = label + 1;
                                                 continue;
                                             }
@@ -3585,7 +3584,7 @@ namespace cv{
                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                         imgLabels_row[c] = label;
                                         P_[label] = label;
-                                        checkLabelTypeOverflow(label);
+                                        checkLabelTypeOverflowBeforeIncrement(label);
                                         label = label + 1;
                                         continue;
                                     }
@@ -4890,7 +4889,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = lunique;
                                                     P[lunique] = lunique;
-                                                    checkLabelTypeOverflow(lunique);
+                                                    checkLabelTypeOverflowBeforeIncrement(lunique);
                                                     lunique = lunique + 1;
                                                     continue;
                                                 }
@@ -4913,7 +4912,7 @@ namespace cv{
                                                 //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                 imgLabels_row[c] = lunique;
                                                 P[lunique] = lunique;
-                                                checkLabelTypeOverflow(lunique);
+                                                checkLabelTypeOverflowBeforeIncrement(lunique);
                                                 lunique = lunique + 1;
                                                 continue;
                                             }
@@ -5267,7 +5266,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = lunique;
                                                     P[lunique] = lunique;
-                                                    checkLabelTypeOverflow(lunique);
+                                                    checkLabelTypeOverflowBeforeIncrement(lunique);
                                                     lunique = lunique + 1;
                                                     continue;
                                                 }
@@ -5292,7 +5291,7 @@ namespace cv{
                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                         imgLabels_row[c] = lunique;
                                         P[lunique] = lunique;
-                                        checkLabelTypeOverflow(lunique);
+                                        checkLabelTypeOverflowBeforeIncrement(lunique);
                                         lunique = lunique + 1;
                                         continue;
                                     }
@@ -5336,7 +5335,7 @@ namespace cv{
                                             //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                             imgLabels_row[c] = lunique;
                                             P[lunique] = lunique;
-                                            checkLabelTypeOverflow(lunique);
+                                            checkLabelTypeOverflowBeforeIncrement(lunique);
                                             lunique = lunique + 1;
                                             continue;
                                         }
@@ -5348,7 +5347,7 @@ namespace cv{
                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                     imgLabels_row[c] = lunique;
                                     P[lunique] = lunique;
-                                    checkLabelTypeOverflow(lunique);
+                                    checkLabelTypeOverflowBeforeIncrement(lunique);
                                     lunique = lunique + 1;
                                     continue;
                                 }

--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -261,13 +261,23 @@ namespace cv{
 
     template<typename LabelT>
     inline static
-    void flattenL(LabelT *P, const int start, const int nElem, LabelT& k){
+    void checkLabelTypeOverflow(const LabelT numLabels){
+        constexpr LabelT max_label_type_value = std::numeric_limits<LabelT>::max();
+        if (numLabels == max_label_type_value) {
+            CV_Error(cv::Error::StsError, "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype");
+        }
+    }
+
+    template<typename LabelT>
+    inline static
+    void flattenLParallel(LabelT *P, const int start, const int nElem, LabelT& k){
         for (int i = start; i < start + nElem; ++i){
             if (P[i] < i){//node that point to root
                 P[i] = P[P[i]];
             }
             else{ //for root node
                 P[i] = k;
+                checkLabelTypeOverflow(k);
                 k = k + 1;
             }
         }
@@ -353,6 +363,7 @@ namespace cv{
 // Action 2: New label (the block has foreground pixels and is not connected to anything else)
 #define ACTION_2 img_labels_row[c] = label; \
                     P_[label] = label; \
+                    checkLabelTypeOverflow(label); \
                     label = label + 1;
 //Action 3: Assign label of block P
 #define ACTION_3 img_labels_row[c] = img_labels_row_prev_prev[c - 2];
@@ -1160,7 +1171,7 @@ namespace cv{
             LabelT nLabels = 1;
             for (int i = 0; i < h; i = chunksSizeAndLabels[i]) {
                 CV_DbgAssert(i + 1 < chunksSizeAndLabelsSize);
-                flattenL(P.data(), stripeFirstLabel8Connectivity<LabelT>(i, w), chunksSizeAndLabels[i + 1], nLabels);
+                flattenLParallel(P.data(), stripeFirstLabel8Connectivity<LabelT>(i, w), chunksSizeAndLabels[i + 1], nLabels);
             }
 
             //Array for statistics data
@@ -1261,6 +1272,7 @@ namespace cv{
                 // Action 2: New label (the block has foreground pixels and is not connected to anything else)
                 #define ACTION_2 img_labels_row[c] = lunique; \
                                  P[lunique] = lunique;        \
+                                 checkLabelTypeOverflow(lunique); \
                                  lunique = lunique + 1;
                 //Action 3: Assign label of block P
                 #define ACTION_3 img_labels_row[c] = img_labels_row_prev_prev[c - 2];
@@ -1789,7 +1801,7 @@ namespace cv{
             mergeLabels(imgLabels, P, chunksSizeAndLabels.data());
 
             for (int i = 0; i < h; i = chunksSizeAndLabels[i]) {
-                flattenL(P, stripeFirstLabel4Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
+                flattenLParallel(P, stripeFirstLabel4Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
             }
 
             //Array for statistics dataof threads
@@ -1854,6 +1866,7 @@ namespace cv{
 #define ACTION_1 img_labels_row[c] = 0;
 #define ACTION_2 img_labels_row[c] = lunique; \
                                      P[lunique] = lunique;        \
+                                     checkLabelTypeOverflow(lunique); \
                                      lunique = lunique + 1; // new label
 #define ACTION_3 img_labels_row[c] = img_labels_row_prev[c]; // x <- q
 #define ACTION_4 img_labels_row[c] = img_labels_row[c - 1]; // x <- s
@@ -2052,6 +2065,7 @@ namespace cv{
                                             //new label
                                             imgLabels_row[c] = label;
                                             P_[label] = label;
+                                            checkLabelTypeOverflow(label);
                                             label = label + 1;
                                         }
                                     }
@@ -2135,6 +2149,7 @@ namespace cv{
                                     //new label
                                     imgLabels_row[c] = label;
                                     P_[label] = label;
+                                    checkLabelTypeOverflow(label);
                                     label = label + 1;
                                 }
                             }
@@ -2320,7 +2335,7 @@ namespace cv{
                 mergeLabels8Connectivity(imgLabels, P, chunksSizeAndLabels.data());
 
                 for (int i = 0; i < h; i = chunksSizeAndLabels[i]){
-                    flattenL(P, stripeFirstLabel8Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
+                    flattenLParallel(P, stripeFirstLabel8Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
                 }
             }
             else{
@@ -2331,7 +2346,7 @@ namespace cv{
                 mergeLabels4Connectivity(imgLabels, P, chunksSizeAndLabels.data());
 
                 for (int i = 0; i < h; i = chunksSizeAndLabels[i]){
-                    flattenL(P, stripeFirstLabel4Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
+                    flattenLParallel(P, stripeFirstLabel4Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
                 }
             }
 
@@ -2433,6 +2448,7 @@ namespace cv{
                                             //new label
                                             imgLabels_row[c] = lunique;
                                             P[lunique] = lunique;
+                                            checkLabelTypeOverflow(lunique);
                                             lunique = lunique + 1;
                                         }
                                     }
@@ -2483,6 +2499,7 @@ namespace cv{
                                     //new label
                                     imgLabels_row[c] = lunique;
                                     P[lunique] = lunique;
+                                    checkLabelTypeOverflow(lunique);
                                     lunique = lunique + 1;
                                 }
                             }
@@ -3108,6 +3125,7 @@ namespace cv{
                                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                         imgLabels_row[c] = label;
                                                         P_[label] = label;
+                                                        checkLabelTypeOverflow(label);
                                                         label = label + 1;
                                                         continue;
                                                     }
@@ -3130,6 +3148,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = label;
                                                     P_[label] = label;
+                                                    checkLabelTypeOverflow(label);
                                                     label = label + 1;
                                                     continue;
                                                 }
@@ -3483,6 +3502,7 @@ namespace cv{
                                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                         imgLabels_row[c] = label;
                                                         P_[label] = label;
+                                                        checkLabelTypeOverflow(label);
                                                         label = label + 1;
                                                         continue;
                                                     }
@@ -3507,6 +3527,7 @@ namespace cv{
                                             //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                             imgLabels_row[c] = label;
                                             P_[label] = label;
+                                            checkLabelTypeOverflow(label);
                                             label = label + 1;
                                             continue;
                                         }
@@ -3550,6 +3571,7 @@ namespace cv{
                                                 //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                 imgLabels_row[c] = label;
                                                 P_[label] = label;
+                                                checkLabelTypeOverflow(label);
                                                 label = label + 1;
                                                 continue;
                                             }
@@ -3561,6 +3583,7 @@ namespace cv{
                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                         imgLabels_row[c] = label;
                                         P_[label] = label;
+                                        checkLabelTypeOverflow(label);
                                         label = label + 1;
                                         continue;
                                     }
@@ -4260,7 +4283,7 @@ namespace cv{
             LabelT nLabels = 1;
             for (int i = 0; i < h; i = chunksSizeAndLabels[i]){
                 CV_DbgAssert(i + 1 < chunksSizeAndLabelsSize);
-                flattenL(P.data(), stripeFirstLabel8Connectivity<LabelT>(i, w), chunksSizeAndLabels[i + 1], nLabels);
+                flattenLParallel(P.data(), stripeFirstLabel8Connectivity<LabelT>(i, w), chunksSizeAndLabels[i + 1], nLabels);
             }
 
             //Array for statistics data
@@ -4865,6 +4888,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = lunique;
                                                     P[lunique] = lunique;
+                                                    checkLabelTypeOverflow(lunique);
                                                     lunique = lunique + 1;
                                                     continue;
                                                 }
@@ -4887,6 +4911,7 @@ namespace cv{
                                                 //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                 imgLabels_row[c] = lunique;
                                                 P[lunique] = lunique;
+                                                checkLabelTypeOverflow(lunique);
                                                 lunique = lunique + 1;
                                                 continue;
                                             }
@@ -5240,6 +5265,7 @@ namespace cv{
                                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                                     imgLabels_row[c] = lunique;
                                                     P[lunique] = lunique;
+                                                    checkLabelTypeOverflow(lunique);
                                                     lunique = lunique + 1;
                                                     continue;
                                                 }
@@ -5264,6 +5290,7 @@ namespace cv{
                                         //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                         imgLabels_row[c] = lunique;
                                         P[lunique] = lunique;
+                                        checkLabelTypeOverflow(lunique);
                                         lunique = lunique + 1;
                                         continue;
                                     }
@@ -5307,6 +5334,7 @@ namespace cv{
                                             //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                             imgLabels_row[c] = lunique;
                                             P[lunique] = lunique;
+                                            checkLabelTypeOverflow(lunique);
                                             lunique = lunique + 1;
                                             continue;
                                         }
@@ -5318,6 +5346,7 @@ namespace cv{
                                     //Action_2: New label (the block has foreground pixels and is not connected to anything else)
                                     imgLabels_row[c] = lunique;
                                     P[lunique] = lunique;
+                                    checkLabelTypeOverflow(lunique);
                                     lunique = lunique + 1;
                                     continue;
                                 }

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -817,7 +817,8 @@ TEST(Imgproc_ConnectedComponents, regression_27568)
                 Mat labels, stats, centroids;
                 try
                 {
-                    connectedComponentsWithStats(image, labels, stats, centroids, connectivity, CV_16U, ccltype);
+                    connectedComponentsWithStats(
+                        image, labels, stats, centroids, connectivity, CV_16U, ccltype);
                     ADD_FAILURE();
                 }
                 catch (const Exception& exception)
@@ -831,7 +832,9 @@ TEST(Imgproc_ConnectedComponents, regression_27568)
 
             {
                 Mat labels, stats, centroids;
-                EXPECT_NO_THROW(connectedComponentsWithStats(image, labels, stats, centroids, connectivity, CV_32S, ccltype));
+                EXPECT_NO_THROW(
+                    connectedComponentsWithStats(
+                        image, labels, stats, centroids, connectivity, CV_32S, ccltype));
             }
         }
     }

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -800,7 +800,7 @@ TEST(Imgproc_ConnectedComponents, 4conn_regression_21366)
 
 TEST(Imgproc_ConnectedComponents, regression_27568)
 {
-    Mat image = Mat::zeros(Size(1000, 1000), CV_8UC1);
+    Mat image = Mat::zeros(Size(512, 512), CV_8UC1);
     for (int row = 0; row < image.rows; row += 2)
     {
         for (int col = 0; col < image.cols; col += 2)

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -798,7 +798,44 @@ TEST(Imgproc_ConnectedComponents, 4conn_regression_21366)
     }
 }
 
+TEST(Imgproc_ConnectedComponents, regression_27568)
+{
+    Mat image = Mat::zeros(Size(1000, 1000), CV_8UC1);
+    for (int row = 0; row < image.rows; row += 2)
+    {
+        for (int col = 0; col < image.cols; col += 2)
+        {
+            image.at<uint8_t>(row, col) = 1;
+        }
+    }
 
+    for (const int connectivity : {4, 8})
+    {
+        for (const int ccltype : {CCL_DEFAULT, CCL_WU, CCL_GRANA, CCL_BOLELLI, CCL_SAUF, CCL_BBDT, CCL_SPAGHETTI})
+        {
+            {
+                Mat labels, stats, centroids;
+                try
+                {
+                    connectedComponentsWithStats(image, labels, stats, centroids, connectivity, CV_16U, ccltype);
+                    ADD_FAILURE();
+                }
+                catch (const Exception& exception)
+                {
+                    EXPECT_TRUE(
+                        strstr(
+                            exception.what(),
+                            "Total number of labels overflowed label type. Try using CV_32S instead of CV_16U as ltype"));
+                }
+            }
+
+            {
+                Mat labels, stats, centroids;
+                EXPECT_NO_THROW(connectedComponentsWithStats(image, labels, stats, centroids, connectivity, CV_32S, ccltype));
+            }
+        }
+    }
+}
 
 }
 } // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #27568 

The problem was caused by a label type overflow (`debug_example.npy` contains `92103` labels, that doesn't fit in the `CV_16U` (`unsigned short`) type). If pass `CV_32S` instead of `CV_16U` as `ltype` - everything will be calculated successfully

Added overflow detection to throw exception with a clear error message instead of strange segfault/assertion error

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
