### PR TITLE
Fix: TopK layer K boundary check allows K == input_dim (#28445)

### DIFF
--- a/modules/dnn/src/layers/topk_layer.cpp
+++ b/modules/dnn/src/layers/topk_layer.cpp
@@ -97,9 +97,9 @@ public:
         // Normalize axis
         int axis_normalized = normalize_axis(axis, input_shape.size());
 
-        // Check if K is in range (0, input_shape[axis])
+        // Check if K is in range (0, input_shape[axis]]
         CV_CheckGT(K, 0, "TopK: K needs to be a positive integer");
-        CV_CheckLT(K, input_shape[axis_normalized], "TopK: K is out of range");
+        CV_CheckLE(K, input_shape[axis_normalized], "TopK: K is out of range");
 
         // Assign output shape
         auto output_shape = input_shape;


### PR DESCRIPTION
The TopK layer was incorrectly rejecting K values equal to the input dimension size. According to ONNX specification, K should be allowed to equal the dimension size (to retrieve all elements).

Changed validation from 'K < input_shape[axis]' to 'K <= input_shape[axis]'

This fixes the error when loading YOLOv10 ONNX models that use TopK with K equal to the dimension size.

Fixes #28445

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
