### PR TITLE
G-API: Implement cfgClampOutputs option to OpenVINO Params

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -363,6 +363,8 @@ public:
     By default, output values are clamped to the valid range for the output precision
     by the device or plugin. Enabling this option moves clamping to the PrePostProcessor stage.
 
+    @note This feature is only available with OpenVINO 2025.2 and newer.
+
     @param flag If true, clamping is performed in the PrePostProcessor;
     otherwise, it is handled by the device or plugin.
     @return reference to this parameter structure.

--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -66,6 +66,8 @@ struct ParamDesc {
         LayerVariantAttr<std::vector<float>> scale_values;
 
         LayerVariantAttr<int> interpolation;
+
+        bool clamp_outputs = false;
     };
 
     struct CompiledModel {
@@ -356,6 +358,22 @@ public:
         return *this;
     }
 
+    /** @brief Enables or disables clamping of model outputs in the PrePostProcessor.
+
+    By default, output values are clamped to the valid range for the output precision
+    by the device or plugin. Enabling this option moves clamping to the PrePostProcessor stage.
+
+    @param flag If true, clamping is performed in the PrePostProcessor;
+    otherwise, it is handled by the device or plugin.
+    @return reference to this parameter structure.
+    */
+    Params<Net>&
+    cfgClampOutputs(bool flag = true) {
+        detail::getModelToSetAttrOrThrow(m_desc.kind, "clamp outputs")
+            .clamp_outputs = std::move(flag);
+        return *this;
+    }
+
     /** @brief Specifies the new shape for input layers.
 
     The function is used to set new shape for input layers.
@@ -622,6 +640,14 @@ public:
     cfgOutputTensorPrecision(detail::AttrMap<int> precision_map) {
         detail::getModelToSetAttrOrThrow(m_desc.kind, "output tensor precision")
             .output_tensor_precision = std::move(precision_map);
+        return *this;
+    }
+
+    /** @see ov::Params::cfgClampOutputs. */
+    Params&
+    cfgClampOutputs(bool flag = true) {
+        detail::getModelToSetAttrOrThrow(m_desc.kind, "clamp outputs")
+            .clamp_outputs = std::move(flag);
         return *this;
     }
 

--- a/modules/gapi/src/backends/ov/govbackend.cpp
+++ b/modules/gapi/src/backends/ov/govbackend.cpp
@@ -1073,9 +1073,17 @@ public:
                     .set_element_type(toOV(*explicit_out_tensor_prec));
 
                 if (m_model_info.clamp_outputs) {
-                    auto [min_val, max_val] = get_CV_type_range(*explicit_out_tensor_prec);
+                    #if INF_ENGINE_RELEASE >= 2025020000
+                    auto clamp_range = get_CV_type_range(*explicit_out_tensor_prec);
                     m_ppp.output(output_name).postprocess()
-                        .clamp(min_val, max_val);
+                        .clamp(clamp_range.first, clamp_range.second);
+                    #else
+                    static bool warned = false;
+                    if (!warned) {
+                        GAPI_LOG_WARNING(NULL, "cfgClampOutputs is enabled, but not supported in this OpenVINO version. Clamping will be ignored.");
+                        warned = true;
+                    }
+                    #endif // INF_ENGINE_RELEASE >= 2025020000
                 }
             }
         }


### PR DESCRIPTION
Added the option `cfgClampOutputs` to control where output clamping is performed for OpenVINO models. When enabled, output values are clamped in the PrePostProcessor stage instead of by the device or plugin. This provides a consistent and standardized clamping method across devices, helping to maintain accuracy regardless of device-specific clamping behavior.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
