### PR TITLE
core: add NEON support for cvFloor in fast_math.hpp

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -237,13 +237,8 @@ CV_INLINE int cvFloor( double value )
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
     return (int)__builtin_floor(value);
-#elif defined(_M_ARM64) && defined(_MSC_VER)
-    float64x1_t val = vdup_n_f64(value);
-    float64x1_t floored = vrndm_f64(val);
-    double floored_scalar = vget_lane_f64(floored, 0);
-    int result = (int)floored_scalar;
-    if (result > value) result--;
-    return result;
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+    return (int)vcvtmd_s64_f64(value);
 #elif defined __loongarch64
     int i;
     double tmp;
@@ -271,6 +266,8 @@ CV_INLINE int cvCeil( double value )
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
     return (int)__builtin_ceil(value);
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+    return (int)vcvtpd_s64_f64(value);
 #elif defined __loongarch64
     int i;
     double tmp;
@@ -369,11 +366,8 @@ CV_INLINE int cvFloor( float value )
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
     return (int)__builtin_floorf(value);
-#elif defined(_M_ARM64) && defined(_MSC_VER)
-    float32x2_t val = vdup_n_f32(value);
-    float32x2_t floored = vrndm_f32(val);
-    int32x2_t i_vec = vcvt_s32_f32(floored);
-    return vget_lane_s32(i_vec, 0);
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+    return (int)vcvtms_s32_f32(value);
 #elif defined __loongarch__
     int i;
     float tmp;
@@ -401,6 +395,8 @@ CV_INLINE int cvCeil( float value )
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
     return (int)__builtin_ceilf(value);
+#elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+    return (int)vcvtps_s32_f32(value);
 #elif defined __loongarch__
     int i;
     float tmp;


### PR DESCRIPTION
- This PR adds NEON intrinsics-based implementation for the cvFloor function in fast_math.hpp for Windows-ARM64.
- Both float and double overloads now use NEON intrinsics for cvFloor Function.
- calchist and calchist1d function uses cvFloor function for its computations. 
- After adding these changes both functions showed improvement in performance.

**Performance Benchmarks:**
<img width="956" height="273" alt="image" src="https://github.com/user-attachments/assets/a00c98cd-d245-4d11-a9fd-361a3bd89f59" />





See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
