### PR TITLE
Use cairosvg for pattern rendering to get rid of double resize.

### DIFF
--- a/.github/workflows/PR-4.x.yaml
+++ b/.github/workflows/PR-4.x.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   Linux:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@as/cairosvg
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Linux.yaml@main
     with:
       workflow_branch: main
 

--- a/apps/pattern-tools/test_charuco_board.py
+++ b/apps/pattern-tools/test_charuco_board.py
@@ -13,7 +13,7 @@ class aruco_objdetect_test(NewOpenCVTests):
         try:
             import cairosvg
         except:
-            raise self.skipTest("libraies svglib and reportlab not found")
+            raise self.skipTest("cairosvg library was not found")
         else:
             cols = 3
             rows = 5
@@ -72,7 +72,7 @@ class aruco_objdetect_test(NewOpenCVTests):
         try:
             import cairosvg
         except:
-            raise self.skipTest("libraies svglib and reportlab not found")
+            raise self.skipTest("cairosvg library was not found")
         else:
             cols = 3
             rows = 5


### PR DESCRIPTION
Depends on https://github.com/opencv/ci-gha-workflow/pull/269

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
