### PR TITLE
Add input validation for empty and invalid paths in samples::findFile()

### DIFF
--- a/modules/core/src/utils/samples.cpp
+++ b/modules/core/src/utils/samples.cpp
@@ -49,21 +49,6 @@ CV_EXPORTS void addSamplesDataSearchSubDirectory(const cv::String& subdir)
 }
 
 
-
-
-cv::String findFile(const cv::String& relative_path, bool required, bool silentMode)
-{
-    // Input validation: empty filename
-if (relative_path.empty())
-{
-    if (required)
-        CV_Error(cv::Error::StsBadArg, "cv::samples::findFile(): relative_path is empty");
-    if (!silentMode)
-        CV_LOG_WARNING(NULL, "cv::samples::findFile(): empty filename provided");
-    return cv::String(); // return empty path
-}
-
-
 // Basic invalid character check (Windows-like)
 #ifdef _WIN32
 const char illegal_chars[] = "<>:\"/\\|?*";


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request



This PR adds basic validation to cv::samples::findFile().

- Detects empty file paths and reports them through warning or error.
- Adds a simple illegal-character check for Windows paths.
- Ensures required=true throws StsBadArg for invalid input.
- Returns empty path when silentMode is enabled and the input is invalid.

This improves reliability of sample file handling without introducing breaking behavior.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
