### PR TITLE
core: fix Mat_ vector constructor docs to say 'single row' instead of 'single column'

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2293,7 +2293,7 @@ public:
     Mat_(const Mat_& m, const std::vector<Range>& ranges);
     //! from a matrix expression
     explicit Mat_(const MatExpr& e);
-    //! makes a matrix out of Vec, std::vector, Point_ or Point3_. The matrix will have a single column
+    //! makes a matrix out of Vec, std::vector, Point_ or Point3_. The matrix will have a single row
     explicit Mat_(const std::vector<_Tp>& vec, bool copyData=false);
     template<int n> explicit Mat_(const Vec<typename DataType<_Tp>::channel_type, n>& vec, bool copyData=true);
     template<int m, int n> explicit Mat_(const Matx<typename DataType<_Tp>::channel_type, m, n>& mtx, bool copyData=true);


### PR DESCRIPTION
### Summary
Updated documentation for `cv::Mat_(const std::vector<T>&, bool)` constructor
to reflect that it creates a **single row** (1xN) matrix instead of a single column (Nx1).

Fixes #27862