### PR TITLE
Fix out of bounds in calibrateAndNormalizePointsPnP

### DIFF
--- a/modules/calib3d/src/p3p.cpp
+++ b/modules/calib3d/src/p3p.cpp
@@ -173,7 +173,7 @@ void p3p::calibrateAndNormalizePointsPnP(const Mat &opoints_, const Mat &ipoints
 
     Mat ipoints;
     convertPoints(ipoints_, ipoints, 2);
-    for (int i = 0; i < ipoints.rows; i++) {
+    for (int i = 0; i < 3; i++) {
         const double k_inv_u = ipoints.at<double>(i, 0);
         const double k_inv_v = ipoints.at<double>(i, 1);
         double x_norm = 1.0 / sqrt(k_inv_u*k_inv_u + k_inv_v*k_inv_v + 1);


### PR DESCRIPTION
ipoints can have 3 or 4 points. If it has 4, there is an out of bound fill of x_copy.

The error comes from https://github.com/opencv/opencv/pull/27736

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
