### PR TITLE
imgproc: replace assertion in cornerSubPix with descriptive error

### DIFF
--- a/modules/imgproc/src/cornersubpix.cpp
+++ b/modules/imgproc/src/cornersubpix.cpp
@@ -96,14 +96,11 @@ void cv::cornerSubPix( InputArray _image, InputOutputArray _corners,
     for( int pt_i = 0; pt_i < count; pt_i++ )
     {
         Point2f cT = corners[pt_i], cI = cT;
-
         if (!Rect(0, 0, src.cols, src.rows).contains(cT))
         {
             CV_Error(Error::StsOutOfRange,
                     "cornerSubPix: initial corner is outside the image.");
         }
- 
-        
         int iter = 0;
         double err = 0;
 


### PR DESCRIPTION
Replace CV_Assert with explicit bounds check for initial corners in cornerSubPix.

This provides a descriptive runtime error instead of abrupt termination,
improving error handling for Python and C++ users.

No algorithmic or behavioral change for valid inputs.

Fixes #25139 (Related to #7276).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
