### PR TITLE
imgcodecs: avif: use UNSPECIFIED matrixCoefficients instead of IDENTITY for YUV400

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -86,7 +86,7 @@ AvifImageUniquePtr ConvertToAvif(const cv::Mat &img, bool lossless, int bit_dept
     result->yuvFormat = AVIF_PIXEL_FORMAT_YUV400;
     result->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     result->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+    result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
     result->yuvRange = AVIF_RANGE_FULL;
     result->yuvPlanes[0] = img.data;
     result->yuvRowBytes[0] = img.step[0];


### PR DESCRIPTION
### Summary
Fixes AVIF writing errors when using libavif 1.3.0+.

libavif now enforces the requirement (AV1 spec 6.4.2) that if
matrix_coefficients == IDENTITY then subsampling must be YUV444.
In OpenCV, monochrome images (YUV400) were assigned
AVIF_MATRIX_COEFFICIENTS_IDENTITY, causing writeanimation() to
fail with:

"subsampling must be 0 (4:4:4) with identity matrix coefficients"

### Fix
Change matrixCoefficients from `AVIF_MATRIX_COEFFICIENTS_IDENTITY`
to `AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED` in grfmt_avif.cpp for
monochrome images.

### Testing
- Built OpenCV with libavif v1.3.0
- Verified that `opencv_test_imgcodecs --gtest_filter="*AVIF*"` passes
- AVIF writing works for YUV400 without runtime error

### Issue
Closes: <insert link to new GitHub issue if needed>

### Notes
This change aligns OpenCV behavior with libavif’s updated conformance
checks and avoids invalid argument failures when writing AVIF images.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
