### PR TITLE
core: support parsing back slash `\` in `parseKey` in FileStorage (JSON)

### DIFF
--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -4,7 +4,6 @@
 
 #include "precomp.hpp"
 #include "persistence.hpp"
-// #include <regex>
 
 namespace cv
 {
@@ -425,12 +424,7 @@ public:
             if (*ptr == '\\') { // skip the next character if current is back slash
                 ++ptr;
                 CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG_CPP();
-                if (*ptr == '"')
-                    key_name += '"';
-                else {
-                    key_name += '\\';
-                    key_name += *ptr;
-                }
+                key_name += *ptr;
                 ++ptr;
                 CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG_CPP();
             } else {
@@ -446,7 +440,6 @@ public:
         if( ptr == beg )
             CV_PARSE_ERROR_CPP( "Key is empty" );
         value_placeholder = fs->addNode(collection, key_name, FileNode::NONE);
-        printf("%s\n", value_placeholder.name().c_str());
 
         ptr++;
         ptr = skipSpaces( ptr );

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1571,30 +1571,24 @@ TEST(Core_InputOutput, FileStorage_json_null_object)
 
 TEST(Core_InputOutput, FileStorage_json_key_backslash)
 {
-     // equivalant to json text {"\"":1,"\\":59,"Ġ\"":366,"\\\\":6852}
-    std::string test =
-        "{ "
-            "\"\\\"\":1,"
-            "\"\\\\\":59,"
-            "\"Ġ\\\"\":366,"
-            "\"\\\\\\\\\":6852"
-        "}";
+    // equivalent to json text {"\"":1,"\\":59,"Ġ\"":366,"\\\\":6852}
+    std::string test = R"({"\"":1,"\\":59,"Ġ\"":366,"\\\\":6852})";
     FileStorage fs(test, FileStorage::READ | FileStorage::MEMORY);
 
-    ASSERT_TRUE(fs["\""].isNamed());
-    ASSERT_TRUE(fs["\\\\"].isNamed());
-    ASSERT_TRUE(fs["Ġ\""].isNamed());
-    ASSERT_TRUE(fs["\\\\\\\\"].isNamed());
+    ASSERT_TRUE(fs[R"(")"].isNamed());  // = "\""
+    ASSERT_TRUE(fs[R"(\)"].isNamed());  // = "\\"
+    ASSERT_TRUE(fs[R"(Ġ")"].isNamed()); // = "Ġ\""
+    ASSERT_TRUE(fs[R"(\\)"].isNamed()); // = "\\\\"
 
-    ASSERT_EQ(fs["\""].name(), "\"");
-    ASSERT_EQ(fs["\\\\"].name(), "\\\\");
-    ASSERT_EQ(fs["Ġ\""].name(), "Ġ\"");
-    ASSERT_EQ(fs["\\\\\\\\"].name(), "\\\\\\\\");
+    ASSERT_EQ(fs[R"(")"].name(), R"(")");
+    ASSERT_EQ(fs[R"(\)"].name(), R"(\)");
+    ASSERT_EQ(fs[R"(Ġ")"].name(), R"(Ġ")");
+    ASSERT_EQ(fs[R"(\\)"].name(), R"(\\)");
 
-    ASSERT_EQ((int)fs["\""], 1);
-    ASSERT_EQ((int)fs["\\\\"], 59);
-    ASSERT_EQ((int)fs["Ġ\""], 366);
-    ASSERT_EQ((int)fs["\\\\\\\\"], 6852);
+    ASSERT_EQ((int)fs[R"(")"], 1);
+    ASSERT_EQ((int)fs[R"(\)"], 59);
+    ASSERT_EQ((int)fs[R"(Ġ")"], 366);
+    ASSERT_EQ((int)fs[R"(\\)"], 6852);
     fs.release();
 }
 


### PR DESCRIPTION
Fixes #27585 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
