### PR TITLE
Fixed warnings produced by x86 builds on Windows.

### DIFF
--- a/modules/imgcodecs/src/grfmt_gif.cpp
+++ b/modules/imgcodecs/src/grfmt_gif.cpp
@@ -764,7 +764,7 @@ bool GifEncoder::lzwEncode() {
     //initialize
     int32_t prev = imgCodeStream[0];
 
-    for (int64_t i = 1; i < height * width; i++) {
+    for (size_t i = 1; i < size_t(height * width); i++) {
         // add the output code to the output buffer
         while (bitLeft >= 8) {
             buffer[bufferLen++] = (uchar)output;

--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -51,10 +51,10 @@ int validateToInt(size_t sz)
     return valueInt;
 }
 
-int64_t validateToInt64(size_t sz)
+int64_t validateToInt64(ptrdiff_t sz)
 {
     int64_t valueInt = static_cast<int64_t>(sz);
-    CV_Assert((size_t)valueInt == sz);
+    CV_Assert((ptrdiff_t)valueInt == sz);
     return valueInt;
 }
 

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -45,7 +45,7 @@
 namespace cv {
 
 int validateToInt(size_t step);
-int64_t validateToInt64(size_t step);
+int64_t validateToInt64(ptrdiff_t step);
 
 template <typename _Tp> static inline
 size_t safeCastToSizeT(const _Tp v_origin, const char* msg)


### PR DESCRIPTION
```
2025-10-09T06:17:48.2340654Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\imgcodecs\src\bitstrm.cpp(156,57): warning C4244: 'argument': conversion from 'int64_t' to 'size_t', possible loss of data [C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\imgcodecs\opencv_imgcodecs.vcxproj]
```
Introduced in https://github.com/opencv/opencv/pull/27811

```
2025-10-09T06:17:44.5328459Z C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\opencv\modules\imgcodecs\src\grfmt_gif.cpp(780,33): warning C4244: 'argument': conversion from 'int64_t' to 'const unsigned int', possible loss of data [C:\GHA-OCV-2\_work\ci-gha-workflow\ci-gha-workflow\build\modules\imgcodecs\opencv_imgcodecs.vcxproj]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
