### PR TITLE
Remove mention of 'tangential lens distortion' from fisheye documentation.

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -4096,7 +4096,7 @@ namespace fisheye
     may additionally scale and shift the result by using a different matrix.
     @param new_size the new size
 
-    The function transforms an image to compensate radial and tangential lens distortion.
+    The function transforms an image to compensate radial lens distortion.
 
     The function is simply a combination of #fisheye::initUndistortRectifyMap (with unity R ) and #remap
     (with bilinear interpolation). See the former function for details of the transformation being


### PR DESCRIPTION
- Fixed documentation for `cv::fisheye::initUndistortRectifyMap`

The current documentation for `fisheye::initUndistortRectifyMap` incorrectly states that the function "compensates radial and tangential lens distortion." However, the fisheye camera model in OpenCV uses only radial distortions with four coefficients (k_1, k_2, k_3, k_4), as implemented [here](https://github.com/opencv/opencv/blob/01f9bdae4c729b72debc6dd1140250eeed8e7c62/modules/calib3d/src/fisheye.cpp#L608).

This confusion likely originates from the standard distortion model in `cv::undistort`, which uses two radial (k_1, k_2) and two tangential (p_1, p_2) coefficients as its first four parameters.

Related Issue: #23961 notes that "OpenCV implements only a radially symmetric fisheye model, taken from Jean-Yves Bouguet's Matlab toolbox."

This documentation fix applies to both 4.x and 5.x versions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
