### PR TITLE
Fix numerical instability in solveCubic for small leading coefficients

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -1586,46 +1586,46 @@ int cv::solveCubic( InputArray _coeffs, OutputArray _roots )
         a3 = coeffs.at<double>(i+3);
     }
 
-// Use float epsilon (approx 1e-7) to catch the 1e-13 case from Issue #27748
-// DBL_EPSILON (1e-16) is too small to fix that specific bug.
-double eps = (double)std::numeric_limits<float>::epsilon();
 
-if( std::abs(a0) <= eps )
-{
-    if( std::abs(a1) <= eps )
+    double eps = (double)std::numeric_limits<float>::epsilon();
+
+    if( std::abs(a0) <= eps )
     {
-        if( std::abs(a2) <= eps ) // constant
-            n = std::abs(a3) <= eps ? -1 : 0;
-        else
+        if( std::abs(a1) <= eps )
         {
-            // linear equation
-            x0 = -a3/a2;
-            n = 1;
-        }
-    }
-    else
-    {
-        // quadratic equation
-        double d = a2*a2 - 4*a1*a3;
-        if( d >= 0 )
-        {
-            d = std::sqrt(d);
-            double q1 = (-a2 + d) * 0.5;
-            double q2 = (a2 + d) * -0.5;
-            if( std::abs(q1) > std::abs(q2) )
-            {
-                x0 = q1 / a1;
-                x1 = a3 / q1;
-            }
+            if( std::abs(a2) <= eps ) // constant
+                n = std::abs(a3) <= eps ? -1 : 0;
             else
             {
-                x0 = q2 / a1;
-                x1 = a3 / q2;
+                // linear equation
+                x0 = -a3/a2;
+                n = 1;
             }
-            n = d > 0 ? 2 : 1;
+        }
+        else
+        {
+            // quadratic equation
+            double d = a2*a2 - 4*a1*a3;
+            if( d >= 0 )
+            {
+                d = std::sqrt(d);
+                double q1 = (-a2 + d) * 0.5;
+                double q2 = (a2 + d) * -0.5;
+                if( std::abs(q1) > std::abs(q2) )
+                {
+                    x0 = q1 / a1;
+                    x1 = a3 / q1;
+                }
+                else
+                {
+                    x0 = q2 / a1;
+                    x1 = a3 / q2;
+                }
+                n = d > 0 ? 2 : 1;
+            }
         }
     }
-}
+
     else
     {
         // cubic equation

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -2620,8 +2620,7 @@ TEST(Core_SolveCubic, regression_27323)
 
 TEST(Core_SolveCubic, Issue_27748_SmallLeadingCoefficient)
 {
-    // Coefficients from GitHub Issue #27748
-    // a0 is approx 2.27e-13, which caused instability before the fix
+
     double coeffs_data[] = {
         2.27373675443232e-13, 
         84.5523809523809, 
@@ -2632,23 +2631,19 @@ TEST(Core_SolveCubic, Issue_27748_SmallLeadingCoefficient)
     cv::Mat coeffs(1, 4, CV_64F, coeffs_data);
     cv::Mat roots;
 
-    // Attempt to solve. With the fix, this should treat it as a quadratic equation.
+
     int n = cv::solveCubic(coeffs, roots);
 
-    // 1. Verify we got a valid number of roots (Quadratic typically returns 2 real roots here)
+
     EXPECT_GE(n, 1); 
     EXPECT_LE(n, 3);
 
-    // 2. Verify values. 
-    // Without fix: Roots were ~ -3.7e14 (Huge)
-    // With fix: Roots should be approx 0.0617 and -0.0287 (Small)
-    
-    // We check that ALL roots are within a reasonable range (e.g., < 10.0)
-    // This proves the numerical explosion is gone.
+
     for(int i = 0; i < n; ++i)
     {
         double r = roots.at<double>(i);
-        EXPECT_LT(std::abs(r), 10.0) << "Root " << i << " is suspiciously large: " << r;
+
+        EXPECT_LT(fabs(r), 10.0) << "Root " << i << " is suspiciously large: " << r;
     }
 }
 


### PR DESCRIPTION

This PR improves the numerical stability of cv::solveCubic by replacing exact zero checks (== 0) with epsilon-based checks. This resolves incorrect root calculations when the leading coefficient (a0) is extremely small (close to zero but non-zero), effectively treating such equations as quadratic to prevent floating-point errors.

Related Issue
Fixes #27748