### PR TITLE
dnn: add NEON intrinsics implementation of fastGEMM1T (use vfmaq_f32)

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -4,8 +4,8 @@ endif()
 
 set(the_description "Deep neural network module. It allows to load models from different frameworks and to make forward pass")
 
-ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX RVV LASX)
-ocv_add_dispatched_file_force_all("int8layers/layers_common" AVX2 AVX512_SKX RVV LASX)
+ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX RVV LASX NEON)
+ocv_add_dispatched_file_force_all("int8layers/layers_common" AVX2 AVX512_SKX RVV LASX NEON)
 ocv_add_dispatched_file_force_all("layers/cpu_kernels/conv_block" AVX AVX2 NEON NEON_FP16)
 ocv_add_dispatched_file_force_all("layers/cpu_kernels/conv_depthwise" AVX AVX2 RVV LASX)
 ocv_add_dispatched_file("layers/cpu_kernels/conv_winograd_f63" AVX AVX2 NEON NEON_FP16)

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -203,7 +203,7 @@ public:
     class FullyConnected : public ParallelLoopBody
     {
     public:
-        FullyConnected() : srcMat(0), weights(0), biasMat(0), activ(0), dstMat(0), nstripes(0), useAVX(false), useAVX2(false), useAVX512(false), useRVV(false), useLASX(false) {}
+        FullyConnected() : srcMat(0), weights(0), biasMat(0), activ(0), dstMat(0), nstripes(0), useNEON(false), useAVX(false), useAVX2(false), useAVX512(false), useRVV(false), useLASX(false) {}
 
         static void run(const Mat& srcMat, const Mat& weights, const Mat& biasMat,
                         Mat& dstMat, const ActivationLayer* activ, int nstripes)
@@ -226,6 +226,7 @@ public:
             p.useAVX = checkHardwareSupport(CPU_AVX);
             p.useAVX2 = checkHardwareSupport(CPU_AVX2);
             p.useAVX512 = CV_CPU_HAS_SUPPORT_AVX512_SKX;
+            p.useNEON = checkHardwareSupport(CPU_NEON);
             p.useRVV = checkHardwareSupport(CPU_RVV);
             p.useLASX = checkHardwareSupport(CPU_LASX);
 
@@ -275,6 +276,11 @@ public:
             #if CV_TRY_AVX
                 if( useAVX )
                     opt_AVX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize_aligned);
+                else
+            #endif
+            #if CV_TRY_NEON
+                if( useNEON )
+                    opt_NEON::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize);
                 else
             #endif
             #if CV_TRY_RVV && CV_RVV
@@ -337,6 +343,7 @@ public:
         const ActivationLayer* activ;
         Mat* dstMat;
         int nstripes;
+        bool useNEON;
         bool useAVX;
         bool useAVX2;
         bool useAVX512;

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -203,7 +203,7 @@ public:
     class FullyConnected : public ParallelLoopBody
     {
     public:
-        FullyConnected() : srcMat(0), weights(0), biasMat(0), activ(0), dstMat(0), nstripes(0), useNEON(false), useAVX(false), useAVX2(false), useAVX512(false), useRVV(false), useLASX(false) {}
+        FullyConnected() : srcMat(0), weights(0), biasMat(0), activ(0), dstMat(0), nstripes(0), useAVX(false), useAVX2(false), useAVX512(false), useRVV(false), useLASX(false) {}
 
         static void run(const Mat& srcMat, const Mat& weights, const Mat& biasMat,
                         Mat& dstMat, const ActivationLayer* activ, int nstripes)
@@ -226,7 +226,6 @@ public:
             p.useAVX = checkHardwareSupport(CPU_AVX);
             p.useAVX2 = checkHardwareSupport(CPU_AVX2);
             p.useAVX512 = CV_CPU_HAS_SUPPORT_AVX512_SKX;
-            p.useNEON = checkHardwareSupport(CPU_NEON);
             p.useRVV = checkHardwareSupport(CPU_RVV);
             p.useLASX = checkHardwareSupport(CPU_LASX);
 
@@ -276,11 +275,6 @@ public:
             #if CV_TRY_AVX
                 if( useAVX )
                     opt_AVX::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize_aligned);
-                else
-            #endif
-            #if CV_TRY_NEON
-                if( useNEON )
-                    opt_NEON::fastGEMM1T( sptr, wptr, wstep, biasptr, dptr, nw, vecsize);
                 else
             #endif
             #if CV_TRY_RVV && CV_RVV
@@ -343,7 +337,6 @@ public:
         const ActivationLayer* activ;
         Mat* dstMat;
         int nstripes;
-        bool useNEON;
         bool useAVX;
         bool useAVX2;
         bool useAVX512;

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -82,10 +82,10 @@ void fastGEMM1T( const float* vec, const float* weights,
         {
             float32x4_t v = vld1q_f32(vec + k);
 
-            vs0 = vmlaq_f32(vs0, vld1q_f32(wptr), v);
-            vs1 = vmlaq_f32(vs1, vld1q_f32(wptr + wstep), v);
-            vs2 = vmlaq_f32(vs2, vld1q_f32(wptr + wstep * 2), v);
-            vs3 = vmlaq_f32(vs3, vld1q_f32(wptr + wstep * 3), v);
+            vs0 = vfmaq_f32(vs0, vld1q_f32(wptr), v);
+            vs1 = vfmaq_f32(vs1, vld1q_f32(wptr + wstep), v);
+            vs2 = vfmaq_f32(vs2, vld1q_f32(wptr + wstep * 2), v);
+            vs3 = vfmaq_f32(vs3, vld1q_f32(wptr + wstep * 3), v);
         }
         if (k != vecsize)
         {
@@ -97,10 +97,10 @@ void fastGEMM1T( const float* vec, const float* weights,
             float32x4_t w1 = vreinterpretq_f32_u32( vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep)), vreinterpretq_u32_f32(tailMask)) );
             float32x4_t w2 = vreinterpretq_f32_u32( vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 2)), vreinterpretq_u32_f32(tailMask)) );
             float32x4_t w3 = vreinterpretq_f32_u32( vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 3)), vreinterpretq_u32_f32(tailMask)) );
-            vs0 = vmlaq_f32(vs0, w0, v);
-            vs1 = vmlaq_f32(vs1, w1, v);
-            vs2 = vmlaq_f32(vs2, w2, v);
-            vs3 = vmlaq_f32(vs3, w3, v);
+            vs0 = vfmaq_f32(vs0, w0, v);
+            vs1 = vfmaq_f32(vs1, w1, v);
+            vs2 = vfmaq_f32(vs2, w2, v);
+            vs3 = vfmaq_f32(vs3, w3, v);
         }
 
         auto hsumq_f32 = [](float32x4_t x) -> float {
@@ -123,7 +123,7 @@ void fastGEMM1T( const float* vec, const float* weights,
         for ( ; k <= vecsize - 4; k += 4, wptr += 4 )
         {
             float32x4_t v = vld1q_f32(vec + k);
-            vs0 = vmlaq_f32(vs0, vld1q_f32(wptr), v);
+            vs0 = vfmaq_f32(vs0, vld1q_f32(wptr), v);
         }
         if (k != vecsize)
         {
@@ -132,7 +132,7 @@ void fastGEMM1T( const float* vec, const float* weights,
             float32x4_t v  = vld1q_f32(vec + k);
             v = vreinterpretq_f32_u32( vandq_u32(vreinterpretq_u32_f32(v), vreinterpretq_u32_f32(tailMask)) );
             float32x4_t w0 = vreinterpretq_f32_u32( vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr)), vreinterpretq_u32_f32(tailMask)) );
-            vs0 = vmlaq_f32(vs0, w0, v);
+            vs0 = vfmaq_f32(vs0, w0, v);
         }
         float32x2_t s2 = vadd_f32(vget_low_f32(vs0), vget_high_f32(vs0));
         s2 = vpadd_f32(s2, s2);

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -138,6 +138,9 @@ class LSTMLayerImpl CV_FINAL : public LSTMLayer
 #if CV_TRY_AVX2
     bool useAVX2;
 #endif
+#if CV_TRY_NEON
+    bool useNEON;
+#endif
 
     // CUDA needs input blobs to be rearranged in a specific way, but some transformations
     // in ONNXImporter are destructive, so we keep a copy.
@@ -152,6 +155,9 @@ public:
 #endif
 #if CV_TRY_AVX2
           , useAVX2(checkHardwareSupport(CPU_AVX2))
+#endif
+#if CV_TRY_NEON
+          , useNEON(checkHardwareSupport(CPU_NEON))
 #endif
     {
         setParamsFrom(params);
@@ -489,6 +495,14 @@ public:
                 && Wh.depth() == CV_32F && hInternal.depth() == CV_32F && gates.depth() == CV_32F
                 && Wh.cols >= 8;
 #endif
+#if CV_TRY_NEON
+            bool canUseNeon = gates.isContinuous() && bias.isContinuous()
+                && Wx.depth() == CV_32F && gates.depth() == CV_32F
+                && bias.depth() == CV_32F && Wx.cols >= 4;
+            bool canUseNeon_hInternal = hInternal.isContinuous() && gates.isContinuous() && bias.isContinuous()
+                && Wh.depth() == CV_32F && hInternal.depth() == CV_32F && gates.depth() == CV_32F
+                && Wh.cols >= 4;
+#endif
 
             int tsStart, tsEnd, tsInc;
             if (reverse || i == 1) {
@@ -540,6 +554,23 @@ public:
                 }
                 else
 #endif
+#if CV_TRY_NEON
+                if (useNEON && canUseNeon && xCurr.isContinuous())
+                {
+                    for (int n = 0; n < xCurr.rows; n++) {
+                        opt_NEON::fastGEMM1T(
+                            xCurr.ptr<float>(n),
+                            Wx.ptr<float>(),
+                            Wx.step1(),
+                            bias.ptr<float>(),
+                            gates.ptr<float>(n),
+                            Wx.rows,
+                            Wx.cols
+                        );
+                    }
+                }
+                else
+#endif
                 {
                     gemm(xCurr, Wx, 1, gates, 0, gates, GEMM_2_T);      // Wx * x_t
                     gemm(dummyOnes, bias, 1, gates, 1, gates);          //+b
@@ -567,6 +598,23 @@ public:
                 {
                     for (int n = 0; n < hInternal.rows; n++) {
                         opt_AVX::fastGEMM1T(
+                            hInternal.ptr<float>(n),
+                            Wh.ptr<float>(),
+                            Wh.step1(),
+                            gates.ptr<float>(n),
+                            gates.ptr<float>(n),
+                            Wh.rows,
+                            Wh.cols
+                        );
+                    }
+                }
+                else
+#endif
+#if CV_TRY_NEON
+                if (useNEON && canUseNeon_hInternal)
+                {
+                    for (int n = 0; n < hInternal.rows; n++) {
+                        opt_NEON::fastGEMM1T(
                             hInternal.ptr<float>(n),
                             Wh.ptr<float>(),
                             Wh.step1(),


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

- This PR improves the performance of the LSTM function on ARM64 targets.
- Added a NEON intrinsics implementation of the fastGEMM1T function and enabled its use in recurrent layers file.
- As a result, ARM64 now benefits from vectorized matrix–vector multiplications, leading to measurable performance improvements in the LSTM layer.
- This change is limited to ARM64 and does not affect other architectures.

**Performance Impact**

- LSTM function showed improvement in performance.

<img width="930" height="313" alt="image" src="https://github.com/user-attachments/assets/d48a6df2-e22c-434e-98bb-f571910dc391" />
