### PR TITLE
imgcodecs: bmp: relax decoding size limit to over 1GiB

### DIFF
--- a/modules/imgcodecs/src/bitstrm.cpp
+++ b/modules/imgcodecs/src/bitstrm.cpp
@@ -120,9 +120,9 @@ void  RBaseStream::release()
 }
 
 
-void  RBaseStream::setPos( int pos )
+void  RBaseStream::setPos( size_t pos )
 {
-    CV_Assert(isOpened() && pos >= 0);
+    CV_Assert(isOpened());
 
     if( !m_file )
     {
@@ -132,7 +132,7 @@ void  RBaseStream::setPos( int pos )
     }
 
     int offset = pos % m_block_size;
-    int old_block_pos = m_block_pos;
+    size_t old_block_pos = m_block_pos;
     m_block_pos = pos - offset;
     m_current = m_start + offset;
     if (old_block_pos != m_block_pos)
@@ -140,18 +140,19 @@ void  RBaseStream::setPos( int pos )
 }
 
 
-int  RBaseStream::getPos()
+size_t RBaseStream::getPos()
 {
     CV_Assert(isOpened());
-    int pos = validateToInt((m_current - m_start) + m_block_pos);
+    ptrdiff_t diff = m_current - m_start;
+    CV_Assert(diff >= 0);
+    size_t pos = static_cast<size_t>(diff) + m_block_pos;
     CV_Assert(pos >= m_block_pos); // overflow check
-    CV_Assert(pos >= 0); // overflow check
+    CV_Assert(pos >= static_cast<size_t>(diff)); // overflow check
     return pos;
 }
 
-void  RBaseStream::skip( int bytes )
+void  RBaseStream::skip( size_t bytes )
 {
-    CV_Assert(bytes >= 0);
     uchar* old = m_current;
     m_current += bytes;
     CV_Assert(m_current >= old);  // overflow check

--- a/modules/imgcodecs/src/bitstrm.hpp
+++ b/modules/imgcodecs/src/bitstrm.hpp
@@ -45,9 +45,9 @@ public:
     virtual bool  open( const Mat& buf );
     virtual void  close();
     bool          isOpened();
-    void          setPos( int pos );
-    int           getPos();
-    void          skip( int bytes );
+    void          setPos( size_t pos );
+    size_t        getPos();
+    void          skip( size_t bytes );
 
 protected:
 
@@ -57,7 +57,7 @@ protected:
     uchar*  m_current;
     FILE*   m_file;
     int     m_block_size;
-    int     m_block_pos;
+    size_t  m_block_pos;
     bool    m_is_opened;
 
     virtual void  readBlock();

--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -48,13 +48,14 @@ namespace cv
 {
 
 static const char* fmtSignBmp = "BM";
+static const size_t INVALID_OFFSET = 0xffffffff;
 
 /************************ BMP decoder *****************************/
 
 BmpDecoder::BmpDecoder()
 {
     m_signature = fmtSignBmp;
-    m_offset = -1;
+    m_offset = INVALID_OFFSET;
     m_buf_supported = true;
     m_origin = ORIGIN_TL;
     m_bpp = 0;
@@ -218,7 +219,7 @@ bool  BmpDecoder::readHeader()
 
     if( !result )
     {
-        m_offset = -1;
+        m_offset = INVALID_OFFSET;
         m_width = m_height = -1;
         m_strm.close();
     }
@@ -237,10 +238,7 @@ bool  BmpDecoder::readData( Mat& img )
     int  nch = color ? 3 : 1;
     int  y, width3 = m_width*nch;
 
-    // FIXIT: use safe pointer arithmetic (avoid 'int'), use size_t, intptr_t, etc
-    CV_Assert(((uint64)m_height * m_width * nch < (CV_BIG_UINT(1) << 30)) && "BMP reader implementation doesn't support large images >= 1Gb");
-
-    if( m_offset < 0 || !m_strm.isOpened())
+    if( m_offset == INVALID_OFFSET || !m_strm.isOpened())
         return false;
 
     if( m_origin == ORIGIN_BL )

--- a/modules/imgcodecs/src/grfmt_bmp.hpp
+++ b/modules/imgcodecs/src/grfmt_bmp.hpp
@@ -87,7 +87,7 @@ protected:
     PaletteEntry    m_palette[256];
     Origin          m_origin;
     int             m_bpp;
-    int             m_offset;
+    size_t          m_offset;
     BmpCompression  m_rle_code;
     uint            m_rgba_mask[4];
     int             m_rgba_bit_offset[4];

--- a/modules/imgcodecs/test/test_bmp.cpp
+++ b/modules/imgcodecs/test/test_bmp.cpp
@@ -1,0 +1,58 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+#include "test_precomp.hpp"
+#include "test_common.hpp"
+
+#include <vector>
+
+namespace opencv_test { namespace {
+
+// See https://github.com/opencv/opencv/issues/27789
+// See https://github.com/opencv/opencv/issues/23233
+TEST(Imgcodecs_BMP, encode_decode_over1GB_regression27789)
+{
+    applyTestTag( CV_TEST_TAG_MEMORY_1GB, CV_TEST_TAG_LONG );
+
+    // Create large Mat over 1GB
+    // 20000 px * 18000 px *  24 bpp(3ch) = 1,080,000,000 bytes
+    // 1 GiB                              = 1,073,741,824 bytes
+    cv::Mat src(20000, 18000, CV_8UC3, cv::Scalar(0,0,0));
+
+    // Encode large BMP file.
+    std::vector<uint8_t> buf;
+    bool ret = false;
+    ASSERT_NO_THROW(ret = cv::imencode(".bmp", src, buf, {}));
+    ASSERT_TRUE(ret);
+
+    // Decode large BMP file.
+    cv::Mat dst;
+    ASSERT_NO_THROW(dst = cv::imdecode(buf, cv::IMREAD_COLOR));
+    ASSERT_FALSE(dst.empty());
+}
+
+TEST(Imgcodecs_BMP, write_read_over1GB_regression27789)
+{
+    applyTestTag( CV_TEST_TAG_MEMORY_1GB, CV_TEST_TAG_LONG );
+    string bmpFilename = cv::tempfile(".bmp");
+
+    // Create large Mat over 1GB
+    // 20000 px * 18000 px *  24 bpp(3ch) = 1,080,000,000 bytes
+    // 1 GiB                              = 1,073,741,824 bytes
+    cv::Mat src(20000, 18000, CV_8UC3, cv::Scalar(0,0,0));
+
+    // Write large BMP file.
+    bool ret = false;
+    ASSERT_NO_THROW(ret = cv::imwrite(bmpFilename, src, {}));
+    ASSERT_TRUE(ret);
+
+    // Read large BMP file.
+    cv::Mat dst;
+    ASSERT_NO_THROW(dst = cv::imread(bmpFilename, cv::IMREAD_COLOR));
+    ASSERT_FALSE(dst.empty());
+
+    remove(bmpFilename.c_str());
+}
+
+
+}} // namespace


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/27789
Close https://github.com/opencv/opencv/issues/23233

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
