### PR TITLE
Renamed templated BlocksCompensator::feed method to exclude claches with base class pure virtual method

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -187,7 +187,7 @@ public:
 
 protected:
     template<class Compensator>
-    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+    void feedWithStrategy(const std::vector<Point> &corners, const std::vector<UMat> &images,
               const std::vector<std::pair<UMat,uchar> > &masks);
 
 private:

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -460,7 +460,7 @@ void ChannelsCompensator::setMatGains(std::vector<Mat>& umv)
 
 
 template<class Compensator>
-void BlocksCompensator::feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+void BlocksCompensator::feedWithStrategy(const std::vector<Point> &corners, const std::vector<UMat> &images,
                              const std::vector<std::pair<UMat,uchar> > &masks)
 {
     CV_Assert(corners.size() == images.size() && images.size() == masks.size());
@@ -605,13 +605,13 @@ void BlocksCompensator::setMatGains(std::vector<Mat>& umv)
 void BlocksGainCompensator::feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
                                  const std::vector<std::pair<UMat,uchar> > &masks)
 {
-    BlocksCompensator::feed<GainCompensator>(corners, images, masks);
+    BlocksCompensator::feedWithStrategy<GainCompensator>(corners, images, masks);
 }
 
 void BlocksChannelsCompensator::feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
                                      const std::vector<std::pair<UMat,uchar> > &masks)
 {
-    BlocksCompensator::feed<ChannelsCompensator>(corners, images, masks);
+    BlocksCompensator::feedWithStrategy<ChannelsCompensator>(corners, images, masks);
 }
 
 


### PR DESCRIPTION
closes https://github.com/opencv/opencv/issues/27752

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
