### PR TITLE
doc: update image codec configuration reference (add AVIF, fix JPEG XL)

### DIFF
--- a/doc/tutorials/introduction/config_reference/config_reference.markdown
+++ b/doc/tutorials/introduction/config_reference/config_reference.markdown
@@ -317,7 +317,7 @@ Following formats can be read by OpenCV without help of any third-party library:
 | [PFM](https://en.wikipedia.org/wiki/Netpbm#File_formats) | `WITH_IMGCODEC_PFM` | _ON_ |
 | [GIF](https://en.wikipedia.org/wiki/GIF) | `WITH_IMGCODEC_GIF` | _ON_ |
 
-### PNG, JPEG, TIFF, WEBP, JPEG 2000, EXR, JPEG XL support
+### PNG, JPEG, TIFF, WEBP, JPEG 2000, EXR, JPEG XL, AVIF support
 
 | Formats | Library | Option | Default | Force build own |
 | --------| ------- | ------ | ------- | --------------- |


### PR DESCRIPTION
This PR updates the build configuration documentation to:
- Add AVIF to the supported format list (it was missing).
- Clarify that some codecs (AVIF, JPEG XL) do not support BUILD_* options because OpenCV does not bundle their source code.
- Update the description to include "write" capabilities for these formats.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
