### PR TITLE
Fix Python blobFromImage handling of 2-D grayscale input

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -545,5 +545,11 @@ class dnn_test(NewOpenCVTests):
         out = net.forward()
         self.assertEqual(out.shape, (1, 2, 3, 4))
 
+    def test_blobFromImage_accepts_2d_grayscale(self):
+        H, W = 64, 64
+        img = np.random.randint(0, 256, (H, W), dtype=np.uint8)
+        blob = cv.dnn.blobFromImage(img)
+        self.assertEqual(blob.shape, (1, 1, H, W))# blob shape should be (N, C, H, W)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -220,6 +220,13 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
         elemsize = CV_ELEM_SIZE(type);
     }
 
+    // Explicitly preserve single-channel intent for 2-D NumPy arrays
+    if (ndims == 2 && !ismultichannel)
+    {
+        type |= CV_MAKETYPE(0, 1);
+    }
+
+
     if (needcopy)
     {
         if (info.outputarg)


### PR DESCRIPTION
This PR fixes a regression in the Python binding of `cv.dnn.blobFromImage`
where 2-D grayscale NumPy arrays `(H, W)` were no longer handled correctly
in recent builds after OpenCV 4.12.

The fix explicitly preserves single-channel intent for 2-D inputs during
NumPy → `cv::Mat` conversion, restoring parity with the C++ API and
documented behavior.

A regression test is added to ensure grayscale inputs produce a blob of
shape `(1, 1, H, W)`.

Fixes #28358

---

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
