### PR TITLE
Fixed logical error in camera calibration tutorial.

### DIFF
--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -647,7 +647,7 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
     {
         objectPoints[0][s.boardSize.width - 2].x = objectPoints[0][0].x + grid_width;
     }
-    else if (s.calibrationPattern != Settings::Pattern::CHESSBOARD)
+    else if (s.calibrationPattern == Settings::Pattern::CHESSBOARD)
     {
         objectPoints[0][s.boardSize.width - 1].x = objectPoints[0][0].x + grid_width;
     }


### PR DESCRIPTION
My mistake. Regression was introduced in https://github.com/opencv/opencv/pull/27571

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
