### PR TITLE
Added option to initialize pairs with stereo and fixed related bugs.

### DIFF
--- a/modules/calib/src/multiview_calibration.cpp
+++ b/modules/calib/src/multiview_calibration.cpp
@@ -370,12 +370,16 @@ static void pairwiseStereoCalibration (const std::vector<std::pair<int,int>> &pa
             T = -R * Ts_prior[c1] + Ts_prior[c2];
         }
 
+        // stereoCalibrate tries to overwrite distortion coefficients
+        Mat dist1 = distortions[c1].clone();
+        Mat dist2 = distortions[c2].clone();
+
         // image size does not matter since intrinsics are used
         if (are_fisheye_cams) {
             extrinsic_flags |= CALIB_FIX_INTRINSIC;
             fisheye::stereoCalibrate(grid_points, image_points1, image_points2,
-                            Ks[c1], distortions[c1],
-                            Ks[c2], distortions[c2],
+                            Ks[c1], dist1,
+                            Ks[c2], dist2,
                             Size(), R, T,
                             extrinsic_flags, criteria);
         } else {
@@ -386,8 +390,8 @@ static void pairwiseStereoCalibration (const std::vector<std::pair<int,int>> &pa
                 extrinsic_flags |= CALIB_THIN_PRISM_MODEL;
 
             stereoCalibrate(grid_points, image_points1, image_points2,
-                            Ks[c1], distortions[c1],
-                            Ks[c2], distortions[c2],
+                            Ks[c1], dist1,
+                            Ks[c2], dist2,
                             Size(), R, T, noArray(), noArray(), noArray(),
                             extrinsic_flags, criteria);
         }


### PR DESCRIPTION
1. Fixed calibrateMultiview assertion with `cv::CALIB_STEREO_REGISTRATION` flag
```
Traceback (most recent call last):
  File "/mnt/Projects/Projects/opencv-next/samples/python/multiview_calibration.py", line 1039, in <module>
    output = calibrateFromImages(
             ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Projects/Projects/opencv-next/samples/python/multiview_calibration.py", line 944, in calibrateFromImages
    return calibrateFromPoints(
           ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/Projects/Projects/opencv-next/samples/python/multiview_calibration.py", line 428, in calibrateFromPoints
    cv.calibrateMultiviewExtended(
cv2.error: OpenCV(5.0.0-pre) /mnt/Projects/Projects/opencv-next/modules/core/src/matrix_wrap.cpp:1350: error: (-2:Unspecified error) in function 'void cv::_OutputArray::create(int, const int*, int, int, bool, DepthMask) const'
> Can't reallocate Mat with locked size (probably due to misused 'const' modifier) (expected: 'm.size[j] == sizes[j]'), where
>     'm.size[j]' is 5
> must be equal to
>     'sizes[j]' is 14
```

2. Added the option to multivew_calibration.py tool.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
