### PR TITLE
cuda(dnn): replace unsafe GEMM assertions with runtime validation errors

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/tensor.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/tensor.hpp
@@ -208,7 +208,14 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
         typename std::enable_if<cxx_utils::is_forward_iterator<ForwardItr>::value, void>
         ::type resize(ForwardItr start, ForwardItr end) {
             CV_Assert(start != end);
-            CV_Assert(std::distance(start, end) <= CSL_MAX_TENSOR_RANK);
+            const auto rank = std::distance(start, end);
+            if (rank > CSL_MAX_TENSOR_RANK) {
+                CV_Error(cv::Error::StsNotImplemented,
+                        cv::format(
+                            "CUDA DNN backend does not support tensor rank %ld (max supported is %d)",
+                            static_cast<long>(rank),
+                            CSL_MAX_TENSOR_RANK));
+            }
 
             using ItrValueType = typename std::iterator_traits<ForwardItr>::value_type;
             auto total = std::accumulate(start, end, 1, std::multiplies<ItrValueType>());
@@ -449,7 +456,14 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
         template <class ForwardItr>
         TensorSpan(pointer ptr_, ForwardItr start, ForwardItr end) : ptr{ ptr_ } {
             CV_Assert(start != end);
-            CV_Assert(std::distance(start, end) <= CSL_MAX_TENSOR_RANK);
+            const auto rank = std::distance(start, end);
+            if (rank > CSL_MAX_TENSOR_RANK) {
+                CV_Error(cv::Error::StsNotImplemented,
+                    cv::format(
+                        "CUDA DNN backend does not support tensor rank %ld (max supported is %d)",
+                        static_cast<long>(rank),
+                        CSL_MAX_TENSOR_RANK));
+            }
 
             using ItrValueType = typename std::iterator_traits<ForwardItr>::value_type;
             if (std::any_of(start, end, [](ItrValueType x) { return x <= 0; })) {


### PR DESCRIPTION
This PR replaces user-triggerable CV_Assert checks in CUDA DNN GEMM tensor operations with descriptive runtime errors. Invalid tensor ranks or incompatible dimensions now fail gracefully with clear diagnostics instead of aborting execution. There is no behavior change for valid inputs.

The CUDA DNN module (opencv_dnn) was built locally in Release configuration with CUDA enabled.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
