### PR TITLE
Fix(imgproc): Disable inconsistent NEON resize for RGB (Issue #28495)

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1785,7 +1785,7 @@ struct HResizeLinearVecU8_X4
                 }
             }
         }
-        else if(cn == 3)
+        else if(cn == 3 && 0) // Disabled due to Issue #28495 (inconsistency)
         {
             /* Peek at the last x offset to find the maximal s offset.  We know the loop
                will terminate prior to value which may be 1 or more elements prior to the


### PR DESCRIPTION
### Issue
Fixes #28495

### Description
The NEON optimization path for 3-channel (`cn == 3`) linear resize in `HResizeLinearVecU8_X4` produces results inconsistent with the 4-channel (`cn == 4`) path and the scalar fallback. This is caused by the 3-channel NEON loop stride logic which differs from the rounding behavior of the 4-channel path, leading to +/-1 pixel errors on ARM platforms (Android/iOS/M1).

This PR disables the 3-channel NEON optimization path (`else if(cn == 3 && 0)`), forcing the use of the generic C++ implementation. This ensures mathematical consistency across RGB and RGBA formats.

### Verification
Verified with the reproducer code from #28495 on Apple Silicon (ARM64).
* **Before:** Output "Images are not the same!"
* **After:** Output "ALL GOOD"

Performance impact is minimal compared to the correctness gain.