### PR TITLE
Enabled fp16 conversions, but disabled NEON FP16 arithmetics on Windows for ARM for now

### DIFF
--- a/cmake/checks/cpu_fp16.cpp
+++ b/cmake/checks/cpu_fp16.cpp
@@ -11,8 +11,7 @@ int test()
     _mm_storel_epi64((__m128i*)dst, v_dst);
     return (int)dst[0];
 }
-#elif (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) /*|| (defined _MSC_VER && defined _M_ARM64)*/
-// Windows + ARM64 case disabled: https://github.com/opencv/opencv/issues/25052
+#elif (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) || (defined _MSC_VER && defined _M_ARM64)
 #include "arm_neon.h"
 int test()
 {

--- a/cmake/checks/cpu_neon_fp16.cpp
+++ b/cmake/checks/cpu_neon_fp16.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
-#if (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) || (defined _MSC_VER && (defined _M_ARM64 || defined _M_ARM64EC))
+#if (defined __GNUC__ && (defined __arm__ || defined __aarch64__)) /* || (defined _MSC_VER && (defined _M_ARM64 || defined _M_ARM64EC)) */
+// Windows + ARM64 case disabled: https://github.com/opencv/opencv/issues/25052
 #include "arm_neon.h"
 
 float16x8_t vld1q_as_f16(const float* src)


### PR DESCRIPTION
Related to https://github.com/opencv/opencv/pull/27775 and https://github.com/opencv/opencv/issues/25052

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
