### PR TITLE
test: add GaussianBlur unit test with non-square kernel

### DIFF
--- a/modules/imgproc/test/test_smooth_bitexact.cpp
+++ b/modules/imgproc/test/test_smooth_bitexact.cpp
@@ -307,3 +307,14 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, GaussianBlurVsBitexact,
 );
 
 }} // namespace
+
+TEST(GaussianBlur_Bitexact, NonSquareKernel)
+{
+    cv::Mat src(100, 100, CV_8UC1, cv::Scalar(128));
+    cv::Mat dst;
+
+    cv::GaussianBlur(src, dst, cv::Size(7, 3), 1.5, 0.5);
+
+    ASSERT_EQ(src.size(), dst.size());
+    ASSERT_EQ(src.type(), dst.type());
+}


### PR DESCRIPTION
### Summary
Adds a new unit test for GaussianBlur with a non-square kernel (7x3).  
Checks that the output has the same size and type as the input, ensuring correct behavior for rectangular kernels and improving test coverage.

### Test Details
- Input: 100x100 CV_8UC1 matrix filled with a constant value.
- Kernel size: 7x3
- Sigmas: 1.5 (x-direction), 0.5 (y-direction)
- Assertions: output matrix has same size and type as input.

This test complements existing GaussianBlur_Bitexact tests and improves coverage for non-square kernels.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
