### PR TITLE
Avoid integer overflow in BmpDecoder::readData

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -337,7 +337,7 @@ bool  BmpDecoder::readData( Mat& img )
                     }
                     else
                     {
-                        int x_shift3 = (int)(line_end - data);
+                        ptrdiff_t x_shift3 = line_end - data;
 
                         if( code == 2 )
                         {
@@ -430,7 +430,7 @@ decode_rle4_bad: ;
                     }
                     else
                     {
-                        int x_shift3 = (int)(line_end - data);
+                        ptrdiff_t x_shift3 = line_end - data;
                         int y_shift = m_height - y;
 
                         if( code || !line_end_flag || x_shift3 < width3 )
@@ -441,7 +441,7 @@ decode_rle4_bad: ;
                                 y_shift = m_strm.getByte();
                             }
 
-                            x_shift3 += (y_shift * width3) & ((code == 0) - 1);
+                            x_shift3 += ((ptrdiff_t)y_shift * width3) & ((code == 0) - 1);
 
                             if( y >= m_height )
                                 break;

--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -435,7 +435,7 @@ bool  IsColorPalette( PaletteEntry* palette, int bpp )
 uchar* FillUniColor( uchar* data, uchar*& line_end,
                      int step, int width3,
                      int& y, int height,
-                     int count3, PaletteEntry clr )
+                     ptrdiff_t count3, PaletteEntry clr )
 {
     do
     {
@@ -444,7 +444,7 @@ uchar* FillUniColor( uchar* data, uchar*& line_end,
         if( end > line_end )
             end = line_end;
 
-        count3 -= (int)(end - data);
+        count3 -= end - data;
 
         for( ; data < end; data += 3 )
         {
@@ -467,7 +467,7 @@ uchar* FillUniColor( uchar* data, uchar*& line_end,
 uchar* FillUniGray( uchar* data, uchar*& line_end,
                     int step, int width,
                     int& y, int height,
-                    int count, uchar clr )
+                    ptrdiff_t count, uchar clr )
 {
     do
     {
@@ -476,7 +476,7 @@ uchar* FillUniGray( uchar* data, uchar*& line_end,
         if( end > line_end )
             end = line_end;
 
-        count -= (int)(end - data);
+        count -= end - data;
 
         for( ; data < end; data++ )
         {

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -124,9 +124,9 @@ void  FillGrayPalette( PaletteEntry* palette, int bpp, bool negative = false );
 bool  IsColorPalette( PaletteEntry* palette, int bpp );
 void  CvtPaletteToGray( const PaletteEntry* palette, uchar* grayPalette, int entries );
 uchar* FillUniColor( uchar* data, uchar*& line_end, int step, int width3,
-                     int& y, int height, int count3, PaletteEntry clr );
+                     int& y, int height, ptrdiff_t count3, PaletteEntry clr );
 uchar* FillUniGray( uchar* data, uchar*& line_end, int step, int width3,
-                     int& y, int height, int count3, uchar clr );
+                     int& y, int height, ptrdiff_t count3, uchar clr );
 
 uchar* FillColorRow8( uchar* data, uchar* indices, int len, PaletteEntry* palette );
 uchar* FillGrayRow8( uchar* data, uchar* indices, int len, uchar* palette );


### PR DESCRIPTION
This solves https://g-issues.oss-fuzz.com/issues/457623761

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
