### PR TITLE
imgproc: add parameter to bypass mandatory edge detection in HoughCir…

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2293,7 +2293,7 @@ centers without finding the radius. #HOUGH_GRADIENT_ALT always computes circle r
 CV_EXPORTS_W void HoughCircles( InputArray image, OutputArray circles,
                                int method, double dp, double minDist,
                                double param1 = 100, double param2 = 100,
-                               int minRadius = 0, int maxRadius = 0 );
+                               int minRadius = 0, int maxRadius = 0, InputArray edges = noArray() );
 
 //! @} imgproc_feature
 

--- a/modules/imgproc/include/opencv2/imgproc/bindings.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/bindings.hpp
@@ -41,11 +41,11 @@ void HoughCirclesWithAccumulator(
         InputArray image, OutputArray circles,
         int method, double dp, double minDist,
         double param1 = 100, double param2 = 100,
-        int minRadius = 0, int maxRadius = 0
+        int minRadius = 0, int maxRadius = 0, InputArray edges = noArray()
 )
 {
     std::vector<Vec4f> circles_acc;
-    HoughCircles(image, circles_acc, method, dp, minDist, param1, param2, minRadius, maxRadius);
+    HoughCircles(image, circles_acc, method, dp, minDist, param1, param2, minRadius, maxRadius, edges);
     Mat(1, static_cast<int>(circles_acc.size()), CV_32FC4, &circles_acc.front()).copyTo(circles);
 }
 

--- a/modules/imgproc/include/opencv2/imgproc/imgproc_c.h
+++ b/modules/imgproc/include/opencv2/imgproc/imgproc_c.h
@@ -935,8 +935,8 @@ CVAPI(CvSeq*) cvHoughCircles( CvArr* image, void* circle_storage,
                               double param1 CV_DEFAULT(100),
                               double param2 CV_DEFAULT(100),
                               int min_radius CV_DEFAULT(0),
-                              int max_radius CV_DEFAULT(0));
-
+                              int max_radius CV_DEFAULT(0),
+                              CvArr* edges CV_DEFAULT(NULL));
 /** @brief Fits a line into set of 2d or 3d points in a robust way (M-estimator technique)
 @see cv::fitLine
 */


### PR DESCRIPTION
Summary:
Add a new optional parameter to cv::HoughCircles to allow bypassing the internal edge detection and blurring steps.

Motivation:
Some applications already perform edge detection before calling HoughCircles.
This change avoids redundant computations and provides more flexibility for custom preprocessing workflows.

Changes:
Added new optional parameter in:
- imgproc.hpp
- bindings.hpp 
- imgproc_c.h

Updated hough.cpp to skip internal edge detection when the parameter is used.

Maintained backward compatibility (default behavior unchanged). 

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
