### PR TITLE
docs: add quick Python import/version check after install

### DIFF
--- a/samples/install/linux_install_a.sh
+++ b/samples/install/linux_install_a.sh
@@ -56,3 +56,11 @@ ls OpenCVModules.cmake
 # [install]
 sudo make install
 # [install]
+
+# [python-quick-check]
+echo "Python quick check:"
+python3 - <<'PY'
+import cv2
+print("OpenCV import OK, version:", cv2.__version__)
+PY
+# [python-quick-check]


### PR DESCRIPTION
Add a Python quick check to verify OpenCV installation.

Scope

Docs only. No library/source changes.