### PR TITLE
docs: clarify cv.split() return type in Python

### DIFF
--- a/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
+++ b/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
@@ -108,6 +108,8 @@ channels to create a BGR image. You can do this simply by:
 >>> b,g,r = cv.split(img)
 >>> img = cv.merge((b,g,r))
 @endcode
+@note In Python, `cv.split()` returns a tuple of single-channel arrays. If you need a mutable container
+(e.g. to replace/mask a channel before merging), use `channels = list(cv.split(img))`.
 Or
 @code
 >>> b = img[:,:,0]


### PR DESCRIPTION
### Summary
Clarify in the Python “Basic Operations on Images” tutorial that `cv.split()` returns a tuple in Python, and show the recommended `list(cv.split(img))` workaround when mutability is required.

### Context
Users reported that `cv2.split()` changed from returning a list to returning a tuple starting in 4.5.4.58, which can be surprising when code expects a mutable container. :contentReference[oaicite:5]{index=5}

### Changes
- Add a short note in the “Splitting and Merging Image Channels” section explaining the tuple return type and how to convert to a list when needed.

### Reference
Refs #24469

### Testing
Docs-only change; no tests / opencv_extra updates required.

 [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x, minor doc fix) :contentReference[oaicite:6]{index=6}
- [x] There is a reference to the original bug report and related work (Refs #24469) :contentReference[oaicite:7]{index=7}
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (N/A - docs-only) :contentReference[oaicite:8]{index=8}
- [x] The feature is well documented and sample code can be built with the project CMake (docs clarification) :contentReference[oaicite:9]{index=9}
