### PR TITLE
docs: fix spelling errors in documentation

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1366,15 +1366,15 @@ public:
 
     /** @overload
      * @param cn New number of channels. If the parameter is 0, the number of channels remains the same.
-     * @param newndims New number of dimentions.
-     * @param newsz Array with new matrix size by all dimentions. If some sizes are zero,
+     * @param newndims New number of dimensions.
+     * @param newsz Array with new matrix size by all dimensions. If some sizes are zero,
      * the original sizes in those dimensions are presumed.
      */
     Mat reshape(int cn, int newndims, const int* newsz) const;
 
     /** @overload
      * @param cn New number of channels. If the parameter is 0, the number of channels remains the same.
-     * @param newshape Vector with new matrix size by all dimentions. If some sizes are zero,
+     * @param newshape Vector with new matrix size by all dimensions. If some sizes are zero,
      * the original sizes in those dimensions are presumed.
      */
     Mat reshape(int cn, const std::vector<int>& newshape) const;

--- a/modules/dnn/src/layers/recurrent_layers.cpp
+++ b/modules/dnn/src/layers/recurrent_layers.cpp
@@ -416,7 +416,7 @@ public:
         if (layout == BATCH_SEQ_HID){
             //swap axis 0 and 1 input x
             cv::Mat tmp;
-            // Since python input is 4 dimentional and C++ input 3 dimentinal
+            // Since python input is 4 dimensional and C++ input 3 dimensional
             // we need to process each differently
             if (input[0].dims == 4){
                 // here !!!

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -245,7 +245,7 @@ struct GAPI_EXPORTS_W_SIMPLE GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 namespace gapi { namespace detail {
-/** Checks GMatDesc fields if the passed matrix is a set of n-dimentional points.
+/** Checks GMatDesc fields if the passed matrix is a set of n-dimensional points.
 @param in GMatDesc to check.
 @param n expected dimensionality.
 @return the amount of points. In case input matrix can't be described as vector of points

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -217,7 +217,7 @@ namespace imgproc {
                 GAPI_Assert (in.depth == CV_32S || in.depth == CV_32F);
                 int amount = detail::checkVector(in, 2u);
                 GAPI_Assert(amount != -1 &&
-                            "Input Mat can't be described as vector of 2-dimentional points");
+                            "Input Mat can't be described as vector of 2-dimensional points");
             }
             return empty_gopaque_desc();
         }
@@ -242,7 +242,7 @@ namespace imgproc {
         static GOpaqueDesc outMeta(GMatDesc in,DistanceTypes,double,double,double) {
             int amount = detail::checkVector(in, 2u);
             GAPI_Assert(amount != -1 &&
-                        "Input Mat can't be described as vector of 2-dimentional points");
+                        "Input Mat can't be described as vector of 2-dimensional points");
             return empty_gopaque_desc();
         }
     };
@@ -276,7 +276,7 @@ namespace imgproc {
         static GOpaqueDesc outMeta(GMatDesc in,int,double,double,double) {
             int amount = detail::checkVector(in, 3u);
             GAPI_Assert(amount != -1 &&
-                        "Input Mat can't be described as vector of 3-dimentional points");
+                        "Input Mat can't be described as vector of 3-dimensional points");
             return empty_gopaque_desc();
         }
     };
@@ -1235,7 +1235,7 @@ weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
 
 @note
  - Function textual ID is "org.opencv.imgproc.shape.fitLine2DMat"
- - In case of an N-dimentional points' set given, Mat should be 2-dimensional, have a single row
+ - In case of an N-dimensional points' set given, Mat should be 2-dimensional, have a single row
 or column if there are N channels, or have N columns if there is a single channel.
 
 @param src Input set of 2D points stored in one of possible containers: Mat,
@@ -1307,7 +1307,7 @@ weights \f$w_i\f$ are adjusted to be inversely proportional to \f$\rho(r_i)\f$ .
 
 @note
  - Function textual ID is "org.opencv.imgproc.shape.fitLine3DMat"
- - In case of an N-dimentional points' set given, Mat should be 2-dimensional, have a single row
+ - In case of an N-dimensional points' set given, Mat should be 2-dimensional, have a single row
 or column if there are N channels, or have N columns if there is a single channel.
 
 @param src Input set of 3D points stored in one of possible containers: Mat,

--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -125,7 +125,7 @@ static void _threshold(InputArray _in, OutputArray _out, int winSize, double con
 
 
 /**
-  * @brief Given a tresholded image, find the contours, calculate their polygonal approximation
+  * @brief Given a thresholded image, find the contours, calculate their polygonal approximation
   * and take those that accomplish some conditions
   */
 static void _findMarkerContours(const Mat &in, vector<vector<Point2f> > &candidates,

--- a/modules/video/include/opencv2/video/background_segm.hpp
+++ b/modules/video/include/opencv2/video/background_segm.hpp
@@ -117,7 +117,7 @@ public:
     CV_WRAP virtual int getNMixtures() const = 0;
     /** @brief Sets the number of gaussian components in the background model.
 
-    The model needs to be reinitalized to reserve memory.
+    The model needs to be reinitialized to reserve memory.
     */
     CV_WRAP virtual void setNMixtures(int nmixtures) = 0;//needs reinitialization!
 
@@ -268,7 +268,7 @@ public:
     CV_WRAP virtual int getNSamples() const = 0;
     /** @brief Sets the number of data samples in the background model.
 
-    The model needs to be reinitalized to reserve memory.
+    The model needs to be reinitialized to reserve memory.
     */
     CV_WRAP virtual void setNSamples(int _nN) = 0;//needs reinitialization!
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

This pull request fixes multiple spelling errors in documentation and comments:

- Fixed "reinitalized" → "reinitialized" in `modules/video/include/opencv2/video/background_segm.hpp` (2 occurrences)
- Fixed "dimentions/dimentional/dimentinal" → "dimensions/dimensional" in multiple files:
  - `modules/core/include/opencv2/core/mat.hpp`
  - `modules/gapi/include/opencv2/gapi/imgproc.hpp`
  - `modules/gapi/include/opencv2/gapi/gmat.hpp`
  - `modules/dnn/src/layers/recurrent_layers.cpp`
- Fixed "tresholded" → "thresholded" in `modules/objdetect/src/aruco/aruco_detector.cpp`

Documentation-only changes with no functional impact.