### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4290,7 +4290,7 @@ area. It takes the set of points and the parameter k as input and returns the ar
 enclosing polygon.
 
 The Implementation is based on a paper by Aggarwal, Chang and Yap @cite Aggarwal1985. They
-provide a \f$\theta(n²log(n)log(k))\f$ algorighm for finding the minimal convex polygon with k
+provide a \f$\theta(n²log(n)log(k))\f$ algorithm for finding the minimal convex polygon with k
 vertices enclosing a 2D convex polygon with n vertices (k < n). Since the #minEnclosingConvexPolygon
 function takes a 2D point set as input, an additional preprocessing step of computing the convex hull
 of the 2D point set is required. The complexity of the #convexHull function is \f$O(n log(n))\f$ which

--- a/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
@@ -62,7 +62,7 @@ public:
 
     /**
      * @brief detect aruco markers and interpolate position of ChArUco board corners
-     * @param image input image necesary for corner refinement. Note that markers are not detected and
+     * @param image input image necessary for corner refinement. Note that markers are not detected and
      * should be sent in corners and ids parameters.
      * @param charucoCorners interpolated chessboard corners.
      * @param charucoIds interpolated chessboard corners identifiers.


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

This pull request fixes minor typos in documentation:

- Fixed "algorighm" → "algorithm" in `modules/imgproc/include/opencv2/imgproc.hpp` (minEnclosingConvexPolygon function documentation)
- Fixed "necesary" → "necessary" in `modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp` (CharucoDetector documentation)

Documentation-only changes with no functional impact.