### PR TITLE
Resolved waring -Woverloaded-virtual on stitching module building

### DIFF
--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -460,8 +460,9 @@ void ChannelsCompensator::setMatGains(std::vector<Mat>& umv)
 
 
 template<class Compensator>
+
 void BlocksCompensator::feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
-                             const std::vector<std::pair<UMat,uchar> > &masks)
+                             const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE
 {
     CV_Assert(corners.size() == images.size() && images.size() == masks.size());
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work Fixes #27467
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
