### PR TITLE
Fixed parallel invoke for warp perspective for best performance

### DIFF
--- a/hal/ipp/include/ipp_hal_imgproc.hpp
+++ b/hal/ipp/include/ipp_hal_imgproc.hpp
@@ -8,22 +8,19 @@
 #include <opencv2/core/base.hpp>
 #include "ipp_utils.hpp"
 
-#ifdef HAVE_IPP_IW
+#if IPP_VERSION_X100 >= 810
 
+#if defined(HAVE_IPP_IW)
 int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width,
                        int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
-
 #undef cv_hal_warpAffine
 #define cv_hal_warpAffine ipp_hal_warpAffine
 #endif
 
-#if IPP_VERSION_X100 >= 810
 int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width,
                             int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);
 #undef cv_hal_warpPerspective
 #define cv_hal_warpPerspective ipp_hal_warpPerspective
-#endif
-
 
 int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
     uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
@@ -32,5 +29,6 @@ int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int s
 #undef cv_hal_remap32f
 #define cv_hal_remap32f ipp_hal_remap32f
 
+#endif //IPP_VERSION_X100 >= 810
 
 #endif //__IPP_HAL_IMGPROC_HPP__


### PR DESCRIPTION
### Pull Request description

- Fix of range splitting for multithreaded execution in warp perspective IPP integration in HAL (it was implemented incorrectly, since destination pointer was not shifted and range operator process the whole image instead of the tile).
- Number of threads logic for IPP HAL functions led to significant performance drops on big images in multithreaded mode, which is fixed by this PR as well.
- Fixed memory management in warp perspective IPP integration in HAL.
- Added the define ```IPP_CALLS_ENFORCED ```  disabled by default in ```ipp_hal_imgproc``` to enable IPP integration with all available mods to simplify preparing custom builds targeted to performance. Set all unsupported mods (like 2-channel, and unsupported datatypes to ```0```) in hal tables (previously was set to 1).
- Removed the preprocessor condition for IPP v7.0, since it is incompatible to integrated functionality.

The major issue resolved is performance drops in multithreaded implementation of warp perspective. The previous logic for the range splitting was trivial and suggested that the distribution of the image across the threads is possible by constant 64Kb portions (division of image size by 2^16). This approach is used in many places across all the library, but is applicable only if the image can be split in a uniform way. Since the ranges in threading for most of the cases is defined by image rows, the logic shall take into account the row width, since the rows cannot be split (image cannot be split in a uniform way for arbitrary number of tiles).

Updated logic for range splitting fixes the performance drop:

- taking into account the range size (```if [range size] < [number of threads], splitting = [range size]```)
- taking into account the row width by specifying the expected payload per thread (in bytes) and calculating the proper splitting for available number of threads.

The old logic based on L2 cache size had another flaw and also shows inefficient results, so it was replaced by fixed payload size (performance drop is fixed as well), the change is applied for
- warp affine
- warp perspective
- remap

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work (N/A, since internal data of contributors)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
