### PR TITLE
fix: Refactor tuple creation in nlm.cu for fixing nvcc build…

### DIFF
--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -199,7 +199,7 @@ namespace cv { namespace cuda { namespace device
             static __device__ __forceinline__ const thrust::tuple<plus<float>, plus<float> > op()
             {
                 plus<float> op;
-                return thrust::make_tuple(op, op);
+                return { op, op };
             }
         };
         template <> struct Unroll<2>
@@ -218,7 +218,7 @@ namespace cv { namespace cuda { namespace device
             static __device__ __forceinline__ const thrust::tuple<plus<float>, plus<float>, plus<float> > op()
             {
                 plus<float> op;
-                return thrust::make_tuple(op, op, op);
+                return { op, op, op };
             }
         };
         template <> struct Unroll<3>
@@ -237,7 +237,7 @@ namespace cv { namespace cuda { namespace device
             static __device__ __forceinline__ const thrust::tuple<plus<float>, plus<float>, plus<float>, plus<float> > op()
             {
                 plus<float> op;
-                return thrust::make_tuple(op, op, op, op);
+                return { op, op, op, op };
             }
         };
         template <> struct Unroll<4>


### PR DESCRIPTION
This pull request fix the compile error when building opencv_photo with cuda 12.9 on windows.
```
Building NVCC (Device) object modules/photo/CMakeFiles/cuda_compile_1.dir/src/cuda/Release/cuda_compile_1_generated_nlm.cu.obj
  nlm.cu
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(202): error : calling a __host__ function("cuda::std::__4::tuple< ::cuda::std::__4::__unwrap_ref_decay<T1> ::type... >  cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > (T1 &&...)") from a __device__ function("cv::cuda::device::imgproc::Unroll<(int)1> ::op") is not allowed [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(202): error : identifier "cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > " is undefined in device code [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(221): error : calling a __host__ function("cuda::std::__4::tuple< ::cuda::std::__4::__unwrap_ref_decay<T1> ::type... >  cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > (T1 &&...)") from a __device__ function("cv::cuda::device::imgproc::Unroll<(int)2> ::op") is not allowed [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(221): error : identifier "cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > " is undefined in device code [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(240): error : calling a __host__ function("cuda::std::__4::tuple< ::cuda::std::__4::__unwrap_ref_decay<T1> ::type... >  cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > (T1 &&...)") from a __device__ function("cv::cuda::device::imgproc::Unroll<(int)3> ::op") is not allowed [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
C:\Users\xingchen\Desktop\xc-build\sources_opencv_4.12.0\modules\photo\src\cuda\nlm.cu(240): error : identifier "cuda::std::__4::make_tuple< ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  &,  ::cv::cuda::device::plus<float>  & > " is undefined in device code [C:\Users\xingchen\Desktop\xc-build\build_cuv12.9_cudnn9.10.1.4_opencv4.12.0\modules\photo\opencv_photo.vcxproj]
  
  6 errors detected in the compilation of "C:/Users/xingchen/Desktop/xc-build/sources_opencv_4.12.0/modules/photo/src/cuda/nlm.cu".
  nlm.cu
  CMake Error at cuda_compile_1_generated_nlm.cu.obj.Release.cmake:278 (message):
    Error generating file
    C:/Users/xingchen/Desktop/xc-build/build_cuv12.9_cudnn9.10.1.4_opencv4.12.0/modules/photo/CMakeFiles/cuda_compile_1.dir/src/cuda/Release/cuda_compile_1_generated_nlm.cu.obj
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
