### PR TITLE
docs: fix spelling errors in code and comments

### DIFF
--- a/modules/dnn/src/vkcom/src/op_matmul.cpp
+++ b/modules/dnn/src/vkcom/src/op_matmul.cpp
@@ -106,7 +106,7 @@ bool OpMatMul::forward(std::vector<Tensor>& ins, std::vector<Tensor>& outs)
     }
 
     desSet->writeTensor(outs[0], 2);
-    desSet->writeTensor(paramTensor, 3); // TODO change the parameter from pushconstance to buffer.
+    desSet->writeTensor(paramTensor, 3); // TODO change the parameter from pushconstant to buffer.
 
     cmdBuffer->beginRecord();
     pipeline->bind(cmdBufferReal, desSet->get());

--- a/modules/gapi/src/streaming/onevpl/utils.cpp
+++ b/modules/gapi/src/streaming/onevpl/utils.cpp
@@ -401,10 +401,10 @@ std::string ext_mem_frame_type_to_cstr(int type) {
     std::stringstream ss;
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_DXVA2_DECODER_TARGET);
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_DXVA2_PROCESSOR_TARGET);
-    // NB: according to VPL source the commented MFX_* constane below are belong to the
+    // NB: according to VPL source the commented MFX_* constant below are belong to the
     // same actual integral value as condition abobe. So it is impossible
     // to distinct them in condition branch.  Just put this comment and possible
-    // constans here...
+    // constants here...
     //APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET);
     //APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET);
     APPEND_STRINGIFY_MASK_N_ERASE(type, "|", MFX_MEMTYPE_SYSTEM_MEMORY);

--- a/modules/highgui/src/window_framebuffer.cpp
+++ b/modules/highgui/src/window_framebuffer.cpp
@@ -519,7 +519,7 @@ fb_fix_screeninfo &FramebufferBackend::getFixInfo()
     return fixInfo;
 }
 
-int FramebufferBackend::getFramebuffrerID()
+int FramebufferBackend::getFramebufferID()
 {
     return fbID;
 }

--- a/modules/highgui/src/window_framebuffer.hpp
+++ b/modules/highgui/src/window_framebuffer.hpp
@@ -101,7 +101,7 @@ public:
 
     fb_var_screeninfo &getVarInfo();
     fb_fix_screeninfo &getFixInfo();
-    int getFramebuffrerID();
+    int getFramebufferID();
     int getFBWidth();
     int getFBHeight();
     int getFBXOffset();

--- a/modules/imgcodecs/test/test_exr.impl.hpp
+++ b/modules/imgcodecs/test/test_exr.impl.hpp
@@ -184,7 +184,7 @@ TEST(Imgcodecs_EXR, readWrite_32FC1_PIZ)
 // Note: YC to GRAYSCALE (IMREAD_GRAYSCALE | IMREAD_ANYDEPTH)
 // outputs a black image,
 // as does Y to RGB (IMREAD_COLOR | IMREAD_ANYDEPTH).
-// This behavoir predates adding EXR alpha support issue
+// This behavior predates adding EXR alpha support issue
 // 16115.
 
 TEST(Imgcodecs_EXR, read_YA_ignore_alpha)

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2372,7 +2372,7 @@ structuring element is used. Kernel can be created using #getStructuringElement
 @param anchor position of the anchor within the element; default value (-1, -1) means that the
 anchor is at the element center.
 @param iterations number of times dilation is applied.
-@param borderType pixel extrapolation method, see #BorderTypes. #BORDER_WRAP is not suported.
+@param borderType pixel extrapolation method, see #BorderTypes. #BORDER_WRAP is not supported.
 @param borderValue border value in case of a constant border
 @sa  erode, morphologyEx, getStructuringElement
  */

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -675,17 +675,17 @@ int CV_WarpPerspectiveTest::prepare_test_case( int test_case_idx )
     s[3] = Point2f(0,src.rows-1.f);
     d[3] = Point2f(0,dst.rows-1.f);
 
-    float bufer[16];
-    Mat tmp( 1, 16, CV_32FC1, bufer );
+    float buffer[16];
+    Mat tmp( 1, 16, CV_32FC1, buffer );
 
     rng.fill( tmp, RNG::NORMAL, Scalar::all(0.), Scalar::all(0.1) );
 
     for( i = 0; i < 4; i++ )
     {
-        s[i].x += bufer[i*4]*src.cols/2;
-        s[i].y += bufer[i*4+1]*src.rows/2;
-        d[i].x += bufer[i*4+2]*dst.cols/2;
-        d[i].y += bufer[i*4+3]*dst.rows/2;
+        s[i].x += buffer[i*4]*src.cols/2;
+        s[i].y += buffer[i*4+1]*src.rows/2;
+        d[i].x += buffer[i*4+2]*dst.cols/2;
+        d[i].y += buffer[i*4+3]*dst.rows/2;
     }
 
     cv::getPerspectiveTransform( s, d ).convertTo( mat, mat.depth() );

--- a/modules/objdetect/src/qrcode_encoder.cpp
+++ b/modules/objdetect/src/qrcode_encoder.cpp
@@ -1576,7 +1576,7 @@ bool QRCodeDecoderImpl::errorCorrectionBlock(std::vector<uint8_t>& codewords) {
     uint8_t b = 1;  // discrepancy from last L update
 
     std::vector<uint8_t> C(numSyndromes, 0);  // Error locator polynomial
-    std::vector<uint8_t> B(numSyndromes, 0);  // A copy of error locator from previos L update
+    std::vector<uint8_t> B(numSyndromes, 0);  // A copy of error locator from previous L update
     C[0] = B[0] = 1;
     for (size_t i = 0; i < numSyndromes; ++i) {
         CV_Assert(m + L - 1 < C.size());  // m >= 1 on any iteration

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -789,7 +789,7 @@ protected:
     bool checkAudioProperties();
 
     template <typename CtrlT>
-    bool readComplexPropery(long prop, long& val) const;
+    bool readComplexProperty(long prop, long& val) const;
     template <typename CtrlT>
     bool writeComplexProperty(long prop, double val, long flags);
     _ComPtr<IMFAttributes> getDefaultSourceConfig(UINT32 num = 10);
@@ -2120,7 +2120,7 @@ bool CvCapture_MSMF::setTime(int numberFrame)
 }
 
 template <typename CtrlT>
-bool CvCapture_MSMF::readComplexPropery(long prop, long & val) const
+bool CvCapture_MSMF::readComplexProperty(long prop, long & val) const
 {
     _ComPtr<CtrlT> ctrl;
     if (FAILED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&ctrl))))
@@ -2188,64 +2188,64 @@ double CvCapture_MSMF::getProperty( int property_id ) const
             else
                 break;
         case CAP_PROP_BRIGHTNESS:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Brightness, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Brightness, cVal))
                 return cVal;
             break;
         case CAP_PROP_CONTRAST:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Contrast, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Contrast, cVal))
                 return cVal;
             break;
         case CAP_PROP_SATURATION:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Saturation, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Saturation, cVal))
                 return cVal;
             break;
         case CAP_PROP_HUE:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Hue, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Hue, cVal))
                 return cVal;
             break;
         case CAP_PROP_GAIN:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Gain, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Gain, cVal))
                 return cVal;
             break;
         case CAP_PROP_SHARPNESS:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Sharpness, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Sharpness, cVal))
                 return cVal;
             break;
         case CAP_PROP_GAMMA:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_Gamma, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_Gamma, cVal))
                 return cVal;
             break;
         case CAP_PROP_BACKLIGHT:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_BacklightCompensation, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_BacklightCompensation, cVal))
                 return cVal;
             break;
         case CAP_PROP_MONOCHROME:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_ColorEnable, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_ColorEnable, cVal))
                 return cVal == 0 ? 1 : 0;
             break;
         case CAP_PROP_TEMPERATURE:
-            if (readComplexPropery<IAMVideoProcAmp>(VideoProcAmp_WhiteBalance, cVal))
+            if (readComplexProperty<IAMVideoProcAmp>(VideoProcAmp_WhiteBalance, cVal))
                 return cVal;
             break;
         case CAP_PROP_PAN:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Pan, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Pan, cVal))
                 return cVal;
             break;
         case CAP_PROP_TILT:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Tilt, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Tilt, cVal))
                 return cVal;
             break;
         case CAP_PROP_ROLL:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Roll, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Roll, cVal))
                 return cVal;
             break;
         case CAP_PROP_IRIS:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Iris, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Iris, cVal))
                 return cVal;
             break;
         case CAP_PROP_EXPOSURE:
         case CAP_PROP_AUTO_EXPOSURE:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Exposure, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Exposure, cVal))
             {
                 if (property_id == CAP_PROP_EXPOSURE)
                     return cVal;
@@ -2254,12 +2254,12 @@ double CvCapture_MSMF::getProperty( int property_id ) const
             }
             break;
         case CAP_PROP_ZOOM:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Zoom, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Zoom, cVal))
                 return cVal;
             break;
         case CAP_PROP_FOCUS:
         case CAP_PROP_AUTOFOCUS:
-            if (readComplexPropery<IAMCameraControl>(CameraControl_Focus, cVal))
+            if (readComplexProperty<IAMCameraControl>(CameraControl_Focus, cVal))
             {
                 if (property_id == CAP_PROP_FOCUS)
                     return cVal;


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

This PR fixes spelling errors in code, comments, and internal identifiers:

**Function/method names:**
- `readComplexPropery` → `readComplexProperty` (cap_msmf.cpp, 19 occurrences)
- `getFramebuffrerID` → `getFramebufferID` (window_framebuffer, 2 occurrences)

**Variable names:**
- `bufer` → `buffer` (test_imgwarp.cpp, 6 occurrences)

**Comments and documentation:**
- `suported` → `supported` (imgproc.hpp)
- `constane/constans` → `constant/constants` (onevpl utils, 2 occurrences)
- `pushconstance` → `pushconstant` (op_matmul.cpp)
- `behavoir` → `behavior` (test_exr.impl.hpp)
- `previos` → `previous` (qrcode_encoder.cpp)

**Total:** 33 fixes across 9 files.

All renamed functions are private/internal methods with consistent updates to declarations, definitions, and call sites. No public API changes.