### PR TITLE
cmake: filter unsupported armv8-a flags for Apple Clang

### DIFF
--- a/hal/kleidicv/CMakeLists.txt
+++ b/hal/kleidicv/CMakeLists.txt
@@ -3,10 +3,29 @@ project(kleidicv_hal)
 if(HAVE_KLEIDICV)
   option(KLEIDICV_ENABLE_SME2 "" OFF) # not compatible with some CLang versions in NDK
   option(KLEIDICV_USE_CV_NAMESPACE_IN_OPENCV_HAL "" OFF)
+
   include("${KLEIDICV_SOURCE_PATH}/adapters/opencv/CMakeLists.txt")
-  # HACK to suppress adapters/opencv/kleidicv_hal.cpp:343:12: warning: unused function 'from_opencv' [-Wunused-function]
-  target_compile_options( kleidicv_hal PRIVATE
+
+  # Inherit KleidiCV compile options, but filter invalid flags on Apple Clang
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+     CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+
+    get_target_property(_kleidicv_opts kleidicv COMPILE_OPTIONS)
+    if(_kleidicv_opts)
+      list(FILTER _kleidicv_opts EXCLUDE REGEX "^-march=armv8-a$")
+    endif()
+
+    target_compile_options(kleidicv_hal PRIVATE
+      ${_kleidicv_opts}
+      "-Wno-old-style-cast" "-Wno-unused-function"
+    )
+
+  else()
+
+    target_compile_options(kleidicv_hal PRIVATE
       $<TARGET_PROPERTY:kleidicv,COMPILE_OPTIONS>
       "-Wno-old-style-cast" "-Wno-unused-function"
-  )
+    )
+
+  endif()
 endif()


### PR DESCRIPTION
### Summary
Fix build failure on macOS caused by passing `-march=armv8-a` to Apple Clang
when KleidiCV is enabled.

### Root cause
KleidiCV propagates `-march=armv8-a` via its compile options. Apple Clang
does not recognize this CPU target and fails with
`unknown target CPU 'armv8-a'`.

### Fix
Filter out the unsupported `-march=armv8-a` flag at the OpenCV integration
layer (`hal/kleidicv/CMakeLists.txt`) when building on macOS with Apple Clang,
while preserving the flag for other ARM toolchains.

### Impact
- Fixes macOS (Apple Clang) builds with KleidiCV enabled
- No change to Linux / Android ARM builds
- Does not modify third-party KleidiCV sources

Fixes #28187



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
