### PR TITLE
Fix to prevent QR code decoding from throwing exception on degenerate quadrilaterals

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -2958,7 +2958,12 @@ std::string ImplContour::decode(InputArray in, InputArray points, OutputArray st
     vector<Point2f> src_points;
     points.copyTo(src_points);
     CV_Assert(src_points.size() == 4);
-    CV_CheckGT(contourArea(src_points), 0.0, "Invalid QR code source points");
+    if (contourArea(src_points) <= 0.0)
+    {
+        if (straight_qrcode.needed())
+            straight_qrcode.release();
+        return std::string();
+    }
 
     QRDecode qrdec(useAlignmentMarkers);
     qrdec.init(inarr, src_points);


### PR DESCRIPTION
This is fixing https://github.com/opencv/opencv/issues/27807 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Changed decode to gracefully return an empty result instead of throwing on zero-area quads. This aligns with decodeMulti which already filters invalid quadrilaterals and avoids exceptions for degenerate inputs. 

The scripts and images mentioned in https://github.com/opencv/opencv/issues/27807 were used to test the changes.