### PR TITLE
Onnx importer2 dispatch map

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -269,6 +269,7 @@ protected:
     void parseOperatorSet();
 
     const std::string str_domain_ai_onnx = "ai.onnx";
+    const std::string str_domain_com_microsoft = "com.microsoft";
 
     bool useLegacyNames;
     bool getParamUseLegacyNames()
@@ -596,7 +597,7 @@ void ONNXImporter2::parseOperatorSet()
 
     for (const auto& pair : onnx_opset_map)
     {
-        if ((pair.first != str_domain_ai_onnx) && (pair.first != "com.microsoft"))
+        if ((pair.first != str_domain_ai_onnx) && (pair.first != str_domain_com_microsoft))
             CV_LOG_INFO(
                 NULL,
                 "DNN/ONNX: unknown domain='" << pair.first << "' version=" << pair.second << ". No dispatch map, you may need to register 'custom' layers."
@@ -2732,7 +2733,7 @@ void ONNXImporter2::buildDispatchMap_COM_MICROSOFT(int opset_version)
     //dispatch["QLinearSoftmax"] = &ONNXImporter2::parseQSoftmax;
     dispatch["Attention"] = &ONNXImporter2::parseAttention;
 
-    domain_dispatch_map["com.microsoft"] = dispatch;
+    domain_dispatch_map[str_domain_com_microsoft] = dispatch;
 }
 
 


### PR DESCRIPTION
in the new onnx_importer all domains in the dispatch map should be included per default. 
See https://github.com/opencv/opencv/pull/27988#issuecomment-3521140872

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
