### PR TITLE
[G-API] Renamed `WorkloadType::notify()` -> `WorkloadType::set()`

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/workload_type.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/workload_type.hpp
@@ -30,6 +30,7 @@ public:
         return id == other.id;
     }
 };
+
 class WorkloadType {
     std::vector<WorkloadListener> listeners;
     uint64_t nextId = 1;
@@ -48,7 +49,7 @@ public:
         }
     }
 
-    void notify(const std::string &type) {
+    void set(const std::string &type) {
         for (const auto &listener : listeners) {
             listener(type);
         }


### PR DESCRIPTION
Renamed `WorkloadType::notify()` method to `WorkloadType::set()`.
Not adding the tests as feature is working only with NPU.

Follow-up PR for https://github.com/opencv/opencv/pull/27460

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
