### PR TITLE
Fix #28279: Add helpful error messages for missing fisheye test data

### DIFF
--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -578,7 +578,7 @@ TEST_F(fisheyeTest, Calibration)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -591,7 +591,7 @@ TEST_F(fisheyeTest, Calibration)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -626,7 +626,7 @@ TEST_F(fisheyeTest, CalibrationWithFixedFocalLength)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -639,7 +639,7 @@ TEST_F(fisheyeTest, CalibrationWithFixedFocalLength)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -686,7 +686,7 @@ TEST_F(fisheyeTest, Homography)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -699,7 +699,7 @@ TEST_F(fisheyeTest, Homography)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -760,7 +760,7 @@ TEST_F(fisheyeTest, EstimateUncertainties)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -773,7 +773,7 @@ TEST_F(fisheyeTest, EstimateUncertainties)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -938,7 +938,7 @@ TEST_F(fisheyeTest, stereoCalibrate)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -951,7 +951,7 @@ TEST_F(fisheyeTest, stereoCalibrate)
     cv::FileStorage fs_right(right_file, cv::FileStorage::READ);
     if (!fs_right.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << right_file << "\n"
+        FAIL() << "Test data not found at: " << right_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -964,7 +964,7 @@ TEST_F(fisheyeTest, stereoCalibrate)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -1025,7 +1025,7 @@ TEST_F(fisheyeTest, stereoCalibrateFixIntrinsic)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -1038,7 +1038,7 @@ TEST_F(fisheyeTest, stereoCalibrateFixIntrinsic)
     cv::FileStorage fs_right(right_file, cv::FileStorage::READ);
     if (!fs_right.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << right_file << "\n"
+        FAIL() << "Test data not found at: " << right_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -1051,7 +1051,7 @@ TEST_F(fisheyeTest, stereoCalibrateFixIntrinsic)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 
@@ -1149,7 +1149,7 @@ TEST_F(fisheyeTest, stereoCalibrateWithPerViewTransformations)
     cv::FileStorage fs_left(left_file, cv::FileStorage::READ);
     if (!fs_left.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << left_file << "\n"
+        FAIL() << "Test data not found at: " << left_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -1162,7 +1162,7 @@ TEST_F(fisheyeTest, stereoCalibrateWithPerViewTransformations)
     cv::FileStorage fs_right(right_file, cv::FileStorage::READ);
     if (!fs_right.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << right_file << "\n"
+        FAIL() << "Test data not found at: " << right_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata\n"
                     << "See https://github.com/opencv/opencv_extra for test data repository";
     }
@@ -1175,7 +1175,7 @@ TEST_F(fisheyeTest, stereoCalibrateWithPerViewTransformations)
     cv::FileStorage fs_object(object_file, cv::FileStorage::READ);
     if (!fs_object.isOpened())
     {
-        GTEST_SKIP() << "Test data not found at: " << object_file << "\n"
+        FAIL() << "Test data not found at: " << object_file << "\n"
                     << "Please set OPENCV_TEST_DATA_PATH environment variable to opencv_extra/testdata";
     }
 


### PR DESCRIPTION
======= Description
This PR addresses issue #28279 by improving error handling in fisheye calibration tests.

======= Changes
- Replaced generic `CV_Assert` with informative `GTEST_SKIP` messages
- Added clear guidance on setting `OPENCV_TEST_DATA_PATH` environment variable
- Show exact file paths when test data is missing
- Reference to opencv_extra repository for obtaining test data

======== Problem Solved
Previously, when test data was missing, tests would fail with unhelpful assertion errors. Now, tests are skipped with clear instructions on how to configure the test environment properly.

======== Testing
The test data exists in opencv_extra at:
`testdata/cv/cameracalibration/fisheye/calib-3_stereo_from_JY/`

Users need to set `OPENCV_TEST_DATA_PATH` to point to the testdata directory.

Fixes #28279

- [✓] I agree to contribute to the project under Apache 2 License.
- [✓] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ✓] The PR is proposed to the proper branch
- [✓] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
