### PR TITLE
Fix: Enable 16-bit APNG encoding by updating IHDR and bpp calculation

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -1724,6 +1724,19 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
         if (animation.frames[i].channels() == 3)
             cvtColor(animation.frames[i], tmpframes[i], COLOR_BGR2RGB);
 
+        if (tmpframes[i].depth() == CV_16U)
+        {
+            Mat& m = tmpframes[i];
+            for (int y = 0; y < m.rows; ++y)
+            {
+                uint16_t* row = m.ptr<uint16_t>(y);
+                for (int x = 0; x < m.cols * m.channels(); ++x)
+                {
+                    row[x] = (uint16_t)((row[x] << 8) | (row[x] >> 8));
+                }
+            }
+        }
+
         apngFrame.setMat(tmpframes[i], animation.durations[i]);
 
         if (i > 0 && !getRect(width, height, frames.back().getPixels(), apngFrame.getPixels(), over1.data(), bpp, rowbytes, 0, 0, 0, 3))
@@ -1840,6 +1853,19 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
 
             if (tmp.channels() > 2)
                 cvtColor(tmp, tmp, COLOR_BGRA2RGBA);
+
+            if (tmp.depth() == CV_16U)
+            {
+                for (int y = 0; y < tmp.rows; ++y)
+                {
+                    uint16_t* row = tmp.ptr<uint16_t>(y);
+                    for (int x = 0; x < tmp.cols * tmp.channels(); ++x)
+                    {
+                        row[x] = (uint16_t)((row[x] << 8) | (row[x] >> 8));
+                    }
+                }
+            }
+            
             apngFrame.setMat(tmp);
 
             deflateRectOp(apngFrame.getPixels(), x0, y0, w0, h0, bpp, rowbytes, zbuf_size, 0);

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -121,6 +121,12 @@
 #define mingw_getsp(...) 0
 #define __builtin_frame_address(...) 0
 
+static bool isLittleEndian()
+{
+    uint16_t x = 0x0001;
+    return *((uint8_t*)&x) != 0;
+}
+
 namespace cv
 {
 
@@ -1724,7 +1730,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
         if (animation.frames[i].channels() == 3)
             cvtColor(animation.frames[i], tmpframes[i], COLOR_BGR2RGB);
 
-        if (tmpframes[i].depth() == CV_16U)
+        if (tmpframes[i].depth() == CV_16U && isLittleEndian())
         {
             Mat& m = tmpframes[i];
             for (int y = 0; y < m.rows; ++y)
@@ -1854,7 +1860,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
             if (tmp.channels() > 2)
                 cvtColor(tmp, tmp, COLOR_BGRA2RGBA);
 
-            if (tmp.depth() == CV_16U)
+            if (tmp.depth() == CV_16U && isLittleEndian())
             {
                 for (int y = 0; y < tmp.rows; ++y)
                 {
@@ -1865,7 +1871,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
                     }
                 }
             }
-            
+
             apngFrame.setMat(tmp);
 
             deflateRectOp(apngFrame.getPixels(), x0, y0, w0, h0, bpp, rowbytes, zbuf_size, 0);

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -1570,6 +1570,77 @@ bool PngEncoder::getRect(uint32_t w, uint32_t h, unsigned char* pimage1, unsigne
                 *pc++ = c2;
             }
     }
+    else if (bpp == 6)
+    {
+        unsigned short* pa = (unsigned short*)pimage1;
+        unsigned short* pb = (unsigned short*)pimage2;
+        unsigned short* pc = (unsigned short*)ptemp;
+
+        for (j = 0; j < h; j++)
+            for (i = 0; i < w; i++)
+            {
+                unsigned short r1 = pa[0], g1 = pa[1], b1 = pa[2];
+                unsigned short r2 = pb[0], g2 = pb[1], b2 = pb[2];
+                bool diff = (r1 != r2 || g1 != g2 || b1 != b2);
+                if (diff)
+                {
+                    diffnum++;
+                    if (has_tcolor)
+                        over_is_possible = 0;
+                    if (i < x_min) 
+                        x_min = i;
+                    if (i > x_max) 
+                        x_max = i;
+                    if (j < y_min) 
+                        y_min = j;
+                    if (j > y_max) 
+                        y_max = j;
+                }
+                else
+                {
+                    r2 = 0; g2 = 0; b2 = 0;
+                }
+
+                pc[0] = r2; pc[1] = g2; pc[2] = b2;  
+                pa += 3; pb += 3; pc += 3;
+            }
+    }
+    else if (bpp == 8)
+    {
+        unsigned short* pa = (unsigned short*)pimage1;
+        unsigned short* pb = (unsigned short*)pimage2;
+        unsigned short* pc = (unsigned short*)ptemp;
+
+        for (j = 0; j < h; j++)
+            for (i = 0; i < w; i++)
+            {
+                unsigned short r1 = pa[0], g1 = pa[1], b1 = pa[2], a1 = pa[3];
+                unsigned short r2 = pb[0], g2 = pb[1], b2 = pb[2], a2 = pb[3];
+                bool diff = (r1 != r2 || g1 != g2 || b1 != b2 || a1 != a2);
+                bool visible = (a1 != 0 || a2 != 0);
+                if (diff && visible)
+                {
+                    diffnum++;
+                    if (a2 != 0xFFFF)
+                        over_is_possible = 0;
+                    if (i < x_min) 
+                        x_min = i;
+                    if (i > x_max) 
+                        x_max = i;
+                    if (j < y_min) 
+                        y_min = j;
+                    if (j > y_max) 
+                        y_max = j;
+                }
+                else 
+                {
+                    r2 = 0; g2 = 0; b2 = 0; a2 = 0;
+                }
+                
+                pc[0] = r2; pc[1] = g2; pc[2] = b2; pc[3] = a2;
+                pa += 4; pb += 4; pc += 4;
+            }
+    }
 
     if (diffnum == 0)
     {

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -41,6 +41,7 @@
 //M*/
 
 #include "precomp.hpp"
+#include "utils.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -120,12 +121,6 @@
 // see http://gcc.gnu.org/ml/gcc/2011-10/msg00324.html for some details
 #define mingw_getsp(...) 0
 #define __builtin_frame_address(...) 0
-
-static bool isLittleEndian()
-{
-    uint16_t x = 0x0001;
-    return *((uint8_t*)&x) != 0;
-}
 
 namespace cv
 {
@@ -1801,7 +1796,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
         if (animation.frames[i].channels() == 3)
             cvtColor(animation.frames[i], tmpframes[i], COLOR_BGR2RGB);
 
-        if (tmpframes[i].depth() == CV_16U && isLittleEndian())
+        if (tmpframes[i].depth() == CV_16U && !isBigEndian())
         {
             Mat& m = tmpframes[i];
             for (int y = 0; y < m.rows; ++y)
@@ -1931,7 +1926,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
             if (tmp.channels() > 2)
                 cvtColor(tmp, tmp, COLOR_BGRA2RGBA);
 
-            if (tmp.depth() == CV_16U && isLittleEndian())
+            if (tmp.depth() == CV_16U && !isBigEndian())
             {
                 for (int y = 0; y < tmp.rows; ++y)
                 {

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -1587,13 +1587,13 @@ bool PngEncoder::getRect(uint32_t w, uint32_t h, unsigned char* pimage1, unsigne
                     diffnum++;
                     if (has_tcolor)
                         over_is_possible = 0;
-                    if (i < x_min) 
+                    if (i < x_min)
                         x_min = i;
-                    if (i > x_max) 
+                    if (i > x_max)
                         x_max = i;
-                    if (j < y_min) 
+                    if (j < y_min)
                         y_min = j;
-                    if (j > y_max) 
+                    if (j > y_max)
                         y_max = j;
                 }
                 else
@@ -1601,7 +1601,7 @@ bool PngEncoder::getRect(uint32_t w, uint32_t h, unsigned char* pimage1, unsigne
                     r2 = 0; g2 = 0; b2 = 0;
                 }
 
-                pc[0] = r2; pc[1] = g2; pc[2] = b2;  
+                pc[0] = r2; pc[1] = g2; pc[2] = b2;
                 pa += 3; pb += 3; pc += 3;
             }
     }
@@ -1623,20 +1623,20 @@ bool PngEncoder::getRect(uint32_t w, uint32_t h, unsigned char* pimage1, unsigne
                     diffnum++;
                     if (a2 != 0xFFFF)
                         over_is_possible = 0;
-                    if (i < x_min) 
+                    if (i < x_min)
                         x_min = i;
-                    if (i > x_max) 
+                    if (i > x_max)
                         x_max = i;
-                    if (j < y_min) 
+                    if (j < y_min)
                         y_min = j;
-                    if (j > y_max) 
+                    if (j > y_max)
                         y_max = j;
                 }
-                else 
+                else
                 {
                     r2 = 0; g2 = 0; b2 = 0; a2 = 0;
                 }
-                
+
                 pc[0] = r2; pc[1] = g2; pc[2] = b2; pc[3] = a2;
                 pa += 4; pb += 4; pc += 4;
             }
@@ -1774,7 +1774,7 @@ bool PngEncoder::writeanimation(const Animation& animation, const std::vector<in
     uint32_t bpp = (coltype == 6) ? 4 : (coltype == 2) ? 3
         : (coltype == 4) ? 2
         : 1;
-    if (animation.frames[0].depth() == CV_16U) 
+    if (animation.frames[0].depth() == CV_16U)
         bpp *= 2;
     uint32_t has_tcolor = (coltype >= 4 || (coltype <= 2 && trnssize)) ? 1 : 0;
     uint32_t tcolor = 0;

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -638,7 +638,7 @@ TEST(Imgcodecs_Png, Regression_27466_APNG_16bit)
 {
     int width = 10, height = 10;
     std::vector<Mat> frames;
-    
+
     Mat f1(height, width, CV_16UC3, Scalar(1000, 1000, 1000));
     frames.push_back(f1);
 
@@ -654,19 +654,19 @@ TEST(Imgcodecs_Png, Regression_27466_APNG_16bit)
     ASSERT_TRUE(imwriteanimation(filename, anim)) << "Failed to write APNG file";
 
     std::vector<Mat> loaded_frames;
-    
+
     ASSERT_TRUE(imreadmulti(filename, loaded_frames, IMREAD_ANYDEPTH | IMREAD_ANYCOLOR));
 
     ASSERT_GE(loaded_frames.size(), 1UL) << "Failed to read any frames!";
 
-    EXPECT_EQ(loaded_frames[0].depth(), CV_16U) 
+    EXPECT_EQ(loaded_frames[0].depth(), CV_16U)
         << "Regression: Frame was forcibly downscaled to 8-bit!";
-    
-    EXPECT_EQ(0, cv::norm(loaded_frames[0], frames[0], NORM_INF)) 
+
+    EXPECT_EQ(0, cv::norm(loaded_frames[0], frames[0], NORM_INF))
         << "Pixel data mismatch in Frame 0";
 
     if (loaded_frames.size() < frames.size()) {
-        std::cout << "[WARNING] Decoder only returned " << loaded_frames.size() 
+        std::cout << "[WARNING] Decoder only returned " << loaded_frames.size()
                   << " frames. This may be a pre-existing decoder limitation, "
                   << "but 16-bit depth preservation is verified." << std::endl;
     } else {

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -634,21 +634,14 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Imgcodecs_Png_ZLIBBUFFER_SIZE,
                                         1048576,   // Maximum limit
                                         1048577));
 
-//================================================================================
-// Regression Test for Issue #27466: 16-bit APNG Support
-//================================================================================
-
 TEST(Imgcodecs_Png, Regression_27466_APNG_16bit)
 {
-    // 1. Setup: Create 16-bit animation
     int width = 10, height = 10;
     std::vector<Mat> frames;
     
-    // Frame 1: Dark Gray (16-bit)
     Mat f1(height, width, CV_16UC3, Scalar(1000, 1000, 1000));
     frames.push_back(f1);
-    
-    // Frame 2: Light Gray (16-bit)
+
     Mat f2(height, width, CV_16UC3, Scalar(60000, 60000, 60000));
     frames.push_back(f2);
 
@@ -657,27 +650,21 @@ TEST(Imgcodecs_Png, Regression_27466_APNG_16bit)
     anim.durations.assign(frames.size(), 100);
     anim.loop_count = 0;
 
-    // 2. Action: Write to file
     string filename = "test_16bit_apng.png";
     ASSERT_TRUE(imwriteanimation(filename, anim)) << "Failed to write APNG file";
 
-    // 3. Verification: Read back
     std::vector<Mat> loaded_frames;
     
-    // Use ANYDEPTH | ANYCOLOR to allow APNG composition while requesting 16-bit
     ASSERT_TRUE(imreadmulti(filename, loaded_frames, IMREAD_ANYDEPTH | IMREAD_ANYCOLOR));
 
-    // 4. THE CORE CHECK: Did we fix the 8-bit downscaling bug?
     ASSERT_GE(loaded_frames.size(), 1UL) << "Failed to read any frames!";
 
-    // Check Frame 0 Depth (This implies the header and data were written as 16-bit)
     EXPECT_EQ(loaded_frames[0].depth(), CV_16U) 
         << "Regression: Frame was forcibly downscaled to 8-bit!";
     
     EXPECT_EQ(0, cv::norm(loaded_frames[0], frames[0], NORM_INF)) 
         << "Pixel data mismatch in Frame 0";
 
-    // Optional: Check Frame 1 (Warn if missing, as decoder strictness varies)
     if (loaded_frames.size() < frames.size()) {
         std::cout << "[WARNING] Decoder only returned " << loaded_frames.size() 
                   << " frames. This may be a pre-existing decoder limitation, "
@@ -686,7 +673,6 @@ TEST(Imgcodecs_Png, Regression_27466_APNG_16bit)
         EXPECT_EQ(0, cv::norm(loaded_frames[1], frames[1], NORM_INF));
     }
 
-    // Cleanup
     remove(filename.c_str());
 }
 


### PR DESCRIPTION
Closes: #27466 

### Summary

This PR fixes a bug where 16-bit images (CV_16U) were being forcibly downscaled to 8-bit when saving as an Animated PNG (APNG). The issue was traced to the manual PNG packet construction in PngEncoder::writeanimation, which had hardcoded 8-bit values in the IHDR chunk and incorrect buffer size calculations for 16-bit data.

### Changes Made

Removed 8-bit Conversion: Deleted the loop in writeanimation that unnecessarily converted 16-bit frames to CV_8U.

Dynamic Header Generation: Updated the manual IHDR chunk construction to correctly set the bit depth byte to 16 when the input is CV_16U.

Correct Memory Allocation: Updated the bpp (Bytes Per Pixel) calculation to double the row buffer size for 16-bit images, preventing potential buffer overflows.

**Result:** The file is now correctly identified as 16-bit by both OpenCV and external tools (e.g., `file` command), and pixel data is preserved without loss.

***
**Note on Decoder:**
I verified that `imreadmulti` correctly reads the generated 16-bit APNGs without modification. The `png_set_strip_16` logic in the decoder appears correct (it only strips if the destination matrix is explicitly 8-bit). 
***
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
