### PR TITLE
Convert grayscale frames into color in interactive calibration preview

### DIFF
--- a/apps/interactive-calibration/frameProcessor.cpp
+++ b/apps/interactive-calibration/frameProcessor.cpp
@@ -308,7 +308,10 @@ cv::Mat CalibProcessor::processFrame(const cv::Mat &frame)
 {
     cv::Mat frameCopy;
     cv::Mat frameCopyToSave;
-    frame.copyTo(frameCopy);
+    if (frame.channels() == 1)
+        cv::cvtColor(frame, frameCopy, cv::COLOR_GRAY2BGR);
+    else
+        frame.copyTo(frameCopy);
     bool isTemplateFound = false;
     mCurrentImagePoints.clear();
 


### PR DESCRIPTION
Currently, if camera produces gray-scale frames the rendered board features are grayscale too. They are not contrast and not convenient.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
