### PR TITLE
Add OPENCV_FFMPEG_SKIP_LOG_CALLBACK to preserve custom FFmpeg logging

### DIFF
--- a/doc/tutorials/introduction/env_reference/env_reference.markdown
+++ b/doc/tutorials/introduction/env_reference/env_reference.markdown
@@ -273,6 +273,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 | OPENCV_FFMPEG_THREADS | num | | set FFmpeg thread count |
 | OPENCV_FFMPEG_DEBUG | bool | false | enable logging messages from FFmpeg |
 | OPENCV_FFMPEG_LOGLEVEL | num | | set FFmpeg logging level |
+| OPENCV_FFMPEG_SKIP_LOG_CALLBACK | bool | false | do not install OpenCV's FFmpeg log callback (preserve default/user callback) |
 | OPENCV_FFMPEG_DLL_DIR | dir path | | directory with FFmpeg plugin (legacy) |
 | OPENCV_FFMPEG_IS_THREAD_SAFE | bool | false | enabling this option will turn off thread safety locks in the FFmpeg backend (use only if you are sure FFmpeg is built with threading support, tested on Linux) |
 | OPENCV_FFMPEG_READ_ATTEMPTS | num | 4096 | number of failed `av_read_frame` attempts before failing read procedure |

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -960,7 +960,7 @@ public:
         if ( debug_option || (!level_option.empty()) )
         {
             av_log_set_level(level);
-            if (!skip_log_callback) 
+            if (!skip_log_callback)
             {
                 av_log_set_callback(ffmpeg_log_callback);
             }
@@ -992,7 +992,7 @@ public:
 #ifdef CV_FFMPEG_LOCKMGR
         av_lockmgr_register(NULL);
 #endif
-        if (!skip_log_callback) 
+        if (!skip_log_callback)
         {
             av_log_set_callback(NULL);
         }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -937,6 +937,8 @@ static void ffmpeg_log_callback(void *ptr, int level, const char *fmt, va_list v
 
 class InternalFFMpegRegister
 {
+    static bool skip_log_callback;
+
 public:
     static void init(const bool threadSafe)
     {
@@ -949,6 +951,7 @@ public:
     {
         const bool debug_option = utils::getConfigurationParameterBool("OPENCV_FFMPEG_DEBUG");
         std::string level_option = utils::getConfigurationParameterString("OPENCV_FFMPEG_LOGLEVEL");
+        skip_log_callback = utils::getConfigurationParameterBool("OPENCV_FFMPEG_SKIP_LOG_CALLBACK");
         int level = AV_LOG_VERBOSE;
         if (!level_option.empty())
         {
@@ -957,7 +960,10 @@ public:
         if ( debug_option || (!level_option.empty()) )
         {
             av_log_set_level(level);
-            av_log_set_callback(ffmpeg_log_callback);
+            if (!skip_log_callback) 
+            {
+                av_log_set_callback(ffmpeg_log_callback);
+            }
         }
         else
         {
@@ -986,9 +992,14 @@ public:
 #ifdef CV_FFMPEG_LOCKMGR
         av_lockmgr_register(NULL);
 #endif
-        av_log_set_callback(NULL);
+        if (!skip_log_callback) 
+        {
+            av_log_set_callback(NULL);
+        }
     }
 };
+
+bool InternalFFMpegRegister::skip_log_callback = false;
 
 inline void fill_codec_context(AVCodecContext * enc, AVDictionary * dict)
 {


### PR DESCRIPTION
OpenCV’s InternalFFMpegRegister overwrites av_log_set_callback, blocking custom FFmpeg log handlers in statically linked apps.

Add `OPENCV_FFMPEG_SKIP_LOG_CALLBACK` to let applications keep their own logging.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
