### PR TITLE
Docs: Clarify BGR color order in drawing sample

### DIFF
--- a/samples/cpp/drawing.cpp
+++ b/samples/cpp/drawing.cpp
@@ -11,6 +11,7 @@ static void help(char** argv)
     "Usage:\n"
     "   %s\n", argv[0]);
 }
+// Note: OpenCV uses BGR (Blue, Green, Red) color order for Scalar
 static Scalar randomColor(RNG& rng)
 {
     int icolor = (unsigned)rng;


### PR DESCRIPTION
I added a comment to the drawing.cpp sample to clarify that OpenCV uses the BGR (Blue, Green, Red) color order for cv::Scalar. This is a small documentation improvement to help beginners avoid confusion with the standard RGB format.