### PR TITLE
Fix ambiguous operator error in Rect assignment for C++ modules

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1931,7 +1931,7 @@ template<typename _Tp> static inline
 Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
 {
     if (a.empty() || b.empty()) {
-        a = Rect();
+        a = Rect_<_Tp>();
         return a;
     }
     const Rect_<_Tp>& Rx_min = (a.x < b.x) ? a : b;
@@ -1945,7 +1945,7 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     // Let us first deal with the following case.
     if ((Rx_min.x < 0 && Rx_min.x + Rx_min.width < Rx_max.x) ||
         (Ry_min.y < 0 && Ry_min.y + Ry_min.height < Ry_max.y)) {
-        a = Rect();
+        a = Rect_<_Tp>();
         return a;
     }
     // We now know that either Rx_min.x >= 0, or
@@ -1957,7 +1957,7 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     a.x = Rx_max.x;
     a.y = Ry_max.y;
     if (a.empty())
-        a = Rect();
+        a = Rect_<_Tp>();
     return a;
 }
 


### PR DESCRIPTION
## Fix ambiguous operator error in Rect assignment for C++ modules

**Summary:**  
This PR resolves an ambiguous operator error encountered when using OpenCV with C++20/23 modules and Clang, as reported in [Issue #27899](https://github.com/opencv/opencv/issues/27899).

**Problem:**  
When `<opencv2/opencv.hpp>` is included in both a module interface (.cppm) and implementation (.cpp) file, Clang reports an error in `opencv2/core/types.hpp` due to ambiguous use of the assignment operator:
```
error: use of overloaded operator '=' is ambiguous (with operand types 'Rect_<double>' and 'Rect' (aka 'Rect_<int>'))
```
The root cause is assigning `a = Rect();` within a template for `Rect_<_Tp>`, which can lead to ambiguity.

**Solution:**  
All assignments of the form `a = Rect();` in template functions for `Rect_<_Tp>` are replaced with `a = Rect_<_Tp>();` to ensure correct type resolution and to avoid ambiguity.


**Impact:**  
- Fixes build errors when using C++ modules with Clang and OpenCV.
- Ensures template assignment is type-correct.
- No impact on existing non-modular builds.

**References:**  
- #27899