### PR TITLE
Add corner cases tests for minEnclosingCircle

### DIFF
--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -56,6 +56,22 @@ TEST(minEnclosingCircle, basic_test)
     Point2f center;
     float radius;
 
+    {
+        const vector<Point2f> pts = { {5, 10} };
+        minEnclosingCircle(pts, center, radius);
+        EXPECT_NEAR(center.x, 5, EPS);
+        EXPECT_NEAR(center.y, 10, EPS);
+        EXPECT_NEAR(radius, 0, EPS);
+    }
+
+    {
+        const vector<Point2f> pts = { {5, 10}, {11, 18} };
+        minEnclosingCircle(pts, center, radius);
+        EXPECT_NEAR(center.x, 8, EPS);
+        EXPECT_NEAR(center.y, 14, EPS);
+        EXPECT_NEAR(radius, 5, EPS);
+    }
+
     // pts[2] is within the circle with diameter pts[0] - pts[1].
     //        2
     // 0             1


### PR DESCRIPTION
### Pull Request Readiness Checklist

There are separate branches for 1-point (`count: case 1`) and 2-points (`count: case 2`) cases in `minEnclosingCircle` implementation
But these cases are not covered by tests

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
