### PR TITLE
Fixed stack-use-after-scope errors in charuco detector

### DIFF
--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -316,8 +316,8 @@ struct CharucoDetector::CharucoDetectorImpl {
         CV_Assert((markerCorners.empty() && markerIds.empty() && !image.empty()) || (markerCorners.total() == markerIds.total()));
         vector<vector<Point2f>> tmpMarkerCorners;
         vector<int> tmpMarkerIds;
-        InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : tmpMarkerCorners;
-        InputOutputArray _markerIds = markerIds.needed() ? markerIds : tmpMarkerIds;
+        InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : _InputOutputArray(tmpMarkerCorners);
+        InputOutputArray _markerIds = markerIds.needed() ? markerIds : _InputOutputArray(tmpMarkerIds);
 
         if (markerCorners.empty() && markerIds.empty()) {
             vector<vector<Point2f> > rejectedMarkers;
@@ -341,8 +341,8 @@ struct CharucoDetector::CharucoDetectorImpl {
                               InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) {
         vector<vector<Point2f>> tmpMarkerCorners;
         vector<int> tmpMarkerIds;
-        InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : tmpMarkerCorners;
-        InputOutputArray _markerIds = markerIds.needed() ? markerIds : tmpMarkerIds;
+        InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : _InputOutputArray(tmpMarkerCorners);
+        InputOutputArray _markerIds = markerIds.needed() ? markerIds : _InputOutputArray(tmpMarkerIds);
         detectBoard(image, charucoCorners, charucoIds, _markerCorners, _markerIds);
         if (charucoParameters.checkMarkers && checkBoard(_markerCorners, _markerIds, charucoCorners, charucoIds) == false) {
             CV_LOG_DEBUG(NULL, "ChArUco board is built incorrectly");
@@ -402,8 +402,8 @@ void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diam
 
     vector<vector<Point2f>> tmpMarkerCorners;
     vector<int> tmpMarkerIds;
-    InputOutputArrayOfArrays _markerCorners = inMarkerCorners.needed() ? inMarkerCorners : tmpMarkerCorners;
-    InputOutputArray _markerIds = inMarkerIds.needed() ? inMarkerIds : tmpMarkerIds;
+    InputOutputArrayOfArrays _markerCorners = inMarkerCorners.needed() ? inMarkerCorners : _InputOutputArray(tmpMarkerCorners);
+    InputOutputArray _markerIds = inMarkerIds.needed() ? inMarkerIds : _InputOutputArray(tmpMarkerIds);
     if (_markerCorners.empty() && _markerIds.empty()) {
         charucoDetectorImpl->arucoDetector.detectMarkers(image, _markerCorners, _markerIds);
     }


### PR DESCRIPTION
The problem here is that `InputOutputArray` and `InputOutputArrayOfArrays` are reference types. The temporary `_InputOutputArray` objects created in the ternary operator can get destructed immediately, which results in references to undefined memory. We can fix this by creating the temporary object explicitly and the lifetimes of the temporary objects are then extended, see http://en.cppreference.com/w/cpp/language/reference_initialization.html#Lifetime_of_a_temporary

I have reproduced #28241 and verified that this fixes #28241. I could only reproduce this with MSVC. I don't think this can be tested apart from enabling address sanitizer in CI.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
