### PR TITLE
Use bitwise operation for flipping the direction

### DIFF
--- a/modules/imgproc/src/contours_new.cpp
+++ b/modules/imgproc/src/contours_new.cpp
@@ -158,7 +158,7 @@ static bool icvTraceContour(Mat& image, const Point& start, const Point& end, bo
                 break;
 
             i3 = i4;
-            s = (s + 4) & 7;
+            s ^= 4;
         }  // end of border following loop
     }
     else
@@ -260,7 +260,7 @@ static void icvFetchContourEx(Mat& image,
                 break;
 
             i3 = i4;
-            s = (s + 4) & 7;
+            s ^= 4;
         }
     }
     rect.width -= rect.x - 1;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Tiny pr for using bitwise operations to turn the direction index 180 degrees. This has already been done on line 206 but has not been extended further.  