### PR TITLE
core: ARM64 loop unrolling in kmeans to improve Weighted Filter performance

### DIFF
--- a/modules/core/src/kmeans.cpp
+++ b/modules/core/src/kmeans.cpp
@@ -120,6 +120,20 @@ static void generateCentersPP(const Mat& data, Mat& _out_centers,
         {
             double p = (double)rng*sum0;
             int ci = 0;
+        #if defined(_M_ARM64)
+            for (; ci + 1 < N - 1; ci += 2)
+            {
+                p -= dist[ci];
+                if (p <= 0) break;
+
+                p -= dist[ci + 1];
+                if (p <= 0)
+                {
+                    ci += 1;
+                    break;
+                }
+            }
+        #endif
             for (; ci < N - 1; ci++)
             {
                 p -= dist[ci];
@@ -131,7 +145,12 @@ static void generateCentersPP(const Mat& data, Mat& _out_centers,
                           KMeansPPDistanceComputer(tdist2, data, dist, ci),
                           (double)divUp((size_t)(dims * N), CV_KMEANS_PARALLEL_GRANULARITY));
             double s = 0;
-            for (int i = 0; i < N; i++)
+            int i = 0;
+        #if defined(_M_ARM64)
+            for (; i + 1 < N; i += 2)
+                s += tdist2[i] + tdist2[i + 1];
+        #endif
+            for (; i < N; i++)
             {
                 s += tdist2[i];
             }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

- This PR improves the performance of the Weighted Filter function from the ximgproc module on Windows on ARM64.
- The optimization is achieved by unrolling two performance-critical loops in the generateCentersPP function in modules/core/src/kmeans.cpp, which is internally used by the Weighted Filter function.
- The unrolling is enabled only for ARM64 builds using #if defined(_M_ARM64) guards to preserve compatibility and maintain performance on other architectures.

**Performance Improvements:** 
- Improves execution time for Weighted Filter performance tests on ARM64 without affecting other platforms.
<img width="772" height="558" alt="image" src="https://github.com/user-attachments/assets/ae28c0af-97d3-460b-ad5a-207d3fc6936f" />






