### PR TITLE
Fix CAP_PROP_FPS issue on Windows (Issue #26250)  Ensure FPS change

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2624,6 +2624,12 @@ static bool setSizeAndSubtype(videoDevice * VD, int attemptWidth, int attemptHei
     //set fps if requested
     if( VD->requestedFrameTime != -1){
         pVih->AvgTimePerFrame = VD->requestedFrameTime;
+                    // FIX for issue #26250: Ensure FPS change is applied by forcefully setting the media type
+            // This prevents caching issues when grab() was called before setting FPS
+            hr = VD->streamConf->SetFormat(VD->pAmMediaType);
+            if(FAILED(hr)) {
+                DebugPrintOut("WARNING: Failed to re-apply FPS setting. FPS caching issue may occur.\n");
+            }
     }
 
     //okay lets try new size


### PR DESCRIPTION
Is applied by forcefully setting the media type after updating AvgTimePerFrame. This resolves the issue where CAP_PROP_FPS returns incorrect value when grab() is called before set(CAP_PROP_FPS)

Forcefully re-apply FPS setting to avoid caching issues.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
