### PR TITLE
Add Python sample utility imread_url for loading images from URLs

### DIFF
--- a/samples/python/common.py
+++ b/samples/python/common.py
@@ -14,6 +14,10 @@ if PY3:
 
 import numpy as np
 import cv2 as cv
+import io
+import urllib.request
+import urllib.parse
+from typing import Optional, Sequence
 
 # built-in modules
 import os
@@ -235,3 +239,91 @@ def draw_keypoints(vis, keypoints, color = (0, 255, 255)):
     for kp in keypoints:
         x, y = kp.pt
         cv.circle(vis, (int(x), int(y)), 2, color)
+
+def imread_url(
+    url: str,
+    flags: int = cv.IMREAD_COLOR,
+    *,
+    timeout: float = 10.0,
+    max_bytes: int = 32 * 1024 * 1024,        # 32 MB safety cap
+    allowed_schemes: Sequence[str] = ("http", "https", "file"),
+    require_image_mime: bool = True,
+    accept_mimes: Sequence[str] = ("image/",),  # prefixes; e.g. "image/png"
+) -> Optional[np.ndarray]:
+    """
+    Fetch an image from a URL and decode it with OpenCV.
+
+    - Timeouts, size caps, MIME checks for robustness.
+    - Returns None on any failure (mirrors cv.imread semantics).
+    - Supports http/https and file:// (useful for tests/CI).
+
+    Parameters
+    ----------
+    url : str
+    flags : int
+        cv.imread flags, e.g., IMREAD_COLOR / GRAYSCALE / UNCHANGED.
+    timeout : float
+        Network timeout in seconds.
+    max_bytes : int
+        Upper bound on bytes to read; protects against huge downloads.
+    allowed_schemes : Sequence[str]
+        Allowed URL schemes; defaults to ("http", "https", "file").
+    require_image_mime : bool
+        If True, enforce Content-Type starts with any `accept_mimes`.
+    accept_mimes : Sequence[str]
+        Acceptable MIME prefixes.
+
+    Returns
+    -------
+    numpy.ndarray or None
+    """
+    try:
+        scheme = urllib.parse.urlparse(url).scheme.lower()
+        if scheme not in allowed_schemes:
+            return None
+
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "opencv-sample-imread-url/1.0",
+                "Accept": ",".join(("image/*", "application/octet-stream")),
+            },
+            method="GET",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # MIME guard (skip for file:// where headers may be missing)
+            ctype = resp.headers.get("Content-Type", "")
+            if require_image_mime and scheme != "file":
+                if not any(ctype.startswith(pfx) for pfx in accept_mimes):
+                    return None
+
+            # Size cap guard using Content-Length if present
+            clen = resp.headers.get("Content-Length")
+            if clen is not None:
+                try:
+                    if int(clen) > max_bytes:
+                        return None
+                except ValueError:
+                    pass
+
+            # Stream into BytesIO up to max_bytes
+            buf = io.BytesIO()
+            chunk = 64 * 1024
+            total = 0
+            while True:
+                b = resp.read(chunk)
+                if not b:
+                    break
+                total += len(b)
+                if total > max_bytes:
+                    return None
+                buf.write(b)
+
+        data = np.frombuffer(buf.getbuffer(), dtype=np.uint8)  # zero-copy
+        if data.size == 0:
+            return None
+        img = cv.imdecode(data, flags)
+        return img
+    except Exception:
+        # Be permissive like cv.imread: swallow and return None
+        return None

--- a/samples/python/imread_url.py
+++ b/samples/python/imread_url.py
@@ -1,0 +1,19 @@
+import sys
+import cv2 as cv
+from common import imread_url
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: imread_url.py <image_url>")
+        return
+    url = sys.argv[1]
+    img = imread_url(url, timeout=10.0)
+    if img is None:
+        print("Failed to load image from:", url)
+        return
+    print("Loaded image shape:", img.shape, "dtype:", img.dtype)
+    cv.imshow('URL image', img)
+    cv.waitKey(0)
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/test_imread_file.py
+++ b/samples/python/test_imread_file.py
@@ -1,0 +1,31 @@
+import os
+import cv2 as cv
+from pathlib import Path
+from common import imread_url
+
+def test_imread_url_file_local(tmp_path: Path):
+    # Create a tiny 2x1 PNG locally
+    tiny = (tmp_path / "tiny.png").as_posix()
+    import numpy as np
+    import cv2 as cv
+    img = np.array([[[255,0,0],[0,255,0]]], dtype=np.uint8)  # 1x2 BGR
+    cv.imwrite(tiny, img)
+    url = "file://" + tiny
+    out = imread_url(url, cv.IMREAD_UNCHANGED)
+    assert out is not None and out.shape[:2] == (1, 2)
+
+def test_imread_url_rejects_non_image(monkeypatch, tmp_path: Path):
+    # Serve non-image via file:// to trigger MIME-less path; simulate with bad data
+    bad = (tmp_path / "bad.txt")
+    bad.write_text("<html>not an image</html>")
+    url = "file://" + bad.as_posix()
+    out = imread_url(url)  # will decode to None
+    assert out is None
+
+def test_imread_url_size_cap(tmp_path: Path):
+    # Create a large random file to exceed cap
+    big = (tmp_path / "big.bin")
+    big.write_bytes(b"\x00" * (33 * 1024 * 1024))
+    url = "file://" + big.as_posix()
+    out = imread_url(url, max_bytes=32 * 1024 * 1024)
+    assert out is None


### PR DESCRIPTION
### PR Description

This PR introduces a Python sample helper imread_url (in samples/python/common.py) and a usage demo (samples/python/imread_url.py).
It addresses one of the most common FAQs: users often try cv2.imread("http://...") and receive None. This sample shows the correct approach using urllib + cv2.imdecode.

**Implementation details**

Based on the Python standard library (urllib.request), no external dependencies.

Signature mirrors cv2.imread, returning None on failure.

Supports http://, https://, and file:// schemes (the last one is useful for offline tests).

**Robustness features**

Network timeout (default 10s)

Maximum download size (default 32 MB)

Optional MIME-type filtering (image/*)

Safe exception handling (never raises, always returns None on error)

Efficient decoding: uses np.frombuffer to avoid unnecessary copies.

**Added files**

samples/python/common.py: imread_url helper implementation

samples/python/imread_url.py: CLI demo (python imread_url.py <url>)

samples/python/test_imread_url.py: offline tests using file:// scheme (no network dependency)

**Benefits**

Provides a copy-and-pasteable solution to a very frequent OpenCV Python question.

Keeps the core API clean (not added to cv2, sample only).

Safe against malformed responses, oversized downloads, or non-image URLs.

Tests run fully offline, avoiding CI instability from internet access.

**Future work**

If there is community demand, this could also be documented in the Python tutorials as “How to load images from URLs.”

## Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.  
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV.  
- [x] The PR is proposed to the proper branch (`master`).  
- [ ] There is a reference to the original bug report and related work (FAQ/issue links can be added).  
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (not needed here — this is a sample only).  
- [x] The feature is well documented and sample code builds with the project CMake.  
