### PR TITLE
videoio(ios): fix NSInvalidArgumentException in VideoWriter release

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -1304,7 +1304,7 @@ void CvVideoWriter_AVFoundation::write(cv::InputArray image) {
         } else {
             cv::cvtColor(image, argbimage, cv::COLOR_GRAY2BGRA);
         }
-        
+
         //IplImage -> CGImage conversion
         CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
         NSData *nsData = [NSData dataWithBytes:argbimage.data length:argbimage.total() * argbimage.elemSize()];


### PR DESCRIPTION
Summary
Fixes a crash on iOS when calling `VideoWriter::release()` in OpenCV 4.12.0.

Issue
Fixes #28165

Detailed Description
This PR resolves a regression where an `NSInvalidArgumentException` was thrown with the message ` -[NSAutoreleasePool retain]: Cannot retain an autorelease pool`.

The crash was caused by the manual usage of `NSAutoreleasePool` in the `~CvVideoWriter_AVFoundation` destructor. The local pool variable was being captured by the completion handler block passed to `[mMovieWriter finishWritingWithCompletionHandler:]`. Since `NSAutoreleasePool` instances cannot be retained, capturing them in a block causes a crash.

Changes:
- Replaced manual `NSAutoreleasePool` allocation and draining with modern `@autoreleasepool` blocks in `CvVideoWriter_AVFoundation`.
- applied this modernization to the Constructor, Destructor, and `write` methods.
- Specifically in the destructor, an inner `@autoreleasepool` is now used inside the completion block, ensuring no pool object needs to be captured from the outer scope.

