### PR TITLE
docs: handle missing sample image in Python display_image tutorial

### DIFF
--- a/samples/python/tutorial_code/introduction/display_image/display_image.py
+++ b/samples/python/tutorial_code/introduction/display_image/display_image.py
@@ -2,17 +2,32 @@
 import cv2 as cv
 import sys
 ## [imports]
+
 ## [imread]
-img = cv.imread(cv.samples.findFile("starry_night.jpg"))
+img_path = cv.samples.findFile("starry_night.jpg", required=False)
+
+if not img_path:
+    print("Error: sample image 'starry_night.jpg' not found.")
+    print(
+        "Download it from:\n"
+        "https://raw.githubusercontent.com/opencv/opencv/master/samples/data/starry_night.jpg"
+    )
+    sys.exit("Sample image not found. See instructions above.")
+
+
+img = cv.imread(img_path)
 ## [imread]
+
 ## [empty]
 if img is None:
     sys.exit("Could not read the image.")
 ## [empty]
+
 ## [imshow]
 cv.imshow("Display window", img)
 k = cv.waitKey(0)
 ## [imshow]
+
 ## [imsave]
 if k == ord("s"):
     cv.imwrite("starry_night.png", img)


### PR DESCRIPTION
### What does this PR do?
Makes the Python “Getting Started with Images” tutorial robust for users who install OpenCV via pip.

### Why is this needed?
The tutorial relies on `cv.samples.findFile("starry_night.jpg")`, which fails for pip-based installs because sample data is not included, causing a crash for beginners.

### What was changed?
- Use `cv.samples.findFile(..., required=False)`
- Add a clear error message with a direct download link for the sample image
- Preserve documentation snippet markers

### Related issue
Fixes #28398
