### PR TITLE
HOG: stay on fast-path by using INTER_LINEAR resize when ALGO_HINT_APPROX is defined

### DIFF
--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -1668,9 +1668,16 @@ public:
             Size sz(cvRound(img.cols/scale), cvRound(img.rows/scale));
             Mat smallerImg(sz, img.type(), smallerImgBuf.ptr());
             if( sz == img.size() )
+            {
                 smallerImg = Mat(sz, img.type(), img.data, img.step);
+            }
             else
-                resize(img, smallerImg, sz, 0, 0, INTER_LINEAR_EXACT);
+            {
+                if(getDefaultAlgorithmHint() == ALGO_HINT_APPROX)
+                    resize(img, smallerImg, sz, 0, 0, INTER_LINEAR);
+                else
+                    resize(img, smallerImg, sz, 0, 0, INTER_LINEAR_EXACT);
+            }
             hog->detect(smallerImg, locations, hitsWeights, hitThreshold, winStride, padding);
             Size scaledWinSize = Size(cvRound(hog->winSize.width*scale), cvRound(hog->winSize.height*scale));
 


### PR DESCRIPTION
#22772 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
