### PR TITLE
Docs: Remove unsupported CV_16U from cvtColor (Fixes #26447)

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3770,7 +3770,7 @@ back.
 If conversion adds the alpha channel, its value will set to the maximum of corresponding channel
 range: 255 for CV_8U, 65535 for CV_16U, 1 for CV_32F.
 
-@param src input image: 8-bit unsigned or single-precision
+@param src input image: 8-bit unsigned, 16-bit unsigned ( CV_16U ) (for linear conversions), or single-precision
 floating-point.
 @param dst output image of the same size and depth as src.
 @param code color space conversion code (see #ColorConversionCodes).


### PR DESCRIPTION
### Description
Fixes Issue #26447.
The documentation claimed `cvtColor` supports `CV_16U` (16-bit unsigned), but this fails for non-linear conversions like BGR->HSV and BGR->Lab with an "Unsupported depth" error.

### Changes
- Removed mentions of `CV_16U` from the `cvtColor` documentation in `imgproc.hpp` to reflect actual supported types (8-bit and 32-bit float).

### Verification
Verified locally with a Python script. Attempting `cv.cvtColor(img_16u, cv.COLOR_BGR2HSV)` throws:
> error: (-2:Unspecified error) ... Unsupported depth of input image: 'VDepth::contains(depth)' where 'depth' is 2 (CV_16U)