### PR TITLE
docs(core): update Universal Intrinsics for VLA (RVV/SVE) and v4.11+ API changes

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -81,9 +81,26 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 
 "Universal intrinsics" is a types and functions set intended to simplify vectorization of code on
 different platforms. Currently a few different SIMD extensions on different architectures are supported.
-128 bit registers of various types support is implemented for a wide range of architectures
-including x86(__SSE/SSE2/SSE4.2__), ARM(__NEON__), PowerPC(__VSX__), MIPS(__MSA__).
-256 bit long registers are supported on x86(__AVX2__) and 512 bit long registers are supported on x86(__AVX512__).
+
+OpenCV Universal Intrinsics support the following instruction sets:
+
+- *128 bit* registers of various types support is implemented for a wide range of architectures including
+  - x86(SSE/SSE2/SSE4.2),
+  - ARM(NEON): 64-bit float (64F) requires AArch64,
+  - PowerPC(VSX),
+  - MIPS(MSA),
+  - LoongArch(LSX),
+  - RISC-V(RVV 0.7.1): Fixed-length implementation,
+  - WASM: 64-bit float (64F) is not supported,
+- *256 bit* registers are supported on
+  - x86(AVX2),
+  - LoongArch (LASX),
+- *512 bit* registers are supported on
+  - x86(AVX512),
+- *Vector Length Agnostic (VLA)* registers are supported on
+  - RISC-V(RVV 1.0)
+  - ARM(SVE/SVE2): Powered by Arm KleidiCV integration (OpenCV 4.11+),
+
 In case when there is no SIMD extension available during compilation, fallback C++ implementation of intrinsics
 will be chosen and code will work as expected although it could be slower.
 


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/28319 .

### Details
This PR updates the Universal Intrinsics documentation to reflect the latest changes in OpenCV 4.11.

- **VLA Support**: Added clear distinction between fixed-width SIMD and Vector Length Agnostic (VLA) architectures, including RISC-V (RVV 1.0) and ARM (SVE/SVE2 via KleidiCV).
- **API Modernization**: Updated code examples to use explicit wrapper functions (e.g., `v_add`, `v_lt`) instead of C++ operators, as recommended since OpenCV 4.11 to ensure VLA compatibility.
- **Reference**: Linked to issue #27267 for the technical background on operator removal.

The goal is to provide accurate guidance for developers working with modern scalable vector architectures.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
