### PR TITLE
python: fix pytest-cov false warnings by compiling config scripts with full path (#27867)

### DIFF
--- a/modules/python/package/cv2/load_config_py3.py
+++ b/modules/python/package/cv2/load_config_py3.py
@@ -5,5 +5,5 @@ import sys
 if sys.version_info[:2] >= (3, 0):
     def exec_file_wrapper(fpath, g_vars, l_vars):
         with open(fpath) as f:
-            code = compile(f.read(), os.path.basename(fpath), 'exec')
+            code = compile(f.read(), fpath, 'exec')
             exec(code, g_vars, l_vars)


### PR DESCRIPTION
This change fixes Issue #27867, where pytest-cov shows warnings for config.py and config-3.py after importing cv2.
The problem came from using exec() without passing the real file path, so coverage tools could not match the files correctly.

The update uses compile() with the actual path before executing the code, which removes the warnings without affecting any existing behavior.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
