### PR TITLE
highgui: fix memory leak in CvWindow Qt backend

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -1740,6 +1740,10 @@ CvWindow::CvWindow(QString name, int arg2)
     show();
 }
 
+CvWindow::~CvWindow()
+{
+    delete myView;
+}
 
 void CvWindow::setMouseCallBack(CvMouseCallback callback, void* param)
 {

--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -298,6 +298,7 @@ class CvWindow : public CvWinModel
     Q_OBJECT
 public:
     CvWindow(QString arg2, int flag = CV_WINDOW_NORMAL);
+    ~CvWindow();
 
     void setMouseCallBack(CvMouseCallback m, void* param);
 


### PR DESCRIPTION
Description
This PR fixes a memory leak in the Qt backend of the highgui module. 
In `CvWindow`, the `myView` member (a `DefaultViewPort` or `OpenGlViewPort`) is allocated in the constructor but was never deleted, causing a leak when the window is destroyed.

Changes
Added a destructor `~CvWindow()` in `modules/highgui/src/window_QT.cpp`.
Implemented `delete myView;` within the destructor to ensure proper cleanup.
Added `~CvWindow();` declaration in `modules/highgui/src/window_QT.h`.

 Issue
Fixes #28101
