### PR TITLE
Allow protobuffer message to be compiled with LITE_RUNTIME

### DIFF
--- a/modules/dnn/src/caffe/caffe_io.hpp
+++ b/modules/dnn/src/caffe/caffe_io.hpp
@@ -119,9 +119,11 @@ void ReadNetParamsFromTextBufferOrDie(const char* data, size_t len,
 
 // Utility functions used internally by Caffe and TensorFlow loaders
 bool ReadProtoFromTextFile(const char* filename, ::google::protobuf::Message* proto);
-bool ReadProtoFromBinaryFile(const char* filename, ::google::protobuf::Message* proto);
+bool ReadProtoFromTextFile(const char* filename, ::google::protobuf::MessageLite* proto);
+bool ReadProtoFromBinaryFile(const char* filename, ::google::protobuf::MessageLite* proto);
 bool ReadProtoFromTextBuffer(const char* data, size_t len, ::google::protobuf::Message* proto);
-bool ReadProtoFromBinaryBuffer(const char* data, size_t len, ::google::protobuf::Message* proto);
+bool ReadProtoFromTextBuffer(const char* data, size_t len, ::google::protobuf::MessageLite* proto);
+bool ReadProtoFromBinaryBuffer(const char* data, size_t len, ::google::protobuf::MessageLite* proto);
 
 }
 }

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -27,6 +27,7 @@ Implementation of Tensorflow models parser
 #include <algorithm>
 #include <string>
 #include <queue>
+#include <type_traits>
 #include "tf_graph_simplifier.hpp"
 #endif
 
@@ -3290,6 +3291,19 @@ Net readNetFromTensorflow(const std::vector<uchar>& bufferModel, const std::vect
                                  bufferConfigPtr, bufferConfig.size());
 }
 
+
+template<class GRAPH_DEF>
+typename std::enable_if<std::is_base_of<Message, GRAPH_DEF>::value, void>::type
+PrintToStringImpl(const GRAPH_DEF& net, std::string* content) {
+  google::protobuf::TextFormat::PrintToString(net, content);
+}
+
+template<class GRAPH_DEF>
+typename std::enable_if<!std::is_base_of<Message, GRAPH_DEF>::value, void>::type
+PrintToStringImpl(const GRAPH_DEF& net, std::string* content) {
+  CV_Error(Error::StsError, "DNN/TF: do not have your message be a MessageLite");
+}
+
 void writeTextGraph(const String& _model, const String& output)
 {
     String model = _model;
@@ -3312,7 +3326,7 @@ void writeTextGraph(const String& _model, const String& output)
     }
 
     std::string content;
-    google::protobuf::TextFormat::PrintToString(net, &content);
+    PrintToStringImpl(net, &content);
 
     std::ofstream ofs(output.c_str());
     ofs << content;


### PR DESCRIPTION
When adding "option optimize_for = LITE_RUNTIME;" to proto messages, they are compiled as lighter MessageLite (the base class of Message).

Those lighter messages do not allow for reflection though:

https://developers.google.com/protocol-buffers/docs/reference/cpp-generated

This fixes https://github.com/opencv/opencv/issues/20275

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
