### PR TITLE
dnn: add error message for unimplemented UMat NCHW blob conversion

### DIFF
--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -228,7 +228,7 @@ void blobFromImagesNCHW(const std::vector<Mat>& images, Mat& blob_, const Image2
 template<typename Tout>
 void blobFromImagesNCHW(const std::vector<UMat>& images, UMat& blob_, const Image2BlobParams& param)
 {
-    CV_Error(Error::StsNotImplemented, "");
+    CV_Error(Error::StsNotImplemented, "blobFromImagesNCHW is not implemented for UMat inputs");
 }
 
 template<class Tmat>


### PR DESCRIPTION
This change adds a descriptive error message for the unimplemented
UMat path in blobFromImagesNCHW. Previously, the function raised an exception with an empty message.

No functional behavior is changed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
