### PR TITLE
core: fix UBSan function pointer type mismatch in countNonZero

### DIFF
--- a/modules/core/src/count_non_zero.simd.hpp
+++ b/modules/core/src/count_non_zero.simd.hpp
@@ -6,7 +6,7 @@
 
 namespace cv {
 
-typedef int (*CountNonZeroFunc)(const uchar*, int);
+typedef int (*CountNonZeroFunc)(const void*, int);
 
 
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
@@ -29,8 +29,9 @@ static int countNonZero_(const T* src, int len )
     return nz;
 }
 
-static int countNonZero8u( const uchar* src, int len )
+static int countNonZero8u( const void* src_ptr, int len )
 {
+    const uchar* src = static_cast<const uchar*>(src_ptr);
     int i=0, nz = 0;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     int len0 = len & -VTraits<v_uint8>::vlanes();
@@ -66,9 +67,9 @@ static int countNonZero8u( const uchar* src, int len )
     return nz;
 }
 
-static int countNonZero16u( const uchar* src_ptr, int len )
+static int countNonZero16u( const void* src_ptr, int len )
 {
-    const ushort* src = reinterpret_cast<const ushort*>(src_ptr);
+    const ushort* src = static_cast<const ushort*>(src_ptr);
     int i = 0, nz = 0;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     int len0 = len & -VTraits<v_int8>::vlanes();
@@ -102,9 +103,9 @@ static int countNonZero16u( const uchar* src_ptr, int len )
     return nz + countNonZero_(src + i, len - i);
 }
 
-static int countNonZero32s( const uchar* src_ptr, int len )
+static int countNonZero32s( const void* src_ptr, int len )
 {
-    const int* src = reinterpret_cast<const int*>(src_ptr);
+    const int* src = static_cast<const int*>(src_ptr);
     int i = 0, nz = 0;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     int len0 = len & -VTraits<v_int8>::vlanes();
@@ -138,9 +139,9 @@ static int countNonZero32s( const uchar* src_ptr, int len )
     return nz + countNonZero_(src + i, len - i);
 }
 
-static int countNonZero32f( const uchar* src_ptr, int len )
+static int countNonZero32f( const void* src_ptr, int len )
 {
-    const float* src = reinterpret_cast<const float*>(src_ptr);
+    const float* src = static_cast<const float*>(src_ptr);
     int i = 0, nz = 0;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     int len0 = len & -VTraits<v_int8>::vlanes();
@@ -174,9 +175,9 @@ static int countNonZero32f( const uchar* src_ptr, int len )
     return nz + countNonZero_(src + i, len - i);
 }
 
-static int countNonZero64f( const uchar* src_ptr, int len )
+static int countNonZero64f( const void* src_ptr, int len )
 {
-    const double* src = reinterpret_cast<const double*>(src_ptr);
+    const double* src = static_cast<const double*>(src_ptr);
     int nz = 0, i = 0;
 #if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
     v_int64 sum1 = vx_setzero_s64();


### PR DESCRIPTION
Fixes #28580

This PR resolves the UndefinedBehaviorSanitizer (UBSan) error caused by calling countNonZero* functions through a pointer of incompatible type.

The function parameters in SIMD implementations have been updated to const uchar* src_ptr to match the CountNonZeroFunc signature, and reinterpret_cast is used internally to maintain the SIMD optimization logic for different data types.

Tested locally with opencv_test_core on Windows (MSVC 19.44).