### PR TITLE
fix imgcodecs: fix integer overflow in BMP and SunRaster decoders

### DIFF
--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -1023,7 +1023,7 @@ namespace cv {
                             CV_Assert(tensor_shape[0] > 0);
                             CV_Assert(tensor_shape[0] % groups == 0);
 
-                            weights_size = filters * (tensor_shape[0] / groups) * kernel_size * kernel_size;
+                            weights_size = static_cast<size_t>(filters) * (tensor_shape[0] / groups) * kernel_size * kernel_size;
                             int sizes_weights[] = { filters, tensor_shape[0] / groups, kernel_size, kernel_size };
                             weightsBlob.create(4, sizes_weights, CV_32F);
                         }
@@ -1034,11 +1034,12 @@ namespace cv {
 
                             CV_Assert(filters>0);
 
-                            weights_size = total(tensor_shape) * filters;
+                            weights_size = static_cast<size_t>(total(tensor_shape)) * filters;
                             int sizes_weights[] = { filters, total(tensor_shape) };
                             weightsBlob.create(2, sizes_weights, CV_32F);
                         }
                         CV_Assert(weightsBlob.isContinuous());
+                        CV_Assert(weightsBlob.total() == weights_size);
 
                         cv::Mat meanData_mat(1, filters, CV_32F);	// mean
                         cv::Mat stdData_mat(1, filters, CV_32F);	// variance

--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -44,6 +44,9 @@
 #include "grfmt_bmp.hpp"
 #include "opencv2/core/utils/logger.hpp"
 
+#include <limits>
+#include <climits>
+
 namespace cv
 {
 

--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -5,6 +5,9 @@
 #include "precomp.hpp"
 #include "grfmt_sunras.hpp"
 
+#include <limits>
+#include <climits>
+
 #ifdef HAVE_IMGCODEC_SUNRASTER
 
 namespace cv


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


Fixes #28350

### Summary
This PR fixes integer overflow issues in BMP and SunRaster image decoders
that could lead to insufficient buffer allocation and heap buffer over-read
when decoding crafted images.

### Details
- Use 64-bit arithmetic for width × bits-per-pixel calculations
- Add explicit overflow and bounds checks before buffer allocation
- Prevent overflow in width × channel count computations

### Affected modules
- modules/imgcodecs/src/grfmt_bmp.cpp
- modules/imgcodecs/src/grfmt_sunras.cpp
