### PR TITLE
dnn(cuda): improve error handling for unsupported tensor ranks

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/tensor.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/tensor.hpp
@@ -208,7 +208,14 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
         typename std::enable_if<cxx_utils::is_forward_iterator<ForwardItr>::value, void>
         ::type resize(ForwardItr start, ForwardItr end) {
             CV_Assert(start != end);
-            CV_Assert(std::distance(start, end) <= CSL_MAX_TENSOR_RANK);
+            const auto rank = std::distance(start, end);
+            if (rank > CSL_MAX_TENSOR_RANK) {
+                CV_Error(cv::Error::StsNotImplemented,
+                        cv::format(
+                            "CUDA DNN backend does not support tensor rank %ld (max supported is %d)",
+                            static_cast<long>(rank),
+                            CSL_MAX_TENSOR_RANK));
+            }
 
             using ItrValueType = typename std::iterator_traits<ForwardItr>::value_type;
             auto total = std::accumulate(start, end, 1, std::multiplies<ItrValueType>());
@@ -449,7 +456,14 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
         template <class ForwardItr>
         TensorSpan(pointer ptr_, ForwardItr start, ForwardItr end) : ptr{ ptr_ } {
             CV_Assert(start != end);
-            CV_Assert(std::distance(start, end) <= CSL_MAX_TENSOR_RANK);
+            const auto rank = std::distance(start, end);
+            if (rank > CSL_MAX_TENSOR_RANK) {
+                CV_Error(cv::Error::StsNotImplemented,
+                    cv::format(
+                        "CUDA DNN backend does not support tensor rank %ld (max supported is %d)",
+                        static_cast<long>(rank),
+                        CSL_MAX_TENSOR_RANK));
+            }
 
             using ItrValueType = typename std::iterator_traits<ForwardItr>::value_type;
             if (std::any_of(start, end, [](ItrValueType x) { return x <= 0; })) {


### PR DESCRIPTION
### Summary

Add an explicit runtime check for tensor rank in the CUDA DNN backend to
prevent unsupported tensor configurations from reaching CUDA execution
paths.

Previously, tensors with rank greater than the supported limit could
trigger assertions or backend-specific failures. This change detects
such cases early and reports a clear, user-facing error.

### Motivation

The CUDA DNN backend supports tensors only up to a fixed maximum rank
(`CSL_MAX_TENSOR_RANK`). When higher-rank tensors are passed, the failure
mode is unclear and difficult to debug.

Adding an explicit validation improves robustness and provides a clear
diagnostic message explaining the limitation.

### What was changed

- Added a defensive rank check in CUDA DNN tensor handling
- Replaced a raw assertion with a descriptive `CV_Error`
- Improved error reporting for unsupported tensor ranks

### Impact

- No behavior change for valid tensor ranks
- Clear failure for unsupported configurations
- Improved stability and debuggability of the CUDA DNN backend

### Compatibility

- No API or ABI changes
- CPU backend behavior unchanged
- CUDA backend behavior is strictly safer

### Tests

- Existing DNN tests remain valid
- Change affects only unsupported execution paths

### Related issues

Related to opencv/opencv#27716

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
