### PR TITLE
videoio(ffmpeg): handle frame reallocation when resolution or type changes

### DIFF
--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -122,7 +122,14 @@ public:
                 return false;
         }
 
-        cv::Mat(height, width, CV_MAKETYPE(depth, cn), data, step).copyTo(frame);
+        int type=CV_MAKETYPE(depth,cn);
+
+        if(frame.empty() || frame.rows()!=height || frame.cols()!=width || frame.type()!=type){
+            frame.release();
+            frame.create(height,width,type);
+        }
+
+        cv::Mat(height,width,type,data,step).copyTo(frame);
         return true;
     }
     bool open(const cv::String& filename, const cv::VideoCaptureParameters& params)


### PR DESCRIPTION
### What does this PR do?
On Linux, when VIDEO_ACCELERATION_ANY is requested, OpenCV currently tries VAAPI first.
This PR adjusts the default order to try CUDA (NVDEC) before VAAPI when available.

### Why?
- FFmpeg supports CUDA/NVDEC decoding when built with --enable-cuda
- NVIDIA GPUs are common on Linux servers
- VAAPI often fails on NVIDIA systems, causing silent CPU fallback

### Behavior
- No behavior change if CUDA is unavailable
- VAAPI remains as fallback
- No Windows impact

### Related issue
Fixes #28207 (cannot use h264_cuvid decoder from Java API)

### Testing
- Verified FFmpeg h264_cuvid decoding works
- OpenCV VideoCapture now selects CUDA instead of VAAPI
