### PR TITLE
Updated Tutorial PSNR for identical images

### DIFF
--- a/samples/cpp/tutorial_code/gpu/gpu-basics-similarity/gpu-basics-similarity.cpp
+++ b/samples/cpp/tutorial_code/gpu/gpu-basics-similarity/gpu-basics-similarity.cpp
@@ -181,14 +181,13 @@ double getPSNR(const Mat& I1, const Mat& I2)
 
     double sse = s.val[0] + s.val[1] + s.val[2]; // sum channels
 
-    if( sse <= 1e-10) // for small values return zero
-        return 0;
-    else
-    {
-        double  mse =sse /(double)(I1.channels() * I1.total());
-        double psnr = 10.0*log10((255*255)/mse);
-        return psnr;
-    }
+    double  mse = sse /(double)(I1.channels() * I1.total());
+
+    // For very small SSE, add epsilon to approximate infinite PSNR (~361 dB)
+    if( sse <= 1e-10) mse+= DBL_EPSILON;
+
+    double psnr = 10.0*log10((255*255)/mse);
+    return psnr;
 }
 //! [getpsnr]
 
@@ -206,14 +205,13 @@ double getPSNR_CUDA_optimized(const Mat& I1, const Mat& I2, BufferPSNR& b)
 
     double sse = cuda::sum(b.gs, b.buf)[0];
 
-    if( sse <= 1e-10) // for small values return zero
-        return 0;
-    else
-    {
-        double mse = sse /(double)(I1.channels() * I1.total());
-        double psnr = 10.0*log10((255*255)/mse);
-        return psnr;
-    }
+    double mse = sse /(double)(I1.channels() * I1.total());
+
+    // For very small SSE, add epsilon to approximate infinite PSNR (~361 dB)
+    if (sse <= 1e-10) mse += DBL_EPSILON;
+
+    double psnr = 10.0*log10((255*255)/mse);
+    return psnr;
 }
 //! [getpsnropt]
 
@@ -234,14 +232,13 @@ double getPSNR_CUDA(const Mat& I1, const Mat& I2)
     Scalar s = cuda::sum(gs);
     double sse = s.val[0] + s.val[1] + s.val[2];
 
-    if( sse <= 1e-10) // for small values return zero
-        return 0;
-    else
-    {
-        double  mse =sse /(double)(gI1.channels() * I1.total());
-        double psnr = 10.0*log10((255*255)/mse);
-        return psnr;
-    }
+    double  mse = sse /(double)(gI1.channels() * I1.total());
+
+    // For very small SSE, add epsilon to approximate infinite PSNR (~361 dB)
+    if( sse <= 1e-10) mse+= DBL_EPSILON;
+
+    double psnr = 10.0*log10((255*255)/mse);
+    return psnr;
 }
 //! [getpsnrcuda]
 

--- a/samples/cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp
+++ b/samples/cpp/tutorial_code/videoio/video-input-psnr-ssim/video-input-psnr-ssim.cpp
@@ -144,8 +144,8 @@ double getPSNR(const Mat& I1, const Mat& I2)
 
     double sse = s.val[0] + s.val[1] + s.val[2]; // sum channels
 
-    if( sse <= 1e-10) // for small values return zero
-        return 0;
+    if( sse <= 1e-10) // For very small values, return 360 to cap PSNR (theoretical value is infinity)
+        return 360.0;
     else
     {
         double mse  = sse / (double)(I1.channels() * I1.total());

--- a/samples/python/tutorial_code/videoio/video-input-psnr-ssim.py
+++ b/samples/python/tutorial_code/videoio/video-input-psnr-ssim.py
@@ -16,7 +16,7 @@ def getPSNR(I1, I2):
     s1 = s1 * s1            # |I1 - I2|^2
     sse = s1.sum()          # sum elements per channel
     if sse <= 1e-10:        # sum channels
-        return 0            # for small values return zero
+        return 360          # For very small SSE, return 360 to cap PSNR (theoretical value is infinity)
     else:
         shape = I1.shape
         mse = 1.0 * sse / (shape[0] * shape[1] * shape[2])


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Addresses Issue: https://github.com/opencv/opencv/issues/27023

This pull request updates the getPSNR, getPSNR_CUDA, and getPSNR_CUDA_optimized implementations and getPSNR in tutorials to handle cases where the sum of squared errors (SSE) is extremely small.  

When two input images are identical or nearly identical, the SSE can approach zero due to floating-point precision limits. In such cases, the PSNR should theoretically tend to infinity. However, the previous implementation returned 0 when sse <= 1e-10, which does not reflect the correct behavior, implemented elsewhere.

To address this, a small numerical safeguard (DBL_EPSILON) is added to the MSE when sse <= 1e-10. This ensures a large but finite PSNR value (~361 dB), consistent with OpenCV’s core implementation.