### PR TITLE
doc: Enable GIF support by default on documentation

### DIFF
--- a/doc/tutorials/introduction/config_reference/config_reference.markdown
+++ b/doc/tutorials/introduction/config_reference/config_reference.markdown
@@ -315,7 +315,7 @@ Following formats can be read by OpenCV without help of any third-party library:
 | [Sun Raster](https://en.wikipedia.org/wiki/Sun_Raster) | `WITH_IMGCODEC_SUNRASTER` | _ON_ |
 | [PPM, PGM, PBM, PAM](https://en.wikipedia.org/wiki/Netpbm#File_formats) | `WITH_IMGCODEC_PXM` | _ON_ |
 | [PFM](https://en.wikipedia.org/wiki/Netpbm#File_formats) | `WITH_IMGCODEC_PFM` | _ON_ |
-| [GIF](https://en.wikipedia.org/wiki/GIF) | `WITH_IMGCODEC_GIF` | _OFF_ |
+| [GIF](https://en.wikipedia.org/wiki/GIF) | `WITH_IMGCODEC_GIF` | _ON_ |
 
 ### PNG, JPEG, TIFF, WEBP, JPEG 2000, EXR, JPEG XL support
 


### PR DESCRIPTION
GIF codecs is enabled on https://github.com/opencv/opencv/pull/27258 .
OpenCV configuration documents should be updated together.

- https://docs.opencv.org/4.12.0/db/d05/tutorial_config_reference.html#autotoc_md925
- https://docs.opencv.org/4.x/db/d05/tutorial_config_reference.html#autotoc_md925


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
