### PR TITLE
dnn: add ONNX Swish importer test

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -2639,6 +2639,11 @@ TEST_P(Test_ONNX_layers, CumSum)
     testONNXModels("cumsum_3d_dim_2");
 }
 
+TEST_P(Test_ONNX_nets, Swish)
+{
+    testONNXModels("swish");
+}
+
 static void testYOLO(const std::string& weightPath, const std::vector<int>& refClassIds,
                      const std::vector<float>& refScores, const std::vector<Rect2d>& refBoxes,
                      Image2BlobParams imgParams, float conf_threshold = 0.3, float iou_threshold = 0.5,


### PR DESCRIPTION
ONNX defines Swish as the activation equivalent of SiLU, and a separate
SiLU operator was intentionally rejected upstream.

This PR adds a minimal ONNX importer test for Swish using the standard
testONNXModels path, ensuring correct model import without duplicating
existing activation accuracy coverage.

Corresponding test model is added in opencv_extra:
https://github.com/opencv/opencv_extra/pull/1300

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
