### PR TITLE
Issue Fix: Race condition in GaussianBlurFixedPoint

### DIFF
--- a/modules/imgproc/src/smooth.simd.hpp
+++ b/modules/imgproc/src/smooth.simd.hpp
@@ -619,7 +619,7 @@ void inline smooth3N121Impl(const ET* src,  int cn, ET *dst, int ito, int idst, 
     int v = idst - 1;
     int len = (width - offset) * cn;
     int x = offset * cn;
-    int maxRow = min((ito - vOffset),height-2);
+    int maxRow = min((ito - vOffset),height-vOffset);
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     VFT v_8 = vx_setall((WET)8);
     const int VECSZ = VTraits<VET>::vlanes();
@@ -708,11 +708,11 @@ template <typename ET, typename FT, typename WET, typename VFT, typename VET>
 void inline smooth5N14641Impl(const ET* src, int cn, ET* dst, int ito, int idst, int width, int height, size_t src_stride, size_t dst_stride)
 {
     int offset = 2;
-    int vOffset = 3;
+    int vOffset = 4;
     int v = idst - 2;
     int len = (width - offset) * cn;
     int x = offset * cn;
-    int maxRow = min((ito - vOffset),height-4);
+    int maxRow = min((ito - vOffset),height-vOffset);
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     VFT v_6 = vx_setall((WET)6);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This PR fixes the issue raised: **#28370** Race condition in GaussianBlurFixedPoint. 

**Root cause:** smooth5N14641 (inner region kernel) and vlineSmooth5N14641 (column kernel) write same dst rows in the bottom of the image. 