### PR TITLE
[cuda] Silence unreferenced function with internal linkage has been removed warnings in Windows

### DIFF
--- a/cmake/OpenCVDetectCUDAUtils.cmake
+++ b/cmake/OpenCVDetectCUDAUtils.cmake
@@ -390,6 +390,7 @@ macro(ocv_nvcc_flags)
   endif()
 
   if(WIN32)
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler=/wd4505)
     if (NOT (CUDA_VERSION VERSION_LESS "11.2"))
         set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcudafe --display_error_number --diag-suppress 1394,1388)
     endif()


### PR DESCRIPTION
e.g.
contrib\modules\cudev\include\opencv2\cudev/ptr2d/warping.hpp(86): warning C4505: 'cv::cudev::affineMap': unreferenced function with internal linkage has been removed
contrib\modules\cudev\include\opencv2\cudev/ptr2d/warping.hpp(134): warning C4505: 'cv::cudev::perspectiveMap': unreferenced function with internal linkage has been removed

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
