### PR TITLE
Get code to compile without FFmpeg's libavdevice

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1170,7 +1170,9 @@ bool CvCapture_FFMPEG::open(const char* _filename, int index, const Ptr<IStreamR
       input_format = av_find_input_format(entry->value);
     }
 
+#ifdef HAVE_FFMPEG_LIBAVDEVICE
     AVDeviceInfoList* device_list = nullptr;
+#endif
     if (index >= 0)
     {
 #ifdef HAVE_FFMPEG_LIBAVDEVICE
@@ -1267,13 +1269,13 @@ bool CvCapture_FFMPEG::open(const char* _filename, int index, const Ptr<IStreamR
         ic->pb = avio_context;
     }
     int err = avformat_open_input(&ic, _filename, input_format, &dict);
+#ifdef HAVE_FFMPEG_LIBAVDEVICE
     if (device_list)
     {
-#ifdef HAVE_FFMPEG_LIBAVDEVICE
         avdevice_free_list_devices(&device_list);
         device_list = nullptr;
-#endif
     }
+#endif
 
     if (err < 0)
     {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
