### PR TITLE
Fixed duplicate declaration issue in Swift/ObjC bindings

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1113,7 +1113,7 @@ public:
     CV_WRAP Subdiv2D(Rect rect);
 
     /** @overload */
-    CV_WRAP Subdiv2D(Rect2f rect);
+    CV_WRAP_AS(Subdiv2D2f) Subdiv2D(Rect2f rect);
 
     /** @overload
 
@@ -1131,7 +1131,7 @@ public:
     @param rect Rectangle that includes all of the 2d points that are to be added to the subdivision.
 
      */
-    CV_WRAP void initDelaunay(Rect2f rect);
+    CV_WRAP_AS(initDelaunay2f) CV_WRAP void initDelaunay(Rect2f rect);
 
     /** @brief Insert a single point into a Delaunay triangulation.
 


### PR DESCRIPTION
Fixed regression:

```
 /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/opencv2.h:80:9: note: in file included from /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/opencv2.h:80:
  #import <opencv2/Subdiv2D.h>
          ^
  /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/Subdiv2D.h:94:1: error: duplicate declaration of method 'initWithRect:'
  - (instancetype)initWithRect:(Rect2f*)rect;
  ^
  /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/Subdiv2D.h:88:1: note: previous declaration is here
  - (instancetype)initWithRect:(Rect2i*)rect;
  ^
  <module-includes>:1:9: note: in file included from <module-includes>:1:
  #import "Headers/opencv2.h"
          ^
  /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/opencv2.h:80:9: note: in file included from /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/opencv2.h:80:
  #import <opencv2/Subdiv2D.h>
          ^
  /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/Subdiv2D.h:120:1: error: duplicate declaration of method 'initDelaunay:'
  - (void)initDelaunay:(Rect2f*)rect NS_SWIFT_NAME(initDelaunay(rect:));
  ^
  /Users/opencv-cn/GHA-OCV-1/_work/opencv/opencv/ios/build/build-armv7-iphoneos/lib/Release/opencv2.framework/Headers/Subdiv2D.h:107:1: note: previous declaration is here
  - (void)initDelaunay:(Rect2i*)rect NS_SWIFT_NAME(initDelaunay(rect:));
```

Introduced in https://github.com/opencv/opencv/pull/27641

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
