### PR TITLE
docs: add copy-to-clipboard icon for code blocks

### DIFF
--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -2290,3 +2290,53 @@ body {
 ::-webkit-scrollbar-corner {
     background-color: var(--scrollbar-background-color);
 }
+
+.copy-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    z-index: 10;
+}
+
+.copy-icon, .tick-icon {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke-width: 2;
+}
+
+.copy-icon {
+    stroke: white;
+    opacity: 0.85;
+}
+
+.copy-button:hover .copy-icon {
+    opacity: 1;
+}
+
+.tick-icon {
+    stroke: #00ff66; /* green tick */
+}
+
+.copy-tooltip {
+    position: absolute;
+    top: -26px;
+    right: 0;
+    background: black;
+    color: white;
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    opacity: 0;
+    white-space: nowrap;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.copy-button:hover .copy-tooltip {
+    opacity: 1;
+}

--- a/doc/tutorial-utils.js
+++ b/doc/tutorial-utils.js
@@ -101,3 +101,47 @@ function addTutorialsButtons() {
     }
     return;
 }
+
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("pre").forEach(function (block) {
+        if (block.querySelector(".copy-button")) return;
+
+        // Save original code text
+        const codeText = block.textContent;
+
+        const button = document.createElement("button");
+        button.className = "copy-button";
+
+        const copyIcon = `
+          <svg class="copy-icon" viewBox="0 0 24 24">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+            <rect x="3" y="3" width="13" height="13" rx="2" ry="2"/>
+          </svg>
+        `;
+
+        const tickIcon = `
+          <svg class="tick-icon" viewBox="0 0 24 24">
+            <polyline points="4,12 9,17 20,6" />
+          </svg>
+        `;
+
+        button.innerHTML = `
+          <span class="icon-wrapper">${copyIcon}</span>
+          <span class="copy-tooltip">Copy</span>
+        `;
+
+        button.addEventListener("click", function () {
+            navigator.clipboard.writeText(codeText);
+
+            const iconWrapper = button.querySelector(".icon-wrapper");
+            iconWrapper.innerHTML = tickIcon;
+
+            setTimeout(function () {
+                iconWrapper.innerHTML = copyIcon;
+            }, 1200);
+        });
+
+        block.style.position = "relative";
+        block.appendChild(button);
+    });
+});


### PR DESCRIPTION
Fixes #28391

## Description

This PR adds a copy-to-clipboard button to all Doxygen-rendered `<pre>` code blocks in the OpenCV documentation.
______________

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
        Patch to opencv_extra has the same branch name.
        (Not applicable)
- [ ] The feature is well documented and sample code can be built with the project CMake
        (Not applicable)
______________

## Files changed

- `doc/tutorial-utils.js` – Adds copy icon and green tick feedback
- `doc/stylesheet.css` – Styles copy icon, tooltip, and success indicator