### PR TITLE
imgcodecs(avif): add safety checks for decoder and encoder image crea…

### DIFF
--- a/modules/imgcodecs/src/grfmt_avif.cpp
+++ b/modules/imgcodecs/src/grfmt_avif.cpp
@@ -409,7 +409,6 @@ bool AvifEncoder::writeanimation(const Animation& animation,
     images.emplace_back(std::move(avifImg));
   }
 
-
   for (size_t i = 0; i < images.size(); i++)
   {
     OPENCV_AVIF_CHECK_STATUS(


### PR DESCRIPTION
Add defensive checks to prevent potential null dereference in AVIF decoder and encoder paths when handling malformed input or allocation failures.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
