### PR TITLE
Unblock system-wide installation of Aravis SDK.

### DIFF
--- a/modules/videoio/cmake/detect_aravis.cmake
+++ b/modules/videoio/cmake/detect_aravis.cmake
@@ -9,12 +9,10 @@ endif()
 if(NOT HAVE_ARAVIS_API)
   find_path(ARAVIS_INCLUDE "arv.h"
     PATHS "${ARAVIS_ROOT}" ENV ARAVIS_ROOT
-    PATH_SUFFIXES "include/aravis-0.8"
-    NO_DEFAULT_PATH)
+    PATH_SUFFIXES "include/aravis-0.8")
   find_library(ARAVIS_LIBRARY "aravis-0.8"
     PATHS "${ARAVIS_ROOT}" ENV ARAVIS_ROOT
-    PATH_SUFFIXES "lib"
-    NO_DEFAULT_PATH)
+    PATH_SUFFIXES "lib")
   if(ARAVIS_INCLUDE AND ARAVIS_LIBRARY)
     set(HAVE_ARAVIS_API TRUE)
     file(STRINGS "${ARAVIS_INCLUDE}/arvversion.h" ver_strings REGEX "#define +ARAVIS_(MAJOR|MINOR|MICRO)_VERSION.*")


### PR DESCRIPTION
Ubuntu provides Aravis SDK packages via default repos, but they are not found by CMake.

Steps to test with Ubuntu 24.04:

1. Install packages
```
sudo apt-get install gstreamer1.0-gtk3 aravis-tools libaravis-dev gstreamer1.0-plugins
```
gstreamer1.0-gtk3 and gstreamer1.0-plugins are needed for Aravis Viewer  https://github.com/AravisProject/aravis/issues/345
2. Get udev rules and put them to /etc/udev/rules.d/ : https://github.com/AravisProject/aravis/blob/main/src/aravis.rules
3. Reboot the host or restart udev.
4. Check camera with Aravis Viever: `arv-viewer-0.8`
5. Build OpenCV with Aravis:
```
mkdir build && cd build
cmake -DWITH_ARAVIS=ON ../opencv
make -j8
```
6. Run calibration tool with Aravis backend: `./bin/opencv_interactive-calibration --vb=ARAVIS`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
