### PR TITLE
[Draft] report error at compile time if OpenCV is built on a big-endian architecture

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -370,6 +370,10 @@ enum CpuFeatures {
 
 #include "cv_cpu_dispatch.h"
 
+#if defined __GNUC__ && defined __BYTE_ORDER__ && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
+    #error "OpenCV 5+ only supports little-endian architectures"
+#endif
+
 #if !defined(CV_STRONG_ALIGNMENT) && defined(__arm__) && !(defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC))
 // int*, int64* should be propertly aligned pointers on ARMv7
 #define CV_STRONG_ALIGNMENT 1


### PR DESCRIPTION
It's getting increasingly more complex to find real modern big-endian-only hardware that can run real modern OS. Some recent news confirm that the trend is to move to little-endian everywhere:  https://www.phoronix.com/news/Torvalds-No-RISC-V-BE.

Since we have enough time before 5.0 gold release, let's see what is potential impact if we disable big-endian in OpenCV.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
