### PR TITLE
Added option to wrap opencv_contrib into JS too.

### DIFF
--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -107,6 +107,10 @@ typedef SimpleBlobDetector::Params SimpleBlobDetector_Params;
 typedef TrackerMIL::Params TrackerMIL_Params;
 #endif
 
+#ifdef HAVE_OPENCV_XIMGPROC
+typedef ximgproc::EdgeDrawing::Params EdgeDrawing_Params;
+#endif
+
 // HACK: JS generator ommits namespace for parameter types for some reason. Added typedef to handle std::string correctly
 typedef std::string string;
 

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -175,6 +175,10 @@ class Builder:
         if flags:
             cmd += ["-DCMAKE_C_FLAGS='%s'" % flags,
                     "-DCMAKE_CXX_FLAGS='%s'" % flags]
+
+        if self.options.extra_modules:
+            cmd.append("-DOPENCV_EXTRA_MODULES_PATH='%s'" % self.options.extra_modules)
+
         return cmd
 
     def get_build_flags(self):
@@ -260,6 +264,8 @@ if __name__ == "__main__":
     # Write a path to modify file like argument of this flag
     parser.add_argument('--config', help="Specify configuration file with own list of exported into JS functions")
     parser.add_argument('--webnn', action="store_true", help="Enable WebNN Backend")
+    parser.add_argument("--extra_modules", required=False, help="Path extra modules location (OPENCV_EXTRA_MODULES_PATH)")
+
 
     transformed_args = ["--cmake_option={}".format(arg) if arg[:2] == "-D" else arg for arg in sys.argv[1:]]
     args = parser.parse_args(transformed_args)


### PR DESCRIPTION
Related patch in main repo: https://github.com/opencv/opencv_contrib/pull/4007

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
