### PR TITLE
Keep convexHull output indices monotone if possible

### DIFF
--- a/modules/imgproc/src/convhull.cpp
+++ b/modules/imgproc/src/convhull.cpp
@@ -268,14 +268,20 @@ void convexHull( InputArray _points, OutputArray _hull, bool clockwise, bool ret
             {
                 auto prev = pointer[hullbuf[(i == 0 ? nout : i) - 1]];
                 auto next = pointer[hullbuf[(i + 1) % nout]];
+                auto cur = pointer[hullbuf[i]];
+                if ((prev < cur && cur < next) || (prev > cur && cur > next))
+                {
+                    continue;
+                }
                 for (int j = hullbuf[i] + 1; j < total; ++j)
                 {
-                    auto cur = pointer[j];
+                    cur = pointer[j];
                     if (*pointer[hullbuf[i]] == *cur)
                     {
                         if ((prev < cur && cur < next) || (prev > cur && cur > next))
                         {
                             hullbuf[i] = j;
+                            break;
                         }
                     }
                     else

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -285,7 +285,7 @@ TEST(Imgproc_FitLine, regression_4903)
 #endif
 
 // the Python test by @hannarud is converted to C++; see the issue #4539
-TEST(DISABLE_Imgproc_ConvexityDefects, ordering_4539)
+TEST(Imgproc_ConvexityDefects, ordering_4539)
 {
     int contour[][2] =
     {
@@ -304,9 +304,11 @@ TEST(DISABLE_Imgproc_ConvexityDefects, ordering_4539)
     vector<int> hull_ind;
     vector<Vec4i> defects;
 
+#if 0  // deprecated behavior
     // first, check the original contour as-is, without intermediate fillPoly/drawContours.
     convexHull(contour_, hull_ind, false, false);
     EXPECT_THROW( convexityDefects(contour_, hull_ind, defects), cv::Exception );
+#endif
 
     int scale = 20;
     contour_ *= (double)scale;
@@ -319,10 +321,12 @@ TEST(DISABLE_Imgproc_ConvexityDefects, ordering_4539)
     findContours(canvas_gray, contours, noArray(), RETR_LIST, CHAIN_APPROX_SIMPLE);
     convexHull(contours[0], hull_ind, false, false);
 
+#if 0  // deprecated behavior
     // the original contour contains self-intersections,
     // therefore convexHull does not return a monotonous sequence of points
     // and therefore convexityDefects throws an exception
     EXPECT_THROW( convexityDefects(contours[0], hull_ind, defects), cv::Exception );
+#endif
 
 #if 1
     // one way to eliminate the contour self-intersection in this particular case is to apply dilate(),


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves https://github.com/opencv/opencv/issues/24907 ?
resolves https://github.com/opencv/opencv/issues/4954

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
