### PR TITLE
Handle zero dimensions in output shape calculation

### DIFF
--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -315,19 +315,20 @@ public:
             {
                 if (shape[i] != outShape[i])
                 {
-                    // Handle zero dimensions per ONNX broadcasting spec
+                    // Handle zero dimensions per ONNX spec
                     if (shape[i] == 0 || outShape[i] == 0)
                     {
                         outShape[i] = 0;
-                        continue;
-                     }
-            
-                     CV_Assert(shape[i] == 1 || outShape[i] == 1);
-                     outShape[i] = std::max(outShape[i], shape[i]);
-                 }
-             }
-         }
-
+                    }
+                    else
+                    {
+                        CV_Assert(shape[i] == 1 || outShape[i] == 1);
+                        outShape[i] = std::max(outShape[i], shape[i]);
+                    }
+                }
+            }
+        }
+        
         return outShape;
     }
 


### PR DESCRIPTION
Added handling for zero dimensions in output shape calculation according to ONNX broadcasting specifications.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
