### PR TITLE
perf(video): add sanity checks and update ECC baselines for grayscale and color inputs.

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -271,7 +271,7 @@ enum
 /**
 @brief Computes the Enhanced Correlation Coefficient (ECC) value between two images
 
-The Enhanced Correlation Coefficient (ECC) is a normalized measure of similarity between two images.
+The Enhanced Correlation Coefficient (ECC) is a normalized measure of similarity between two images @cite EP08.
 The result lies in the range [-1, 1], where 1 corresponds to perfect similarity (modulo affine shift and scale),
 0 indicates no correlation, and -1 indicates perfect negative correlation.
 

--- a/modules/video/perf/perf_ecc.cpp
+++ b/modules/video/perf/perf_ecc.cpp
@@ -55,8 +55,7 @@ PERF_TEST_P(ECCPerfTest, findTransformECC,
                          TermCriteria(TermCriteria::COUNT + TermCriteria::EPS, 5, -1));
     }
 
-    // TODO: Update baseline for new test
-    SANITY_CHECK_NOTHING();
+    SANITY_CHECK(warpMat, 3e-3);
 }
 
 }  // namespace opencv_test


### PR DESCRIPTION
In https://github.com/opencv/opencv/pull/27524 ECC gained multichannel (1/3-channel) support; perf tests were left without sanity due to missing baselines. This PR adds the required sanity entries for the new test layout (C1/C3, all motion types). No functional changes; only perf test was updated. Related opencv_extra PR with updated baseline https://github.com/opencv/opencv_extra/pull/1281

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
