### PR TITLE
Fixed out-of-bound access during extra params handing in BMP encoder.

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -633,7 +633,7 @@ bool  BmpEncoder::write( const Mat& img, const std::vector<int>& params )
     // sRGB colorspace requires BITMAPV5HEADER.
     // See https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
     bool useV5BitFields = true;
-    for(size_t i = 0 ; i < params.size(); i++)
+    for(size_t i = 0; i < params.size(); i+=2)
     {
         const int value = params[i+1];
         switch(params[i])


### PR DESCRIPTION
The issue was introduced in https://github.com/opencv/opencv/pull/27559

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
