### PR TITLE
dnn(onnx): infer Conv kernel size from weights when missing

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2018,6 +2018,16 @@ void ONNXImporter::parseConv(LayerParams& layerParams, const opencv_onnx::NodePr
     int outCn = layerParams.blobs.empty() ? outShapes[node_proto.input(1)][0] : layerParams.blobs[0].size[0];
     layerParams.set("num_output", outCn);
 
+    if (!layerParams.has("kernel_h") || !layerParams.has("kernel_w"))
+    {
+        CV_Assert(!layerParams.blobs.empty());
+        const Mat& weights = layerParams.blobs[0];
+        CV_Assert(weights.dims == 4);
+
+        layerParams.set("kernel_h", weights.size[2]);
+        layerParams.set("kernel_w", weights.size[3]);
+    }
+
     addLayer(layerParams, node_proto);
 }
 


### PR DESCRIPTION
Fixes #28268 

Summary

Improve robustness of the ONNX importer by inferring convolution kernel size
from the weight tensor when kernel_shape attributes are missing.

Motivation

Some valid ONNX models (including officially exported YOLOv5 models) omit
explicit kernel_shape, kernel_h, or kernel_w attributes for Conv nodes.
In such cases, OpenCV DNN currently fails during ONNX import with:

kernel_size (or kernel_h and kernel_w) not specified


This behavior is stricter than ONNX Runtime, which correctly infers the kernel
size from the convolution weight tensor.

What was changed

Added a fallback in ONNXImporter::parseConv to infer:

kernel_h and kernel_w from the weight tensor shape when missing

The inference is applied only when:

Kernel attributes are absent

Convolution weights are constant and available

Existing behavior is unchanged for models that already specify kernel size

Impact

Enables successful import of valid ONNX models that previously failed

Improves compatibility with models exported from PyTorch / Ultralytics

Aligns OpenCV DNN behavior more closely with ONNX Runtime

Compatibility

No API or ABI changes

Affects only ONNX import path

Safe fallback limited to missing-attribute cases

Tests

Existing ONNX tests pass

Verified loading of YOLOv5 ONNX model that previously failed

No regressions observed in CPU ONNX test suite

Reproducer
import cv2
net = cv2.dnn.readNetFromONNX("yolov5s.onnx")


The model passes onnx.checker.check_model and runs in ONNX Runtime.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake