### PR TITLE
[videoio][ffmpeg] Fix Windows build error

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1724,12 +1724,13 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
     if (!sw_picture || !sw_picture->data[0])
         return false;
 
-    CV_LOG_DEBUG(NULL, "Input picture format: " << av_get_pix_fmt_name((AVPixelFormat)sw_picture->format) << ", colorspace: "
 #if LIBAVUTIL_BUILD >= CALC_FFMPEG_VERSION(56, 72, 0)
-        << av_color_space_name(sw_picture->colorspace)
+    const char* color_space_name = av_color_space_name(sw_picture->colorspace);
 #else
-        << av_get_colorspace_name(sw_picture->colorspace)
+    const char* color_space_name = av_get_colorspace_name(sw_picture->colorspace);
 #endif
+    CV_LOG_DEBUG(NULL, "Input picture format: " << av_get_pix_fmt_name((AVPixelFormat)sw_picture->format)
+        << ", colorspace: " << color_space_name
         << ", range: " << av_color_range_name(sw_picture->color_range)
         << ", primaries: " << av_color_primaries_name(sw_picture->color_primaries)
         << ", transfer: " << av_color_transfer_name(sw_picture->color_trc)


### PR DESCRIPTION
https://github.com/opencv/opencv/pull/27741 included a preprocessor directive inside the `CV_LOG_DEBUG` macro resulting in the following build errors on Windows with `OPENCV_FFMPEG_USE_FIND_PACKAGE=ON`

> D:\repos\opencv\opencv\modules\videoio\src\cap_ffmpeg_impl.hpp(1727): error C2121: '#': invalid character: possibly the result of a macro expansion
> D:\repos\opencv\opencv\modules\videoio\src\cap_ffmpeg_impl.hpp(1727): error C2143: syntax error: missing ';' before 'if'
> D:\repos\opencv\opencv\modules\videoio\src\cap_ffmpeg_impl.hpp(1727): error C2059: syntax error: '>='

PR moves the preprocessor directive outside of macro.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
