### PR TITLE
fix: respect LOG_LEVEL_SILENT in imcount_() decoder errors

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -1046,7 +1046,7 @@ size_t imcount_(const String& filename, int flags)
         return collection.size();
     } catch(cv::Exception const& e) {
         // Reading header or finding decoder for the filename is failed
-        CV_LOG_ERROR(NULL, "imcount_('" << filename << "'): can't read header or can't find decoder: " << e.what());
+        CV_LOG_WARNING(NULL, "imcount_('" << filename << "'): can't read header or can't find decoder: " << e.what());
     }
     return 0;
 }


### PR DESCRIPTION
Fixes #28081

### Problem
When `imread()` or `imcount()` fails to decode an image (e.g., unsupported HEIC format), error messages are printed even when `OPENCV_LOG_LEVEL=OFF` or `LOG_LEVEL_SILENT` is set.

### Root Cause
The `imcount_()` function uses `CV_LOG_ERROR` which bypasses the log level settings.

### Solution
Changed `CV_LOG_ERROR` to `CV_LOG_WARNING` in `imcount_()` to align with other imread operations in the same file (lines 278, 835).

### Impact
- Developers can now properly suppress error logs when handling unsupported image formats
- Maintains consistency with other image read failures in loadsave.cpp
- Critical for production environments where graceful error handling is needed

### Testing
The fix allows the reproduction case from #28081 to work as expected:
- Setting `OPENCV_LOG_LEVEL=OFF` now suppresses the decoder error
- Setting `LOG_LEVEL_SILENT` via API now works correctly