### PR TITLE
fix missing vec_cvfo on IBM POWER9 due to unavailable VSX float64 conversion

### DIFF
--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -5,13 +5,6 @@
 #ifndef OPENCV_HAL_VSX_UTILS_HPP
 #define OPENCV_HAL_VSX_UTILS_HPP
 
-#if defined(__x86_64__) || defined(__riscv) || defined(__s390x__) || defined(__aarch64__) || defined(__loongarch64) \
-    || defined(__POWER10__) || (defined(__powerpc64__) && defined(__ARCH_PWR10__))
-  #define CV_VSX_HAS_FLOAT64_CONVERT 1
-#else
-  #define CV_VSX_HAS_FLOAT64_CONVERT 0
-#endif
-
 #include "opencv2/core/cvdef.h"
 
 #ifndef SKIP_INCLUDES
@@ -264,8 +257,8 @@ VSX_IMPL_1VRG(vec_udword2, vec_udword2, vpopcntd, vec_popcntu)
 VSX_IMPL_1VRG(vec_udword2, vec_dword2,  vpopcntd, vec_popcntu)
 
 // converts between single and double-precision
-
-#if CV_VSX_HAS_FLOAT64_CONVERT
+// vec_floate and vec_doubleo are available since Power10 and z14
+#if defined(__POWER10__) || (defined(__powerpc64__) && defined(__ARCH_PWR10__)
 //  Use VSX double<->float conversion instructions (if supported by the architecture)
     VSX_REDIRECT_1RG(vec_float4,  vec_double2, vec_cvfo, vec_floate)
     VSX_REDIRECT_1RG(vec_double2, vec_float4,  vec_cvfo, vec_doubleo)
@@ -275,7 +268,7 @@ VSX_IMPL_1VRG(vec_udword2, vec_dword2,  vpopcntd, vec_popcntu)
     {
         float r0 = static_cast<float>(reinterpret_cast<const double*>(&a)[0]);
         float r1 = static_cast<float>(reinterpret_cast<const double*>(&a)[1]);
-        return (vec_float4){r0, r1, 0.f, 0.f};
+        return (vec_float4){r0, 0.f, r1, 0.f};
     }
 
     static inline vec_double2 vec_cvfo(const vec_float4& a)


### PR DESCRIPTION
Replaces https://github.com/opencv/opencv/pull/27633
Closes https://github.com/opencv/opencv/issues/27635

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
