### PR TITLE
dnn: refactor packWeight() to use indexed buffer offsets

### DIFF
--- a/modules/dnn/src/layers/attention_layer.cpp
+++ b/modules/dnn/src/layers/attention_layer.cpp
@@ -13,14 +13,15 @@ namespace cv { namespace dnn {
 static void packWeight(size_t num_heads, size_t head_size, size_t input_hidden_size,
                        const float *weight_data, size_t hidden_size, std::vector<float> &packed_weight, const FastGemmOpt &opt) {
     // num_heads * pack(head_size, input_hidden_size)
-    size_t pack_size = fastGemmPackBSize(head_size, input_hidden_size, opt);
-    size_t packed_weight_size = num_heads * pack_size;
-    packed_weight.resize(packed_weight_size, 0.f);
-    auto *packed_weight_data = packed_weight.data();
+    const size_t pack_size = fastGemmPackBSize(head_size, input_hidden_size, opt);
+    const size_t packed_weight_size = num_heads * pack_size;
+    packed_weight.resize(packed_weight_size);
+    float *base_packed_dst = packed_weight.data();
     for (size_t i = 0; i < num_heads; i++) {
-        fastGemmPackB(false, head_size, input_hidden_size, weight_data, hidden_size, packed_weight_data, opt);
-        packed_weight_data += pack_size;
-        weight_data += head_size;
+        const float *current_src = weight_data + i * head_size;
+        float *current_dst = base_packed_dst + i * pack_size;
+
+        fastGemmPackB(false, head_size, input_hidden_size, current_src, hidden_size, current_dst, opt);
     }
 }
 


### PR DESCRIPTION
Refactor packWeight() to use index-based source and destination offsets instead of
mutating pointers. This improves readability and makes the loop safe for future
parallelization without changing behavior.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
