### PR TITLE
highgui(cocoa): fix moveWindow Y conversion when Dock is visible

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -244,7 +244,8 @@ CV_IMPL void cvShowImage( const char* name, const CvArr* arr)
                         int y = [window y0];
                         if(x >= 0 && y >= 0)
                         {
-                            y = [[window screen] visibleFrame].size.height - y;
+                            NSRect visibleFrame = [[window screen] visibleFrame];
+                            y = NSMaxY(visibleFrame) - y;
                             [window setFrameTopLeftPoint:NSMakePoint(x, y)];
                         }
                     }
@@ -285,7 +286,8 @@ CV_IMPL void cvMoveWindow( const char* name, int x, int y)
                 [window setY0:y];
             }
             else {
-                y = [[window screen] visibleFrame].size.height - y;
+                NSRect visibleFrame = [[window screen] visibleFrame];
+                y = NSMaxY(visibleFrame) - y;
                 [window setFrameTopLeftPoint:NSMakePoint(x, y)];
             }
         }


### PR DESCRIPTION
# HighGUI/Cocoa: fix moveWindow Y offset when Dock is visible

## Description
Fixes #28571 

`cv::moveWindow(name, x, y)` on macOS placed windows too low when the Dock was visible at the bottom.
The Cocoa code converted Y using `visibleFrame.size.height - y`, which ignores `visibleFrame.origin.y`
(the Dock offset). This produced a vertical error equal to the Dock height.

This PR uses the top of the visible frame (`NSMaxY(visibleFrame)`) for coordinate conversion, so
window placement is correct whether the Dock is visible or hidden.

## Changes
Modified `modules/highgui/src/window_cocoa.mm`:
- changed Y conversion from from 
`[[window screen] visibleFrame].size.height - y`
to:
```
NSRect visibleFrame = [[window screen] visibleFrame];
NSMaxY(visibleFrame) - y
```

## Verification
Build:
- [x] I verified that the code builds successfully without errors.
- [x] There is reproducer code and related data files (videos, images, onnx, etc)
- [x] Verified on macOS.
- [x] Existing HighGUI tests pass.


Runtime:
- Reproduced with:
 ```
 #include <opencv2/highgui.hpp>

int main() {
    cv::namedWindow("test", cv::WINDOW_AUTOSIZE);
    cv::moveWindow("test", 100, 0); // should be flush below menu bar
    cv::imshow("test", cv::Mat());
    cv::waitKey(0);
}
```
- With Dock visible at bottom: window now appears at the expected top position (below menu bar), no Dock-height offset.
- With Dock hidden: behavior remains correct.

### Pull Request Readiness Checklist
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake