### PR TITLE
Install binaries under bin/opencv

### DIFF
--- a/cmake/OpenCVInstallLayout.cmake
+++ b/cmake/OpenCVInstallLayout.cmake
@@ -77,7 +77,7 @@ elseif(QNX)
 else() # UNIX
 
   include(GNUInstallDirs)
-  ocv_update(OPENCV_BIN_INSTALL_PATH           "bin")
+  ocv_update(OPENCV_BIN_INSTALL_PATH           "bin/opencv")
   ocv_update(OPENCV_TEST_INSTALL_PATH          "${OPENCV_BIN_INSTALL_PATH}")
   ocv_update(OPENCV_SAMPLES_BIN_INSTALL_PATH   "${OPENCV_BIN_INSTALL_PATH}")
   ocv_update(OPENCV_LIB_INSTALL_PATH           "${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
Install binaries under bin/opencv to
avoid conflict with other files/directories
on rootfs.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
