### PR TITLE
Fix minEnclosingCircle

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -62,25 +62,8 @@ static void findCircle3pts(Point2f *pts, Point2f &center, float &radius)
     float det = v1.x * v2.y - v1.y * v2.x;
     if (fabs(det) <= EPS)
     {
-        // v1 and v2 are colinear, so the longest distance between any 2 points
-        // is the diameter of the minimum enclosing circle.
-        float d1 = normL2Sqr<float>(pts[0] - pts[1]);
-        float d2 = normL2Sqr<float>(pts[0] - pts[2]);
-        float d3 = normL2Sqr<float>(pts[1] - pts[2]);
-        radius = sqrt(std::max(d1, std::max(d2, d3))) * 0.5f + EPS;
-        if (d1 >= d2 && d1 >= d3)
-        {
-            center = (pts[0] + pts[1]) * 0.5f;
-        }
-        else if (d2 >= d1 && d2 >= d3)
-        {
-            center = (pts[0] + pts[2]) * 0.5f;
-        }
-        else
-        {
-            CV_DbgAssert(d3 >= d1 && d3 >= d2);
-            center = (pts[1] + pts[2]) * 0.5f;
-        }
+        // triangle is degenerate, so this is 2-points case
+        // 2-points case should be taken into account in previous step
         return;
     }
     float cx = (c1 * v2.y - c2 * v1.y) / det;

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -127,6 +127,44 @@ TEST(Imgproc_minEnclosingCircle, regression_16051) {
     EXPECT_NEAR(2.1024551f, radius, 1e-3);
 }
 
+TEST(Imgproc_minEnclosingCircle, regression_27891) {
+    {
+        const vector<Point2f> pts = { {219, 301}, {639, 635}, {740, 569}, {740, 569}, {309, 123}, {349, 88} };
+
+        Point2f center;
+        float radius;
+        minEnclosingCircle(pts, center, radius);
+
+        EXPECT_NEAR(center.x, 522.476f, 1e-3f);
+        EXPECT_NEAR(center.y, 346.4029f, 1e-3f);
+        EXPECT_NEAR(radius, 311.2331f, 1e-3f);
+    }
+
+    {
+        const vector<Point2f> pts = { {219, 301}, {639, 635}, {740, 569}, {740, 569}, {349, 88} };
+
+        Point2f center;
+        float radius;
+        minEnclosingCircle(pts, center, radius);
+
+        EXPECT_NEAR(center.x, 522.476f, 1e-3f);
+        EXPECT_NEAR(center.y, 346.4029f, 1e-3f);
+        EXPECT_NEAR(radius, 311.2331f, 1e-3f);
+    }
+
+    {
+        const vector<Point2f> pts = { {639, 635}, {740, 569}, {740, 569}, {349, 88} };
+
+        Point2f center;
+        float radius;
+        minEnclosingCircle(pts, center, radius);
+
+        EXPECT_NEAR(center.x, 522.476f, 1e-3f);
+        EXPECT_NEAR(center.y, 346.4029f, 1e-3f);
+        EXPECT_NEAR(radius, 311.2331f, 1e-3f);
+    }
+}
+
 PARAM_TEST_CASE(ConvexityDefects_regression_5908, bool, int)
 {
 public:


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix #27891 

For reference: the original check was introduced in https://github.com/opencv/opencv/pull/16136 to get rid of NaNs in result.

```
# Load points
points = np.load('/home/mithridat/Downloads/points.npy').astype(np.float32).reshape(-1, 1, 2)
# points = np.array([[219, 301], [639, 635], [740, 569], [740, 569], [309, 123], [349, 88],]).astype(np.float32).reshape(-1, 1, 2)
# points = np.array([[219, 301], [639, 635], [740, 569], [740, 569], [349, 88],]).astype(np.float32).reshape(-1, 1, 2)
# points = np.array([[639, 635], [740, 569], [740, 569], [349, 88],]).astype(np.float32).reshape(-1, 1, 2)
```

Before
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-10-26" src="https://github.com/user-attachments/assets/04c6d240-400e-464b-b4a9-a05ffa08f17e" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-10-39" src="https://github.com/user-attachments/assets/e506a4f2-6207-4e07-acc5-cd9e40ee0a63" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-11-03" src="https://github.com/user-attachments/assets/2498ec4a-109b-4a26-a848-f280731fab09" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-11-21" src="https://github.com/user-attachments/assets/4b6778bd-1651-46ec-9469-93822af4b1b9" />

After
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-21-13" src="https://github.com/user-attachments/assets/9491b7c6-fc21-4380-af6b-76b7bd501acc" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-21-48" src="https://github.com/user-attachments/assets/7c3b10a0-8858-4965-9fdc-a2946adf3d9e" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-22-02" src="https://github.com/user-attachments/assets/55225ef6-64ba-4b70-9d86-611dfd450e4c" />
<img width="1920" height="1080" alt="Screenshot from 2025-10-15 01-22-15" src="https://github.com/user-attachments/assets/f4fca96c-cbdc-4df2-8527-f60f17e8f4cc" />

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
