### PR TITLE
fix: disable omp_set_dynamic() by default to prevent unpredictable th…

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -465,7 +465,7 @@ namespace {
 static inline int _initMaxThreads()
 {
     int maxThreads = omp_get_max_threads();
-    if (!utils::getConfigurationParameterBool("OPENCV_FOR_OPENMP_DYNAMIC_DISABLE", false))
+    if (!utils::getConfigurationParameterBool("OPENCV_FOR_OPENMP_DYNAMIC_DISABLE", true))
     {
         omp_set_dynamic(1);
     }


### PR DESCRIPTION
## Description

Fixes #25717

This PR disables `omp_set_dynamic()` by default to prevent unpredictable OpenMP threading behavior that severely impacts performance on Linux systems.

## Problem

The current default behavior calls `omp_set_dynamic(1)`, which on Linux systems using libgomp determines thread count based on `(num_cores - 15min_load_average)`. This causes several critical issues:

1. **Apps use only 1 thread even when system is idle** - if the system was busy 10-15 minutes ago
2. **Thread count is locked at process startup** - programs stay slow forever if started during/after load
3. **Server workloads achieve only ~50% CPU utilization** on average when processing job queues
4. **Completely irreproducible performance** - behavior depends on historical load from 15 minutes ago

Example: On an 8-core server processing a queue of 15-minute jobs:
- Job 1 starts at 0 load → uses 8 cores
- Job 2 starts → uses only 1 core (sees load of 8)
- Job 3 starts → uses 7 cores (sees load of 1)
- Job 4 starts → uses 1 core (sees load of 7)
- Result: ~50% average CPU utilization instead of 100%

## Solution

Changed the default value for `OPENCV_FOR_OPENMP_DYNAMIC_DISABLE` from `false` to `true`, so `omp_set_dynamic()` is **not** called by default.

Users who need the old behavior (e.g., for specific testing scenarios with background jobs) can still enable it by:
- Setting environment variable `OPENCV_FOR_OPENMP_DYNAMIC_DISABLE=0`
- Calling `omp_set_dynamic(1)` from their own code

## Changes

- `modules/core/src/parallel.cpp`: Changed default parameter from `false` to `true` (1 character change)

## Impact

This change provides:
- Predictable, reproducible performance
- Full CPU utilization on idle systems
- Consistent threading regardless of historical load
- Backward compatibility - users can still opt-in to old behavior

## Background

The original PR #12796 introduced `omp_set_dynamic(1)` to handle background jobs during CI testing. However, the libgomp implementation's reliance on 15-minute load average makes this unsuitable as a default for production workloads.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x)
- [x] There is a reference to the original bug report and related work (issue #25717)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      - N/A - This is a default configuration change that affects runtime behavior, not algorithm correctness
- [x] The feature is well documented and sample code can be built with the project CMake
      - The existing environment variable `OPENCV_FOR_OPENMP_DYNAMIC_DISABLE` is already documented in the code