### PR TITLE
Avoid compiling FP16 intrinsic while using MSVC

### DIFF
--- a/modules/core/include/opencv2/core/cv_cpu_helper.h
+++ b/modules/core/include/opencv2/core/cv_cpu_helper.h
@@ -441,7 +441,7 @@
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_NEON_DOTPROD(fn, args, mode, ...)  CV_CPU_CALL_NEON_DOTPROD(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
 
-#if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON_FP16
+#if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON_FP16 && !defined(_MSC_VER)
 #  define CV_TRY_NEON_FP16 1
 #  define CV_CPU_FORCE_NEON_FP16 1
 #  define CV_CPU_HAS_SUPPORT_NEON_FP16 1


### PR DESCRIPTION
Hi OpenCV Dev!

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
* I am currently working on supporting OpenCV-python wheels for Windows on ARM devices by using MSVC toolchain.
* Currently, MSVC doesn't supports all dispatch features supported by OpenCV(Supports only NEON). Dispatch features like Dotproduct, FP16 and BF16 are not supported by MSVC. Kindly refer to MSVC [docs](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170).
* Even the CMAKE system disables these dispatch features by default, somehow the fp16 intrinsic code under  `conv_winograd_f63.simd.hpp` is getting compiled and causing build issues for OpenCV-python. 
* Adding guard to the fp16 block, compiles OpenCV-python successfully. 

Suggestions are always welcome!

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
