### PR TITLE
Add useIPP check to hal_ipp functions

### DIFF
--- a/hal/ipp/include/ipp_utils.hpp
+++ b/hal/ipp/include/ipp_utils.hpp
@@ -25,4 +25,6 @@
 
 #define CV_INSTRUMENT_FUN_IPP(FUN, ...) ((FUN)(__VA_ARGS__))
 
+#define CV_HAL_CHECK_USE_IPP() if(!cv::ipp::useIPP()) return CV_HAL_ERROR_NOT_IMPLEMENTED;
+
 #endif

--- a/hal/ipp/src/cart_polar_ipp.cpp
+++ b/hal/ipp/src/cart_polar_ipp.cpp
@@ -9,6 +9,7 @@
 
 int ipp_hal_polarToCart32f(const float* mag, const float* angle, float* x, float* y, int len, bool angleInDegrees)
 {
+    CV_HAL_CHECK_USE_IPP();
     const bool isInPlace = (x == mag) || (x == angle) || (y == mag) || (y == angle);
     if (isInPlace || angleInDegrees)
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
@@ -21,6 +22,7 @@ int ipp_hal_polarToCart32f(const float* mag, const float* angle, float* x, float
 
 int ipp_hal_polarToCart64f(const double* mag, const double* angle, double* x, double* y, int len, bool angleInDegrees)
 {
+    CV_HAL_CHECK_USE_IPP();
     const bool isInPlace = (x == mag) || (x == angle) || (y == mag) || (y == angle);
     if (isInPlace || angleInDegrees)
         return CV_HAL_ERROR_NOT_IMPLEMENTED;

--- a/hal/ipp/src/mean_ipp.cpp
+++ b/hal/ipp/src/mean_ipp.cpp
@@ -196,6 +196,7 @@ static int ipp_meanStdDev(const uchar* src_data, size_t src_step, int width, int
 int ipp_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                        double* mean_val, double* stddev_val, uchar* mask, size_t mask_step)
 {
+    CV_HAL_CHECK_USE_IPP();
     if (stddev_val)
     {
         return ipp_meanStdDev(src_data, src_step, width, height, src_type, mean_val, stddev_val, mask, mask_step);

--- a/hal/ipp/src/minmax_ipp.cpp
+++ b/hal/ipp/src/minmax_ipp.cpp
@@ -160,6 +160,7 @@ typedef IppStatus (*IppMinMaxSelector)(const void* pSrc, int srcStep, IppiSize s
 int ipp_hal_minMaxIdxMaskStep(const uchar* src_data, size_t src_step, int width, int height, int depth,
                               double* _minVal, double* _maxVal, int* _minIdx, int* _maxIdx, uchar* mask, size_t mask_step)
 {
+    CV_HAL_CHECK_USE_IPP();
 #if IPP_VERSION_X100 < 201800
     // cv::minMaxIdx problem with NaN input
     // Disable 32F processing only

--- a/hal/ipp/src/norm_ipp.cpp
+++ b/hal/ipp/src/norm_ipp.cpp
@@ -12,6 +12,7 @@
 int ipp_hal_norm(const uchar* src, size_t src_step, const uchar* mask, size_t mask_step,
                  int width, int height, int type, int norm_type, double* result)
 {
+    CV_HAL_CHECK_USE_IPP();
     if( mask )
     {
         IppiSize sz = { width, height };
@@ -131,6 +132,7 @@ int ipp_hal_norm(const uchar* src, size_t src_step, const uchar* mask, size_t ma
 int ipp_hal_normDiff(const uchar* src1, size_t src1_step, const uchar* src2, size_t src2_step, const uchar* mask,
                      size_t mask_step, int width, int height, int type, int norm_type, double* result)
 {
+    CV_HAL_CHECK_USE_IPP();
     if( norm_type & cv::NORM_RELATIVE )
     {
         norm_type &= cv::NORM_TYPE_MASK;

--- a/hal/ipp/src/sum_ipp.cpp
+++ b/hal/ipp/src/sum_ipp.cpp
@@ -11,6 +11,7 @@
 
 int ipp_hal_sum(const uchar *src_data, size_t src_step, int src_type, int width, int height, double *result)
 {
+    CV_HAL_CHECK_USE_IPP();
     int cn = CV_MAT_CN(src_type);
     if (cn > 4)
     {

--- a/hal/ipp/src/transforms_ipp.cpp
+++ b/hal/ipp/src/transforms_ipp.cpp
@@ -24,6 +24,7 @@ namespace cv
 int ipp_hal_transpose2d(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step, int src_width,
                         int src_height, int element_size)
 {
+    CV_HAL_CHECK_USE_IPP();
     typedef IppStatus (CV_STDCALL * IppiTranspose)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize);
     typedef IppStatus (CV_STDCALL * IppiTransposeI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize);
     IppiTranspose ippiTranspose = nullptr;
@@ -99,6 +100,7 @@ int ipp_hal_flip(int src_type, const uchar* src_data, size_t src_step, int src_w
                  uchar* dst_data, size_t dst_step, int flip_mode)
 
 {
+    CV_HAL_CHECK_USE_IPP();
     int64_t total = src_step*src_height*CV_ELEM_SIZE(src_type);
     // Details: https://github.com/opencv/opencv/issues/12943
     if (flip_mode <= 0 /* swap rows */

--- a/hal/ipp/src/warp_ipp.cpp
+++ b/hal/ipp/src/warp_ipp.cpp
@@ -73,6 +73,7 @@ private:
 int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width,
                               int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4])
 {
+    CV_HAL_CHECK_USE_IPP();
     //CV_INSTRUMENT_REGION_IPP();
 
     IppiInterpolationType ippInter  = ippiGetInterpolation(interpolation);
@@ -324,6 +325,7 @@ private:
 int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar * dst_data, size_t dst_step,
                             int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4])
 {
+    CV_HAL_CHECK_USE_IPP();
     //CV_INSTRUMENT_REGION_IPP();
 
     if (src_height <= 1 || src_width <= 1)
@@ -505,6 +507,7 @@ int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int s
                      float *mapx, size_t mapx_step, float *mapy, size_t mapy_step,
                      int interpolation, int border_type, const double border_value[4])
 {
+    CV_HAL_CHECK_USE_IPP();
     if (!((interpolation == cv::INTER_LINEAR || interpolation == cv::INTER_CUBIC || interpolation == cv::INTER_NEAREST) &&
         (border_type == cv::BORDER_CONSTANT || border_type == cv::BORDER_TRANSPARENT)))
     {


### PR DESCRIPTION
### Summary

Add check for useIPP, which was lost after moving IPP functions to hal. `CV_IPP_RUN` macros use this condition in non-hal IPP calls.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
