### PR TITLE
features2d: performance optimization of detect function on Windows-ARM64

### DIFF
--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -48,7 +48,7 @@ The references are:
 namespace cv
 {
 
-#if (defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#if (defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 
 static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold)
 {
@@ -7444,7 +7444,7 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
 
 
 
-#else // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#else // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 
 static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, AgastFeatureDetector::DetectorType agasttype)
 {
@@ -7932,7 +7932,7 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     AGAST_ALL(_img, keypoints, threshold, AgastFeatureDetector::OAST_9_16);
 }
 
-#endif // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#endif // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 
 void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression)
 {

--- a/modules/features2d/src/agast_score.cpp
+++ b/modules/features2d/src/agast_score.cpp
@@ -90,7 +90,7 @@ void makeAgastOffsets(int pixel[16], int rowStride, AgastFeatureDetector::Detect
         pixel[k] = offsets[k][0] + offsets[k][1] * rowStride;
 }
 
-#if (defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#if (defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 // 16 pixel mask
 template<>
 int agast_cornerScore<AgastFeatureDetector::OAST_9_16>(const uchar* ptr, const int pixel[], int threshold)
@@ -9373,7 +9373,7 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_5_8>(const uchar* ptr, const i
         b_test = (bmin + bmax) / 2;
     }
 }
-#else // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#else // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 
 
 int agast_tree_search(const uint32_t table_struct32[], int pixel_[], const unsigned char* const ptr, int threshold)
@@ -9858,6 +9858,6 @@ int agast_cornerScore<AgastFeatureDetector::OAST_9_16>(const uchar* ptr, const i
     return AGAST_ALL_SCORE(ptr, pixel, threshold, AgastFeatureDetector::OAST_9_16);
 }
 
-#endif // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64))
+#endif // !(defined __i386__ || defined(_M_IX86) || defined __x86_64__ || defined(_M_X64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__arm__))
 
 } // namespace cv


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

- This PR improves the performance of the detect function on Windows ARM64 targets.
- Added the defined(_M_ARM64) macro in agast.cpp and agast_score.cpp files, aligning ARM64 behavior with how x64 selects internal functions for computation.
- As a result, ARM64 now executes the same internal functions as x64 where applicable, leading to measurable performance improvements in detect function.
- This changes is limited to Windows ARM64 and does not affect other architectures

**Performance impact:**
- Detect function shows improved runtime on ARM64 targets due to reuse of existing efficient computation paths.
<img width="1419" height="408" alt="image" src="https://github.com/user-attachments/assets/feab411a-d256-4bff-bec2-22b2583f63d1" />

