### PR TITLE
Remove deprecated bitcode support from Apple framework build scripts

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -50,7 +50,7 @@ CURRENT_FILE_DIR = os.path.dirname(__file__)
 
 
 class Builder:
-    def __init__(self, opencv, contrib, dynamic, embed_bitcode, exclude, disable, enablenonfree, targets, debug, debug_info, framework_name, run_tests, build_docs, swiftdisabled):
+    def __init__(self, opencv, contrib, dynamic, exclude, disable, enablenonfree, targets, debug, debug_info, framework_name, run_tests, build_docs, swiftdisabled):
         self.opencv = os.path.abspath(opencv)
         self.contrib = None
         if contrib:
@@ -60,7 +60,6 @@ class Builder:
             else:
                 print("Note: contrib repository is bad - modules subfolder not found", file=sys.stderr)
         self.dynamic = dynamic
-        self.embed_bitcode = embed_bitcode
         self.exclude = exclude
         self.build_objc_wrapper = not "objc" in self.exclude
         self.disable = disable
@@ -112,9 +111,6 @@ class Builder:
             cmake_flags = []
             if self.contrib:
                 cmake_flags.append("-DOPENCV_EXTRA_MODULES_PATH=%s" % self.contrib)
-            if xcode_ver >= 7 and target[1] == 'iPhoneOS' and self.embed_bitcode:
-                cmake_flags.append("-DCMAKE_C_FLAGS=-fembed-bitcode")
-                cmake_flags.append("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
             if xcode_ver >= 7 and target[1] == 'Catalyst':
                 sdk_path = check_output(["xcodebuild", "-version", "-sdk", "macosx", "Path"]).decode('utf-8').rstrip()
                 c_flags = [
@@ -123,8 +119,6 @@ class Builder:
                     "-iframework %s/System/iOSSupport/System/Library/Frameworks" % sdk_path,
                     "-isystem %s/System/iOSSupport/usr/include" % sdk_path,
                 ]
-                if self.embed_bitcode:
-                    c_flags.append("-fembed-bitcode")
                 cmake_flags.append("-DCMAKE_C_FLAGS=" + " ".join(c_flags))
                 cmake_flags.append("-DCMAKE_CXX_FLAGS=" + " ".join(c_flags))
                 cmake_flags.append("-DCMAKE_EXE_LINKER_FLAGS=" + " ".join(c_flags))
@@ -239,9 +233,6 @@ class Builder:
         buildcmd = [
             "xcodebuild",
         ]
-
-        if (self.dynamic or self.build_objc_wrapper) and self.embed_bitcode and target == "iPhoneOS":
-            buildcmd.append("BITCODE_GENERATION_MODE=bitcode")
 
         buildcmd += [
             "IPHONEOS_DEPLOYMENT_TARGET=" + os.environ['IPHONEOS_DEPLOYMENT_TARGET'],
@@ -372,7 +363,6 @@ class Builder:
                 link_target = "%s-apple-ios14.0-macabi" % target[:target.find("-")]
             else:
                 link_target = "%s-apple-darwin" % target[:target.find("-")]
-        bitcode_flags = ["-fembed-bitcode", "-Xlinker", "-bitcode_verify"] if is_device and self.embed_bitcode else []
         toolchain_dir = get_xcode_setting("TOOLCHAIN_DIR", builddir)
         sdk_dir = get_xcode_setting("SDK_DIR", builddir)
         framework_options = []
@@ -407,7 +397,7 @@ class Builder:
             "-install_name", "@rpath/" + self.framework_name + ".framework/" + self.framework_name,
             "-dynamiclib", "-dead_strip", "-fobjc-link-runtime", "-all_load",
             "-o", res
-        ] + swift_link_dirs + bitcode_flags + module + libs + libs3)
+        ] + swift_link_dirs + module + libs + libs3)
 
     def makeFramework(self, outdir, builddirs):
         name = self.framework_name
@@ -540,7 +530,6 @@ if __name__ == "__main__":
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework. To exclude multiple, specify this flag again, e.g. "--without video --without objc"')
     parser.add_argument('--disable', metavar='FEATURE', default=[], action='append', help='OpenCV features to disable (add WITH_*=OFF). To disable multiple, specify this flag again, e.g. "--disable tbb --disable openmp"')
     parser.add_argument('--dynamic', default=False, action='store_true', help='build dynamic framework (default is "False" - builds static framework)')
-    parser.add_argument('--embed_bitcode', default=False, dest='embed_bitcode', action='store_true', help='disable bitcode (enabled by default)')
     parser.add_argument('--iphoneos_deployment_target', default=os.environ.get('IPHONEOS_DEPLOYMENT_TARGET', IPHONEOS_DEPLOYMENT_TARGET), help='specify IPHONEOS_DEPLOYMENT_TARGET')
     parser.add_argument('--build_only_specified_archs', default=False, action='store_true', help='if enabled, only directly specified archs are built and defaults are ignored')
     parser.add_argument('--iphoneos_archs', default=None, help='select iPhoneOS target ARCHS. Default is "armv7,armv7s,arm64"')
@@ -606,6 +595,6 @@ if __name__ == "__main__":
         if iphonesimulator_archs:
             targets.append((iphonesimulator_archs, "iPhoneSimulator"))
 
-    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.embed_bitcode, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
+    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
 
     b.build(args.out)

--- a/platforms/ios/build_visionos_framework.py
+++ b/platforms/ios/build_visionos_framework.py
@@ -112,5 +112,5 @@ if __name__ == "__main__":
     if visionsimulator_archs:
         targets.append((visionsimulator_archs, "XRSimulator")),
 
-    b = visionOSBuilder(args.opencv, args.contrib, args.dynamic, True, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
+    b = visionOSBuilder(args.opencv, args.contrib, args.dynamic, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
     b.build(args.out)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -128,5 +128,5 @@ if __name__ == "__main__":
     if catalyst_archs:
         targets.append((catalyst_archs, "Catalyst")),
 
-    b = OSXBuilder(args.opencv, args.contrib, args.dynamic, True, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
+    b = OSXBuilder(args.opencv, args.contrib, args.dynamic, args.without, args.disable, args.enablenonfree, targets, args.debug, args.debug_info, args.framework_name, args.run_tests, args.build_docs, args.swiftdisabled)
     b.build(args.out)


### PR DESCRIPTION
Removes all bitcode-related configurations from iOS and macOS framework build scripts. Bitcode has been deprecated by Apple since Xcode 14 and is no longer accepted for App Store submissions.

Apple Doc: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
Fixes #28344
