### PR TITLE
imgproc: fix -Wstringop-overflow false-positive in minEnclosingConvexPolygon

### DIFF
--- a/modules/imgproc/src/min_enclosing_convex_polygon.cpp
+++ b/modules/imgproc/src/min_enclosing_convex_polygon.cpp
@@ -913,6 +913,7 @@ std::vector<Side> Chains::reconstructHSidedChain(int h, int i, int j)
 std::vector<Side> Chains::findKSides(int k, int i, int j)
 {
     std::vector<Side> sides;
+    sides.reserve(k); // Optimization and avoiding GCC's false positive warning (-Wstringop-overflow)
     sides.push_back({i, true});
     sides.push_back({j, true});
 


### PR DESCRIPTION
Closes #28568

This commit addresses a compiler warning encountered when building with GCC 13 and C++20. The compiler triggers a false-positive -Wstringop-overflow warning in `findKSides`.

By adding `sides.reserve(k)`, we explicitly inform the compiler about the required memory allocation, which suppresses the warning and provides a minor optimization by avoiding potential reallocations.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
