### PR TITLE
Fixed picture_sw object leak in ffmpeg backend with hardware codecs.

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1966,8 +1966,8 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
 #endif
 
         if (img_convert_ctx == NULL) {
-CV_LOG_ERROR(NULL, "Cannot initialize the conversion context!");
-            #if USE_AV_HW_CODECS
+            CV_LOG_ERROR(NULL, "Cannot initialize the conversion context!");
+#if USE_AV_HW_CODECS
             if (sw_picture != picture)
                 av_frame_free(&sw_picture);
 #endif


### PR DESCRIPTION
Replacement for https://github.com/opencv/opencv/pull/28221

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
