### PR TITLE
Fix: Allow None for cameraMatrix and distCoeffs in calibrateCamera ty…

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -379,6 +379,7 @@ def _find_argument_index(arguments: Sequence[FunctionNode.Arg],
 NODES_TO_REFINE = {
     SymbolName(("cv", ), (), "resize"): make_optional_arg("dsize"),
     SymbolName(("cv", ), (), "calcHist"): make_optional_arg("mask"),
+    SymbolName(("cv", ), (), "calibrateCamera"): make_optional_arg("cameraMatrix", "distCoeffs"),
     SymbolName(("cv", ), (), "floodFill"): make_optional_arg("mask"),
     SymbolName(("cv", ), ("Feature2D", ), "detectAndCompute"): make_optional_arg("mask"),
     SymbolName(("cv", ), (), "findEssentialMat"): make_optional_arg(


### PR DESCRIPTION
Fixes #28469

In Python, cv2.calibrateCamera accepts None for cameraMatrix and distCoeffs when they are used purely as outputs or to indicate no initial guess. The generated type stubs previously required valid arrays, causing type checking errors.

Added 'cameraMatrix' and 'distCoeffs' to the manual API refinement list for calibrateCamera to mark them as optional (Optional[MatLike]).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
