### PR TITLE
docs: add pythons bindings build notes to configuration reference

### DIFF
--- a/doc/tutorials/introduction/config_reference/config_reference.markdown
+++ b/doc/tutorials/introduction/config_reference/config_reference.markdown
@@ -613,6 +613,32 @@ Following options can be used to change installation layout for common scenarios
 | `BUILD_opencv_python2` | _ON_ | Build python2 bindings (deprecated). Python with development files and numpy must be installed. |
 | `BUILD_opencv_python3` | _ON_ | Build python3 bindings. Python with development files and numpy must be installed. |
 
+#### Python bindings build notes
+
+OpenCV Python bindings are built as part of the main OpenCV build when
+`BUILD_opencv_python3` is enabled. In addition to a compatible Python
+interpreter, the corresponding Python development headers and NumPy
+must be available at configuration time.
+
+When multiple Python versions are installed on the system, explicitly
+specifying Python-related CMake variables helps avoid accidental
+detection of an unintended interpreter.
+
+Typical configuration options for building Python 3 bindings:
+
+```sh
+cmake \
+  -DBUILD_opencv_python3=ON \
+  -DPYTHON3_EXECUTABLE=$(which python3) \
+  -DPYTHON3_INCLUDE_DIR=$(python3 -c "from sysconfig import get_paths; print(get_paths()['include'])") \
+  -DPYTHON3_PACKAGES_PATH=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+  ../opencv
+```
+
+The resulting Python module is installed into the configured Python
+packages directory when the `install` target is executed.
+
+
 TODO: need separate tutorials covering bindings builds
 
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


This change adds a short note describing how Python bindings are built
and how to explicitly configure Python 3 when multiple versions are
installed.

The note complements the existing configuration reference and partially
addresses the TODO related to bindings documentation.
