### PR TITLE
Fix copyTo on empty fixed-type matrices (#28343)

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -553,7 +553,7 @@ void Mat::release()
     for(int i = 0; i < dims; i++)
         size.p[i] = 0;
 #ifdef _DEBUG
-    flags = MAGIC_VAL;
+    flags = (flags & CV_MAT_TYPE_MASK) | MAGIC_VAL;
     dims = rows = cols = 0;
     if(step.p != step.buf)
     {

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1394,6 +1394,25 @@ TEST(Core_Mat, copyToConvertTo_Empty)
     ASSERT_EQ(C.type(), CV_32SC2);
 }
 
+// Regression test for https://github.com/opencv/opencv/issues/28343
+// copyTo on empty fixed-type matrices should be a no-op and succeed
+template <typename T> class Core_Mat_copyTo : public testing::Test {};
+TYPED_TEST_CASE_P(Core_Mat_copyTo);
+
+TYPED_TEST_P(Core_Mat_copyTo, EmptyFixedType)
+{
+    cv::Mat_<TypeParam> a;
+    cv::Mat_<TypeParam> b;
+    EXPECT_NO_THROW(a.copyTo(b));
+    EXPECT_TRUE(b.empty());
+    // Verify type is still consistent after copyTo
+    EXPECT_EQ(b.type(), cv::traits::Type<TypeParam>::value);
+}
+
+REGISTER_TYPED_TEST_CASE_P(Core_Mat_copyTo, EmptyFixedType);
+typedef ::testing::Types<uchar, schar, ushort, short, int, float, double> AllMatDepths;
+INSTANTIATE_TYPED_TEST_CASE_P(CopyToTest, Core_Mat_copyTo, AllMatDepths);
+
 TEST(Core_Mat, copyNx1ToVector)
 {
     cv::Mat_<uchar> src(5, 1);


### PR DESCRIPTION
Resolves #28343

### Problem

PR #27972 added `_dst.create(size(), type())` in `copyTo`'s empty source block. This causes an assertion failure in Debug builds when copying empty fixed-type matrices (e.g., `Mat_<double>`).

**Root cause:** In Debug builds, `Mat::release()` resets `flags = MAGIC_VAL` (type becomes 0). When `_dst.create(size(), type())` is subsequently called, the assertion `!fixedType() || ((Mat*)obj)->type() == mtype` in `matrix_wrap.cpp:1321` fails because the destination's type (reset to 0) doesn't match the source's type.

### Solution

Skip `_dst.create()` for fixed-type destinations since they already have the correct type set, and calling `create()` with a potentially different type triggers the assertion failure.

```cpp
if( empty() )
{
    _dst.release();
    if( !_dst.fixedType() )
        _dst.create(size(), type());
    return;
}
```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
