### PR TITLE
Dropped depricated PYTHON_DEBUG_LIBRARIES and resolved options clash with Clang

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -14,7 +14,7 @@ ocv_module_include_directories(
 
 # try to use dynamic symbols linking with libpython.so
 set(OPENCV_FORCE_PYTHON_LIBS OFF CACHE BOOL "")
-string(REPLACE "-Wl,--no-undefined" "" CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
+string(REGEX REPLACE "(^| )-Wl,--no-undefined( |$)" " " CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
 if(NOT WIN32 AND NOT APPLE AND NOT OPENCV_PYTHON_SKIP_LINKER_EXCLUDE_LIBS)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--exclude-libs=ALL")
 endif()
@@ -59,11 +59,7 @@ endif()
 if(APPLE)
   set_target_properties(${the_module} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 elseif(WIN32 OR OPENCV_FORCE_PYTHON_LIBS)
-  if(${PYTHON}_DEBUG_LIBRARIES AND NOT ${PYTHON}_LIBRARIES MATCHES "optimized.*debug")
-    ocv_target_link_libraries(${the_module} PRIVATE debug ${${PYTHON}_DEBUG_LIBRARIES} optimized ${${PYTHON}_LIBRARIES})
-  else()
-    ocv_target_link_libraries(${the_module} PRIVATE ${${PYTHON}_LIBRARIES})
-  endif()
+  ocv_target_link_libraries(${the_module} PRIVATE ${${PYTHON}_LIBRARIES})
 endif()
 
 if(TARGET gen_opencv_python_source)


### PR DESCRIPTION
PYTHON_DEBUG_LIBRARIES deprecated since CMake .2.8.8. See https://cmake.org/cmake/help/latest/module/FindPythonLibs.html
Fixes https://github.com/opencv/opencv/issues/27842

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
