### PR TITLE
Fix typo in Python bindings comment in cv2.cpp

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1,4 +1,4 @@
-// must be defined before importing numpy headers
+// // This macro must be defined before importing NumPy headers
 // https://numpy.org/doc/1.17/reference/c-api.array.html#importing-the-api
 #define PY_ARRAY_UNIQUE_SYMBOL opencv_ARRAY_API
 


### PR DESCRIPTION
### Summary
This PR fixes a small typo in the Python bindings source file `cv2.cpp`.

### What was corrected
- Corrected the comment: "must be defined before importing numpy headers"
  → changed to a clearer version.

### Why this matters
Improves readability and consistency in the Python bindings source.

### Files changed
- modules/python/src2/cv2.cpp
