### PR TITLE
fix(features2d): Correct pointer arithmetic in BRISK corner traversal

### DIFF
--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -626,7 +626,7 @@ BRISK_Impl::smoothedIntensity(const cv::Mat& image, const cv::Mat& integral, con
     ret_val = A * int(*ptr);
     ptr += dx + 1;
     ret_val += B * int(*ptr);
-    ptr += dy * imagecols + 1;
+    ptr += (dy + 1) * imagecols;
     ret_val += C * int(*ptr);
     ptr -= dx + 1;
     ret_val += D * int(*ptr);


### PR DESCRIPTION
The pointer offset to move from top-right to bottom-right was incorrect. This change corrects the pointer calculation to use the proper row stride, ensuring it lands on the correct pixel.

Given the definitions

https://github.com/opencv/opencv/blob/1c712fe2ff7c7d984b5806932206c5e16a77d08f/modules/features2d/src/brisk.cpp#L610-L611

In the following code, the four corners of a patch are sampled:

https://github.com/opencv/opencv/blob/1c712fe2ff7c7d984b5806932206c5e16a77d08f/modules/features2d/src/brisk.cpp#L625-L632

To move from the top-left to the top-right corner, the pointer is correctly advanced by dx + 1, which resolves to the required horizontal distance of x_right - x_left.

To move from the top-right to the bottom-right corner, the offset should be (dy + 1) * imagecols to cover the vertical distance of y_bottom - y_top.

However, the original line ptr += dy * imagecols + 1; is incorrect. It moves the pointer down by only dy rows and also shifts it right by 1 pixel.

In the common case, this bug causes the third corner's value to be sampled from a pixel diagonally up and to the right of the correct location. If the patch is at the right edge of the image, this can cause the pointer to incorrectly wrap from the end of the bottom row to the beginning, which would result in a completely wrong value for the bottom-right corner. It would also affect the subsequent calculation for the bottom-left corner.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
