### PR TITLE
libpng update to version 1.6.53.

### DIFF
--- a/3rdparty/libpng/CHANGES
+++ b/3rdparty/libpng/CHANGES
@@ -6315,6 +6315,12 @@ Version 1.6.52 [December 3, 2025]
   Added allocation failure fuzzing to oss-fuzz.
     (Contributed by Philippe Antoine.)
 
+Version 1.6.53 [December 5, 2025]
+  Fixed a build failure on RISC-V RVV caused by a misspelled intrinsic.
+    (Contributed by Alexander Smorkalov.)
+  Fixed a build failure with CMake 4.1 or newer, on Windows, when using
+    Visual C++ without MASM installed.
+
 Send comments/corrections/commendations to png-mng-implement at lists.sf.net.
 Subscription is required; visit
 https://lists.sourceforge.net/lists/listinfo/png-mng-implement

--- a/3rdparty/libpng/README
+++ b/3rdparty/libpng/README
@@ -1,4 +1,4 @@
-README for libpng version 1.6.52
+README for libpng version 1.6.53
 ================================
 
 See the note about version numbers near the top of `png.h`.

--- a/3rdparty/libpng/png.c
+++ b/3rdparty/libpng/png.c
@@ -13,7 +13,7 @@
 #include "pngpriv.h"
 
 /* Generate a compiler error if there is an old png.h in the search path. */
-typedef png_libpng_version_1_6_52 Your_png_h_is_not_version_1_6_52;
+typedef png_libpng_version_1_6_53 Your_png_h_is_not_version_1_6_53;
 
 /* Sanity check the chunks definitions - PNG_KNOWN_CHUNKS from pngpriv.h and the
  * corresponding macro definitions.  This causes a compile time failure if
@@ -817,7 +817,7 @@ png_get_copyright(png_const_structrp png_ptr)
    return PNG_STRING_COPYRIGHT
 #else
    return PNG_STRING_NEWLINE \
-      "libpng version 1.6.52" PNG_STRING_NEWLINE \
+      "libpng version 1.6.53" PNG_STRING_NEWLINE \
       "Copyright (c) 2018-2025 Cosmin Truta" PNG_STRING_NEWLINE \
       "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
       PNG_STRING_NEWLINE \

--- a/3rdparty/libpng/png.h
+++ b/3rdparty/libpng/png.h
@@ -1,6 +1,6 @@
 /* png.h - header file for PNG reference library
  *
- * libpng version 1.6.52
+ * libpng version 1.6.53
  *
  * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
@@ -14,7 +14,7 @@
  *   libpng versions 0.89, June 1996, through 0.96, May 1997: Andreas Dilger
  *   libpng versions 0.97, January 1998, through 1.6.35, July 2018:
  *     Glenn Randers-Pehrson
- *   libpng versions 1.6.36, December 2018, through 1.6.52, December 2025:
+ *   libpng versions 1.6.36, December 2018, through 1.6.53, December 2025:
  *     Cosmin Truta
  *   See also "Contributing Authors", below.
  */
@@ -238,7 +238,7 @@
  *    ...
  *    1.5.30                  15    10530  15.so.15.30[.0]
  *    ...
- *    1.6.52                  16    10651  16.so.16.52[.0]
+ *    1.6.53                  16    10651  16.so.16.53[.0]
  *
  *    Henceforth the source version will match the shared-library major and
  *    minor numbers; the shared-library major version number will be used for
@@ -274,7 +274,7 @@
  */
 
 /* Version information for png.h - this should match the version in png.c */
-#define PNG_LIBPNG_VER_STRING "1.6.52"
+#define PNG_LIBPNG_VER_STRING "1.6.53"
 #define PNG_HEADER_VERSION_STRING " libpng version " PNG_LIBPNG_VER_STRING "\n"
 
 /* The versions of shared library builds should stay in sync, going forward */
@@ -285,7 +285,7 @@
 /* These should match the first 3 components of PNG_LIBPNG_VER_STRING: */
 #define PNG_LIBPNG_VER_MAJOR   1
 #define PNG_LIBPNG_VER_MINOR   6
-#define PNG_LIBPNG_VER_RELEASE 52
+#define PNG_LIBPNG_VER_RELEASE 53
 
 /* This should be zero for a public release, or non-zero for a
  * development version.
@@ -316,7 +316,7 @@
  * From version 1.0.1 it is:
  * XXYYZZ, where XX=major, YY=minor, ZZ=release
  */
-#define PNG_LIBPNG_VER 10652 /* 1.6.52 */
+#define PNG_LIBPNG_VER 10653 /* 1.6.53 */
 
 /* Library configuration: these options cannot be changed after
  * the library has been built.
@@ -426,7 +426,7 @@ extern "C" {
 /* This triggers a compiler error in png.c, if png.c and png.h
  * do not agree upon the version number.
  */
-typedef char* png_libpng_version_1_6_52;
+typedef char* png_libpng_version_1_6_53;
 
 /* Basic control structions.  Read libpng-manual.txt or libpng.3 for more info.
  *

--- a/3rdparty/libpng/pngconf.h
+++ b/3rdparty/libpng/pngconf.h
@@ -1,6 +1,6 @@
 /* pngconf.h - machine-configurable file for libpng
  *
- * libpng version 1.6.52
+ * libpng version 1.6.53
  *
  * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson

--- a/3rdparty/libpng/pngread.c
+++ b/3rdparty/libpng/pngread.c
@@ -3278,7 +3278,7 @@ png_image_read_composite(png_voidp argument)
                            /* Clamp to the valid range to defend against
                             * unforeseen cases where the data might be sRGB
                             * instead of linear premultiplied.
-                            * (Belt-and-suspenders for GitHub Issue #764.)
+                            * (Belt-and-suspenders for CVE-2025-66293.)
                             */
                            if (component > 255*65535)
                               component = 255*65535;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
