### PR TITLE
docs: fix typos in documentation and code comments

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -671,7 +671,7 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
     std::vector<cv::Point2f> out_corners;
 
     if (is_plain)
-      CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale images are supported whith CALIB_CB_PLAIN flag enable");
+      CV_CheckType(type, depth == CV_8U && cn == 1, "Only 8-bit grayscale images are supported with CALIB_CB_PLAIN flag enable");
 
     if (img.channels() != 1)
     {

--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -2242,7 +2242,7 @@ int Chessboard::Board::detectMarkers(cv::InputArray image)
             cv::bitwise_and(field,mask2,temp);
             double noise= cv::sum(temp)[0]/noise_size;
 
-            // calc refrence value
+            // calc reference value
             Cell *cell2 = getCell(y,abs(x-1));
             src[0] = *cell2->top_left;
             src[1] = *cell2->top_right;

--- a/modules/calib3d/src/usac.hpp
+++ b/modules/calib3d/src/usac.hpp
@@ -68,7 +68,7 @@ class NormTransform : public Algorithm {
 public:
     /*
      * @norm_points is output matrix of size pts_size x 4
-     * @sample constains indices of points
+     * @sample contains indices of points
      * @sample_number is number of used points in sample <0; sample_number)
      * @T1, T2 are output transformation matrices
      */

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -626,7 +626,7 @@ void CV_CameraCalibrationTest::run( int start_from )
         if( code < 0 )
             break;
 
-        /* ----- Compare rot matrixs ----- */
+        /* ----- Compare rot matrices ----- */
         CV_Assert(rotMatrs.size() == (size_t)numImages);
         CV_Assert(transVects.size() == (size_t)numImages);
 
@@ -646,7 +646,7 @@ void CV_CameraCalibrationTest::run( int start_from )
         if( code < 0 )
             break;
 
-        /* ----- Compare rot matrixs ----- */
+        /* ----- Compare rot matrices ----- */
         code = compare(transVects[0].val, goodTransVects[0].val, 3*numImages, 0.1, "translation vectors");
         if( code < 0 )
             break;

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1299,7 +1299,7 @@ void ONNXImporter::parseSlice(LayerParams& layerParams, const opencv_onnx::NodeP
     {
         // dims should be added to the negative axes
         cur_axe = axes_.getIntValue(i) < 0 ? axes_.getIntValue(i) + dims : axes_.getIntValue(i);
-        CV_CheckGE(cur_axe, 0, "Axes should be grater or equal to '-dims'.");
+        CV_CheckGE(cur_axe, 0, "Axes should be greater or equal to '-dims'.");
         CV_CheckLT(cur_axe, dims, "Axes should be less than 'dim'.");
         CV_CheckEQ(flag[cur_axe], false, "Axes shouldn't have duplicated values.");
         flag[cur_axe] = true;

--- a/modules/dnn/src/op_timvx.cpp
+++ b/modules/dnn/src/op_timvx.cpp
@@ -905,7 +905,7 @@ void forwardTimVX(std::vector<Ptr<BackendWrapper> >& outputs, const Ptr<BackendN
     else
         return;
 
-    // set ouput
+    // set output
     Ptr<TimVXBackendWrapper> outWarpper;
     for (int i = 0; i < outputs.size(); i++)
     {

--- a/modules/features2d/src/sift.simd.hpp
+++ b/modules/features2d/src/sift.simd.hpp
@@ -604,7 +604,7 @@ public:
                         }
                     }
 
-                } else  { // val cant be zero here (first abs took care of zero), must be negative
+                } else  { // val can't be zero here (first abs took care of zero), must be negative
                     sift_wt vmin = std::min(std::min(std::min(_00,_01),std::min(_02,_10)),std::min(std::min(_12,_20),std::min(_21,_22)));
                     if (val <= vmin)
                     {

--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -258,7 +258,7 @@ struct CV_EXPORTS_W_SIMPLE RefineParameters {
      */
     CV_PROP_RW float errorCorrectionRate;
 
-    /** @brief checkAllOrders consider the four posible corner orders in the rejectedCorners array.
+    /** @brief checkAllOrders consider the four possible corner orders in the rejectedCorners array.
      *
      * If it set to false, only the provided corner order is considered (default true).
      */

--- a/modules/objdetect/include/opencv2/objdetect/aruco_dictionary.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_dictionary.hpp
@@ -67,7 +67,7 @@ class CV_EXPORTS_W_SIMPLE Dictionary {
 
     /** @brief Returns Hamming distance of the input bits to the specific id.
      *
-     * If `allRotations` flag is set, the four posible marker rotations are considered
+     * If `allRotations` flag is set, the four possible marker rotations are considered
      */
     CV_WRAP int getDistanceToId(InputArray bits, int id, bool allRotations = true) const;
 

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -518,9 +518,9 @@ void CharucoBoardImpl::generateImage(Size outSize, OutputArray img, int marginSi
         for(int x = 0; x < size.width; x++) {
 
             if(legacyPattern && (size.height % 2 == 0)) { // legacy behavior only for even row count patterns
-                if((y + 1) % 2 != x % 2) continue; // white corner, dont do anything
+                if((y + 1) % 2 != x % 2) continue; // white corner, don't do anything
             } else {
-                if(y % 2 != x % 2) continue; // white corner, dont do anything
+                if(y % 2 != x % 2) continue; // white corner, don't do anything
             }
 
             float startX = pixInSquare * float(x);

--- a/modules/objdetect/src/aruco/aruco_detector.cpp
+++ b/modules/objdetect/src/aruco/aruco_detector.cpp
@@ -1399,7 +1399,7 @@ void ArucoDetector::refineDetectedMarkers(InputArray _image, const Board& _board
 
             // last filter, check if inner code is close enough to the assigned marker code
             int codeDistance = 0;
-            // if errorCorrectionRate, dont check code
+            // if errorCorrectionRate, don't check code
             if(refineParams.errorCorrectionRate >= 0) {
 
                 // extract bits

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -117,7 +117,7 @@ struct CharucoDetector::CharucoDetectorImpl {
                     minDist = min(dist, minDist);
                     counter++;
                 }
-                // if this is the first closest marker, dont do anything
+                // if this is the first closest marker, don't do anything
                 if(counter == 0)
                     continue;
                 else {

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -299,7 +299,7 @@ public:
      */
     CV_WRAP Status stitch(InputArrayOfArrays images, InputArrayOfArrays masks, OutputArray pano);
 
-    /** @brief Returns indeces of input images used in panorama stitching
+    /** @brief Returns indices of input images used in panorama stitching
      */
     CV_WRAP std::vector<int> component() const { return indices_; }
 

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -414,7 +414,7 @@ void testECCProperties(Mat x, float eps) {
     EXPECT_NEAR(computeECC(X, 2 * Y + X), 1.0 / sqrt(5.0), eps);
 }
 
-TEST(Video_ECC_Test_Compute, properies) {
+TEST(Video_ECC_Test_Compute, properties) {
     Mat xline(1, 100, CV_32F), x;
     for (int i = 0; i < xline.cols; ++i) xline.at<float>(0, i) =  (float)i;
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -231,7 +231,7 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
     }
     else
     {
-        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong. "
+        CV_LOG_DEBUG(NULL, "VIDEOIO: chosen backend does not work or wrong. "
             "Please make sure that your computer support chosen backend and OpenCV built "
             "with right flags.");
     }
@@ -356,7 +356,7 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     }
     else
     {
-        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong. "
+        CV_LOG_DEBUG(NULL, "VIDEOIO: chosen backend does not work or wrong. "
             "Please make sure that your computer support chosen backend and OpenCV built "
             "with right flags.");
     }
@@ -494,7 +494,7 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
     }
     else
     {
-        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong."
+        CV_LOG_DEBUG(NULL, "VIDEOIO: chosen backend does not work or wrong."
             "Please make sure that your computer support chosen backend and OpenCV built "
             "with right flags.");
     }
@@ -811,7 +811,7 @@ bool VideoWriter::open(const String& filename, int apiPreference, int fourcc, do
     }
     else
     {
-        CV_LOG_DEBUG(NULL, "VIDEOIO: choosen backend does not work or wrong."
+        CV_LOG_DEBUG(NULL, "VIDEOIO: chosen backend does not work or wrong."
             "Please make sure that your computer support chosen backend and OpenCV built "
             "with right flags.");
     }


### PR DESCRIPTION
## Summary
This PR fixes 19 spelling errors in documentation and code comments across 15 files.

## Changes
- `properies` → `properties` (1 occurrence in video/test/test_ecc.cpp)
- `posible` → `possible` (2 occurrences in objdetect/aruco headers)
- `indeces` → `indices` (1 occurrence in stitching/stitching.hpp)
- `matrixs` → `matrices` (2 occurrences in calib3d/test/test_cameracalibration.cpp)
- `grater` → `greater` (1 occurrence in dnn/onnx_importer.cpp)
- `whith` → `with` (1 occurrence in calib3d/calibinit.cpp)
- `ouput` → `output` (1 occurrence in dnn/op_timvx.cpp)
- `choosen` → `chosen` (4 occurrences in videoio/cap.cpp)
- `constains` → `contains` (1 occurrence in calib3d/usac.hpp)
- `refrence` → `reference` (1 occurrence in calib3d/chessboard.cpp)
- `dont` → `don't` (4 occurrences in objdetect/aruco)
- `cant` → `can't` (1 occurrence in features2d/sift.simd.hpp)

## Test plan
- [x] No API changes
- [x] Documentation and comments only
- [x] Code compiles without errors