### PR TITLE
DNN: Add QLinearAdd/Mul support to new ONNX engine

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -2291,11 +2291,15 @@ void ONNXImporter2::parseQEltwise(LayerParams& layerParams, const opencv_onnx::N
     // Configure Eltwise Layer
     std::vector<float> coeffs;
     float offset;
+
     if (op == "sum") {
+        // Sum: S1/So * (x - z1) + S2/So * (y - z2) + zo
         coeffs = {inp_0_sc / out_sc, inp_1_sc / out_sc};
         offset = out_zp - coeffs[0] * inp_0_zp - coeffs[1] * inp_1_zp;
     } else {
-        coeffs = {inp_0_sc / out_sc, inp_1_sc};
+        // Prod: (S1 * S2 / So) * [(x - z1) * (y - z2)] + zo
+        float prod_scale = (inp_0_sc * inp_1_sc) / out_sc;
+        coeffs = {prod_scale, 1.0f}; 
         offset = out_zp;
     }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -3466,5 +3466,22 @@ TEST_P(Test_ONNX_layers, TopK) {
 }
 
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
+TEST_P(Test_ONNX_layers, QLinearAdd)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+
+    // Arguments: model_name, extension, l1, lInf, useSoftmax, checkNoFallbacks, numInputs
+    testONNXModels("qlinear_add", npy, 0.15, 2.0, false, true, 2);
+}
+
+TEST_P(Test_ONNX_layers, QLinearMul)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+
+    // Arguments: model_name, extension, l1, lInf, useSoftmax, checkNoFallbacks, numInputs
+    testONNXModels("qlinear_mul", npy, 0.05, 0.5, false, true, 2);
+}
 
 }} // namespace


### PR DESCRIPTION
Fixes #26310 Implemented parseQEltwise in ONNXImporter2 to support QLinearAdd and QLinearMul layers in the new DNN engine. Verification: Verified locally by exporting a quantized Add model from PyTorch (opset 13) and running inference successfully with cv::dnn::readNetFromONNX.
