### PR TITLE
Fix(imgproc): Fix inconsistent NEON resize for RGB (Issue #28495)

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1787,11 +1787,14 @@ struct HResizeLinearVecU8_X4
         }
         else if(cn == 3)
         {
-            /* Peek at the last x offset to find the maximal s offset.  We know the loop
-               will terminate prior to value which may be 1 or more elements prior to the
-               final valid offset. xofs[] is constucted to be an array of increasingly
-               large offsets (i.e xofs[x] <= xofs[x+1] for x < xmax). */
-            int smax = xofs[dmax-cn];
+            // Fix #28495:
+            // 1. Process 4 pixels at a time (step=4) to match SIMD width.
+            // 2. Perform a manual gather to load pairs: (R, R_next), (G, G_next), etc.
+            //    This avoids v_load_expand mixing channels and avoids v_pack/shift type issues on NEON.
+
+            const int step = 4;
+            const int len0 = xmax & -step;
+            CV_UNUSED(dmax);
 
             for( ; k <= (count - 2); k+=2 )
             {
@@ -1800,25 +1803,44 @@ struct HResizeLinearVecU8_X4
                 const uchar *S1 = src[k+1];
                 int *D1 = dst[k+1];
 
-                for( dx = 0; (xofs[dx] + cn) < smax; dx += cn )
+                for( dx = 0; dx < len0; dx += step )
                 {
                     v_int16x8 a = v_load(alpha+dx*2);
-                    v_store(&D0[dx], v_dotprod(v_reinterpret_as_s16(v_or(v_load_expand_q(S0 + xofs[dx]), v_shl<16>(v_load_expand_q(S0 + xofs[dx] + cn)))), a));
-                    v_store(&D1[dx], v_dotprod(v_reinterpret_as_s16(v_or(v_load_expand_q(S1 + xofs[dx]), v_shl<16>(v_load_expand_q(S1 + xofs[dx] + cn)))), a));
+
+                    int o0 = xofs[dx];
+                    int o1 = xofs[dx+1];
+                    int o2 = xofs[dx+2];
+                    int o3 = xofs[dx+3];
+
+                    // Gather Row 0
+                    v_uint16x8 v_src0((ushort)S0[o0], (ushort)S0[o0+3], (ushort)S0[o1], (ushort)S0[o1+3],
+                                      (ushort)S0[o2], (ushort)S0[o2+3], (ushort)S0[o3], (ushort)S0[o3+3]);
+                    v_store(&D0[dx], v_dotprod(v_reinterpret_as_s16(v_src0), a));
+
+                    // Gather Row 1
+                    v_uint16x8 v_src1((ushort)S1[o0], (ushort)S1[o0+3], (ushort)S1[o1], (ushort)S1[o1+3],
+                                      (ushort)S1[o2], (ushort)S1[o2+3], (ushort)S1[o3], (ushort)S1[o3+3]);
+                    v_store(&D1[dx], v_dotprod(v_reinterpret_as_s16(v_src1), a));
                 }
             }
             for( ; k < count; k++ )
             {
                 const uchar *S = src[k];
                 int *D = dst[k];
-                for( dx = 0; (xofs[dx] + cn) < smax; dx += cn )
+                for( dx = 0; dx < len0; dx += step )
                 {
                     v_int16x8 a = v_load(alpha+dx*2);
-                    v_store(&D[dx], v_dotprod(v_reinterpret_as_s16(v_or(v_load_expand_q(S + xofs[dx]), v_shl<16>(v_load_expand_q(S + xofs[dx] + cn)))), a));
+
+                    int o0 = xofs[dx];
+                    int o1 = xofs[dx+1];
+                    int o2 = xofs[dx+2];
+                    int o3 = xofs[dx+3];
+
+                    v_uint16x8 v_src((ushort)S[o0], (ushort)S[o0+3], (ushort)S[o1], (ushort)S[o1+3],
+                                     (ushort)S[o2], (ushort)S[o2+3], (ushort)S[o3], (ushort)S[o3+3]);
+                    v_store(&D[dx], v_dotprod(v_reinterpret_as_s16(v_src), a));
                 }
             }
-            /* Debug check to ensure truthiness that we never vector the final value. */
-            CV_DbgAssert(dx < dmax);
         }
         else if(cn == 4)
         {

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1790,7 +1790,8 @@ struct HResizeLinearVecU8_X4
             // Fix #28495:
             // 1. Process 4 pixels at a time (step=4) to match SIMD width.
             // 2. Perform a manual gather to load pairs: (R, R_next), (G, G_next), etc.
-            //    This avoids v_load_expand mixing channels and avoids v_pack/shift type issues on NEON.
+            //    This is required because 'xofs' may skip pixels (scaling), so we cannot
+            //    assume contiguous memory (which v_load/v_extract would require).
 
             const int step = 4;
             const int len0 = xmax & -step;
@@ -1813,6 +1814,8 @@ struct HResizeLinearVecU8_X4
                     int o3 = xofs[dx+3];
 
                     // Gather Row 0
+                    // We cast to ushort to ensure the v_uint16x8 constructor handles the promotion correctly
+                    // before v_reinterpret_as_s16 is used by v_dotprod.
                     v_uint16x8 v_src0((ushort)S0[o0], (ushort)S0[o0+3], (ushort)S0[o1], (ushort)S0[o1+3],
                                       (ushort)S0[o2], (ushort)S0[o2+3], (ushort)S0[o3], (ushort)S0[o3+3]);
                     v_store(&D0[dx], v_dotprod(v_reinterpret_as_s16(v_src0), a));

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -240,4 +240,27 @@ TEST(Resize_Bitexact, Nearest8U)
     }
 }
 
+TEST(Resize_Bitexact, Regression_28495)
+{
+    Mat rgb(4160, 3120, CV_8UC3);
+    randu(rgb, Scalar::all(0), Scalar::all(255));
+
+    Mat rgba;
+    cvtColor(rgb, rgba, COLOR_RGB2RGBA);
+
+    const double scale = std::min(640.0 / rgb.cols, 640.0 / rgb.rows);
+    const int newWidth = static_cast<int>(std::round(scale * rgb.cols));
+    const int newHeight = static_cast<int>(std::round(scale * rgb.rows));
+
+    Mat rgbResized, rgbaResized;
+
+    cv::resize(rgb, rgbResized, Size(newWidth, newHeight), 0, 0, INTER_LINEAR);
+    cv::resize(rgba, rgbaResized, Size(newWidth, newHeight), 0, 0, INTER_LINEAR);
+
+    Mat rgba2rgbResized;
+    cvtColor(rgbaResized, rgba2rgbResized, COLOR_RGBA2RGB);
+
+    EXPECT_EQ(cv::norm(rgbResized, rgba2rgbResized, NORM_INF), 0.0);
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -242,25 +242,30 @@ TEST(Resize_Bitexact, Nearest8U)
 
 TEST(Resize_Bitexact, Regression_28495)
 {
+    // 1. Setup Data: Large enough to trigger SIMD paths
     Mat rgb(4160, 3120, CV_8UC3);
     randu(rgb, Scalar::all(0), Scalar::all(255));
 
     Mat rgba;
     cvtColor(rgb, rgba, COLOR_RGB2RGBA);
 
+    // 2. Define Resize Parameters (from issue reproducer)
     const double scale = std::min(640.0 / rgb.cols, 640.0 / rgb.rows);
     const int newWidth = static_cast<int>(std::round(scale * rgb.cols));
     const int newHeight = static_cast<int>(std::round(scale * rgb.rows));
 
     Mat rgbResized, rgbaResized;
 
+    // 3. Perform Resize using INTER_LINEAR (the path that was broken)
     cv::resize(rgb, rgbResized, Size(newWidth, newHeight), 0, 0, INTER_LINEAR);
     cv::resize(rgba, rgbaResized, Size(newWidth, newHeight), 0, 0, INTER_LINEAR);
 
+    // 4. Convert back to compare
     Mat rgba2rgbResized;
     cvtColor(rgbaResized, rgba2rgbResized, COLOR_RGBA2RGB);
 
-    EXPECT_EQ(cv::norm(rgbResized, rgba2rgbResized, NORM_INF), 0.0);
+    // 5. Compare using L-infinity norm (max absolute difference)
+    EXPECT_LE(cv::norm(rgbResized, rgba2rgbResized, NORM_INF), 1.0);
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -264,8 +264,8 @@ TEST(Resize_Bitexact, Regression_28495)
     Mat rgba2rgbResized;
     cvtColor(rgbaResized, rgba2rgbResized, COLOR_RGBA2RGB);
 
-    // 5. Compare using L-infinity norm (max absolute difference)
-    EXPECT_LE(cv::norm(rgbResized, rgba2rgbResized, NORM_INF), 1.0);
+    // 5. Compare using L-infinity norm. We expect 0 difference (bit-exact).
+    EXPECT_EQ(cv::norm(rgbResized, rgba2rgbResized, NORM_INF), 0.0);
 }
 
 }} // namespace


### PR DESCRIPTION
### Issue
Fixes #28495

### Description
The NEON optimization path for 3-channel (`cn == 3`) linear resize in `HResizeLinearVecU8_X4` produced results inconsistent with the 4-channel path and scalar fallback on ARM targets.

**Analysis:**
1. The original implementation utilized `v_load_expand` which loads contiguous bytes. For 3-channel images, this mixes channels (R, G, B) into the vector registers improperly for the subsequent dot product.
2. It relied on `v_shl<16>` on `v_uint16x8` types, which zeroed out the high bits intended for the "next pixel" contribution, effectively corrupting the interpolation.

**Fix:**
This PR implements a manual gather approach to explicitly construct the `(Pixel, Pixel_Next)` vectors required by `v_dotprod`.
- Explicitly loads offsets `S[o]` and `S[o+3]` for each channel.
- Uses the `v_uint16x8` constructor to avoid `v_pack` type mismatches on NEON.
- Ensures mathematical consistency with the scalar C++ implementation.

### Verification
Verified with the reproducer code from #28495 on Apple Silicon (M1/ARM64).
* **Before:** Output "Images are not the same!" (Mismatch found)
* **After:** Output "ALL GOOD" (Bit-exact match with 4-channel resize)

Ran `opencv_test_imgproc` (Resize filter) and all tests passed.