### PR TITLE
fix: use export_name as resolved typename for AliasTypeNode

### DIFF
--- a/modules/python/src2/typing_stubs_generation/nodes/type_node.py
+++ b/modules/python/src2/typing_stubs_generation/nodes/type_node.py
@@ -274,14 +274,21 @@ class AliasTypeNode(TypeNode):
                  required_modules: Tuple[str, ...] = ()) -> None:
         super().__init__(ctype_name, required_modules)
         self.value = value
-        self._export_name = export_name
+        # If alias is exported as is - use its ctype_name
+        if export_name is None:
+            forbidden_symbols = (":", "*", "&")
+            assert all(symbol not in ctype_name for symbol in forbidden_symbols), (
+                "Failed to create AliasTypeNode without export_name. "
+                f"'{ctype_name}' should not contain any of {forbidden_symbols}"
+            )
+            self._export_name = ctype_name
+        else:
+            self._export_name = export_name
         self.doc = doc
 
     @property
     def typename(self) -> str:
-        if self._export_name is not None:
-            return self._export_name
-        return self.ctype_name
+        return self._export_name
 
     @property
     def full_typename(self) -> str:


### PR DESCRIPTION
Use `ctype_name` as export name for `AliasTypeNode` if export name is not explicitly provided.

Resolves #27995

`AliasTypeNode.ctype_name` might be overwritten in [`create_type_node`](https://github.com/opencv/opencv/blob/adaa369bb1b7d6ed809424f9178cf4677284f88b/modules/python/src2/typing_stubs_generation/types_conversion.py#L289), so `AliasTypeNode.export_name` should be used as resolved typename.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
