### PR TITLE
 Generate shallow bundle structure for iOS framework to resolve Xcode build errors

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -418,10 +418,7 @@ class Builder:
             shutil.rmtree(framework_dir)
         os.makedirs(framework_dir)
 
-        if self.dynamic:
-            dstdir = framework_dir
-        else:
-            dstdir = os.path.join(framework_dir, "Versions", "A")
+        dstdir = framework_dir
 
         # copy headers from one of build folders
         shutil.copytree(os.path.join(builddirs[0], "install", "include", "opencv2"), os.path.join(dstdir, "Headers"))
@@ -466,31 +463,12 @@ class Builder:
         print("Creating universal library from:\n\t%s" % "\n\t".join(libs), file=sys.stderr)
         execute(lipocmd)
 
-        # dynamic framework has different structure, just copy the Plist directly
-        if self.dynamic:
-            resdir = dstdir
-            shutil.copyfile(self.getInfoPlist(builddirs), os.path.join(resdir, "Info.plist"))
-        else:
-            # copy Info.plist
-            resdir = os.path.join(dstdir, "Resources")
-            os.makedirs(resdir)
-            shutil.copyfile(self.getInfoPlist(builddirs), os.path.join(resdir, "Info.plist"))
+        # copy Info.plist
+        shutil.copyfile(self.getInfoPlist(builddirs), os.path.join(dstdir, "Info.plist"))
 
-            # make symbolic links
-            links = [
-                (["A"], ["Versions", "Current"]),
-                (["Versions", "Current", "Headers"], ["Headers"]),
-                (["Versions", "Current", "Resources"], ["Resources"]),
-                (["Versions", "Current", "Modules"], ["Modules"]),
-                (["Versions", "Current", name], [name])
-            ]
-            for l in links:
-                s = os.path.join(*l[0])
-                d = os.path.join(framework_dir, *l[1])
-                os.symlink(s, d)
         # Copy Apple privacy manifest
         shutil.copyfile(os.path.join(CURRENT_FILE_DIR, "PrivacyInfo.xcprivacy"),
-                        os.path.join(resdir, "PrivacyInfo.xcprivacy"))
+                        os.path.join(dstdir, "PrivacyInfo.xcprivacy"))
 
     def copy_samples(self, outdir):
         return


### PR DESCRIPTION
### Summary
This PR modifies the iOS framework build script (`platforms/ios/build_framework.py`) to generate a **Shallow Bundle** structure instead of a Deep Bundle structure. This ensures compatibility with modern Xcode versions (Xcode 15/16+) and resolves build errors related to `Info.plist` placement.

### Problem
Currently, the build script creates a "Deep Bundle" structure (standard for macOS), placing the binary and `Info.plist` inside `Versions/A/`.
When using the generated framework in recent iOS projects, Xcode fails with the error:
> `expected Info.plist at the root level since the platform uses shallow bundles`

### Solution
* Updated `platforms/ios/build_framework.py` to stop creating the `Versions/A` directory hierarchy.
* The binary, `Info.plist`, `Headers`, and `Modules` are now placed directly at the root of the `.framework` folder.
* Removed unneeded symlink creation logic for `Versions/Current`.

### Changes
- Modified `makeFramework` method in `platforms/ios/build_framework.py`.
- Changed destination directory `dstdir` to point to the framework root.
- Updated `Info.plist` copy logic to target the root directory.

### Related Issue
Fixes #28170