### PR TITLE
feat(keypoint): add explicit area/scale support

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -816,7 +816,15 @@ public:
     CV_PROP_RW float response; //!< the response by which the most strong keypoints have been selected. Can be used for the further sorting or subsampling
     CV_PROP_RW int octave; //!< octave (pyramid layer) from which the keypoint has been extracted
     CV_PROP_RW int class_id; //!< object class (if the keypoints need to be clustered by an object they belong to)
+    CV_PROP_RW float area; //!< area (in pixel^2) of the keypoint region, if known
 };
+
+/** @brief Returns the area of the keypoint.
+If the keypoint has a valid area set (area>0), returns it.
+Otherwise, computes the area from the keypoint size assuming a circular region.
+@param kp KeyPoint
+*/
+CV_EXPORTS_W float keypointArea(const KeyPoint& kp);
 
 #ifdef OPENCV_TRAITS_ENABLE_DEPRECATED
 template<> class DataType<KeyPoint>
@@ -2432,15 +2440,15 @@ Scalar operator * (const Matx<double, 4, 4>& a, const Scalar& b)
 
 inline
 KeyPoint::KeyPoint()
-    : pt(0,0), size(0), angle(-1), response(0), octave(0), class_id(-1) {}
+    : pt(0,0), size(0), angle(-1), response(0), octave(0), class_id(-1), area(0) {}
 
 inline
 KeyPoint::KeyPoint(Point2f _pt, float _size, float _angle, float _response, int _octave, int _class_id)
-    : pt(_pt), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+    : pt(_pt), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id), area(0) {}
 
 inline
 KeyPoint::KeyPoint(float x, float y, float _size, float _angle, float _response, int _octave, int _class_id)
-    : pt(x, y), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id) {}
+    : pt(x, y), size(_size), angle(_angle), response(_response), octave(_octave), class_id(_class_id), area(0) {}
 
 
 

--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -57,9 +57,18 @@ size_t KeyPoint::hash() const
     u.f = size; _Val = (scale * _Val) ^ u.u;
     u.f = angle; _Val = (scale * _Val) ^ u.u;
     u.f = response; _Val = (scale * _Val) ^ u.u;
+    u.f = area; _Val = (scale * _Val) ^ u.u;
     _Val = (scale * _Val) ^ ((size_t) octave);
     _Val = (scale * _Val) ^ ((size_t) class_id);
     return _Val;
+}
+
+float keypointArea(const KeyPoint& kp)
+{
+    if (kp.area > 0)
+        return kp.area;
+    else
+        return (float)(CV_PI * 0.25 * kp.size * kp.size);
 }
 
 void KeyPoint::convert(const std::vector<KeyPoint>& keypoints, std::vector<Point2f>& points2f,

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -108,6 +108,7 @@ protected:
       Point2d location;
       double radius;
       double confidence;
+      double area;
   };
 
   virtual void detect( InputArray image, std::vector<KeyPoint>& keypoints, InputArray mask=noArray() ) CV_OVERRIDE;
@@ -323,6 +324,7 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
         if(moms.m00 == 0.0)
             continue;
         center.location = Point2d(moms.m10 / moms.m00, moms.m01 / moms.m00);
+        center.area = moms.m00;
 
         if (params.filterByColor)
         {
@@ -467,6 +469,7 @@ void SimpleBlobDetectorImpl::detect(InputArray image, std::vector<cv::KeyPoint>&
         }
         sumPoint *= (1. / normalizer);
         KeyPoint kpt(sumPoint, (float)(centers[i][centers[i].size() / 2].radius) * 2.0f);
+        kpt.area = (float)centers[i][centers[i].size() / 2].area;
         keypoints.push_back(kpt);
     }
 

--- a/modules/features2d/test/test_keypoint_area.cpp
+++ b/modules/features2d/test/test_keypoint_area.cpp
@@ -1,0 +1,61 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(Core_KeyPoint, AreaHelper)
+{
+    // Test 1: Area not set (default 0)
+    cv::KeyPoint kp(10, 10, 20.0f); // size = 20.0f
+    EXPECT_EQ(kp.area, 0.0f);
+
+    float expectedAreaFromSize = (float)(CV_PI * 0.25 * 20.0f * 20.0f);
+    EXPECT_NEAR(cv::keypointArea(kp), expectedAreaFromSize, 1e-5);
+
+    // Test 2: Area set explicitly
+    kp.area = 100.0f;
+    EXPECT_EQ(cv::keypointArea(kp), 100.0f);
+}
+
+TEST(Features2d_BlobDetector, AreaPopulation)
+{
+    // Create a synthetic image with a known blob
+    // Circle with radius 20 -> diameter 40 -> Area = pi * 20^2 = ~1256.6
+    cv::Mat image = cv::Mat::zeros(cv::Size(200, 200), CV_8UC1);
+    cv::circle(image, cv::Point(100, 100), 20, cv::Scalar(255), -1);
+
+    SimpleBlobDetector::Params params;
+    params.minThreshold = 100;
+    params.maxThreshold = 200;
+    params.filterByArea = true;
+    params.minArea = 1000;
+    params.maxArea = 1500;
+    // Disable other filters for simplicity to ensure we detect the blob
+    params.filterByCircularity = false;
+    params.filterByInertia = false;
+    params.filterByConvexity = false;
+    params.filterByColor = true;
+    params.blobColor = 255;
+
+    Ptr<SimpleBlobDetector> detector = SimpleBlobDetector::create(params);
+    std::vector<KeyPoint> keypoints;
+    detector->detect(image, keypoints);
+
+    ASSERT_EQ(keypoints.size(), 1u);
+    KeyPoint kp = keypoints[0];
+
+    // Check area
+    // The area computed by moments (m00) for a drawn circle might be slightly different from mathematical area due to discretization
+    double exactArea = CV_PI * 20 * 20; // 1256.6
+    // Allow some tolerance for rasterization (e.g. +/- 5%)
+    EXPECT_NEAR(kp.area, exactArea, exactArea * 0.05);
+    EXPECT_GT(kp.area, 0.0f);
+
+    // Check keypointArea helper
+    EXPECT_EQ(cv::keypointArea(kp), kp.area);
+}
+
+}} // namespace


### PR DESCRIPTION
## feat(keypoint): add explicit area/scale support

### Description
This PR adds an explicit `area` field to `cv::KeyPoint` to store keypoint area/scale information.
It also introduces a helper function `cv::keypointArea()` and updates `SimpleBlobDetector`
to populate this field when the area is known.

### Motivation
Currently, `cv::KeyPoint` only stores `size` (diameter), which is insufficient for applications
that require precise area or scale information (e.g. SLAM, blob detection, feature filtering).
Users must repeatedly infer area from `size`, leading to duplicated logic and inconsistent behavior.

This change allows detectors to expose exact area measurements while providing a consistent API
for downstream users.

### Changes

#### Core
- Added `float area` member to `cv::KeyPoint` (initialized to `0`)
- Added helper function `cv::keypointArea(const KeyPoint&)`
- Updated `KeyPoint::hash()` to include `area`

#### Features2D
- Updated `SimpleBlobDetector` to compute and store blob area in `KeyPoint.area`

#### Tests
- Added `modules/features2d/test/test_keypoint_area.cpp`
  - Verifies default `area` initialization
  - Verifies `cv::keypointArea()` fallback behavior
  - Verifies `SimpleBlobDetector` integration

### Backward Compatibility
- Existing detectors remain unchanged
- If `area` is not set, `cv::keypointArea()` computes the area from `size`
  to preserve existing behavior
