### PR TITLE
Added option to define Aruco index offset in pattern generator

### DIFF
--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -16,6 +16,7 @@ python gen_pattern.py -o out.svg -r 11 -c 8 -T circles -s 20.0 -R 5.0 -u mm -w 2
 -m, --markers - list of cells with markers for the radon checkerboard
 -p, --aruco_marker_size - aruco markers size for ChAruco pattern (default 10.0)
 -f, --dict_file - file name of custom aruco dictionary for ChAruco pattern
+-do, --dict_offset - index of the first ArUco index used
 -H, --help - show help
 """
 
@@ -27,7 +28,7 @@ from svgfig import *
 
 
 class PatternMaker:
-    def __init__(self, cols, rows, output, units, square_size, radius_rate, page_width, page_height, markers, aruco_marker_size, dict_file):
+    def __init__(self, cols, rows, output, units, square_size, radius_rate, page_width, page_height, markers, aruco_marker_size, dict_file, dict_offset):
         self.cols = cols
         self.rows = rows
         self.output = output
@@ -39,6 +40,7 @@ class PatternMaker:
         self.markers = markers
         self.aruco_marker_size = aruco_marker_size #for charuco boards only
         self.dict_file = dict_file
+        self.dict_offset = dict_offset
 
         self.g = SVG("g")  # the svg group container
 
@@ -188,7 +190,7 @@ class PatternMaker:
         ch_ar_border = (self.square_size - self.aruco_marker_size)/2
         if ch_ar_border < side*0.7:
             print("Marker border {} is less than 70% of ArUco pin size {}. Please increase --square_size or decrease --marker_size for stable board detection".format(ch_ar_border, int(side)))
-        marker_id = 0
+        marker_id = self.dict_offset
         for y in range(0, self.rows):
             for x in range(0, self.cols):
 
@@ -248,6 +250,8 @@ def main():
                         action="store", dest="aruco_marker_size", type=float)
     parser.add_argument("-f", "--dict_file", help="file name of custom aruco dictionary for ChAruco pattern", default="DICT_ARUCO_ORIGINAL.json",
                         action="store", dest="dict_file", type=str)
+    parser.add_argument("-do", "--dict_offset", help="index of the first ArUco index used", default=0,
+                        action="store", dest="dict_offset", type=int)
     args = parser.parse_args()
 
     show_help = args.show_help
@@ -263,6 +267,7 @@ def main():
     radius_rate = args.radius_rate
     aruco_marker_size = args.aruco_marker_size
     dict_file = args.dict_file
+    dict_offset = args.dict_offset
 
     if 'page_width' and 'page_height' in args:
         page_width = args.page_width
@@ -288,7 +293,7 @@ def main():
     if p_type == "charuco_board" and aruco_marker_size >= square_size:
         raise ValueError("ArUco markers size must be smaller than square size")
 
-    pm = PatternMaker(columns, rows, output, units, square_size, radius_rate, page_width, page_height, markers, aruco_marker_size, dict_file)
+    pm = PatternMaker(columns, rows, output, units, square_size, radius_rate, page_width, page_height, markers, aruco_marker_size, dict_file, dict_offset)
     # dict for easy lookup of pattern type
     mp = {"circles": pm.make_circles_pattern, "acircles": pm.make_acircles_pattern,
           "checkerboard": pm.make_checkerboard_pattern, "radon_checkerboard": pm.make_radon_checkerboard_pattern,

--- a/doc/pattern_tools/test_charuco_board.py
+++ b/doc/pattern_tools/test_charuco_board.py
@@ -46,7 +46,7 @@ class aruco_objdetect_test(NewOpenCVTests):
                     basedir = os.path.abspath(os.path.dirname(__file__))
                     pm = gen_pattern.PatternMaker(cols, rows, filesvg, "px", square_size, 0, board_width,
                                 board_height, "charuco_checkboard", marker_size,
-                                os.path.join(basedir, aruco_type_str[aruco_type_i]+'.json.gz'))
+                                os.path.join(basedir, aruco_type_str[aruco_type_i]+'.json.gz'), 0)
                     pm.make_charuco_board()
                     pm.save()
                     drawing = svg2rlg(filesvg)
@@ -103,7 +103,7 @@ class aruco_objdetect_test(NewOpenCVTests):
                 try:
                     basedir = os.path.abspath(os.path.dirname(__file__))
                     pm = gen_pattern.PatternMaker(cols, rows, filesvg, "px", square_size, 0, board_width,
-                                board_height, "charuco_checkboard", marker_size, os.path.join(basedir, aruco_type_str+'.json.gz'))
+                                board_height, "charuco_checkboard", marker_size, os.path.join(basedir, aruco_type_str+'.json.gz'), 0)
                     pm.make_charuco_board()
                     pm.save()
                     drawing = svg2rlg(filesvg)


### PR DESCRIPTION
The index is needed to generate several different boards with the same dictionary.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
