### PR TITLE
Disabled incorrect in-place flip HAL on RISC-V RVV

### DIFF
--- a/hal/riscv-rvv/src/core/flip.cpp
+++ b/hal/riscv-rvv/src/core/flip.cpp
@@ -322,8 +322,10 @@ int flip(int src_type, const uchar* src_data, size_t src_step, int src_width, in
     if (src_width < 0 || src_height < 0 || esz > 32)
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
 
+    // BUG: https://github.com/opencv/opencv/issues/28124
     if (src_data == dst_data) {
-        return flip_inplace(esz, dst_data, dst_step, src_width, src_height, flip_mode);
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+        //return flip_inplace(esz, dst_data, dst_step, src_width, src_height, flip_mode);
     }
 
     if (flip_mode == 0)


### PR DESCRIPTION
Related issue: https://github.com/opencv/opencv/issues/28124
Disabled in-place processing branch for now.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
