### PR TITLE
Fixed wrong NaN handling when scaling depth for OdometryFrame

### DIFF
--- a/modules/3d/src/rgbd/odometry_functions.cpp
+++ b/modules/3d/src/rgbd/odometry_functions.cpp
@@ -48,13 +48,18 @@ static UMat prepareScaledDepth(OdometryFrame& frame)
     frame.getDepth(depth);
     CV_Assert(!depth.empty());
 
+    UMat depthFlt;
+    depth.convertTo(depthFlt, CV_32FC1);
+    patchNaNs(depthFlt, 0);
     // Odometry works well with depth values in range [0, 10)
     // If it's bigger, let's scale it down by 5000, a typical depth factor
     double maxv;
-    cv::minMaxLoc(depth, nullptr, &maxv);
-    UMat depthFlt;
-    depth.convertTo(depthFlt, CV_32FC1, maxv > 10 ? (1.f / 5000.f) : 1.f);
-    patchNaNs(depthFlt, 0);
+    cv::minMaxLoc(depthFlt, nullptr, &maxv);
+    if (maxv > 10)
+    {
+        cv::multiply(depthFlt, (1.f / 5000.f), depthFlt);
+    }
+
     frame.impl->scaledDepth = depthFlt;
 
     return depthFlt;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
