### PR TITLE
Support Conv kernel inference from initializer weights

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -2014,6 +2014,25 @@ void ONNXImporter::parseConv(LayerParams& layerParams, const opencv_onnx::NodePr
             layerParams.blobs.push_back(getBlob(node_proto, j));
         }
     }
+    // ONNX allows omitting 'kernel_shape' attribute for Conv. In that case, it should be inferred from weights.
+    // See: https://onnx.ai/onnx/operators/onnx__Conv.html
+    if (!layerParams.has("kernel_size"))
+    {
+        Mat weights;
+        if (!layerParams.blobs.empty())
+            weights = layerParams.blobs[0];
+        else if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
+            weights = getBlob(node_proto, 1);
+
+        if (!weights.empty() && weights.dims >= 3)
+        {
+            const int kDims = weights.dims - 2;
+            std::vector<int32_t> kernel(kDims);
+            for (int i = 0; i < kDims; ++i)
+                kernel[i] = weights.size[2 + i];
+            layerParams.set("kernel_size", DictValue::arrayInt(kernel.data(), static_cast<int>(kernel.size())));
+        }
+    }
     int outCn = layerParams.blobs.empty() ? outShapes[node_proto.input(1)][0] : layerParams.blobs[0].size[0];
     layerParams.set("num_output", outCn);
 
@@ -2029,6 +2048,20 @@ void ONNXImporter::parseConvTranspose(LayerParams& layerParams, const opencv_onn
     }
     layerParams.set("num_output", layerParams.blobs[0].size[1] * layerParams.get<int>("group", 1));
     layerParams.set("bias_term", node_proto.input_size() == 3);
+
+    // ONNX allows omitting 'kernel_shape' attribute for ConvTranspose. Infer it from weights if needed.
+    if (!layerParams.has("kernel_size"))
+    {
+        const Mat& weights = layerParams.blobs[0];
+        if (!weights.empty() && weights.dims >= 3)
+        {
+            const int kDims = weights.dims - 2;
+            std::vector<int32_t> kernel(kDims);
+            for (int i = 0; i < kDims; ++i)
+                kernel[i] = weights.size[2 + i];
+            layerParams.set("kernel_size", DictValue::arrayInt(kernel.data(), static_cast<int>(kernel.size())));
+        }
+    }
 
     if (!layerParams.has("kernel_size"))
         CV_Error(Error::StsNotImplemented,


### PR DESCRIPTION
Initial version inherited from https://github.com/opencv/opencv/pull/28270. Credits to [shahkarnav115-beep](https://github.com/shahkarnav115-beep).

Closes: https://github.com/opencv/opencv/issues/28268
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
