### PR TITLE
docs: fix typos and missing parameter description in flann and calib3d

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -4094,7 +4094,7 @@ namespace fisheye
     the number of points in the view.
     @param imagePoints Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, or
     vector\<Point2f\>.
-    @param affine
+    @param affine Pose of the camera.
     @param K Camera intrinsic matrix \f$\cameramatrix{K}\f$.
     @param D Input vector of distortion coefficients \f$\distcoeffsfisheye\f$.
     @param alpha The skew coefficient.

--- a/modules/flann/include/opencv2/flann.hpp
+++ b/modules/flann/include/opencv2/flann.hpp
@@ -175,9 +175,9 @@ public:
 
         /** @brief Constructs a nearest neighbor search index for a given dataset.
 
-        @param features Matrix of containing the features(points) to index. The size of the matrix is
+        @param features Matrix containing the features(points) to index. The size of the matrix is
         num_features x feature_dimensionality and the data type of the elements in the matrix must
-        coincide with the type of the index.
+        match the type of the index.
         @param params Structure containing the index parameters. The type of index that will be
         constructed depends on the type of this parameter. See the description.
         @param distance


### PR DESCRIPTION
### Description
This PR improves documentation clarity:

- Fixed typos and wording issues in flann.hpp
- Improved readability of matrix description
- Added missing description for the affine parameter in fisheye::projectPoints

These changes improve usability and developer understanding.