### PR TITLE
Visualization script for one or more cameras calibration with calibration.cpp

### DIFF
--- a/samples/python/visualize_mono_calibration.py
+++ b/samples/python/visualize_mono_calibration.py
@@ -8,8 +8,8 @@
 Loads YAMLS from calibration.cpp sample code and displays an interactive 3d plot using meshlab and matplotlib
 
 usage:
-    python3 multicam_vis.py cam1.yml
-    python3 multicam_vis.py cam1.yml cam2.yml --view board --export scene
+    python3 visualize_mono_calibration.py cam1.yml
+    python3 visualize_mono_calibration.py cam1.yml cam2.yml --view board --export scene
 
 Arguments:
     calib_files       YAML files with calibration data
@@ -284,6 +284,7 @@ def plot_scene_board_view(
 def export_scene_to_obj_multi(
     base_name: str,
     calibs: List[Dict[str, object]],
+    board_size: Tuple[int, int],
     view: str = "camera",
     max_frustums_per_cam: Optional[int] = None,
 ) -> None:
@@ -305,16 +306,13 @@ def export_scene_to_obj_multi(
             rvec = row[:3]
             tvec = row[3:]
             R, _ = cv2.Rodrigues(rvec)
-            ux = np.unique(grid[:, 0])
-            uy = np.unique(grid[:, 1])
-            nx, ny = ux.size, uy.size
             pts_h = (R @ grid.T).T + tvec.reshape(1, 3)
-            world = pts_h.reshape((nx, ny, 3), order="F")
+            world = pts_h.reshape((board_size[0], board_size[1], 3), order="F")
             corners = [
                 world[0, 0],
-                world[nx - 1, 0],
-                world[nx - 1, ny - 1],
-                world[0, ny - 1],
+                world[board_size[0] - 1, 0],
+                world[board_size[0] - 1, board_size[1] - 1],
+                world[0, board_size[1] - 1],
             ]
             v0 = len(vertices)
             vertices.extend([tuple(v.tolist()) for v in corners])
@@ -491,6 +489,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         export_scene_to_obj_multi(
             args.export,
             calibs,
+            board_size,
             view=view,
             max_frustums_per_cam=args.max_frustums,
         )


### PR DESCRIPTION
* It reads one or more YAML files produced by `calibration.cpp`.
* displays an interactive 3D scene of the calibration setup with camera frustums and board meshes.
* Supports both **camera-centric** and **board-centric** views.
* exports the entire scene as a `.obj/.mtl` for use in meshlab.
* also includes an error bar plot and frustum highlighting for single-camera setups.

calibration results generated by `calibration.cpp`: https://drive.google.com/drive/folders/13NvZHaxTFdAB-bzlNve8kKSMIg9gAu6K

Results Uploaded at: https://drive.google.com/drive/folders/1fkFyoBRGcNY4UCQhGgadO6uKlAkrzjTe
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
