### PR TITLE
Tunned Python bindings for logging.

### DIFF
--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -335,23 +335,6 @@ namespace fs {
 //! @}  // core_utils
 }  // namespace cv::utils
 
-//! @cond IGNORED
-
-CV_WRAP static inline
-int setLogLevel(int level)
-{
-    // NB: Binding generators doesn't work with enums properly yet, so we define separate overload here
-    return cv::utils::logging::setLogLevel((cv::utils::logging::LogLevel)level);
-}
-
-CV_WRAP static inline
-int getLogLevel()
-{
-    return cv::utils::logging::getLogLevel();
-}
-
-//! @endcond IGNORED
-
 } // namespaces cv /  utils
 
 #endif // OPENCV_CORE_BINDINGS_UTILS_HPP

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -22,9 +22,9 @@ namespace logging {
 /** Set global logging level
 @return previous logging level
 */
-CV_EXPORTS LogLevel setLogLevel(LogLevel logLevel);
+CV_EXPORTS_W LogLevel setLogLevel(LogLevel logLevel);
 /** Get global logging level */
-CV_EXPORTS LogLevel getLogLevel();
+CV_EXPORTS_W LogLevel getLogLevel();
 
 CV_EXPORTS void registerLogTag(cv::utils::logging::LogTag* plogtag);
 

--- a/modules/python/bindings/CMakeLists.txt
+++ b/modules/python/bindings/CMakeLists.txt
@@ -51,7 +51,7 @@ ocv_list_filterout(opencv_hdrs "modules/core/include/opencv2/core/fast_math.hpp"
 ocv_list_filterout(opencv_hdrs "modules/core/.*/cuda/")
 ocv_list_filterout(opencv_hdrs "modules/core/.*/hal/")
 ocv_list_filterout(opencv_hdrs "modules/core/.*/opencl/")
-ocv_list_filterout(opencv_hdrs "modules/.+/utils/.*")
+ocv_list_filterout(opencv_hdrs "modules/.+/utils/trace.hpp")
 ocv_list_filterout(opencv_hdrs "modules/.*\\\\.inl\\\\.h*")
 ocv_list_filterout(opencv_hdrs "modules/.*_inl\\\\.h*")
 ocv_list_filterout(opencv_hdrs "modules/.*\\\\.details\\\\.h*")


### PR DESCRIPTION
Python API changes:

- cv.setLogLevel -> cv.utils.setLogLevel
- cv.getLogLevel -> cv.utils.getLogLevel
- log level constants

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
