### PR TITLE
imgproc: disable RISC-V optimization for warpPerspective to fix accuracy regression in 5.x

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2861,6 +2861,7 @@ static void warpPerspective(int src_type,
     }
 
     if (interpolation == INTER_LINEAR) {
+#if !defined(__riscv)
         switch (src_type) {
             case CV_8UC1: {
                 if (hint == cv::ALGO_HINT_APPROX) {
@@ -2915,6 +2916,7 @@ static void warpPerspective(int src_type,
             }
             // no default
         }
+#endif
     }
 
     Mat src(Size(src_width, src_height), src_type, const_cast<uchar*>(src_data), src_step);


### PR DESCRIPTION
Summary This PR fixes the Imgproc_WarpPerspective_Test.accuracy test failure on RISC-V platforms by temporarily disabling the RISC-V Vector (RVV) optimization dispatch for warpPerspective with linear interpolation.

Related Issue Fixes #27281

Detailed Description

Problem: The reference implementation of warpPerspective (and remap) in the OpenCV 5.x branch was updated to use floating-point arithmetic. However, the existing RISC-V optimized kernels utilize fixed-point arithmetic. This discrepancy leads to precision mismatches that cause accuracy tests to fail on RISC-V hardware.

Solution: This patch adds a preprocessor check #if !defined(__riscv) around the CV_CPU_DISPATCH calls in cv::hal::warpPerspective. This forces the execution path to fall back to the generic C++ implementation, which correctly handles the floating-point arithmetic required by OpenCV 5.x specifications.

Impact: This restores functional correctness and passes the Imgproc_WarpPerspective_Test.accuracy test on RISC-V, albeit with a performance cost due to the disabled optimization. This is intended as a correctness fix until the RVV kernels can be rewritten to support floating-point arithmetic.