### PR TITLE
Fix ml::KDTree::findNearest

### DIFF
--- a/modules/ml/src/knearest.cpp
+++ b/modules/ml/src/knearest.cpp
@@ -396,8 +396,21 @@ public:
         {
             Mat _res, _nr, _d;
             tr.findNearest(test_samples.row(i), k, Emax, _res, _nr, _d, noArray());
-            res.push_back(_res.t());
-            _results.assign(res);
+            if( _results.needed() )
+            {
+                res.push_back(_res.t());
+                _results.assign(res);
+            }
+            if( _neighborResponses.needed() )
+            {
+                nr.push_back(_nr.t());
+                _neighborResponses.assign(nr);
+            }
+            if( _dists.needed() )
+            {
+                d.push_back(_d.t());
+                _dists.assign(d);
+            }
         }
 
         return result; // currently always 0

--- a/modules/ml/test/test_knearest.cpp
+++ b/modules/ml/test/test_knearest.cpp
@@ -39,11 +39,16 @@ TEST(ML_KNearest, accuracy)
     {
         SCOPED_TRACE("KDTree");
         Mat neighborIndexes;
+        Mat neighborResponses;
+        Mat dists;
         float err = 1000;
         Ptr<KNearest> knn = KNearest::create();
         knn->setAlgorithmType(KNearest::KDTREE);
         knn->train(trainData, ml::ROW_SAMPLE, trainLabels);
-        knn->findNearest(testData, 4, neighborIndexes);
+        knn->findNearest(testData, 4, neighborIndexes, neighborResponses, dists);
+        EXPECT_EQ(neighborIndexes.size(), Size(4, pointsCount));
+        EXPECT_EQ(neighborResponses.size(), Size(4, pointsCount * 2));
+        EXPECT_EQ(dists.size(), Size(4, pointsCount));
         Mat bestLabels;
         // The output of the KDTree are the neighbor indexes, not actual class labels
         // so we need to do some extra work to get actual predictions


### PR DESCRIPTION
### Pull Request Readiness Checklist

Fix https://github.com/opencv/opencv_contrib/issues/3651

Rework #21217 

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
