### PR TITLE
Fix the issue of obtaining the size of the _src

### DIFF
--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -401,7 +401,7 @@ static bool ocl_moments( InputArray _src, Moments& m, bool binary)
     const int TILE_SIZE = 32;
     const int K = 10;
 
-    Size sz = _src.getSz();
+    Size sz = _src.size();
     int xtiles = divUp(sz.width, TILE_SIZE);
     int ytiles = divUp(sz.height, TILE_SIZE);
     int ntiles = xtiles*ytiles;


### PR DESCRIPTION
Size sz = _src.getSz(); sz = 0 results in ntiles = xtiles * ytiles = 0; the program does not perform GPU acceleration.
Solution: Add Size size = _src.size(); to obtain the size of the input src for the following judgment and execution of GPU acceleration.