### PR TITLE
NEON: fix dot product accumulation causing NORM test failures on Windows ARM64

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -888,9 +888,10 @@ inline v_uint32x4 v_dotprod_expand_fast(const v_uint8x16& a, const v_uint8x16& b
 
 inline v_int32x4 v_dotprod_expand_fast(const v_int8x16& a, const v_int8x16& b)
 {
-    int16x8_t prod = vmull_s8(vget_low_s8(a.val), vget_low_s8(b.val));
-    prod = vmlal_s8(prod, vget_high_s8(a.val), vget_high_s8(b.val));
-    return v_int32x4(vaddl_s16(vget_low_s16(prod), vget_high_s16(prod)));
+    int16x8_t p0 = vmull_s8(vget_low_s8(a.val),  vget_low_s8(b.val));
+    int16x8_t p1 = vmull_s8(vget_high_s8(a.val), vget_high_s8(b.val));
+    int32x4_t s0 = vaddl_s16(vget_low_s16(p0), vget_low_s16(p1));
+    return v_int32x4(vaddq_s32(s0, vaddl_s16(vget_high_s16(p0), vget_high_s16(p1))));
 }
 inline v_int32x4 v_dotprod_expand_fast(const v_int8x16& a, const v_int8x16& b, const v_int32x4& c)
 {


### PR DESCRIPTION
This PR fixes 4 failing performance tests on Windows ARM64 from core module by addressing an integer overflow issue in the v_dotprod_expand_fast function.

**Failing Tests**
- Size_MatType_NormType_norm.norm/8 where GetParam() = (640x480, 8SC1, NORM_L2)
- Size_MatType_NormType_norm.norm/32 where GetParam() = (1280x720, 8SC1, NORM_L2)
- Size_MatType_NormType_norm.norm/56 where GetParam() = (1920x1080, 8SC1, NORM_L2)
- Size_MatType_NormType_norm2.norm2/113 where GetParam() = (1920x1080, 8SC1, NORM_L2|NORM_RELATIVE)

Current implementation uses vmlal_s8 to accumulate products directly into an int16x8_t accumulator. For large input values, the intermediate sum could overflow 16-bit lanes, leading to incorrect results and test failures.

The updated implementation:
- Computes low and high halves separately using vmull_s8
- Performs widening and accumulation directly in int32 using vaddl_s16
- Preserves the original mathematical behavior while ensuring overflow safety

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
