### PR TITLE
Fix potential pointer overflow in BlockSum

### DIFF
--- a/modules/imgproc/src/box_filter.simd.hpp
+++ b/modules/imgproc/src/box_filter.simd.hpp
@@ -44,6 +44,7 @@
 
 #include "precomp.hpp"
 #include "opencv2/core/hal/intrin.hpp"
+#include <cstddef>
 
 namespace cv {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
@@ -1513,7 +1514,7 @@ void BlockSum(const Mat& _src, Mat& _dst, Size ksize, Point anchor, const Size &
                                       borderLeft*sizeof(T), inplace);
         }
         else
-            ref = (const T*)(src+(srcY-roi.y)*srcStep);
+            ref = (const T*)(src+(srcY-roi.y)*(ptrdiff_t)srcStep);
 
         S = ref;
         R = (T*)alignPtr(border, VEC_ALIGN);


### PR DESCRIPTION
srcY-roi.y is promoted to size_t which creates problems when it is
negative.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
