### PR TITLE
videoio: add missing CV_OVERRIDE to VideoCapture_DShow::isOpened()

### DIFF
--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -30,7 +30,7 @@ public:
     virtual bool grabFrame() CV_OVERRIDE;
     virtual bool retrieveFrame(int outputType, OutputArray frame) CV_OVERRIDE;
     virtual int getCaptureDomain() CV_OVERRIDE;
-    virtual bool isOpened() const;
+    virtual bool isOpened() const CV_OVERRIDE;
 protected:
     void open(int index);
     void close();


### PR DESCRIPTION
This aligns with other virtual method declarations in cap_dshow.hpp and silences compiler warnings (-Wsuggest-override) while improving compile-time safety.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
