### PR TITLE
Update Conan URL to use official Conan Center

### DIFF
--- a/doc/tutorials/introduction/general_install/general_install.markdown
+++ b/doc/tutorials/introduction/general_install/general_install.markdown
@@ -26,7 +26,7 @@ Other organizations and people maintain their own binary distributions of OpenCV
 - System packages in popular Linux distributions (https://pkgs.org/search/?q=opencv)
 - PyPI (https://pypi.org/search/?q=opencv)
 - Conda (https://anaconda.org/search?q=opencv)
-- Conan (https://github.com/conan-community/conan-opencv)
+- Conan (https://conan.io/center/recipes/opencv)
 - vcpkg (https://github.com/microsoft/vcpkg/tree/master/ports/opencv)
 - NuGet (https://www.nuget.org/packages?q=opencv)
 - Brew (https://formulae.brew.sh/formula/opencv)


### PR DESCRIPTION
Greetings!

Doing a read into the documentation, the Conan URL for OpenCV is outdated. The Conan Community is no longer maintained for several months and was archived in April: https://github.com/conan-community

Instead, all recipes are now kept in [ConanCenterIndex](https://github.com/conan-io/conan-center-index/tree/master/recipes/opencv) and indexed in the Conan Center website: https://conan.io/center

Regards! 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
