### PR TITLE
ECC: refactor findTransformECC to motion-model interface (no functional changes)

### DIFF
--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -47,241 +47,283 @@
 
 using namespace cv;
 
-static void image_jacobian_homo_ECC(const Mat& src1, const Mat& src2, const Mat& src3, const Mat& src4, const Mat& src5,
-                                    Mat& dst) {
-    CV_Assert(src1.size() == src2.size());
-    CV_Assert(src1.size() == src3.size());
-    CV_Assert(src1.size() == src4.size());
+class Jacobian {
+    int paramsNum;
+    Mat m;
+    Size size;
+public:
+    Jacobian(int num, int h, int w, int type): paramsNum(num), size(w, h) {
+        m = Mat(h, w * paramsNum, type);
+    }
 
-    CV_Assert(src1.rows == dst.rows);
-    CV_Assert(dst.cols == (src1.cols * 8));
-    CV_Assert(dst.type() == CV_MAKETYPE(CV_32F, src1.channels()));
+    Jacobian(int num, Size _size, int type): paramsNum(num), size(_size) {
+        m = Mat(size.height, size.width * paramsNum, type);
+     }
 
-    CV_Assert(src5.isContinuous());
+     // Access block dF/dp_i
+    Mat dFdp(int i) {
+        return m.colRange(i * size.width, (i + 1) * size.width);
+    }
 
-    const float* hptr = src5.ptr<float>(0);
-
-    const float h0_ = hptr[0];
-    const float h1_ = hptr[3];
-    const float h2_ = hptr[6];
-    const float h3_ = hptr[1];
-    const float h4_ = hptr[4];
-    const float h5_ = hptr[7];
-    const float h6_ = hptr[2];
-    const float h7_ = hptr[5];
-
-    const int w = src1.cols;
-
-    // create denominator for all points as a block
-    Mat den_;
-    addWeighted(src3, h2_, src4, h5_, 1.0, den_);
-
-    // create projected points
-    Mat hatX_, hatY_;
-    addWeighted(src3, h0_, src4, h3_, 0.0, hatX_);
-    hatX_ += h6_;
-
-    addWeighted(src3, h1_, src4, h4_, 0.0, hatY_);
-    hatY_ += h7_;
-
-    divide(-hatY_, den_, hatY_);
-    divide(-hatX_, den_, hatX_);
-
-    // instead of dividing each block with den,
-    // just pre-divide the block of gradients (it's more efficient)
-
-    Mat src1Divided_;
-    Mat src2Divided_;
-
-    divide(src1, den_, src1Divided_);
-    divide(src2, den_, src2Divided_);
-
-    // compute Jacobian blocks (8 blocks)
-
-    dst.colRange(0, w) = src1Divided_.mul(src3);  // 1
-
-    dst.colRange(w, 2 * w) = src2Divided_.mul(src3);  // 2
-
-    Mat temp_ = (hatX_.mul(src1Divided_) + hatY_.mul(src2Divided_));
-    dst.colRange(2 * w, 3 * w) = temp_.mul(src3);  // 3
-
-    hatX_.release();
-    hatY_.release();
-
-    dst.colRange(3 * w, 4 * w) = src1Divided_.mul(src4);  // 4
-
-    dst.colRange(4 * w, 5 * w) = src2Divided_.mul(src4);  // 5
-
-    dst.colRange(5 * w, 6 * w) = temp_.mul(src4);  // 6
-
-    src1Divided_.copyTo(dst.colRange(6 * w, 7 * w));  // 7
-
-    src2Divided_.copyTo(dst.colRange(7 * w, 8 * w));  // 8
-}
-
-static void image_jacobian_euclidean_ECC(const Mat& src1, const Mat& src2, const Mat& src3, const Mat& src4,
-                                         const Mat& src5, Mat& dst) {
-    CV_Assert(src1.size() == src2.size());
-    CV_Assert(src1.size() == src3.size());
-    CV_Assert(src1.size() == src4.size());
-
-    CV_Assert(src1.rows == dst.rows);
-    CV_Assert(dst.cols == (src1.cols * 3));
-    CV_Assert(dst.type() == CV_MAKETYPE(CV_32F, src1.channels()));
-
-    CV_Assert(src5.isContinuous());
-
-    const float* hptr = src5.ptr<float>(0);
-
-    const float h0 = hptr[0];  // cos(theta)
-    const float h1 = hptr[3];  // sin(theta)
-
-    const int w = src1.cols;
-
-    // create -sin(theta)*X -cos(theta)*Y for all points as a block -> hatX
-    Mat hatX = -(src3 * h1) - (src4 * h0);
-
-    // create cos(theta)*X -sin(theta)*Y for all points as a block -> hatY
-    Mat hatY = (src3 * h0) - (src4 * h1);
-
-    // compute Jacobian blocks (3 blocks)
-    dst.colRange(0, w) = (src1.mul(hatX)) + (src2.mul(hatY));  // 1
-
-    src1.copyTo(dst.colRange(w, 2 * w));      // 2
-    src2.copyTo(dst.colRange(2 * w, 3 * w));  // 3
-}
-
-static void image_jacobian_affine_ECC(const Mat& src1, const Mat& src2, const Mat& src3, const Mat& src4, Mat& dst) {
-    CV_Assert(src1.size() == src2.size());
-    CV_Assert(src1.size() == src3.size());
-    CV_Assert(src1.size() == src4.size());
-
-    CV_Assert(src1.rows == dst.rows);
-    CV_Assert(dst.cols == (6 * src1.cols));
-
-    CV_Assert(dst.type() == CV_MAKETYPE(CV_32F, src1.channels()));
-
-    const int w = src1.cols;
-
-    // compute Jacobian blocks (6 blocks)
-
-    dst.colRange(0, w) = src1.mul(src3);          // 1
-    dst.colRange(w, 2 * w) = src2.mul(src3);      // 2
-    dst.colRange(2 * w, 3 * w) = src1.mul(src4);  // 3
-    dst.colRange(3 * w, 4 * w) = src2.mul(src4);  // 4
-    src1.copyTo(dst.colRange(4 * w, 5 * w));      // 5
-    src2.copyTo(dst.colRange(5 * w, 6 * w));      // 6
-}
-
-static void image_jacobian_translation_ECC(const Mat& src1, const Mat& src2, Mat& dst) {
-    CV_Assert(src1.size() == src2.size());
-
-    CV_Assert(src1.rows == dst.rows);
-    CV_Assert(dst.cols == (src1.cols * 2));
-    CV_Assert(dst.type() == CV_MAKETYPE(CV_32F, src1.channels()));
-
-    const int w = src1.cols;
-
-    // compute Jacobian blocks (2 blocks)
-    src1.copyTo(dst.colRange(0, w));
-    src2.copyTo(dst.colRange(w, 2 * w));
-}
-
-static void project_onto_jacobian_ECC(const Mat& src1, const Mat& src2, Mat& dst) {
-    /* this functions is used for two types of projections. If src1.cols ==src.cols
-    it does a blockwise multiplication (like in the outer product of vectors)
-    of the blocks in matrices src1 and src2 and dst
-    has size (number_of_blcks x number_of_blocks), otherwise dst is a vector of size
-    (number_of_blocks x 1) since src2 is "multiplied"(dot) with each block of src1.
-
-    The number_of_blocks is equal to the number of parameters we are lloking for
-    (i.e. rtanslation:2, euclidean: 3, affine: 6, homography: 8)
-
-    */
-    CV_Assert(src1.rows == src2.rows);
-    CV_Assert((src1.cols % src2.cols) == 0);
-    int w;
-
-    float* dstPtr = dst.ptr<float>(0);
-
-    if (src1.cols != src2.cols) {  // dst.cols==1
-        w = src2.cols;
-        for (int i = 0; i < dst.rows; i++) {
-            dstPtr[i] = (float)src2.dot(src1.colRange(i * w, (i + 1) * w));
+    // Performs dst = J^T * src
+    void project(Mat e, Mat dst) {
+        for (int i = 0; i < paramsNum; ++i) {
+            dst.at<float>(i) = (e.dot(dFdp(i)));
         }
     }
 
-    else {
-        CV_Assert(dst.cols == dst.rows);  // dst is square (and symmetric)
-        w = src2.cols / dst.cols;
-        Mat mat;
-        for (int i = 0; i < dst.rows; i++) {
-            mat = Mat(src1.colRange(i * w, (i + 1) * w));
-            dstPtr[i * (dst.rows + 1)] = (float)pow(norm(mat), 2);  // diagonal elements
+    // Performs  J^T*J
+    void getHessian(Mat H) {
+        float* dstPtr = H.ptr<float>(0);
 
-            for (int j = i + 1; j < dst.cols; j++) {  // j starts from i+1
-                dstPtr[i * dst.cols + j] = (float)mat.dot(src2.colRange(j * w, (j + 1) * w));
-                dstPtr[j * dst.cols + i] = dstPtr[i * dst.cols + j];  // due to symmetry
+        CV_Assert(H.cols == H.rows);  // H is square (and symmetric)
+        int w = m.cols / H.cols;
+        Mat mat;
+        for (int i = 0; i < H.rows; i++) {
+            mat = Mat(m.colRange(i * w, (i + 1) * w));
+            dstPtr[i * (H.rows + 1)] = (float)pow(norm(mat), 2);  // diagonal elements
+
+            for (int j = i + 1; j < H.cols; j++) {  // j starts from i+1
+                dstPtr[i * H.cols + j] = (float)mat.dot(m.colRange(j * w, (j + 1) * w));
+                dstPtr[j * H.cols + i] = dstPtr[i * H.cols + j];  // due to symmetry
             }
         }
     }
-}
+};
 
-static void update_warping_matrix_ECC(Mat& map_matrix, const Mat& update, const int motionType) {
-    CV_Assert(map_matrix.type() == CV_32FC1);
-    CV_Assert(update.type() == CV_32FC1);
-
-    CV_Assert(motionType == MOTION_TRANSLATION || motionType == MOTION_EUCLIDEAN || motionType == MOTION_AFFINE ||
-              motionType == MOTION_HOMOGRAPHY);
-
-    if (motionType == MOTION_HOMOGRAPHY)
-        CV_Assert(map_matrix.rows == 3 && update.rows == 8);
-    else if (motionType == MOTION_AFFINE)
-        CV_Assert(map_matrix.rows == 2 && update.rows == 6);
-    else if (motionType == MOTION_EUCLIDEAN)
-        CV_Assert(map_matrix.rows == 2 && update.rows == 3);
-    else
-        CV_Assert(map_matrix.rows == 2 && update.rows == 2);
-
-    CV_Assert(update.cols == 1);
-
-    CV_Assert(map_matrix.isContinuous());
-    CV_Assert(update.isContinuous());
-
-    float* mapPtr = map_matrix.ptr<float>(0);
-    const float* updatePtr = update.ptr<float>(0);
-
-    if (motionType == MOTION_TRANSLATION) {
-        mapPtr[2] += updatePtr[0];
-        mapPtr[5] += updatePtr[1];
+/* Generic transformation interface. The derived class should define:
+ * The warp transformation from image to template coordinates.
+ * The block of coordinates  partial derivatives with respect to a transformation parameter ∂X/∂p_i, ∂Y/∂p_i
+ * The operation of the parameters updating.
+ * */
+class MotionModel {
+    Mat T;
+public:
+    MotionModel(Mat map): T(map) {
     }
-    if (motionType == MOTION_AFFINE) {
-        mapPtr[0] += updatePtr[0];
-        mapPtr[3] += updatePtr[1];
-        mapPtr[1] += updatePtr[2];
-        mapPtr[4] += updatePtr[3];
-        mapPtr[2] += updatePtr[4];
-        mapPtr[5] += updatePtr[5];
-    }
-    if (motionType == MOTION_HOMOGRAPHY) {
-        mapPtr[0] += updatePtr[0];
-        mapPtr[3] += updatePtr[1];
-        mapPtr[6] += updatePtr[2];
-        mapPtr[1] += updatePtr[3];
-        mapPtr[4] += updatePtr[4];
-        mapPtr[7] += updatePtr[5];
-        mapPtr[2] += updatePtr[6];
-        mapPtr[5] += updatePtr[7];
-    }
-    if (motionType == MOTION_EUCLIDEAN) {
-        double new_theta = updatePtr[0];
-        new_theta += asin(mapPtr[3]);
 
-        mapPtr[2] += updatePtr[1];
-        mapPtr[5] += updatePtr[2];
-        mapPtr[0] = mapPtr[4] = (float)cos(new_theta);
-        mapPtr[3] = (float)sin(new_theta);
-        mapPtr[1] = -mapPtr[3];
+    int getNumParams() const {
+        return T.total();
+    }
+
+    virtual Mat getMat() const {
+        return T;
+    }
+
+    float p(int idx) const {
+        return T.at<float>(idx, 0);
+    }
+
+    // Default affine warp transform
+    virtual void warp(const Mat src, Mat dst, const int flags) const {
+        warpAffine(src, dst, getMat(), dst.size(), flags);
+    }
+
+    // Calculates spatial derivatives of pixel intensities I(x, y, c) w.r.t model parameters.
+    virtual void calcJacobian(const Mat& gradX, const Mat& gradY, const Mat& X, const Mat& Y, Jacobian& jac) = 0;
+
+    // Updates transformation.
+    void updateTransform(const Mat& update) {
+        T += update;
+    }
+
+    virtual ~MotionModel() {}
+
+    static cv::Ptr<MotionModel> make(const int motionType, const Mat map);
+};
+
+class MotionTranslation : public MotionModel {
+    const int tx = 0;
+    const int ty = 1;
+public:
+    MotionTranslation(const Mat map): MotionModel(map.col(1)) {
+    }
+
+    Mat getMat() const override {
+
+        return  (cv::Mat_<float>(2, 3) << 1, 0, p(tx),
+                                          0, 1, p(ty));
+    }
+
+    void calcJacobian(const Mat& gradX, const Mat& gradY, const Mat& X, const Mat& Y,
+            Jacobian& jac) override
+    {
+        (void)X;
+        (void)Y;
+
+        gradX.copyTo(jac.dFdp(tx)); // dI/dtx = dI/dx * dx/dtx; dx/dtx = 1
+        gradY.copyTo(jac.dFdp(ty)); // dI/dty = dI/dy * dy/dty; dy/dty = 1
+    }
+};
+
+class MotionEuclidean: public MotionModel {
+    const int theta = 0;
+    const int tx = 1;
+    const int ty = 2;
+
+    static Mat extract(const Mat &map){
+        // Assume user matrix is approximately Euclidean:
+        // [ c  -s  tx ]
+        // [ s   c  ty ]
+        const float c = map.at<float>(0,0);
+        const float s = map.at<float>(1,0);
+
+        float theta = std::asin(s);
+        float tx = map.at<float>(0,2);
+        float ty = map.at<float>(1,2);
+        return Mat_<float>(3, 1) << theta, tx, ty;
+    }
+public:
+
+    MotionEuclidean(const Mat &map): MotionModel(extract(map)) {
+    }
+
+    Mat getMat() const override{
+        const float c = std::cos(p(theta));
+        const float s = std::sin(p(theta));
+
+        return (cv::Mat_<float>(2,3) << c, -s, p(tx),
+                                        s, c,  p(ty));
+    }
+
+    void calcJacobian(const Mat& gradX, const Mat& gradY, const Mat& X, const Mat& Y, Jacobian& jac) override {
+        const float c = std::cos(p(theta));
+        const float s = std::sin(p(theta));
+
+        // hatX = -sin(theta)*X - cos(theta)*Y
+        // hatY =  cos(theta)*X - sin(theta)*Y
+        Mat hatX = -(X * s) - (Y * c);
+        Mat hatY =  (X * c) - (Y * s);
+
+        // compute Jacobian blocks (3 blocks)
+        // dI/dtheta = Ix * dx/dtheta + Iy * dy/dtheta
+        jac.dFdp(theta) = (gradX.mul(hatX)) + (gradY.mul(hatY));
+        gradX.copyTo(jac.dFdp(tx)); // dI/dtx = Ix  (dx/dtx = 1, dy/dtx = 0)
+        gradY.copyTo(jac.dFdp(ty)); // dI/dty = Iy  (dx/dty = 0, dy/dty = 1)
+    }
+};
+
+class MotionAffine: public MotionModel {
+public:
+    MotionAffine(const Mat map): MotionModel (map.reshape(1,6)) {
+    }
+
+    virtual Mat getMat() const {
+        return MotionModel::getMat().reshape(1, 2);
+    }
+
+    void calcJacobian(const Mat& gradX, const Mat& gradY, const Mat& X, const Mat& Y, Jacobian& jac) override {
+        // compute Jacobian blocks (6 blocks)
+        jac.dFdp(0) = gradX.mul(X);  // dI/da00
+        jac.dFdp(1) = gradX.mul(Y);  // dI/da01
+        gradX.copyTo(jac.dFdp(2));   // dI/da12
+        jac.dFdp(3) = gradY.mul(X);  // dI/da10
+        jac.dFdp(4) = gradY.mul(Y);  // dI/da11
+        gradY.copyTo(jac.dFdp(5));   // dI/da12
+    }
+};
+
+class MotionHomography : public MotionModel {
+public:
+    MotionHomography(const Mat& map): MotionModel(map.reshape(1, 9).rowRange(0, 8)) {
+    }
+
+    Mat getMat() const override {
+
+        return (Mat_<float>(3, 3) << p(0), p(1), p(2),
+                                     p(3), p(4), p(5),
+                                     p(6), p(7), 1.0f);
+    }
+
+    void warp(const Mat src, Mat dst, const int flags) const override {
+        warpPerspective(src, dst, getMat(), dst.size(), flags);
+    }
+
+    void calcJacobian(const Mat& gradX,
+                      const Mat& gradY,
+                      const Mat& X,
+                      const Mat& Y,
+                      Jacobian& jac) override
+    {
+        const float H00 = p(0);
+        const float H01 = p(1);
+        const float H02 = p(2);
+        const float H10 = p(3);
+        const float H11 = p(4);
+        const float H12 = p(5);
+        const float H20 = p(6);
+        const float H21 = p(7);
+
+        Mat den_;
+        addWeighted(X, H20, Y, H21, 1.0, den_);
+
+        // hatX numerator = h0 * X + h3 * Y + h6
+        //                = H00 * X + H01 * Y + H02
+        Mat hatX_;
+        Mat hatY_;
+        addWeighted(X, H00, Y, H01, 0.0, hatX_);
+        hatX_ += H02;
+
+        addWeighted(X, H10, Y, H11, 0.0, hatY_);
+        hatY_ += H12;
+
+        // -x'/w, -y'/w
+        divide(-hatX_, den_, hatX_);
+        divide(-hatY_, den_, hatY_);
+
+        // Pre-divide gradients by denominator
+        Mat gradXDivided_;
+        Mat gradYDivided_;
+        divide(gradX, den_, gradXDivided_);
+        divide(gradY, den_, gradYDivided_);
+
+        Mat temp_ = hatX_.mul(gradXDivided_) + hatY_.mul(gradYDivided_);
+
+        jac.dFdp(0) = gradXDivided_.mul(X); // dI/dp0 = dI/dh0
+        jac.dFdp(1) = gradXDivided_.mul(Y); // dI/dp1 = dI/dh3
+        gradXDivided_.copyTo(jac.dFdp(2));  // dI/dp2 = dI/dh6
+        jac.dFdp(3) = gradYDivided_.mul(X); // dI/dp3 = dI/dh1
+        jac.dFdp(4) = gradYDivided_.mul(Y); // dI/dp4 = dI/dh4
+        gradYDivided_.copyTo(jac.dFdp(5));  // dI/dp5 = dI/dh7
+        jac.dFdp(6) = temp_.mul(X);         // dI/dp6 = dI/dh2
+        jac.dFdp(7) = temp_.mul(Y);         // dI/dp7 = dI/dh5
+    }
+};
+
+cv::Ptr<MotionModel> MotionModel::make(const int motionType,const Mat map){
+
+    if (!map.empty())
+        if (map.type() != CV_32FC1)
+                CV_Error(Error::StsUnsupportedFormat, "warpMatrix must be single-channel floating-point matrix");
+
+    switch (motionType) {
+    case MOTION_TRANSLATION:
+        if (!map.empty()){
+            CV_Assert(map.cols == 3 && map.rows == 2);
+            return cv::makePtr<MotionTranslation>(map);
+        } else
+            return cv::makePtr<MotionTranslation>(Mat::eye(2,3,CV_32F));
+    case MOTION_EUCLIDEAN:
+        if (!map.empty()){
+            CV_Assert(map.cols == 3 && map.rows == 2);
+            return cv::makePtr<MotionEuclidean>(map);
+        } else
+            return cv::makePtr<MotionEuclidean>(Mat::eye(2,3,CV_32F));
+    case MOTION_AFFINE:
+        if (!map.empty()){
+            CV_Assert(map.cols == 3 && map.rows == 2);
+            return cv::makePtr<MotionAffine>(map);
+        } else
+            return cv::makePtr<MotionAffine>(Mat::eye(2,3,CV_32F));
+    case MOTION_HOMOGRAPHY:
+        if (!map.empty()){
+            CV_Assert(map.cols == 3 && map.rows == 3);
+            return cv::makePtr<MotionHomography>(map);
+        } else
+            return cv::makePtr<MotionHomography>(Mat::eye(3, 3, CV_32F));
+    default:
+        CV_Error(cv::Error::StsBadArg,"Unsupported motion type");
+        return cv::Ptr<MotionModel>();
     }
 }
 
@@ -354,28 +396,10 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     CV_Assert(src.depth() == dst.depth());
     CV_Assert(src.depth() == CV_8U || src.depth() == CV_16U || src.depth() == CV_32F || src.depth() == CV_64F);
 
-    // If the user passed an un-initialized warpMatrix, initialize to identity
-    if (map.empty()) {
-        int rowCount = 2;
-        if (motionType == MOTION_HOMOGRAPHY)
-            rowCount = 3;
-
-        warpMatrix.create(rowCount, 3, CV_32FC1);
-        map = warpMatrix.getMat();
-        map = Mat::eye(rowCount, 3, CV_32F);
-    }
-
     if (!(src.type() == dst.type()))
         CV_Error(Error::StsUnmatchedFormats, "Both input images must have the same data type");
 
-    if (map.type() != CV_32FC1)
-        CV_Error(Error::StsUnsupportedFormat, "warpMatrix must be single-channel floating-point matrix");
-
-    CV_Assert(map.cols == 3);
-    CV_Assert(map.rows == 2 || map.rows == 3);
-
-    CV_Assert(motionType == MOTION_AFFINE || motionType == MOTION_HOMOGRAPHY || motionType == MOTION_EUCLIDEAN ||
-              motionType == MOTION_TRANSLATION);
+    auto model = MotionModel::make(motionType, map);
 
     if (motionType == MOTION_HOMOGRAPHY) {
         CV_Assert(map.rows == 3);
@@ -385,20 +409,7 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     const int numberOfIterations = (criteria.type & TermCriteria::COUNT) ? criteria.maxCount : 200;
     const double termination_eps = (criteria.type & TermCriteria::EPS) ? criteria.epsilon : -1;
 
-    int paramTemp = 6;  // default: affine
-    switch (motionType) {
-        case MOTION_TRANSLATION:
-            paramTemp = 2;
-            break;
-        case MOTION_EUCLIDEAN:
-            paramTemp = 3;
-            break;
-        case MOTION_HOMOGRAPHY:
-            paramTemp = 8;
-            break;
-    }
-
-    const int numberOfParameters = paramTemp;
+    const int numberOfParameters = model->getNumParams();
 
     const int ws = src.cols;
     const int hs = src.rows;
@@ -500,7 +511,8 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     }
 
     // matrices needed for solving linear equation system for maximizing ECC
-    Mat jacobian = Mat(hs, ws * numberOfParameters, type);
+
+    Jacobian jacobian(numberOfParameters, hs, ws, type);
     Mat hessian = Mat(numberOfParameters, numberOfParameters, CV_32F);
     Mat hessianInv = Mat(numberOfParameters, numberOfParameters, CV_32F);
     Mat imageProjection = Mat(numberOfParameters, 1, CV_32F);
@@ -514,22 +526,16 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     const int imageFlags = INTER_LINEAR + WARP_INVERSE_MAP;
     const int maskFlags = INTER_NEAREST + WARP_INVERSE_MAP;
 
-    // iteratively update map_matrix
+    // Iteratively update map_matrix using Gauss–Newton algorithm
+    // w[i+1] = w[i] -
     double rho = -1;
     double last_rho = -termination_eps;
     for (int i = 1; (i <= numberOfIterations) && (fabs(rho - last_rho) >= termination_eps); i++) {
-        // warp-back portion of the inputImage and gradients to the coordinate space of the templateImage
-        if (motionType != MOTION_HOMOGRAPHY) {
-            warpAffine(imageFloat, imageWarped, map, imageWarped.size(), imageFlags);
-            warpAffine(gradientX, gradientXWarped, map, gradientXWarped.size(), imageFlags);
-            warpAffine(gradientY, gradientYWarped, map, gradientYWarped.size(), imageFlags);
-            warpAffine(preMask, imageMask, map, imageMask.size(), maskFlags);
-        } else {
-            warpPerspective(imageFloat, imageWarped, map, imageWarped.size(), imageFlags);
-            warpPerspective(gradientX, gradientXWarped, map, gradientXWarped.size(), imageFlags);
-            warpPerspective(gradientY, gradientYWarped, map, gradientYWarped.size(), imageFlags);
-            warpPerspective(preMask, imageMask, map, imageMask.size(), maskFlags);
-        }
+        //
+        model->warp(imageFloat, imageWarped, imageFlags);
+        model->warp(gradientX, gradientXWarped, imageFlags);
+        model->warp(gradientY, gradientYWarped, imageFlags);
+        model->warp(preMask, imageMask, maskFlags);
 
         if (!templateMask.empty())
         {
@@ -552,24 +558,11 @@ double cv::findTransformECCWithMask( InputArray templateImage,
         double tmpNorm = std::sqrt(validPixels * cv::norm(tmpStd, cv::NORM_L2SQR));
         double imgNorm = std::sqrt(validPixels * cv::norm(imgStd, cv::NORM_L2SQR));
 
-        // calculate jacobian of image wrt parameters
-        switch (motionType) {
-            case MOTION_AFFINE:
-                image_jacobian_affine_ECC(gradientXWarped, gradientYWarped, Xgrid, Ygrid, jacobian);
-                break;
-            case MOTION_HOMOGRAPHY:
-                image_jacobian_homo_ECC(gradientXWarped, gradientYWarped, Xgrid, Ygrid, map, jacobian);
-                break;
-            case MOTION_TRANSLATION:
-                image_jacobian_translation_ECC(gradientXWarped, gradientYWarped, jacobian);
-                break;
-            case MOTION_EUCLIDEAN:
-                image_jacobian_euclidean_ECC(gradientXWarped, gradientYWarped, Xgrid, Ygrid, map, jacobian);
-                break;
-        }
+        model->calcJacobian(gradientXWarped, gradientYWarped, Xgrid, Ygrid, jacobian);
 
         // calculate Hessian and its inverse
-        project_onto_jacobian_ECC(jacobian, jacobian, hessian);
+        jacobian.getHessian(hessian);
+//        project_onto_jacobian_ECC(jacobian.m, jacobian.m, hessian);
 
         hessianInv = hessian.inv();
 
@@ -583,8 +576,8 @@ double cv::findTransformECCWithMask( InputArray templateImage,
         }
 
         // project images into jacobian
-        project_onto_jacobian_ECC(jacobian, imageWarped, imageProjection);
-        project_onto_jacobian_ECC(jacobian, templateZM, templateProjection);
+        jacobian.project(imageWarped, imageProjection);
+        jacobian.project(templateZM, templateProjection);
 
         // calculate the parameter lambda to account for illumination variation
         imageProjectionHessian = hessianInv * imageProjection;
@@ -600,13 +593,14 @@ double cv::findTransformECCWithMask( InputArray templateImage,
 
         // estimate the update step delta_p
         error = lambda * templateZM - imageWarped;
-        project_onto_jacobian_ECC(jacobian, error, errorProjection);
+        jacobian.project(error, errorProjection);
         deltaP = hessianInv * errorProjection;
 
-        // update warping matrix
-        update_warping_matrix_ECC(map, deltaP, motionType);
+        // Update warping matrix. w <- w + deltaP
+        model->updateTransform(deltaP);
     }
 
+    model->getMat().copyTo(map);
     // return final correlation coefficient
     return rho;
 }


### PR DESCRIPTION
### Summary
This PR refactors `findTransformECC` to use a generic motion model interface (`WarpModel`) without changing the external API or the numerical behaviour of ECC for the existing motion types.

The goal is to make it easy and safe to add new motion models (and eventually **expose this as a public extension point**) without touching the core ECC optimization loop.

### Motivation
The Enhanced Correlation Coefficient (ECC) optimizer is a powerful and model-agnostic way to estimate parameters of a geometric transformation that aligns an input image to a template. In OpenCV, findTransformECC currently supports only four motion models (`MOTION_TRANSLATION`, `MOTION_EUCLIDEAN`, `MOTION_AFFINE`, `MOTION_HOMOGRAPHY`). The current implementation tightly couples the ECC optimization loop with these specific models:

- warping is selected via if/switch branches on motionType,
- Jacobian computation is selected via another switch,
- parameter updates are hard-coded in a separate helper (`update_warping_matrix_ECC`),
- auxiliary data such as coordinate grids (`Xgrid`, `Ygrid`) are managed in the ECC core and passed around explicitly.

As a result, supporting a new motion model requires touching multiple places in ecc.cpp, which is error-prone and makes further extensions (e.g. camera distortion, custom user models) difficult.

This PR restructures the code so that adding a new motion model is a local operation: implementing a new class instead of editing the ECC core. In the long term this interface can be **promoted to a public extension point for user-defined motion models**.

### Design: WarpModel interface

The key change is the introduction of an abstract `WarpModel` class, which encapsulates:
- the parameter vector being optimized,
- the geometric warp used to map source image coordinates to template coordinates, 
- the computation of the Jacobian of image intensities with respect to model parameters.

Conceptually:

```
class WarpModel {
public:
    // Construct model from the initial warp matrix.
    // 'size' and 'type' describe the template image.
    WarpModel(InputArray map, Size size, int type);

    // Return the warp in canonical matrix form (e.g. 2x3 or 3x3),
    // compatible with warpAffine/warpPerspective.
    virtual Mat getMat() const;

    // Apply the warp to an image.
    virtual void warp(InputArray src, OutputArray dst, int flags) const;

    // Photometric Jacobian: dI/dp for all parameters.
    // dI/dp_k = dI/dx * dx/dp_k + dI/dy * dy/dp_k
    virtual void calcJacobian(InputArray gradX,
                              InputArray gradY,
                              Jacobian& dI) const = 0;

    // Update model parameters: T <- T + Δp
    void updateTransform(InputArray update);

    // Factory: selects concrete model implementation based on motionType.
    static Ptr<WarpModel> make(int motionType,
                               InputArray map,
                               Size size,
                               int type);
};
```

### Problems Solved by the Refactor
This architectural change addresses several limitations in the previous monolithic implementation, leading to improved modularity and extensibility:

| Issue                           | Before this PR                                                                                                                                          | After this PR                                                                                                                                                                                     |
|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Warping function               | The ECC core chooses between `warpAffine` and `warpPerspective` via `if`/`switch` on `motionType`. Adding a new motion model requires editing this central branch. | The ECC core simply calls `model->warp(src, dst, flags)`. Each motion model encapsulates its own warping logic. Adding a new model does not change the ECC core.                                  |
| Jacobian computation           | Jacobians are computed via a `switch (motionType)` with separate functions such as `image_jacobian_affine_ECC`, `image_jacobian_homo_ECC`, etc. The ECC core must know all supported models. | The ECC core calls `model->calcJacobian(gradX, gradY, jacobian)`. Each model implements its own Jacobian. The ECC core does not need to be updated when a new model is added.                    |
| Auxiliary data (coord. grids)  | Coordinate maps (`Xgrid`, `Ygrid`) are allocated and maintained in the ECC core, and explicitly passed to Jacobian functions. New Jacobian code must be wired into this plumbing.           | Auxiliary data such as coordinate grids are stored inside the model (e.g. `X`, `Y`) and initialized once when the model is constructed. The ECC core does not know about these details. |
| Parameter update               | Parameter updates are hard-coded in a shared helper like `update_warping_matrix_ECC`, with specific logic per motion type (e.g. which elements of the 2×3 or 3×3 matrix are updated).     | All motion models expose a uniform parameter vector. The ECC core updates it via `model->updateTransform(Δp)` (simple `T += Δp`). Packing/unpacking between the parameter vector and the canonical matrix representation is encapsulated in `getMat()` inside the model. |
| Initial warp                   | `warpMatrix` is modified directly by the ECC core, and behaviour is undefined if the initial matrix layout does not exactly match the chosen `motionType`.                                 | The model constructor is responsible for extracting the parameter vector from the initial `warpMatrix`. The ECC core only sees the abstract `WarpModel` and uses its public methods; direct modification of internal parameters is not allowed. |

### Notes
During the refactoring, an **alternative** API was considered:
```
// geometric Jacobian instead of photometric one
virtual void calcGeometricJacobian(Jacobian& dx, Jacobian& dy);
```

In this design, ECC would compute `dI/dp = gradX ⊙ dx/dp + gradY ⊙ dy/dp` internally, and models would only need to provide `dx/dp` and `dy/dp`. This simplifies the conceptual API (models deal purely with geometric derivatives), but has significant performance and memory drawbacks:
- In many cases dx/dp or dy/dp are constant or even identically zero for some parameters.
- Storing full dense Jacobians for such parameters leads to large matrices filled with constants or zeros and unnecessary multiplications/additions in the ECC core.
- In benchmarks this approach was 2–3× slower than the current photometric` calcJacobian() `interface.

These overheads could be mitigated by introducing an additional abstraction layer for Jacobians (e.g. allowing constant columns, deferred evaluation, etc.), but this would substantially complicate the implementation. For now, the more direct and efficient `calcJacobian(gradX, gradY, dI) ` interface is kept, and a geometric Jacobian API is left as a potential future extension if a suitable lightweight representation is designed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
