### PR TITLE
core: fix signed overflow UB in cv_absdiff(int,int)

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -317,7 +317,8 @@ inline int cv_absdiff(schar x, schar y) { return (int)std::abs((int)x - (int)y);
 inline int cv_absdiff(ushort x, ushort y) { return (int)std::abs((int)x - (int)y); }
 inline int cv_absdiff(short x, short y) { return (int)std::abs((int)x - (int)y); }
 inline unsigned cv_absdiff(int x,int y){
-    return (unsigned)std::max(x,y)-(unsigned)std::min(x,y);
+    int64_t d=(int64_t)x-(int64_t)y;
+    return (unsigned)(d<0?-d:d);
 }
 inline unsigned cv_absdiff(unsigned x, unsigned y) { return std::max(x, y) - std::min(x, y); }
 inline uint64 cv_absdiff(uint64 x, uint64 y) { return std::max(x, y) - std::min(x, y); }


### PR DESCRIPTION
Fixes undefined behavior caused by signed int overflow in cv_absdiff(int,int).
The previous implementation performed subtraction in int, leading to
compiler- and optimization-dependent results in normL1.

This change promotes operands to int64 before subtraction, guaranteeing
defined behavior across compilers and optimization levels.

Related to **#27080**.