### PR TITLE
fix min_theta parameter ignored in OpenCL HoughLines

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -762,7 +762,7 @@ static bool ocl_makePointsList(InputArray _src, OutputArray _pointsList, InputOu
     return pointListKernel.run(2, globalThreads, localThreads, false);
 }
 
-static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle)
+static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, double min_theta, int numrho, int numangle)
 {
     UMat pointsList = _pointsList.getUMat();
     _accum.create(numangle + 2, numrho + 2, CV_32SC1);
@@ -786,7 +786,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
             return false;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, (float) min_theta, numrho, numangle);
         return fillAccumKernel.run(2, globalThreads, NULL, false);
     }
     else
@@ -797,8 +797,11 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
             return false;
         localThreads[0] = workgroup_size; localThreads[1] = 1;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle+2;
+
+    
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, (float) min_theta, numrho, numangle);
+        
         return fillAccumKernel.run(2, globalThreads, localThreads, false);
     }
 }
@@ -836,9 +839,9 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+ 
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, min_theta, numrho, numangle))
         return false;
-
     const int pixPerWI = 8;
     ocl::Kernel getLinesKernel("get_lines", ocl::imgproc::hough_lines_oclsrc,
                                format("-D GET_LINES"));
@@ -890,8 +893,9 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
-        return false;
+
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, 0.0, numrho, numangle))
+            return false;
 
     ocl::Kernel getLinesKernel("get_lines", ocl::imgproc::hough_lines_oclsrc,
                                format("-D GET_LINES_PROBABOLISTIC"));


### PR DESCRIPTION
Summary This PR fixes a bug in the OpenCL optimization of cv::HoughLines where the min_theta parameter was being ignored. Previously, the GPU implementation always assumed a starting angle of 0.0, regardless of the user input, leading to incorrect line detection angles when min_theta > 0.

Relates to Fixes #28036

Detailed Changes

Host Code (modules/imgproc/src/hough.cpp):

Updated the signature of ocl_fillAccum to accept the min_theta offset.

Updated ocl_HoughLines to pass the user-provided min_theta to the helper function.

Updated ocl_HoughLinesP (Probabilistic Hough) to pass 0.0 explicitly, ensuring existing behavior is preserved for probabilistic detection (which does not expose a min_theta argument).

Device Code (modules/imgproc/src/opencl/hough_lines.cl):

Updated fill_accum_global and fill_accum_local kernels to accept min_theta.

Corrected the angle calculation formula from val_theta = n * theta to val_theta = (n * theta) + min_theta.
