### PR TITLE
More warning fixes G-API on Windows

### DIFF
--- a/modules/gapi/src/backends/common/serialization.cpp
+++ b/modules/gapi/src/backends/common/serialization.cpp
@@ -393,10 +393,9 @@ IOStream& operator<< (IOStream& os, const cv::GArrayDesc &) {return os;}
 IIStream& operator>> (IIStream& is,       cv::GArrayDesc &) {return is;}
 
 #if !defined(GAPI_STANDALONE)
-IOStream& operator<< (IOStream& os, const cv::UMat &)
+IOStream& operator<< (IOStream&, const cv::UMat &)
 {
     GAPI_Error("Serialization: Unsupported << for UMat");
-    return os;
 }
 IIStream& operator >> (IIStream&, cv::UMat &)
 {

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -341,7 +341,6 @@ void cv::gimpl::GCompiler::validateInputMeta()
         default:
             GAPI_Error("InternalError");
         }
-        return false; // should never happen
     };
 
     GAPI_LOG_DEBUG(nullptr, "Total count: " << m_metas.size());


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
