### PR TITLE
Fixed cv::mul overflow for U16 type.

### DIFF
--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -1437,6 +1437,15 @@ struct op_mul
     { return saturate_cast<T1>(a * b); }
 };
 
+template<typename Tvec>
+struct op_mul<uint16_t, Tvec>
+{
+    static inline Tvec r(const Tvec& a, const Tvec& b)
+    { return v_mul(a, b); }
+    static inline uint16_t r(uint16_t a, uint16_t b)
+    { return saturate_cast<uint16_t>(static_cast<uint32_t>(a) * static_cast<uint32_t>(b)); }
+};
+
 template<typename T1, typename T2, typename Tvec>
 struct op_mul_scale
 {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -3411,4 +3411,16 @@ TEST_P(Core_LUT, accuracy_multi2)
 
 INSTANTIATE_TEST_CASE_P(/**/, Core_LUT, testing::Combine( LutIdxType::all(), LutMatType::all()));
 
+TEST(Core_Arithm, mul_overflow_28557)
+{
+    uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
+    cv::Mat m(1, 6, CV_16U, data);
+    cv::Mat res = m.mul(m);
+
+    for (int i = 0; i < 6; i++)
+    {
+        EXPECT_EQ(65535, res.at<uint16_t>(0, i));
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/28557

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
