### PR TITLE
Fixed unrichable code with MSVC on x86 32-bit systems.

### DIFF
--- a/.github/workflows/PR-4.x.yaml
+++ b/.github/workflows/PR-4.x.yaml
@@ -12,11 +12,6 @@ jobs:
     with:
       workflow_branch: main
 
-  Windows:
-    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-Windows.yaml@main
-    with:
-      workflow_branch: main
-
   Ubuntu2004-ARM64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-ARM64.yaml@main
 
@@ -29,6 +24,12 @@ jobs:
   Ubuntu2004-x64-CUDA:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'category: dnn') }} || ${{ contains(github.event.pull_request.labels.*.name, 'category: dnn (onnx)') }}"
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml@main
+
+  Windows10-x64:
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10.yaml@main
+
+  Windows10-x64-Vulkan:
+    uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml@main
 
   macOS-ARM64:
     uses: opencv/ci-gha-workflow/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml@main


### PR DESCRIPTION
Suppress the following warnings:
```
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\file_data_provider.cpp(131): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(77): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(82): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(103): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(90): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(94): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(86): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\onevpl\source.cpp(99): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\gstreamer\gstreamersource.cpp(366): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\gstreamer\gstreamersource.cpp(360): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
  Warning: C:\GHA-OCV-5\_work\opencv\opencv\opencv\modules\gapi\src\streaming\gstreamer\gstreamerpipeline.cpp(77): warning C4702: unreachable code [C:\GHA-OCV-5\_work\opencv\opencv\build\modules\gapi\opencv_gapi.vcxproj]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
