### PR TITLE
Fix integer overflow in medianBlur for large images and ROIs

### DIFF
--- a/modules/imgproc/src/median_blur.simd.hpp
+++ b/modules/imgproc/src/median_blur.simd.hpp
@@ -388,12 +388,19 @@ medianBlur_8u_Om( const Mat& _src, Mat& _dst, int m )
         const uchar* src_top = src;
         const uchar* src_bottom = src;
         int k, c;
-        int src_step1 = (int)src_step, dst_step1 = (int)dst_step;
+        ptrdiff_t src_step1 = (ptrdiff_t)src_step, dst_step1 = (ptrdiff_t)dst_step;
 
         if( x % 2 != 0 )
         {
-            src_bottom = src_top += src_step*(size.height-1);
-            dst_cur += dst_step*(size.height-1);
+            size_t src_off = (size_t)src_step * (size_t)(size.height - 1);
+            CV_Assert(src_off == 0 || src_off / src_step == (size_t)(size.height - 1));
+            src_top += src_off;
+            src_bottom = src_top;
+
+            size_t dst_off = (size_t)dst_step * (size_t)(size.height - 1);
+            CV_Assert(dst_off == 0 || dst_off / dst_step == (size_t)(size.height - 1));
+            dst_cur += dst_off;
+
             src_step1 = -src_step1;
             dst_step1 = -dst_step1;
         }


### PR DESCRIPTION
This PR fixes a crash in cv::medianBlur when processing very large images or large ROIs, as reported in issue #28385.

The root cause was 32-bit integer overflow in internal size and stride computations such as:
- step × rows
- (stripe + border) × channels
- large vertical pointer offsets

These overflows could lead to incorrect buffer allocation and pointer wrap-around, causing heap corruption and segmentation faults.

The patch hardens all medianBlur backends (SortNet, 8u O(m), and 8u O(1)) by:
- Switching buffer and stride calculations to size_t
- Using ptrdiff_t for signed pointer stepping
- Adding overflow-safe CV_Assert guards for large products
- Preserving ROI behavior by always using Mat::step instead of recomputing from width

The filtering algorithm, SIMD paths, and median selection logic are unchanged; only integer types and safety checks were updated.

This prevents crashes for cases such as:

cv::Mat img(50000, 50000, CV_16U);
cv::medianBlur(img, out, 3);

cv::Mat sub = img(cv::Rect(0, 0, 100, 50000));
cv::medianBlur(sub, out, 3);

as well as large 8-bit images and ROIs.

Closes #28385


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
