### PR TITLE
Added source comments to mark TSAN false positives

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3500,8 +3500,10 @@ struct Kernel::Impl
 
     void addUMat(const UMat& m, bool dst)
     {
+        // TSAN false positive: see #27638
         CV_Assert(nu < MAX_ARRS && m.u && m.u->urefcount > 0);
         u[nu] = m.u;
+        // TSAN false positive: see #27638
         CV_XADD(&m.u->urefcount, 1);
         nu++;
         if(dst && m.u->tempUMat())
@@ -5670,6 +5672,7 @@ public:
         if(!u)
             return;
 
+        // Next two lines: TSAN false positive: see #27638
         CV_Assert(u->urefcount == 0);
         CV_Assert(u->refcount == 0 && "UMat deallocation error: some derived Mat is still alive");
 
@@ -6602,11 +6605,13 @@ public:
 
     void flushCleanupQueue() const
     {
+        // TSAN false positive: see #27638
         if (!cleanupQueue.empty())
         {
             std::deque<UMatData*> q;
             {
                 cv::AutoLock lock(cleanupQueueMutex);
+                // TSAN false positive: see #27638
                 q.swap(cleanupQueue);
             }
             for (std::deque<UMatData*>::const_iterator i = q.begin(); i != q.end(); ++i)


### PR DESCRIPTION
See: #27638

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
