### PR TITLE
Fixed linking for HighGUI against Qt 6.9 and newer

### DIFF
--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -125,7 +125,7 @@ elseif(HAVE_QT)
     endif()
 
     foreach(dt_dep ${qt_deps})
-      add_definitions(${Qt${QT_VERSION_MAJOR}${dt_dep}_DEFINITIONS})
+      link_libraries(${Qt${QT_VERSION_MAJOR}${dt_dep}})
       include_directories(${Qt${QT_VERSION_MAJOR}${dt_dep}_INCLUDE_DIRS})
       list(APPEND HIGHGUI_LIBRARIES ${Qt${QT_VERSION_MAJOR}${dt_dep}_LIBRARIES})
     endforeach()


### PR DESCRIPTION
Use `link_libraries` instead of `add_defintions` to link against Qt 6.9 and newer to avoid un-expanded generator expressions from Qt cmake files being appended to linker flags when building the HighGUI module.

The actual bug is likely in how Qt cmake files end up with these un-expanded generator expressions in the first place — see discussion in https://bugreports.qt.io/browse/QTBUG-134774 — but the recommended way to link against the library is to use `link_libraries` anyway, so this fix should do the trick.

Fixes #27223
Fixes #27630
Fixes #27511

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
