### PR TITLE
imgcodecs: avif: support to encode with metadata for 1ch Mat

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -91,10 +91,7 @@ AvifImageUniquePtr ConvertToAvif(const cv::Mat &img, bool lossless, int bit_dept
     result->yuvPlanes[0] = img.data;
     result->yuvRowBytes[0] = img.step[0];
     result->imageOwnsYUVPlanes = AVIF_FALSE;
-    return AvifImageUniquePtr(result);
-  }
-
-  if (lossless) {
+  } else if (lossless) {
     result =
         avifImageCreate(width, height, bit_depth, AVIF_PIXEL_FORMAT_YUV444);
     if (result == nullptr) return nullptr;
@@ -139,22 +136,24 @@ AvifImageUniquePtr ConvertToAvif(const cv::Mat &img, bool lossless, int bit_dept
 #endif
   }
 
-  avifRGBImage rgba;
-  avifRGBImageSetDefaults(&rgba, result);
-  if (img.channels() == 3) {
-    rgba.format = AVIF_RGB_FORMAT_BGR;
-  } else {
-    CV_Assert(img.channels() == 4);
-    rgba.format = AVIF_RGB_FORMAT_BGRA;
-  }
-  rgba.rowBytes = (uint32_t)img.step[0];
-  rgba.depth = bit_depth;
-  rgba.pixels =
-      const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(img.data));
+  if (img.channels() > 1) {
+    avifRGBImage rgba;
+    avifRGBImageSetDefaults(&rgba, result);
+    if (img.channels() == 3) {
+      rgba.format = AVIF_RGB_FORMAT_BGR;
+    } else {
+      CV_Assert(img.channels() == 4);
+      rgba.format = AVIF_RGB_FORMAT_BGRA;
+    }
+    rgba.rowBytes = (uint32_t)img.step[0];
+    rgba.depth = bit_depth;
+    rgba.pixels =
+        const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(img.data));
 
-  if (avifImageRGBToYUV(result, &rgba) != AVIF_RESULT_OK) {
-    avifImageDestroy(result);
-    return nullptr;
+    if (avifImageRGBToYUV(result, &rgba) != AVIF_RESULT_OK) {
+      avifImageDestroy(result);
+      return nullptr;
+    }
   }
   return AvifImageUniquePtr(result);
 }

--- a/modules/imgcodecs/test/test_exif.cpp
+++ b/modules/imgcodecs/test/test_exif.cpp
@@ -296,13 +296,15 @@ INSTANTIATE_TEST_CASE_P(Imgcodecs, Exif,
                         testing::ValuesIn(exif_files));
 
 #ifdef HAVE_AVIF
-TEST(Imgcodecs_Avif, ReadWriteWithExif)
+typedef testing::TestWithParam<int> MatChannels;
+
+TEST_P(MatChannels, Imgcodecs_Avif_ReadWriteWithExif)
 {
     int avif_nbits = 10;
     int avif_speed = 10;
     int avif_quality = 85;
     int imgdepth = avif_nbits > 8 ? CV_16U : CV_8U;
-    int imgtype = CV_MAKETYPE(imgdepth, 3);
+    int imgtype = CV_MAKETYPE(imgdepth, GetParam());
     const string outputname = cv::tempfile(".avif");
     Mat img = makeCirclesImage(Size(1280, 720), imgtype, avif_nbits);
 
@@ -328,7 +330,7 @@ TEST(Imgcodecs_Avif, ReadWriteWithExif)
     EXPECT_EQ(img2.rows, img.rows);
     EXPECT_EQ(img2.type(), imgtype);
     EXPECT_EQ(read_metadata_types, read_metadata_types2);
-    EXPECT_GE(read_metadata_types.size(), 1u);
+    ASSERT_GE(read_metadata_types.size(), 1u);
     EXPECT_EQ(read_metadata, read_metadata2);
     EXPECT_EQ(read_metadata_types[0], IMAGE_METADATA_EXIF);
     EXPECT_EQ(read_metadata_types.size(), read_metadata.size());
@@ -338,6 +340,9 @@ TEST(Imgcodecs_Avif, ReadWriteWithExif)
     EXPECT_LT(mse, 1500);
     remove(outputname.c_str());
 }
+
+INSTANTIATE_TEST_CASE_P(Imgcodecs, MatChannels,
+                        testing::Values(1,3,4));
 #endif // HAVE_AVIF
 
 #ifdef HAVE_WEBP


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/28071

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
