### PR TITLE
BUG: Disable FP16 compilation while using MSVC on Windows ARM64

### DIFF
--- a/cmake/checks/cpu_neon_fp16.cpp
+++ b/cmake/checks/cpu_neon_fp16.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
-#if (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) || (defined _MSC_VER && (defined _M_ARM64 || defined _M_ARM64EC))
+#if (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) /*|| (defined _MSC_VER && (defined _M_ARM64 || defined _M_ARM64EC))*/
+// Windows + ARM64 case disabled: https://github.com/opencv/opencv/issues/25052
 #include "arm_neon.h"
 
 float16x8_t vld1q_as_f16(const float* src)


### PR DESCRIPTION
Disable FP16 compilation while using MSVC on Windows ARM64:

- Building OpenCV-Python on Windows ARM64 with the MSVC compiler fails due to FP16 intrinsics in [conv_winograd_f63.simd.hpp](https://github.com/opencv/opencv/blob/4.x/modules/dnn/src/layers/cpu_kernels/conv_winograd_f63.simd.hpp#L1356)
- MSVC currently lacks support for OpenCV’s dispatcher units such as NEON_FP16 and NEON_DOTPROD, since the required FP16 and dot-product intrinsics are not supported by MSVC.
- This PR introduces MSVC-specific guards to skip compilation of NEON FP16 code paths globally, as well as the FP16 intrinsic blocks that trigger build errors leading to successful OpenCV-Python build for Windows ARM64.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [] There is a reference to the original bug report and related work
- [] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [] The feature is well documented and sample code can be built with the project CMake
