### PR TITLE
imgproc: reset GrabCut models in init modes

### DIFF
--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -558,6 +558,20 @@ void cv::grabCut( InputArray _img, InputOutputArray _mask, Rect rect,
     if( img.type() != CV_8UC3 )
         CV_Error( cv::Error::StsBadArg, "image must have CV_8UC3 type" );
 
+    // In init modes, models are scratch buffers. If user passes pre-allocated (but possibly
+    // uninitialized) mats, the garbage contents can trigger singular covariances in GMM.
+    // Reset models here BEFORE constructing GMM wrappers.
+    if( mode == GC_INIT_WITH_RECT || mode == GC_INIT_WITH_MASK )
+    {
+        if( bgdModel.empty() || bgdModel.rows != 1 || bgdModel.cols != 65 || bgdModel.type() != CV_64FC1 )
+            bgdModel.create( 1, 65, CV_64FC1 );
+        if( fgdModel.empty() || fgdModel.rows != 1 || fgdModel.cols != 65 || fgdModel.type() != CV_64FC1 )
+            fgdModel.create( 1, 65, CV_64FC1 );
+
+        bgdModel.setTo( Scalar::all(0) );
+        fgdModel.setTo( Scalar::all(0) );
+    }
+
     GMM bgdGMM( bgdModel ), fgdGMM( fgdModel );
     Mat compIdxs( img.size(), CV_32SC1 );
 
@@ -570,7 +584,7 @@ void cv::grabCut( InputArray _img, InputOutputArray _mask, Rect rect,
         initGMMs( img, mask, bgdGMM, fgdGMM );
     }
 
-    if( iterCount <= 0)
+    if( iterCount <= 0 )
         return;
 
     if( mode == GC_EVAL_FREEZE_MODEL )
@@ -592,7 +606,9 @@ void cv::grabCut( InputArray _img, InputOutputArray _mask, Rect rect,
         assignGMMsComponents( img, mask, bgdGMM, fgdGMM, compIdxs );
         if( mode != GC_EVAL_FREEZE_MODEL )
             learnGMMs( img, mask, compIdxs, bgdGMM, fgdGMM );
-        constructGCGraph(img, mask, bgdGMM, fgdGMM, lambda, leftW, upleftW, upW, uprightW, graph );
+        constructGCGraph( img, mask, bgdGMM, fgdGMM, lambda, leftW, upleftW, upW, uprightW, graph );
         estimateSegmentation( graph, mask );
     }
 }
+
+/* End of file. */

--- a/modules/imgproc/test/test_grabcut_init_models.cpp
+++ b/modules/imgproc/test/test_grabcut_init_models.cpp
@@ -1,0 +1,95 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+
+#include "test_precomp.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <limits>
+
+namespace opencv_test {
+
+static cv::Mat makeSynth(int W, int H)
+{
+    cv::Mat img(H, W, CV_8UC3, cv::Scalar(128, 128, 128));
+    cv::rectangle(img, cv::Rect(W/4, H/4, W/2, H/2), cv::Scalar(140, 140, 140), cv::FILLED);
+    cv::line(img, cv::Point(0, H/2), cv::Point(W - 1, H/2), cv::Scalar(255, 255, 255), 1);
+    cv::circle(img, cv::Point(W/2, H/2), 1, cv::Scalar(0, 0, 0), cv::FILLED);
+    return img;
+}
+
+TEST(Imgproc_GrabCut, InitModeIgnoresUninitializedModels_Rect)
+{
+    cv::Mat image = makeSynth(300, 300);
+    cv::Mat mask = cv::Mat::zeros(image.size(), CV_8UC1);
+    cv::Rect rect(50, 50, image.cols - 100, image.rows - 100);
+
+    cv::Mat bgdModel, fgdModel;
+    bgdModel.create(1, 65, CV_64F);
+    fgdModel.create(1, 65, CV_64F);
+
+    // Deterministic "bad" contents (simulates uninitialized / garbage memory)
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    bgdModel.setTo(cv::Scalar::all(nan));
+    fgdModel.setTo(cv::Scalar::all(nan));
+
+    EXPECT_NO_THROW(cv::grabCut(image, mask, rect, bgdModel, fgdModel, 5, cv::GC_INIT_WITH_RECT));
+}
+
+TEST(Imgproc_GrabCut, InitModeIgnoresUninitializedModels_Mask)
+{
+    cv::Mat image = makeSynth(100, 100);
+    cv::Mat mask = cv::Mat::zeros(image.size(), CV_8UC1);
+    mask.at<uchar>(image.rows / 2, image.cols / 2) = cv::GC_FGD; // seed one FG pixel
+
+    cv::Mat bgdModel, fgdModel;
+    bgdModel.create(1, 65, CV_64F);
+    fgdModel.create(1, 65, CV_64F);
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    bgdModel.setTo(cv::Scalar::all(nan));
+    fgdModel.setTo(cv::Scalar::all(nan));
+
+    cv::Rect dummyRect; // ignored for INIT_WITH_MASK
+    EXPECT_NO_THROW(cv::grabCut(image, mask, dummyRect, bgdModel, fgdModel, 1, cv::GC_INIT_WITH_MASK));
+}
+
+} // namespace opencv_test


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at [https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request](https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request)

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
* [x] The PR is proposed to the proper branch
* [x] There is a reference to the original bug report and related work
* [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
  N/A: regression test uses synthetic images; no new opencv_extra data needed.
* [ ] The feature is well documented and sample code can be built with the project CMake
  N/A: this is a bugfix + regression test (no new feature/sample).

---

Fixes #27058

### What was happening

In GrabCut init modes (`GC_INIT_WITH_RECT` / `GC_INIT_WITH_MASK`), callers often pre-allocate `bgdModel` / `fgdModel` using `Mat::create(1, 65, CV_64F)`. `create()` allocates memory but does not initialize it, so the models may contain garbage values. That can lead to degenerate GMM covariance and trigger the assertion in `GMM::calcInverseCovAndDeterm` (`dtrm > epsilon`).

### What this PR changes

* In init modes only, (re)create models if needed and reset them to zero before constructing `GMM` wrappers.
* `GC_EVAL` / `GC_EVAL_FREEZE_MODEL` behavior is unchanged (models are expected to be reused).

### Tests

Adds regression tests that fill models with NaNs and verify GrabCut init modes do not throw/assert.

