### PR TITLE
Add Java wrapper support for List<List<MatShape>>

### DIFF
--- a/modules/dnn/misc/java/gen_dict.json
+++ b/modules/dnn/misc/java/gen_dict.json
@@ -11,11 +11,20 @@
         },
         "vector_MatShape": {
             "j_type": "List<MatOfInt>",
-            "jn_type": "List<MatOfInt>",
-            "jni_type": "jobject",
+            "jn_type": "long",
+            "jni_type": "jlong",
             "jni_var": "std::vector< MatShape > %(n)s",
-            "suffix": "Ljava_util_List",
-            "v_type": "vector_MatShape",
+            "suffix": "J",
+            "v_type": "Mat",
+            "j_import": "org.opencv.core.MatOfInt"
+        },
+        "vector_vector_MatShape": {
+            "j_type": "List<List<MatOfInt>>",
+            "jn_type": "long",
+            "jni_type": "jlong",
+            "jni_var": "std::vector< std::vector<MatShape> > %(n)s",
+            "suffix": "J",
+            "v_type": "vector_Mat",
             "j_import": "org.opencv.core.MatOfInt"
         },
         "vector_size_t": {

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
@@ -22,7 +22,11 @@ void Mat_to_MatShape(cv::Mat& mat, MatShape& matshape);
 
 void MatShape_to_Mat(MatShape& matshape, cv::Mat& mat);
 
-std::vector<MatShape> List_to_vector_MatShape(JNIEnv* env, jobject list);
+void Mat_to_vector_MatShape(cv::Mat& mat, std::vector<MatShape>& v_matshape);
+void vector_MatShape_to_Mat(std::vector<MatShape>& v_matshape, cv::Mat& mat);
+
+void Mat_to_vector_vector_MatShape(cv::Mat& mat, std::vector< std::vector< MatShape > >& vv_matshape);
+void vector_vector_MatShape_to_Mat(std::vector< std::vector< MatShape > >& vv_matshape, cv::Mat& mat);
 
 jobject vector_Ptr_Layer_to_List(JNIEnv* env, std::vector<cv::Ptr<cv::dnn::Layer> >& vs);
 

--- a/modules/dnn/misc/java/test/DnnListRegressionTest.java
+++ b/modules/dnn/misc/java/test/DnnListRegressionTest.java
@@ -116,4 +116,36 @@ public class DnnListRegressionTest extends OpenCVTestCase {
             fail("Net getFLOPS failed: " + e.getMessage());
         }
     }
+
+    public void testGetLayersShapes() {
+        List<MatOfInt> netInputShapes = new ArrayList();
+        netInputShapes.add(new MatOfInt(1, 3, 224, 224));
+
+        MatOfInt layersIds = new MatOfInt();
+        List<List<MatOfInt>> inLayersShapes = new ArrayList();
+        List<List<MatOfInt>> outLayersShapes = new ArrayList();
+        try {
+            net.getLayersShapes(netInputShapes, layersIds, inLayersShapes, outLayersShapes);
+
+            assertEquals(layersIds.total(), inLayersShapes.size());
+            assertEquals(layersIds.total(), outLayersShapes.size());
+
+            // Layer ID for "conv2d0_pre_relu/conv"
+            int layerId = 1;
+
+            MatOfInt expectedInShape = new MatOfInt(1, 3, 224, 224);
+            MatOfInt expectedOutShape = new MatOfInt(1, 64, 112, 112);
+
+            // Test inLayersShapes
+            MatOfInt actualInShape = inLayersShapes.get(layerId).get(0);
+            assertMatEqual(expectedInShape, actualInShape);
+
+            // Test outLayersShapes
+            MatOfInt actualOutShape = outLayersShapes.get(layerId).get(0);
+            assertMatEqual(expectedOutShape, actualOutShape);
+
+        } catch(Exception e) {
+            fail("Net getLayersShapes failed: " + e.getMessage());
+        }
+    }
 }

--- a/modules/java/generator/src/java/org/opencv/utils/Converters.java
+++ b/modules/java/generator/src/java/org/opencv/utils/Converters.java
@@ -7,6 +7,7 @@ import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
 import org.opencv.core.MatOfDMatch;
+import org.opencv.core.MatOfInt;
 import org.opencv.core.MatOfKeyPoint;
 import org.opencv.core.MatOfPoint;
 import org.opencv.core.MatOfPoint2f;
@@ -837,5 +838,76 @@ public class Converters {
         for (int i = 0; i < count; i++) {
             rs.add(new RotatedRect(new Point(buff[5 * i], buff[5 * i + 1]), new Size(buff[5 * i + 2], buff[5 * i + 3]), buff[5 * i + 4]));
         }
+    }
+
+    // vector_MatShape
+    public static Mat vector_MatShape_to_Mat(List<MatOfInt> matOfInts) {
+        Mat res;
+        int count = (matOfInts != null) ? matOfInts.size() : 0;
+        if (count > 0) {
+            res = new Mat(count, 1, CvType.CV_32SC2);
+            int[] buff = new int[count * 2];
+            for (int i = 0; i < count; i++) {
+                long addr = matOfInts.get(i).nativeObj;
+                buff[i * 2] = (int) (addr >> 32);
+                buff[i * 2 + 1] = (int) (addr & 0xffffffff);
+            }
+            res.put(0, 0, buff);
+        } else {
+            res = new Mat();
+        }
+        return res;
+    }
+
+    public static void Mat_to_vector_MatShape(Mat m, List<MatOfInt> matOfInts) {
+        if (matOfInts == null)
+            throw new IllegalArgumentException("matOfInts == null");
+        int count = m.rows();
+        if (CvType.CV_32SC2 != m.type() || m.cols() != 1)
+            throw new IllegalArgumentException(
+                    "CvType.CV_32SC2 != m.type() ||  m.cols()!=1\n" + m);
+
+        matOfInts.clear();
+        int[] buff = new int[count * 2];
+        m.get(0, 0, buff);
+        for (int i = 0; i < count; i++) {
+            long addr = (((long) buff[i * 2]) << 32) | (((long) buff[i * 2 + 1]) & 0xffffffffL);
+            matOfInts.add(MatOfInt.fromNativeAddr(addr));
+        }
+    }
+
+    // vector_vector_MatShape
+    public static Mat vector_vector_MatShape_to_Mat(List<List<MatOfInt>> vecMatOfInts, List<Mat> mats) {
+        Mat res;
+        int lCount = (vecMatOfInts != null) ? vecMatOfInts.size() : 0;
+        if (lCount > 0) {
+            for (List<MatOfInt> matList : vecMatOfInts) {
+                Mat mat = vector_MatShape_to_Mat(matList);
+                mats.add(mat);
+            }
+            res = vector_Mat_to_Mat(mats);
+        } else {
+            res = new Mat();
+        }
+        return res;
+    }
+
+    public static void Mat_to_vector_vector_MatShape(Mat m, List<List<MatOfInt>> vecMatOfInts) {
+        if (vecMatOfInts == null)
+            throw new IllegalArgumentException("Output List can't be null");
+
+        if (m == null)
+            throw new IllegalArgumentException("Input Mat can't be null");
+
+        vecMatOfInts.clear();
+        List<Mat> mats = new ArrayList<Mat>(m.rows());
+        Mat_to_vector_Mat(m, mats);
+        for (Mat mi : mats) {
+            List<MatOfInt> rowList = new ArrayList<MatOfInt>(mi.rows());
+            Mat_to_vector_MatShape(mi, rowList);
+            vecMatOfInts.add(rowList);
+            mi.release();
+        }
+        mats.clear();
     }
 }


### PR DESCRIPTION
- Added vector_MatShape and vector_vector_MatShape to gen_dict.json
- Implemented MatShape_to_vector_MatShape, vector_MatShape_to_MatShape, MatShape_to_vector_vector_MatShape, and vector_vector_MatShape_to_MatShape conversion functions in dnn_converters.h/cpp and Converters.java
- Added testGetLayersShapes test to verify List<List<MatShape>> conversion

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
