### PR TITLE
docs(features2d): document getBlobContours and collectContours in SimpleBlobDetector

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -769,9 +769,9 @@ public:
       CV_PROP_RW bool filterByConvexity;
       CV_PROP_RW float minConvexity, maxConvexity;
 
-      /** @brief Flag to enable contour collection. 
-      If set to true, the detector will store the contours of the detected blobs in memory, 
-      which can be retrieved after the detect() call using getBlobContours(). 
+      /** @brief Flag to enable contour collection.
+      If set to true, the detector will store the contours of the detected blobs in memory,
+      which can be retrieved after the detect() call using getBlobContours().
       @note Default value is false.
       */
       CV_PROP_RW bool collectContours;
@@ -789,8 +789,7 @@ public:
   CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
 
   /** @brief Returns the contours of the blobs detected during the last call to detect().
-  
-  @note The @ref Params::collectContours parameter must be set to true before calling 
+  @note The @ref Params::collectContours parameter must be set to true before calling
   detect() for this method to return any data.
   */
   CV_WRAP virtual const std::vector<std::vector<cv::Point> >& getBlobContours() const;


### PR DESCRIPTION
Description: This PR adds missing Doxygen documentation for the getBlobContours() method and the collectContours parameter in SimpleBlobDetector. These features were previously undocumented, making the contour collection functionality difficult for users to discover and use correctly.

Changes:
Added a @brief and detailed note for SimpleBlobDetector::Params::collectContours.
Added documentation for SimpleBlobDetector::getBlobContours(), including a @note regarding the required parameter setup.

Testing:
Verified the documentation build locally on macOS using ninja opencv_docs.
Confirmed the generated HTML displays the descriptions and cross-references accurately.

Partially fixes: #25904
Related PR that adds method: https://github.com/opencv/opencv/pull/21942

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work.
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
