### PR TITLE
WIP: OpenCV HAL on top of Apple Accelerate framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ OCV_OPTION(WITH_1394 "Include IEEE1394 support" OFF
 OCV_OPTION(WITH_AVFOUNDATION "Use AVFoundation for Video I/O (iOS/visionOS/Mac)" ON
   VISIBLE_IF APPLE
   VERIFY HAVE_AVFOUNDATION)
+OCV_OPTION(WITH_ACCELERATE "Use Accelerate framework" ON
+  VISIBLE_IF APPLE
+  VERIFY HAVE_ACCELERATE)
 OCV_OPTION(WITH_AVIF "Enable AVIF support" ON
   VERIFY HAVE_AVIF)
 OCV_OPTION(WITH_CAP_IOS "Enable iOS video capture" ON
@@ -1003,6 +1006,13 @@ if(WITH_HAL_RVV)
   endif()
 endif()
 
+if(HAVE_ACCELERATE)
+  ocv_debug_message(STATUS "Enable Accelerate framework acceleration")
+  if(NOT ";${OpenCV_HAL};" MATCHES ";accelerate;")
+    set(OpenCV_HAL "accelerate;${OpenCV_HAL}")
+  endif()
+endif()
+
 foreach(hal ${OpenCV_HAL})
   if(hal STREQUAL "carotene")
     if(";${CPU_BASELINE_FINAL};" MATCHES ";NEON;")
@@ -1048,6 +1058,10 @@ foreach(hal ${OpenCV_HAL})
     add_subdirectory(hal/openvx)
     ocv_hal_register(OPENVX_HAL_LIBRARIES OPENVX_HAL_HEADERS OPENVX_HAL_INCLUDE_DIRS)
     list(APPEND OpenCV_USED_HAL "openvx (ver ${OPENVX_HAL_VERSION})")
+  elseif(hal STREQUAL "accelerate")
+    add_subdirectory(hal/accelerate)
+    ocv_hal_register(ACCELERATE_HAL_LIBRARIES ACCELERATE_HAL_HEADERS ACCELERATE_HAL_INCLUDE_DIRS)
+    list(APPEND OpenCV_USED_HAL "Accelerate (ver ${ACCELERATE_HAL_VERSION})")
   else()
     ocv_debug_message(STATUS "OpenCV HAL: ${hal} ...")
     ocv_clear_vars(OpenCV_HAL_LIBRARIES OpenCV_HAL_HEADERS OpenCV_HAL_INCLUDE_DIRS)

--- a/cmake/OpenCVFindLAPACK.cmake
+++ b/cmake/OpenCVFindLAPACK.cmake
@@ -235,7 +235,7 @@ if(WITH_LAPACK)
             LAPACKE_H "lapacke.h"
             INCLUDE_DIR "${CBLAS_INCLUDE_DIR}" "${LAPACKE_INCLUDE_DIR}"
             LIBRARIES "${LAPACK_LIBRARIES}")
-        elseif(APPLE)
+        elseif(WITH_ACCELERATE)
           ocv_lapack_check(IMPL "LAPACK/Apple"
             CBLAS_H "Accelerate/Accelerate.h"
             LAPACKE_H "Accelerate/Accelerate.h")
@@ -248,7 +248,7 @@ if(WITH_LAPACK)
     endif()
   endif()
 
-  if(NOT LAPACK_LIBRARIES AND APPLE AND NOT OPENCV_LAPACK_FIND_PACKAGE_ONLY)
+  if(NOT LAPACK_LIBRARIES AND WITH_ACCELERATE AND NOT OPENCV_LAPACK_FIND_PACKAGE_ONLY)
     ocv_lapack_check(IMPL "Apple"
       CBLAS_H "Accelerate/Accelerate.h"
       LAPACKE_H "Accelerate/Accelerate.h"

--- a/cmake/OpenCVFindLibsPerf.cmake
+++ b/cmake/OpenCVFindLibsPerf.cmake
@@ -220,3 +220,13 @@ if(WITH_FASTCV)
     endif()
   endif()
 endif(WITH_FASTCV)
+
+# --- Accelerate ---
+if(WITH_ACCELERATE)
+  find_library(ACCELERATE_FRAMEWORK Accelerate)
+  if(ACCELERATE_FRAMEWORK)
+    set(HAVE_ACCELERATE ON CACHE BOOL "Accelerate status")
+  else()
+    set(HAVE_ACCELERATE OFF CACHE BOOL "Accelerate status")
+  endif()
+endif()

--- a/hal/accelerate/CMakeLists.txt
+++ b/hal/accelerate/CMakeLists.txt
@@ -1,0 +1,30 @@
+project(ACCELERATE_HAL)
+
+set(ACCELERATE_HAL_VERSION 0.0.1 CACHE INTERNAL "")
+set(ACCELERATE_HAL_LIBRARIES "accelerate_hal" CACHE INTERNAL "")
+set(ACCELERATE_HAL_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE INTERNAL "")
+set(ACCELERATE_HAL_HEADERS
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/accelerate_hal_core.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/accelerate_hal_imgproc.hpp"
+  CACHE INTERNAL "")
+
+add_library(accelerate_hal STATIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/accelerate_hal_core.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/accelerate_hal_imgproc.cpp"
+)
+
+target_link_libraries(accelerate_hal PRIVATE "-framework Accelerate")
+
+target_include_directories(accelerate_hal PRIVATE
+  ${CMAKE_SOURCE_DIR}/modules/core/include
+  ${ACCELERATE_HAL_INCLUDE_DIRS})
+
+set_target_properties(accelerate_hal PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH})
+
+if(NOT BUILD_SHARED_LIBS)
+  ocv_install_target(accelerate_hal EXPORT OpenCVModules ARCHIVE DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)
+endif()
+
+if(ENABLE_SOLUTION_FOLDERS)
+  set_target_properties(accelerate_hal PROPERTIES FOLDER "3rdparty")
+endif()

--- a/hal/accelerate/include/accelerate_hal_core.hpp
+++ b/hal/accelerate/include/accelerate_hal_core.hpp
@@ -7,8 +7,8 @@
 
 #include <opencv2/core/base.hpp>
 
-#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_10_4) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_4_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
 
 int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                               double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);

--- a/hal/accelerate/include/accelerate_hal_core.hpp
+++ b/hal/accelerate/include/accelerate_hal_core.hpp
@@ -1,0 +1,16 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#ifndef __ACCELERATE_HAL_CORE_HPP__
+#define __ACCELERATE_HAL_CORE_HPP__
+
+#include <opencv2/core/base.hpp>
+
+int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
+                              double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
+
+#undef cv_hal_meanStdDev
+#define cv_hal_meanStdDev accelerate_hal_meanStdDev
+
+#endif

--- a/hal/accelerate/include/accelerate_hal_core.hpp
+++ b/hal/accelerate/include/accelerate_hal_core.hpp
@@ -7,10 +7,15 @@
 
 #include <opencv2/core/base.hpp>
 
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
+
 int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                               double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
 
 #undef cv_hal_meanStdDev
 #define cv_hal_meanStdDev accelerate_hal_meanStdDev
+
+#endif
 
 #endif

--- a/hal/accelerate/include/accelerate_hal_imgproc.hpp
+++ b/hal/accelerate/include/accelerate_hal_imgproc.hpp
@@ -8,10 +8,10 @@
 #include <opencv2/core/base.hpp>
 
 
-#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
-     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
-     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_11_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_7_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_14_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
 
 int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
                                        uchar* dst_data, size_t dst_step, int dst_type,

--- a/hal/accelerate/include/accelerate_hal_imgproc.hpp
+++ b/hal/accelerate/include/accelerate_hal_imgproc.hpp
@@ -7,6 +7,12 @@
 
 #include <opencv2/core/base.hpp>
 
+
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
+
 int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
                                        uchar* dst_data, size_t dst_step, int dst_type,
                                        int width, int height, int full_width, int full_height, int offset_x, int offset_y,
@@ -16,5 +22,7 @@ int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, i
 
 #undef cv_hal_sepFilter_stateless
 #define cv_hal_sepFilter_stateless accelerate_hal_sepFilter_stateless
+
+#endif
 
 #endif

--- a/hal/accelerate/include/accelerate_hal_imgproc.hpp
+++ b/hal/accelerate/include/accelerate_hal_imgproc.hpp
@@ -1,0 +1,20 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#ifndef __ACCELERATE_HAL_IMGPROC_HPP__
+#define __ACCELERATE_HAL_IMGPROC_HPP__
+
+#include <opencv2/core/base.hpp>
+
+int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
+                                       uchar* dst_data, size_t dst_step, int dst_type,
+                                       int width, int height, int full_width, int full_height, int offset_x, int offset_y,
+                                       const uchar* kernelx_data, int kernelx_len,
+                                       const uchar* kernely_data, int kernely_len,
+                                       int kernel_type, int anchor_x, int anchor_y, double delta, int borderType);
+
+#undef cv_hal_sepFilter_stateless
+#define cv_hal_sepFilter_stateless accelerate_hal_sepFilter_stateless
+
+#endif

--- a/hal/accelerate/src/accelerate_hal_core.cpp
+++ b/hal/accelerate/src/accelerate_hal_core.cpp
@@ -8,8 +8,8 @@
 #include <Accelerate/Accelerate.h>
 
 
-#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_10_4) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_4_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
 
 int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                               double* mean_val, double* stddev_val, uchar* mask, size_t mask_step)

--- a/hal/accelerate/src/accelerate_hal_core.cpp
+++ b/hal/accelerate/src/accelerate_hal_core.cpp
@@ -8,6 +8,9 @@
 #include <Accelerate/Accelerate.h>
 
 
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_4) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0))
+
 int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                               double* mean_val, double* stddev_val, uchar* mask, size_t mask_step)
 {
@@ -42,3 +45,5 @@ int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width,
     }
     return CV_HAL_ERROR_OK;
 }
+
+#endif

--- a/hal/accelerate/src/accelerate_hal_core.cpp
+++ b/hal/accelerate/src/accelerate_hal_core.cpp
@@ -1,0 +1,44 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "accelerate_hal_core.hpp"
+#include "opencv2/core/utility.hpp"
+
+#include <Accelerate/Accelerate.h>
+
+
+int accelerate_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
+                              double* mean_val, double* stddev_val, uchar* mask, size_t mask_step)
+{
+    (void)mask_step;
+    if (src_type != CV_32F || mask != nullptr) {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    const int step = src_step / 4;
+    const float *src = reinterpret_cast<const float*>(src_data);
+    float mean;
+    cv::AutoBuffer<float> means(height);
+    for (int i = 0; i < height; ++i, src += step) {
+        vDSP_meanv(src, 1, means.data() + i, width);
+    }
+    vDSP_meanv(means.data(), 1, &mean, height);
+    if (mean_val != nullptr) {
+        *mean_val = mean;
+    }
+    if (stddev_val != nullptr) {
+        float var;
+        src = reinterpret_cast<const float*>(src_data);
+        mean *= -1.f;
+        cv::AutoBuffer<float> vars(height);
+        cv::AutoBuffer<float> tmp(width);
+        for (int i = 0; i < height; ++i, src += step) {
+            vDSP_vsadd(src, 1, &mean, tmp.data(), 1, width);
+            vDSP_measqv(tmp.data(), 1, vars.data() + i, width);
+        }
+        vDSP_meanv(vars.data(), 1, &var, height);
+        *stddev_val = std::sqrt(var);
+    }
+    return CV_HAL_ERROR_OK;
+}

--- a/hal/accelerate/src/accelerate_hal_imgproc.cpp
+++ b/hal/accelerate/src/accelerate_hal_imgproc.cpp
@@ -1,0 +1,88 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "accelerate_hal_imgproc.hpp"
+#include "opencv2/core/base.hpp"
+#include "opencv2/core/cvdef.h"
+#include "opencv2/core/utility.hpp"
+
+#include <algorithm>
+#include <Accelerate/Accelerate.h>
+
+
+int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
+                                       uchar* dst_data, size_t dst_step, int dst_type,
+                                       int width, int height, int full_width, int full_height, int offset_x, int offset_y,
+                                       const uchar* kernelx_data, int kernelx_len,
+                                       const uchar* kernely_data, int kernely_len,
+                                       int kernel_type, int anchor_x, int anchor_y, double delta, int borderType)
+{
+    if (kernel_type != CV_32F || (borderType != cv::BORDER_CONSTANT && borderType != cv::BORDER_REPLICATE) || anchor_x != -1 || anchor_y != -1) {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    uchar* _dst_data = dst_data;
+    size_t _dst_step = dst_step;
+    const int elem_size = CV_ELEM_SIZE(src_type);
+    cv::AutoBuffer<uchar> dst;
+
+    // In-place processing is not allowed
+    if (src_data == dst_data) {
+        dst = cv::AutoBuffer<uchar>(width * height * elem_size);
+        _dst_step = width * elem_size;
+        _dst_data = dst.data();
+    }
+
+    const vImage_Buffer src_buffer{
+        const_cast<void*>(static_cast<const void *>(src_data - offset_x * elem_size - src_step * offset_y)),
+        static_cast<vImagePixelCount>(full_height),
+        static_cast<vImagePixelCount>(full_width),
+        src_step,
+    };
+    const vImage_Buffer dst_buffer{
+        const_cast<void*>(static_cast<const void *>(_dst_data)),
+        static_cast<vImagePixelCount>(height),
+        static_cast<vImagePixelCount>(width),
+        _dst_step,
+    };
+    const vImage_Flags flags = borderType == cv::BORDER_CONSTANT ? kvImageBackgroundColorFill : kvImageEdgeExtend;
+    vImage_Error result;
+    if (src_type == CV_8U && dst_type == CV_8U) {
+        result = vImageSepConvolve_Planar8(&src_buffer, &dst_buffer, nullptr,
+            offset_x, offset_y,
+            reinterpret_cast<const float*>(kernelx_data), kernelx_len,
+            reinterpret_cast<const float*>(kernely_data), kernely_len,
+            delta, Pixel_F{}, flags);
+    } else if (src_type == CV_16F && dst_type == CV_16F) {
+        result = vImageSepConvolve_Planar16F(&src_buffer, &dst_buffer, nullptr,
+            offset_x, offset_y,
+            reinterpret_cast<const float*>(kernelx_data), kernelx_len,
+            reinterpret_cast<const float*>(kernely_data), kernely_len,
+            delta, Pixel_F{}, flags);
+    } else if (src_type == CV_32F && dst_type == CV_32F) {
+        result = vImageSepConvolve_PlanarF(&src_buffer, &dst_buffer, nullptr,
+            offset_x, offset_y,
+            reinterpret_cast<const float*>(kernelx_data), kernelx_len,
+            reinterpret_cast<const float*>(kernely_data), kernely_len,
+            delta, Pixel_F{}, flags);
+    } else if (src_type == CV_8U && dst_type == CV_16U) {
+        result = vImageSepConvolve_Planar8to16U(&src_buffer, &dst_buffer, nullptr,
+            offset_x, offset_y,
+            reinterpret_cast<const float*>(kernelx_data), kernelx_len,
+            reinterpret_cast<const float*>(kernely_data), kernely_len,
+            1.f, delta, Pixel_8{}, flags);
+    } else {
+        // vImageSepConvolve_Planar16U fails Imgproc_Sobel.accuracy tests
+        // vImageSepConvolve_ARGB8888 fails SepFilter2D.Mat_BitExact test
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    if (src_data == dst_data) {
+        for (int i = 0; i < height; i++) {
+            std::copy(_dst_data + i * _dst_step, _dst_data + (i + 1) * _dst_step, dst_data + i * dst_step);
+        }
+    }
+
+    return result == kvImageNoError ? CV_HAL_ERROR_OK : CV_HAL_ERROR_NOT_IMPLEMENTED;
+}

--- a/hal/accelerate/src/accelerate_hal_imgproc.cpp
+++ b/hal/accelerate/src/accelerate_hal_imgproc.cpp
@@ -11,6 +11,11 @@
 #include <Accelerate/Accelerate.h>
 
 
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
+
 int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
                                        uchar* dst_data, size_t dst_step, int dst_type,
                                        int width, int height, int full_width, int full_height, int offset_x, int offset_y,
@@ -55,11 +60,18 @@ int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, i
             reinterpret_cast<const float*>(kernely_data), kernely_len,
             delta, Pixel_F{}, flags);
     } else if (src_type == CV_16F && dst_type == CV_16F) {
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_16_0))
         result = vImageSepConvolve_Planar16F(&src_buffer, &dst_buffer, nullptr,
             offset_x, offset_y,
             reinterpret_cast<const float*>(kernelx_data), kernelx_len,
             reinterpret_cast<const float*>(kernely_data), kernely_len,
             delta, Pixel_F{}, flags);
+#else
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+#endif
     } else if (src_type == CV_32F && dst_type == CV_32F) {
         result = vImageSepConvolve_PlanarF(&src_buffer, &dst_buffer, nullptr,
             offset_x, offset_y,
@@ -86,3 +98,5 @@ int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, i
 
     return result == kvImageNoError ? CV_HAL_ERROR_OK : CV_HAL_ERROR_NOT_IMPLEMENTED;
 }
+
+#endif

--- a/hal/accelerate/src/accelerate_hal_imgproc.cpp
+++ b/hal/accelerate/src/accelerate_hal_imgproc.cpp
@@ -11,10 +11,10 @@
 #include <Accelerate/Accelerate.h>
 
 
-#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
-     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
-     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_11_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_7_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_7_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_14_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_14_0))
 
 int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, int src_type,
                                        uchar* dst_data, size_t dst_step, int dst_type,
@@ -60,10 +60,10 @@ int accelerate_hal_sepFilter_stateless(const uchar* src_data, size_t src_step, i
             reinterpret_cast<const float*>(kernely_data), kernely_len,
             delta, Pixel_F{}, flags);
     } else if (src_type == CV_16F && dst_type == CV_16F) {
-#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0) || \
-     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0) || \
-     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0) || \
-     (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_16_0))
+#if ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && defined(__MAC_13_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_16_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_16_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && defined(__TVOS_16_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_16_0))
         result = vImageSepConvolve_Planar16F(&src_buffer, &dst_buffer, nullptr,
             offset_x, offset_y,
             reinterpret_cast<const float*>(kernelx_data), kernelx_len,


### PR DESCRIPTION
**This PR is just a draft at the moment**

I have made a small proof of concept to integrate the [Accelerate Framework](https://developer.apple.com/documentation/accelerate) as a backend for OpenCV, as it offers many routines which are also used in OpenCV. Right now, I have only implemented `meanStdDev` and `sepFilter_stateless`. Performance improvements on my M1 Max are like this:

| Performance Test                                           | 4.x     | this PR | Speedup |
|------------------------------------------------------------|---------|---------|---------|
| Size_MatType_meanStdDev.meanStdDev/8                       | 2.59 ms | 0.32 ms | 8.1     |
| Size_MatType_BorderType_gaussianBlur5x5.gaussianBlur5x5/76 | 0.45 ms | 0.10 ms | 4.5     |

Note that most of these impressive speedups are simply due to Accelerate algorithms being multi-threaded instead of the current single-threaded OpenCV implementations.

I can continue working in that direction, but is this actually something the OpenCV team is interested in eventually merging?

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
