### PR TITLE
[core][cuda] Move throw_no_cuda to it an independant stub

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -54,6 +54,7 @@
 #include "opencv2/core/base.hpp"
 
 #include "opencv2/core/cuda.hpp"
+#include "opencv2/core/private/cuda_stubs.hpp"
 
 #ifdef HAVE_CUDA
 #  include <cuda.h>
@@ -101,15 +102,9 @@ namespace cv { namespace cuda {
     CV_EXPORTS void syncOutput(const GpuMat& dst, OutputArray _dst, Stream& stream);
 }}
 
-#ifndef HAVE_CUDA
-
-static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::GpuNotSupported, "The library is compiled without CUDA support"); }
-
-#else // HAVE_CUDA
+#ifdef HAVE_CUDA
 
 #define nppSafeSetStream(oldStream, newStream) { if(oldStream != newStream) { cudaStreamSynchronize(oldStream); nppSetStream(newStream); } }
-
-static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform"); }
 
 namespace cv { namespace cuda
 {

--- a/modules/core/include/opencv2/core/private/cuda_stubs.hpp
+++ b/modules/core/include/opencv2/core/private/cuda_stubs.hpp
@@ -1,0 +1,21 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_PRIVATE_CUDA_STUBS_HPP
+#define OPENCV_CORE_PRIVATE_CUDA_STUBS_HPP
+
+#ifndef __OPENCV_BUILD
+#  error this is a private header which should not be used from outside of the OpenCV library
+#endif
+
+#include "opencv2/core/cvdef.h"
+#include "opencv2/core/base.hpp"
+
+#ifndef HAVE_CUDA
+static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::GpuNotSupported, "The library is compiled without CUDA support"); }
+#else
+static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform"); }
+#endif
+
+#endif // OPENCV_CORE_PRIVATE_CUDA_STUBS_HPP

--- a/modules/photo/CMakeLists.txt
+++ b/modules/photo/CMakeLists.txt
@@ -5,3 +5,7 @@ if(HAVE_CUDA)
 endif()
 
 ocv_define_module(photo opencv_imgproc OPTIONAL opencv_cudaarithm opencv_cudaimgproc WRAP java objc python js)
+
+if(HAVE_CUDA AND ENABLE_CUDA_FIRST_CLASS_LANGUAGE AND HAVE_OPENCV_CUDAARITHM AND HAVE_OPENCV_CUDAIMGPROC)
+  ocv_target_link_libraries(${the_module} PUBLIC "CUDA::cudart${CUDA_LIB_EXT}")
+endif()

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -43,7 +43,6 @@
 #include "precomp.hpp"
 
 #include "opencv2/photo/cuda.hpp"
-#include "opencv2/core/private.cuda.hpp"
 
 #include "opencv2/opencv_modules.hpp"
 
@@ -60,11 +59,14 @@ using namespace cv::cuda;
 
 #if !defined (HAVE_CUDA) || !defined(HAVE_OPENCV_CUDAARITHM) || !defined(HAVE_OPENCV_CUDAIMGPROC)
 
+#include "opencv2/core/private/cuda_stubs.hpp"
 void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoising(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoisingColored(InputArray, OutputArray, float, float, int, int, Stream&) { throw_no_cuda(); }
 
 #else
+
+#include "opencv2/core/private.cuda.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////
 //// Non Local Means Denosing (brute force)

--- a/modules/stitching/CMakeLists.txt
+++ b/modules/stitching/CMakeLists.txt
@@ -11,3 +11,7 @@ endif()
 ocv_define_module(stitching opencv_imgproc opencv_features2d opencv_calib3d opencv_flann
                   OPTIONAL opencv_cudaarithm opencv_cudawarping opencv_cudafeatures2d opencv_cudalegacy opencv_cudaimgproc ${STITCHING_CONTRIB_DEPS}
                   WRAP python)
+
+if(HAVE_CUDA AND ENABLE_CUDA_FIRST_CLASS_LANGUAGE)
+  ocv_target_link_libraries(${the_module} PUBLIC "CUDA::cudart${CUDA_LIB_EXT}")
+endif()


### PR DESCRIPTION
As discussed in https://github.com/opencv/opencv/pull/27797 `throw_no_cuda` is included in the same header which requires **cudart** when `HAVE_CUDA` is defined.

This is fine in most modules where the `HAVE_CUDA` condition dictates when **cudart** is required.  e.g.

```
#define HAVE_CUDA
#include "opencv2/core/private.cuda.hpp"
#if !defined (HAVE_CUDA)
    // OK: cudart target not added and private.cuda.hpp does not import cuda_runtime.hpp
    void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
```

If however `HAVE_CUDA` is defined but due to other conditions (e.g. `!defined(HAVE_OPENCV_CUDAARITHM`) CUDA functionality is disabled the following will not build

```
#define HAVE_CUDA
#include "opencv2/core/private.cuda.hpp"
#if !defined (HAVE_CUDA) || !defined(HAVE_OPENCV_CUDAARITHM) || !defined(HAVE_OPENCV_CUDAIMGPROC)
    // ERROR: cudart tartget not added but private.cuda.hpp imports cuda_runtime.hpp when HAVE_CUDA is defined
    void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
