### PR TITLE
[RFC] dnn: experimental hybrid CPU/CUDA execution scaffold

### DIFF
--- a/modules/dnn/test/test_hybrid_backend.cpp
+++ b/modules/dnn/test/test_hybrid_backend.cpp
@@ -1,0 +1,79 @@
+#include "test_precomp.hpp"
+#include <opencv2/dnn.hpp>
+
+namespace opencv_test {
+
+TEST(DNN_Hybrid, MixedCPUAndCUDAExecution)
+{
+    cv::dnn::Net net;
+
+    // Input
+    cv::Mat input = cv::Mat::ones(1, 3, 8, 8, CV_32F);
+    net.setInput(input);
+
+    // CUDA supported layer (Conv)
+    cv::dnn::LayerParams conv;
+    conv.type = "Convolution";
+    conv.set("kernel_size", 1);
+    conv.set("num_output", 3);
+    conv.blobs.push_back(cv::Mat::ones(3, 3, CV_32F));
+    conv.blobs.push_back(cv::Mat::zeros(3, 1, CV_32F));
+
+    int conv1 = net.addLayer("conv1", "Convolution", conv);
+
+    // CUDA unsupported layer (Shape)
+    cv::dnn::LayerParams shape;
+    int shapeId = net.addLayer("shape", "Shape", shape);
+    net.connect(conv1, 0, shapeId, 0);
+
+    // CUDA supported layer again
+    int conv2 = net.addLayer("conv2", "Convolution", conv);
+    net.connect(shapeId, 0, conv2, 0);
+
+    // Enable hybrid
+    net.enableHybridBackend(true);
+    net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
+    net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
+
+    // Forward should succeed
+    EXPECT_NO_THROW(net.forward());
+}
+
+} // namespace opencv_test
+
+TEST(DNN_Hybrid, ExcessiveTransitionsDisableHybrid)
+{
+    cv::dnn::Net net;
+
+    cv::Mat input = cv::Mat::ones(1, 3, 8, 8, CV_32F);
+    net.setInput(input);
+
+    cv::dnn::LayerParams conv;
+    conv.type = "Convolution";
+    conv.set("kernel_size", 1);
+    conv.set("num_output", 3);
+    conv.blobs.push_back(cv::Mat::ones(3, 3, CV_32F));
+    conv.blobs.push_back(cv::Mat::zeros(3, 1, CV_32F));
+
+    int prev = net.addLayer("conv0", "Convolution", conv);
+
+    // Alternate CPU-only layers to force transitions
+    for (int i = 0; i < 4; i++)
+    {
+        cv::dnn::LayerParams shape;
+        int sid = net.addLayer("shape_" + std::to_string(i), "Shape", shape);
+        net.connect(prev, 0, sid, 0);
+
+        int cid = net.addLayer("conv_" + std::to_string(i), "Convolution", conv);
+        net.connect(sid, 0, cid, 0);
+
+        prev = cid;
+    }
+
+    net.enableHybridBackend(true);
+    net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
+    net.setHybridTransitionLimit(1); // very strict
+
+    // Should fallback safely
+    EXPECT_NO_THROW(net.forward());
+}


### PR DESCRIPTION
### Summary
This PR introduces an **experimental hybrid execution scaffold** in the DNN
module that allows a single network to execute CPU- and CUDA-supported layers
in **separate contiguous blocks**, with controlled backend transitions.

The feature is **strictly opt-in** and does **not alter existing execution
paths** unless explicitly enabled. Default DNN behavior remains unchanged.

---

### Motivation
While investigating backend fallback behavior in DNN, it became apparent that
current execution is limited to a single backend per network, even when
individual layers could be executed more efficiently on different backends.

This work explores an alternative execution direction by enabling **explicit,
controlled multi-backend execution**, without changing existing semantics.

---

### Design Highlights
- Per-layer backend capability detection (CPU / CUDA)
- Grouping of contiguous layers into execution blocks
- Explicit backend transition boundaries
- Hard cap on backend transitions with safe fallback
- Zero behavior change when hybrid mode is disabled

---

### Performance Considerations
Hybrid execution is guarded by a configurable maximum transition threshold to
avoid excessive CPU↔GPU synchronization overhead. If the threshold is exceeded,
execution automatically falls back to the existing single-backend path.

This ensures safety and prevents regressions in performance-sensitive cases.

---

### Tests
- All existing DNN CPU and CUDA tests pass unchanged
- Hybrid execution tests are included under:
  `modules/dnn/test/test_hybrid_backend.cpp`

These tests validate execution-block construction and backend transition logic.
They are not part of the current DNN accuracy-test framework and are provided
for review and future integration.

---

### Status
This PR is opened as an **RFC / Draft** to validate the design direction and
suitability for **OpenCV 5.0**, before further development or stabilization.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
