### PR TITLE
Fix setup usage example async syntax

### DIFF
--- a/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
+++ b/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
@@ -71,7 +71,7 @@ For example, you can create a cv.Mat from an image by cv.imread.
 @note Because image loading is asynchronous, you need to put cv.Mat creation inside the `onload` callback.
 
 @code{.js}
-imgElement.onload = await function() {
+imgElement.onload = async function() {
   cv = (cv instanceof Promise) ? await cv : cv;
   let mat = cv.imread(imgElement);
 }


### PR DESCRIPTION
The syntax used to declare an async function in the setup usage tutorial is incorrect. It tries to use the `await` keyword to declare an async function, however, to do that you have to use the `async` keyword.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
