### PR TITLE
docs: Fix MorphTypes enum to use 'kernel' instead of 'element' in LaTeX formulas

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -217,15 +217,15 @@ enum MorphTypes{
     MORPH_ERODE    = 0, //!< see #erode
     MORPH_DILATE   = 1, //!< see #dilate
     MORPH_OPEN     = 2, //!< an opening operation
-                        //!< \f[\texttt{dst} = \mathrm{open} ( \texttt{src} , \texttt{element} )= \mathrm{dilate} ( \mathrm{erode} ( \texttt{src} , \texttt{element} ))\f]
+                        //!< \f[\texttt{dst} = \mathrm{open} ( \texttt{src} , \texttt{kernel} )= \mathrm{dilate} ( \mathrm{erode} ( \texttt{src} , \texttt{kernel} ))\f]
     MORPH_CLOSE    = 3, //!< a closing operation
-                        //!< \f[\texttt{dst} = \mathrm{close} ( \texttt{src} , \texttt{element} )= \mathrm{erode} ( \mathrm{dilate} ( \texttt{src} , \texttt{element} ))\f]
+                        //!< \f[\texttt{dst} = \mathrm{close} ( \texttt{src} , \texttt{kernel} )= \mathrm{erode} ( \mathrm{dilate} ( \texttt{src} , \texttt{kernel} ))\f]
     MORPH_GRADIENT = 4, //!< a morphological gradient
-                        //!< \f[\texttt{dst} = \mathrm{morph\_grad} ( \texttt{src} , \texttt{element} )= \mathrm{dilate} ( \texttt{src} , \texttt{element} )- \mathrm{erode} ( \texttt{src} , \texttt{element} )\f]
+                        //!< \f[\texttt{dst} = \mathrm{morph\_grad} ( \texttt{src} , \texttt{kernel} )= \mathrm{dilate} ( \texttt{src} , \texttt{kernel} )- \mathrm{erode} ( \texttt{src} , \texttt{kernel} )\f]
     MORPH_TOPHAT   = 5, //!< "top hat"
-                        //!< \f[\texttt{dst} = \mathrm{tophat} ( \texttt{src} , \texttt{element} )= \texttt{src} - \mathrm{open} ( \texttt{src} , \texttt{element} )\f]
+                        //!< \f[\texttt{dst} = \mathrm{tophat} ( \texttt{src} , \texttt{kernel} )= \texttt{src} - \mathrm{open} ( \texttt{src} , \texttt{kernel} )\f]
     MORPH_BLACKHAT = 6, //!< "black hat"
-                        //!< \f[\texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{element} )= \mathrm{close} ( \texttt{src} , \texttt{element} )- \texttt{src}\f]
+                        //!< \f[\texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{kernel} )= \mathrm{close} ( \texttt{src} , \texttt{kernel} )- \texttt{src}\f]
     MORPH_HITMISS  = 7  //!< "hit or miss"
                         //!<   .- Only supported for CV_8UC1 binary images. A tutorial can be found in the documentation
 };


### PR DESCRIPTION
## Description

Fixes #28513

This PR fixes a documentation inconsistency in the `MorphTypes` enum where LaTeX formulas were using `\texttt{element}` instead of `\texttt{kernel}` to match the actual parameter names in the related functions.

## Problem

The MorphTypes enum (lines 219-228 in `modules/imgproc/include/opencv2/imgproc.hpp`) used `\texttt{element}` in LaTeX formulas, but the actual parameter in `morphologyEx()`, `erode()`, and `dilate()` functions is `kernel`:

```cpp
CV_EXPORTS_W void morphologyEx( InputArray src, OutputArray dst,
                                int op, InputArray kernel, ...);
```

## Solution

Updated all LaTeX formulas in the following enum values to use `\texttt{kernel}`:
- MORPH_OPEN (line 220)
- MORPH_CLOSE (line 222)
- MORPH_GRADIENT (line 224)
- MORPH_TOPHAT (line 226)
- MORPH_BLACKHAT (line 228)

## Testing

- Documentation-only change
- Verified all instances of `element` in formulas were replaced with `kernel`
- No functional code changes

## Related

Similar fix was done in #18095 for other documentation inconsistencies.

## Files Changed

- `modules/imgproc/include/opencv2/imgproc.hpp` (5 lines modified)
