### PR TITLE
Fix CMake foreach loops

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -1667,7 +1667,7 @@ function(ocv_install_used_external_targets)
   if(NOT BUILD_SHARED_LIBS
       AND NOT (CMAKE_VERSION VERSION_LESS "3.13.0")  # upgrade CMake: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2152
   )
-    foreach(tgt in ${ARGN})
+    foreach(tgt IN LISTS ARGN)
       if(tgt MATCHES "^ocv\.3rdparty\.")
         list(FIND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}" _found)
         if(_found EQUAL -1)  # don't export target twice

--- a/modules/js/generator/CMakeLists.txt
+++ b/modules/js/generator/CMakeLists.txt
@@ -50,7 +50,7 @@ if(DEFINED ENV{OPENCV_JS_WHITELIST})
 else()
   #generate white list from modules/<module_name>/misc/js/whitelist.json
   set(OPENCV_JS_WHITELIST_FILE "${CMAKE_CURRENT_BINARY_DIR}/whitelist.json")
-  foreach(m in ${OPENCV_JS_MODULES})
+  foreach(m IN LISTS OPENCV_JS_MODULES)
     set(js_whitelist "${OPENCV_MODULE_${m}_LOCATION}/misc/js/gen_dict.json")
     if (EXISTS "${js_whitelist}")
       file(READ "${js_whitelist}" whitelist_content)


### PR DESCRIPTION
`in` is not a CMake keyword, but it is also not intented to be used as loop iteration here.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
