### PR TITLE
Fix avif identity yuv444

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -100,7 +100,12 @@ AvifImageUniquePtr ConvertToAvif(const cv::Mat &img, bool lossless, int bit_dept
     if (result == nullptr) return nullptr;
     result->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
     result->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-    result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+    // IDENTITY may only be used with 4:4:4 subsampling (AVIF spec, sec. 6.4.2)
+    if (result->yuvFormat == AVIF_PIXEL_FORMAT_YUV444) {
+        result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+    } else {
+        result->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+    }
     result->yuvRange = AVIF_RANGE_FULL;
   } else {
     result =


### PR DESCRIPTION
### Summary

Fixes Issue #28062 — "avif: YUV400 and COEFFICIENTS_IDENTITY cannot be set at the same time".

According to the AV1 specification (Section 6.4.2) and libavif ≥ 1.3.0
enforcement, AVIF_MATRIX_COEFFICIENTS_IDENTITY is only valid when using
4:4:4 subsampling (AVIF_PIXEL_FORMAT_YUV444).

Lossless AVIF encoding in OpenCV always uses YUV444, so IDENTITY is allowed.
However, OpenCV did not explicitly prevent IDENTITY from being used with other
subsampling formats in future paths or refactoring.

### Fix

- For lossless images (YUV444), keep IDENTITY.
- For all other formats (e.g., YUV400, YUV420), set matrixCoefficients to
  AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED to comply with the AVIF spec.

This ensures OpenCV is always compliant with AV1/AVIF requirements and avoids
libavif runtime errors such as:
"subsampling must be 0 (4:4:4) with identity matrix coefficients".

### Issue

Closes: https://github.com/opencv/opencv/issues/28062

### Checklist

- [x] Code builds successfully
- [x] Fix aligns with AVIF specification and libavif behavior
- [x] No API changes
- [x] No new tests required (metadata correction only)
- [x] Ready for review
