### PR TITLE
Docs : clarify sample image availability in display image tutorial

### DIFF
--- a/doc/tutorials/introduction/display_image/display_image.markdown
+++ b/doc/tutorials/introduction/display_image/display_image.markdown
@@ -67,6 +67,12 @@ By declaring `using namespace cv;`, in the following, the library functions can 
 
 @add_toggle_python
 As a first step, the OpenCV python library is imported.
+
+@note
+When installing OpenCV via PyPI('pip install opencv-python'), sample images such as 'starry_night.jpg' are not included in the package.
+If the example fails to locate the image, download it manually from:
+https://github.com/opencv/opencv/blob/4.x/samples/data/starry_night.jpg
+
 The proper way to do this is to additionally assign it the name *cv*, which is used in the following to reference the library.
 
 @snippet samples/python/tutorial_code/introduction/display_image/display_image.py imports


### PR DESCRIPTION
# ⚠️ Clarification: Sample Images Not Included in PyPI OpenCV

When installing OpenCV via PyPI:

```bash
pip install opencv-python
```

**sample images like `starry_night.jpg` are NOT included.**
This can cause beginners following the *"Getting Started with Images (Python)"* tutorial to encounter file errors.

---

## Example Code

```python
import cv2

# Attempting to load a sample image
img = cv2.imread("starry_night.jpg")  # ❌ FileNotFoundError
cv2.imshow("Starry Night", img)
cv2.waitKey(0)
cv2.destroyAllWindows()
```

##  Resulting Error

<img width="1094" height="157" alt="image_2026-01-14_012143050" src="https://github.com/user-attachments/assets/5298c8d7-a166-4cf6-91bd-f2a793c47067" />


---

## Explanation

The tutorial assumes these images are present locally, but they **aren't included** in the PyPI package. Users can either:

### Download the images manually

```python
import urllib.request

url = "https://github.com/opencv/opencv/raw/master/samples/data/starry_night.jpg"
urllib.request.urlretrieve(url, "starry_night.jpg")
```
