### PR TITLE
dnn(onnx): add regression test for Conv kernel inference from weights

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -3276,6 +3276,21 @@ TEST_P(Test_ONNX_layers, RandomNormalLike_complex)
     EXPECT_EQ(countNonZero(out != out2), 0);
 }
 
+TEST(DNN_ONNX, ConvKernelInferredFromWeights)
+{
+    const std::string model = cvtest::findDataFile("dnn/onnx/conv_kernel_infer.onnx", false);
+    Net net = readNetFromONNX(model);
+    ASSERT_FALSE(net.empty());
+
+    int inpDims[] = {1, 3, 8, 8};
+    Mat input = Mat::ones(4, inpDims, CV_32F);
+    net.setInput(input);
+
+    Mat out = net.forward();
+    EXPECT_EQ(out.dims, 4);
+    EXPECT_EQ(out.size[1], 2);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
### Summary
This PR adds a regression test for ONNX Conv nodes where `kernel_shape`
is not explicitly specified and must be inferred from initializer
(weight) tensor dimensions.

This scenario is valid per ONNX spec and is exercised by real-world
models such as YOLOv5.

### Motivation
OpenCV DNN previously failed to import such models, while ONNX Runtime
handled them correctly. The corresponding bug was fixed in #28282.
This test ensures the behavior remains covered going forward.

### What is tested
- Conv node without `kernel_shape` attribute
- Kernel size inferred from weight tensor shape
- Correct network import and output shape

### Tests
- `DNN_ONNX.ConvKernelInferredFromWeights`

The ONNX model used by this test is provided in:
opencv/opencv_extra#1304

### Related issues / PRs
- Fix: #28282
- Original issue: #28268

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
