### PR TITLE
[js] Remove obsolete C++11 definition in 5.x branch

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -79,8 +79,6 @@ ocv_add_module(js BINDINGS PRIVATE_REQUIRED opencv_js_bindings_generator)
 
 ocv_module_include_directories(${EMSCRIPTEN_INCLUDE_DIR})
 
-add_definitions("-std=c++11")
-
 set(deps ${OPENCV_MODULE_${the_module}_DEPS})
 list(REMOVE_ITEM deps opencv_js_bindings_generator)  # don't add dummy module
 link_libraries(${deps})


### PR DESCRIPTION
In OpenCV 5.x, C++17 is the minimum requirement.
The hardcoded `-std=c++11` in `modules/js/CMakeLists.txt` is no longer necessary and actually causes build failures when using **Emscripten 4.0.20+**, as Embind now requires C++17 or newer.

Unlike the fix in #28178 for the 4.x branch,
this PR takes a cleanup approach for the 5.x branch by removing the legacy flag entirely.

- Fixes build failure with Emscripten 4.0.20+ on 5.x branch.
- Aligns with the C++17 requirement of OpenCV 5.x.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
