### PR TITLE
Docs(imgcodecs): clarify animation frame duration units

### DIFF
--- a/doc/tutorials/app/animations.markdown
+++ b/doc/tutorials/app/animations.markdown
@@ -66,8 +66,8 @@ Explanation
 ## Displaying Frames
 
    Each frame in the `animation.frames` vector can be displayed as a standalone image. This loop iterates through each frame, displaying it in a window with a short delay to simulate the animation.
-   
-> **Note:** Frame durations in `cv::Animation` are expressed in milliseconds.  
+
+> **Note:** Frame durations in `cv::Animation` are expressed in milliseconds.
 > When displaying frames manually using `cv::waitKey`, make sure to use the corresponding duration value to preserve the original animation timing.
 
 @add_toggle_cpp


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
Docs-only change. No code or tests affected.

