### PR TITLE
Set limitation to IPP Bilateral Filter tiles number to avoid too small tiles

### DIFF
--- a/modules/imgproc/src/bilateral_filter.dispatch.cpp
+++ b/modules/imgproc/src/bilateral_filter.dispatch.cpp
@@ -412,13 +412,14 @@ static bool ipp_bilateralFilter(Mat &src, Mat &dst, int d, double sigmaColor, do
 
             // Tile height can't be smaller than the radius.
             // Otherwise, the second tile has mixed top border (pixels from both
-            // inmem and outside should be used), which is not supported in IPP
+            // inmem and outside should be used), which is not supported in IPP.
             int maxTiles = (int)iwDst.m_size.height / radius;
-            int tiles = threads * 4;
-            if (tiles > maxTiles) {
-                tiles = (maxTiles / threads) * threads;
+            int numTiles = threads * 4;
+            if (numTiles > maxTiles) {
+                // Keep the tiles number as multiple of threads for the better workload balance.
+                numTiles = (maxTiles / threads) * threads;
             }
-            parallel_for_(range, invoker, tiles);
+            parallel_for_(range, invoker, numTiles);
 
             if(!ok)
                 return false;


### PR DESCRIPTION
### Pull Request Readiness Checklist

This PR fixes the following issue in Bilateral Filter tiling in IPP integration: image ROI can't be closer to the image border than the filter window radius. This issue shows itself during separation of the image to tiles for multithreaded processing. If the tile size small enough, the second tile is closer to the upper image border than the bilateral filter radius, which leads to the incorrect result. To fix this, we need a limitation to the tile size - done in this PR.

_Note: red build status looks like unrelated to the current change_

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
