### PR TITLE
Out of buffer access fix in the new 5.x tests.

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -3528,8 +3528,9 @@ TEST_P(MinMaxSupportedMatDepth, minMaxIdx)
 {
     cv::Mat src = cv::Mat::zeros(16,16, CV_MAKETYPE(GetParam(), 1));
     double minV=0.0, maxV=0.0;
-    int minIdx=0, maxIdx=0;
-    EXPECT_NO_THROW(cv::minMaxIdx(src, &minV, &maxV, &minIdx, &maxIdx));
+    int minIdx[2] = {0, 0};
+    int maxIdx[2] = {0, 0};
+    EXPECT_NO_THROW(cv::minMaxIdx(src, &minV, &maxV, minIdx, maxIdx));
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Closes https://github.com/opencv/opencv/issues/27768

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
