### PR TITLE
optimize: replace push_back with emplace_back in core loops

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1024,7 +1024,7 @@ void HoughLinesPointSet( InputArray _point, OutputArray _lines, int lines_max, i
         int r = idx - (n+1)*(numrho+2) - 1;
         line.rho = static_cast<float>(min_rho) + r * (float)rho_step;
         line.angle = static_cast<float>(min_theta) + n * (float)theta_step;
-        lines.push_back(Vec3d((double)accum[idx], (double)line.rho, (double)line.angle));
+        lines.emplace_back((double)accum[idx], (double)line.rho, (double)line.angle);
     }
 
     Mat(lines).copyTo(_lines);
@@ -1125,7 +1125,7 @@ public:
             {
                 if (ptr[x])
                 {
-                    list.push_back(Point(x, y));
+                    list.emplace_back(x, y);
                 }
             }
         }
@@ -1489,7 +1489,7 @@ protected:
             // Check if the circle has enough support
             if(maxCount > accThreshold)
             {
-                circlesLocal.push_back(EstimatedCircle(Vec3f(curCenter.x, curCenter.y, rBest), maxCount));
+                circlesLocal.emplace_back(Vec3f(curCenter.x, curCenter.y, rBest), maxCount);
             }
         }
 
@@ -1847,7 +1847,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
                 continue;
 
             mdata[y*mstep + x] = (uchar)1;
-            stack.push_back(Point(x, y));
+            stack.emplace_back(x, y);
             bool backtrace_mode = false;
 
             do
@@ -1858,7 +1858,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
                 int vy = dyData[p.y*dxystep + p.x];
 
                 float mag = std::sqrt((float)vx*vx+(float)vy*vy);
-                nz.push_back(Vec4f((float)p.x, (float)p.y, (float)vx, (float)vy));
+                nz.emplace_back((float)p.x, (float)p.y, (float)vx, (float)vy);
                 CV_Assert(mdata[p.y*mstep + p.x] == 1);
 
                 int sx = cvRound(vx * RAY_FP_SCALE / mag);
@@ -1903,7 +1903,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
                     if( mdata[y_*mstep + x_] || !edgeData[y_*estep + x_])
                         continue;
                     mdata[y_*mstep + x_] = (uchar)1;
-                    stack.push_back(Point(x_, y_));
+                    stack.emplace_back(x_, y_);
                     neighbors++;
                 }
 
@@ -1919,7 +1919,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
             // insert a special "stop marker" in the end of each
             // connected component to make sure we
             // finalize and analyze the arc segment
-            nz.push_back(Vec4f(0.f, 0.f, 0.f, 0.f));
+            nz.emplace_back(0.f, 0.f, 0.f, 0.f);
         }
     }
 
@@ -1951,7 +1951,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
             {
                 float cx = (float)((left + x - 1)*dp*0.5f);
                 float cy = (float)(y*dp);
-                centers.push_back(Point2f(cx, cy));
+                centers.emplace_back(cx, cy);
                 left = -1;
             }
         }
@@ -2223,7 +2223,7 @@ static void HoughCirclesAlt( const Mat& img, std::vector<EstimatedCircle>& circl
                 //       (accepted ? '+' : '-'), cx, cy, rk, cjk.weight, count, max_runlen, cjk.mask);
 
                 if( accepted )
-                    local_circles.push_back(EstimatedCircle(Vec3f(cx, cy, (float)rk), cjk.weight));
+                    local_circles.emplace_back(Vec3f(cx, cy, (float)rk), cjk.weight);
             }
         }
     }

--- a/modules/imgproc/src/subdivision2d.cpp
+++ b/modules/imgproc/src/subdivision2d.cpp
@@ -265,7 +265,7 @@ int Subdiv2D::newPoint(Point2f pt, bool isvirtual, int firstEdge)
 {
     if( freePoint == 0 )
     {
-        vtx.push_back(Vertex());
+        vtx.emplace_back();
         freePoint = (int)(vtx.size()-1);
     }
     int vidx = freePoint;
@@ -520,8 +520,8 @@ void Subdiv2D::initDelaunay( Rect rect )
     Point2f ppB( rx, ry + big_coord );
     Point2f ppC( rx - big_coord, ry - big_coord );
 
-    vtx.push_back(Vertex());
-    qedges.push_back(QuadEdge());
+    vtx.emplace_back();
+    qedges.emplace_back();
 
     freeQEdge = 0;
     freePoint = 0;
@@ -566,8 +566,8 @@ void Subdiv2D::initDelaunay( Rect2f rect )
     Point2f ppB( rx, ry + big_coord );
     Point2f ppC( rx - big_coord, ry - big_coord );
 
-    vtx.push_back(Vertex());
-    qedges.push_back(QuadEdge());
+    vtx.emplace_back();
+    qedges.emplace_back();
 
     freeQEdge = 0;
     freePoint = 0;
@@ -784,7 +784,7 @@ void Subdiv2D::getEdgeList(std::vector<Vec4f>& edgeList) const
         {
             Point2f org = vtx[qedges[i].pt[0]].pt;
             Point2f dst = vtx[qedges[i].pt[2]].pt;
-            edgeList.push_back(Vec4f(org.x, org.y, dst.x, dst.y));
+            edgeList.emplace_back(org.x, org.y, dst.x, dst.y);
         }
     }
 }
@@ -836,7 +836,7 @@ void Subdiv2D::getTriangleList(std::vector<Vec6f>& triangleList) const
         edgemask[edge_a] = true;
         edgemask[edge_b] = true;
         edgemask[edge_c] = true;
-        triangleList.push_back(Vec6f(a.x, a.y, b.x, b.y, c.x, c.y));
+        triangleList.emplace_back(a.x, a.y, b.x, b.y, c.x, c.y);
     }
 }
 

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1063,9 +1063,9 @@ public:
                         if( classifier->data.stages.size() + result == 0 )
                         {
                             mtx->lock();
-                            rectangles->push_back(Rect(cvRound(x*scalingFactor),
-                                                       cvRound(y*scalingFactor),
-                                                       winSize.width, winSize.height));
+                            rectangles->emplace_back(cvRound(x*scalingFactor),
+                                                     cvRound(y*scalingFactor),
+                                                     winSize.width, winSize.height);
                             rejectLevels->push_back(-result);
                             levelWeights->push_back(gypWeight);
                             mtx->unlock();
@@ -1074,9 +1074,9 @@ public:
                     else if( result > 0 )
                     {
                         mtx->lock();
-                        rectangles->push_back(Rect(cvRound(x*scalingFactor),
-                                                   cvRound(y*scalingFactor),
-                                                   winSize.width, winSize.height));
+                        rectangles->emplace_back(cvRound(x*scalingFactor),
+                                                 cvRound(y*scalingFactor),
+                                                 winSize.width, winSize.height);
                         mtx->unlock();
                     }
                     if( result == 0 )
@@ -1222,10 +1222,10 @@ bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<fl
         for( int i = 0; i < nfaces; i++ )
         {
             const FeatureEvaluator::ScaleData& s = featureEvaluator->getScaleData(fptr[i*3 + 1]);
-            candidates.push_back(Rect(cvRound(fptr[i*3 + 2]*s.scale),
-                                      cvRound(fptr[i*3 + 3]*s.scale),
-                                      cvRound(data.origWinSize.width*s.scale),
-                                      cvRound(data.origWinSize.height*s.scale)));
+            candidates.emplace_back(cvRound(fptr[i*3 + 2]*s.scale),
+                                    cvRound(fptr[i*3 + 3]*s.scale),
+                                    cvRound(data.origWinSize.width*s.scale),
+                                    cvRound(data.origWinSize.height*s.scale));
         }
     }
     return ok;
@@ -1570,8 +1570,8 @@ bool CascadeClassifierImpl::Data::read(const FileNode &root)
             for( int i = 0; i < ntrees; i++, nodeOfs++, leafOfs+= 2 )
             {
                 const DTreeNode& node = nodes[nodeOfs];
-                stumps.push_back(Stump(node.featureIdx, node.threshold,
-                                       leaves[leafOfs], leaves[leafOfs+1]));
+                stumps.emplace_back(node.featureIdx, node.threshold,
+                                    leaves[leafOfs], leaves[leafOfs+1]);
             }
         }
     }

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -412,9 +412,9 @@ void QRDetect::fixationPoints(vector<Point2f> &local_point)
         list_area_pnt.push_back(current_point);
 
         vector<LineIterator> list_line_iter;
-        list_line_iter.push_back(LineIterator(bin_barcode, current_point, left_point));
-        list_line_iter.push_back(LineIterator(bin_barcode, current_point, central_point));
-        list_line_iter.push_back(LineIterator(bin_barcode, current_point, right_point));
+        list_line_iter.emplace_back(bin_barcode, current_point, left_point);
+        list_line_iter.emplace_back(bin_barcode, current_point, central_point);
+        list_line_iter.emplace_back(bin_barcode, current_point, right_point);
 
         for (size_t k = 0; k < list_line_iter.size(); k++)
         {
@@ -757,7 +757,7 @@ vector<Point2f> QRDetect::getQuadrilateral(vector<Point2f> angle_list)
     {
         int x = cvRound(angle_list[i].x);
         int y = cvRound(angle_list[i].y);
-        locations.push_back(Point(x, y));
+        locations.emplace_back(x,y);
     }
 
     vector<Point> integer_hull;
@@ -2217,13 +2217,13 @@ bool QRDecode::straightenQRCodeInParts()
 
         vector<Point2f> perspective_points;
 
-        perspective_points.push_back(Point2f(0.0, start_cut));
-        perspective_points.push_back(Point2f(perspective_curved_size, start_cut));
+        perspective_points.emplace_back(0.0, start_cut);
+        perspective_points.emplace_back(perspective_curved_size, start_cut);
 
-        perspective_points.push_back(Point2f(perspective_curved_size, start_cut + dist));
-        perspective_points.push_back(Point2f(0.0, start_cut+dist));
+        perspective_points.emplace_back(perspective_curved_size, start_cut + dist);
+        perspective_points.emplace_back(0.0, start_cut+dist);
 
-        perspective_points.push_back(Point2f(perspective_curved_size * 0.5f, start_cut + dist * 0.5f));
+        perspective_points.emplace_back(perspective_curved_size * 0.5f, start_cut + dist * 0.5f);
 
         if (i == 1)
         {
@@ -2294,13 +2294,13 @@ bool QRDecode::straightenQRCodeInParts()
     }
 
     vector<Point2f> perspective_straight_points;
-    perspective_straight_points.push_back(Point2f(0.f, 0.f));
-    perspective_straight_points.push_back(Point2f(perspective_curved_size, 0.f));
+    perspective_straight_points.emplace_back(0.f, 0.f);
+    perspective_straight_points.emplace_back(perspective_curved_size, 0.f);
 
-    perspective_straight_points.push_back(Point2f(perspective_curved_size, perspective_curved_size));
-    perspective_straight_points.push_back(Point2f(0.f, perspective_curved_size));
+    perspective_straight_points.emplace_back(perspective_curved_size, perspective_curved_size);
+    perspective_straight_points.emplace_back(0.f, perspective_curved_size);
 
-    perspective_straight_points.push_back(Point2f(perspective_curved_size * 0.5f, perspective_curved_size * 0.5f));
+    perspective_straight_points.emplace_back(perspective_curved_size * 0.5f, perspective_curved_size * 0.5f);
 
     Mat H = findHomography(original_curved_points, perspective_straight_points);
     if (H.empty())
@@ -3319,9 +3319,9 @@ void QRDetectMulti::fixationPoints(vector<Point2f> &local_point)
         list_area_pnt.push_back(current_point);
 
         vector<LineIterator> list_line_iter;
-        list_line_iter.push_back(LineIterator(bin_barcode_temp, current_point, left_point));
-        list_line_iter.push_back(LineIterator(bin_barcode_temp, current_point, central_point));
-        list_line_iter.push_back(LineIterator(bin_barcode_temp, current_point, right_point));
+        list_line_iter.emplace_back(bin_barcode_temp, current_point, left_point);
+        list_line_iter.emplace_back(bin_barcode_temp, current_point, central_point);
+        list_line_iter.emplace_back(bin_barcode_temp, current_point, right_point);
 
         for (size_t k = 0; k < list_line_iter.size(); k++)
         {

--- a/modules/stitching/src/seam_finders.cpp
+++ b/modules/stitching/src/seam_finders.cpp
@@ -338,8 +338,8 @@ void DpSeamFinder::findComponents()
                     states_.push_back(SECOND);
 
                 floodFill(labels_, Point(x, y), ++ncomps_);
-                tls_.push_back(Point(x, y));
-                brs_.push_back(Point(x+1, y+1));
+                tls_.emplace_back(x,y);
+                brs_.emplace_back(x+1, y+1);
                 contours_.push_back(std::vector<Point>());
             }
 
@@ -356,7 +356,7 @@ void DpSeamFinder::findComponents()
                 if ((x == 0 || labels_(y, x-1) != l) || (x == unionSize_.width-1 || labels_(y, x+1) != l) ||
                     (y == 0 || labels_(y-1, x) != l) || (y == unionSize_.height-1 || labels_(y+1, x) != l))
                 {
-                    contours_[ci].push_back(Point(x, y));
+                    contours_[ci].emplace_back(x,y);
                 }
             }
         }
@@ -517,7 +517,7 @@ void DpSeamFinder::resolveConflicts(
                             if ((x == 0 || labels_(y, x-1) != l[i]) || (x == unionSize_.width-1 || labels_(y, x+1) != l[i]) ||
                                 (y == 0 || labels_(y-1, x) != l[i]) || (y == unionSize_.height-1 || labels_(y+1, x) != l[i]))
                             {
-                                contours_[c[i]].push_back(Point(x, y));
+                                contours_[c[i]].emplace_back(x,y);
                             }
                         }
                     }
@@ -637,7 +637,7 @@ bool DpSeamFinder::getSeamTips(int comp1, int comp2, Point &p1, Point &p2)
              (x < unionSize_.width-1 && labels_(y, x+1) == l2) ||
              (y < unionSize_.height-1 && labels_(y+1, x) == l2)))
         {
-            specialPoints.push_back(Point(x, y));
+            specialPoints.emplace_back(x,y);
         }
     }
 


### PR DESCRIPTION
**Title:**
`optimize: use emplace_back instead of push_back in imgproc, objdetect, and stitching`

### Summary

This PR replaces instances of `std::vector::push_back(Type(...))` with `std::vector::emplace_back(...)` in performance-critical loops.

### Motivation

Using `emplace_back` constructs the object directly in the vector's memory, avoiding the creation, copy/move, and destruction of temporary objects. This is a standard C++ optimization that reduces overhead, particularly in heavy algorithms like Hough Transforms, Seam Finding, and Cascade Detection.

### Changes

* **modules/imgproc:** Optimized vector insertions in `HoughLines`, `HoughCircles`, and `Subdivision2D`.
* **modules/objdetect:** Optimized `Rect`, `Stump`, and `LineIterator` insertions in `CascadeClassifier` and `QRCodeDetector`.
* **modules/stitching:** Optimized `Point` insertions in `SeamFinder`.

### Verification

* Compiled and verified with targets `opencv_imgproc`, `opencv_objdetect`, and `opencv_stitching`.
* Build passed successfully on local machine (macOS).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
