### PR TITLE
Fix the issue of obtaining the size of the _src

### DIFF
--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -401,7 +401,7 @@ static bool ocl_moments( InputArray _src, Moments& m, bool binary)
     const int TILE_SIZE = 32;
     const int K = 10;
 
-    Size sz = _src.getSz();
+    Size sz = _src.size();
     int xtiles = divUp(sz.width, TILE_SIZE);
     int ytiles = divUp(sz.height, TILE_SIZE);
     int ntiles = xtiles*ytiles;


### PR DESCRIPTION
Size sz = _src.getSz(); sz = 0 results in ntiles = xtiles * ytiles = 0; the program does not perform GPU acceleration.
Solution: Add Size size = _src.size(); to obtain the size of the input src for the following judgment and execution of GPU acceleration

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
