### PR TITLE
imgproc: fix HoughLines OpenCL min_theta/max_theta handling

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -762,7 +762,7 @@ static bool ocl_makePointsList(InputArray _src, OutputArray _pointsList, InputOu
     return pointListKernel.run(2, globalThreads, localThreads, false);
 }
 
-static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle)
+static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle, double min_theta)
 {
     UMat pointsList = _pointsList.getUMat();
     _accum.create(numangle + 2, numrho + 2, CV_32SC1);
@@ -786,7 +786,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
             return false;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, (float) min_theta, numrho, numangle);
         return fillAccumKernel.run(2, globalThreads, NULL, false);
     }
     else
@@ -798,7 +798,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
         localThreads[0] = workgroup_size; localThreads[1] = 1;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle+2;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, (float) min_theta, numrho, numangle);
         return fillAccumKernel.run(2, globalThreads, localThreads, false);
     }
 }
@@ -836,7 +836,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, min_theta))
         return false;
 
     const int pixPerWI = 8;
@@ -849,7 +849,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     UMat lines(linesMax, 1, CV_32FC2);
 
     getLinesKernel.args(ocl::KernelArg::ReadOnly(accum), ocl::KernelArg::WriteOnlyNoSize(lines),
-                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta);
+                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta, (float) min_theta);
 
     size_t globalThreads[2] = { ((size_t)numrho + pixPerWI - 1)/pixPerWI, (size_t)numangle };
     if (!getLinesKernel.run(2, globalThreads, NULL, false))
@@ -890,7 +890,7 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, 0.0))
         return false;
 
     ocl::Kernel getLinesKernel("get_lines", ocl::imgproc::hough_lines_oclsrc,

--- a/modules/imgproc/src/opencl/hough_lines.cl
+++ b/modules/imgproc/src/opencl/hough_lines.cl
@@ -58,13 +58,13 @@ __kernel void make_point_list(__global const uchar * src_ptr, int src_step, int 
 
 __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, int list_offset,
                                 __global uchar * accum_ptr, int accum_step, int accum_offset,
-                                int total_points, float irho, float theta, int numrho, int numangle)
+                                int total_points, float irho, float theta, float min_theta, int numrho, int numangle)
 {
     int theta_idx = get_global_id(1);
     int count_idx = get_global_id(0);
     int glob_size = get_global_size(0);
     float cosVal;
-    float sinVal = sincos(theta * ((float)theta_idx), &cosVal);
+    float sinVal = sincos(min_theta + theta * ((float)theta_idx), &cosVal);
     sinVal *= irho;
     cosVal *= irho;
 
@@ -90,7 +90,7 @@ __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, 
 
 __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, int list_offset,
                                __global uchar * accum_ptr, int accum_step, int accum_offset,
-                               int total_points, float irho, float theta, int numrho, int numangle)
+                               int total_points, float irho, float theta, float min_theta, int numrho, int numangle)
 {
     int theta_idx = get_group_id(1);
     int count_idx = get_local_id(0);
@@ -99,7 +99,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
     if (theta_idx > 0 && theta_idx < numangle + 1)
     {
         float cosVal;
-        float sinVal = sincos(theta * (float) (theta_idx-1), &cosVal);
+        float sinVal = sincos(min_theta + theta * (float) (theta_idx-1), &cosVal);
         sinVal *= irho;
         cosVal *= irho;
 
@@ -139,7 +139,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
 
 __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_offset, int accum_rows, int accum_cols,
                          __global uchar * lines_ptr, int lines_step, int lines_offset, __global int* lines_index_ptr,
-                         int linesMax, int threshold, float rho, float theta)
+                         int linesMax, int threshold, float rho, float theta, float min_theta)
 {
     int x0 = get_global_id(0);
     int y = get_global_id(1);
@@ -163,7 +163,7 @@ __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_of
                 if (index < linesMax)
                 {
                     float radius = (x - (accum_cols - 3) / 2) * rho;
-                    float angle = y * theta;
+                    float angle = min_theta + y * theta;
 
                     lines[index] = (float2)(radius, angle);
                 }


### PR DESCRIPTION
## Summary
Fixes a bug where the OpenCL-accelerated implementation of `cv::HoughLines` ignored `min_theta` and `max_theta` parameters, always computing angles from 0 instead of the specified range.

## Problem Description
When calling `cv::HoughLines` with OpenCL acceleration and specifying `min_theta`/`max_theta` parameters (e.g., to detect only horizontal lines with theta ∈ [80°, 100°]), the function would fail to find any lines. This is because:

1. The C++ code correctly computed `numangle` based on the theta range
2. But the OpenCL kernels always computed angles starting from 0, ignoring `min_theta`
3. This caused a mismatch between the accumulator indexing and actual angles

## Changes Made

### C++ code (`hough.cpp`):
- Added `min_theta` parameter to `ocl_fillAccum` function signature
- Updated calls to `ocl_fillAccum` in `ocl_HoughLines` (passes `min_theta`) and `ocl_HoughLinesP` (passes `0.0` for default [0, π] range)
- Updated `getLinesKernel.args` to pass `min_theta` to the kernel

### OpenCL kernels (`hough_lines.cl`):
- Updated `fill_accum_global` and `fill_accum_local` kernels to accept `min_theta` parameter
- Changed angle computation from `theta * theta_idx` to `min_theta + theta * theta_idx`
- Updated `get_lines` kernel to correctly compute detected line angles as `min_theta + y * theta`

## Testing
The fix resolves the issue described in #28036 where horizontal line detection with `min_theta=80°, max_theta=100°` failed with OpenCL but worked without it.

## Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x)
- [x] There is a reference to the original bug report and related work (#28036)
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake

Fixes #28036