### PR TITLE
Disable MSAn for lapack_LU

### DIFF
--- a/modules/core/src/hal_internal.cpp
+++ b/modules/core/src/hal_internal.cpp
@@ -69,10 +69,12 @@
 #include <sanitizer/msan_interface.h>
 #define CV_ANNOTATE_MEMORY_IS_INITIALIZED(address, size) \
 __msan_unpoison(address, size)
+#define CV_ANNOTATE_NO_SANITIZE_MEMORY __attribute__((no_sanitize("memory")))
 #endif
 #endif
 #ifndef CV_ANNOTATE_MEMORY_IS_INITIALIZED
 #define CV_ANNOTATE_MEMORY_IS_INITIALIZED(address, size) do { } while(0)
+#define CV_ANNOTATE_NO_SANITIZE_MEMORY
 #endif
 
 //lapack stores matrices in column-major order so transposing is needed everywhere
@@ -108,8 +110,9 @@ set_value(fptype *dst, size_t dst_ld, fptype value, size_t m, size_t n)
             dst[i*dst_ld + j] = value;
 }
 
+// MSAN can't see that the fortran LAPACK functions initialize `info`
 template <typename fptype> static inline int
-lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int* info)
+CV_ANNOTATE_NO_SANITIZE_MEMORY lapack_LU(fptype* a, size_t a_step, int m, fptype* b, size_t b_step, int n, int* info)
 {
 #if defined (ACCELERATE_NEW_LAPACK) && defined (ACCELERATE_LAPACK_ILP64)
     cv::AutoBuffer<long> piv_buff(m);


### PR DESCRIPTION
One of the arguments is sent to Fortran so the whole function has to be disabled fro MSAN. Arguments cannot be unpoisoned, cf https://g3doc.corp.google.com/testing/msan/g3doc/index.md?cl=head#memorysanitizer-api

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
