### PR TITLE
samples/python: avoid unnecessary frame copy in dense optical flow example

### DIFF
--- a/samples/python/dis_opt_flow.py
+++ b/samples/python/dis_opt_flow.py
@@ -72,7 +72,8 @@ def main():
     show_glitch = False
     use_spatial_propagation = False
     use_temporal_propagation = True
-    cur_glitch = prev.copy()
+    # No deep copy needed here: prev is not modified and this avoids unnecessary memory overhead
+    cur_glitch = prev
     inst = cv.DISOpticalFlow.create(cv.DISOPTICAL_FLOW_PRESET_MEDIUM)
     inst.setUseSpatialPropagation(use_spatial_propagation)
 


### PR DESCRIPTION
### Description
This PR improves the Python dense optical flow sample by removing an unnecessary deep copy of the input frame.

The frame is not modified in-place, so keeping a reference avoids extra memory overhead and provides a better example for users.

### Scope
- Python sample only
- No changes to OpenCV core behavior

### Related issue
Fixes #25347
