### PR TITLE
dnn: Tune CONV_NR_FP32 size for WASM

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -1853,7 +1853,7 @@ void convBlockMR1_F32(int np, const float* a, const float* b, float *c, const fl
 }
 
 #if CV_SIMD128
-#if !CV_WASM_SIMD
+#if CONV_NR_FP32 > 8
 static inline void convBlock4x24(int np, const float* a, const float* b, float* c, int ldc, bool init_c, const int convMR, const int convNR)
 {
     v_float32x4 c0  = v_setzero_f32(), c1 = c0, c2 = c0, c3 = c0, c4 = c0, c5 = c0;
@@ -2087,7 +2087,7 @@ void convBlock_F32(int np, const float* a, const float* b, float* c, int ldc, bo
     // The possible outLen range is [24, 8~1].
 #if CV_SIMD128
     CV_Assert(convMR == 4);
-#if !CV_WASM_SIMD
+#if CONV_NR_FP32 > 8
     if (outLen > 8 && convNR == 24)
     {
         convBlock4x24(np, a, b, c, ldc, init_c, convMR, convNR);

--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -1853,6 +1853,7 @@ void convBlockMR1_F32(int np, const float* a, const float* b, float *c, const fl
 }
 
 #if CV_SIMD128
+#if !CV_WASM_SIMD
 static inline void convBlock4x24(int np, const float* a, const float* b, float* c, int ldc, bool init_c, const int convMR, const int convNR)
 {
     v_float32x4 c0  = v_setzero_f32(), c1 = c0, c2 = c0, c3 = c0, c4 = c0, c5 = c0;
@@ -1957,6 +1958,7 @@ static inline void convBlock4x24(int np, const float* a, const float* b, float* 
     v_store(c + ldc * 3 + 16, c22);
     v_store(c + ldc * 3 + 20, c23);
 }
+#endif
 
 static inline void convBlock4x8(int np, const float* a, const float* b, float* c, int ldc, bool init_c, const int convMR, const int convNR)
 {
@@ -2085,11 +2087,13 @@ void convBlock_F32(int np, const float* a, const float* b, float* c, int ldc, bo
     // The possible outLen range is [24, 8~1].
 #if CV_SIMD128
     CV_Assert(convMR == 4);
+#if !CV_WASM_SIMD
     if (outLen > 8 && convNR == 24)
     {
         convBlock4x24(np, a, b, c, ldc, init_c, convMR, convNR);
         return;
     }
+#endif
 
     if (outLen <= 8 && outLen > 4)
     {

--- a/modules/dnn/src/layers/cpu_kernels/convolution.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.hpp
@@ -28,6 +28,9 @@
 #elif CV_NEON              // 16 registers.
 #define CONV_MR_FP32 4
 #define CONV_NR_FP32 12
+#elif CV_WASM_SIMD
+#define CONV_MR_FP32 4
+#define CONV_NR_FP32 8
 #else // SIMD 128, AVX or AVX2
 #define CONV_MR_FP32 4
 #define CONV_NR_FP32 24


### PR DESCRIPTION
We can see ~20% inference time reduction on local benchmark.
The local benchmark includes face detection with res10_300x300_ssd_iter_140000_fp16.caffemodel and image classification with squeezenet.onnx .

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
