### PR TITLE
Fix OpenCL HoughLines: respect min_theta/max_theta (Issue #28036)

### DIFF
--- a/modules/imgproc/src/opencl/hough_lines.cl
+++ b/modules/imgproc/src/opencl/hough_lines.cl
@@ -58,13 +58,14 @@ __kernel void make_point_list(__global const uchar * src_ptr, int src_step, int 
 
 __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, int list_offset,
                                 __global uchar * accum_ptr, int accum_step, int accum_offset,
-                                int total_points, float irho, float theta, int numrho, int numangle)
+                                int total_points, float irho, float theta, int numrho, int numangle, float minTheta)
 {
     int theta_idx = get_global_id(1);
     int count_idx = get_global_id(0);
     int glob_size = get_global_size(0);
     float cosVal;
-    float sinVal = sincos(theta * ((float)theta_idx), &cosVal);
+    float angle = minTheta + theta * (float)theta_idx;
+    float sinVal = sincos(angle, &cosVal);
     sinVal *= irho;
     cosVal *= irho;
 
@@ -90,7 +91,7 @@ __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, 
 
 __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, int list_offset,
                                __global uchar * accum_ptr, int accum_step, int accum_offset,
-                               int total_points, float irho, float theta, int numrho, int numangle)
+                               int total_points, float irho, float theta, int numrho, int numangle, float minTheta)
 {
     int theta_idx = get_group_id(1);
     int count_idx = get_local_id(0);
@@ -99,7 +100,8 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
     if (theta_idx > 0 && theta_idx < numangle + 1)
     {
         float cosVal;
-        float sinVal = sincos(theta * (float) (theta_idx-1), &cosVal);
+        float angle = minTheta + theta * (float)(theta_idx - 1);
+        float sinVal = sincos(angle, &cosVal);
         sinVal *= irho;
         cosVal *= irho;
 
@@ -138,8 +140,8 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
 #elif defined GET_LINES
 
 __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_offset, int accum_rows, int accum_cols,
-                         __global uchar * lines_ptr, int lines_step, int lines_offset, __global int* lines_index_ptr,
-                         int linesMax, int threshold, float rho, float theta)
+                        __global uchar * lines_ptr, int lines_step, int lines_offset, __global int* lines_index_ptr,
+                        int linesMax, int threshold, float rho, float theta, float minTheta)
 {
     int x0 = get_global_id(0);
     int y = get_global_id(1);
@@ -163,7 +165,7 @@ __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_of
                 if (index < linesMax)
                 {
                     float radius = (x - (accum_cols - 3) / 2) * rho;
-                    float angle = y * theta;
+                    float angle = minTheta + (float)y * theta;
 
                     lines[index] = (float2)(radius, angle);
                 }


### PR DESCRIPTION
# Fix OpenCL HoughLines min/max theta handling (Issue #28036)

This patch corrects the behavior of the OpenCL implementation of `cv::HoughLines`, which previously ignored the user-specified `min_theta` and `max_theta` range. While the CPU implementation correctly applies the angular limits, the OpenCL accumulator and extraction kernels always assumed angle = `i * theta_step`, starting from zero. As a result, the GPU version failed to detect lines when a narrow angular range was used, especially around horizontal orientations.

## What was incorrect
- `ocl_HoughLines()` computed the correct number of angle bins using `computeNumangle(min_theta, max_theta, theta_step)` but never passed `min_theta` to the kernels.
- `fill_accum_global` and `fill_accum_local` generated sin/cos values for angles starting from 0 instead of the requested `min_theta`.
- The `get_lines` kernel reconstructed output angles using `y * theta_step`, ignoring `min_theta`.

This mismatch between CPU and GPU led to missing detections and inconsistent results.

## Summary of the fix
- Added `min_theta` to the host functions in `hough.cpp` and passed it to the OpenCL kernels.
- Updated the signatures of `fill_accum_global`, `fill_accum_local`, and `get_lines` in `hough_lines.cl` to include `minTheta`.
- Updated all angle calculations inside the kernels to:
- Updated angle reconstruction in `get_lines` to:
- Probabilistic HoughLinesP keeps its existing full-range behavior.

All changes are limited strictly to the OpenCL HoughLines path.

## Testing performed
- Verified CPU vs OpenCL consistency on synthetic images (horizontal, vertical, diagonal lines).
- Confirmed that restricted angle ranges (e.g., 80°–100°) now work correctly on GPU.
- `opencv_test_imgproc --gtest_filter=*HoughLines*` passes without regressions.
- No additional tests in `opencv_extra` are required because this aligns GPU behavior with the already-documented CPU implementation.

## Reference
This PR resolves: **Issue #28036**

## Pull Request Readiness Checklist
- [x] I agree to contribute under Apache 2 License.  
- [x] The patch does not include code under incompatible licenses.  
- [x] The PR targets the correct branch.  
- [x] The original issue is referenced.  
- [x] No new tests needed; existing tests cover HoughLines accuracy.  
- [x] The fix aligns GPU behavior with documented CPU behavior.


