### PR TITLE
core: improve performance of normalize and normalize_32f

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -523,8 +523,27 @@ template<typename _Tp, typename _AccTp> static inline
 _AccTp normInf(const _Tp* a, int n)
 {
     _AccTp s = 0;
-    for( int i = 0; i < n; i++ )
+    int i = 0;
+#if CV_ENABLE_UNROLLED
+    for (; i <= n - 8; i += 8) {
+        _AccTp t0 = (_AccTp)cv_abs(a[i]);
+        _AccTp t1 = (_AccTp)cv_abs(a[i + 1]);
+        _AccTp t2 = (_AccTp)cv_abs(a[i + 2]);
+        _AccTp t3 = (_AccTp)cv_abs(a[i + 3]);
+        _AccTp t4 = (_AccTp)cv_abs(a[i + 4]);
+        _AccTp t5 = (_AccTp)cv_abs(a[i + 5]);
+        _AccTp t6 = (_AccTp)cv_abs(a[i + 6]);
+        _AccTp t7 = (_AccTp)cv_abs(a[i + 7]);
+        _AccTp blockMax = std::max(
+        std::max(std::max(t0, t1), std::max(t2, t3)),
+        std::max(std::max(t4, t5), std::max(t6, t7))
+        );
+        s = std::max(s, blockMax);
+    }
+#endif
+    for (; i < n; i++) {
         s = std::max(s, (_AccTp)cv_abs(a[i]));
+    }
     return s;
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

- This PR optimizes the normInf function by implementing 8x loop unrolling, significantly improving Windows-ARM64 performance.
- 6 tests in normalize and normalize_32f were non-competitive on Windows ARM64. 
- The root cause is that cv::norm uses an optimized IPP implementation on x64 but falls back to a scalar implementation on ARM64.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
