### PR TITLE
Replace imread/imwrite with std::filesystem::path versions (fixes #27275)

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -44,6 +44,7 @@
 #define OPENCV_IMGCODECS_HPP
 
 #include "opencv2/core.hpp"
+#include <filesystem>
 
 /**
   @defgroup imgcodecs Image file reading and writing
@@ -364,7 +365,7 @@ Currently, the following file formats are supported:
 @param filename Name of the file to be loaded.
 @param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_COLOR_BGR.
 */
-CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR_BGR );
+CV_EXPORTS_W Mat imread( const std::filesystem::path& filepath, int flags = IMREAD_COLOR_BGR );
 
 /** @brief Loads an image from a file.
 
@@ -375,7 +376,7 @@ This is an overloaded member function, provided for convenience. It differs from
 @note
 The image passing through the img parameter can be pre-allocated. The memory is reused if the shape and the type match with the load image.
  */
-CV_EXPORTS_W void imread( const String& filename, OutputArray dst, int flags = IMREAD_COLOR_BGR );
+CV_EXPORTS_W void imread( const std::filesystem::path& filepath, OutputArray dst, int flags = IMREAD_COLOR_BGR );
 
 /** @brief Reads an image from a file along with associated metadata.
 
@@ -540,7 +541,7 @@ It also demonstrates how to save multiple images in a TIFF file:
 @param img (Mat or vector of Mat) Image or Images to be saved.
 @param params Format-specific parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .) see cv::ImwriteFlags
 */
-CV_EXPORTS_W bool imwrite( const String& filename, InputArray img,
+CV_EXPORTS_W bool imwrite( const std::filesystem::path& filepath, InputArray img,
               const std::vector<int>& params = std::vector<int>());
 
 /** @brief Saves an image to a specified file with metadata

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -750,7 +750,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats, int star
  * @param[in] filename File to load
  * @param[in] flags Flags you wish to set.
 */
-Mat imread( const String& filename, int flags )
+Mat imread( const std::filesystem::path& filepath, int flags )
 {
     CV_TRACE_FUNCTION();
 
@@ -758,7 +758,7 @@ Mat imread( const String& filename, int flags )
     Mat img;
 
     /// load the data
-    imread_( filename, flags, img, nullptr, noArray() );
+    imread_( filepath.string(), flags, img, nullptr, noArray() );
 
     /// return a reference to the data
     return img;
@@ -781,12 +781,12 @@ Mat imreadWithMetadata( const String& filename,
     return img;
 }
 
-void imread( const String& filename, OutputArray dst, int flags )
+void imread( const std::filesystem::path& filepath, OutputArray dst, int flags )
 {
     CV_TRACE_FUNCTION();
 
     /// load the data
-    imread_(filename, flags, dst, nullptr, noArray());
+    imread_(filepath.string(), flags, dst, nullptr, noArray());
 }
 
 /**
@@ -1165,7 +1165,7 @@ static bool imwrite_( const String& filename, const std::vector<Mat>& img_vec,
     return code;
 }
 
-bool imwrite( const String& filename, InputArray _img,
+bool imwrite( const std::filesystem::path& filepath, InputArray _img,
               const std::vector<int>& params )
 {
     CV_TRACE_FUNCTION();
@@ -1179,7 +1179,7 @@ bool imwrite( const String& filename, InputArray _img,
         img_vec.push_back(_img.getMat());
 
     CV_Assert(!img_vec.empty());
-    return imwrite_(filename, img_vec, {}, noArray(), params, false);
+    return imwrite_(filepath.string(), img_vec, {}, noArray(), params, false);
 }
 
 bool imwriteWithMetadata( const String& filename, InputArray _img,

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 #include "test_common.hpp"
+#include <filesystem>
 
 namespace opencv_test { namespace {
 
@@ -617,6 +618,17 @@ TEST(Imgcodecs_Params, imencode_regression_22752)
 //  params.push_back(100)); // Forget it.
     vector<uchar> buf;
     EXPECT_ANY_THROW(cv::imencode("test.jpg", img, buf, params));  // parameters size or missing JPEG codec
+}
+
+TEST(Imgcodecs, read_write_filesystem_path) {
+    std::filesystem::path path = cvtest::TS::ptr()->get_data_path() + "../cv/shared/fruits.png";
+    ASSERT_TRUE(std::filesystem::exists(path)) << "File missing: " << path.string();
+    cv::Mat img = cv::imread(path, cv::IMREAD_COLOR);
+    EXPECT_FALSE(img.empty()) << "Failed to read with std::filesystem::path";
+    std::filesystem::path out_path = "output.png";
+    ASSERT_TRUE(cv::imwrite(out_path, img)) << "Failed to write with std::filesystem::path";
+    ASSERT_TRUE(std::filesystem::exists(out_path)) << "Output file not created";
+    std::filesystem::remove(out_path);
 }
 
 }} // namespace


### PR DESCRIPTION
Fixes #27275: Replaced cv::imread and cv::imwrite with versions using std::filesystem::path.
- Uses std::filesystem::path.string() to delegate to internal string-based logic.
- Added test in modules/imgcodecs/test/test_read_write.cpp (Imgcodecs, read_write_filesystem_path).
- All 707 tests pass on 5.x including all tests from main repo (see attached test_results.txt)
- No opencv_extra patch needed as test uses existing testdata.
- Documentation updates for imread/imwrite can be added if requested by reviewers.

Attached: 
[test_results.txt](https://github.com/user-attachments/files/22061032/test_results.txt)