### PR TITLE
docs: clarify Canny edge threshold explanation in edge.py sample

### DIFF
--- a/samples/python/edge.py
+++ b/samples/python/edge.py
@@ -6,7 +6,8 @@ This sample demonstrates Canny edge detection.
 Usage:
   edge.py [<video source>]
 
-Trackbars control the Canny edge detection thresholds (values are scaled higher in this sample for better visualization).
+  Trackbars control the Canny edge detection thresholds (values are scaled higher in this sample for better visualization).
+
 
 
 '''


### PR DESCRIPTION
This PR improves the documentation in `samples/python/edge.py` by clarifying how the trackbars control the Canny edge detection thresholds.

The values are intentionally scaled higher in this sample for better visualization. This helps beginners understand why the ranges differ from typical 0–255 values.
