### PR TITLE
videoio(obsensor): replace unnecessary get<double>() usage with integer types

### DIFF
--- a/modules/videoio/src/cap_obsensor_liborbbec.cpp
+++ b/modules/videoio/src/cap_obsensor_liborbbec.cpp
@@ -42,9 +42,9 @@ VideoCapture_obsensor::VideoCapture_obsensor(int, const cv::VideoCaptureParamete
     alignFilter = std::make_shared<ob::Align>(OB_STREAM_COLOR);
 #endif
 
-    int color_width = params.get<double>(CAP_PROP_FRAME_WIDTH, OB_WIDTH_ANY);
-    int color_height = params.get<double>(CAP_PROP_FRAME_HEIGHT, OB_HEIGHT_ANY);
-    int color_fps = params.get<double>(CAP_PROP_FPS, OB_FPS_ANY);
+    int color_width = params.get<int>(CAP_PROP_FRAME_WIDTH, OB_WIDTH_ANY);
+    int color_height = params.get<int>(CAP_PROP_FRAME_HEIGHT, OB_HEIGHT_ANY);
+    int color_fps = params.get<int>(CAP_PROP_FPS, OB_FPS_ANY);
 
     auto colorProfiles = pipe->getStreamProfileList(OB_SENSOR_COLOR);
     if (color_width == OB_WIDTH_ANY && color_height == OB_HEIGHT_ANY && color_fps == OB_FPS_ANY)
@@ -60,9 +60,9 @@ VideoCapture_obsensor::VideoCapture_obsensor(int, const cv::VideoCaptureParamete
         config->enableStream(colorProfile->as<ob::VideoStreamProfile>());
     }
 
-    int depth_width = params.get<double>(CAP_PROP_OBSENSOR_DEPTH_WIDTH, OB_WIDTH_ANY);
-    int depth_height = params.get<double>(CAP_PROP_OBSENSOR_DEPTH_HEIGHT, OB_HEIGHT_ANY);
-    int depth_fps = params.get<double>(CAP_PROP_OBSENSOR_DEPTH_FPS, OB_FPS_ANY);
+    int depth_width = params.get<int>(CAP_PROP_OBSENSOR_DEPTH_WIDTH, OB_WIDTH_ANY);
+    int depth_height = params.get<int>(CAP_PROP_OBSENSOR_DEPTH_HEIGHT, OB_HEIGHT_ANY);
+    int depth_fps = params.get<int>(CAP_PROP_OBSENSOR_DEPTH_FPS, OB_FPS_ANY);
 
     auto depthProfiles = pipe->getStreamProfileList(OB_SENSOR_DEPTH);
     if (depth_width == OB_WIDTH_ANY && depth_height == OB_HEIGHT_ANY && depth_fps == OB_FPS_ANY)


### PR DESCRIPTION
Close https://github.com/opencv/opencv/issues/28498 (for obsensor)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
