### PR TITLE
Fix: Make 'Getting Started with Images' tutorial work without sample …

### DIFF
--- a/samples/python/tutorial_code/introduction/display_image/display_image.py
+++ b/samples/python/tutorial_code/introduction/display_image/display_image.py
@@ -4,6 +4,14 @@ import sys
 ## [imports]
 ## [imread]
 img = cv.imread(cv.samples.findFile("starry_night.jpg"))
+if img is None:
+    # If sample image is not available (e.g., pip install), create a sample image
+    # This ensures the tutorial works out-of-the-box with pip install opencv-python
+    import numpy as np
+    img = np.random.randint(0, 256, (480, 640, 3), dtype=np.uint8)
+    print("Note: Sample image not found. Using generated image for demonstration.")
+    print("For the full tutorial with the actual starry_night.jpg, download the OpenCV samples:")
+    print("https://github.com/opencv/opencv/tree/master/samples")
 ## [imread]
 ## [empty]
 if img is None:


### PR DESCRIPTION
…files  Fixes #28398

- Added fallback to generate a sample image when starry_night.jpg is not found
- Ensures tutorial works out-of-the-box with 'pip install opencv-python'
- Provides helpful hints to users about accessing the full sample repository
- Resolves issue where beginners would encounter a hard crash

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
