### PR TITLE
docs: fix spelling errors

### DIFF
--- a/modules/calib3d/src/chessboard.hpp
+++ b/modules/calib3d/src/chessboard.hpp
@@ -149,7 +149,7 @@ class Chessboard: public cv::Feature2D
             int max_tests;            //!< maximal number of tested hypothesis
             bool super_resolution;    //!< use super-repsolution for chessboard detection
             bool larger;              //!< indicates if larger boards should be returned
-            bool marker;              //!< indicates that valid boards must have a white and black cirlce marker used for orientation
+            bool marker;              //!< indicates that valid boards must have a white and black circle marker used for orientation
 
             Parameters()
             {

--- a/modules/core/test/test_ds.cpp
+++ b/modules/core/test/test_ds.cpp
@@ -1641,7 +1641,7 @@ int  Core_GraphTest::test_graph_ops( int iters )
             edge = (CvGraphEdge*)&elem_buf[0];
 
             // assign some default weight that is easy to check for
-            // consistensy, 'cause an edge weight is not stored
+            // consistency, 'cause an edge weight is not stored
             // in the simple graph
             edge->weight = (float)(v_idx[0] + v_idx[1]);
             pass_data = cvtest::randInt(rng) % 2;

--- a/modules/dnn/src/layers/const_layer.cpp
+++ b/modules/dnn/src/layers/const_layer.cpp
@@ -102,14 +102,14 @@ public:
         {
             case CV_32F: break;
             case CV_32S: ge_dtype = ge::DT_INT32; break;
-            default: CV_Error(Error::StsNotImplemented, "Unsuppported data type");
+            default: CV_Error(Error::StsNotImplemented, "Unsupported data type");
         }
         auto size_of_type = sizeof(float);
         switch (blobs[0].type())
         {
             case CV_32F: break;
             case CV_32S: size_of_type = sizeof(int); break;
-            default: CV_Error(Error::StsNotImplemented, "Unsuppported data type");
+            default: CV_Error(Error::StsNotImplemented, "Unsupported data type");
         }
 
         auto desc = std::make_shared<ge::TensorDesc>(ge_shape, ge::FORMAT_NCHW, ge_dtype);

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -687,7 +687,7 @@ public:
     CV_WRAP static Ptr<GFTTDetector> create( int maxCorners=1000, double qualityLevel=0.01, double minDistance=1,
                                              int blockSize=3, bool useHarrisDetector=false, double k=0.04 );
     CV_WRAP static Ptr<GFTTDetector> create( int maxCorners, double qualityLevel, double minDistance,
-                                             int blockSize, int gradiantSize, bool useHarrisDetector=false, double k=0.04 );
+                                             int blockSize, int gradientSize, bool useHarrisDetector=false, double k=0.04 );
     CV_WRAP virtual void setMaxFeatures(int maxFeatures) = 0;
     CV_WRAP virtual int getMaxFeatures() const = 0;
 

--- a/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
+++ b/modules/gapi/test/cpu/gapi_ocv_stateful_kernel_tests.cpp
@@ -575,7 +575,7 @@ TEST(StatefulKernel, StateIsResetOnceOnReshapeInStreaming)
 
     run("cv/video/768x576.avi", 1);
     // FIXME: it should be 2, not 3 for expectedSetupsCount here.
-    // With current implemention both GCPUExecutable reshape() and
+    // With current implementation both GCPUExecutable reshape() and
     // handleNewStream() call setupKernelStates()
     run("cv/video/1920x1080.avi", 3);
 }

--- a/modules/imgcodecs/test/test_exr.impl.hpp
+++ b/modules/imgcodecs/test/test_exr.impl.hpp
@@ -210,7 +210,7 @@ TEST(Imgcodecs_EXR, read_YA_unchanged)
     ASSERT_FALSE(img.empty());
     ASSERT_EQ(CV_32FC2, img.type());
 
-    // Cannot test writing, 2 channel writing not suppported by loadsave
+    // Cannot test writing, 2 channel writing not supported by loadsave
 }
 
 TEST(Imgcodecs_EXR, read_YC_changeDepth)

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -1053,7 +1053,7 @@ TEST_P(minEnclosingTriangle_Modes, accuracy)
             const Mat midPoint = (cur + next) / 2;
             EXPECT_TRUE(isPointOnHull(hull, midPoint));
 
-            // at least one of hull edges must be on tirangle edge
+            // at least one of hull edges must be on triangle edge
             hasEdgeOnHull = hasEdgeOnHull || isEdgeOnHull(hull, cur, next);
         }
         EXPECT_TRUE(hasEdgeOnHull);

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1103,7 +1103,7 @@ bool CvCaptureCAM_V4L::grabFrame()
         FirstCapture = false;
 
 #if defined(V4L_ABORT_BADJPEG)
-        // skip first frame. it is often bad -- this is unnotied in traditional apps,
+        // skip first frame. it is often bad -- this is unnoticed in traditional apps,
         //  but could be fatal if bad jpeg is enabled
         if (!read_frame_v4l2())
             return false;

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -787,7 +787,7 @@ TEST_P(videocapture_acceleration, read)
             {
                 if (filename == "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4")
                     throw SkipTestException("Unable to read the first frame with VP9 codec (media stack misconfiguration / bug)");
-                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't suppport hardware accelerated AV1 decoding.
+                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't support hardware accelerated AV1 decoding.
                 if (filename == "sample_322x242_15frames.yuv420p.libaom-av1.mp4")
                     throw SkipTestException("Unable to read the first frame with AV1 codec (missing support)");
             }
@@ -809,7 +809,7 @@ TEST_P(videocapture_acceleration, read)
             {
                 if (filename == "sample_322x242_15frames.yuv420p.libvpx-vp9.mp4")
                     throw SkipTestException("Unable to read the first frame with VP9 codec (media stack misconfiguration / bug)");
-                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't suppport hardware accelerated AV1 decoding.
+                // FFMPEG: [av1 @ 0000027ac07d1340] Your platform doesn't support hardware accelerated AV1 decoding.
                 if (filename == "sample_322x242_15frames.yuv420p.libaom-av1.mp4")
                     throw SkipTestException("Unable to read the first frame with AV1 codec (missing support)");
             }


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch

### Description

Fixed spelling errors:

- 'tirangle' → 'triangle' (test_convhull.cpp)
- 'cirlce' → 'circle' (chessboard.hpp)
- 'gradiantSize' → 'gradientSize' (features2d.hpp)
- 'unnotied' → 'unnoticed' (cap_v4l.cpp)
- 'consistensy' → 'consistency' (test_ds.cpp)
- 'implemention' → 'implementation' (gapi test)
- 'suppported/Unsuppported/suppport' → 'supported/Unsupported/support' (test files, const_layer.cpp, 5x)

Total: 11 fixes across 9 files. Comments and error messages only.