### PR TITLE
Fix UB in cv::error when breakOnError set to true

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1282,8 +1282,7 @@ void error( const Exception& exc )
 
     if(breakOnError)
     {
-        static volatile int* p = 0;
-        *p = 0;
+        std::terminate();
     }
 
     throw exc;


### PR DESCRIPTION
Fixes #28436.
Replaces a nullptr dereference (unguaranteed to cause a SEGFAULT) by `std::terminate` which will call 
the current `std::terminate_handler` and then SIGARBT.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
