### PR TITLE
Stitching: Update default features to SIFT and use USAC solver

### DIFF
--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -424,7 +424,7 @@ void BestOf2NearestMatcher::match(const ImageFeatures &features1, const ImageFea
     }
 
     // Find pair-wise motion
-    matches_info.H = findHomography(src_points, dst_points, matches_info.inliers_mask, RANSAC);
+    matches_info.H = findHomography(src_points, dst_points, USAC_MAGSAC, 3.0, matches_info.inliers_mask);
     if (matches_info.H.empty() || std::abs(determinant(matches_info.H)) < std::numeric_limits<double>::epsilon())
         return;
 
@@ -471,7 +471,7 @@ void BestOf2NearestMatcher::match(const ImageFeatures &features1, const ImageFea
     }
 
     // Rerun motion estimation on inliers only
-    matches_info.H = findHomography(src_points, dst_points, RANSAC);
+    matches_info.H = findHomography(src_points, dst_points, USAC_MAGSAC, 3.0);
 }
 
 void BestOf2NearestMatcher::collectGarbage()

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -54,7 +54,7 @@ Ptr<Stitcher> Stitcher::create(Mode mode)
     stitcher->setPanoConfidenceThresh(1);
     stitcher->setSeamFinder(makePtr<detail::GraphCutSeamFinder>(detail::GraphCutSeamFinderBase::COST_COLOR));
     stitcher->setBlender(makePtr<detail::MultiBandBlender>(false));
-    stitcher->setFeaturesFinder(ORB::create());
+    stitcher->setFeaturesFinder(SIFT::create());
     stitcher->setInterpolationFlags(INTER_LINEAR);
 
     stitcher->work_scale_ = 1;


### PR DESCRIPTION
### Description
This PR addresses part of issue #26504 ("Refresh stitching module"). 

It updates the default configuration for the stitching module:
1.  **SIFT Default:** Switched `Stitcher::create` to use `SIFT` instead of `ORB` as the default feature finder, aligning with the `features2d` reorganization.
2.  **USAC Solver:** Updated `BestOf2NearestMatcher` to use `USAC_MAGSAC` instead of `RANSAC` for homography estimation, providing more robust and faster estimation.

### Checks
- [x] Logic verified locally (SIFT creation and USAC flags updated).
- [ ] Stitched panorama verified (Pending CI execution).