### PR TITLE
samples(python): guard against invalid STFT time step

### DIFF
--- a/samples/python/audio_spectrogram.py
+++ b/samples/python/audio_spectrogram.py
@@ -330,6 +330,10 @@ class AudioDrawing:
         """
 
         time_step = self.windLen - self.overlap
+        if time_step <= 0:
+            raise ValueError(
+                "Invalid STFT parameters: overlap must be smaller than window length"
+            )
         stft = []
 
         if self.windowType == "Hann":


### PR DESCRIPTION
This change adds a defensive guard in the Python audio spectrogram sample to
prevent invalid STFT parameters when overlap >= window length, which could
otherwise result in a non-terminating loop.

The fix does not affect valid inputs and only rejects invalid configurations
early with a clear error message.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake