### PR TITLE
DNN: Add TFLite Minimum layer support

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -288,7 +288,7 @@ TFLiteImporter::DispatchMap TFLiteImporter::buildDispatchMap()
     dispatch["ADD"] = dispatch["MUL"] = dispatch["SUB"] =
         dispatch["SQRT"] = dispatch["DIV"] = dispatch["NEG"] =
         dispatch["RSQRT"] = dispatch["SQUARED_DIFFERENCE"] =
-        dispatch["MAXIMUM"] = &TFLiteImporter::parseEltwise;
+        dispatch["MAXIMUM"] = dispatch["MINIMUM"]= &TFLiteImporter::parseEltwise;
     dispatch["RELU"] = dispatch["PRELU"] = dispatch["HARD_SWISH"] =
         dispatch["LOGISTIC"] = dispatch["LEAKY_RELU"] = &TFLiteImporter::parseActivation;
     dispatch["MAX_POOL_2D"] = dispatch["AVERAGE_POOL_2D"] = &TFLiteImporter::parsePooling;
@@ -581,6 +581,9 @@ void TFLiteImporter::parseEltwise(const Operator& op, const std::string& opcode,
     }
     else if (opcode == "MAXIMUM" && !isOpInt8) {
         layerParams.set("operation", "max");
+    }
+    else if (opcode == "MINIMUM" && !isOpInt8) {
+        layerParams.set("operation", "min");
     }else {
         CV_Error(Error::StsNotImplemented, cv::format("DNN/TFLite: Unknown opcode for %s Eltwise layer '%s'", isOpInt8 ? "INT8" : "FP32", opcode.c_str()));
     }

--- a/modules/dnn/test/test_tflite_importer.cpp
+++ b/modules/dnn/test/test_tflite_importer.cpp
@@ -311,6 +311,34 @@ TEST_P(Test_TFLite, maximum)
     normAssert(ref, out, "", l1, lInf);
 }
 
+TEST_P(Test_TFLite, minimum)
+{
+    Net net = readNetFromTFLite(findDataFile("dnn/tflite/minimum.tflite"));
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    Mat input_x = blobFromNPY(findDataFile("dnn/tflite/minimum_input_x.npy"));
+    Mat input_y = blobFromNPY(findDataFile("dnn/tflite/minimum_input_y.npy"));
+
+    net.setInput(input_x, "x");
+    net.setInput(input_y, "y");
+
+    Mat out = net.forward();
+    Mat ref = blobFromNPY(findDataFile("dnn/tflite/minimum_output.npy"));
+
+    double l1 = 1e-5;
+    double lInf = 1e-4;
+
+    if (target == DNN_TARGET_CUDA_FP16 || target == DNN_TARGET_OPENCL_FP16)
+    {
+        l1 = 1e-3;
+        lInf = 1e-3;
+    }
+
+    normAssert(ref, out, "", l1, lInf);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_TFLite, dnnBackendsAndTargets());
 
 }}  // namespace


### PR DESCRIPTION
Fixes #28238 
OpenCV Extra: https://github.com/opencv/opencv_extra/pull/1299

This PR adds support for the `MINIMUM` layer in the TFLite importer.
It maps the TFLite `MINIMUM` opcode to the existing OpenCV Element-wise `Min` operation.

All related input and output test data are on opencv_extra.
opencv_extra_pr=https://github.com/opencv/opencv_extra/pull/1299

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake