### PR TITLE
samples(python): fix argparse boolean flag for --try_cuda

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -95,10 +95,8 @@ parser.add_argument(
 )
 parser.add_argument(
     '--try_cuda',
-    action='store',
-    default=False,
+    action='store_true',
     help="Try to use CUDA. The default value is no. All default values are for CPU mode.",
-    type=bool, dest='try_cuda'
 )
 parser.add_argument(
     '--work_megapix', action='store', default=0.6,


### PR DESCRIPTION
### Summary

Fix incorrect argparse boolean handling for `--try_cuda` in the Python
`stitching_detailed.py` sample.

Previously, the flag used `type=bool`, which causes unexpected behavior
when parsing command-line arguments. This change switches to
`action='store_true'`, matching standard argparse usage.

### Impact

- No behavior change for valid usage
- Correct and predictable flag parsing
- Improves sample robustness

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake