### PR TITLE
docs: fix parameter name inconsistency in erode/dilate documentation

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -217,15 +217,15 @@ enum MorphTypes{
     MORPH_ERODE    = 0, //!< see #erode
     MORPH_DILATE   = 1, //!< see #dilate
     MORPH_OPEN     = 2, //!< an opening operation
-                        //!< \f[\texttt{dst} = \mathrm{open} ( \texttt{src} , \texttt{element} )= \mathrm{dilate} ( \mathrm{erode} ( \texttt{src} , \texttt{element} ))\f]
+                        //!< \f[\texttt{dst} = \mathrm{open} ( \texttt{src} , \texttt{kernel} )= \mathrm{dilate} ( \mathrm{erode} ( \texttt{src} , \texttt{kernel} ))\f]
     MORPH_CLOSE    = 3, //!< a closing operation
-                        //!< \f[\texttt{dst} = \mathrm{close} ( \texttt{src} , \texttt{element} )= \mathrm{erode} ( \mathrm{dilate} ( \texttt{src} , \texttt{element} ))\f]
+                        //!< \f[\texttt{dst} = \mathrm{close} ( \texttt{src} , \texttt{kernel} )= \mathrm{erode} ( \mathrm{dilate} ( \texttt{src} , \texttt{kernel} ))\f]
     MORPH_GRADIENT = 4, //!< a morphological gradient
-                        //!< \f[\texttt{dst} = \mathrm{morph\_grad} ( \texttt{src} , \texttt{element} )= \mathrm{dilate} ( \texttt{src} , \texttt{element} )- \mathrm{erode} ( \texttt{src} , \texttt{element} )\f]
+                        //!< \f[\texttt{dst} = \mathrm{morph\_grad} ( \texttt{src} , \texttt{kernel} )= \mathrm{dilate} ( \texttt{src} , \texttt{kernel} )- \mathrm{erode} ( \texttt{src} , \texttt{kernel} )\f]
     MORPH_TOPHAT   = 5, //!< "top hat"
-                        //!< \f[\texttt{dst} = \mathrm{tophat} ( \texttt{src} , \texttt{element} )= \texttt{src} - \mathrm{open} ( \texttt{src} , \texttt{element} )\f]
+                        //!< \f[\texttt{dst} = \mathrm{tophat} ( \texttt{src} , \texttt{kernel} )= \texttt{src} - \mathrm{open} ( \texttt{src} , \texttt{kernel} )\f]
     MORPH_BLACKHAT = 6, //!< "black hat"
-                        //!< \f[\texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{element} )= \mathrm{close} ( \texttt{src} , \texttt{element} )- \texttt{src}\f]
+                        //!< \f[\texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{kernel} )= \mathrm{close} ( \texttt{src} , \texttt{kernel} )- \texttt{src}\f]
     MORPH_HITMISS  = 7  //!< "hit or miss"
                         //!<   .- Only supported for CV_8UC1 binary images. A tutorial can be found in the documentation
 };
@@ -2327,7 +2327,7 @@ Check @ref tutorial_opening_closing_hats "the corresponding tutorial" for more d
 The function erodes the source image using the specified structuring element that determines the
 shape of a pixel neighborhood over which the minimum is taken:
 
-\f[\texttt{dst} (x,y) =  \min _{(x',y'):  \, \texttt{element} (x',y') \ne0 } \texttt{src} (x+x',y+y')\f]
+\f[\texttt{dst} (x,y) =  \min _{(x',y'):  \, \texttt{kernel} (x',y') \ne0 } \texttt{src} (x+x',y+y')\f]
 
 The function supports the in-place mode. Erosion can be applied several ( iterations ) times. In
 case of multi-channel images, each channel is processed independently.
@@ -2335,7 +2335,7 @@ case of multi-channel images, each channel is processed independently.
 @param src input image; the number of channels can be arbitrary, but the depth should be one of
 CV_8U, CV_16U, CV_16S, CV_32F or CV_64F.
 @param dst output image of the same size and type as src.
-@param kernel structuring element used for erosion; if `element=Mat()`, a `3 x 3` rectangular
+@param kernel structuring element used for erosion; if `kernel=Mat()`, a `3 x 3` rectangular
 structuring element is used. Kernel can be created using #getStructuringElement.
 @param anchor position of the anchor within the element; default value (-1, -1) means that the
 anchor is at the element center.
@@ -2359,7 +2359,7 @@ Check @ref tutorial_erosion_dilatation "the corresponding tutorial" for more det
 
 The function dilates the source image using the specified structuring element that determines the
 shape of a pixel neighborhood over which the maximum is taken:
-\f[\texttt{dst} (x,y) =  \max _{(x',y'):  \, \texttt{element} (x',y') \ne0 } \texttt{src} (x+x',y+y')\f]
+\f[\texttt{dst} (x,y) =  \max _{(x',y'):  \, \texttt{kernel} (x',y') \ne0 } \texttt{src} (x+x',y+y')\f]
 
 The function supports the in-place mode. Dilation can be applied several ( iterations ) times. In
 case of multi-channel images, each channel is processed independently.
@@ -2367,7 +2367,7 @@ case of multi-channel images, each channel is processed independently.
 @param src input image; the number of channels can be arbitrary, but the depth should be one of
 CV_8U, CV_16U, CV_16S, CV_32F or CV_64F.
 @param dst output image of the same size and type as src.
-@param kernel structuring element used for dilation; if element=Mat(), a 3 x 3 rectangular
+@param kernel structuring element used for dilation; if `kernel=Mat()`, a `3 x 3` rectangular
 structuring element is used. Kernel can be created using #getStructuringElement
 @param anchor position of the anchor within the element; default value (-1, -1) means that the
 anchor is at the element center.


### PR DESCRIPTION
## Summary

- Change `element` to `kernel` in LaTeX formulas to match actual parameter name
- Fix backtick formatting in `dilate()` documentation

## Details

The `erode()` and `dilate()` function documentation incorrectly referenced `element` in several places, but the actual parameter name is `kernel`:

| Location | Before | After |
|----------|--------|-------|
| erode LaTeX formula | `\texttt{element}` | `\texttt{kernel}` |
| erode @param kernel | `` `element=Mat()` `` | `` `kernel=Mat()` `` |
| dilate LaTeX formula | `\texttt{element}` | `\texttt{kernel}` |
| dilate @param kernel | `element=Mat()` | `` `kernel=Mat()` `` |

Note: "structuring element" (concept) and "anchor is at the element center" are correctly left unchanged.

Resolves #18095

## Test plan

- [x] Documentation-only change, no code affected
- [x] Verified LaTeX syntax is correct
- [x] Verified consistency with function signatures