### PR TITLE
parallel_impl.cpp: fix assembler syntax for powerpc*-darwin

### DIFF
--- a/modules/core/src/parallel_impl.cpp
+++ b/modules/core/src/parallel_impl.cpp
@@ -53,6 +53,8 @@ DECLARE_CV_PAUSE
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("" ::: "memory"); } } while (0)
 # elif defined __GNUC__ && defined __mips__ && __mips_isa_rev >= 2
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("pause" ::: "memory"); } } while (0)
+# elif defined __APPLE__ && defined __POWERPC__
+#   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("or r27,r27,r27" ::: "memory"); } } while (0)
 # elif defined __GNUC__ && defined __PPC64__
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("or 27,27,27" ::: "memory"); } } while (0)
 # elif defined __GNUC__ && defined __riscv


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV

This is a trivial fix. Darwin powerpc assembler requires prefixed registers, so the current code is unnecessarily broken.

The patch is used by MacPorts since https://github.com/macports/macports-ports/commit/4f7ccf4d1e5e3f1ba4c8e095a62c834c7679e881