### PR TITLE
videoio(ffmpeg): prefer CUDA hwaccel for decoding on Linux

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_hw.hpp
+++ b/modules/videoio/src/cap_ffmpeg_hw.hpp
@@ -112,14 +112,14 @@ std::string getDecoderConfiguration(VideoAccelerationType va_type, AVDictionary 
     case VIDEO_ACCELERATION_ANY: return "d3d11va";
     case VIDEO_ACCELERATION_D3D11: return "d3d11va";
     case VIDEO_ACCELERATION_VAAPI: return "";
-    case VIDEO_ACCELERATION_MFX: return ""; // "qsv" fails if non-Intel D3D11 device
+    case VIDEO_ACCELERATION_MFX: return "";
     }
     return "";
 #else
     switch (va_type)
     {
     case VIDEO_ACCELERATION_NONE: return "";
-    case VIDEO_ACCELERATION_ANY: return "vaapi.iHD";
+    case VIDEO_ACCELERATION_ANY: return "cuda,vaapi.iHD";
     case VIDEO_ACCELERATION_D3D11: return "";
     case VIDEO_ACCELERATION_VAAPI: return "vaapi.iHD";
     case VIDEO_ACCELERATION_MFX: return "qsv.iHD";
@@ -128,6 +128,7 @@ std::string getDecoderConfiguration(VideoAccelerationType va_type, AVDictionary 
     return "";
 #endif
 }
+
 
 static
 std::string getEncoderConfiguration(VideoAccelerationType va_type, AVDictionary *dict)


### PR DESCRIPTION
### Description
Prefer CUDA (NVDEC) over VAAPI for FFmpeg decoding when `VIDEO_ACCELERATION_ANY` is used on Linux.

This change only adjusts the default acceleration priority order:
- CUDA is tried first
- VAAPI remains as fallback

No runtime probing or capability checks are introduced; FFmpeg handles decoder availability and fallback internally.

### Motivation
On NVIDIA systems, FFmpeg supports hardware-accelerated decoding via NVDEC, but OpenCV currently defaults to VAAPI on Linux. This change aligns Linux behavior with Windows-style priority ordering and improves out-of-the-box performance on CUDA-capable systems.

### Scope of change
- Linux only
- FFmpeg backend only
- No API or ABI changes

### Testing
- Build-only change
- Runtime behavior remains unchanged on non-NVIDIA systems
