### PR TITLE
[DNN] Add initial Tokenizer support (BPE) for GenAI workflow

### DIFF
--- a/modules/dnn/include/opencv2/dnn/tokenizer.hpp
+++ b/modules/dnn/include/opencv2/dnn/tokenizer.hpp
@@ -1,0 +1,37 @@
+#ifndef OPENCV_DNN_TOKENIZER_HPP
+#define OPENCV_DNN_TOKENIZER_HPP
+
+#include <opencv2/core.hpp>
+#include <string>
+#include <vector>
+
+namespace cv {
+namespace dnn {
+
+/**
+ * @brief Base class for text tokenizers in the DNN module.
+ */
+class CV_EXPORTS_W Tokenizer {
+public:
+    virtual ~Tokenizer() {}
+
+    /** @brief Encodes text into a sequence of token IDs. */
+    CV_WRAP virtual std::vector<int> encode(const std::string& text) = 0;
+
+    /** @brief Decodes a sequence of token IDs back into text. */
+    CV_WRAP virtual std::string decode(const std::vector<int>& tokens) = 0;
+
+    /** @brief Converts token IDs into an OpenCV Mat (suitable for dnn::Net input). */
+    CV_WRAP virtual Mat tokensToMat(const std::vector<int>& tokens);
+
+    /** @brief Load vocabulary/merges from a file (e.g., JSON or YAML). */
+    CV_WRAP virtual void load(const std::string& path) = 0;
+
+    // Factory method to create specific instances
+    CV_WRAP static Ptr<Tokenizer> createBPE(const std::string& vocabPath);
+};
+
+} // namespace dnn
+} // namespace cv
+
+#endif

--- a/modules/dnn/src/tokenizer.cpp
+++ b/modules/dnn/src/tokenizer.cpp
@@ -1,0 +1,129 @@
+#include "precomp.hpp"
+#include <opencv2/dnn/tokenizer.hpp>
+#include <map>
+#include <vector>
+#include <string>
+#include <limits>
+
+namespace cv {
+namespace dnn {
+
+// --- Base Class Definition ---
+// Defining this here fixes the "Undefined symbols" for Tokenizer typeinfo and vtable.
+Mat Tokenizer::tokensToMat(const std::vector<int>& tokens) {
+    if (tokens.empty()) {
+        return Mat();
+    }
+    // Create a 1 x N matrix of type 32-bit Signed Integer.
+    // We use .clone() so the Mat owns its data independently of the input vector.
+    Mat m(1, (int)tokens.size(), CV_32S, (void*)tokens.data());
+    return m.clone(); 
+}
+
+// --- BPE Implementation Class ---
+class TokenizerBPE : public Tokenizer {
+private:
+    std::map<std::string, int> vocab;
+    std::map<std::pair<std::string, std::string>, int> merge_ranks;
+
+public:
+    TokenizerBPE(const std::string& vocabPath) {
+        if (!vocabPath.empty()) {
+            load(vocabPath);
+        }
+    }
+
+    void load(const std::string& path) override {
+        FileStorage fs(path, FileStorage::READ);
+        if (!fs.isOpened()) return;
+
+        // Clear existing data if re-loading
+        vocab.clear();
+        merge_ranks.clear();
+
+        // Load Vocab: {"token": id}
+        FileNode v = fs["vocab"];
+        for (FileNodeIterator it = v.begin(); it != v.end(); ++it) {
+            vocab[(*it).name()] = (int)*it;
+        }
+
+        // Load Merges: ["char1 char2", "char3 char4"]
+        FileNode m = fs["merges"];
+        int rank = 0;
+        for (FileNodeIterator it = m.begin(); it != m.end(); ++it) {
+            std::string pair_str = (std::string)*it;
+            size_t space = pair_str.find(' ');
+            if (space != std::string::npos) {
+                auto p = std::make_pair(pair_str.substr(0, space), pair_str.substr(space + 1));
+                merge_ranks[p] = rank++;
+            }
+        }
+    }
+
+    std::vector<int> encode(const std::string& text) override {
+        if (text.empty()) return {};
+
+        // Start with individual characters
+        std::vector<std::string> symbols;
+        for (char c : text) {
+            symbols.push_back(std::string(1, c));
+        }
+
+        
+
+        while (symbols.size() > 1) {
+            int best_rank = std::numeric_limits<int>::max();
+            int best_idx = -1;
+
+            for (size_t i = 0; i < symbols.size() - 1; ++i) {
+                auto p = std::make_pair(symbols[i], symbols[i+1]);
+                if (merge_ranks.count(p) && merge_ranks[p] < best_rank) {
+                    best_rank = merge_ranks[p];
+                    best_idx = (int)i;
+                }
+            }
+
+            if (best_idx == -1) break;
+
+            // Merge the best pair
+            std::vector<std::string> next_symbols;
+            for (int i = 0; i < (int)symbols.size(); ++i) {
+                if (i == best_idx) {
+                    next_symbols.push_back(symbols[i] + symbols[i+1]);
+                    i++; 
+                } else {
+                    next_symbols.push_back(symbols[i]);
+                }
+            }
+            symbols = next_symbols;
+        }
+
+        std::vector<int> ids;
+        for (const auto& s : symbols) {
+            ids.push_back(vocab.count(s) ? vocab[s] : -1);
+        }
+        return ids;
+    }
+
+    std::string decode(const std::vector<int>& tokens) override {
+        // Create an inverse map for decoding
+        std::map<int, std::string> inv_vocab;
+        for (auto const& [str, id] : vocab) {
+            inv_vocab[id] = str;
+        }
+
+        std::string result;
+        for (int id : tokens) {
+            if (inv_vocab.count(id)) result += inv_vocab[id];
+        }
+        return result;
+    }
+};
+
+// --- Factory Method ---
+Ptr<Tokenizer> Tokenizer::createBPE(const std::string& vocabPath) {
+    return makePtr<TokenizerBPE>(vocabPath);
+}
+
+} // namespace dnn
+} // namespace cv

--- a/modules/dnn/test/test_tokenizer.cpp
+++ b/modules/dnn/test/test_tokenizer.cpp
@@ -1,0 +1,38 @@
+#include "test_precomp.hpp"
+#include <opencv2/dnn/tokenizer.hpp>
+#include <fstream>
+#include <cstdio> // For std::remove
+
+namespace opencv_test { namespace {
+
+TEST(DNN_Tokenizer, BPE_FunctionalTest) {
+    // 1. Create a dummy JSON file on disk
+    std::string temp_file = "temp_bpe_vocab.json";
+    std::ofstream out(temp_file);
+    out << "{ \"vocab\": { \"h\":0, \"e\":1, \"l\":2, \"o\":3, \"he\":4, \"hel\":5, \"hello\":6 },"
+        << "  \"merges\": [ \"h e\", \"he l\", \"hel l\", \"hell o\" ] }";
+    out.close();
+    
+    // 2. Initialize Tokenizer with the PATH to the temp file
+    // This triggers the 'load()' function in your implementation
+    Ptr<dnn::Tokenizer> tokenizer = dnn::Tokenizer::createBPE(temp_file);
+    
+    // 3. Test Encoding
+    std::string input = "hello";
+    std::vector<int> ids = tokenizer->encode(input);
+    
+    // 4. Assert results
+    // We expect "hello" -> ID 6. 
+    // If this fails with size 5, it means merges didn't happen.
+    ASSERT_EQ(ids.size(), 1);
+    EXPECT_EQ(ids[0], 6);
+
+    // 5. Test Decoding
+    std::string decoded = tokenizer->decode(ids);
+    EXPECT_EQ(decoded, "hello");
+
+    // 6. Cleanup
+    std::remove(temp_file.c_str());
+}
+
+}} // namespace


### PR DESCRIPTION
### Summary
This PR introduces a new `Tokenizer` class to the `dnn` module, providing the infrastructure for text processing within OpenCV's deep learning pipeline. It includes an initial implementation of **Byte Pair Encoding (BPE)**, which is essential for supporting modern GenAI and Large Language Models (LLMs).

This contribution addresses Issue #27121 and targets the OpenCV 5.0 roadmap for better LLM integration.

### Changes
* **New Header (`modules/dnn/include/opencv2/dnn/tokenizer.hpp`):**
    * Defines the abstract base class `Tokenizer`.
    * Exports `createBPE()` factory method.
    * Includes `tokensToMat()` helper to convert token IDs directly into `cv::Mat` (CV_32S) for model inference.
    * Python bindings enabled via `CV_WRAP`.

* **New Source (`modules/dnn/src/tokenizer.cpp`):**
    * Implements `TokenizerBPE` using a greedy merge strategy.
    * Uses `cv::FileStorage` to load vocabularies, ensuring native support for JSON, XML, and YAML formats without external dependencies.
    * Implements efficient `encode` (text to ID) and `decode` (ID to text) logic.

* **New Test (`modules/dnn/test/test_tokenizer.cpp`):**
    * Added functional tests using GoogleTest.
    * Verifies end-to-end flow: `load` -> `encode` -> `decode`.
    * Validates correct merging of characters into tokens (e.g., "h", "e", "l", "l", "o" -> "hello").

### Implementation Details
The BPE implementation follows the standard approach used in libraries like `sentencepiece` and `huggingface/tokenizers`:
1.  **Vocabulary Loading:** Reads a map of tokens-to-IDs and a list of merge rules from a JSON file.
2.  **Merging:** Iteratively finds the highest-priority pair (lowest rank) in the current symbol list and merges them until no further merges are possible.
3.  **Mat Conversion:** The `tokensToMat` method ensures the output is immediately compatible with `cv::dnn::Net::setInput`.

### How to Test
1.  Build the `opencv_test_dnn` target:
    ```bash
    make opencv_test_dnn
    ```
2.  Run the specific tokenizer test:
    ```bash
    ./bin/opencv_test_dnn --gtest_filter="DNN_Tokenizer.*"
    ```

### Future Work
* Optimize the merge loop for performance on very long texts (currently O(N²)).
* Add support for special tokens (e.g., `<PAD>`, `<UNK>`, `<BOS>`, `<EOS>`).
* Implement `WordPiece` and `Unigram` tokenizers as subclasses.