### PR TITLE
docs(env_reference): clarify OpenEXR optional support and security rationale

### DIFF
--- a/doc/tutorials/introduction/env_reference/env_reference.markdown
+++ b/doc/tutorials/introduction/env_reference/env_reference.markdown
@@ -352,3 +352,7 @@ Some external dependencies can be detached into a dynamic library, which will be
 | OPENCV_IO_MAX_IMAGE_PIXELS | num | 1 << 30 | |
 | OPENCV_IO_ENABLE_OPENEXR | bool | true (set build option OPENCV_IO_FORCE_OPENEXR or use external OpenEXR), false (otherwise) | enable OpenEXR backend |
 | OPENCV_IO_ENABLE_JASPER | bool | true (set build option OPENCV_IO_FORCE_JASPER), false (otherwise) | enable Jasper backend |
+
+### Note
+* OpenEXR support in OpenCV is optional. Source builds may include a bundled 3rdparty OpenEXR 2.3.0, but runtime support must be explicitly enabled via `OPENCV_IO_ENABLE_OPENEXR`. Users can also build OpenCV against a system-installed OpenEXR library.
+* Support is disabled by default due to historical security considerations with malformed EXR files in older OpenEXR versions. Upgrading to OpenEXR 3.x is not a drop-in change and requires API and ABI adaptations.


### PR DESCRIPTION
Summary
This PR updates the OpenCV environment variables reference to clarify OpenEXR support. It explains why OpenEXR is disabled by default, how users can enable it, and why upgrading to OpenEXR 3.x is not a drop-in change.

Details
- OpenEXR support in OpenCV is optional.
- Source builds may include a bundled 3rdparty OpenEXR 2.3.0.
- Runtime support must be explicitly enabled via `OPENCV_IO_ENABLE_OPENEXR`.
- Users can also build OpenCV against a system-installed OpenEXR library.
- Support is disabled by default due to historical security considerations with malformed EXR files in older OpenEXR versions.
- Upgrading to OpenEXR 3.x requires API and ABI adaptations.

Motivation
- Addresses user confusion about OpenEXR version in OpenCV.
- Improves clarity for users consulting `env_reference.markdown`.
- Provides context for why `OPENCV_IO_ENABLE_OPENEXR` is required at runtime.

File modified
- `docs/tutorials/core/env_reference.markdown`

Links
- Related issue: #28209 

