### PR TITLE
Fixed DPI in pattern generator test for charuco

### DIFF
--- a/apps/pattern-tools/test_charuco_board.py
+++ b/apps/pattern-tools/test_charuco_board.py
@@ -50,7 +50,7 @@ class aruco_objdetect_test(NewOpenCVTests):
                     pm.make_charuco_board()
                     pm.save()
                     drawing = svg2rlg(filesvg)
-                    renderPM.drawToFile(drawing, filepng, fmt='PNG', dpi=72)
+                    renderPM.drawToFile(drawing, filepng, fmt='PNG', dpi=96)
                     from_svg_img = cv.imread(filepng)
                     _charucoCorners, _charuco_ids_svg, marker_corners_svg, marker_ids_svg = charuco_detector.detectBoard(from_svg_img)
                     _charucoCorners, _charuco_ids_cv, marker_corners_cv, marker_ids_cv = charuco_detector.detectBoard(from_cv_img)
@@ -107,7 +107,7 @@ class aruco_objdetect_test(NewOpenCVTests):
                     pm.make_charuco_board()
                     pm.save()
                     drawing = svg2rlg(filesvg)
-                    renderPM.drawToFile(drawing, filepng, fmt='PNG', dpi=72)
+                    renderPM.drawToFile(drawing, filepng, fmt='PNG', dpi=96)
                     from_svg_img = cv.imread(filepng)
 
                     #test


### PR DESCRIPTION
Regression appeared after https://github.com/opencv/ci-gha-workflow/pull/265

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
