### PR TITLE
stitching: suppress overloaded-virtual warning for GCC15

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -49,6 +49,13 @@
 
 #include "opencv2/core.hpp"
 
+#if defined(__GNUC__) && __GNUC__ >= 15 && !defined(__clang__)
+// See https://github.com/opencv/opencv/issues/27752
+// GCC 15 warns ExposureCompensator::feed(...) was hidden, but it is false-positive because it is pure virtual function.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 namespace cv {
 namespace detail {
 
@@ -241,5 +248,9 @@ public:
 
 } // namespace detail
 } // namespace cv
+
+#if defined(__GNUC__) && __GNUC__ >= 15 && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif // OPENCV_STITCHING_EXPOSURE_COMPENSATE_HPP


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/27752

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
