### PR TITLE
dnn(cuda): restrict Resize CUDA support to scale-based cases

### DIFF
--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -72,7 +72,17 @@ public:
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
         if (backendId == DNN_BACKEND_CUDA)
-            return interpolation == "nearest" || interpolation == "bilinear" || interpolation == "opencv_linear";
+        {
+            // CUDA Resize supports only simple, static scale-based cases
+            if (!(interpolation == "nearest" || interpolation == "bilinear" || interpolation == "opencv_linear"))
+                return false;
+
+            // Reject ONNX Resize with dynamic or explicit sizes
+            if (scaleWidth <= 0 || scaleHeight <= 0)
+                return false;
+
+            return true;
+        }
 
         if (backendId == DNN_BACKEND_CANN)
             return interpolation == "nearest" || interpolation == "bilinear" || interpolation == "opencv_linear";


### PR DESCRIPTION
CUDA backend does not fully support ONNX Resize when explicit output sizes
are used. Previously, such configurations were allowed through
supportBackend(), which could lead to silent fallback or undefined behavior.

This change restricts CUDA Resize support to simple, static scale-based
cases only. There is no behavior change for supported configurations.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
