### PR TITLE
Optional Known Foreground Mask for Background Subtractors

### DIFF
--- a/modules/video/include/opencv2/video/background_segm.hpp
+++ b/modules/video/include/opencv2/video/background_segm.hpp
@@ -64,12 +64,15 @@ public:
 
     @param image Next video frame.
     @param fgmask The output foreground mask as an 8-bit binary image.
+    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
     @param learningRate The value between 0 and 1 that indicates how fast the background model is
     learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
     rate. 0 means that the background model is not updated at all, 1 means that the background model
     is completely reinitialized from the last frame.
      */
     CV_WRAP virtual void apply(InputArray image, OutputArray fgmask, double learningRate=-1) = 0;
+
+    CV_WRAP virtual void apply(InputArray image, OutputArray fgmask,InputArray knownForegroundMask, double learningRate=-1) = 0;
 
     /** @brief Computes a background image.
 
@@ -200,12 +203,15 @@ public:
 
     @param image Next video frame. Floating point frame will be used without scaling and should be in range \f$[0,255]\f$.
     @param fgmask The output foreground mask as an 8-bit binary image.
+    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
     @param learningRate The value between 0 and 1 that indicates how fast the background model is
     learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
     rate. 0 means that the background model is not updated at all, 1 means that the background model
     is completely reinitialized from the last frame.
      */
     CV_WRAP virtual void apply(InputArray image, OutputArray fgmask, double learningRate=-1) CV_OVERRIDE = 0;
+
+    CV_WRAP virtual void apply(InputArray image, OutputArray fgmask,InputArray knownForegroundMask, double learningRate=-1) CV_OVERRIDE = 0;
 };
 
 /** @brief Creates MOG2 Background Subtractor

--- a/modules/video/include/opencv2/video/background_segm.hpp
+++ b/modules/video/include/opencv2/video/background_segm.hpp
@@ -64,7 +64,6 @@ public:
 
     @param image Next video frame.
     @param fgmask The output foreground mask as an 8-bit binary image.
-    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
     @param learningRate The value between 0 and 1 that indicates how fast the background model is
     learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
     rate. 0 means that the background model is not updated at all, 1 means that the background model
@@ -72,7 +71,20 @@ public:
      */
     CV_WRAP virtual void apply(InputArray image, OutputArray fgmask, double learningRate=-1) = 0;
 
-    CV_WRAP virtual void apply(InputArray image, OutputArray fgmask,InputArray knownForegroundMask, double learningRate=-1) = 0;
+    /** @brief Computes a foreground mask with known foreground mask input.
+
+    @param image Next video frame. Floating point frame will be used without scaling and should be in range \f$[0,255]\f$.
+    @param fgmask The output foreground mask as an 8-bit binary image.
+    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
+    @param learningRate The value between 0 and 1 that indicates how fast the background model is
+    learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
+    rate. 0 means that the background model is not updated at all, 1 means that the background model
+    is completely reinitialized from the last frame.
+
+    @note This method has a default virtual implementation that throws a "not impemented" error.
+    Foreground masking may not be supported by all background subtractors.
+    */
+    CV_WRAP virtual void apply(InputArray image, InputArray knownForegroundMask, OutputArray fgmask, double learningRate=-1) = 0;
 
     /** @brief Computes a background image.
 
@@ -203,7 +215,6 @@ public:
 
     @param image Next video frame. Floating point frame will be used without scaling and should be in range \f$[0,255]\f$.
     @param fgmask The output foreground mask as an 8-bit binary image.
-    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
     @param learningRate The value between 0 and 1 that indicates how fast the background model is
     learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
     rate. 0 means that the background model is not updated at all, 1 means that the background model
@@ -211,7 +222,17 @@ public:
      */
     CV_WRAP virtual void apply(InputArray image, OutputArray fgmask, double learningRate=-1) CV_OVERRIDE = 0;
 
-    CV_WRAP virtual void apply(InputArray image, OutputArray fgmask,InputArray knownForegroundMask, double learningRate=-1) CV_OVERRIDE = 0;
+    /** @brief Computes a foreground mask and skips known foreground in evaluation.
+
+    @param image Next video frame. Floating point frame will be used without scaling and should be in range \f$[0,255]\f$.
+    @param fgmask The output foreground mask as an 8-bit binary image.
+    @param knownForegroundMask The mask for inputting already known foreground, allows model to ignore pixels.
+    @param learningRate The value between 0 and 1 that indicates how fast the background model is
+    learnt. Negative parameter value makes the algorithm to use some automatically chosen learning
+    rate. 0 means that the background model is not updated at all, 1 means that the background model
+    is completely reinitialized from the last frame.
+     */
+    CV_WRAP virtual void apply(InputArray image, InputArray knownForegroundMask, OutputArray fgmask, double learningRate=-1) CV_OVERRIDE = 0;
 };
 
 /** @brief Creates MOG2 Background Subtractor

--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -777,12 +777,11 @@ void BackgroundSubtractorKNNImpl::apply(InputArray _image, OutputArray _fgmask,I
     _fgmask.create( image.size(), CV_8U );
     Mat fgmask = _fgmask.getMat();
 
-    Mat tmpKnownMask;
     const Mat *knownMaskPtr = nullptr;
     if (!_knownForegroundMask.empty()) {
         // store a local Mat so the pointer stays alive for the parallel_for_
-        tmpKnownMask = _knownForegroundMask.getMat();
-        knownMaskPtr = &tmpKnownMask;
+        Mat tmp = _knownForegroundMask.getMat();
+        knownMaskPtr = &tmp;
     }
 
     ++nframes;

--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -778,10 +778,11 @@ void BackgroundSubtractorKNNImpl::apply(InputArray _image, OutputArray _fgmask,I
     Mat fgmask = _fgmask.getMat();
 
     const Mat *knownMaskPtr = nullptr;
+    Mat tmpKnownMask;
     if (!_knownForegroundMask.empty()) {
         // store a local Mat so the pointer stays alive for the parallel_for_
-        Mat tmp = _knownForegroundMask.getMat();
-        knownMaskPtr = &tmp;
+        tmpKnownMask = _knownForegroundMask.getMat();
+        knownMaskPtr = &tmpKnownMask;
     }
 
     ++nframes;

--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -596,6 +596,8 @@ public:
                     // If input mask states pixel is foreground
                     if (knownForegroundMask->at<uchar>(y, x) > 0) {
                         mask[x] = 255; // ensure output mask marks this pixel as FG
+                        data += nchannels;
+                        m_aModel += m_nN*3*ndata;
                         continue;
                     }
                 }
@@ -775,11 +777,12 @@ void BackgroundSubtractorKNNImpl::apply(InputArray _image, OutputArray _fgmask,I
     _fgmask.create( image.size(), CV_8U );
     Mat fgmask = _fgmask.getMat();
 
+    Mat tmpKnownMask;
     const Mat *knownMaskPtr = nullptr;
     if (!_knownForegroundMask.empty()) {
         // store a local Mat so the pointer stays alive for the parallel_for_
-        Mat tmp = _knownForegroundMask.getMat();
-        knownMaskPtr = &tmp;
+        tmpKnownMask = _knownForegroundMask.getMat();
+        knownMaskPtr = &tmpKnownMask;
     }
 
     ++nframes;

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -886,11 +886,12 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
     _fgmask.create( image.size(), CV_8U );
     Mat fgmask = _fgmask.getMat();
 
+    Mat tmpKnownMask;
     const Mat *knownMaskPtr = nullptr;
     if (!_knownForegroundMask.empty()) {
         // store a local Mat so the pointer stays alive for the parallel_for_
-        Mat tmp = _knownForegroundMask.getMat();
-        knownMaskPtr = &tmp;
+        tmpKnownMask = _knownForegroundMask.getMat();
+        knownMaskPtr = &tmpKnownMask;
     }
 
     ++nframes;

--- a/modules/video/test/test_bgfg2.cpp
+++ b/modules/video/test/test_bgfg2.cpp
@@ -31,31 +31,15 @@ TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsTrue)
     //White Rectangle
     Mat knownFG = Mat::zeros(input.size(), CV_8U);
 
-    rectangle(knownFG, Rect(3,3,6,6), Scalar(255,255,255), -1);
+    rectangle(knownFG, Rect(3,3,8,8), Scalar(255,255,255), -1);
 
     Mat output;
+    mog2->apply(input, output, knownFG);
 
-    int frames_remaining = 1000;
-
-    while(frames_remaining > 0){
-
-        mog2->apply(input, output, knownFG);
-
-        if(frames_remaining == 10){
-            for(int y = 3; y < 6; y++){
-                for (int x = 3; x < 6; x++){
-                    EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
-                }
-            }
-        waitKey(0);
+    for(int y = 3; y < 8; y++){
+        for (int x = 3; x < 8; x++){
+            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
         }
-
-        imshow("In", input);
-        imshow("KnownFG", knownFG);
-        imshow("Out", output);
-
-        frames_remaining--;
-//        cout << frames_remaining << endl;
     }
 }
 

--- a/modules/video/test/test_bgfg2.cpp
+++ b/modules/video/test/test_bgfg2.cpp
@@ -1,0 +1,131 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include "opencv2/video/background_segm.hpp"
+
+namespace opencv_test { namespace {
+
+using namespace cv;
+
+class CV_MOG2Test : public cvtest::BaseTest
+{
+public:
+    // CV_MOG2Test();
+protected:
+    // void SetUp() override {}
+    // void TearDown() override {}
+
+    Mat vid;
+};
+
+///////////////////////// MOG2 //////////////////////////////
+TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsTrue)
+{
+    Ptr<BackgroundSubtractorMOG2> mog2 = createBackgroundSubtractorMOG2(500, 16, true);
+
+    //Black Frame
+    Mat input = Mat::zeros(480,640 , CV_8UC3);
+
+    //White Rectangle
+    Mat knownFG = Mat::zeros(input.size(), CV_8U);
+
+    rectangle(knownFG, Rect(3,3,6,6), Scalar(255,255,255), -1);
+
+    Mat output;
+
+    int frames_remaining = 1000;
+
+    while(frames_remaining > 0){
+
+        mog2->apply(input, output, knownFG);
+
+        if(frames_remaining == 10){
+            for(int y = 3; y < 6; y++){
+                for (int x = 3; x < 6; x++){
+                    EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+                }
+            }
+        waitKey(0);
+        }
+
+        imshow("In", input);
+        imshow("KnownFG", knownFG);
+        imshow("Out", output);
+
+        frames_remaining--;
+//        cout << frames_remaining << endl;
+    }
+}
+
+TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsFalse)
+{
+    Ptr<BackgroundSubtractorMOG2> mog2 = createBackgroundSubtractorMOG2(500, 16, false);
+
+    //Black Frame
+    Mat input = Mat::zeros(480,640 , CV_8UC3);
+
+    //White Rectangle
+    Mat knownFG = Mat::zeros(input.size(), CV_8U);
+
+    rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
+
+    Mat output;
+    mog2->apply(input, output, knownFG);
+
+    for(int y = 3; y < 8; y++){
+        for (int x = 3; x < 8; x++){
+            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+        }
+    }
+}
+
+///////////////////////// KNN //////////////////////////////
+
+TEST(BackgroundSubtractorKNN, KnownForegroundMaskShadowsTrue)
+{
+    Ptr<BackgroundSubtractorKNN> knn = createBackgroundSubtractorKNN(500, 400.0, true);
+
+    //Black Frame
+    Mat input = Mat::zeros(480,640 , CV_8UC3);
+
+    //White Rectangle
+    Mat knownFG = Mat::zeros(input.size(), CV_8U);
+
+    rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
+
+    Mat output;
+    knn->apply(input, output, knownFG);
+
+    for(int y = 3; y < 8; y++){
+        for (int x = 3; x < 8; x++){
+            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+        }
+    }
+}
+
+TEST(BackgroundSubtractorKNN, KnownForegroundMaskShadowsFalse)
+{
+    Ptr<BackgroundSubtractorKNN> knn = createBackgroundSubtractorKNN(500, 400.0, false);
+
+    //Black Frame
+    Mat input = Mat::zeros(480,640 , CV_8UC3);
+
+    //White Rectangle
+    Mat knownFG = Mat::zeros(input.size(), CV_8U);
+
+    rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
+
+    Mat output;
+    knn->apply(input, output, knownFG);
+
+    for(int y = 3; y < 8; y++){
+        for (int x = 3; x < 8; x++){
+            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+        }
+    }
+}
+
+}} // namespace
+/* End of file. */

--- a/modules/video/test/test_bgfg2.cpp
+++ b/modules/video/test/test_bgfg2.cpp
@@ -9,17 +9,6 @@ namespace opencv_test { namespace {
 
 using namespace cv;
 
-class CV_MOG2Test : public cvtest::BaseTest
-{
-public:
-    // CV_MOG2Test();
-protected:
-    // void SetUp() override {}
-    // void TearDown() override {}
-
-    Mat vid;
-};
-
 ///////////////////////// MOG2 //////////////////////////////
 TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsTrue)
 {
@@ -31,14 +20,15 @@ TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsTrue)
     //White Rectangle
     Mat knownFG = Mat::zeros(input.size(), CV_8U);
 
-    rectangle(knownFG, Rect(3,3,8,8), Scalar(255,255,255), -1);
+    rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), -1);
 
     Mat output;
-    mog2->apply(input, output, knownFG);
+    mog2->apply(input, knownFG, output);
 
-    for(int y = 3; y < 8; y++){
+    for(int y = 3; y < 8; y++)
+    {
         for (int x = 3; x < 8; x++){
-            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+            EXPECT_EQ(255,output.at<uchar>(y,x)) << "Expected foreground at (" << x << "," << y << ")";
         }
     }
 }
@@ -56,11 +46,12 @@ TEST(BackgroundSubtractorMOG2, KnownForegroundMaskShadowsFalse)
     rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
 
     Mat output;
-    mog2->apply(input, output, knownFG);
+    mog2->apply(input, knownFG, output);
 
-    for(int y = 3; y < 8; y++){
+    for(int y = 3; y < 8; y++)
+    {
         for (int x = 3; x < 8; x++){
-            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+            EXPECT_EQ(255,output.at<uchar>(y,x)) << "Expected foreground at (" << x << "," << y << ")";
         }
     }
 }
@@ -80,11 +71,12 @@ TEST(BackgroundSubtractorKNN, KnownForegroundMaskShadowsTrue)
     rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
 
     Mat output;
-    knn->apply(input, output, knownFG);
+    knn->apply(input, knownFG, output);
 
-    for(int y = 3; y < 8; y++){
+    for(int y = 3; y < 8; y++)
+    {
         for (int x = 3; x < 8; x++){
-            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+            EXPECT_EQ(255,output.at<uchar>(y,x)) << "Expected foreground at (" << x << "," << y << ")";
         }
     }
 }
@@ -102,11 +94,12 @@ TEST(BackgroundSubtractorKNN, KnownForegroundMaskShadowsFalse)
     rectangle(knownFG, Rect(3,3,5,5), Scalar(255,255,255), FILLED);
 
     Mat output;
-    knn->apply(input, output, knownFG);
+    knn->apply(input, knownFG, output);
 
-    for(int y = 3; y < 8; y++){
+    for(int y = 3; y < 8; y++)
+    {
         for (int x = 3; x < 8; x++){
-            EXPECT_EQ(output.at<uchar>(y,x),255) << "Expected foreground at (" << x << "," << y << ")";
+            EXPECT_EQ(255,output.at<uchar>(y,x)) << "Expected foreground at (" << x << "," << y << ")";
         }
     }
 }

--- a/samples/python/background_subtractor_mask.py
+++ b/samples/python/background_subtractor_mask.py
@@ -19,6 +19,7 @@ frame_count = 0
 # Allows for a frame buffer for the mask to learn pre known foreground
 show_count = 0
 
+
 while True:
     ret, frame = cap.read()
     if not ret:

--- a/samples/python/background_subtractor_mask.py
+++ b/samples/python/background_subtractor_mask.py
@@ -12,10 +12,12 @@ if not cap.isOpened:
 
 # Create background subtractor
 bg_subtractor = cv2.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
+#bg_subtractor = cv2.createBackgroundSubtractorKNN(history=300, detectShadows=False)
+
 
 frame_count = 0
 # Allows for a frame buffer for the mask to learn pre known foreground
-show_count = 200
+show_count = 0
 
 while True:
     ret, frame = cap.read()
@@ -34,10 +36,8 @@ while True:
     with_mask = bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
     without_mask = bg_subtractor.apply(frame)
 
-
-    cv2.imshow("Actual FG Mask", with_mask)
+    cv2.imshow("With FG Mask", with_mask)
     cv2.imshow("Without FG Mask", without_mask)
-
 
     key = cv2.waitKey(30)
     if key == 27:  # ESC

--- a/samples/python/background_subtractor_mask.py
+++ b/samples/python/background_subtractor_mask.py
@@ -1,0 +1,49 @@
+
+import sys
+#sys.path.insert(0, "/home/your_user/opencv-install/lib/python3.*/site-packages")
+import cv2
+print(cv2.__file__)
+import numpy as np
+
+cap = cv2.VideoCapture(0)
+if not cap.isOpened:
+    print("Capture source avaialable.")
+    exit()
+
+# Create background subtractor
+bg_subtractor = cv2.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
+
+frame_count = 0
+# Allows for a frame buffer for the mask to learn pre known foreground
+show_count = 200
+
+while True:
+    ret, frame = cap.read()
+    if not ret:
+        break
+
+    x = 100 + (frame_count % 10) * 3
+
+    frame = cv2.resize(frame, (640, 480))
+    aKnownForegroundMask = np.zeros(frame.shape[:2], dtype=np.uint8)
+
+    if frame_count > show_count:
+        cv2.rectangle(aKnownForegroundMask, (x,200), (x+50,300), 255, -1)
+        cv2.rectangle(aKnownForegroundMask, (540,180), (640,480), 255, -1)
+
+    with_mask = bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
+    without_mask = bg_subtractor.apply(frame)
+
+
+    cv2.imshow("Actual FG Mask", with_mask)
+    cv2.imshow("Without FG Mask", without_mask)
+
+
+    key = cv2.waitKey(30)
+    if key == 27:  # ESC
+        break
+
+    frame_count += 1
+
+cap.release()
+cv2.destroyAllWindows()

--- a/samples/python/background_subtractor_mask.py
+++ b/samples/python/background_subtractor_mask.py
@@ -11,14 +11,12 @@ if not cap.isOpened:
     exit()
 
 # Create background subtractor
-bg_subtractor = cv2.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
-#bg_subtractor = cv2.createBackgroundSubtractorKNN(history=300, detectShadows=False)
-
+mog2_bg_subtractor = cv2.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
+knn_bg_subtractor = cv2.createBackgroundSubtractorKNN(history=300, detectShadows=False)
 
 frame_count = 0
 # Allows for a frame buffer for the mask to learn pre known foreground
-show_count = 0
-
+show_count = 10
 
 while True:
     ret, frame = cap.read()
@@ -30,15 +28,22 @@ while True:
     frame = cv2.resize(frame, (640, 480))
     aKnownForegroundMask = np.zeros(frame.shape[:2], dtype=np.uint8)
 
+    # Allow for models to "settle"/learn
     if frame_count > show_count:
         cv2.rectangle(aKnownForegroundMask, (x,200), (x+50,300), 255, -1)
         cv2.rectangle(aKnownForegroundMask, (540,180), (640,480), 255, -1)
 
-    with_mask = bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
-    without_mask = bg_subtractor.apply(frame)
+    mog2_with_mask = mog2_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
+    mog2_without_mask = mog2_bg_subtractor.apply(frame)
 
-    cv2.imshow("With FG Mask", with_mask)
-    cv2.imshow("Without FG Mask", without_mask)
+    knn_with_mask = knn_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
+    knn_without_mask = knn_bg_subtractor.apply(frame)
+
+    # Display the 3 parameter apply and the 4 parameter apply for both subtractors
+    cv2.imshow("MOG2 With FG Mask", mog2_with_mask)
+    cv2.imshow("MOG2 Without FG Mask", mog2_without_mask)
+    cv2.imshow("KNN With FG Mask", knn_with_mask)
+    cv2.imshow("KNN Without FG Mask", knn_without_mask)
 
     key = cv2.waitKey(30)
     if key == 27:  # ESC

--- a/samples/python/background_subtractor_mask.py
+++ b/samples/python/background_subtractor_mask.py
@@ -1,55 +1,68 @@
 
-import sys
-#sys.path.insert(0, "/home/your_user/opencv-install/lib/python3.*/site-packages")
-import cv2
-print(cv2.__file__)
+'''
+Showcases the use of background subtraction from a live video feed,
+aswell as pass through of a known foreground parameter
+'''
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
 import numpy as np
+import cv2 as cv
 
-cap = cv2.VideoCapture(0)
-if not cap.isOpened:
-    print("Capture source avaialable.")
-    exit()
+def main():
+    cap = cv.VideoCapture(0)
+    if not cap.isOpened:
+        print("Capture source avaialable.")
+        exit()
 
-# Create background subtractor
-mog2_bg_subtractor = cv2.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
-knn_bg_subtractor = cv2.createBackgroundSubtractorKNN(history=300, detectShadows=False)
+    # Create background subtractor
+    mog2_bg_subtractor = cv.createBackgroundSubtractorMOG2(history=300, varThreshold=50, detectShadows=False)
+    knn_bg_subtractor = cv.createBackgroundSubtractorKNN(history=300, detectShadows=False)
 
-frame_count = 0
-# Allows for a frame buffer for the mask to learn pre known foreground
-show_count = 10
+    frame_count = 0
+    # Allows for a frame buffer for the mask to learn pre known foreground
+    show_count = 10
 
-while True:
-    ret, frame = cap.read()
-    if not ret:
-        break
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
 
-    x = 100 + (frame_count % 10) * 3
+        x = 100 + (frame_count % 10) * 3
 
-    frame = cv2.resize(frame, (640, 480))
-    aKnownForegroundMask = np.zeros(frame.shape[:2], dtype=np.uint8)
+        frame = cv.resize(frame, (640, 480))
+        aKnownForegroundMask = np.zeros(frame.shape[:2], dtype=np.uint8)
 
-    # Allow for models to "settle"/learn
-    if frame_count > show_count:
-        cv2.rectangle(aKnownForegroundMask, (x,200), (x+50,300), 255, -1)
-        cv2.rectangle(aKnownForegroundMask, (540,180), (640,480), 255, -1)
+        # Allow for models to "settle"/learn
+        if frame_count > show_count:
+            cv.rectangle(aKnownForegroundMask, (x,200), (x+50,300), 255, -1)
+            cv.rectangle(aKnownForegroundMask, (540,180), (640,480), 255, -1)
 
-    mog2_with_mask = mog2_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
-    mog2_without_mask = mog2_bg_subtractor.apply(frame)
+        #MOG2 Subtraction
+        mog2_with_mask = mog2_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
+        mog2_without_mask = mog2_bg_subtractor.apply(frame)
 
-    knn_with_mask = knn_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
-    knn_without_mask = knn_bg_subtractor.apply(frame)
+        #KNN Subtraction
+        knn_with_mask = knn_bg_subtractor.apply(frame,knownForegroundMask=aKnownForegroundMask)
+        knn_without_mask = knn_bg_subtractor.apply(frame)
 
-    # Display the 3 parameter apply and the 4 parameter apply for both subtractors
-    cv2.imshow("MOG2 With FG Mask", mog2_with_mask)
-    cv2.imshow("MOG2 Without FG Mask", mog2_without_mask)
-    cv2.imshow("KNN With FG Mask", knn_with_mask)
-    cv2.imshow("KNN Without FG Mask", knn_without_mask)
+        # Display the 3 parameter apply and the 4 parameter apply for both subtractors
+        cv.imshow("MOG2 With a Foreground Mask", mog2_with_mask)
+        cv.imshow("MOG2 Without a Foreground Mask", mog2_without_mask)
+        cv.imshow("KNN With a Foreground Mask", knn_with_mask)
+        cv.imshow("KNN Without a Foreground Mask", knn_without_mask)
 
-    key = cv2.waitKey(30)
-    if key == 27:  # ESC
-        break
+        key = cv.waitKey(30)
+        if key == 27:  # ESC
+            break
 
-    frame_count += 1
+        frame_count += 1
 
-cap.release()
-cv2.destroyAllWindows()
+    cap.release()
+    cv.destroyAllWindows()
+
+if __name__ == '__main__':
+    print(__doc__)
+    main()
+    cv.destroyAllWindows()


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description
This adds an optional foreground input mask parameter to the MOG2 and KNN background subtractors, in line with issue https://github.com/opencv/opencv/issues/26476

4 tests are added under test_bgfg2.cpp:
2 for each subtractor type (1 with shadow detection and 1 without)
A demo shows the feature with only 3 parameters and with a 4th optional foreground mask for both core subtractor types.

Note: To patch contrib inheritance of the background subtraction class, empty apply method which throws a not implemented error is added to contrib subclasses. This is done to keep the overloaded apply function as pure virtual. Contrib PR to be made and linked shortly.  
Contrib Repo Paired Pull Request: https://github.com/opencv/opencv_contrib/pull/4017