### PR TITLE
Fix/string property binding

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -914,7 +914,7 @@ class JSWrapperGenerator(object):
 
 
 
-            # Generate bindings for properties
+            # Generate bindings for properties(prop)
             for prop in class_info.props:
                 if prop.tp in type_dict and not self._is_string_type(prop.tp):
                     _class_property = class_property_enum_template


### PR DESCRIPTION
##This PR fixes the binding generation logic in embindgen.py to correctly handle enum and string properties:

Enum properties now use binding_utils::underlying_ptr(&Class::property).

Standard string properties are bound directly with &Class::property.

Other properties continue to use the default template.

Fixes the issue on : (#27712 )

Testing:

Verified generated bindings locally to ensure the expected output for enums and strings.


