### PR TITLE
Use MatShape instead of MatSize inside cv::Mat/cv::UMat

### DIFF
--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -751,7 +751,7 @@ namespace cv {
 
 inline
 Mat::Mat(const cuda::GpuMat& m)
-    : flags(0), dims(0), rows(0), cols(0), data(0), datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&rows)
+    : flags(0), dims(0), rows(0), cols(0), data(0), datastart(0), dataend(0), datalimit(0), allocator(0), u(0)
 {
     m.download(*this);
 }

--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -169,16 +169,22 @@ std::ostream& operator << (std::ostream& out, const Rect_<_Tp>& rect)
     return out << "[" << rect.width << " x " << rect.height << " from (" << rect.x << ", " << rect.y << ")]";
 }
 
-static inline std::ostream& operator << (std::ostream& out, const MatSize& msize)
+static inline std::ostream& operator << (std::ostream& strm, const MatShape& shape)
 {
-    int i, dims = msize.dims();
-    for( i = 0; i < dims; i++ )
-    {
-        out << msize[i];
-        if( i < dims-1 )
-            out << " x ";
+    strm << '[';
+    if (shape.empty()) {
+        strm << "<empty>";
+    } else {
+        size_t n = shape.size();
+        if (n == 0) {
+            strm << "<scalar>";
+        } else {
+            for(size_t i = 0; i < n; ++i)
+                strm << (i > 0 ? " x " : "") << shape[i];
+        }
     }
-    return out;
+    strm << "]";
+    return strm;
 }
 
 static inline std::ostream &operator<< (std::ostream &s, cv::Range &r)

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -148,10 +148,9 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     const int& back() const;
     void push_back(int value);
     void emplace_back(int value);
-    int& operator [](size_t idx);
     const int& operator [](size_t idx) const;
+    int& operator [](size_t idx);
     Size operator()() const; // for compatibility with MatSize
-    operator const int* () const { return p; } // for compatibility with MatSize
 
     CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 
@@ -164,7 +163,6 @@ struct CV_EXPORTS_W_SIMPLE MatShape
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 
-    operator std::vector<int>() const;
     std::string str() const;
 
     int dims;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2744,6 +2744,8 @@ public:
     //! constructs n-dimensional matrix
     UMat(int ndims, const int* sizes, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     UMat(int ndims, const int* sizes, int type, const Scalar& s, UMatUsageFlags usageFlags = USAGE_DEFAULT);
+    UMat(const MatShape& shape, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
+    UMat(const MatShape& shape, int type, const Scalar& s, UMatUsageFlags usageFlags = USAGE_DEFAULT);
 
     //! copy constructor
     UMat(const UMat& m);
@@ -2815,9 +2817,11 @@ public:
     CV_NODISCARD_STD static UMat zeros(int rows, int cols, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat zeros(Size size, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat zeros(int ndims, const int* sz, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
+    CV_NODISCARD_STD static UMat zeros(const MatShape& shape, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat ones(int rows, int cols, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat ones(Size size, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat ones(int ndims, const int* sz, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
+    CV_NODISCARD_STD static UMat ones(const MatShape& shape, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat eye(int rows, int cols, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
     CV_NODISCARD_STD static UMat eye(Size size, int type, UMatUsageFlags usageFlags = USAGE_DEFAULT);
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -163,6 +163,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 
+    std::vector<int> vec() const;
     std::string str() const;
 
     int dims;
@@ -1619,8 +1620,7 @@ public:
     CV_NODISCARD_STD static MatExpr zeros(int ndims, const int* sz, int type);
 
     /** @overload
-    @param ndims Array dimensionality.
-    @param sz Array of integers specifying the array shape.
+    @param shape Array shape.
     @param type Created matrix type.
     */
     CV_NODISCARD_STD static MatExpr zeros(const MatShape& shape, int type);
@@ -1657,8 +1657,7 @@ public:
     CV_NODISCARD_STD static MatExpr ones(int ndims, const int* sz, int type);
 
     /** @overload
-    @param ndims Array dimensionality.
-    @param sz Array of integers specifying the array shape.
+    @param shape Array shape.
     @param type Created matrix type.
     */
     CV_NODISCARD_STD static MatExpr ones(const MatShape& shape, int type);

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -151,6 +151,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     int& operator [](size_t idx);
     const int& operator [](size_t idx) const;
     Size operator()() const; // for compatibility with MatSize
+    operator const int* () const { return p; } // for compatibility with MatSize
 
     CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -150,6 +150,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     void emplace_back(int value);
     int& operator [](size_t idx);
     const int& operator [](size_t idx) const;
+    Size operator()() const; // for compatibility with MatSize
 
     CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 
@@ -723,20 +724,7 @@ struct CV_EXPORTS UMatData
 };
 CV_ENUM_FLAGS(UMatData::MemoryFlag)
 
-
-struct CV_EXPORTS MatSize
-{
-    explicit MatSize(int* _p) CV_NOEXCEPT;
-    int dims() const CV_NOEXCEPT;
-    Size operator()() const;
-    const int& operator[](int i) const;
-    int& operator[](int i);
-    operator const int*() const CV_NOEXCEPT;  // TODO OpenCV 4.0: drop this
-    bool operator == (const MatSize& sz) const CV_NOEXCEPT;
-    bool operator != (const MatSize& sz) const CV_NOEXCEPT;
-
-    int* p;
-};
+typedef MatShape MatSize;
 
 struct CV_EXPORTS MatStep
 {
@@ -746,11 +734,9 @@ struct CV_EXPORTS MatStep
     size_t& operator[](int i) CV_NOEXCEPT;
     operator size_t() const;
     MatStep& operator = (size_t s);
+    void clear();
 
-    size_t* p;
-    size_t buf[3];
-protected:
-    MatStep& operator = (const MatStep&);
+    size_t p[MatShape::MAX_DIMS];
 };
 
 /** @example samples/cpp/cout_mat.cpp

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1618,6 +1618,13 @@ public:
     */
     CV_NODISCARD_STD static MatExpr zeros(int ndims, const int* sz, int type);
 
+    /** @overload
+    @param ndims Array dimensionality.
+    @param sz Array of integers specifying the array shape.
+    @param type Created matrix type.
+    */
+    CV_NODISCARD_STD static MatExpr zeros(const MatShape& shape, int type);
+
     /** @brief Returns an array of all 1's of the specified size and type.
 
     The method returns a Matlab-style 1's array initializer, similarly to Mat::zeros. Note that using
@@ -1648,6 +1655,13 @@ public:
     @param type Created matrix type.
     */
     CV_NODISCARD_STD static MatExpr ones(int ndims, const int* sz, int type);
+
+    /** @overload
+    @param ndims Array dimensionality.
+    @param sz Array of integers specifying the array shape.
+    @param type Created matrix type.
+    */
+    CV_NODISCARD_STD static MatExpr ones(const MatShape& shape, int type);
 
     /** @brief Returns an identity matrix of the specified size and type.
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -94,13 +94,13 @@ inline const int* MatShape::data() const { return p; }
 
 inline int& MatShape::operator [](size_t idx)
 {
-    CV_Assert(idx < (size_t)(dims >= 0 ? dims : 1));
+    CV_Assert(idx < (size_t)(dims > 0 ? dims : 1));
     return p[idx];
 }
 
 inline const int& MatShape::operator [](size_t idx) const
 {
-    CV_Assert(idx < (size_t)(dims >= 0 ? dims : 1));
+    CV_Assert(idx < (size_t)(dims > 0 ? dims : 1));
     return p[idx];
 }
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -104,6 +104,14 @@ inline const int& MatShape::operator [](size_t idx) const
     return p[idx];
 }
 
+inline Size MatShape::operator()() const
+{
+    CV_Assert(dims <= 2);
+    int cols = dims > 0 ? p[dims > 1] : int(dims >= 0);
+    int rows = dims > 1 ? p[0] : int(dims >= 0);
+    return Size(cols, rows);
+}
+
 template<typename _It> inline MatShape::MatShape(_It begin, _It end)
 {
     int buf[MAX_DIMS];
@@ -540,11 +548,11 @@ template<typename _Tp> inline
 Mat::Mat(const std::vector<_Tp>& vec, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(1), rows(1),
       cols((int)vec.size()), data(0), datastart(0), dataend(0), datalimit(0),
-      allocator(0), u(0), size(&cols)
+      allocator(0), u(0), size(1)
 {
-    step.buf[1] = sizeof(_Tp);
-    step.buf[0] = cols*step.buf[1];
-    step.p = &step.buf[1];
+    size[0] = cols;
+    step[1] = sizeof(_Tp);
+    step[0] = cols*step[1];
 
     if(vec.empty())
         return;
@@ -585,11 +593,11 @@ template<typename _Tp, std::size_t _Nm> inline
 Mat::Mat(const std::array<_Tp, _Nm>& arr, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(1), rows(1),
       cols((int)arr.size()), data(0), datastart(0), dataend(0), datalimit(0),
-      allocator(0), u(0), size(&cols), step(0)
+      allocator(0), u(0), size(1), step(0)
 {
-    step.buf[1] = sizeof(_Tp);
-    step.buf[0] = cols*step.buf[1];
-    step.p = &step.buf[1];
+    size[0] = cols;
+    step[1] = sizeof(_Tp);
+    step[0] = cols*step[1];
 
     if(arr.empty())
         return;
@@ -605,13 +613,13 @@ Mat::Mat(const std::array<_Tp, _Nm>& arr, bool copyData)
 template<typename _Tp, int n> inline
 Mat::Mat(const Vec<_Tp, n>& vec, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(1), rows(1), cols(n), data(0),
-      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&cols), step(0)
+      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(1), step(0)
 {
     if( !copyData )
     {
-        step.p = &step.buf[1];
-        step.buf[1] = sizeof(_Tp);
-        step.buf[0] = cols*step.buf[1];
+        size[0] = cols;
+        step[1] = sizeof(_Tp);
+        step[0] = cols*step[1];
         datastart = data = (uchar*)vec.val;
         datalimit = dataend = datastart + cols * step[0];
     }
@@ -623,13 +631,13 @@ Mat::Mat(const Vec<_Tp, n>& vec, bool copyData)
 template<typename _Tp, int m, int n> inline
 Mat::Mat(const Matx<_Tp,m,n>& M, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(2), rows(m), cols(n), data(0),
-      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&rows), step(0)
+      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(1), step(0)
 {
     if( !copyData )
     {
-        step.p = &step.buf[0];
-        step.buf[1] = sizeof(_Tp);
-        step.buf[0] = n*sizeof(_Tp);
+        size[0] = cols;
+        step[1] = sizeof(_Tp);
+        step[0] = n*sizeof(_Tp);
         datastart = data = (uchar*)M.val;
         datalimit = dataend = datastart + rows * step[0];
     }
@@ -640,13 +648,13 @@ Mat::Mat(const Matx<_Tp,m,n>& M, bool copyData)
 template<typename _Tp> inline
 Mat::Mat(const Point_<_Tp>& pt, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(1), rows(1), cols(2), data(0),
-      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&cols), step(0)
+      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(1), step(0)
 {
     if( !copyData )
     {
-        step.p = &step.buf[1];
-        step.buf[1] = sizeof(_Tp);
-        step.buf[0] = cols*step.buf[1];
+        size[0] = cols;
+        step[1] = sizeof(_Tp);
+        step[0] = cols*step[1];
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + cols * step[0];
     }
@@ -661,20 +669,21 @@ Mat::Mat(const Point_<_Tp>& pt, bool copyData)
 
 template<typename _Tp> inline
 Mat::Mat(const Point3_<_Tp>& pt, bool copyData)
-    : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(2), rows(3), cols(1), data(0),
-      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&rows), step(0)
+    : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(1), rows(1), cols(3), data(0),
+      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(1), step(0)
 {
     if( !copyData )
     {
-        step.p = &step.buf[1];
-        step.buf[1] = sizeof(_Tp);
-        step.buf[0] = cols*step.buf[1];
+        size[0] = cols;
+        step[1] = sizeof(_Tp);
+        step[0] = cols*step[1];
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + cols * step[0];
     }
     else
     {
-        create(3, 1, traits::Type<_Tp>::value);
+        int sz = 3;
+        create(1, &sz, traits::Type<_Tp>::value);
         ((_Tp*)data)[0] = pt.x;
         ((_Tp*)data)[1] = pt.y;
         ((_Tp*)data)[2] = pt.z;
@@ -684,7 +693,7 @@ Mat::Mat(const Point3_<_Tp>& pt, bool copyData)
 template<typename _Tp> inline
 Mat::Mat(const MatCommaInitializer_<_Tp>& commaInitializer)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(0), rows(0), cols(0), data(0),
-      datastart(0), dataend(0), allocator(0), u(0), size(&rows)
+      datastart(0), dataend(0), allocator(0), u(0)
 {
     *this = commaInitializer.operator Mat_<_Tp>();
 }
@@ -789,6 +798,12 @@ inline
 int Mat::channels() const
 {
     return CV_MAT_CN(flags);
+}
+
+inline
+MatShape Mat::shape() const
+{
+    return size;
 }
 
 inline
@@ -1093,9 +1108,9 @@ const _Tp& Mat::at(int i0) const
     if( isContinuous() || rows == 1 )
         return ((const _Tp*)data)[i0];
     if( cols == 1 )
-        return *(const _Tp*)(data + step.buf[0] * i0);
+        return *(const _Tp*)(data + step[0] * i0);
     int i = i0 / cols, j = i0 - i * cols;
-    return ((const _Tp*)(data + step.buf[0] * i))[j];
+    return ((const _Tp*)(data + step[0] * i))[j];
 }
 
 template<typename _Tp> inline
@@ -1315,6 +1330,7 @@ void Mat::push_back(const std::vector<_Tp>& v)
 
 ///////////////////////////// MatSize ////////////////////////////
 
+/*
 inline
 MatSize::MatSize(int* _p) CV_NOEXCEPT
     : p(_p) {}
@@ -1364,21 +1380,21 @@ bool MatSize::operator != (const MatSize& sz) const CV_NOEXCEPT
 {
     return !(*this == sz);
 }
-
-
+*/
 
 ///////////////////////////// MatStep ////////////////////////////
 
 inline
 MatStep::MatStep() CV_NOEXCEPT
 {
-    p = buf; p[0] = p[1] = 0; p[2] = 153;
+    clear();
 }
 
 inline
 MatStep::MatStep(size_t s) CV_NOEXCEPT
 {
-    p = buf; p[0] = s; p[1] = 0; p[2] = 153;
+    clear();
+    p[0] = s;
 }
 
 inline
@@ -1395,18 +1411,20 @@ size_t& MatStep::operator[](int i) CV_NOEXCEPT
 
 inline MatStep::operator size_t() const
 {
-    CV_DbgAssert( p == buf || p == buf+1 );
-    return *p;
+    return p[0];
 }
 
 inline MatStep& MatStep::operator = (size_t s)
 {
-    CV_DbgAssert( p == buf || p == buf+1 );
-    *p = s;
+    p[0] = s;
     return *this;
 }
 
-
+inline void MatStep::clear()
+{
+    for (int i = 0; i < MatShape::MAX_DIMS; i++)
+        p[i] = 0;
+}
 
 ////////////////////////////// Mat_<_Tp> ////////////////////////////
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -551,8 +551,7 @@ Mat::Mat(const std::vector<_Tp>& vec, bool copyData)
       allocator(0), u(0), size(1)
 {
     size[0] = cols;
-    step[1] = sizeof(_Tp);
-    step[0] = cols*step[1];
+    step[0] = sizeof(_Tp);
 
     if(vec.empty())
         return;
@@ -596,8 +595,7 @@ Mat::Mat(const std::array<_Tp, _Nm>& arr, bool copyData)
       allocator(0), u(0), size(1), step(0)
 {
     size[0] = cols;
-    step[1] = sizeof(_Tp);
-    step[0] = cols*step[1];
+    step[0] = sizeof(_Tp);
 
     if(arr.empty())
         return;
@@ -618,8 +616,7 @@ Mat::Mat(const Vec<_Tp, n>& vec, bool copyData)
     if( !copyData )
     {
         size[0] = cols;
-        step[1] = sizeof(_Tp);
-        step[0] = cols*step[1];
+        step[0] = sizeof(_Tp);
         datastart = data = (uchar*)vec.val;
         datalimit = dataend = datastart + cols * step[0];
     }
@@ -631,11 +628,12 @@ Mat::Mat(const Vec<_Tp, n>& vec, bool copyData)
 template<typename _Tp, int m, int n> inline
 Mat::Mat(const Matx<_Tp,m,n>& M, bool copyData)
     : flags(+MAGIC_VAL + traits::Type<_Tp>::value + CV_MAT_CONT_FLAG), dims(2), rows(m), cols(n), data(0),
-      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(1), step(0)
+      datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(2), step(0)
 {
     if( !copyData )
     {
-        size[0] = cols;
+        size[1] = cols;
+        size[0] = rows;
         step[1] = sizeof(_Tp);
         step[0] = n*sizeof(_Tp);
         datastart = data = (uchar*)M.val;
@@ -653,8 +651,7 @@ Mat::Mat(const Point_<_Tp>& pt, bool copyData)
     if( !copyData )
     {
         size[0] = cols;
-        step[1] = sizeof(_Tp);
-        step[0] = cols*step[1];
+        step[0] = sizeof(_Tp);
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + cols * step[0];
     }
@@ -675,8 +672,7 @@ Mat::Mat(const Point3_<_Tp>& pt, bool copyData)
     if( !copyData )
     {
         size[0] = cols;
-        step[1] = sizeof(_Tp);
-        step[0] = cols*step[1];
+        step[0] = sizeof(_Tp);
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + cols * step[0];
     }
@@ -1302,6 +1298,10 @@ void Mat::push_back(const _Tp& elem)
     if( !isSubmatrix() && isContinuous() && tmp <= datalimit )
     {
         *(_Tp*)(data + (size.p[0]++) * step.p[0]) = elem;
+        if (dims == 2)
+            rows = size.p[0];
+        else if (dims == 1)
+            cols = size.p[0];
         dataend = tmp;
     }
     else

--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -1623,7 +1623,7 @@ void cv::compare(InputArray _src1, InputArray _src2, OutputArray _dst, int op)
 
     int cn = src1.channels();
 
-    _dst.create(src1.dims, src1.size, CV_8UC(cn));
+    _dst.create(src1.size, CV_8UC(cn));
     src1 = src1.reshape(1); src2 = src2.reshape(1);
     Mat dst = _dst.getMat().reshape(1);
 

--- a/modules/core/src/convert.dispatch.cpp
+++ b/modules/core/src/convert.dispatch.cpp
@@ -164,7 +164,7 @@ void Mat::convertTo(OutputArray dst, int type_, double alpha, double beta) const
     bool allowTransposed = dims == 1 ||
         dst.kind() == _InputArray::STD_VECTOR ||
         (dst.fixedSize() && dst.dims() == 1);
-    dst.create( dims, size, dtype, -1, allowTransposed );
+    dst.create( size, dtype, -1, allowTransposed );
     Mat dstMat = dst.getMat();
 
     if( dims <= 2 )

--- a/modules/core/src/convert_scale.dispatch.cpp
+++ b/modules/core/src/convert_scale.dispatch.cpp
@@ -94,7 +94,7 @@ void convertScaleAbs(InputArray _src, OutputArray _dst, double alpha, double bet
     Mat src = _src.getMat();
     int cn = src.channels();
     double scale[] = {alpha, beta};
-    _dst.create( src.dims, src.size, CV_8UC(cn) );
+    _dst.create( src.size, CV_8UC(cn) );
     Mat dst = _dst.getMat();
     BinaryFunc func = getCvtScaleAbsFunc(src.depth());
     CV_Assert( func != 0 );

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -520,7 +520,7 @@ void Mat::copyTo( OutputArray _dst ) const
         return;
     }
 
-    _dst.create( dims, size, stype );
+    _dst.create( size, stype );
     Mat dst = _dst.getMat();
     if( data == dst.data )
         return;
@@ -595,7 +595,7 @@ void Mat::copyTo( OutputArray _dst, InputArray _mask ) const
     Mat dst;
     {
         Mat dst0 = _dst.getMat();
-        _dst.create(dims, size, type()); // TODO Prohibit 'dst' re-creation, user should pass it explicitly with correct size/type or empty
+        _dst.create(size, type()); // TODO Prohibit 'dst' re-creation, user should pass it explicitly with correct size/type or empty
         dst = _dst.getMat();
 
         if (dst.data != dst0.data) // re-allocation happened

--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -2381,7 +2381,7 @@ static bool ocl_dft(InputArray _src, OutputArray _dst, int flags, int nonzero_ro
         else
         {
             _dst.createSameSize(src, CV_MAKETYPE(depth, 1));
-            output.create(src.dims, src.size, CV_MAKETYPE(depth, 2));
+            output.create(src.size, CV_MAKETYPE(depth, 2));
         }
     }
 

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -155,7 +155,7 @@ void magnitude( InputArray src1, InputArray src2, OutputArray dst )
                ocl_math_op(src1, src2, dst, OCL_OP_MAG))
 
     Mat X = src1.getMat(), Y = src2.getMat();
-    dst.create(X.dims, X.size, X.type());
+    dst.create(X.size, X.type());
     Mat Mag = dst.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Mag, 0};
@@ -191,7 +191,7 @@ void phase( InputArray src1, InputArray src2, OutputArray dst, bool angleInDegre
                ocl_math_op(src1, src2, dst, angleInDegrees ? OCL_OP_PHASE_DEGREES : OCL_OP_PHASE_RADIANS))
 
     Mat X = src1.getMat(), Y = src2.getMat();
-    dst.create( X.dims, X.size, type );
+    dst.create( X.size, type );
     Mat Angle = dst.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Angle, 0};
@@ -288,8 +288,8 @@ void cartToPolar( InputArray src1, InputArray src2,
     Mat X = src1.getMat(), Y = src2.getMat();
     int type = X.type(), depth = X.depth(), cn = X.channels();
     CV_Assert( X.size == Y.size && type == Y.type() && (depth == CV_32F || depth == CV_64F));
-    dst1.create( X.dims, X.size, type );
-    dst2.create( X.dims, X.size, type );
+    dst1.create( X.size, type );
+    dst2.create( X.size, type );
     Mat Mag = dst1.getMat(), Angle = dst2.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Mag, &Angle, 0};
@@ -393,8 +393,8 @@ void polarToCart( InputArray src1, InputArray src2,
 
     Mat Mag = src1.getMat(), Angle = src2.getMat();
     CV_Assert( Mag.empty() || Angle.size == Mag.size);
-    dst1.create( Angle.dims, Angle.size, type );
-    dst2.create( Angle.dims, Angle.size, type );
+    dst1.create( Angle.size, type );
+    dst2.create( Angle.size, type );
     Mat X = dst1.getMat(), Y = dst2.getMat();
 
     const Mat* arrays[] = {&Mag, &Angle, &X, &Y, 0};
@@ -445,7 +445,7 @@ void exp( InputArray _src, OutputArray _dst )
                ocl_math_op(_src, noArray(), _dst, OCL_OP_EXP))
 
     Mat src = _src.getMat();
-    _dst.create( src.dims, src.size, type );
+    _dst.create( src.size, type );
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};
@@ -478,7 +478,7 @@ void log( InputArray _src, OutputArray _dst )
                 ocl_math_op(_src, noArray(), _dst, OCL_OP_LOG))
 
     Mat src = _src.getMat();
-    _dst.create( src.dims, src.size, type );
+    _dst.create( src.size, type );
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};
@@ -1032,7 +1032,7 @@ void pow( InputArray _src, double power, OutputArray _dst )
     CV_OCL_RUN(useOpenCL, ocl_pow(_src, power, _dst, is_ipower, ipower))
 
     Mat src = _src.getMat();
-    _dst.create( src.dims, src.size, type );
+    _dst.create( src.size, type );
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};

--- a/modules/core/src/matmul.dispatch.cpp
+++ b/modules/core/src/matmul.dispatch.cpp
@@ -656,7 +656,7 @@ void scaleAdd(InputArray _src1, double alpha, InputArray _src2, OutputArray _dst
     Mat src1 = _src1.getMat(), src2 = _src2.getMat();
     CV_Assert(src1.size == src2.size);
 
-    _dst.create(src1.dims, src1.size, type);
+    _dst.create(src1.size, type);
     Mat dst = _dst.getMat();
 
     float falpha = (float)alpha;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -191,6 +191,13 @@ size_t MatShape::total() const
     return result;
 }
 
+std::vector<int> MatShape::vec() const
+{
+    if (dims < 0)
+        return std::vector<int>(1, 0);
+    return std::vector<int>(p, p + dims);
+}
+
 std::string MatShape::str() const
 {
     std::stringstream sstrm;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -401,13 +401,6 @@ MatShape MatShape::expand(const MatShape& another) const
     return result;
 }
 
-MatShape::operator std::vector<int>() const
-{
-    if (dims < 0)
-        return std::vector<int>(1, 0);
-    return std::vector<int>(p, p + dims);
-}
-
 /////////////////////////// MatAllocator ////////////////////////////
 
 void MatAllocator::map(UMatData*, AccessFlag) const
@@ -614,7 +607,7 @@ void setSize( Mat& m, int _dims, const int* _sz, const size_t* _steps, bool auto
         size_t autostep = m.size[i+1]*m.step[i+1];
         if (_steps) {
             m.step[i] = _steps[i];
-            CV_Assert(m.step[i] >= autostep);
+            //CV_Assert(m.step[i] >= autostep);
         } else if (autoSteps) {
             m.step[i] = autostep;
         } else {

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1114,7 +1114,7 @@ void Mat::create(int d0, const int* _sizes, int _type)
 
     addref();
     finalizeHdr(*this);
-    dims = d0;
+    size.dims = dims = d0;
 }
 
 void Mat::create(const std::vector<int>& _sizes, int _type)
@@ -1680,6 +1680,8 @@ Mat Mat::reshape(int new_cn, int new_rows) const
         hdr.step[0] = total_width * elemSize1();
     } else {
         hdr.size[0] = hdr.rows = rows;
+        if (dims <= 1)
+            hdr.step[0] = cols * CV_ELEM_SIZE(flags);
     }
 
     int new_width = total_width / new_cn;

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -1679,7 +1679,7 @@ void MatOp_Initializer::assign(const MatExpr& e, Mat& m, int _type) const
     if( _type == -1 )
         _type = e.a.type();
 
-    m.create(e.a.dims, e.a.size, _type);
+    m.create(e.a.size, _type);
 
     if( e.flags == 'I' && e.a.dims <= 2 )
         setIdentity(m, Scalar(e.alpha));

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -1767,6 +1767,15 @@ MatExpr Mat::zeros(int ndims, const int* sizes, int type)
     return e;
 }
 
+MatExpr Mat::zeros(const MatShape& shape, int type)
+{
+    CV_INSTRUMENT_REGION();
+
+    MatExpr e;
+    MatOp_Initializer::makeExpr(e, '0', shape.dims, shape.p, type);
+    return e;
+}
+
 MatExpr Mat::ones(int rows, int cols, int type)
 {
     CV_INSTRUMENT_REGION();
@@ -1791,6 +1800,15 @@ MatExpr Mat::ones(int ndims, const int* sizes, int type)
 
     MatExpr e;
     MatOp_Initializer::makeExpr(e, '1', ndims, sizes, type);
+    return e;
+}
+
+MatExpr Mat::ones(const MatShape& shape, int type)
+{
+    CV_INSTRUMENT_REGION();
+
+    MatExpr e;
+    MatOp_Initializer::makeExpr(e, '1', shape.dims, shape.p, type);
     return e;
 }
 

--- a/modules/core/src/matrix_iterator.cpp
+++ b/modules/core/src/matrix_iterator.cpp
@@ -82,7 +82,7 @@ void NAryMatIterator::init(const Mat** _arrays, Mat* _planes, uchar** _ptrs, int
 
     if( i0 >= 0 )
     {
-        size = arrays[i0]->size[d > 0 ? d-1 : 0];
+        size = arrays[i0]->size[std::max(d-1, 0)];
         for( j = d-1; j > iterdepth; j-- )
         {
             int64 total1 = (int64)size*arrays[i0]->size[j-1];

--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -29,24 +29,8 @@ void cv::swap( Mat& a, Mat& b )
     std::swap(a.allocator, b.allocator);
     std::swap(a.u, b.u);
 
-    std::swap(a.size.p, b.size.p);
-    std::swap(a.step.p, b.step.p);
-    std::swap(a.step.buf[0], b.step.buf[0]);
-    std::swap(a.step.buf[1], b.step.buf[1]);
-
-    if(a.dims <= 2)
-    {
-        int a_1d = a.dims <= 1;
-        a.step.p = &a.step.buf[a_1d];
-        a.size.p = &a.rows + a_1d;
-    }
-
-    if(b.dims <= 2)
-    {
-        int b_1d = b.dims <= 1;
-        b.step.p = &b.step.buf[b_1d];
-        b.size.p = &b.rows + b_1d;
-    }
+    std::swap(a.size, b.size);
+    std::swap(a.step, b.step);
 }
 
 

--- a/modules/core/src/matrix_sparse.cpp
+++ b/modules/core/src/matrix_sparse.cpp
@@ -273,7 +273,7 @@ size_t SparseMat::hash(const int* idx) const
 SparseMat::SparseMat(const Mat& m)
 : flags(MAGIC_VAL), hdr(0)
 {
-    create( m.dims, m.size, m.type() );
+    create( m.dims, m.size.p, m.type() );
 
     int i, idx[CV_MAX_DIM] = {0}, d = m.dims, lastSize = m.size[d - 1];
     size_t esz = m.elemSize();

--- a/modules/core/src/merge.dispatch.cpp
+++ b/modules/core/src/merge.dispatch.cpp
@@ -136,7 +136,7 @@ void merge(const Mat* mv, size_t n, OutputArray _dst)
     }
 
     CV_Assert( 0 < cn && cn <= CV_CN_MAX );
-    _dst.create(mv[0].dims, mv[0].size, CV_MAKETYPE(depth, cn));
+    _dst.create(mv[0].size, CV_MAKETYPE(depth, cn));
     Mat dst = _dst.getMat();
 
     if( n == 1 )

--- a/modules/core/src/split.dispatch.cpp
+++ b/modules/core/src/split.dispatch.cpp
@@ -132,7 +132,7 @@ void split(const Mat& src, Mat* mv)
 
     for( k = 0; k < cn; k++ )
     {
-        mv[k].create(src.dims, src.size, depth);
+        mv[k].create(src.size, depth);
     }
 
     CV_IPP_RUN_FAST(ipp_split(src, mv, cn));

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -469,7 +469,7 @@ void setSize( UMat& m, int _dims, const int* _sz,
         size_t autostep = m.size[i+1]*m.step[i+1];
         if (_steps) {
             m.step[i] = _steps[i];
-            CV_Assert(m.step[i] >= autostep);
+            //CV_Assert(m.step[i] >= autostep);
         } else if (autoSteps) {
             m.step[i] = autostep;
         } else {

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -302,6 +302,19 @@ UMat::UMat(int _dims, const int* _sz, int _type, const Scalar& _s, UMatUsageFlag
     *this = _s;
 }
 
+UMat::UMat(const MatShape& _shape, int _type, UMatUsageFlags _usageFlags)
+: flags(MAGIC_VAL), dims(0), rows(0), cols(0), allocator(0), usageFlags(_usageFlags), u(0), offset(0)
+{
+    create(_shape.dims, _shape.p, _type);
+}
+
+UMat::UMat(const MatShape& _shape, int _type, const Scalar& _s, UMatUsageFlags _usageFlags)
+: flags(MAGIC_VAL), dims(0), rows(0), cols(0), allocator(0), usageFlags(_usageFlags), u(0), offset(0)
+{
+    create(_shape.dims, _shape.p, _type);
+    *this = _s;
+}
+
 UMat::UMat(const UMat& m)
 : flags(m.flags), dims(m.dims), rows(m.rows), cols(m.cols), allocator(m.allocator),
   usageFlags(m.usageFlags), u(m.u), offset(m.offset), size(m.size), step(m.step)
@@ -1377,6 +1390,11 @@ UMat UMat::zeros(int ndims, const int* sz, int type, UMatUsageFlags usageFlags)
     return UMat(ndims, sz, type, Scalar::all(0), usageFlags);
 }
 
+UMat UMat::zeros(const MatShape& shape, int type, UMatUsageFlags usageFlags)
+{
+    return UMat(shape.dims, shape.p, type, Scalar::all(0), usageFlags);
+}
+
 UMat UMat::ones(int rows, int cols, int type, UMatUsageFlags usageFlags)
 {
     return UMat(rows, cols, type, Scalar(1), usageFlags);
@@ -1390,6 +1408,11 @@ UMat UMat::ones(Size size, int type, UMatUsageFlags usageFlags)
 UMat UMat::ones(int ndims, const int* sz, int type, UMatUsageFlags usageFlags)
 {
     return UMat(ndims, sz, type, Scalar(1), usageFlags);
+}
+
+UMat UMat::ones(const MatShape& shape, int type, UMatUsageFlags usageFlags)
+{
+    return UMat(shape.dims, shape.p, type, Scalar(1), usageFlags);
 }
 
 }

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -372,6 +372,7 @@ void UMat::release()
 {
     if( u && CV_XADD(&(u->urefcount), -1) == 1 )
         deallocate();
+    u = 0;
     size.clear();
     dims = cols = rows = 0;
 }

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -654,7 +654,7 @@ void UMat::create(int d0, const int* _sizes, int _type, UMatUsageFlags _usageFla
 
     finalizeHdr(*this);
     addref();
-    dims = d0;
+    size.dims = dims = d0;
 }
 
 void UMat::create(const std::vector<int>& _sizes, int _type, UMatUsageFlags _usageFlags)
@@ -995,6 +995,8 @@ UMat UMat::reshape(int new_cn, int new_rows) const
         hdr.step[0] = total_width * elemSize1();
     } else {
         hdr.size[0] = hdr.rows = rows;
+        if (dims <= 1)
+            hdr.step[0] = cols * CV_ELEM_SIZE(flags);
     }
 
     int new_width = total_width / new_cn;

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -614,7 +614,7 @@ static void inRange(const Mat& src, const Mat& lb, const Mat& rb, Mat& dst)
 {
     CV_Assert( src.type() == lb.type() && src.type() == rb.type() &&
               src.size == lb.size && src.size == rb.size );
-    dst.create( src.dims, &src.size[0], CV_8U );
+    dst.create( src.size, CV_8U );
     const Mat *arrays[]={&src, &lb, &rb, &dst, 0};
     Mat planes[4];
 
@@ -678,7 +678,7 @@ static void inRange(const Mat& src, const Mat& lb, const Mat& rb, Mat& dst)
 
 static void inRangeS(const Mat& src, const Scalar& lb, const Scalar& rb, Mat& dst)
 {
-    dst.create( src.dims, &src.size[0], CV_8U );
+    dst.create( src.size, CV_8U );
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
 
@@ -836,7 +836,7 @@ static void finiteMask_(const _Tp *src, uchar *dst, size_t total, int cn)
 
 static void finiteMask(const Mat& src, Mat& dst)
 {
-    dst.create(src.dims, &src.size[0], CV_8UC1);
+    dst.create(src.size, CV_8UC1);
 
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
@@ -1019,7 +1019,7 @@ namespace reference {
 static void flip(const Mat& src, Mat& dst, int flipcode)
 {
     CV_Assert(src.dims <= 2);
-    dst.createSameSize(src, src.type());
+    dst.create(src.size, src.type());
     int i, j, k, esz = (int)src.elemSize(), width = src.cols*esz;
 
     for( i = 0; i < dst.rows; i++ )
@@ -1191,7 +1191,7 @@ struct SetZeroOp : public BaseElemWiseOp
 namespace reference {
 static void exp(const Mat& src, Mat& dst)
 {
-    dst.create( src.dims, &src.size[0], src.type() );
+    dst.create( src.size, src.type() );
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
 
@@ -1220,7 +1220,7 @@ static void exp(const Mat& src, Mat& dst)
 
 static void log(const Mat& src, Mat& dst)
 {
-    dst.create( src.dims, &src.size[0], src.type() );
+    dst.create( src.size, src.type() );
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
 
@@ -1312,8 +1312,8 @@ static void cartToPolar(const Mat& mx, const Mat& my, Mat& mmag, Mat& mangle, bo
 {
     CV_Assert( (mx.type() == CV_32F || mx.type() == CV_64F) &&
               mx.type() == my.type() && mx.size == my.size );
-    mmag.create( mx.dims, &mx.size[0], mx.type() );
-    mangle.create( mx.dims, &mx.size[0], mx.type() );
+    mmag.create( mx.size, mx.type() );
+    mangle.create( mx.size, mx.type() );
     const Mat *arrays[]={&mx, &my, &mmag, &mangle, 0};
     Mat planes[4];
 
@@ -1380,7 +1380,7 @@ struct CartToPolarToCartOp : public BaseArithmOp
 
         Mat msrc[] = {mag, angle, x, y};
         int pairs[] = {0, 0, 1, 1, 2, 2, 3, 3};
-        dst.create(src[0].dims, src[0].size, CV_MAKETYPE(src[0].depth(), 4));
+        dst.create(src[0].size, CV_MAKETYPE(src[0].depth(), 4));
         cv::mixChannels(msrc, 4, &dst, 1, pairs, 4);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
@@ -1389,7 +1389,7 @@ struct CartToPolarToCartOp : public BaseArithmOp
         reference::cartToPolar(src[0], src[1], mag, angle, angleInDegrees);
         Mat msrc[] = {mag, angle, src[0], src[1]};
         int pairs[] = {0, 0, 1, 1, 2, 2, 3, 3};
-        dst.create(src[0].dims, src[0].size, CV_MAKETYPE(src[0].depth(), 4));
+        dst.create(src[0].size, CV_MAKETYPE(src[0].depth(), 4));
         cv::mixChannels(msrc, 4, &dst, 1, pairs, 4);
     }
     void generateScalars(int, RNG& rng)

--- a/modules/core/test/test_hasnonzero.cpp
+++ b/modules/core/test/test_hasnonzero.cpp
@@ -160,14 +160,14 @@ TEST_P(HasNonZeroNd, hasNonZeroNd)
       std::vector<size_t> steps(ndims);
       std::vector<int> sizes(ndims);
       size_t totalBytes = 1;
-      for(int dim = 0 ; dim<ndims ; ++dim)
+      for(int dim = ndims-1; dim >= 0; --dim)
       {
           const bool isFirstDim = (dim == 0);
           const bool isLastDim = (dim+1 == ndims);
           const int length = rng.uniform(1, 64);
-          steps[dim] = (isLastDim ? 1 : static_cast<size_t>(length))*CV_ELEM_SIZE(type);
+          steps[dim] = isLastDim ? CV_ELEM_SIZE(type) : sizes[dim+1]*steps[dim+1];
           sizes[dim] = (isFirstDim || continuous) ? length : rng.uniform(1, length);
-          totalBytes *= steps[dim]*static_cast<size_t>(sizes[dim]);
+          totalBytes *= steps[dim];
       }
 
       std::vector<unsigned char> buffer(totalBytes);

--- a/modules/core/test/test_hasnonzero.cpp
+++ b/modules/core/test/test_hasnonzero.cpp
@@ -169,14 +169,17 @@ TEST_P(HasNonZeroNd, hasNonZeroNd)
           sizes[dim] = (isFirstDim || continuous) ? length : rng.uniform(1, length);
           totalBytes *= steps[dim];
       }
+      totalBytes *= sizes[0];
 
-      std::vector<unsigned char> buffer(totalBytes);
-      void* data = buffer.data();
+      unsigned char magicval = 153;
+      size_t border = 128;
+      std::vector<unsigned char> buffer(totalBytes+border*2, magicval);
+      void* data = buffer.data() + border;
 
       Mat m = Mat(ndims, sizes.data(), type, data, steps.data());
 
       std::vector<Range> nzRange(ndims);
-      for(int dim = 0 ; dim<ndims ; ++dim)
+      for(int dim = 0; dim < ndims ; ++dim)
       {
         const int pos = rng.uniform(0, sizes[dim]);
         nzRange[dim] = Range(pos, pos+1);
@@ -187,6 +190,10 @@ TEST_P(HasNonZeroNd, hasNonZeroNd)
 
       const int nzCount = countNonZero(m);
       EXPECT_EQ((nzCount>0), hasNonZero(m));
+      for (size_t j = 0; j < border; j++) {
+          ASSERT_EQ(buffer[j], magicval);
+          ASSERT_EQ(buffer[border + totalBytes + j], magicval);
+      }
     }
 }
 

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -131,13 +131,13 @@ protected:
                 static_cast<int>(cvtest::randInt(rng)%10+1),
                 static_cast<int>(cvtest::randInt(rng)%10+1),
             };
-            MatND test_mat_nd(3, sz, CV_MAKETYPE(depth, cn));
+            Mat test_mat_nd(3, sz, CV_MAKETYPE(depth, cn));
 
             rng0.fill(test_mat_nd, RNG::UNIFORM, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
             if( depth >= CV_32F )
             {
                 exp(test_mat_nd, test_mat_nd);
-                MatND test_mat_scale(test_mat_nd.dims, test_mat_nd.size, test_mat_nd.type());
+                Mat test_mat_scale(test_mat_nd.size, test_mat_nd.type());
                 rng0.fill(test_mat_scale, RNG::UNIFORM, Scalar::all(-1), Scalar::all(1));
                 cv::multiply(test_mat_nd, test_mat_scale, test_mat_nd);
             }
@@ -148,8 +148,9 @@ protected:
                 static_cast<int>(cvtest::randInt(rng)%10+1),
                 static_cast<int>(cvtest::randInt(rng)%10+1),
             };
-            SparseMat test_sparse_mat = cvTsGetRandomSparseMat(4, ssz, cvtest::randInt(rng)%(CV_64F+1),
-                                                               cvtest::randInt(rng) % 10000, 0, 100, rng);
+            SparseMat test_sparse_mat =
+                cvTsGetRandomSparseMat(4, ssz, cvtest::randInt(rng)%(CV_64F+1),
+                                       cvtest::randInt(rng) % 10000, 0, 100, rng);
 
             fs << "test_int" << test_int << "test_real" << test_real << "test_string" << test_string;
             fs << "test_mat" << test_mat;

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2411,7 +2411,7 @@ TEST(Mat1D, basic)
     m1.at<uchar>(50) = 10;
     EXPECT_FALSE(m1.empty());
     ASSERT_EQ(1, m1.dims);
-    ASSERT_EQ(1, m1.size.dims());  // hack map on .rows
+    ASSERT_EQ(1, m1.size.dims);  // hack map on .rows
     EXPECT_EQ(Size(100, 1), m1.size());
 
     {

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2598,7 +2598,7 @@ TEST(Mat, Recreate1DMatWithSameMeta)
     cv::Mat m(dims, depth);
 
     // By default m has dims: [1, 100]
-    m.dims = 1;
+    m.size.dims = m.dims = 1;
 
     EXPECT_NO_THROW(m.create(dims, depth));
 }

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -208,24 +208,6 @@ static inline MatShape concat(const MatShape& a, const MatShape& b)
     return c;
 }
 
-static inline std::ostream& operator << (std::ostream& strm, const MatShape& shape)
-{
-    strm << '[';
-    if (shape.empty()) {
-        strm << "<empty>";
-    } else {
-        size_t n = shape.size();
-        if (n == 0) {
-            strm << "<scalar>";
-        } else {
-            for(size_t i = 0; i < n; ++i)
-                strm << (i > 0 ? " x " : "") << shape[i];
-        }
-    }
-    strm << "]";
-    return strm;
-}
-
 static inline std::string toString(const MatShape& shape, const String& name = "")
 {
     std::ostringstream ss;

--- a/modules/dnn/misc/objc/gen_dict.json
+++ b/modules/dnn/misc/objc/gen_dict.json
@@ -26,18 +26,18 @@
         "MatShape": {
             "objc_type": "IntVector*",
             "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
-            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]"
+            "from_cpp": "[IntVector fromNative:%(n)s.vec()]"
         },
         "vector_MatShape": {
             "objc_type": "IntVector*",
             "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
-            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]",
+            "from_cpp": "[IntVector fromNative:%(n)s.vec()]",
             "v_type": "MatShape"
         },
         "vector_vector_MatShape": {
             "objc_type": "IntVector*",
             "to_cpp": "cv::MatShape(%(n)s.nativeRef)",
-            "from_cpp": "[IntVector fromNative:(std::vector<int>)%(n)s]",
+            "from_cpp": "[IntVector fromNative:%(n)s.vec()]",
             "v_v_type": "MatShape"
         },
         "LayerId": {

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -271,7 +271,7 @@ public:
             CV_Assert(pbBlob.data_size() == (int)dstBlob.total());
 
             CV_DbgAssert(pbBlob.GetDescriptor()->FindFieldByLowercaseName("data")->cpp_type() == FieldDescriptor::CPPTYPE_FLOAT);
-            Mat(dstBlob.dims, &dstBlob.size[0], CV_32F, (void*)pbBlob.data().data()).copyTo(dstBlob);
+            Mat(dstBlob.size, CV_32F, (void*)pbBlob.data().data()).copyTo(dstBlob);
         }
         else
         {

--- a/modules/dnn/src/dnn_common.hpp
+++ b/modules/dnn/src/dnn_common.hpp
@@ -147,7 +147,9 @@ static inline std::string toString(const Mat& blob, const std::string& name = st
     else if (blob.dims == 1)
     {
         Mat blob_ = blob;
-        blob_.dims = 2;  // hack
+        blob_.size.dims = blob_.dims = 2;  // hack
+        blob_.size[1] = blob_.size[0];
+        blob_.size[0] = 1;
         ss << blob_.t();
     }
     else

--- a/modules/dnn/src/int8layers/convolution_layer.cpp
+++ b/modules/dnn/src/int8layers/convolution_layer.cpp
@@ -86,7 +86,7 @@ public:
         MatSize weightShape = blobs[0].size;
 
         CV_Assert(inputs[0].dims == outputs[0].dims);
-        if (weightShape.dims() == 3)
+        if (weightShape.dims == 3)
         {
             kernel_size.resize(1, kernel_size[0]);
             strides.resize(1, strides[0]);
@@ -94,7 +94,7 @@ public:
             pads_begin.resize(1, pads_begin[0]);
             pads_end.resize(1, pads_end[0]);
         }
-        CV_Assert(weightShape.dims() == kernel_size.size() + 2);
+        CV_Assert(weightShape.dims == kernel_size.size() + 2);
         for (int i = 0; i < kernel_size.size(); i++) {
             CV_Assert(weightShape[i + 2] == kernel_size[i]);
         }

--- a/modules/dnn/src/layer_internals.hpp
+++ b/modules/dnn/src/layer_internals.hpp
@@ -273,7 +273,7 @@ struct DataLayer : public Layer
                         std::vector<cv::Range> plane(4, Range::all());
                         plane[0] = Range(n, n + 1);
                         plane[1] = Range(c, c + 1);
-                        UMat out = outputs[i](plane).reshape(1, inp.dims, inp.size.p);
+                        UMat out = outputs[i](plane).reshape(1, inp.size);
 
                         if (isFP16)
                         {

--- a/modules/dnn/src/layer_internals.hpp
+++ b/modules/dnn/src/layer_internals.hpp
@@ -273,7 +273,7 @@ struct DataLayer : public Layer
                         std::vector<cv::Range> plane(4, Range::all());
                         plane[0] = Range(n, n + 1);
                         plane[1] = Range(c, c + 1);
-                        UMat out = outputs[i](plane).reshape(1, inp.dims, inp.size);
+                        UMat out = outputs[i](plane).reshape(1, inp.dims, inp.size.p);
 
                         if (isFP16)
                         {

--- a/modules/dnn/src/layers/accum_layer.cpp
+++ b/modules/dnn/src/layers/accum_layer.cpp
@@ -107,7 +107,7 @@ public:
         const int out_h = outputs[0].size[2];
         const int out_w = outputs[0].size[3];
         float* out_data = outputs[0].ptr<float>();
-        std::vector<int> sizes(&outputs[0].size[0], &outputs[0].size[0] + outputs[0].size.dims());
+        std::vector<int> sizes(&outputs[0].size[0], &outputs[0].size[0] + outputs[0].size.dims);
         for (int i = 0; i < inputs.size() - have_reference; i++)
         {
             sizes[1] = inputs[i].size[1];

--- a/modules/dnn/src/layers/bitshift_layer.cpp
+++ b/modules/dnn/src/layers/bitshift_layer.cpp
@@ -29,7 +29,7 @@ static inline T doShift(T inputVal, U shiftVal, int direction, int bitWidth)
 template<typename T, int CvTypeConst, int BitWidth>
 void runBitShift(const Mat& input, const Mat& shift, Mat& output, int direction)
 {
-    output.create(input.dims, input.size.p, input.type());
+    output.create(input.size, input.type());
     const size_t numElements = input.total();
 
     const T* inputPtr = input.ptr<T>();

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -617,7 +617,7 @@ public:
         if (fusedWeights)
         {
             weightsMat.copyTo(weightVK); // to handle the case of isContinuous() == false
-            weightVK = weightVK.reshape(1, blobs[0].dims, blobs[0].size.p);
+            weightVK = weightVK.reshape(1, blobs[0].size);
         }
         else
             weightVK = blobs[0];

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -617,7 +617,7 @@ public:
         if (fusedWeights)
         {
             weightsMat.copyTo(weightVK); // to handle the case of isContinuous() == false
-            weightVK = weightVK.reshape(1, blobs[0].dims, blobs[0].size);
+            weightVK = weightVK.reshape(1, blobs[0].dims, blobs[0].size.p);
         }
         else
             weightVK = blobs[0];

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -252,7 +252,7 @@ public:
                              const cv::String& code_type, const bool variance_encoded_in_target,
                              const bool clip, std::vector<LabelBBox>& all_decode_bboxes)
     {
-        UMat outmat = UMat(loc_mat.dims, loc_mat.size, CV_32F);
+        UMat outmat = UMat(loc_mat.size, CV_32F);
         size_t nthreads = loc_mat.total();
         String kernel_name;
 
@@ -382,7 +382,7 @@ public:
             return true;
         }
 
-        UMat umat = use_half ? UMat::zeros(4, outputs[0].size, CV_32F) : outputs[0];
+        UMat umat = use_half ? UMat::zeros(outputs[0].size, CV_32F) : outputs[0];
 
         if (!use_half)
             umat.setTo(0);

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -252,7 +252,7 @@ public:
                              const cv::String& code_type, const bool variance_encoded_in_target,
                              const bool clip, std::vector<LabelBBox>& all_decode_bboxes)
     {
-        UMat outmat = UMat(loc_mat.size, CV_32F);
+        UMat outmat(loc_mat.size, CV_32F);
         size_t nthreads = loc_mat.total();
         String kernel_name;
 

--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -532,7 +532,7 @@ public:
 
                 // create temporary variable
                 MatShape tmpResult;
-                for (int i = 0; i < result.size.dims(); i++)
+                for (int i = 0; i < result.size.dims; i++)
                     tmpResult.emplace_back(result.size[i]);
 
 
@@ -656,7 +656,7 @@ void LayerEinsumImpl::preProcessInputs(InputArrayOfArrays& inputs_arr)
         }
 
         if (IsTransposeRequired(
-            !preprocessed.empty() ? preprocessed.size.dims() : inputs[inputIter].size.dims(),
+            !preprocessed.empty() ? preprocessed.size.dims : inputs[inputIter].size.dims,
             permutation))
         {
             // call transpose

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -671,7 +671,7 @@ public:
             CV_Assert(!weightsMat.empty());
             Mat wm;
             weightsMat.copyTo(wm); // to handle the case of isContinuous() == false
-            wm = wm.reshape(1, blobs[0].dims, blobs[0].size.p);
+            wm = wm.reshape(1, blobs[0].size);
             vkBlobs.push_back(wm.t());
 
             Ptr<VkComBackendWrapper> inputWrap = inputs[0].dynamicCast<VkComBackendWrapper>();

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -671,7 +671,7 @@ public:
             CV_Assert(!weightsMat.empty());
             Mat wm;
             weightsMat.copyTo(wm); // to handle the case of isContinuous() == false
-            wm = wm.reshape(1, blobs[0].dims, blobs[0].size);
+            wm = wm.reshape(1, blobs[0].dims, blobs[0].size.p);
             vkBlobs.push_back(wm.t());
 
             Ptr<VkComBackendWrapper> inputWrap = inputs[0].dynamicCast<VkComBackendWrapper>();

--- a/modules/dnn/src/layers/is_inf_layer.cpp
+++ b/modules/dnn/src/layers/is_inf_layer.cpp
@@ -101,7 +101,7 @@ public:
 
         const int defaultOutType = CV_BoolC1;
         const int outType = Y.empty() ? defaultOutType : Y.type();
-        Y.create(X.dims, X.size.p, outType);
+        Y.create(X.size, outType);
 
         const int depth = CV_MAT_DEPTH(X.type());
         const size_t total = X.total();

--- a/modules/dnn/src/layers/is_nan_layer.cpp
+++ b/modules/dnn/src/layers/is_nan_layer.cpp
@@ -70,7 +70,7 @@ public:
 
         const int defaultOutType = CV_BoolC1;
         const int outType = (Y.empty() || Y.type() < 0) ? defaultOutType : Y.type();
-        Y.create(X.dims, X.size.p, outType);
+        Y.create(X.size, outType);
 
         const int depth = CV_MAT_DEPTH(X.type());
         const size_t total = X.total();

--- a/modules/dnn/src/layers/recurrent2_layers.cpp
+++ b/modules/dnn/src/layers/recurrent2_layers.cpp
@@ -26,7 +26,7 @@ static void tanh(const Mat &src, Mat &dst)
 
 static void tanh(const Mat &src, Mat &dst)
 {
-    dst.create(src.dims, (const int*)src.size, src.type());
+    dst.create(src.size, src.type());
     if (src.type() == CV_32F)
         tanh<float>(src, dst);
     else if (src.type() == CV_64F)

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -70,7 +70,7 @@ static void tanh(const Mat &src, Mat &dst)
 //TODO: make utils method
 static void tanh(const Mat &src, Mat &dst)
 {
-    dst.create(src.dims, (const int*)src.size, src.type());
+    dst.create(src.size, src.type());
 
     if (src.type() == CV_32F)
         tanh<float>(src, dst);

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -280,7 +280,7 @@ public:
                 }
 
                 if (useSoftmax) {  // Yolo v2
-                    Mat _inpBlob = inpBlob.reshape(0, outBlob.dims, outBlob.size.p);
+                    Mat _inpBlob = inpBlob.reshape(0, outBlob.size);
                     softmax(outBlob, _inpBlob, -1, 5, classes);
                 }
                 else if (useLogistic) {  // Yolo v3

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -280,7 +280,7 @@ public:
                 }
 
                 if (useSoftmax) {  // Yolo v2
-                    Mat _inpBlob = inpBlob.reshape(0, outBlob.dims, outBlob.size);
+                    Mat _inpBlob = inpBlob.reshape(0, outBlob.dims, outBlob.size.p);
                     softmax(outBlob, _inpBlob, -1, 5, classes);
                 }
                 else if (useLogistic) {  // Yolo v3

--- a/modules/dnn/src/legacy_backend.hpp
+++ b/modules/dnn/src/legacy_backend.hpp
@@ -213,7 +213,7 @@ public:
             {
                 reuse(bestBlobPin, lp);
                 dst = bestBlob.reshape(1, 1).colRange(0, targetTotal).reshape(1, shape);
-                dst.dims = shape.size();
+                dst.size.dims = dst.dims = shape.size();
                 return;
             }
         }

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -626,7 +626,7 @@ void Net::Impl::allocateLayers(const std::vector<LayerPin>& blobsToKeep_)
             {
                 type = CV_16F;
                 if (layers[0].dtype == CV_32F)
-                    layers[0].outputBlobs[i].create(inp.dims, inp.size, CV_16F);
+                    layers[0].outputBlobs[i].create(inp.size, CV_16F);
             }
         }
         inputShapes.push_back(shape(inp));
@@ -1426,7 +1426,7 @@ void Net::Impl::updateLayersShapes()
             preferableTarget == DNN_TARGET_OPENCL_FP16 &&
             inputLayerData.dtype == CV_32F)
         {
-            inp.create(inp.dims, inp.size, CV_16F);
+            inp.create(inp.size, CV_16F);
         }
         inputShapes.push_back(shape(inp));
         inputTypes.push_back(inp.type());

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1927,8 +1927,9 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToI
         CV_LOG_ERROR(NULL, errorMsg);
         return blob;
     }
-    if (tensor_proto.dims_size() == 0)
-        blob.dims = 1;  // To force 1-dimensional cv::Mat for scalars.
+    if (tensor_proto.dims_size() == 0) {
+        blob.size.dims = blob.dims = 1;  // To force 1-dimensional cv::Mat for scalars.
+    }
     return blob;
 }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -3870,7 +3870,7 @@ void ONNXImporter::parseQConcat(LayerParams& layerParams, const opencv_onnx::Nod
         for (size_t i = 2; i < num_inputs; i += 3)
         {
             Mat blob = getBlob(node_proto, i);
-            if (blob.size.dims() > inputShape.size())
+            if (blob.size.dims > inputShape.size())
             {
                 inputShape = shape(blob);
             }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2193,7 +2193,7 @@ void ONNXImporter::parseSqueeze(LayerParams& layerParams, const opencv_onnx::Nod
     {
         Mat inp = getBlob(node_proto, 0);
         Mat out = inp.reshape(1, outShape);
-        out.dims = outShape.size();  // to workaround dims == 1
+        out.size.dims = out.dims = outShape.size();  // to workaround dims == 1
         addConstant(node_proto.output(0), out);
         return;
     }
@@ -2508,7 +2508,7 @@ void ONNXImporter::parseCast(LayerParams& layerParams, const opencv_onnx::NodePr
         }
         Mat dst;
         blob.convertTo(dst, type);
-        dst.dims = blob.dims;
+        dst.size.dims = dst.dims = blob.dims;
         addConstant(node_proto.output(0), dst);
         return;
     }
@@ -2918,8 +2918,8 @@ void ONNXImporter::parseElementWise(LayerParams& layerParams, const opencv_onnx:
                 LayerParams constParams;
                 constParams.name = node_proto.input(i);
                 constParams.type = "Const";
-                // Non-constant propagated layers cannot output 1-d or 0-d tensors.
-                inp.dims = std::max(inp.dims, 2);
+                // Non-constant propagated layers cannot output 0-d tensors.
+                inp.size.dims = inp.dims = std::max(inp.dims, 1);
                 constParams.blobs.push_back(inp);
 
                 opencv_onnx::NodeProto proto;

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2465,7 +2465,7 @@ void ONNXImporter::parseShape(LayerParams& layerParams, const opencv_onnx::NodeP
     int dims = static_cast<int>(inpShape.size());
     if (isInput1D)
         dims = 1;
-    Mat shapeMat(1, dims, CV_64S);
+    Mat shapeMat(1, &dims, CV_64S);
     bool isDynamicShape = false;
     for (int j = 0; j < dims; ++j)
     {
@@ -2473,7 +2473,6 @@ void ONNXImporter::parseShape(LayerParams& layerParams, const opencv_onnx::NodeP
         isDynamicShape |= (sz == 0);
         shapeMat.at<int64_t>(j) = sz;
     }
-    shapeMat.dims = 1;  // FIXIT Mat 1D
 
     if (isDynamicShape)
     {
@@ -2508,7 +2507,7 @@ void ONNXImporter::parseCast(LayerParams& layerParams, const opencv_onnx::NodePr
         }
         Mat dst;
         blob.convertTo(dst, type);
-        dst.size.dims = dst.dims = blob.dims;
+        //dst.size.dims = dst.dims = blob.dims;
         addConstant(node_proto.output(0), dst);
         return;
     }

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -106,7 +106,7 @@ static std::string dataType2str(int dt)
 static Mat getMatFromTensor2(const opencv_onnx::TensorProto& tensor_proto, const std::string base_path="")
 {
     Mat m = getMatFromTensor(tensor_proto, false, base_path);
-    m.dims = (int)tensor_proto.dims_size();
+    m.size.dims = m.dims = (int)tensor_proto.dims_size();
     return m;
 }
 

--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -130,7 +130,7 @@ Mat TFLiteImporter::parseTensor(const Tensor& tensor)
     Mat res = Mat(shape, dtype, const_cast<void*>(data));
     // workaround for scalars support
     if (!tensor_shape || shape.size() == 1)
-        res.dims = 1;
+        res.size.dims = res.dims = 1;
     return res;
 }
 
@@ -287,7 +287,7 @@ void TFLiteImporter::populateNet()
                     Mat dataFP32;
                     data.convertTo(dataFP32, CV_32F);
                     // workaround for scalars support
-                    dataFP32.dims = data.dims;
+                    dataFP32.size.dims = dataFP32.dims = data.dims;
                     allTensors[op_outputs->Get(0)] = dataFP32;
                     continue;
                 }

--- a/modules/dnn/test/test_int.cpp
+++ b/modules/dnn/test/test_int.cpp
@@ -100,7 +100,7 @@ TEST_P(Test_NaryEltwise_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], input1.size[0]);
     EXPECT_EQ(re.size[1], input1.size[1]);
     EXPECT_EQ(re.size[2], input1.size[2]);
@@ -175,7 +175,7 @@ TEST_P(Test_Const_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], input1.size[0]);
     EXPECT_EQ(re.size[1], input1.size[1]);
     EXPECT_EQ(re.size[2], input1.size[2]);
@@ -281,7 +281,7 @@ TEST_P(Test_ScatterND_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     ASSERT_EQ(shape(input), shape(re));
 
     std::vector<int> reIndices(4);
@@ -364,7 +364,7 @@ TEST_P(Test_Concat_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], input1.size[0]);
     EXPECT_EQ(re.size[1], input1.size[1] + input2.size[1]);
     EXPECT_EQ(re.size[2], input1.size[2]);
@@ -441,7 +441,7 @@ TEST_P(Test_ArgMax_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), CV_64S);
-    EXPECT_EQ(re.size.dims(), 3);
+    EXPECT_EQ(re.size.dims, 3);
     EXPECT_EQ(re.size[0], inShape[0]);
     EXPECT_EQ(re.size[1], inShape[2]);
     EXPECT_EQ(re.size[2], inShape[3]);
@@ -510,7 +510,7 @@ TEST_P(Test_Blank_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], 2);
     EXPECT_EQ(re.size[1], 3);
     EXPECT_EQ(re.size[2], 4);
@@ -568,7 +568,7 @@ TEST_P(Test_Expand_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], 2);
     EXPECT_EQ(re.size[1], 3);
     EXPECT_EQ(re.size[2], 4);
@@ -631,7 +631,7 @@ TEST_P(Test_Permute_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], 2);
     EXPECT_EQ(re.size[1], 4);
     EXPECT_EQ(re.size[2], 5);
@@ -705,7 +705,7 @@ TEST_P(Test_GatherElements_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     ASSERT_EQ(shape(indicesMat), shape(re));
 
     std::vector<int> inIndices(4);
@@ -823,7 +823,7 @@ TEST_P(Test_Cast_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), outMatType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
 
     ASSERT_EQ(shape(input), shape(re));
     normAssert(outputRef, re);
@@ -865,7 +865,7 @@ TEST_P(Test_Pad_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], 2);
     EXPECT_EQ(re.size[1], 3);
     EXPECT_EQ(re.size[2], 5);
@@ -940,7 +940,7 @@ TEST_P(Test_Slice_Int, random)
     Mat out = net.forward();
 
     Mat gt = input(range);
-    EXPECT_EQ(out.size.dims(), 4);
+    EXPECT_EQ(out.size.dims, 4);
     EXPECT_EQ(out.size[0], gt.size[0]);
     EXPECT_EQ(out.size[1], gt.size[1]);
     EXPECT_EQ(out.size[2], gt.size[2]);
@@ -981,7 +981,7 @@ TEST_P(Test_Reshape_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], outShape[0]);
     EXPECT_EQ(re.size[1], outShape[1]);
     EXPECT_EQ(re.size[2], outShape[2]);
@@ -1022,7 +1022,7 @@ TEST_P(Test_Flatten_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 2);
+    EXPECT_EQ(re.size.dims, 2);
     EXPECT_EQ(re.size[0], inShape[0]);
     EXPECT_EQ(re.size[1], inShape[1] * inShape[2] * inShape[3]);
 
@@ -1062,7 +1062,7 @@ TEST_P(Test_Tile_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 4);
+    EXPECT_EQ(re.size.dims, 4);
     EXPECT_EQ(re.size[0], inShape[0] * repeats[0]);
     EXPECT_EQ(re.size[1], inShape[1] * repeats[1]);
     EXPECT_EQ(re.size[2], inShape[2] * repeats[2]);
@@ -1142,7 +1142,7 @@ TEST_P(Test_Reduce_Int, random)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 3);
+    EXPECT_EQ(re.size.dims, 3);
     EXPECT_EQ(re.size[0], inShape[0]);
     EXPECT_EQ(re.size[1], inShape[2]);
     EXPECT_EQ(re.size[2], inShape[3]);
@@ -1219,7 +1219,7 @@ TEST_P(Test_Reduce_Int, two_axes)
     Mat re;
     re = net.forward();
     EXPECT_EQ(re.depth(), matType);
-    EXPECT_EQ(re.size.dims(), 2);
+    EXPECT_EQ(re.size.dims, 2);
     EXPECT_EQ(re.size[0], inShape[0]);
     EXPECT_EQ(re.size[1], inShape[2]);
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -965,7 +965,7 @@ TEST_P(Scale_untrainable, Accuracy)
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     Mat out = net.forward();
 
-    Mat ref(input.dims, input.size, CV_32F);
+    Mat ref(input.size, CV_32F);
     float* inpData = (float*)input.data;
     float* refData = (float*)ref.data;
     float* weightsData = (float*)weights.data;
@@ -1060,7 +1060,7 @@ TEST_P(Crop, Accuracy)
     for (int i = axis; i < 4; i++)
         crop_range[i] = Range(offsetVal, sizShape[i] + offsetVal);
 
-    Mat ref(sizImage.dims, sizImage.size, CV_32F);
+    Mat ref(sizImage.size, CV_32F);
     inpImage(&crop_range[0]).copyTo(ref);
     normAssert(out, ref);
 }

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1438,7 +1438,7 @@ TEST_P(Layer_FullyConnected_Test, Accuracy_01D)
     Mat input(input_shape, CV_32F);
     randn(input, 0, 1);
     Mat output_ref = input.reshape(1, 1) * weights;
-    output_ref.dims = input_shape.dims;
+    output_ref.size.dims = output_ref.dims = input_shape.dims;
 
     std::vector<Mat> inputs{input};
     std::vector<Mat> outputs;

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -776,17 +776,18 @@ void cv::Laplacian( InputArray _src, OutputArray _dst, int ddepth, int ksize,
         const uchar* sptr = src.ptr() + src.step[0] * y;
 
         int dy0 = std::min(std::max((int)(STRIPE_SIZE/(CV_ELEM_SIZE(stype)*src.cols)), 1), src.rows);
-        Mat d2x( dy0 + kd.rows - 1, src.cols, wtype );
-        Mat d2y( dy0 + kd.rows - 1, src.cols, wtype );
+        Mat d2xbuf( dy0 + kd.rows - 1, src.cols, wtype );
+        Mat d2ybuf( dy0 + kd.rows - 1, src.cols, wtype );
 
         for( ; dsty < src.rows; sptr += dy0*src.step, dsty += dy )
         {
-            fx->proceed( sptr, (int)src.step, dy0, d2x.ptr(), (int)d2x.step );
-            dy = fy->proceed( sptr, (int)src.step, dy0, d2y.ptr(), (int)d2y.step );
+            fx->proceed( sptr, (int)src.step, dy0, d2xbuf.ptr(), (int)d2xbuf.step );
+            dy = fy->proceed( sptr, (int)src.step, dy0, d2ybuf.ptr(), (int)d2ybuf.step );
             if( dy > 0 )
             {
                 Mat dstripe = dst.rowRange(dsty, dsty + dy);
-                d2x.rows = d2y.rows = dy; // modify the headers, which should work
+                Mat d2x = d2xbuf.rowRange(0, dy);
+                Mat d2y = d2ybuf.rowRange(0, dy);
                 d2x += d2y;
                 d2x.convertTo( dstripe, ddepth, scale, delta );
             }

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -929,7 +929,7 @@ void cv::calcHist( const Mat* images, int nimages, const int* channels,
     Size imsize;
 
     CV_Assert( mask.empty() || mask.type() == CV_8UC1 || mask.type() == CV_BoolC1);
-    histPrepareImages( images, nimages, channels, mask, dims, hist.size, ranges,
+    histPrepareImages( images, nimages, channels, mask, dims, hist.size.p, ranges,
                        uniform, ptrs, deltas, imsize, uniranges );
     const double* _uniranges = uniform ? &uniranges[0] : 0;
 
@@ -1568,7 +1568,7 @@ void cv::calcBackProject( const Mat* images, int nimages, const int* channels,
     CV_Assert( dims > 0 && !hist.empty() );
     _backProject.create( images[0].size(), images[0].depth() );
     Mat backProject = _backProject.getMat();
-    histPrepareImages( images, nimages, channels, backProject, dims, hist.size, ranges,
+    histPrepareImages( images, nimages, channels, backProject, dims, hist.size.p, ranges,
                        uniform, ptrs, deltas, imsize, uniranges );
     const double* _uniranges = uniform ? &uniranges[0] : 0;
 

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -187,7 +187,7 @@ void add(const Mat& _a, double alpha, const Mat& _b, double beta,
     if( ctype < 0 )
         ctype = a.depth();
     ctype = CV_MAKETYPE(CV_MAT_DEPTH(ctype), a.channels());
-    c.create(a.dims, &a.size[0], ctype);
+    c.create(a.size, ctype);
     const Mat *arrays[] = {&a, &b, &c, 0};
     Mat planes[3], buf[3];
 
@@ -349,7 +349,7 @@ void convert(const Mat& src, cv::OutputArray _dst,
     int ddepth = CV_MAT_DEPTH(dtype);
 
     dtype = CV_MAKETYPE(ddepth, src.channels());
-    _dst.create(src.dims, &src.size[0], dtype);
+    _dst.create(src.size, dtype);
     Mat dst = _dst.getMat();
     if( alpha == 0 )
     {
@@ -424,7 +424,7 @@ void convert(const Mat& src, cv::OutputArray _dst,
 
 void copy(const Mat& src, Mat& dst, const Mat& mask, bool invertMask)
 {
-    dst.create(src.dims, &src.size[0], src.type());
+    dst.create(src.size, src.type());
 
     if(mask.empty())
     {
@@ -576,7 +576,7 @@ void insert(const Mat& src, Mat& dst, int coi)
 
 void extract(const Mat& src, Mat& dst, int coi)
 {
-    dst.create( src.dims, &src.size[0], src.depth() );
+    dst.create( src.size, src.depth() );
     CV_Assert( 0 <= coi && coi < src.channels() );
 
     const Mat* arrays[] = {&src, &dst, 0};
@@ -1770,7 +1770,7 @@ void logicOp( const Mat& src1, const Mat& src2, Mat& dst, char op )
 {
     CV_Assert( op == '&' || op == '|' || op == '^' );
     CV_Assert( src1.type() == src2.type() && src1.size == src2.size );
-    dst.create( src1.dims, &src1.size[0], src1.type() );
+    dst.create( src1.size, src1.type() );
     const Mat *arrays[]={&src1, &src2, &dst, 0};
     Mat planes[3];
 
@@ -1792,7 +1792,7 @@ void logicOp( const Mat& src1, const Mat& src2, Mat& dst, char op )
 void logicOp(const Mat& src, const Scalar& s, Mat& dst, char op)
 {
     CV_Assert( op == '&' || op == '|' || op == '^' || op == '~' );
-    dst.create( src.dims, &src.size[0], src.type() );
+    dst.create( src.size, src.type() );
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
 
@@ -1887,7 +1887,7 @@ compareS_(const _Tp* src1, _WTp value, uchar* dst, size_t total, int cmpop)
 void compare(const Mat& src1, const Mat& src2, Mat& dst, int cmpop)
 {
     CV_Assert( src1.type() == src2.type() && src1.channels() == 1 && src1.size == src2.size );
-    dst.create( src1.dims, &src1.size[0], CV_8U );
+    dst.create( src1.size, CV_8U );
     const Mat *arrays[]={&src1, &src2, &dst, 0};
     Mat planes[3];
 
@@ -1949,7 +1949,7 @@ void compare(const Mat& src1, const Mat& src2, Mat& dst, int cmpop)
 void compare(const Mat& src, double value, Mat& dst, int cmpop)
 {
     CV_Assert( src.channels() == 1 );
-    dst.create( src.dims, &src.size[0], CV_8U );
+    dst.create( src.size, CV_8U );
     const Mat *arrays[]={&src, &dst, 0};
     Mat planes[2];
 
@@ -2749,7 +2749,7 @@ minmax16f_(const _Tp* src1, const _Tp* src2, _Tp* dst, size_t total, char op)
 
 static void minmax(const Mat& src1, const Mat& src2, Mat& dst, char op)
 {
-    dst.create(src1.dims, src1.size, src1.type());
+    dst.create(src1.size, src1.type());
     CV_Assert( src1.type() == src2.type() && src1.size == src2.size );
     const Mat *arrays[]={&src1, &src2, &dst, 0};
     Mat planes[3];
@@ -2845,7 +2845,7 @@ minmax_16f(const _Tp* src1, _Tp val_, _Tp* dst, size_t total, char op)
 
 static void minmax(const Mat& src1, double val, Mat& dst, char op)
 {
-    dst.create(src1.dims, src1.size, src1.type());
+    dst.create(src1.size, src1.type());
     const Mat *arrays[]={&src1, &dst, 0};
     Mat planes[2];
 
@@ -2947,7 +2947,7 @@ muldiv_16f(const _Tp* src1, const _Tp* src2, _Tp* dst, size_t total, double scal
 
 static void muldiv(const Mat& src1, const Mat& src2, Mat& dst, int ctype, double scale, char op)
 {
-    dst.create(src2.dims, src2.size, (ctype >= 0 ? ctype : src2.type()));
+    dst.create(src2.size, (ctype >= 0 ? ctype : src2.type()));
     CV_Assert( src1.empty() || (src1.type() == src2.type() && src1.size == src2.size) );
     const Mat *arrays[]={&src1, &src2, &dst, 0};
     Mat planes[3];


### PR DESCRIPTION
**Merge together with https://github.com/opencv/opencv_contrib/pull/3996**
---

This PR continues cv::Mat/cv::UMat refactoring. See #26056, where `MatShape` was introduced. Now it's put inside cv::Mat/cv::UMat instead of a weird `MatSize`. MatSize is now an alias for MatShape:

**before:**

```
struct MatShape { ... };
struct MatSize { ... };

struct Mat {
    ...
    int dims;
    int rows;
    int cols;

    ...

    MatShape shape() const { ... /* constructs MatShape out of MatSize and returns it;
                                    layout is always 'unknown', because we don't store it */ }

    MatSize size; // size is not valid without the parent cv::Mat,
                  // because size.p may point to Mat::rows or to Mat::cols,
                  // depending on the dimensionality, and dims() returns Mat::dims.
    MatStep step; // may allocate memory, depending on the dimensionality.
    ...
};
```

**after:**

```
struct MatShape { ... };
typedef MatShape MatSize; // they are now synonyms

struct Mat {
    ...
    int dims;
    int rows;
    int cols;

    ...

    MatShape shape() const { return size; } // just return the embedded shape (including the proper layout information)

    MatSize size; // size is self-contained data structure that can be used without the parent cv::Mat.
                  // size.dims is now a copy of dims; size.p[*] contains copies of Mat::rows and Mat::cols when dims <= 2.
    MatStep step; // does not allocate extra memory buffers.
    ...
};
```

There are several reasons to do that:

1. the main reason is to be able to store data layout (MatShape::layout) inside each cv::Mat/cv::UMat. This is necessary for the proper shape inference in DNN module. In particular, it's necessary for the next step of DNN inference optimization where we introduce block-layout-optimized convolution and other operations. Later on, we can use layout information to support non-interleaved images (e.g. RRR...GGG...BBB...) or even batches of such images in core/imgproc modules.
2. the other reason is to represent 3D/4D/5D etc. tensors as cv::Mat/cv::UMat instances more conveniently, without extra dynamic memory allocation. Before this patch we allocated some memory buffers dynamically to store shape & steps for more than 2D arrays. Now the whole cv::Mat/cv::UMat header can be stored completely on stack/in a container. Creating another copy of Mat/UMat header is now done more efficiently.
3. the third reason is to introduce the new coding pattern: `dst.create(src.size, <dst_type>);`. The pattern is suitable for most of element-wise (including cloning) and filtering operations. This pattern does not only look crisp and self-documenting, it will also automatically copy shape (including layout) from the source tensor into the destination matrix/tensor.
4. in the future we might add `colorspace` member to MatShape that will allow to distinguish RGB from BGR or NV12. `dst.create(src.size, <dst_type>);` will then copy the colorspace information as well.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
