### PR TITLE
dnn(onnx): reject empty initializer tensors

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -420,6 +420,12 @@ std::map<std::string, Mat> ONNXImporter::getGraphTensors(
         const opencv_onnx::TensorProto& tensor_proto = graph_proto.initializer(i);
         dumpTensorProto(i, tensor_proto, "initializer");
         Mat mat = getMatFromTensor(tensor_proto);
+        if (mat.empty())
+        {
+            CV_Error(Error::StsBadArg,
+                cv::format("ONNX initializer '%s' has empty tensor data",
+                        tensor_proto.name().c_str()));
+        }
         releaseONNXTensor(const_cast<opencv_onnx::TensorProto&>(tensor_proto));  // drop already loaded data
 
         if (DNN_DIAGNOSTICS_RUN && mat.empty())

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -3276,6 +3276,13 @@ TEST_P(Test_ONNX_layers, RandomNormalLike_complex)
     EXPECT_EQ(countNonZero(out != out2), 0);
 }
 
+TEST(ONNX_Importer, EmptyInitializer)
+{
+    const std::string model =
+        findDataFile("dnn/onnx/conv_empty_initializer.onnx");
+    EXPECT_THROW(readNetFromONNX(model), cv::Exception);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
### Summary
This PR adds a regression test and a fix to reject ONNX models containing
empty initializer tensors.

### Problem
Currently, OpenCV accepts ONNX graphs with empty initializer tensors and
fails later during layer processing with an uncontrolled exception.

### Solution
The ONNX importer now validates initializer tensors early and rejects empty
initializers with a clear `cv::Exception`.

### Testing
- Added `ONNX_Importer.EmptyInitializer` regression test
- Test fails on current `4.x` and passes with this fix

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
