### PR TITLE
Fix regex escape warning in _coverage.py by using raw string

### DIFF
--- a/samples/python/_coverage.py
+++ b/samples/python/_coverage.py
@@ -2,7 +2,6 @@
 
 '''
 Utility for measuring python opencv API coverage by samples.
-
 '''
 
 # Python 2/3 compatibility


### PR DESCRIPTION
while i am running '_coverage.py' I noticed there is a syntax warning:"\." It is an invalid escape sequence
The regex was written as a normal string with '\.' which is not valid escape in string literals and give problems and error in a new python versions. 
To fix this switch to raw string(r'cv2?\.\w+') which can passes the backslashes directly to the regex engine. This removes the warning and keeps the code  and pattern working properly.

This is a small fix but important for future compatibilities.