### PR TITLE
Rename fields in camera calibration results

### DIFF
--- a/apps/interactive-calibration/calibController.cpp
+++ b/apps/interactive-calibration/calibController.cpp
@@ -306,10 +306,10 @@ bool calib::calibDataController::saveCurrentCameraParameters() const
                 parametersWriter << "calibrationDate" << buf;
                 parametersWriter << "framesCount" << std::max((int)mCalibData->objectPoints.size(), (int)mCalibData->allCharucoCorners.size());
                 parametersWriter << "cameraResolution" << mCalibData->imageSize;
-                parametersWriter << "cameraMatrix" << mCalibData->cameraMatrix;
-                parametersWriter << "cameraMatrix_std_dev" << mCalibData->stdDeviations.rowRange(cv::Range(0, 4));
-                parametersWriter << "dist_coeffs" << mCalibData->distCoeffs;
-                parametersWriter << "dist_coeffs_std_dev" << mCalibData->stdDeviations.rowRange(cv::Range(4, 9));
+                parametersWriter << "camera_matrix" << mCalibData->cameraMatrix;
+                parametersWriter << "camera_matrix_std_dev" << mCalibData->stdDeviations.rowRange(cv::Range(0, 4));
+                parametersWriter << "distortion_coefficients" << mCalibData->distCoeffs;
+                parametersWriter << "distortion_coefficients_std_dev" << mCalibData->stdDeviations.rowRange(cv::Range(4, 9));
                 parametersWriter << "avg_reprojection_error" << mCalibData->totalAvgErr;
 
                 parametersWriter.release();

--- a/doc/tutorials/calib3d/interactive_calibration/interactive_calibration.markdown
+++ b/doc/tutorials/calib3d/interactive_calibration/interactive_calibration.markdown
@@ -180,34 +180,34 @@ Example of output XML file:
 <framesCount>21</framesCount>
 <cameraResolution>
   1280 720</cameraResolution>
-<cameraMatrix type_id="opencv-matrix">
+<camera_matrix type_id="opencv-matrix">
   <rows>3</rows>
   <cols>3</cols>
   <dt>d</dt>
   <data>
     1.2519588293098975e+03 0. 6.6684948780852471e+02 0.
-    1.2519588293098975e+03 3.6298123112613683e+02 0. 0. 1.</data></cameraMatrix>
-<cameraMatrix_std_dev type_id="opencv-matrix">
+    1.2519588293098975e+03 3.6298123112613683e+02 0. 0. 1.</data></camera_matrix>
+<camera_matrix_std_dev type_id="opencv-matrix">
   <rows>4</rows>
   <cols>1</cols>
   <dt>d</dt>
   <data>
     0. 1.2887048808572649e+01 2.8536856683866230e+00
-    2.8341737483430314e+00</data></cameraMatrix_std_dev>
-<dist_coeffs type_id="opencv-matrix">
+    2.8341737483430314e+00</data></camera_matrix_std_dev>
+<distortion_coefficients type_id="opencv-matrix">
   <rows>1</rows>
   <cols>5</cols>
   <dt>d</dt>
   <data>
     1.3569117181595716e-01 -8.2513063822554633e-01 0. 0.
-    1.6412101575010554e+00</data></dist_coeffs>
-<dist_coeffs_std_dev type_id="opencv-matrix">
+    1.6412101575010554e+00</data></distortion_coefficients>
+<distortion_coefficients_std_dev type_id="opencv-matrix">
   <rows>5</rows>
   <cols>1</cols>
   <dt>d</dt>
   <data>
     1.5570675523402111e-02 8.7229075437543435e-02 0. 0.
-    1.8382427901856876e-01</data></dist_coeffs_std_dev>
+    1.8382427901856876e-01</data></distortion_coefficients_std_dev>
 <avg_reprojection_error>4.2691743074130178e-01</avg_reprojection_error>
 </opencv_storage>
 @endcode

--- a/doc/tutorials/objdetect/aruco_board_detection/aruco_board_detection.markdown
+++ b/doc/tutorials/objdetect/aruco_board_detection/aruco_board_detection.markdown
@@ -127,7 +127,7 @@ in ascending order starting on 0, so they will be 0, 1, 2, ..., 34.
 
 After creating a grid board, we probably want to print it and use it.
 There are two ways to do this:
-1. By using the script `apps/pattern_tools/generate_pattern.py `, see @subpage tutorial_camera_calibration_pattern.
+1. By using the script `apps/pattern-tools/generate_pattern.py`, see @subpage tutorial_camera_calibration_pattern.
 2. By using the function `cv::aruco::GridBoard::generateImage()`.
 
 The function `cv::aruco::GridBoard::generateImage()` is provided in cv::aruco::GridBoard class and

--- a/doc/tutorials/objdetect/charuco_detection/charuco_detection.markdown
+++ b/doc/tutorials/objdetect/charuco_detection/charuco_detection.markdown
@@ -77,7 +77,7 @@ through `board.ids`, like in the `cv::aruco::Board` parent class.
 
 Once we have our `cv::aruco::CharucoBoard` object, we can create an image to print it. There are
 two ways to do this:
-1. By using the script `apps/pattern_tools/generate_pattern.py `, see @subpage tutorial_camera_calibration_pattern.
+1. By using the script `apps/pattern-tools/generate_pattern.py`, see @subpage tutorial_camera_calibration_pattern.
 2. By using the function `cv::aruco::CharucoBoard::generateImage()`.
 
 The function `cv::aruco::CharucoBoard::generateImage()` is provided in cv::aruco::CharucoBoard class


### PR DESCRIPTION
### Pull Request Readiness Checklist

All subsequent scripts rely on `camera_matrix` and `distortion_coefficients` fields names. For example

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
