### PR TITLE
samples: add compatibility note for Mask R-CNN in OpenCV 5.0

### DIFF
--- a/samples/dnn/mask_rcnn.py
+++ b/samples/dnn/mask_rcnn.py
@@ -7,7 +7,7 @@ The default model configuration (.pbtxt) used in this sample relies on retrievin
 intermediate layers (e.g., 'detection_out_final'). OpenCV 5.0 introduces stricter
 graph optimization which may prune intermediate layers not explicitly registered as outputs.
 If you encounter an error such as "the number of requested and actual outputs must be the same",
-please note that the provided .pbtxt may need to be updated to explicitly declare 
+please note that the provided .pbtxt may need to be updated to explicitly declare
 'detection_out_final' as an output node.
 '''
 import cv2 as cv
@@ -102,7 +102,7 @@ while cv.waitKey(1) < 0:
 
     # Run a model
     net.setInput(blob)
-    
+
     # NOTE: In OpenCV 5.0, requesting 'detection_out_final' will fail if the .pbtxt
     # does not register it as an output. See file header for details.
     boxes, masks = net.forward(['detection_out_final', 'detection_masks'])


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Summary
Updates documentation in `samples/dnn/mask_rcnn.py` to clarify a compatibility issue with OpenCV 5.0.

### Details
As verified in issue #27240, OpenCV 5.0 introduces stricter graph optimization. The default `.pbtxt` used in this sample treats `detection_out_final` as an intermediate layer (it is not listed in `getUnconnectedOutLayersNames`).

While OpenCV 4.x implicitly allows retrieving this layer, OpenCV 5.0 throws an error when requesting it:
> "the number of requested and actual outputs must be the same"

This PR adds:
1. A warning note in the file header explaining the strict output requirement.
2. An inline comment near `net.forward()` to guide users debugging this error.

Relates to issue: #27240
