### PR TITLE
dnn: document backend fallback behavior

### DIFF
--- a/doc/tutorials/dnn/table_of_content_dnn.markdown
+++ b/doc/tutorials/dnn/table_of_content_dnn.markdown
@@ -14,6 +14,18 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
 -   @subpage tutorial_dnn_text_spotting
 -   @subpage tutorial_dnn_face
 
+### Backend selection and fallback behavior
+
+When using the DNN module, selecting a preferred backend (for example, OpenVINO,
+CUDA, or the default OpenCV backend) represents a request rather than a strict
+guarantee. If the selected backend cannot support certain layers, model
+configurations, or execution requirements, OpenCV may automatically fall back to
+another backend to ensure successful execution.
+
+This fallback may occur without an explicit error or warning. Users who rely on a
+specific backend for performance evaluation or benchmarking are encouraged to
+verify which backend is actually used at runtime.
+
 #### PyTorch models with OpenCV
 In this section you will find the guides, which describe how to run classification, segmentation and detection PyTorch DNN models with OpenCV.
 -   @subpage pytorch_cls_tutorial_dnn_conversion


### PR DESCRIPTION
This PR documents the existing DNN backend fallback behavior, where OpenCV
may transparently fall back to another backend when the requested backend
is unavailable or unsupported for a given network or layer.

No functional changes are introduced.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
