### PR TITLE
Fixed -Wretrun-type warning in Highgui

### DIFF
--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -1115,9 +1115,9 @@ const std::string cv::currentUIFramework()
     return std::string("COCOA");
 #elif defined (HAVE_WAYLAND)
     return std::string("WAYLAND");
-#else
-    return std::string();
 #endif
+
+    return std::string();
 }
 
 // Without OpenGL


### PR DESCRIPTION
Warning:
```
/home/pi/opencv/modules/highgui/src/window.cpp: In function ‘const std::string cv::currentUIFramework()’:
/home/pi/opencv/modules/highgui/src/window.cpp:1121:1: warning: control reaches end of non-void function [-Wreturn-type]
 1121 | }
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
