### PR TITLE
Fix crash in sample launcher when no item is selected

### DIFF
--- a/samples/python/demo.py
+++ b/samples/python/demo.py
@@ -112,7 +112,11 @@ class App:
         webbrowser.open(url)
 
     def on_demo_select(self, evt):
-        name = self.demos_lb.get( self.demos_lb.curselection()[0] )
+        selection = self.demos_lb.curselection()
+        if not selection:
+            return
+
+        name = self.demos_lb.get(selection[0])
         fn = self.samples[name]
 
         descr = ""


### PR DESCRIPTION
### Summary

Fix a crash in the Python sample launcher (`demo.py`) that occurs when
no item is selected in the listbox.

Previously, accessing the selection without checking caused an
IndexError. This change adds a defensive guard to safely handle
empty selections.

### Impact

- Prevents runtime crash in the sample launcher
- No behavior change for valid selections
- Improves robustness of Python samples

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
