### PR TITLE
imgcodecs: avif: Do not set for monochrome + identity matrix

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -86,7 +86,7 @@ AvifImageUniquePtr ConvertToAvif(const cv::Mat &img, bool lossless, int bit_dept
     result->yuvFormat = AVIF_PIXEL_FORMAT_YUV400;
     result->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     result->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+    result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
     result->yuvRange = AVIF_RANGE_FULL;
     result->yuvPlanes[0] = img.data;
     result->yuvRowBytes[0] = img.step[0];


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/28060

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
