### PR TITLE
Fixes for issues found by PVS Studio in GAPI module.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/util/any.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/any.hpp
@@ -17,6 +17,7 @@
 
 #if defined(_MSC_VER)
    // disable MSVC warning on "multiple copy constructors specified"
+   #pragma warning(push)
 #  pragma warning(disable: 4521)
 #endif
 
@@ -184,7 +185,7 @@ namespace util
 
 #if defined(_MSC_VER)
    // Enable "multiple copy constructors specified" back
-#  pragma warning(default: 4521)
+#  pragma warning(pop)
 #endif
 
 #endif // OPENCV_GAPI_UTIL_ANY_HPP

--- a/modules/gapi/src/streaming/queue_source.cpp
+++ b/modules/gapi/src/streaming/queue_source.cpp
@@ -67,7 +67,7 @@ cv::GMetaArg QueueSourceBase::descr_of() const {
 
 QueueInput::QueueInput(const cv::GMetaArgs &args) {
     for (auto &&m : args) {
-        m_sources.emplace_back(new cv::gapi::wip::QueueSourceBase(m));
+        m_sources.emplace_back(std::make_shared<cv::gapi::wip::QueueSourceBase>(m));
     }
 }
 

--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -359,7 +359,7 @@ TYPED_TEST_CASE_P(cancel);
 
 TYPED_TEST_P(cancel, basic)
 {
-#if defined(__GNUC__) && __GNUC__ >= 11
+#if defined(__GNUC__) && __GNUC__ == 11
     // std::vector<TypeParam> requests can't handle type with ctor parameter (SelfCanceling)
     FAIL() << "Test code is not available due to compilation error with GCC 11";
 #else


### PR DESCRIPTION
Partially fixes https://github.com/opencv/opencv/issues/28167
Paper: https://pvs-studio.com/en/blog/posts/cpp/1321/

Closed items: N3, N9.

Continues https://github.com/opencv/opencv/pull/28185

Also unblocked AsyncAPICancelation/cancel/* tests as they can be built with modern GCC

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
