### PR TITLE
Clarified supported types in cv::patchNaNs() documentation

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1721,8 +1721,6 @@ The input matrix must be of type `CV_32F` or `CV_64F`; other types are not suppo
 */
 CV_EXPORTS_W void patchNaNs(InputOutputArray a, double val = 0);
 
-CV_EXPORTS_W void patchNaNs(InputOutputArray a, double val = 0);
-
 /** @brief Performs generalized matrix multiplication.
 
 The function cv::gemm performs generalized matrix multiplication similar to the


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake



Updated the docs for cv::patchNaNs() to specify that both CV_32F and CV_64F types are supported. Fixes incomplete information.