### PR TITLE
build: fix OpenBLAS cmake search

### DIFF
--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -191,7 +191,7 @@ if(WITH_LAPACK)
           CBLAS_H "cblas.h"
           LAPACKE_H "lapacke.h"
           INCLUDE_DIR "${OpenBLAS_INCLUDE_DIRS}"
-          LIBRARIES "${OpenBLAS_LIBRARIES}")
+          LIBRARIES "${OpenBLAS_LIBRARY};${OpenBLAS_LIBRARIES}")
       endif()
     endif()
     if(NOT LAPACK_LIBRARIES AND UNIX)


### PR DESCRIPTION
Resolves #27743

OpenBLAS cmake package states:
```
# OpenBLAS cmake module.
# This module sets the following variables in your project::
#
#   OpenBLAS_FOUND - true if OpenBLAS and all required components found on the system
#   OpenBLAS_VERSION - OpenBLAS version in format Major.Minor.Release
#   OpenBLAS_INCLUDE_DIRS - Directory where OpenBLAS header is located.
#   OpenBLAS_INCLUDE_DIR - same as DIRS
#   OpenBLAS_LIBRARIES - OpenBLAS library to link against.
#   OpenBLAS_LIBRARY - same as LIBRARIES
```

But in reality variables `LIBRARY`/`LIBRARIES` are different:
```
LIBRARY=/usr/local/lib/libopenblas.so.0.3
LIBRARIES=m
```

Note: `INCLUDE_DIR`/`INCLUDE_DIRS` are different too, but we use the one which actually works (`DIRS`).