### PR TITLE
fix: mark distCoeffs, cameraMatrix as optional in calibrateCamera fun…

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -397,6 +397,7 @@ NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "solvePnPRefineVVS"): make_optional_arg("distCoeffs"),
     SymbolName(("cv", ), (), "undistort"): make_optional_arg("distCoeffs"),
     SymbolName(("cv", ), (), "undistortPoints"): make_optional_arg("distCoeffs"),
+    SymbolName(("cv", ), (), "calibrateCamera"): make_optional_arg("cameraMatrix", "distCoeffs"),
     SymbolName(("cv", "fisheye"), (), "initUndistortRectifyMap"): make_optional_arg("D"),
     SymbolName(("cv", ), (), "imread"): make_optional_none_return,
     SymbolName(("cv", ), (), "imdecode"): make_optional_none_return,


### PR DESCRIPTION
Fixes #28469 based on #27564 .

before Patch:
```python
(
    objectPoints: Sequence[UMat],
    imagePoints: Sequence[UMat],
    imageSize: Sequence[int],
    cameraMatrix: UMat,
    distCoeffs: UMat,
    rvecs: Sequence[UMat] | None = ...,
    tvecs: Sequence[UMat] | None = ...,
    flags: int = ...,
    criteria: tuple[int, int, int | float] = ...
) -> tuple[int | float, UMat, UMat, Sequence[UMat], Sequence[UMat]]
```

after patch:
```python
(
    objectPoints: Sequence[UMat],
    imagePoints: Sequence[UMat],
    imageSize: Sequence[int],
    cameraMatrix: UMat | None,  # Changed
    distCoeffs: UMat | None,    # Changed
    rvecs: Sequence[UMat] | None = ...,
    tvecs: Sequence[UMat] | None = ...,
    flags: int = ...,
    criteria: tuple[int, int, int | float] = ...
) -> tuple[int | float, UMat, UMat, Sequence[UMat], Sequence[UMat]]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
