### PR TITLE
feat: add PathLike type hints for args annotated with CV_WRAP_FILE_PATH

### DIFF
--- a/modules/python/src2/typing_stubs_generation/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/__init__.py
@@ -12,6 +12,7 @@ from .nodes import (
     SequenceTypeNode,
     AnyTypeNode,
     AggregatedTypeNode,
+    PathLikeTypeNode,
 )
 
 from .types_conversion import (

--- a/modules/python/src2/typing_stubs_generation/ast_utils.py
+++ b/modules/python/src2/typing_stubs_generation/ast_utils.py
@@ -4,7 +4,7 @@ import keyword
 
 from .nodes import (ASTNode, NamespaceNode, ClassNode, FunctionNode,
                     EnumerationNode, ClassProperty, OptionalTypeNode,
-                    TupleTypeNode)
+                    TupleTypeNode, PathLikeTypeNode)
 
 from .types_conversion import create_type_node
 
@@ -167,12 +167,16 @@ def create_function_node_in_scope(scope: Union[NamespaceNode, ClassNode],
                                   func_info) -> FunctionNode:
     def prepare_overload_arguments_and_return_type(variant):
         arguments = []  # type: list[FunctionNode.Arg]
-        # Enumerate is requried, because `argno` in `variant.py_arglist`
+        # Enumerate is required, because `argno` in `variant.py_arglist`
         # refers to position of argument in C++ function interface,
         # but `variant.py_noptargs` refers to position in `py_arglist`
         for i, (_, argno) in enumerate(variant.py_arglist):
             arg_info = variant.args[argno]
             type_node = create_type_node(arg_info.tp)
+            # Special handling for string representation of the file system path
+            if arg_info.pathlike and type_node.typename == "str":
+                type_node = PathLikeTypeNode.string_or_pathlike_()
+
             default_value = None
             if len(arg_info.defval):
                 default_value = arg_info.defval

--- a/modules/python/src2/typing_stubs_generation/nodes/__init__.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/__init__.py
@@ -8,5 +8,5 @@ from .type_node import (
     TypeNode, OptionalTypeNode, UnionTypeNode, NoneTypeNode, TupleTypeNode,
     ASTNodeTypeNode, AliasTypeNode, SequenceTypeNode, AnyTypeNode,
     AggregatedTypeNode, NDArrayTypeNode, AliasRefTypeNode, PrimitiveTypeNode,
-    CallableTypeNode, DictTypeNode, ClassTypeNode
+    CallableTypeNode, DictTypeNode, ClassTypeNode, PathLikeTypeNode
 )

--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -43,7 +43,7 @@ class TypeNode(abc.ABC):
         Returns:
             str: short name of the type node.
         """
-        pass
+        return ""
 
     @property
     def full_typename(self) -> str:
@@ -123,12 +123,11 @@ class TypeNode(abc.ABC):
     def is_resolved(self) -> bool:
         return True
 
-    def relative_typename(self, module_full_export_name: str) -> str:
+    def relative_typename(self, module: str) -> str:
         """Type name relative to the provided module.
 
         Args:
-            module_full_export_name (str): Full export name of the module to
-                get relative name to.
+            module (str): Full export name of the module to get relative name to.
 
         Returns:
             str: If module name of the type node doesn't match `module`, then
@@ -715,11 +714,11 @@ class ContainerTypeNode(AggregatedTypeNode):
 
     @abc.abstractproperty
     def type_format(self) -> str:
-        pass
+        return ""
 
     @abc.abstractproperty
     def types_separator(self) -> str:
-        pass
+        return ""
 
 
 class SequenceTypeNode(ContainerTypeNode):
@@ -893,6 +892,31 @@ class ClassTypeNode(ContainerTypeNode):
     @property
     def types_separator(self) -> str:
         return ", "
+
+
+class PathLikeTypeNode(TypeNode):
+    """Type node representing a PathLike object.
+    """
+    def __init__(self, ctype_name: str) -> None:
+        super().__init__(ctype_name)
+
+    @property
+    def typename(self) -> str:
+        return "os.PathLike[str]"
+
+    @property
+    def required_usage_imports(self) -> Generator[str, None, None]:
+        yield "import os"
+
+    @staticmethod
+    def string_or_pathlike_(ctype_name: str = "string") -> UnionTypeNode:
+        return UnionTypeNode(
+            ctype_name,
+            items=(
+                PrimitiveTypeNode.str_(ctype_name),
+                PathLikeTypeNode(ctype_name)
+            )
+        )
 
 
 def _resolve_symbol(root: Optional[ASTNode], full_symbol_name: str) -> Optional[ASTNode]:


### PR DESCRIPTION
Closes #27727

Generated type hint example:

```python
@_typing.overload
def imread(filename: str | os.PathLike[str], flags: int = ...) -> cv2.typing.MatLike | None: ...
@_typing.overload
def imread(filename: str | os.PathLike[str], dst: cv2.typing.MatLike | None = ..., flags: int = ...) -> cv2.typing.MatLike | None: ...
@_typing.overload
def imread(filename: str | os.PathLike[str], dst: UMat | None = ..., flags: int = ...) -> UMat | None: ...

```

<details>
<summary>List of affected functions and arguments </summary>

```txt
Algorithm::save pathlike argument = filename
FileStorage::FileStorage pathlike argument = filename
FileStorage::open pathlike argument = filename
Index::save pathlike argument = filename
Index::load pathlike argument = filename
Index::load pathlike argument = filename
NormalBayesClassifier::load pathlike argument = filepath
KNearest::load pathlike argument = filepath
SVM::load pathlike argument = filepath
EM::load pathlike argument = filepath
DTrees::load pathlike argument = filepath
RTrees::load pathlike argument = filepath
Boost::load pathlike argument = filepath
ANN_MLP::load pathlike argument = filepath
LogisticRegression::load pathlike argument = filepath
SVMSGD::load pathlike argument = filepath
Net::readFromModelOptimizer pathlike argument = xml
Net::readFromModelOptimizer pathlike argument = bin
Net::dumpToFile pathlike argument = path
Net::dumpToPbtxt pathlike argument = path
Model::Model pathlike argument = model
Model::Model pathlike argument = config
ClassificationModel::ClassificationModel pathlike argument = model
ClassificationModel::ClassificationModel pathlike argument = config
KeypointsModel::KeypointsModel pathlike argument = model
KeypointsModel::KeypointsModel pathlike argument = config
SegmentationModel::SegmentationModel pathlike argument = model
SegmentationModel::SegmentationModel pathlike argument = config
DetectionModel::DetectionModel pathlike argument = model
DetectionModel::DetectionModel pathlike argument = config
TextRecognitionModel::TextRecognitionModel pathlike argument = model
TextRecognitionModel::TextRecognitionModel pathlike argument = config
TextDetectionModel_EAST::TextDetectionModel_EAST pathlike argument = model
TextDetectionModel_EAST::TextDetectionModel_EAST pathlike argument = config
TextDetectionModel_DB::TextDetectionModel_DB pathlike argument = model
TextDetectionModel_DB::TextDetectionModel_DB pathlike argument = config
Feature2D::write pathlike argument = fileName
Feature2D::read pathlike argument = fileName
DescriptorMatcher::write pathlike argument = fileName
DescriptorMatcher::read pathlike argument = fileName
VideoCapture::VideoCapture pathlike argument = filename
VideoCapture::VideoCapture pathlike argument = filename
VideoCapture::open pathlike argument = filename
VideoCapture::open pathlike argument = filename
VideoWriter::VideoWriter pathlike argument = filename
VideoWriter::VideoWriter pathlike argument = filename
VideoWriter::VideoWriter pathlike argument = filename
VideoWriter::VideoWriter pathlike argument = filename
VideoWriter::open pathlike argument = filename
VideoWriter::open pathlike argument = filename
VideoWriter::open pathlike argument = filename
VideoWriter::open pathlike argument = filename
CascadeClassifier::CascadeClassifier pathlike argument = filename
CascadeClassifier::load pathlike argument = filename
HOGDescriptor::HOGDescriptor pathlike argument = filename
HOGDescriptor::load pathlike argument = filename
HOGDescriptor::save pathlike argument = filename
BarcodeDetector::BarcodeDetector pathlike argument = prototxt_path
BarcodeDetector::BarcodeDetector pathlike argument = model_path
FaceDetectorYN::create pathlike argument = model
FaceDetectorYN::create pathlike argument = config
FaceRecognizerSF::create pathlike argument = model
FaceRecognizerSF::create pathlike argument = config
cv::haveImageReader pathlike argument = filename
cv::haveImageWriter pathlike argument = filename
cv::imcount pathlike argument = filename
cv::imread pathlike argument = filename
cv::imread pathlike argument = filename
cv::imread pathlike argument = filename
cv::imreadWithMetadata pathlike argument = filename
cv::imreadWithMetadata pathlike argument = filename
cv::imreadanimation pathlike argument = filename
cv::imreadmulti pathlike argument = filename
cv::imreadmulti pathlike argument = filename
cv::imwrite pathlike argument = filename
cv::imwrite pathlike argument = filename
cv::imwriteWithMetadata pathlike argument = filename
cv::imwriteWithMetadata pathlike argument = filename
cv::imwriteanimation pathlike argument = filename
cv::imwritemulti pathlike argument = filename
cv::imwritemulti pathlike argument = filename
dnn::readNet pathlike argument = model
dnn::readNet pathlike argument = config
dnn::readNetFromCaffe pathlike argument = prototxt
dnn::readNetFromCaffe pathlike argument = caffeModel
dnn::readNetFromDarknet pathlike argument = cfgFile
dnn::readNetFromDarknet pathlike argument = darknetModel
dnn::readNetFromModelOptimizer pathlike argument = xml
dnn::readNetFromModelOptimizer pathlike argument = bin
dnn::readNetFromONNX pathlike argument = onnxFile
dnn::readNetFromTFLite pathlike argument = model
dnn::readNetFromTensorflow pathlike argument = model
dnn::readNetFromTensorflow pathlike argument = config
dnn::readNetFromTorch pathlike argument = model
dnn::readTensorFromONNX pathlike argument = path
dnn::readTorchBlob pathlike argument = filename
dnn::shrinkCaffeModel pathlike argument = src
dnn::shrinkCaffeModel pathlike argument = dst
dnn::writeTextGraph pathlike argument = model
dnn::writeTextGraph pathlike argument = output

```
</details>
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
