### PR TITLE
Fix INTER_NEAREST_EXACT to match PIL/scikit-image nearest neighbor be…

### DIFF
--- a/hal/riscv-rvv/src/imgproc/resize.cpp
+++ b/hal/riscv-rvv/src/imgproc/resize.cpp
@@ -40,15 +40,15 @@ static inline int invoke(int height, std::function<int(int, int, Args...)> func,
 }
 
 template<int cn>
-static inline int resizeNN(int start, int end, const uchar *src_data, size_t src_step, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, double scale_y, int interpolation, const ushort* x_ofs)
+static inline int resizeNN(int start, int end, const uchar *src_data, size_t src_step, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, int interpolation, const ushort* x_ofs, const ushort* y_ofs_arr)
 {
-    const int ify = ((src_height << 16) + dst_height / 2) / dst_height;
-    const int ify0 = ify / 2 - src_height % 2;
+    (void)src_height;  // Already used in precomputed y_ofs_arr
+    (void)dst_height;  // Already used in precomputed y_ofs_arr
+    (void)interpolation;  // Already handled in precomputed arrays
 
     for (int i = start; i < end; i++)
     {
-        int y_ofs = interpolation == CV_HAL_INTER_NEAREST ? static_cast<int>(std::floor(i * scale_y)) : (ify * i + ify0) >> 16;
-        y_ofs = std::min(y_ofs, src_height - 1);
+        int y_ofs = y_ofs_arr[i];
 
         int vl;
         switch (cn)
@@ -744,24 +744,48 @@ static inline int resizeNN(int src_type, const uchar *src_data, size_t src_step,
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
 
     std::vector<ushort> x_ofs(dst_width);
-    const int ifx = ((src_width << 16) + dst_width / 2) / dst_width;
-    const int ifx0 = ifx / 2 - src_width % 2;
-    for (int i = 0; i < dst_width; i++)
+    std::vector<ushort> y_ofs(dst_height);
+
+    if (interpolation == CV_HAL_INTER_NEAREST)
     {
-        x_ofs[i] = interpolation == CV_HAL_INTER_NEAREST ? static_cast<ushort>(std::floor(i * scale_x)) : (ifx * i + ifx0) >> 16;
-        x_ofs[i] = std::min(x_ofs[i], static_cast<ushort>(src_width - 1)) * cn;
+        for (int i = 0; i < dst_width; i++)
+        {
+            x_ofs[i] = static_cast<ushort>(std::min(static_cast<int>(std::floor(i * scale_x)), src_width - 1)) * cn;
+        }
+        for (int i = 0; i < dst_height; i++)
+        {
+            y_ofs[i] = static_cast<ushort>(std::min(static_cast<int>(std::floor(i * scale_y)), src_height - 1));
+        }
+    }
+    else // CV_HAL_INTER_NEAREST_EXACT
+    {
+        // Use double-precision iterative accumulation to match PIL/Pillow's behavior exactly.
+        // PIL computes source coordinates using iterative floating-point addition which
+        // accumulates rounding errors differently than direct computation.
+        double xo = scale_x * 0.5;
+        for (int i = 0; i < dst_width; i++)
+        {
+            x_ofs[i] = static_cast<ushort>(std::min(static_cast<int>(xo), src_width - 1)) * cn;
+            xo += scale_x;
+        }
+        double yo = scale_y * 0.5;
+        for (int i = 0; i < dst_height; i++)
+        {
+            y_ofs[i] = static_cast<ushort>(std::min(static_cast<int>(yo), src_height - 1));
+            yo += scale_y;
+        }
     }
 
     switch (src_type)
     {
     case CV_8UC1:
-        return invoke(dst_height, {resizeNN<1>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
+        return invoke(dst_height, {resizeNN<1>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, interpolation, x_ofs.data(), y_ofs.data());
     case CV_8UC2:
-        return invoke(dst_height, {resizeNN<2>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
+        return invoke(dst_height, {resizeNN<2>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, interpolation, x_ofs.data(), y_ofs.data());
     case CV_8UC3:
-        return invoke(dst_height, {resizeNN<3>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
+        return invoke(dst_height, {resizeNN<3>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, interpolation, x_ofs.data(), y_ofs.data());
     case CV_8UC4:
-        return invoke(dst_height, {resizeNN<4>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
+        return invoke(dst_height, {resizeNN<4>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, interpolation, x_ofs.data(), y_ofs.data());
     }
     return CV_HAL_ERROR_NOT_IMPLEMENTED;
 }

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1174,18 +1174,17 @@ resizeNN( const Mat& src, Mat& dst, double fx, double fy )
 class resizeNN_bitexactInvoker : public ParallelLoopBody
 {
 public:
-    resizeNN_bitexactInvoker(const Mat& _src, Mat& _dst, int* _x_ofse, int _ify, int _ify0)
-        : src(_src), dst(_dst), x_ofse(_x_ofse), ify(_ify), ify0(_ify0) {}
+    resizeNN_bitexactInvoker(const Mat& _src, Mat& _dst, int* _x_ofse, int* _y_ofse)
+        : src(_src), dst(_dst), x_ofse(_x_ofse), y_ofse(_y_ofse) {}
 
     virtual void operator() (const Range& range) const CV_OVERRIDE
     {
-        Size ssize = src.size(), dsize = dst.size();
+        Size dsize = dst.size();
         int pix_size = (int)src.elemSize();
         for( int y = range.start; y < range.end; y++ )
         {
             uchar* D = dst.ptr(y);
-            int _sy = (ify * y + ify0) >> 16;
-            int sy = std::min(_sy, ssize.height-1);
+            int sy = y_ofse[y];
             const uchar* S = src.ptr(sy);
 
             int x = 0;
@@ -1260,30 +1259,45 @@ private:
     const Mat& src;
     Mat& dst;
     int* x_ofse;
-    const int ify;
-    const int ify0;
+    int* y_ofse;
 };
 
 static void resizeNN_bitexact( const Mat& src, Mat& dst, double /*fx*/, double /*fy*/ )
 {
     Size ssize = src.size(), dsize = dst.size();
-    int ifx = ((ssize.width << 16) + dsize.width / 2) / dsize.width; // 16bit fixed-point arithmetic
-    int ifx0 = ifx / 2 - ssize.width % 2;                       // This method uses center pixel coordinate as Pillow and scikit-images do.
-    int ify = ((ssize.height << 16) + dsize.height / 2) / dsize.height;
-    int ify0 = ify / 2 - ssize.height % 2;
+
+    // Use double-precision iterative accumulation to match PIL/Pillow's behavior exactly.
+    // PIL computes source coordinates using iterative floating-point addition which
+    // accumulates rounding errors differently than direct computation. To match PIL
+    // exactly, we must replicate this behavior.
+    double scale_x = static_cast<double>(ssize.width) / static_cast<double>(dsize.width);
+    double scale_y = static_cast<double>(ssize.height) / static_cast<double>(dsize.height);
 
     cv::utils::BufferArea area;
     int* x_ofse = 0;
+    int* y_ofse = 0;
     area.allocate(x_ofse, dsize.width, CV_SIMD_WIDTH);
+    area.allocate(y_ofse, dsize.height, CV_SIMD_WIDTH);
     area.commit();
 
+    // Compute x offsets using iterative accumulation (like PIL)
+    double xo = scale_x * 0.5;
     for( int x = 0; x < dsize.width; x++ )
     {
-        int sx = (ifx * x + ifx0) >> 16;
-        x_ofse[x] = std::min(sx, ssize.width-1);    // offset in element (not byte)
+        x_ofse[x] = std::min(static_cast<int>(xo), ssize.width - 1);
+        xo += scale_x;
     }
+
+    // Compute y offsets using iterative accumulation (like PIL)
+    double yo = scale_y * 0.5;
+    for( int y = 0; y < dsize.height; y++ )
+    {
+        y_ofse[y] = std::min(static_cast<int>(yo), ssize.height - 1);
+        yo += scale_y;
+    }
+
     Range range(0, dsize.height);
-    resizeNN_bitexactInvoker invoker(src, dst, x_ofse, ify, ify0);
+    resizeNN_bitexactInvoker invoker(src, dst, x_ofse, y_ofse);
     parallel_for_(range, invoker, dst.total()/(double)(1<<16));
 }
 


### PR DESCRIPTION
…havior

Issue: #28429
- Fixed ifx0 and ify0 calculation to use (if - (1 << 16)) >> 1 instead of if / 2 - size % 2

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
