### PR TITLE
Fixed mesh loading when indices are not in std::vector

### DIFF
--- a/modules/3d/src/pointcloud/load_point_cloud.cpp
+++ b/modules/3d/src/pointcloud/load_point_cloud.cpp
@@ -188,8 +188,7 @@ void loadMesh(const String &filename, OutputArray vertices, OutputArrayOfArrays 
         }
         else
         {
-            indices.create(1, (int)vec_indices.size(), CV_32SC3);
-            std::vector<Vec3i>& vec = *(std::vector<Vec3i>*)indices.getObj();
+            std::vector<Vec3i> vec(vec_indices.size());
             for (int i = 0; i < vecsz; ++i)
             {
                 Vec3i tri;
@@ -207,6 +206,8 @@ void loadMesh(const String &filename, OutputArray vertices, OutputArrayOfArrays 
                 }
                 vec[i] = tri;
             }
+            indices.create(1, (int)vec_indices.size(), CV_32SC3);
+            Mat(1, static_cast<int>(vec_indices.size()), CV_32SC3, vec.data()).copyTo(indices);
         }
     }
 


### PR DESCRIPTION
When passing index to `cv::loadMesh` it was assumed that `indices` is kept in nested array or in `std::vector<Vec3i>` as the only option for flat arrays.
That was fixed to support `cv::Mat`, `cv::UMat` and other types.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
