### PR TITLE
 clarify Python usage for calibrateHandEye to avoid argument shadowing

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2353,10 +2353,10 @@ A minimum of 2 motions with non parallel rotation axes are necessary to determin
 So at least 3 different poses are required, but it is strongly recommended to use many more poses.
 
  */
-CV_EXPORTS_W void calibrateHandEye( InputArrayOfArrays R_gripper2base, InputArrayOfArrays t_gripper2base,
-                                    InputArrayOfArrays R_target2cam, InputArrayOfArrays t_target2cam,
-                                    OutputArray R_cam2gripper, OutputArray t_cam2gripper,
-                                    HandEyeCalibrationMethod method=CALIB_HAND_EYE_TSAI );
+CV_EXPORTS_W void calibrateHandEye(InputArrayOfArrays R_gripper2base, InputArrayOfArrays t_gripper2base,
+                                   InputArrayOfArrays R_target2cam, InputArrayOfArrays t_target2cam,
+                                   OutputArray R_cam2gripper, OutputArray t_cam2gripper,
+                                   int method = CALIB_HAND_EYE_TSAI);
 
 /** @brief Computes Robot-World/Hand-Eye calibration: \f$_{}^{w}\textrm{T}_b\f$ and \f$_{}^{c}\textrm{T}_g\f$
 


### PR DESCRIPTION
Resolves:#27625

Summary
This PR updates the documentation for `calibrateHandEye` to address a common confusion among Python users.

### The Issue
As reported in #27625, users often call the function with 5 arguments:
`cv2.calibrateHandEye(R_g2b, t_g2b, R_t2c, t_t2c, cv2.CALIB_HAND_EYE_PARK)`

In this scenario, the `method` flag (an integer) is passed into the 5th argument (`R_cam2gripper`, an output array), while the actual `method` parameter (7th argument) defaults to `CALIB_HAND_EYE_TSAI`. This causes the function to appear broken as it always returns results from the Tsai method, regardless of the flag passed.

### The Fix
Added a Doxygen `@note` explicitly warning Python users to use keyword arguments (e.g., `method=cv2.CALIB_HAND_EYE_PARK`) or pass `None` for the intermediate output arrays.
