### PR TITLE
Improve precision of RotatedRect::points

### DIFF
--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -176,14 +176,18 @@ void RotatedRect::points(Point2f pt[]) const
     float b = (float)cos(_angle)*0.5f;
     float a = (float)sin(_angle)*0.5f;
 
-    pt[0].x = center.x - a*size.height - b*size.width;
-    pt[0].y = center.y + b*size.height - a*size.width;
-    pt[1].x = center.x + a*size.height - b*size.width;
-    pt[1].y = center.y - b*size.height - a*size.width;
-    pt[2].x = 2*center.x - pt[0].x;
-    pt[2].y = 2*center.y - pt[0].y;
-    pt[3].x = 2*center.x - pt[1].x;
-    pt[3].y = 2*center.y - pt[1].y;
+    const float ah = a*size.height;
+    const float aw = a*size.width;
+    const float bh = b*size.height;
+    const float bw = b*size.width;
+    pt[0].x = center.x - ah - bw;
+    pt[0].y = center.y + bh - aw;
+    pt[1].x = center.x + ah - bw;
+    pt[1].y = center.y - bh - aw;
+    pt[2].x = center.x + ah + bw;
+    pt[2].y = center.y - bh + aw;
+    pt[3].x = center.x - ah + bw;
+    pt[3].y = center.y + bh + aw;
 }
 
 void RotatedRect::points(std::vector<Point2f>& pts) const {

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -585,6 +585,19 @@ TEST(Imgproc_minAreaRect, reproducer_19769)
     EXPECT_TRUE(checkMinAreaRect(rr, contour)) << rr.center << " " << rr.size << " " << rr.angle;
 }
 
+TEST(Imgproc_minAreaRect, roundtrip_accuracy)
+{
+    RotatedRect rect(Point2f(12.f, 56.f), Size2f(10.f, 25.f), -45.f);
+    std::vector<Point2f> points;
+    rect.points(points);
+    RotatedRect rect_out = minAreaRect(points);
+    EXPECT_LT(std::abs(rect.center.x - rect_out.center.x), 1e-5);
+    EXPECT_LT(std::abs(rect.center.y - rect_out.center.y), 1e-5);
+    EXPECT_LT(std::abs(rect.size.width - rect_out.size.width), 1e-5);
+    EXPECT_LT(std::abs(rect.size.height - rect_out.size.height), 1e-5);
+    EXPECT_LT(std::abs(rect.angle - rect_out.angle), 1e-5);
+}
+
 TEST(Imgproc_minEnclosingTriangle, regression_17585)
 {
     const int N = 3;


### PR DESCRIPTION
Not by much but enough to get a test to pass.

The inaccuracy of the roundtrip actually does not come from minAreaRect (even though it is in floats), but from tthe points() function

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
