### PR TITLE
Optimized Bilateral Filter (32f) with AVX512

### DIFF
--- a/modules/imgproc/CMakeLists.txt
+++ b/modules/imgproc/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(the_description "Image Processing")
 ocv_add_dispatched_file(accum SSE4_1 AVX AVX2)
-ocv_add_dispatched_file(bilateral_filter SSE2 AVX2)
+ocv_add_dispatched_file(bilateral_filter SSE2 AVX2 AVX512_SKX AVX512_ICL)
 ocv_add_dispatched_file(box_filter SSE2 SSE4_1 AVX2 AVX512_SKX)
 ocv_add_dispatched_file(filter SSE2 SSE4_1 AVX2)
 ocv_add_dispatched_file(color_hsv SSE2 SSE4_1 AVX2)


### PR DESCRIPTION
- Optimized Bilateral Filter performance for Zen 4(AVX_SKX) and above architectures.
- Enhanced BilateralFilter (32f) implementation with AVX512 optimizations.
- Added AVX512_SKX and AVX512_ICL dispatch support.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

