### PR TITLE
dnn: Fix compilation errors when build with WITH_VULKAN option

### DIFF
--- a/modules/dnn/src/op_vkcom.cpp
+++ b/modules/dnn/src/op_vkcom.cpp
@@ -83,7 +83,7 @@ void copyToTensor(vkcom::Tensor &dst, const Mat &src)
 {
     CV_Assert(src.isContinuous() && src.type() == CV_32F);
 
-    std::vector<int> mat_shape = shape(src);
+    std::vector<int> mat_shape = shape(src).vec();
 
     // The following code will copy the src data from CPU Mat to GPU VkBuffer.
     dst.reshape((const char*)src.data, mat_shape);
@@ -168,7 +168,7 @@ VkComBackendWrapper::VkComBackendWrapper(const Ptr<BackendWrapper>& baseBuffer, 
     host = &m;
     tensor = base->tensor;
     CV_Assert(tensor.count() >= m.total());
-    tensor.reshape(0, shape(m));
+    tensor.reshape(0, shape(m).vec());
     hostDirty = false;
     deviceDirty = false;
 }

--- a/modules/dnn/src/vkcom/src/op_conv.cpp
+++ b/modules/dnn/src/vkcom/src/op_conv.cpp
@@ -84,7 +84,7 @@ OpConv::OpConv(const Mat& weightBlob, const std::vector<float>& biasvec, int _ac
         // Create weightTensor
         Tensor weightTensor;
         CV_Assert(weightBlob.isContinuous() && weightBlob.type() == CV_32F);
-        std::vector<int> matShape = shape(weightBlob);
+        std::vector<int> matShape = shape(weightBlob).vec();
         weightTensor.reshape((const char*)weightBlob.data, matShape); // This code will copy the src data from Mat to VkBuffer.
 
         weightTensorPtr = makePtr<Tensor>(weightTensor);

--- a/modules/dnn/src/vkcom/src/op_matmul.cpp
+++ b/modules/dnn/src/vkcom/src/op_matmul.cpp
@@ -23,7 +23,7 @@ OpMatMul::OpMatMul(std::vector<Mat>& matBlobs, const int _M, const int _K, const
     {
         Tensor weightTensor;
         CV_Assert(matBlobs[0].isContinuous() && matBlobs[0].type() == CV_32F);
-        std::vector<int> matShape = shape(matBlobs[0]);
+        std::vector<int> matShape = shape(matBlobs[0]).vec();
         weightTensor.reshape((const char*)matBlobs[0].data, matShape); // This code will copy the src data from Mat to VkBuffer.
 
         weightTensorPtr = makePtr<Tensor>(weightTensor);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Summary

Since the branch `5.x` has a brand new class `MatShape`, it cannot be convert to `std::vector<int>` directly, like what we have done on branch `4.x`.

Here, we use the `MatShape::vec()` to fix compilation errors when having `WITH_VULKAN=ON` option.