### PR TITLE
Fixed Subdiv2D constructor overload.

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1113,7 +1113,7 @@ public:
     CV_WRAP Subdiv2D(Rect rect);
 
     /** @overload */
-    CV_WRAP_AS(Subdiv2D2f) Subdiv2D(Rect2f rect);
+    CV_WRAP Subdiv2D(Rect2f rect2f);
 
     /** @overload
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
