### PR TITLE
Support Symbol.dispose for using keyword in OpenCV.js (#26157)

### DIFF
--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -397,3 +397,16 @@ Module['matFromImageData'] = function(imageData) {
     mat.data.set(imageData.data);
     return mat;
 };
+// Add Symbol.dispose support for using declaration in TypeScript 5.2+ and future JS
+if (
+    typeof Symbol !== "undefined" &&
+    Symbol.dispose &&
+    typeof cv !== "undefined" &&
+    cv.Mat &&
+    typeof cv.Mat.prototype.delete === "function"
+) {
+    cv.Mat.prototype[Symbol.dispose] = cv.Mat.prototype.delete;
+    // Optionally repeat for other types that require manual cleanup:
+    if (cv.UMat) cv.UMat.prototype[Symbol.dispose] = cv.UMat.prototype.delete;
+    // Add more as OpenCV gains new manual-cleanup classes
+}


### PR DESCRIPTION
This PR adds support for the new `Symbol.dispose` proposal, allowing OpenCV.js objects such as `cv.Mat` and `cv.UMat` to be used with the upcoming `using` keyword in JavaScript (TC39 proposal) and TypeScript 5.2+.

- Adds `[Symbol.dispose]` as an alias to `.delete()` for resource-managed OpenCV.js classes
- Conditional logic ensures compatibility and no effect on environments without `Symbol.dispose`
- Minimal, easily extensible design for future OpenCV classes

Closes #26157.

**Motivation:**
Manual `.delete()` calls can be error-prone and verbose. Supporting the new `using` keyword will improve resource safety and developer ergonomics per the [TC39 proposal](https://github.com/tc39/proposal-explicit-resource-management) and [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management).

Please let me know if there’s any other class to include, or if you’d like further tests or documentation.