### PR TITLE
Fix loop counter type in scalarToRawData_

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -57,11 +57,12 @@ namespace cv
 template <typename T> static inline
 void scalarToRawData_(const Scalar& s, T * const buf, const int cn, const int unroll_to)
 {
-    int i = 0;
-    for(; i < cn; i++)
-        buf[i] = saturate_cast<T>(s.val[i]);
-    for(; i < unroll_to; i++)
-        buf[i] = buf[i-cn];
+   for(size_t i = 0; i < (size_t)cn; i++)
+    buf[i] = saturate_cast<T>(s.val[i]);
+
+    for(size_t i = cn; i < (size_t)unroll_to; i++)
+     buf[i] = buf[i - cn];
+
 }
 
 void scalarToRawData(const Scalar& s, void* _buf, int type, int unroll_to)


### PR DESCRIPTION
Replaced `int` with `size_t` for the loop counter in scalarToRawData_ to avoid signed/unsigned comparison warnings. 
This makes the code safer when working with large buffer sizes.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
