### PR TITLE
cleanup: Remove redundant 'noneValue' static constant

### DIFF
--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -8,7 +8,7 @@ namespace cv
 {
 
 namespace {
-static const char* noneValue = "<none>";
+//static const char* noneValue = "<none>";
 
 static String cat_string(const String& str)
 {
@@ -132,7 +132,7 @@ void CommandLineParser::getByName(const String& name, bool space_delete, Param t
                         v = cat_string(v);
 
                     // the key was neither specified nor has a default value
-                    if((v.empty() && type != Param::STRING) || v == noneValue) {
+                    if((v.empty() && type != Param::STRING) || v == "<none>") {
                         impl->error = true;
                         impl->error_message = impl->error_message + "Missing parameter: '" + name + "'\n";
                         return;
@@ -167,7 +167,7 @@ void CommandLineParser::getByIndex(int index, bool space_delete, Param type, voi
                 if (space_delete == true) v = cat_string(v);
 
                 // the key was neither specified nor has a default value
-                if((v.empty() && type != Param::STRING) || v == noneValue) {
+                if((v.empty() && type != Param::STRING) || v == "<none>") {
                     impl->error = true;
                     impl->error_message = impl->error_message + format("Missing parameter #%d\n", index);
                     return;
@@ -358,7 +358,7 @@ bool CommandLineParser::has(const String& name) const
             if (name == impl->data[i].keys[j])
             {
                 const String v = cat_string(impl->data[i].def_value);
-                return !v.empty() && v != noneValue;
+                return !v.empty() && v != "<none>";
             }
         }
     }


### PR DESCRIPTION
Replaces the local static variable 'noneValue' with a direct string literal in CommandLineParser accessors, as it was only used for simple constant comparison across multiple functions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
