### PR TITLE
Fix OpenBLAS detection on Fedora/RHEL: header path + threaded library selection (Issue #28049)

### DIFF
--- a/cmake/OpenCVFindOpenBLAS.cmake
+++ b/cmake/OpenCVFindOpenBLAS.cmake
@@ -20,8 +20,10 @@ if(NOT OpenBLAS_FOUND)
 endif()
 
 if(NOT OpenBLAS_FOUND)
-  find_library(OpenBLAS_LIBRARIES NAMES openblas)
-  find_path(OpenBLAS_INCLUDE_DIRS NAMES cblas.h)
+  find_library(OpenBLAS_LIBRARIES NAMES openblasp openblas)
+  find_path(OpenBLAS_INCLUDE_DIRS
+            NAMES cblas.h
+            PATH_SUFFIXES openblas)
   find_path(OpenBLAS_LAPACKE_DIR NAMES lapacke.h PATHS "${OpenBLAS_INCLUDE_DIRS}")
   if(OpenBLAS_LIBRARIES AND OpenBLAS_INCLUDE_DIRS)
     message(STATUS "Found OpenBLAS in the system")


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable  
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description

This PR fixes two issues in `OpenCVFindOpenBLAS.cmake` that affect Fedora/RHEL platforms, exactly as reported in **Issue #28049**. These systems install OpenBLAS headers in a namespaced directory and also provide multiple OpenBLAS library variants, causing OpenCV to fail to detect LAPACK support and to link against the wrong (serial) OpenBLAS library.

#### 1. Header Detection Failure  
On Fedora/RHEL, OpenBLAS headers are located at:  
`/usr/include/openblas/cblas.h`  
The previous CMake logic searched only standard include roots and did not look inside the `openblas/` subdirectory. As a result, OpenCV incorrectly reported:  
`Lapack: NO`  
This PR adds `PATH_SUFFIXES openblas` to the search path so that `cblas.h` is detected correctly.

#### 2. Wrong Library Selected (serial instead of pthreads)  
Fedora/RHEL provide two OpenBLAS libraries:  
- `libopenblasp.so` (multi-threaded, pthreads)  
- `libopenblas.so` (serial, single-threaded)  

The previous CMake logic matched only `openblas`, linking OpenCV to the serial version and significantly reducing performance.  
This PR updates the search order to:  
`find_library(OpenBLAS_LIBRARIES NAMES openblasp openblas)`  
which ensures the faster, multi-threaded library is selected when available.

### Motivation and Impact

- Restores correct OpenBLAS/LAPACK detection on Fedora/RHEL.
- Ensures OpenCV links to the multi-threaded BLAS implementation, restoring expected performance.
- Fixes failures in pip wheel builds (`opencv-python-headless`) and source builds on Fedora/RHEL.
- Does not change behavior on Ubuntu, Debian, Arch, macOS, or Windows.

### Related Issue

Fixes: **#28049**

### Testing

The fix was validated using the Fedora container example from the issue report.

**Before the fix:**  
`Lapack: NO`

**After the fix:**  
`Lapack: YES (/usr/lib64/libopenblasp.so)`

### Summary

This is a minimal and safe CMake update that restores full OpenBLAS detection on Fedora/RHEL systems, selecting the correct threaded library and enabling LAPACK support. Behavior on all other platforms remains unchanged.
