### PR TITLE
features2d: Add DISK (Deep Image Structure and Keypoints) detector via DNN module

### DIFF
--- a/modules/features/CMakeLists.txt
+++ b/modules/features/CMakeLists.txt
@@ -6,7 +6,7 @@ set(debug_modules "")
 if(DEBUG_opencv_features)
   list(APPEND debug_modules opencv_highgui)
 endif()
-ocv_define_module(features opencv_imgproc ${debug_modules} OPTIONAL opencv_flann WRAP java objc python js)
+ocv_define_module(features opencv_imgproc ${debug_modules} OPTIONAL opencv_flann opencv_dnn WRAP java objc python js)
 
 ocv_install_3rdparty_licenses(mscr "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/mscr/chi_table_LICENSE.txt")
 ocv_install_3rdparty_licenses(annoylib "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/annoy/LICENSE")

--- a/modules/features/include/opencv2/features.hpp
+++ b/modules/features/include/opencv2/features.hpp
@@ -587,6 +587,21 @@ public:
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
 };
 
+class CV_EXPORTS_W DISK : public Feature2D
+{
+public:
+    /**
+     * @param modelPath Path to the ONNX model file.
+     * @param backendId The DNN backend to use (default: DNN_BACKEND_DEFAULT = 0).
+     * @param targetId The DNN target to use (default: DNN_TARGET_CPU = 0).
+     */
+    static Ptr<DISK> create(const String& modelPath,
+                            int backendId = 0,  // DNN_BACKEND_DEFAULT
+                            int targetId = 0);  // DNN_TARGET_CPU
+
+    virtual String getDefaultName() const CV_OVERRIDE;
+};
+
 /** @brief Class for extracting blobs from an image. :
 
 The class implements a simple algorithm for extracting blobs from an image:

--- a/modules/features/src/disk.cpp
+++ b/modules/features/src/disk.cpp
@@ -1,0 +1,110 @@
+#include "precomp.hpp"
+#include "opencv2/features.hpp"
+#include <opencv2/dnn.hpp>
+
+namespace cv {
+
+using namespace dnn;
+
+class DISK_Impl : public DISK {
+public:
+
+    DISK_Impl(const String& _modelPath, int _backendId, int _targetId)
+        : modelPath(_modelPath), backendId(_backendId), targetId(_targetId)
+    {
+        net = readNetFromONNX(modelPath);
+        net.setPreferableBackend(backendId);
+        net.setPreferableTarget(targetId);
+    }
+
+    void detectAndCompute(InputArray _image, InputArray _mask,
+                          std::vector<KeyPoint>& keypoints,
+                          OutputArray _descriptors,
+                          bool /*useProvidedKeypoints*/) CV_OVERRIDE {
+
+        CV_UNUSED(_mask);
+        Mat image = _image.getMat();
+        if (image.empty()) return;
+
+        // 1. Preprocessing (DISK expects 1024x1024)
+        const int inputW = 1024;
+        const int inputH = 1024;
+
+        float scaleX = (float)image.cols / inputW;
+        float scaleY = (float)image.rows / inputH;
+
+        Mat inputBlob;
+        blobFromImage(image, inputBlob, 1.0/255.0, Size(inputW, inputH), Scalar(), true, false);
+
+        net.setInput(inputBlob, "image");
+
+        // 2. Inference
+        std::vector<String> outNames = {"keypoints", "scores", "descriptors"};
+        std::vector<Mat> outs;
+        net.forward(outs, outNames);
+
+        // 3. Parse Outputs
+        Mat kptsBlob = outs[0].reshape(1, outs[0].size[1]);
+        Mat scoresBlob = outs[1].reshape(1, outs[1].size[1]);
+        Mat descBlob = outs[2].reshape(1, outs[2].size[1]);
+
+        int numFeatures = kptsBlob.rows;
+        const float* kptsData = kptsBlob.ptr<float>();
+        const float* scoresData = scoresBlob.ptr<float>();
+
+        keypoints.clear();
+        std::vector<int> validIndices;
+        validIndices.reserve(numFeatures); // Optimization
+
+        for (int i = 0; i < numFeatures; ++i) {
+            float score = scoresData[i];
+            if (score > 0.0f) {
+                float x = kptsData[i * 2] * scaleX;
+                float y = kptsData[i * 2 + 1] * scaleY;
+
+                KeyPoint kp(x, y, 1.0f, -1, score);
+                keypoints.push_back(kp);
+                validIndices.push_back(i);
+            }
+        }
+
+        // 4. Filter Descriptors
+        if (_descriptors.needed()) {
+            if (validIndices.empty()) {
+                _descriptors.release();
+                return;
+            }
+
+            // Read dimension from the reshaped blob
+            int dim = descBlob.cols;
+            _descriptors.create((int)validIndices.size(), dim, CV_32F);
+            Mat descriptors = _descriptors.getMat();
+
+            for (size_t i = 0; i < validIndices.size(); ++i) {
+                // Copy the row corresponding to the valid keypoint directly
+                descBlob.row(validIndices[i]).copyTo(descriptors.row((int)i));
+            }
+        }
+    }
+
+    String getDefaultName() const CV_OVERRIDE {
+        return "Feature2D.DISK";
+    }
+
+private:
+    String modelPath;
+    int backendId;
+    int targetId;
+    Net net;
+};
+
+String DISK::getDefaultName() const {
+    return "Feature2D.DISK";
+}
+
+// Updated factory method
+Ptr<DISK> DISK::create(const String& modelPath, int backendId, int targetId) {
+    return makePtr<DISK_Impl>(modelPath, backendId, targetId);
+}
+
+} // namespace cv

--- a/modules/features/test/test_disk.cpp
+++ b/modules/features/test/test_disk.cpp
@@ -1,0 +1,47 @@
+#include "test_precomp.hpp"
+#include "opencv2/features.hpp"
+#include <fstream>
+#include <opencv2/core/utils/filesystem.hpp>
+
+namespace opencv_test { namespace {
+
+TEST(Features2d_DISK, Regression)
+{
+    // 1. Locate the model
+    // Using cvtest::findDataFile as requested by the maintainer.
+    std::string modelPath;
+    try {
+        modelPath = cvtest::findDataFile("dnn/disk_standalone.onnx", false);
+    } catch (...) {
+        std::cout << "[ SKIPPED ] DISK test: model not found (check opencv_extra)." << std::endl;
+        return;
+    }
+
+    // 2. Create the detector
+    Ptr<Feature2D> detector;
+    try {
+        detector = DISK::create(modelPath);
+    } catch (const cv::Exception& e) {
+        FAIL() << "Failed to create DISK detector: " << e.what();
+    }
+    ASSERT_TRUE(detector);
+
+    // 3. Load standard test image
+    // cvtest::findDataFile throws if not found, which causes the test to fail (correct behavior for CI)
+    std::string imgPath = cvtest::findDataFile("shared/lena.png");
+    Mat img = imread(imgPath);
+    ASSERT_FALSE(img.empty()) << "Could not load test image: " << imgPath;
+
+    // 4. Detect and Compute
+    std::vector<KeyPoint> keypoints;
+    Mat descriptors;
+    detector->detectAndCompute(img, noArray(), keypoints, descriptors);
+
+    // 5. Verification
+    EXPECT_GT(keypoints.size(), 2000u);
+    EXPECT_EQ(descriptors.rows, (int)keypoints.size());
+    EXPECT_EQ(descriptors.cols, 128);
+    EXPECT_EQ(descriptors.type(), CV_32F);
+}
+
+}} // namespace


### PR DESCRIPTION
fixes - [https://github.com/opencv/opencv/issues/27083](url)
Dependencies: opencv/opencv_extra#1313

Summary
This PR introduces the DISK (Deep Image Structure and Keypoints) feature detector and descriptor to the features2d module. The implementation wraps the inference logic using cv::dnn, allowing users to load a lightweight ONNX model for state-of-the-art local feature extraction.

DISK is a learned local feature detector that offers high-quality keypoints and descriptors, often used as a modern alternative to SIFT/ORB in deep-learning-based pipelines .

Key Changes
New Class: Added cv::DISK (derived from cv::Feature2D) in modules/features2d.

Implementation:
Uses cv::dnn::readNetFromONNX to load the model.
Handles image preprocessing (resizing/normalization) internally to match the model's requirements.
Outputs standard std::vector<KeyPoint> and cv::Mat descriptors (128-dim).

Testing:
Added modules/features2d/test/test_disk.cpp to verify regression and model loading.
Tests check for keypoint quantity, descriptor dimensionality (128), and data types.

References
Original Paper: DISK: Learning local features with policy gradient (NeurIPS 2020)
Model Source: Adapted from [LightGlue-ONNX](https://github.com/fabio-sim/LightGlue-ONNX) (specifically disk_standalone.onnx).

Test Results
Platform: macOS (x86_64)

Build Config: C++17, ProtoBuf enabled.

Test: Features2d_DISK.Regression passed successfully.

Plaintext

[ RUN      ] Features2d_DISK.Regression
[       OK ] Features2d_DISK.Regression (5289 ms)


Notes for Reviewers
This implementation introduces a dependency between features2d and dnn.

The detector requires an external .onnx model file to function. The test currently skips if the model file is not found in the working directory.[](url)