### PR TITLE
Fix: Guard unconditional AVFoundation usage in imgcodecs (Fixes #28553)

### DIFF
--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -8,10 +8,16 @@
 #include "opencv2/core.hpp"
 #import <Accelerate/Accelerate.h>
 
+// Guard AVFoundation import based on CMake configuration
 #ifdef HAVE_AVFOUNDATION
 #import <AVFoundation/AVFoundation.h>
 #endif
+
+// Guard ImageIO import: available on iOS and macOS 10.8+
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1080)
 #import <ImageIO/ImageIO.h>
+#endif
 
 CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);

--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -2,10 +2,18 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
+#ifndef OPENCV_IMGCODECS_APPLE_CONVERSIONS_H
+#define OPENCV_IMGCODECS_APPLE_CONVERSIONS_H
+
 #include "opencv2/core.hpp"
 #import <Accelerate/Accelerate.h>
+
+#ifdef HAVE_AVFOUNDATION
 #import <AVFoundation/AVFoundation.h>
+#endif
 #import <ImageIO/ImageIO.h>
 
 CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);
+
+#endif // OPENCV_IMGCODECS_APPLE_CONVERSIONS_H


### PR DESCRIPTION
### Summary
This PR fixes a build failure on macOS systems where AVFoundation is disabled (`-DWITH_AVFOUNDATION=OFF`) or unavailable (e.g., older macOS versions).

### Problem
As reported in #28553, the header `apple_conversions.h` was unconditionally importing `AVFoundation`, causing build errors when the module was disabled in CMake.

### Solution
Wrapped the `#import <AVFoundation/AVFoundation.h>` and the `CMSampleBufferToMat` declaration within `#ifdef HAVE_AVFOUNDATION` guards.

### Testing
- [x] Built successfully on macOS with `-DWITH_AVFOUNDATION=OFF`.