### PR TITLE
Fix JS Ptr factory namespace regression

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -722,11 +722,15 @@ class JSWrapperGenerator(object):
             ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
 
             ret_type = ret_type.strip()
-            # Same namespace fix for factory methods: Ptr<EdgeDrawing> -> Ptr<cv::ximgproc::EdgeDrawing>
+            # Same namespace fix for factory methods
             if factory and class_info is not None and ret_type.startswith('Ptr<'):
                 inner = ret_type[len('Ptr<'):-1].strip()
-                if '::' not in inner and inner == class_info.name:
-                    ret_type = 'Ptr<%s>' % class_info.cname
+
+            # Only rewrite if the pointee class is known and unqualified
+                if '::' not in inner and inner in self.classes:
+                    ret_type = f"Ptr<{self.classes[inner].cname}>"
+            # else: leave ret_type unchanged
+
 
             if ret_type.startswith('Ptr'): #smart pointer
                 ptr_type = ret_type.replace('Ptr<', '').replace('>', '')


### PR DESCRIPTION
This PR fixes a regression in the JS bindings generator where factory methods
returning Ptr<T> were not correctly namespace-qualified.

The fix restores unconditional namespace qualification when '::' is missing
and ensures the type substitution loop always runs.

Verified locally with:
make gen_opencv_js_source

