### PR TITLE
videoio: replace deprecated ffmpeg funtions

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -685,7 +685,7 @@ void CvCapture_FFMPEG::close()
     if( video_st )
     {
 #ifdef CV_FFMPEG_CODECPAR
-        avcodec_close( context );
+        avcodec_free_context(&context);
 #endif
         video_st = NULL;
     }
@@ -2005,7 +2005,7 @@ void CvCapture_FFMPEG::get_rotation_angle()
     rotation_angle = 0;
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(57, 68, 100)
     const uint8_t *data = 0;
-    data = av_stream_get_side_data(video_st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
+    data = av_packet_get_side_data(&packet, AV_PKT_DATA_DISPLAYMATRIX, NULL);
     if (data)
     {
         rotation_angle = -cvRound(av_display_rotation_get((const int32_t*)data));
@@ -2773,7 +2773,7 @@ void CvVideoWriter_FFMPEG::close()
 #else
     /* close codec */
     if (context)  // fixed after https://github.com/FFmpeg/FFmpeg/commit/3e1f507f3e8f16b716aa115552d243b48ae809bd
-        avcodec_close(context);
+        avcodec_free_context(&context);
     context = NULL;
 #endif
 


### PR DESCRIPTION
FFMPEG 8 has removed avcodec_close and av_stream_get_side_data. We should replace them with non-deprecated functions such as avcodec_free_context and av_packet_get_side_data respectively.

Currently opencv is not building with FFMPEG 8 (pre-release). This patch attempts at fixing them.

Closes: https://github.com/opencv/opencv/issues/27688

I'm open to recommendation and feedback.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
