### PR TITLE
Fix generation when returned class and function are in a namespace

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -849,6 +849,10 @@ class JSWrapperGenerator(object):
                         # Register the smart pointer
                         base_class_name = variant.rettype
                         base_class_name = base_class_name.replace("Ptr<","").replace(">","").strip()
+                        if base_class_name not in self.classes:
+                            new_base_class_name = '%s_%s' % (ns_id, base_class_name)
+                            print(base_class_name, ' not found in classes for registering smart pointer using ', new_base_class_name, 'instead')
+                            base_class_name = new_base_class_name
                         self.classes[base_class_name].has_smart_ptr = True
 
                         # Adds the external constructor


### PR DESCRIPTION
This is to fix js generation at HEAD with ximgproc.

Otherwise, at HEAD, I get:
```
 make -j gen_opencv_js_source
[100%] Generate source files for JavaScript bindings
Traceback (most recent call last):
  File "modules/js/generator/embindgen.py", line 1060, in <module>
    generator.gen(bindings_cpp, headers, core_bindings_path)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "modules/js/generator/embindgen.py", line 852, in gen
    self.classes[base_class_name].has_smart_ptr = True
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'EdgeDrawing'
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
