### PR TITLE
Fix HoughLines OpenCL to correctly use min_theta/max_theta parameters

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -762,7 +762,7 @@ static bool ocl_makePointsList(InputArray _src, OutputArray _pointsList, InputOu
     return pointListKernel.run(2, globalThreads, localThreads, false);
 }
 
-static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle)
+static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle, double min_theta)
 {
     UMat pointsList = _pointsList.getUMat();
     _accum.create(numangle + 2, numrho + 2, CV_32SC1);
@@ -786,7 +786,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
             return false;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, numrho, numangle, (float) min_theta);
         return fillAccumKernel.run(2, globalThreads, NULL, false);
     }
     else
@@ -798,7 +798,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
         localThreads[0] = workgroup_size; localThreads[1] = 1;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle+2;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, numrho, numangle, (float) min_theta);
         return fillAccumKernel.run(2, globalThreads, localThreads, false);
     }
 }
@@ -836,7 +836,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, min_theta))
         return false;
 
     const int pixPerWI = 8;
@@ -849,7 +849,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     UMat lines(linesMax, 1, CV_32FC2);
 
     getLinesKernel.args(ocl::KernelArg::ReadOnly(accum), ocl::KernelArg::WriteOnlyNoSize(lines),
-                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta);
+                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta, (float) min_theta);
 
     size_t globalThreads[2] = { ((size_t)numrho + pixPerWI - 1)/pixPerWI, (size_t)numangle };
     if (!getLinesKernel.run(2, globalThreads, NULL, false))
@@ -890,7 +890,7 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, 0.0))
         return false;
 
     ocl::Kernel getLinesKernel("get_lines", ocl::imgproc::hough_lines_oclsrc,

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -819,6 +819,8 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     }
 
     UMat src = _src.getUMat();
+    // numangle is computed from max_theta to ensure we cover the full range [min_theta, max_theta]
+    // The actual angles are computed as: min_theta + theta * i, for i in [0, numangle-1]
     int numangle = computeNumangle(min_theta, max_theta, theta);
     int numrho = cvRound(((src.cols + src.rows) * 2 + 1) / rho);
 

--- a/modules/imgproc/src/opencl/hough_lines.cl
+++ b/modules/imgproc/src/opencl/hough_lines.cl
@@ -58,13 +58,13 @@ __kernel void make_point_list(__global const uchar * src_ptr, int src_step, int 
 
 __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, int list_offset,
                                 __global uchar * accum_ptr, int accum_step, int accum_offset,
-                                int total_points, float irho, float theta, int numrho, int numangle)
+                                int total_points, float irho, float theta, int numrho, int numangle, float min_theta)
 {
     int theta_idx = get_global_id(1);
     int count_idx = get_global_id(0);
     int glob_size = get_global_size(0);
     float cosVal;
-    float sinVal = sincos(theta * ((float)theta_idx), &cosVal);
+    float sinVal = sincos(min_theta + theta * ((float)theta_idx), &cosVal);
     sinVal *= irho;
     cosVal *= irho;
 
@@ -90,7 +90,7 @@ __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, 
 
 __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, int list_offset,
                                __global uchar * accum_ptr, int accum_step, int accum_offset,
-                               int total_points, float irho, float theta, int numrho, int numangle)
+                               int total_points, float irho, float theta, int numrho, int numangle, float min_theta)
 {
     int theta_idx = get_group_id(1);
     int count_idx = get_local_id(0);
@@ -99,7 +99,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
     if (theta_idx > 0 && theta_idx < numangle + 1)
     {
         float cosVal;
-        float sinVal = sincos(theta * (float) (theta_idx-1), &cosVal);
+        float sinVal = sincos(min_theta + theta * (float) (theta_idx-1), &cosVal);
         sinVal *= irho;
         cosVal *= irho;
 
@@ -139,7 +139,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
 
 __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_offset, int accum_rows, int accum_cols,
                          __global uchar * lines_ptr, int lines_step, int lines_offset, __global int* lines_index_ptr,
-                         int linesMax, int threshold, float rho, float theta)
+                         int linesMax, int threshold, float rho, float theta, float min_theta)
 {
     int x0 = get_global_id(0);
     int y = get_global_id(1);
@@ -163,7 +163,7 @@ __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_of
                 if (index < linesMax)
                 {
                     float radius = (x - (accum_cols - 3) / 2) * rho;
-                    float angle = y * theta;
+                    float angle = min_theta + y * theta;
 
                     lines[index] = (float2)(radius, angle);
                 }

--- a/modules/imgproc/test/ocl/test_houghlines.cpp
+++ b/modules/imgproc/test/ocl/test_houghlines.cpp
@@ -45,12 +45,24 @@ PARAM_TEST_CASE(HoughLines, double, double, int)
         src_size = randomSize(500, 1920);
         src.create(src_size, CV_8UC1);
         src.setTo(Scalar::all(0));
-        line(src, Point(0, 100), Point(100, 100), Scalar::all(255), 1);
-        line(src, Point(0, 200), Point(100, 200), Scalar::all(255), 1);
-        line(src, Point(0, 400), Point(100, 400), Scalar::all(255), 1);
-        line(src, Point(100, 0), Point(100, 200), Scalar::all(255), 1);
-        line(src, Point(200, 0), Point(200, 200), Scalar::all(255), 1);
-        line(src, Point(400, 0), Point(400, 200), Scalar::all(255), 1);
+
+        // Horizontal lines (theta ≈ π, ~180°) - should be filtered when max_theta < π
+        line(src, Point(0, 100), Point(200, 100), Scalar::all(255), 1);
+        line(src, Point(0, 200), Point(200, 200), Scalar::all(255), 1);
+        line(src, Point(0, 400), Point(200, 400), Scalar::all(255), 1);
+
+        // Vertical lines (theta ≈ π/2, ~90°) - should be filtered when max_theta < π/2
+        line(src, Point(100, 50), Point(100, 250), Scalar::all(255), 1);
+        line(src, Point(200, 50), Point(200, 250), Scalar::all(255), 1);
+        line(src, Point(400, 50), Point(400, 250), Scalar::all(255), 1);
+
+        // Diagonal lines at ~30° (theta ≈ π/6, should pass when max_theta > π/6)
+        line(src, Point(50, 50), Point(200, 137), Scalar::all(255), 1);
+        line(src, Point(250, 150), Point(400, 237), Scalar::all(255), 1);
+
+        // Diagonal lines at ~60° (theta ≈ π/3, should pass when min_theta < π/3 and max_theta > π/3)
+        line(src, Point(50, 250), Point(108, 350), Scalar::all(255), 1);
+        line(src, Point(300, 150), Point(358, 250), Scalar::all(255), 1);
 
         src.copyTo(usrc);
     }
@@ -169,6 +181,80 @@ OCL_TEST_P(HoughLinesP, RealImage)
     OCL_ON(cv::HoughLinesP(usrc, udst, rhoStep, thetaStep, threshold, minLineLength, maxGap));
 
     Near(0.25);
+}
+
+OCL_TEST_P(HoughLines, ThetaRange)
+{
+    // Test that min_theta and max_theta parameters are correctly used
+    // In Hough space: rho = x*cos(theta) + y*sin(theta)
+    // theta = 0: vertical line, theta = π/2: horizontal line
+    
+    // Test 1: theta range [0, π/4] (0 to 45 degrees)
+    src_size = Size(400, 400);
+    src.create(src_size, CV_8UC1);
+    src.setTo(Scalar::all(0));
+
+    // Draw lines with theta in [0, 45 degrees]
+    // Vertical lines (theta ≈ 0)
+    line(src, Point(100, 50), Point(100, 350), Scalar::all(255), 1);
+    line(src, Point(200, 50), Point(200, 350), Scalar::all(255), 1);
+    // Diagonal lines (theta ≈ 22.5 degrees)
+    line(src, Point(50, 300), Point(200, 200), Scalar::all(255), 1);
+    // Diagonal lines (theta ≈ 45 degrees)  
+    line(src, Point(50, 350), Point(250, 150), Scalar::all(255), 1);
+
+    src.copyTo(usrc);
+
+    double min_theta = 0.0;
+    double max_theta = CV_PI / 4;  // 0 to 45 degrees
+
+    OCL_OFF(cv::HoughLines(src, dst, rhoStep, thetaStep, threshold, 0, min_theta, max_theta));
+    OCL_ON(cv::HoughLines(usrc, udst, rhoStep, thetaStep, threshold, 0, min_theta, max_theta));
+
+    // Verify that all detected lines have theta within the specified range
+    Mat lines_gpu;
+    udst.copyTo(lines_gpu);
+    for (int i = 0; i < lines_gpu.rows; i++)
+    {
+        Vec2f line = lines_gpu.at<Vec2f>(i);
+        double theta = line[1];
+        EXPECT_GE(theta, min_theta) << "Line " << i << " has theta " << theta << " which is less than min_theta " << min_theta;
+        EXPECT_LE(theta, max_theta) << "Line " << i << " has theta " << theta << " which is greater than max_theta " << max_theta;
+    }
+
+    Near(1e-5);
+
+    // Test 2: theta range [π/3, 2π/3] (60 to 120 degrees)
+    src.setTo(Scalar::all(0));
+
+    // Draw lines with theta in [60, 120 degrees]
+    // Lines at theta ≈ 60 degrees
+    line(src, Point(50, 250), Point(250, 100), Scalar::all(255), 1);
+    // Lines at theta ≈ 90 degrees (horizontal)
+    line(src, Point(50, 100), Point(350, 100), Scalar::all(255), 1);
+    line(src, Point(50, 200), Point(350, 200), Scalar::all(255), 1);
+    // Lines at theta ≈ 120 degrees
+    line(src, Point(50, 150), Point(250, 300), Scalar::all(255), 1);
+
+    src.copyTo(usrc);
+
+    min_theta = CV_PI / 3;  // 60 degrees
+    max_theta = 2 * CV_PI / 3;  // 120 degrees
+
+    OCL_OFF(cv::HoughLines(src, dst, rhoStep, thetaStep, threshold, 0, min_theta, max_theta));
+    OCL_ON(cv::HoughLines(usrc, udst, rhoStep, thetaStep, threshold, 0, min_theta, max_theta));
+
+    // Verify that all detected lines have theta within the specified range
+    udst.copyTo(lines_gpu);
+    for (int i = 0; i < lines_gpu.rows; i++)
+    {
+        Vec2f line = lines_gpu.at<Vec2f>(i);
+        double theta = line[1];
+        EXPECT_GE(theta, min_theta) << "Line " << i << " has theta " << theta << " which is less than min_theta " << min_theta;
+        EXPECT_LE(theta, max_theta) << "Line " << i << " has theta " << theta << " which is greater than max_theta " << max_theta;
+    }
+
+    Near(1e-5);
 }
 
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, HoughLines, Combine(Values(1, 0.5),                        // rhoStep


### PR DESCRIPTION
This PR fixes issue #28036 where the OpenCL implementation of `cv::HoughLines` was ignoring the `min_theta` and `max_theta` parameters.

## Problem

When using `cv::HoughLines` with OpenCL acceleration and specifying `min_theta`/`max_theta` parameters to search for lines in a specific angle range (e.g., horizontal lines with min_theta=80°, max_theta=100°), the function failed to find lines. However, without these parameters (using the default 0 to π range), it worked correctly.

The root cause was that the OpenCL kernels (`fill_accum_global`, `fill_accum_local`, and `get_lines`) were always calculating angles starting from 0, completely ignoring the `min_theta` parameter.

## Solution

Updated the OpenCL implementation to properly use the `min_theta` parameter:

1. **Modified `ocl_fillAccum()` function signature**: Added `min_theta` parameter and passed it to the OpenCL kernels
2. **Updated `fill_accum_global` kernel**: Changed angle calculation from `theta * theta_idx` to `min_theta + theta * theta_idx`
3. **Updated `fill_accum_local` kernel**: Changed angle calculation from `theta * (theta_idx-1)` to `min_theta + theta * (theta_idx-1)`
4. **Updated `get_lines` kernel**: Changed angle output from `y * theta` to `min_theta + y * theta`
5. **Updated `ocl_HoughLines()`**: Passes `min_theta` to both `ocl_fillAccum()` and the `get_lines` kernel
6. **Updated `ocl_HoughLinesP()`**: Passes 0.0 as `min_theta` to maintain existing behavior (since HoughLinesP doesn't support angle range parameters)

## Testing

The fix ensures that:
- When detecting horizontal lines (e.g., min_theta=80°, max_theta=100°), the algorithm correctly searches only in the specified angle range
- Vertical line detection still works correctly with appropriate angle ranges
- Default behavior (0 to π) remains unchanged when min_theta and max_theta are not specified
- The probabilistic HoughLinesP function continues to work as before

## Related Issue

Fixes #28036

### Merge checklist

- [x] I have read the contribution guidelines
- [x] The changes follow OpenCV coding style
- [x] The commit message follows OpenCV guidelines