### PR TITLE
Remove useless variables from fitEllipse tests

### DIFF
--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -64,13 +64,11 @@ TEST(Imgproc_FitEllipse_Issue_6544, accuracy) {
 
 TEST(Imgproc_FitEllipse_Issue_10270, accuracy) {
     vector<Point2f> pts;
-    float scale = 1;
-    Point2f shift(0, 0);
-    pts.push_back(Point2f(0, 1)*scale+shift);
-    pts.push_back(Point2f(0, 2)*scale+shift);
-    pts.push_back(Point2f(0, 3)*scale+shift);
-    pts.push_back(Point2f(2, 3)*scale+shift);
-    pts.push_back(Point2f(0, 4)*scale+shift);
+    pts.push_back(Point2f(0, 1));
+    pts.push_back(Point2f(0, 2));
+    pts.push_back(Point2f(0, 3));
+    pts.push_back(Point2f(2, 3));
+    pts.push_back(Point2f(0, 4));
 
     // check that we get almost vertical ellipse centered around (1, 3)
     RotatedRect e = fitEllipse(pts);
@@ -82,13 +80,11 @@ TEST(Imgproc_FitEllipse_Issue_10270, accuracy) {
 
 TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
     vector<Point2f> pts;
-    float scale = 1;
-    Point2f shift(0, 0);
-    pts.push_back(Point2f(0, 0)*scale+shift);
-    pts.push_back(Point2f(1, 1)*scale+shift);
-    pts.push_back(Point2f(-1, 1)*scale+shift);
-    pts.push_back(Point2f(-1, -1)*scale+shift);
-    pts.push_back(Point2f(1, -1)*scale+shift);
+    pts.push_back(Point2f(0, 0));
+    pts.push_back(Point2f(1, 1));
+    pts.push_back(Point2f(-1, 1));
+    pts.push_back(Point2f(-1, -1));
+    pts.push_back(Point2f(1, -1));
 
     // check that we get almost circle centered around (0, 0)
     RotatedRect e = fitEllipse(pts);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
