### PR TITLE
Added CMake define option to enforce IPP calls in IPP HAL when building with IPP integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,9 +284,6 @@ OCV_OPTION(WITH_WAYLAND "Include Wayland support" OFF
 OCV_OPTION(WITH_IPP "Include Intel IPP support" (NOT MINGW AND NOT CV_DISABLE_OPTIMIZATION)
   VISIBLE_IF (X86_64 OR X86) AND NOT WINRT AND NOT IOS AND NOT XROS
   VERIFY HAVE_IPP)
-OCV_OPTION(WITH_IPP_CALLS_ENFORCED "Enforce IPP calls prioritizing performance over accuracy" OFF
-  VISIBLE_IF WITH_IPP
-  VERIFY HAVE_IPP)
 OCV_OPTION(WITH_HALIDE "Include Halide support" OFF
   VISIBLE_IF TRUE
   VERIFY HAVE_HALIDE)
@@ -1762,7 +1759,6 @@ if(WITH_IPP AND HAVE_IPP)
   if(NOT HAVE_IPP_ICV)
     status("       linked:" BUILD_WITH_DYNAMIC_IPP THEN "dynamic" ELSE "static")
   endif()
-  status("       enforced IPP calls: " ${WITH_IPP_CALLS_ENFORCED})
   if(HAVE_IPP_IW)
     if(BUILD_IPP_IW)
       status("    Intel IPP IW:" "sources (${IW_VERSION_MAJOR}.${IW_VERSION_MINOR}.${IW_VERSION_UPDATE})")

--- a/hal/ipp/CMakeLists.txt
+++ b/hal/ipp/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(ipphal STATIC
 #TODO: HAVE_IPP_ICV and HAVE_IPP_IW added as private macro till OpenCV itself is
 #      source of IPP and public definitions lead to redefinition warning
 #      The macro should be redefined as PUBLIC when IPP part is removed from core
-#      to make HAL the source of IPP integration
+#      to make HAL the source of IPP integration. The same is true for WITH_IPP_CALLS_ENFORCED
 if(HAVE_IPP_ICV)
   target_compile_definitions(ipphal PRIVATE HAVE_IPP_ICV)
 endif()
@@ -32,6 +32,7 @@ endif()
 
 if(WITH_IPP_CALLS_ENFORCED)
   target_compile_definitions(ipphal PRIVATE IPP_CALLS_ENFORCED)
+  message("WITH_IPP_CALLS_ENFORCED=${WITH_IPP_CALLS_ENFORCED}: enforced IPP calls are enabled in IPP HAL")
 endif()
 
 target_include_directories(ipphal PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")


### PR DESCRIPTION
Extra build option needed to simplify custom builds with IPP integration to ensure the IPP calls done even in cases when the results are not bitwise compliant to the reference OpenCV implementation. Option name is ```WITH_IPP_CALLS_ENFORCED```, and it is disabled by default.

Requested by some IPP customers and might be used in general as a way providing calls with better performance for the cases the aligned precision is not as important aspect.

Supposed to be used in HAL only, so added only in IPP HAL CMake, currently it affects only Warp Affine, Warp Perspective and Remap integrations since the results may vary depending on HW and algorithm implementations.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
