### PR TITLE
Use Mat::total() in Darknet IO

### DIFF
--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -1008,7 +1008,6 @@ namespace cv {
 
                     if (layer_type == "convolutional" || layer_type == "connected")
                     {
-                        size_t weights_size;
                         int filters;
                         bool use_batch_normalize;
                         cv::Mat weightsBlob;
@@ -1023,7 +1022,6 @@ namespace cv {
                             CV_Assert(tensor_shape[0] > 0);
                             CV_Assert(tensor_shape[0] % groups == 0);
 
-                            weights_size = filters * (tensor_shape[0] / groups) * kernel_size * kernel_size;
                             int sizes_weights[] = { filters, tensor_shape[0] / groups, kernel_size, kernel_size };
                             weightsBlob.create(4, sizes_weights, CV_32F);
                         }
@@ -1034,7 +1032,6 @@ namespace cv {
 
                             CV_Assert(filters>0);
 
-                            weights_size = total(tensor_shape) * filters;
                             int sizes_weights[] = { filters, total(tensor_shape) };
                             weightsBlob.create(2, sizes_weights, CV_32F);
                         }
@@ -1051,7 +1048,7 @@ namespace cv {
                             ifile.read(reinterpret_cast<char *>(meanData_mat.ptr<float>()), sizeof(float)*filters);
                             ifile.read(reinterpret_cast<char *>(stdData_mat.ptr<float>()), sizeof(float)*filters);
                         }
-                        ifile.read(reinterpret_cast<char *>(weightsBlob.ptr<float>()), sizeof(float)*weights_size);
+                        ifile.read(reinterpret_cast<char *>(weightsBlob.ptr<float>()), sizeof(float)*weightsBlob.total());
 
                         // set conv/connected weights
                         std::vector<cv::Mat> layer_blobs;


### PR DESCRIPTION
We don't need `weights_size`, because it's the same as `Mat::total()`. Another advantage of calling `Mat::total()` is that it casts to `size_t` before multiplying, so potential integer overflow can't happen anymore. This closes #28352

I haven't added a test for it. If you like I can do so (I would generate the 2.3GB dummy weights file in the test code).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
