### PR TITLE
Update windows_install.markdown - add set opencv path for vc18

### DIFF
--- a/doc/tutorials/introduction/windows_install/windows_install.markdown
+++ b/doc/tutorials/introduction/windows_install/windows_install.markdown
@@ -379,6 +379,9 @@ our OpenCV library that we use in our projects. Start up a command window and en
 
     setx OpenCV_DIR D:\OpenCV\build\x64\vc17     (suggested for Visual Studio 2022 - 64 bit Windows)
     setx OpenCV_DIR D:\OpenCV\build\x86\vc17     (suggested for Visual Studio 2022 - 32 bit Windows)
+
+    setx OpenCV_DIR D:\OpenCV\build\x64\vc18     (suggested for Visual Studio 2026 - 64 bit Windows)
+    setx OpenCV_DIR D:\OpenCV\build\x86\vc18     (suggested for Visual Studio 2026 - 32 bit Windows)
 @endcode
 Here the directory is where you have your OpenCV binaries (*extracted* or *built*). You can have
 different platform (e.g. x64 instead of x86) or compiler type, so substitute appropriate value.


### PR DESCRIPTION
This PR was created because we needed to revise our installation documentation as part of supporting Visual Studio 2026/vc18.

Related PR https://github.com/opencv/opencv/pull/28015
Related issue https://github.com/opencv/opencv/issues/28013

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
