### PR TITLE
Update usage of ov::Tensor::data in govbackend

### DIFF
--- a/modules/gapi/src/backends/ov/govbackend.cpp
+++ b/modules/gapi/src/backends/ov/govbackend.cpp
@@ -185,7 +185,7 @@ static void copyFromOV(const ov::Tensor &tensor, cv::Mat &mat) {
                                        mat.ptr<int>(),
                                        total);
     } else {
-        std::copy_n(reinterpret_cast<uint8_t*>(tensor.data()),
+        std::copy_n(reinterpret_cast<const uint8_t*>(tensor.data()),
                     tensor.get_byte_size(),
                     mat.ptr<uint8_t>());
     }


### PR DESCRIPTION
### Summary
Fixing OpenCV build error below.
Relates to OpenVINO 2026.0 updates on `ov::Tensor::data()` (https://github.com/openvinotoolkit/openvino/pull/32569).
```
[2025-11-14T11:10:06.193Z] C:\jenkins\workspace\openVINO-builder\opencv_source\opencv-opencv-252403b\modules\gapi\src\backends\ov\govbackend.cpp(188): error C2440: 'reinterpret_cast': cannot convert from 'const void *' to 'uint8_t *'
[2025-11-14T11:10:06.193Z] C:\jenkins\workspace\openVINO-builder\opencv_source\opencv-opencv-252403b\modules\gapi\src\backends\ov\govbackend.cpp(188): note: Conversion loses qualifiers
[2025-11-14T11:10:06.193Z] C:\jenkins\workspace\openVINO-builder\opencv_source\opencv-opencv-252403b\modules\gapi\src\backends\ov\govbackend.cpp(188): error C2672: 'std::copy_n': no matching overloaded function found
```

### Pull Request Readiness Checklist
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

