### PR TITLE
Fix inRange type signature to accept Scalar values

### DIFF
--- a/modules/python/src2/typing_stubs_generation/api_refinement.py
+++ b/modules/python/src2/typing_stubs_generation/api_refinement.py
@@ -8,7 +8,7 @@ from .nodes import (NamespaceNode, FunctionNode, OptionalTypeNode, TypeNode,
                     ClassProperty, PrimitiveTypeNode, ASTNodeTypeNode,
                     AggregatedTypeNode, CallableTypeNode, AnyTypeNode,
                     TupleTypeNode, UnionTypeNode, ProtocolClassNode,
-                    DictTypeNode, ClassTypeNode)
+                    DictTypeNode, ClassTypeNode, AliasRefTypeNode)
 from .ast_utils import (find_function_node, SymbolName,
                         for_each_function_overload)
 from .types_conversion import create_type_node
@@ -378,16 +378,16 @@ def _find_argument_index(arguments: Sequence[FunctionNode.Arg],
 
 def make_matlike_or_scalar_arg(*arg_names: str) -> Callable[[NamespaceNode, SymbolName], None]:
     """Make arguments accept both MatLike and Scalar types.
-    
+
     This is used for functions like inRange where the C++ InputArray parameter
     can accept both Mat objects and Scalar values (tuples, floats, etc.).
-    
+
     Example: cv2.inRange(img, (0, 0, 0), (255, 255, 255)) should be valid.
     """
     def _make_matlike_or_scalar_arg(root_node: NamespaceNode,
                                      function_symbol_name: SymbolName) -> None:
         from .predefined_types import PREDEFINED_TYPES
-        
+
         function = find_function_node(root_node, function_symbol_name)
         for arg_name in arg_names:
             found_overload_with_arg = False
@@ -400,7 +400,7 @@ def make_matlike_or_scalar_arg(*arg_names: str) -> Callable[[NamespaceNode, Symb
                     continue
 
                 current_type = overload.arguments[arg_idx].type_node
-                
+
                 # Check if it's already a union or if it already includes Scalar
                 if isinstance(current_type, UnionTypeNode):
                     # Check if Scalar is already in the union


### PR DESCRIPTION
Fixes #28534

The Python type signature for cv2.inRange was too restrictive, requiring MatLike for lowerb and upperb parameters. However, the C++ implementation accepts InputArray which includes Scalar values (tuples, floats, etc.).

This caused type checkers to incorrectly flag valid code from official tutorials as type errors.

Added make_matlike_or_scalar_arg() refinement function to create union types MatLike | Scalar for affected parameters, matching the C++ InputArray behavior.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
