### PR TITLE
Fix Qt HighGUI lifecycle issue when external QApplication exists

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -854,14 +854,17 @@ GuiReceiver::GuiReceiver() : bTimeOut(false), nb_windows(0)
 
 void GuiReceiver::isLastWindow()
 {
-    if (--nb_windows <= 0)
+    if (qApp->quitOnLastWindowClosed())
     {
-        delete guiMainThread;//delete global_control_panel too
-        guiMainThread = NULL;
-
-        if (doesExternalQAppExist)
+        if (--nb_windows <= 0)
         {
-            qApp->quit();
+            delete guiMainThread; // delete global_control_panel too
+            guiMainThread = NULL;
+
+            if (doesExternalQAppExist)
+            {
+                qApp->quit();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #28291

This PR addresses a design issue in the Qt HighGUI backend where closing the last OpenCV window unintentionally terminates externally managed Qt applications.
 #27873 

========Changes

Modified `GuiReceiver::isLastWindow()` to respect `QApplication::quitOnLastWindowClosed()` before calling `qApp->quit()`.

**Before:**
- OpenCV unconditionally called `qApp->quit()` when the last HighGUI window closed, even for external Qt applications
- This broke Qt applications that embedded OpenCV and needed to continue running

**After:**
- OpenCV checks `quitOnLastWindowClosed()` first
- If the user set `qApp->setQuitOnLastWindowClosed(false)`, OpenCV respects it
- Default behavior (quitOnLastWindowClosed == true) remains unchanged

====== Backward Compatibility

✓ Fully backward compatible
- Default Qt behavior unchanged
- Only affects applications that explicitly call `setQuitOnLastWindowClosed(false)`

### Related Issue

Fixes #28291

### Testing

Tested with external Qt application where:
1. `setQuitOnLastWindowClosed(false)` is set → Qt app continues after closing OpenCV windows 
2. Default settings → Qt app quits as before 

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
