### PR TITLE
Optimize VideoCapture with cvtColor instead of sws_scale

### DIFF
--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -112,6 +112,9 @@ int cvtBGRtoYUV(const uchar * src_data, size_t src_step, uchar * dst_data, size_
 int cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx, int yIdx);
 int cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx);
 int cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx);
+int cvtThreePlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * u_data, size_t u_step, const uchar * v_data, size_t v_step,
+                          uchar * dst_data, size_t dst_step, int dst_width, int dst_height,
+                          int dcn, bool swapBlue);
 int cvtOnePlaneBGRtoYUV(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int width, int height, int scn, bool swapBlue, int uIdx, int yIdx);
 int cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step, uchar * y_data, size_t y_step, uchar * uv_data, size_t uv_step, int width, int height, int scn, bool swapBlue, int uIdx);
 int cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int width, int height, int scn, bool swapBlue, int uIdx);

--- a/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
@@ -223,6 +223,12 @@ CV_EXPORTS void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                                       int dcn, bool swapBlue, int uIdx,
                                       AlgorithmHint hint = ALGO_HINT_DEFAULT);
 
+CV_EXPORTS void cvtThreePlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * u_data, size_t u_step, const uchar * v_data, size_t v_step,
+                                      uchar * dst_data, size_t dst_step,
+                                      int dst_width, int dst_height,
+                                      int dcn, bool swapBlue,
+                                      AlgorithmHint hint = ALGO_HINT_DEFAULT);
+
 CV_EXPORTS void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
                                       uchar * dst_data, size_t dst_step,
                                       int width, int height,

--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -207,6 +207,29 @@ void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
 // 4:2:0, three planes in one array: Y, U, V
 // Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
 // 20-bit fixed-point arithmetics
+void cvtThreePlaneYUVtoBGR(const uchar * y_data, size_t y_step,
+                           const uchar * u_data, size_t u_step,
+                           const uchar * v_data, size_t v_step,
+                           uchar * dst_data, size_t dst_step,
+                           int dst_width, int dst_height,
+                           int dcn, bool swapBlue, AlgorithmHint hint)
+{
+    CV_INSTRUMENT_REGION();
+
+    // if (hint == ALGO_HINT_APPROX)
+    // {
+    //     CALL_HAL(cvtThreePlaneYUVtoBGR, cv_hal_cvtThreePlaneYUVtoBGRApprox, src_data, src_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue, uIdx);
+    // }
+
+    CALL_HAL(cvtThreePlaneYUVtoBGR, cv_hal_cvtThreePlaneYUVtoBGR, y_data, y_step, u_data, u_step, v_data, v_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue);
+
+    CV_CPU_DISPATCH(cvtThreePlaneYUVtoBGR, (y_data, y_step, u_data, u_step, v_data, v_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
+
+// 4:2:0, three planes in one array: Y, U, V
+// Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+// 20-bit fixed-point arithmetics
 void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
                            uchar * dst_data, size_t dst_step,
                            int width, int height,

--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -216,10 +216,10 @@ void cvtThreePlaneYUVtoBGR(const uchar * y_data, size_t y_step,
 {
     CV_INSTRUMENT_REGION();
 
-    // if (hint == ALGO_HINT_APPROX)
-    // {
-    //     CALL_HAL(cvtThreePlaneYUVtoBGR, cv_hal_cvtThreePlaneYUVtoBGRApprox, src_data, src_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue, uIdx);
-    // }
+    if (hint == ALGO_HINT_APPROX)
+    {
+        CALL_HAL(cvtThreePlaneYUVtoBGR, cv_hal_cvtThreePlaneYUVtoBGRApprox, y_data, y_step, u_data, u_step, v_data, v_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue);
+    }
 
     CALL_HAL(cvtThreePlaneYUVtoBGR, cv_hal_cvtThreePlaneYUVtoBGR, y_data, y_step, u_data, u_step, v_data, v_step, dst_data, dst_step, dst_width, dst_height, dcn, swapBlue);
 

--- a/modules/imgproc/src/hal_replacement.hpp
+++ b/modules/imgproc/src/hal_replacement.hpp
@@ -829,6 +829,26 @@ inline int hal_ni_cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
 inline int hal_ni_cvtThreePlaneYUVtoBGRApprox(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 /**
+   @brief Analog of hal_cvtThreePlaneYUVtoBGR that allows approximations (not bit-exact)
+   @param y_data source image data (Y plane)
+   @param y_step Y plane step
+   @param u_data source image data (U plane)
+   @param u_step Y plane step
+   @param v_data source image data (V plane)
+   @param v_step Y plane step
+   @param dst_data destination image data
+   @param dst_step destination image step
+   @param dst_width destination image width
+   @param dst_height destination image height
+   @param dcn destination image channels (3 or 4)
+   @param swapBlue if set to true B and R destination channels will be swapped (write RGB)
+   Convert from YUV (YUV420p (or YV12/YV21) - Y plane followed by U and V planes) to BGR, RGB, BGRA or RGBA.
+   Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+ */
+inline int hal_ni_cvtThreePlaneYUVtoBGRApprox(const uchar * y_data, size_t y_step, const uchar * u_data, size_t u_step, const uchar * v_data, size_t v_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+
+/**
    @brief hal_cvtThreePlaneYUVtoBGR
    @param y_data source image data (Y plane)
    @param y_step Y plane step

--- a/modules/imgproc/src/hal_replacement.hpp
+++ b/modules/imgproc/src/hal_replacement.hpp
@@ -829,6 +829,26 @@ inline int hal_ni_cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
 inline int hal_ni_cvtThreePlaneYUVtoBGRApprox(const uchar * src_data, size_t src_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue, int uIdx) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 
 /**
+   @brief hal_cvtThreePlaneYUVtoBGR
+   @param y_data source image data (Y plane)
+   @param y_step Y plane step
+   @param u_data source image data (U plane)
+   @param u_step Y plane step
+   @param v_data source image data (V plane)
+   @param v_step Y plane step
+   @param dst_data destination image data
+   @param dst_step destination image step
+   @param dst_width destination image width
+   @param dst_height destination image height
+   @param dcn destination image channels (3 or 4)
+   @param swapBlue if set to true B and R destination channels will be swapped (write RGB)
+   Convert from YUV (YUV420p (or YV12/YV21) - Y plane followed by U and V planes) to BGR, RGB, BGRA or RGBA.
+   Only for CV_8U.
+   Y : [16, 235]; Cb, Cr: [16, 240] centered at 128
+ */
+inline int hal_ni_cvtThreePlaneYUVtoBGR(const uchar * y_data, size_t y_step, const uchar * u_data, size_t u_step, const uchar * v_data, size_t v_step, uchar * dst_data, size_t dst_step, int dst_width, int dst_height, int dcn, bool swapBlue) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+
+/**
    @brief hal_cvtBGRtoThreePlaneYUV
    @param src_data source image data
    @param src_step source image step

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1736,6 +1736,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
 
     if (!useSwscale && (
         (sw_picture->format == AV_PIX_FMT_YUV420P && result_format == AV_PIX_FMT_BGR24) ||
+        (sw_picture->format == AV_PIX_FMT_YUVJ420P && result_format == AV_PIX_FMT_BGR24) ||
         (sw_picture->format == AV_PIX_FMT_NV12 && (result_format == AV_PIX_FMT_BGR24 || result_format == AV_PIX_FMT_GRAY8))
     ))
     {
@@ -1752,7 +1753,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
             frame.width = video_st->CV_FFMPEG_CODEC_FIELD->width;
             frame.height = video_st->CV_FFMPEG_CODEC_FIELD->height;
         }
-        if (sw_picture->format == AV_PIX_FMT_YUV420P)
+        if (sw_picture->format == AV_PIX_FMT_YUV420P || sw_picture->format == AV_PIX_FMT_YUVJ420P)
         {
             hal::cvtThreePlaneYUVtoBGR(sw_picture->data[0], sw_picture->linesize[0],
                                        sw_picture->data[1], sw_picture->linesize[1],


### PR DESCRIPTION
### Pull Request Readiness Checklist

Test code that reads every frame with FFMpeg from 1600x900 1 hour mp4 video:

* using CPU:
total time: 45.6 seconds -> 30.6 seconds

* using GPU HW acceleration
total time: 232 seconds -> 69 seconds

  HW utilization with sws_scale:
  ```
  Device 0 [NVIDIA GeForce RTX 4090] PCIe GEN 4@16x RX: 54.54 MiB/s TX: 869.8 MiB/s
  GPU 2805MHz MEM 10501MH TEMP  34°C FAN  32% POW 109 / 480 W
  GPU[||                        7%] MEM[|          0.905Gi/23.988Gi] DEC[|||   29%]
  ```

  HW utilization with cvtColor:
  ```
  Device 0 [NVIDIA GeForce RTX 4090] PCIe GEN 4@16x RX: 46.44 MiB/s TX: 2.885 GiB/s
  GPU 2805MHz MEM 10501MH TEMP  34°C FAN  32% POW 107 / 480 W
  GPU[||||||                   21%] MEM[|          0.905Gi/23.988Gi] DEC[|||||100%]
  ```

```python
import time
import numpy as np
import os
import cv2 as cv

os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = "hwaccel;cuvid|video_codec;h264_cuvid|vsync;0"

start = time.time()
cap = cv.VideoCapture("test.mp4", cv.CAP_FFMPEG)
assert(cap.isOpened())
while True:
    has_frame, frame = cap.read()
    if not has_frame:
        break
print(time.time() - start)

```

```
$ ffprobe -i test.mp4

ffprobe version n7.0.3 Copyright (c) 2007-2025 the FFmpeg developers
  built with gcc 13 (Ubuntu 13.2.0-23ubuntu4)
  configuration: --enable-nonfree --enable-cuda-nvcc --enable-libnpp --enable-nvdec --enable-swresample --extra-cflags=-I/usr/local/cuda/include --extra-ldflags=-L/usr/local/cuda/lib64 --disable-static --enable-shared
  libavutil      59.  8.100 / 59.  8.100
  libavcodec     61.  3.100 / 61.  3.100
  libavformat    61.  1.100 / 61.  1.100
  libavdevice    61.  1.100 / 61.  1.100
  libavfilter    10.  1.100 / 10.  1.100
  libswscale      8.  1.100 /  8.  1.100
  libswresample   5.  1.100 /  5.  1.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'test.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf60.3.100
  Duration: 00:55:27.48, start: 0.000000, bitrate: 199 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1600x900, 126 kb/s, 25 fps, 25 tbr, 12800 tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
        encoder         : Lavc60.3.100 libx264
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 66 kb/s (default)
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
```

resolves #21969

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
