### PR TITLE
docs: fix typo 'neccessary' in gapi module

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ov.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ov.hpp
@@ -214,7 +214,7 @@ public:
 
     This function is used to ensure that all tensors in the model have names.
     It goes through all input and output nodes of the model and sets the names
-    if they are not set. This is neccessary for models with nameless tensors.
+    if they are not set. This is necessary for models with nameless tensors.
 
     If a tensor does not have a name, it will be assigned a default name
     based on the producer node's friendly name. If the producer node has multiple


### PR DESCRIPTION
Fixed a spelling mistake in modules/gapi/include/opencv2/gapi/infer/ov.hpp.
neccessary -> necessary

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
