### PR TITLE
Update documentation for Mat_ constructor to clarify vector behavior …

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2562,7 +2562,7 @@ public:
     Mat_(const Mat_& m, const std::vector<Range>& ranges);
     //! from a matrix expression
     explicit Mat_(const MatExpr& e);
-    //! makes a matrix out of Vec, std::vector, Point_ or Point3_. 
+    //! makes a matrix out of Vec, std::vector, Point_ or Point3_.
     //! In OpenCV 5.x, from std::vector, creates a matrix with a single row (cols = vector size).
     //! (Previous versions: the matrix had a single column.)
     explicit Mat_(const std::vector<_Tp>& vec, bool copyData=false);


### PR DESCRIPTION

This PR updates the documentation comment for the constructor:

`explicit Mat_(const std::vector<_Tp>& vec, bool copyData=false);`
The original docstring stated that this constructor creates a matrix with a single column. However, in OpenCV version 5.x, this constructor now creates a matrix with a single row and the number of columns equal to the size of the vector.

This change clarifies the behavior for users migrating to or working with OpenCV 5.x and reduces confusion due to the discrepancy between documented and actual matrix shape.

This PR addresses GitHub issue #27862.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
